### PR TITLE
refactor: unify reasoning_summaries and supports_reasoning into single field

### DIFF
--- a/docs/rfcs/extensible-model-provider-configuration.md
+++ b/docs/rfcs/extensible-model-provider-configuration.md
@@ -144,7 +144,7 @@ The persisted runtime config should evolve toward this shape:
         "runtime_max_output_tokens": 8192,
         "capabilities": {
           "image_input": true,
-          "reasoning_summaries": true
+          "supports_reasoning": true
         }
       }
     }

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -1,3 +1,6 @@
+   Compiling holon v0.23.0 (/home/jolestar/opensource/src/github.com/holon-run/holon)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.55s
+     Running `target/debug/holon-docgen models`
 ---
 title: Supported Models
 description: Complete reference of all built-in models and providers supported by Holon.
@@ -6,7 +9,7 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **39 providers** and **233 models**.
+Holon includes built-in configuration for **40 providers** and **248 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -55,8 +58,9 @@ running Holon.
 | `venice` | OpenAI Chat Completions | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
 | `vercel-ai-gateway` | Anthropic Messages | `https://ai-gateway.vercel.sh` | `VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY or VERCEL_AI_GATEWAY_API_KEY` |
 | `vllm` | OpenAI Chat Completions | `http://127.0.0.1:8000/v1` | `—` |
-| `volcengine` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/v3` | `VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `volcengine-coding` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/compatible` | `VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine-agent` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/plan` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine-coding` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/coding` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
 | `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
 | `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
@@ -69,12 +73,12 @@ and capabilities.
 
 | Provider | Model | Usage | Context Window | Max Output | Reasoning | Image |
 |----------|-------|-------|----------------|------------|-----------|-------|
-| `anthropic` | `claude-haiku-4-5` | `anthropic/claude-haiku-4-5` | 200000 | 32000 | — | ✅ |
+| `anthropic` | `claude-haiku-4-5` | `anthropic/claude-haiku-4-5` | 200000 | 32000 | ✅ | ✅ |
 | `anthropic` | `claude-opus-4-5` | `anthropic/claude-opus-4-5` | 200000 | 64000 | ✅ | ✅ |
 | `anthropic` | `claude-opus-4-6` | `anthropic/claude-opus-4-6` | 1000000 | 128000 | ✅ | ✅ |
 | `anthropic` | `claude-opus-4-7` | `anthropic/claude-opus-4-7` | 1000000 | 128000 | ✅ | ✅ |
 | `anthropic` | `claude-sonnet-4-5` | `anthropic/claude-sonnet-4-5` | 200000 | 64000 | ✅ | ✅ |
-| `anthropic` | `claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` | 200000 | 32000 | — | ✅ |
+| `anthropic` | `claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` | 200000 | 32000 | ✅ | ✅ |
 | `arcee` | `trinity-large-preview` | `arcee/trinity-large-preview` | 131072 | 16384 | — | — |
 | `arcee` | `trinity-large-thinking` | `arcee/trinity-large-thinking` | 262144 | 80000 | ✅ | — |
 | `arcee` | `trinity-mini` | `arcee/trinity-mini` | 131072 | 80000 | — | — |
@@ -120,7 +124,7 @@ and capabilities.
 | `dashscope` | `qwen3.5-flash` | `dashscope/qwen3.5-flash` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.5-plus` | `dashscope/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
 | `dashscope` | `qwen3.6-flash` | `dashscope/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope` | `qwen3.6-plus` | `dashscope/qwen3.6-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope` | `qwen3.6-plus` | `dashscope/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.7-max` | `dashscope/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-max-2026-05-20` | `dashscope/qwen3.7-max-2026-05-20` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
@@ -134,18 +138,18 @@ and capabilities.
 | `dashscope-coding-plan` | `qwen3-coder-plus` | `dashscope-coding-plan/qwen3-coder-plus` | 1000000 | 65536 | — | — |
 | `dashscope-coding-plan` | `qwen3-max-2026-01-23` | `dashscope-coding-plan/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
 | `dashscope-coding-plan` | `qwen3.5-plus` | `dashscope-coding-plan/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
