### PR TITLE
fix: refresh memory index before search to prevent stale results

### DIFF
--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -334,6 +334,15 @@ fn ensure_memory_index_current(
     ensure_memory_indexes_current(storage, active_workspace_id, &[])
 }
 
+pub(crate) fn ensure_memory_indexes_fresh(
+    storage: &AppStorage,
+    active_workspace_id: Option<&str>,
+    agent_storages: &[AppStorage],
+) -> Result<()> {
+    ensure_memory_indexes_current(storage, active_workspace_id, agent_storages)?;
+    Ok(())
+}
+
 fn ensure_memory_indexes_current(
     storage: &AppStorage,
     active_workspace_id: Option<&str>,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod refs;
 pub mod working;
 
 pub use episode::refresh_episode_memory;
+pub(crate) use index::ensure_memory_indexes_fresh;
 pub use index::{
     get_memory, rebuild_memory_index, refresh_memory_index_bounded, repair_memory_index_for_paths,
     request_memory_index_rebuild, search_memory, search_memory_query,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -614,6 +614,12 @@ impl RuntimeHandle {
         let storage = self.inner.storage.clone();
         let query = query.to_string();
         tokio::task::spawn_blocking(move || {
+            // Consume pending index entries so search results are not stale.
+            let _ = crate::memory::ensure_memory_indexes_fresh(
+                &storage,
+                active_workspace_id.as_deref(),
+                &[],
+            );
             crate::memory::search_memory_query(
                 &storage,
                 &query,
@@ -653,6 +659,13 @@ impl RuntimeHandle {
         let query = query.to_string();
         let agent_ids = agent_ids.to_vec();
         tokio::task::spawn_blocking(move || {
+            // Consume pending index entries from all relevant storages so that
+            // search results are not stale due to background indexer lag.
+            let _ = crate::memory::ensure_memory_indexes_fresh(
+                &storage,
+                active_workspace_id.as_deref(),
+                &agent_storages,
+            );
             crate::memory::search_memory_query_for_agent_storages(
                 &storage,
                 &query,


### PR DESCRIPTION
## Problem

CI on `main` failed after merging #2055. The test `runtime_search_route_filters_memory_results_by_agent_ids` was flaky.

## Root Cause

The HTTP search path opened the FTS index and searched **without consuming pending index entries first**. All agents share one index DB (`shared_indexes_dir()` at host scope). When messages are appended to agent-scoped storage (alpha/beta), they enter a pending queue consumed by a background indexer polling every 5 seconds. The test searches immediately after appending, racing the indexer.

The non-agent-filtered search test was unaffected because the default runtime's background indexer is more active.

## Fix

Call `ensure_memory_indexes_fresh` in the lifecycle layer (`search_memory` and `search_memory_for_agents`) before the actual search, mirroring what `get_memory` already does via `ensure_memory_index_current`.

The low-level `search_memory_query*` functions remain unchanged so that unit tests testing stale index behavior (`memory_search_consumes_runtime_outbox_without_full_rebuild`) still pass.

## Verification

- `cargo check --all-targets` with `RUSTFLAGS="-D warnings"` ✅
- `cargo fmt --all -- --check` ✅
- Flaky test passed 5/5 consecutive runs ✅
- All 8 `memory_search` unit tests pass ✅
- All 40 `http_control` integration tests pass ✅