-| `dashscope-coding-plan` | `qwen3.6-plus` | `dashscope-coding-plan/qwen3.6-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope-coding-plan` | `qwen3.6-plus` | `dashscope-coding-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope-coding-plan` | `qwen3.7-plus` | `dashscope-coding-plan/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope-token-plan` | `MiniMax-M2.5` | `dashscope-token-plan/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
 | `dashscope-token-plan` | `deepseek-v3.2` | `dashscope-token-plan/deepseek-v3.2` | 128000 | 32768 | ✅ | — |
-| `dashscope-token-plan` | `deepseek-v4-flash` | `dashscope-token-plan/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
-| `dashscope-token-plan` | `deepseek-v4-pro` | `dashscope-token-plan/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `dashscope-token-plan` | `deepseek-v4-flash` | `dashscope-token-plan/deepseek-v4-flash` | 1000000 | 65536 | ✅ | — |
+| `dashscope-token-plan` | `deepseek-v4-pro` | `dashscope-token-plan/deepseek-v4-pro` | 1000000 | 65536 | ✅ | — |
 | `dashscope-token-plan` | `glm-5` | `dashscope-token-plan/glm-5` | 202752 | 16384 | ✅ | — |
-| `dashscope-token-plan` | `glm-5.1` | `dashscope-token-plan/glm-5.1` | 202752 | 131072 | ✅ | — |
-| `dashscope-token-plan` | `glm-5.2` | `dashscope-token-plan/glm-5.2` | 1000000 | 131072 | ✅ | — |
+| `dashscope-token-plan` | `glm-5.1` | `dashscope-token-plan/glm-5.1` | 202752 | 65536 | ✅ | — |
+| `dashscope-token-plan` | `glm-5.2` | `dashscope-token-plan/glm-5.2` | 1000000 | 65536 | ✅ | — |
 | `dashscope-token-plan` | `kimi-k2.5` | `dashscope-token-plan/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
-| `dashscope-token-plan` | `kimi-k2.6` | `dashscope-token-plan/kimi-k2.6` | 262144 | 98304 | ✅ | ✅ |
-| `dashscope-token-plan` | `kimi-k2.7-code` | `dashscope-token-plan/kimi-k2.7-code` | 262144 | 98304 | ✅ | ✅ |
+| `dashscope-token-plan` | `kimi-k2.6` | `dashscope-token-plan/kimi-k2.6` | 262144 | 65536 | ✅ | ✅ |
+| `dashscope-token-plan` | `kimi-k2.7-code` | `dashscope-token-plan/kimi-k2.7-code` | 262144 | 65536 | ✅ | ✅ |
 | `dashscope-token-plan` | `qwen3.6-flash` | `dashscope-token-plan/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope-token-plan` | `qwen3.6-plus` | `dashscope-token-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope-token-plan` | `qwen3.7-max` | `dashscope-token-plan/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
@@ -197,12 +201,18 @@ and capabilities.
 | `openai` | `gpt-5.4` | `openai/gpt-5.4` | 272000 | — | ✅ | ✅ |
 | `openai` | `gpt-5.4-mini` | `openai/gpt-5.4-mini` | 128000 | — | ✅ | ✅ |
 | `openai` | `gpt-5.5` | `openai/gpt-5.5` | 272000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-5.6-luna` | `openai/gpt-5.6-luna` | 272000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-5.6-sol` | `openai/gpt-5.6-sol` | 272000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-5.6-terra` | `openai/gpt-5.6-terra` | 272000 | 128000 | ✅ | ✅ |
 | `openai-codex` | `gpt-5.2` | `openai-codex/gpt-5.2` | 272000 | 128000 | ✅ | ✅ |
 | `openai-codex` | `gpt-5.3-codex` | `openai-codex/gpt-5.3-codex` | 272000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.3-codex-spark` | `openai-codex/gpt-5.3-codex-spark` | 128000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.4` | `openai-codex/gpt-5.4` | 272000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.4-mini` | `openai-codex/gpt-5.4-mini` | 272000 | 128000 | ✅ | ✅ |
 | `openai-codex` | `gpt-5.5` | `openai-codex/gpt-5.5` | 272000 | 128000 | ✅ | ✅ |
+| `openai-codex` | `gpt-5.6-luna` | `openai-codex/gpt-5.6-luna` | 272000 | 128000 | ✅ | ✅ |
+| `openai-codex` | `gpt-5.6-sol` | `openai-codex/gpt-5.6-sol` | 272000 | 128000 | ✅ | ✅ |
+| `openai-codex` | `gpt-5.6-terra` | `openai-codex/gpt-5.6-terra` | 272000 | 128000 | ✅ | ✅ |
 | `opencode-go` | `deepseek-v4-flash` | `opencode-go/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `opencode-go` | `deepseek-v4-pro` | `opencode-go/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
 | `openrouter` | `auto` | `openrouter/auto` | 200000 | 8192 | — | ✅ |
@@ -257,6 +267,17 @@ and capabilities.
 | `volcengine` | `doubao-seed-2-0-lite-260215` | `volcengine/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
 | `volcengine` | `doubao-seed-2-0-pro-260215` | `volcengine/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | ✅ |
 | `volcengine` | `glm-4-7-251222` | `volcengine/glm-4-7-251222` | 204800 | 131072 | ✅ | — |
+| `volcengine-agent` | `ark-code-latest` | `volcengine-agent/ark-code-latest` | 256000 | 65536 | ✅ | — |
+| `volcengine-agent` | `deepseek-v3-2-251201` | `volcengine-agent/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
+| `volcengine-agent` | `deepseek-v4-flash` | `volcengine-agent/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
+| `volcengine-agent` | `deepseek-v4-pro` | `volcengine-agent/deepseek-v4-pro` | 1000000 | 8192 | ✅ | — |
+| `volcengine-agent` | `doubao-seed-2-0-code-preview-260215` | `volcengine-agent/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | — |
+| `volcengine-agent` | `doubao-seed-2-0-lite-260215` | `volcengine-agent/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
+| `volcengine-agent` | `doubao-seed-2-0-pro-260215` | `volcengine-agent/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | — |
+| `volcengine-agent` | `glm-4-7-251222` | `volcengine-agent/glm-4-7-251222` | 204800 | 131072 | ✅ | — |
+| `volcengine-agent` | `glm-5.2` | `volcengine-agent/glm-5.2` | 204800 | 131072 | ✅ | — |
+| `volcengine-agent` | `kimi-k2.6` | `volcengine-agent/kimi-k2.6` | 262144 | 32768 | ✅ | — |
+| `volcengine-agent` | `kimi-k2.7-code` | `volcengine-agent/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
 | `volcengine-coding` | `ark-code-latest` | `volcengine-coding/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `volcengine-coding` | `deepseek-v3-2-251201` | `volcengine-coding/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
 | `volcengine-coding` | `deepseek-v4-flash` | `volcengine-coding/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
@@ -267,7 +288,7 @@ and capabilities.
 | `volcengine-coding` | `glm-4-7-251222` | `volcengine-coding/glm-4-7-251222` | 204800 | 131072 | ✅ | — |
 | `volcengine-coding` | `glm-5.2` | `volcengine-coding/glm-5.2` | 204800 | 131072 | ✅ | — |
 | `volcengine-coding` | `kimi-k2.6` | `volcengine-coding/kimi-k2.6` | 262144 | 32768 | ✅ | — |
-| `volcengine-coding` | `kimi-k2.7-code` | `volcengine-coding/kimi-k2.7-code` | 262144 | 65536 | ✅ | — |
+| `volcengine-coding` | `kimi-k2.7-code` | `volcengine-coding/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
 | `xai` | `grok-3` | `xai/grok-3` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-fast` | `xai/grok-3-fast` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-mini` | `xai/grok-3-mini` | 131072 | 8192 | ✅ | — |
@@ -300,3 +321,4 @@ and capabilities.
 | `zai` | `glm-5.1` | `zai/glm-5.1` | 202800 | 131072 | ✅ | — |
 | `zai` | `glm-5.2` | `zai/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-5v-turbo` | `zai/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |
+Generated model reference: 40 providers, 248 models.

--- a/src/bin/holon-docgen.rs
+++ b/src/bin/holon-docgen.rs
@@ -119,7 +119,7 @@ and capabilities.
             model = m.model_ref.model,
             ctx = m.context_window_tokens.map_or("—".to_string(), format_tokens),
             max_out = m.default_max_output_tokens.map_or("—".to_string(), format_tokens),
-            reasoning = if m.capabilities.reasoning_summaries { "✅" } else { "—" },
+            reasoning = if m.capabilities.supports_reasoning { "✅" } else { "—" },
             image = if m.capabilities.image_input { "✅" } else { "—" },
         );
     }

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -341,8 +341,8 @@ pub(crate) fn merged_model_capabilities(
         if let Some(value) = override_config.parallel_tool_calls {
             capabilities.parallel_tool_calls = value;
         }
-        if let Some(value) = override_config.reasoning_summaries {
-            capabilities.reasoning_summaries = value;
+        if let Some(value) = override_config.supports_reasoning {
+            capabilities.supports_reasoning = value;
         }
         if let Some(value) = override_config.image_input {
             capabilities.image_input = value;

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -32,8 +32,6 @@ pub struct ModelCapabilityFlags {
     #[serde(default)]
     pub parallel_tool_calls: bool,
     #[serde(default)]
-    pub reasoning_summaries: bool,
-    #[serde(default)]
     pub image_input: bool,
     #[serde(default)]
     pub supports_reasoning: bool,
@@ -46,8 +44,6 @@ pub struct ModelCapabilityOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parallel_tool_calls: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning_summaries: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_input: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_reasoning: Option<bool>,
@@ -58,7 +54,6 @@ pub struct ModelCapabilityOverride {
 impl ModelCapabilityOverride {
     pub fn is_empty(&self) -> bool {
         self.parallel_tool_calls.is_none()
-            && self.reasoning_summaries.is_none()
             && self.image_input.is_none()
             && self.supports_reasoning.is_none()
             && self.interactive_exec.is_none()
@@ -67,9 +62,6 @@ impl ModelCapabilityOverride {
     fn apply_to(&self, base: &mut ModelCapabilityFlags) {
         if let Some(value) = self.parallel_tool_calls {
             base.parallel_tool_calls = value;
-        }
-        if let Some(value) = self.reasoning_summaries {
-            base.reasoning_summaries = value;
         }
         if let Some(value) = self.image_input {
             base.image_input = value;
@@ -482,7 +474,7 @@ fn catalog_model(
     display_name: &str,
     context_window_tokens: usize,
     max_output_tokens: u32,
-    reasoning_summaries: bool,
+    supports_reasoning: bool,
     image_input: bool,
 ) -> BuiltInModelMetadata {
     let model_ref = ModelRef::new(provider_id(provider), model);
@@ -503,18 +495,11 @@ fn catalog_model(
         ),
         capabilities: ModelCapabilityFlags {
             image_input,
-            reasoning_summaries,
+            supports_reasoning,
             ..ModelCapabilityFlags::default()
         },
         source: ModelMetadataSource::BuiltInCatalog,
     }
-}
-
-/// Mark a built-in catalog entry as supporting reasoning/thinking parameters.
-/// Only models flagged here will receive reasoning_effort at the transport layer.
-fn with_reasoning(mut entry: BuiltInModelMetadata) -> BuiltInModelMetadata {
-    entry.capabilities.supports_reasoning = true;
-    entry
 }
 
 fn mirror_catalog_models(
@@ -589,7 +574,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -609,7 +593,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -629,7 +612,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -649,7 +631,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -669,7 +650,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
@@ -688,7 +668,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
@@ -707,7 +686,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
-                reasoning_summaries: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
@@ -724,7 +702,7 @@ fn default_verbosity_for_model(model_ref: &ModelRef) -> Option<ModelVerbosity> {
 
 fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
     let mut entries = vec![
-        with_reasoning(catalog_model(
+        catalog_model(
             "anthropic",
             "claude-opus-4-7",
             "Claude Opus 4.7",
@@ -732,8 +710,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "anthropic",
             "claude-opus-4-6",
             "Claude Opus 4.6",
@@ -741,8 +719,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "anthropic",
             "claude-opus-4-5",
             "Claude Opus 4.5",
@@ -750,8 +728,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             64_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "anthropic",
             "claude-sonnet-4-5",
             "Claude Sonnet 4.5",
@@ -759,8 +737,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             64_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai-codex",
             "gpt-5.5",
             "GPT-5.5 (Codex)",
@@ -768,8 +746,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai-codex",
             "gpt-5.6-sol",
             "GPT-5.6 Sol (Codex)",
@@ -777,8 +755,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai-codex",
             "gpt-5.6-terra",
             "GPT-5.6 Terra (Codex)",
@@ -786,8 +764,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai-codex",
             "gpt-5.6-luna",
             "GPT-5.6 Luna (Codex)",
@@ -795,8 +773,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai-codex",
             "gpt-5.4-mini",
             "GPT-5.4 Mini (Codex)",
@@ -804,8 +782,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai-codex",
             "gpt-5.2",
             "GPT-5.2 (Codex)",
@@ -813,8 +791,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai",
             "gpt-5.6-sol",
             "GPT-5.6 Sol",
@@ -822,8 +800,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai",
             "gpt-5.6-terra",
             "GPT-5.6 Terra",
@@ -831,8 +809,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
-        with_reasoning(catalog_model(
+        ),
+        catalog_model(
             "openai",
             "gpt-5.6-luna",
             "GPT-5.6 Luna",
@@ -840,11 +818,11 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
+        ),
         // Standard OpenAI transport (OpenAiProvider) never sends reasoning params
-        // (its complete_turn hardcodes reasoning_effort: None), so with_reasoning()
-        // is intentionally omitted here. If that transport is ever wired to send
-        // reasoning, wrap these entries with with_reasoning().
+        // (its complete_turn hardcodes reasoning_effort: None). supports_reasoning
+        // is true but unused by this transport; catalog.rs only passes it to
+        // Anthropic and Codex transports.
         catalog_model("openai", "gpt-5.5", "GPT-5.5", 272_000, 128_000, true, true),
         catalog_model("openai", "gpt-5.2", "GPT-5.2", 272_000, 128_000, true, true),
         catalog_model(
@@ -1063,7 +1041,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
-        with_reasoning(catalog_model(
+        catalog_model(
             "litellm",
             "claude-opus-4-6",
             "Claude Opus 4.6",
@@ -1071,7 +1049,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        )),
+        ),
         catalog_model(
             "minimax",
             "MiniMax-M3",
@@ -1457,7 +1435,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "qwen3.6-plus",
             1_000_000,
             65_536,
-            false,
+            true,
             true,
         ),
         catalog_model(
@@ -1655,7 +1633,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "qwen3.6-plus",
             1_000_000,
             65_536,
-            false,
+            true,
             true,
         ),
         catalog_model(
@@ -2747,7 +2725,7 @@ mod tests {
         assert_eq!(policy.context_window_tokens, Some(1_000_000));
         assert_eq!(policy.prompt_budget_estimated_tokens, 950_000);
         assert_eq!(policy.runtime_max_output_tokens, 384_000);
-        assert!(policy.capabilities.reasoning_summaries);
+        assert!(policy.capabilities.supports_reasoning);
         assert_eq!(policy.source, ModelMetadataSource::BuiltInCatalog);
 
         // GPT-5.6 family (Sol/Terra/Luna) added from the OpenAI limited preview.
@@ -2763,7 +2741,7 @@ mod tests {
         assert_eq!(sol.context_window_tokens, Some(272_000));
         assert_eq!(sol.runtime_max_output_tokens, 128_000);
         assert!(sol.capabilities.image_input);
-        assert!(sol.capabilities.reasoning_summaries);
+        assert!(sol.capabilities.supports_reasoning);
         assert_eq!(sol.source, ModelMetadataSource::BuiltInCatalog);
 
         assert!(catalog
@@ -2787,7 +2765,7 @@ mod tests {
         assert_eq!(nearai.display_name, "GLM 5.1 (NEAR AI Cloud TEE)");
         assert_eq!(nearai.context_window_tokens, Some(202_752));
         assert_eq!(nearai.runtime_max_output_tokens, 131_072);
-        assert!(nearai.capabilities.reasoning_summaries);
+        assert!(nearai.capabilities.supports_reasoning);
         assert_eq!(nearai.source, ModelMetadataSource::BuiltInCatalog);
     }
 
@@ -2819,7 +2797,7 @@ mod tests {
         assert_eq!(xiaomi.display_name, "Xiaomi MiMo V2.5 Pro");
         assert_eq!(xiaomi.context_window_tokens, Some(1_000_000));
         assert_eq!(xiaomi.runtime_max_output_tokens, 131_072);
-        assert!(xiaomi.capabilities.reasoning_summaries);
+        assert!(xiaomi.capabilities.supports_reasoning);
         assert_eq!(xiaomi.source, ModelMetadataSource::BuiltInCatalog);
 
         let xiaomi_ultraspeed = catalog.resolve_policy(
@@ -2836,7 +2814,7 @@ mod tests {
         );
         assert_eq!(xiaomi_ultraspeed.context_window_tokens, Some(1_000_000));
         assert_eq!(xiaomi_ultraspeed.runtime_max_output_tokens, 131_072);
-        assert!(xiaomi_ultraspeed.capabilities.reasoning_summaries);
+        assert!(xiaomi_ultraspeed.capabilities.supports_reasoning);
         assert_eq!(
             xiaomi_ultraspeed.source,
             ModelMetadataSource::BuiltInCatalog

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -218,7 +218,7 @@ fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
 }
 
 fn supports_reasoning_effort(entry: &ResolvedModelAvailability) -> bool {
-    entry.policy.capabilities.reasoning_summaries
+    entry.policy.capabilities.supports_reasoning
         && entry.transport.as_deref() == Some("openai_codex_responses")
 }
 
@@ -253,7 +253,7 @@ mod tests {
             tool_output_truncation_estimated_tokens: 2_500,
             max_output_tokens_upper_limit: Some(128_000),
             capabilities: ModelCapabilityFlags {
-                reasoning_summaries: reasoning,
+                supports_reasoning: reasoning,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -282,7 +282,7 @@ fn sample_model_availability(
             tool_output_truncation_estimated_tokens: 2_500,
             max_output_tokens_upper_limit: Some(64_000),
             capabilities: crate::model_catalog::ModelCapabilityFlags {
-                reasoning_summaries: reasoning,
+                supports_reasoning: reasoning,
                 ..crate::model_catalog::ModelCapabilityFlags::default()
             },
             source: crate::model_catalog::ModelMetadataSource::RemoteDiscovered,


### PR DESCRIPTION
## Summary

Remove the redundant `reasoning_summaries` field from `ModelCapabilityFlags` and `ModelCapabilityOverride`. Both fields encoded the same fact — whether a model supports reasoning/thinking — but were consumed by different layers (display vs transport), creating a risk of inconsistency where the model picker could show reasoning support while the transport silently dropped thinking parameters.

### Changes

- **`src/model_catalog.rs`**: `catalog_model()` now takes `supports_reasoning` directly; removed `reasoning_summaries` from `ModelCapabilityFlags`/`Override`; deleted the `with_reasoning()` wrapper and the sync-check test (no longer needed since there is only one field)
- **`src/config/models.rs`**: `merged_model_capabilities` now overrides `supports_reasoning` (was only overriding `reasoning_summaries`, leaving transport behavior stale when a config overrode reasoning support)
- **`src/bin/holon-docgen.rs`** / **`src/tui/model_picker.rs`**: display layer reads `supports_reasoning` instead of `reasoning_summaries`
- **`src/tui/tests.rs`**: test updated for the renamed field
- **`docs/rfcs/extensible-model-provider-configuration.md`**: RFC example updated
- **`docs/website/reference/models.md`**: regenerated

### Root cause

Discovered while investigating why DashScope models that advertised reasoning support in the picker never actually sent `thinking` parameters via the Anthropic transport. `catalog_model()` defaulted `supports_reasoning=false` while `reasoning_summaries` was set independently — any mismatch meant the display promised something the transport never delivered. Unifying to one field eliminates this entire class of bug.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- 245 catalog/model tests pass
