### PR TITLE
refactor: remove root HTTP routes, unify all paths under /api prefix

### DIFF
--- a/docs/website/guides/skills.md
+++ b/docs/website/guides/skills.md
@@ -216,8 +216,8 @@ The HTTP control plane separates library and agent operations:
 | `POST` | `/control/agents/:agent_id/skills/enable` | Enable for agent |
 | `POST` | `/control/agents/:agent_id/skills/disable` | Disable for agent |
 
-> **Deprecated:** `POST /control/agents/:agent_id/skills/install` and
-> `POST /control/agents/:agent_id/skills/uninstall` remain for
+> **Deprecated:** `POST /api/control/agents/:agent_id/skills/install` and
+> `POST /api/control/agents/:agent_id/skills/uninstall` remain for
 > compatibility but are superseded by enable/disable and
 > add/remove.
 

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -109,7 +109,7 @@ sidebar when a workspace is attached:
   a larger reading surface, accessible via the file tree context menu.
 
 The file browser uses the workspace file browsing API
-(`GET /workspaces/{id}/files` and `GET /workspaces/{id}/files/{path}`).
+(`GET /api/workspaces/{id}/files` and `GET /api/workspaces/{id}/files/{path}`).
 Path traversal and symlink escapes are blocked; file reads are capped
 at 1 MB.
 

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -37,10 +37,10 @@ trusting caller-supplied provenance fields.
 
 | Ingress class | Routes | Auth boundary | Origin/trust/authority | Priority | Supported posture |
 |---------------|--------|---------------|------------------------|----------|-------------------|
-| Public enqueue | `POST /enqueue`, `POST /agents/:id/enqueue` | Bearer token in bearer mode; local process boundary in local mode. | Caller may provide only channel or webhook origin. Caller-provided `trust` is rejected. Channel origins become untrusted external evidence; webhook origins become integration signals. Runtime-owned kinds such as `system_tick` and `callback_event` are rejected. | `next`, `normal`, or `background`; `interject` is rejected. | Candidate stable external ingress for non-operator evidence. |
+| Public enqueue | `POST /api/enqueue`, `POST /api/agents/:id/enqueue` | Bearer token in bearer mode; local process boundary in local mode. | Caller may provide only channel or webhook origin. Caller-provided `trust` is rejected. Channel origins become untrusted external evidence; webhook origins become integration signals. Runtime-owned kinds such as `system_tick` and `callback_event` are rejected. | `next`, `normal`, or `background`; `interject` is rejected. | Candidate stable external ingress for non-operator evidence. |
 | Callback capability | `POST /callbacks/wake/:callback_token`, `POST /callbacks/enqueue/:callback_token` | Capability token in the URL path resolves to an active external trigger and matching delivery mode. Do not log, repeat, or publish full callback URLs. | Delivery is admitted as an external-trigger capability and an integration signal. Wake callbacks enqueue runtime-owned inspection ticks; callback payload text is untrusted evidence for the agent to inspect. | Runtime-selected by delivery mode; callers do not choose queue priority. | Capability surface for durable external systems that need to wake or notify an agent. |
-| Operator transport binding | `POST /control/agents/:id/operator-bindings` | Control-plane auth. Delivery credentials are stored on the binding and redacted from audit events. | Creates or updates the binding that later authorizes remote operator ingress. | N/A. | Experimental operator adapter setup surface. |
-| Operator transport ingress | `POST /control/agents/:id/operator-ingress` | Control-plane auth plus active binding, matching target agent, matching operator actor, and matching provider when supplied. | Enqueues a `trusted_operator` `operator_prompt` with `operator_instruction` authority and remote-operator transport metadata. | Always `interject`. | Experimental authenticated operator adapter ingress. |
+| Operator transport binding | `POST /api/control/agents/:id/operator-bindings` | Control-plane auth. Delivery credentials are stored on the binding and redacted from audit events. | Creates or updates the binding that later authorizes remote operator ingress. | N/A. | Experimental operator adapter setup surface. |
+| Operator transport ingress | `POST /api/control/agents/:id/operator-ingress` | Control-plane auth plus active binding, matching target agent, matching operator actor, and matching provider when supplied. | Enqueues a `trusted_operator` `operator_prompt` with `operator_instruction` authority and remote-operator transport metadata. | Always `interject`. | Experimental authenticated operator adapter ingress. |
 | Generic webhook compatibility | `POST /webhooks/generic/:agent_id` | Bearer token in bearer mode; local process boundary in local mode. | Converts JSON payload into a trusted-integration webhook event with `generic_webhook` origin. Callers cannot set origin, trust, or priority through this route. | Always `normal`. | Internal/debug compatibility route; prefer public enqueue or a dedicated capability callback for new external integrations. |
 
 ## Endpoint reference
@@ -90,16 +90,16 @@ Returns model catalog and runtime availability.
 
 ### Agents
 
-**`GET /agents/list`** — List agent entries
+**`GET /api/agents/list`** — List agent entries
 
 Returns lightweight public agent entries for selection and navigation without
 loading full per-agent runtime summaries.
 
-**`GET /agents/:id/status`** — Single agent status
+**`GET /api/agents/:id/status`** — Single agent status
 
 Returns the same `AgentSummary` shape for the named agent.
 
-**`GET /agents/:id/state`** — Lightweight agent state bootstrap
+**`GET /api/agents/:id/state`** — Lightweight agent state bootstrap
 
 Returns a bounded bootstrap page: agent summary, session info (current run,
 pending count), active task summaries, recent timers, slim work items, waiting
@@ -107,19 +107,19 @@ intents, external triggers, and workspace occupancy. Operator notifications,
 execution details, task details, and full work item records are available from
 events or dedicated routes.
 
-**`GET /agents/:id/briefs`** — Recent briefs
+**`GET /api/agents/:id/briefs`** — Recent briefs
 
 Returns recent briefs (acknowledgements and results) for the agent.
 
-**`GET /agents/:id/tasks`** — Active tasks
+**`GET /api/agents/:id/tasks`** — Active tasks
 
 Returns active and recent tasks with status, kind, and timing metadata.
 
-**`GET /agents/:id/tasks/:task_id`** — Task status
+**`GET /api/agents/:id/tasks/:task_id`** — Task status
 
 Returns the structured task lifecycle snapshot for one managed task.
 
-**`GET /agents/:id/tasks/:task_id/output`** — Task output
+**`GET /api/agents/:id/tasks/:task_id/output`** — Task output
 
 Returns a bounded task output result. Query parameters:
 
@@ -128,16 +128,16 @@ Returns a bounded task output result. Query parameters:
 | `block` | Whether to wait for output/completion before returning |
 | `timeout_ms` | Optional bounded wait duration when `block=true` |
 
-**`GET /agents/:id/timers`** — Recent timers
+**`GET /api/agents/:id/timers`** — Recent timers
 
 Returns recent timer records.
 
-**`GET /agents/:id/timers/:timer_id`** — Timer detail
+**`GET /api/agents/:id/timers/:timer_id`** — Timer detail
 
 Returns a single timer record by id, or a shared error envelope when the timer
 is not found for the target agent.
 
-**`GET /agents/:id/events`** — Event log
+**`GET /api/agents/:id/events`** — Event log
 
 Returns recent runtime events (turn entries, system events). Query parameters:
 
@@ -165,7 +165,7 @@ page contains events where `after_seq < event_seq < before_seq`. Event pages are
 loaded from the durable event log, so an unknown cursor can yield an empty page
 rather than a cursor error.
 
-**`GET /agents/:id/events/stream`** — Server-sent events
+**`GET /api/agents/:id/events/stream`** — Server-sent events
 
 SSE stream of raw agent events. Supports `after_seq` and `limit` query params.
 The SSE `id` field is the per-agent durable `event_seq`, and the
@@ -209,17 +209,17 @@ Migration note:
   `/agents/:id/events?max_level=info`. Stream clients should keep subscribing
   to `/agents/:id/events/stream` and apply any presentation filtering locally.
 
-**`GET /agents/:id/transcript`** — Turn transcript
+**`GET /api/agents/:id/transcript`** — Turn transcript
 
 Returns the current turn transcript entries.
 
-**`GET /agents/:id/worktree-summary`** — Worktree summary
+**`GET /api/agents/:id/worktree-summary`** — Worktree summary
 
 Returns managed worktree entries for the agent's workspace.
 
 ### Enqueue (public ingress)
 
-**`POST /agents/:id/enqueue`** — Enqueue a message
+**`POST /api/agents/:id/enqueue`** — Enqueue a message
 
 Accepts external callers on the public HTTP surface. When the server is in
 **bearer mode**, this route calls `authorize_remote_access` and requires the
@@ -254,7 +254,7 @@ Response:
 { "ok": true, "agent_id": "main", "message_id": "msg-abc123" }
 ```
 
-**`POST /enqueue`** (no agent in path) — Enqueue to default agent.
+**`POST /api/enqueue`** (no agent in path) — Enqueue to default agent.
 
 **`POST /webhooks/generic/:agent_id`** — Generic webhook compatibility
 
@@ -272,7 +272,7 @@ needs a secret URL.
 All `/control/*` routes require a control token when the server is in bearer
 mode.
 
-**`POST /control/agents/:id/prompt`** — Send an operator prompt
+**`POST /api/control/agents/:id/prompt`** — Send an operator prompt
 
 Sends a prompt that enters the agent queue as an operator message with
 `trusted_operator` classification.
@@ -281,7 +281,7 @@ Sends a prompt that enters the agent queue as an operator message with
 { "text": "What is the current status?" }
 ```
 
-**`POST /control/agents/:id/wake`** — Explicit wake
+**`POST /api/control/agents/:id/wake`** — Explicit wake
 
 Wakes a sleeping agent with a control-plane wake hint.
 
@@ -295,7 +295,7 @@ Response:
 { "ok": true, "agent_id": "main", "disposition": "woken" }
 ```
 
-**`POST /control/agents/:id/control`** — Control action
+**`POST /api/control/agents/:id/control`** — Control action
 
 Sends a control action. Request body:
 
@@ -303,7 +303,7 @@ Sends a control action. Request body:
 { "action": "stop", "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/current-run/abort`** — Abort current run
+**`POST /api/control/agents/:id/current-run/abort`** — Abort current run
 
 Aborts the current agent run loop. New callers should use
 `mode: "stop_after_abort"`. The legacy `pause_after_abort` value is accepted as
@@ -313,7 +313,7 @@ a compatibility alias and is treated as `stop_after_abort`.
 { "mode": "stop_after_abort" }
 ```
 
-**`POST /control/agents/:id/create`** — Create agent
+**`POST /api/control/agents/:id/create`** — Create agent
 
 Creates a new agent managed by the host. The agent id comes from the URL path.
 
@@ -321,7 +321,7 @@ Creates a new agent managed by the host. The agent id comes from the URL path.
 { "template": null, "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/tasks`** — Create command task
+**`POST /api/control/agents/:id/tasks`** — Create command task
 
 Starts a background command task for the agent.
 
@@ -335,7 +335,7 @@ Starts a background command task for the agent.
 }
 ```
 
-**`POST /control/agents/:id/tasks/:task_id/input`** — Send task input
+**`POST /api/control/agents/:id/tasks/:task_id/input`** — Send task input
 
 Delivers text input to a managed task using trusted operator authority. Command
 tasks receive stdin or TTY text when they were created with interactive input
@@ -345,7 +345,7 @@ enabled; supervised child-agent tasks receive a follow-up input.
 { "text": "continue\n", "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/tasks/:task_id/stop`** — Stop task
+**`POST /api/control/agents/:id/tasks/:task_id/stop`** — Stop task
 
 Requests cancellation for a managed task and returns the structured task stop
 receipt.
@@ -354,7 +354,7 @@ receipt.
 { "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/work-items`** — Create work item
+**`POST /api/control/agents/:id/work-items`** — Create work item
 
 Creates a durable work item for the agent.
 
@@ -365,7 +365,7 @@ Creates a durable work item for the agent.
 }
 ```
 
-**`POST /control/agents/:id/work-items/:work_item_id/pick`** — Pick work item
+**`POST /api/control/agents/:id/work-items/:work_item_id/pick`** — Pick work item
 
 Makes an existing open work item the current focus for the agent. The response
 returns the previous focus, current focus, current work item id, and the
@@ -375,7 +375,7 @@ recorded focus transition.
 { "reason": "external scheduler selected next work", "authority_class": "integration_signal" }
 ```
 
-**`PATCH /control/agents/:id/work-items/:work_item_id`** — Update work item
+**`PATCH /api/control/agents/:id/work-items/:work_item_id`** — Update work item
 
 Mutates one or more WorkItem fields. Empty updates are rejected. `blocked_by`
 uses a nested optional shape: a string sets the blocker, `null` clears it, and
@@ -393,7 +393,7 @@ requires a non-empty blocker.
 }
 ```
 
-**`POST /control/agents/:id/work-items/:work_item_id/complete`** — Complete work item
+**`POST /api/control/agents/:id/work-items/:work_item_id/complete`** — Complete work item
 
 Marks an open work item completed and returns the updated `WorkItemRecord`.
 Cancel, close-without-completion, and delete are intentionally out of scope for
@@ -403,7 +403,7 @@ this lifecycle surface.
 { "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/timers`** — Create timer
+**`POST /api/control/agents/:id/timers`** — Create timer
 
 Creates a timer that will deliver a `TimerTick` to the agent.
 
@@ -416,7 +416,7 @@ Creates a timer that will deliver a `TimerTick` to the agent.
 }
 ```
 
-**`POST /control/agents/:id/timers/:timer_id/cancel`** — Cancel timer
+**`POST /api/control/agents/:id/timers/:timer_id/cancel`** — Cancel timer
 
 Cancels an active timer and returns the updated `TimerRecord`. Cancellation is
 idempotent for an already-cancelled timer. A missing timer returns a shared
@@ -428,7 +428,7 @@ projections and emits `timer_cancelled`.
 { "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/debug-prompt`** — Debug prompt
+**`POST /api/control/agents/:id/debug-prompt`** — Debug prompt
 
 Sends a debug-mode prompt (runtime-internal classification). Request body:
 
@@ -436,7 +436,7 @@ Sends a debug-mode prompt (runtime-internal classification). Request body:
 { "text": "debug instruction", "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/operator-bindings`** — Create operator transport binding
+**`POST /api/control/agents/:id/operator-bindings`** — Create operator transport binding
 
 Sets up a callback URL or transport binding for operator notifications.
 Request body:
@@ -456,7 +456,7 @@ Request body:
 }
 ```
 
-**`POST /control/agents/:id/operator-ingress`** — Operator ingress
+**`POST /api/control/agents/:id/operator-ingress`** — Operator ingress
 
 Direct ingress path for operator-origin messages through the control plane.
 Request body:
@@ -472,13 +472,13 @@ Request body:
 }
 ```
 
-**`POST /control/agents/:id/workspace/attach`** — Attach workspace
+**`POST /api/control/agents/:id/workspace/attach`** — Attach workspace
 
 ```json
 { "path": "/path/to/workspace" }
 ```
 
-**`POST /control/agents/:id/workspace/exit`** — Exit current workspace
+**`POST /api/control/agents/:id/workspace/exit`** — Exit current workspace
 
 Returns to the agent home workspace. Accepts an optional body:
 
@@ -486,7 +486,7 @@ Returns to the agent home workspace. Accepts an optional body:
 { "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/workspace/detach`** — Detach workspace
+**`POST /api/control/agents/:id/workspace/detach`** — Detach workspace
 
 Removes a workspace registration without switching. Request body:
 
@@ -494,13 +494,13 @@ Removes a workspace registration without switching. Request body:
 { "workspace_id": "ws-abc123", "authority_class": "operator_instruction" }
 ```
 
-**`POST /control/agents/:id/model`** — Set agent model
+**`POST /api/control/agents/:id/model`** — Set agent model
 
 ```json
 { "model": "claude-sonnet-4-20250514" }
 ```
 
-**`POST /control/agents/:id/model/clear`** — Clear model override
+**`POST /api/control/agents/:id/model/clear`** — Clear model override
 
 Reverts to the default model. Accepts an optional body:
 
@@ -510,17 +510,17 @@ Reverts to the default model. Accepts an optional body:
 
 ### Runtime management
 
-**`GET /control/runtime/status`** — Runtime status
+**`GET /api/control/runtime/status`** — Runtime status
 
 Returns daemon and runtime health info including configured models, control
 token status, and activity markers.
 
-**`GET /control/runtime/config`** — Runtime config
+**`GET /api/control/runtime/config`** — Runtime config
 
 Returns the daemon's current effective runtime configuration surface and the
 `config.json` path that backs persisted runtime-mutable settings.
 
-**`PATCH /control/runtime/config`** — Update runtime config
+**`PATCH /api/control/runtime/config`** — Update runtime config
 
 Persists runtime-mutable config key updates and classifies each attempted
 change. The current implementation writes supported keys to `config.json` and
@@ -557,7 +557,7 @@ keys return `rejected` with a reason.
 }
 ```
 
-**`POST /control/runtime/shutdown`** — Graceful shutdown
+**`POST /api/control/runtime/shutdown`** — Graceful shutdown
 
 Shuts down the runtime and daemon gracefully.
 
@@ -649,9 +649,9 @@ endpoint. A good integration should be able to ask:
 The following routes exist in `src/http.rs` but are not yet fully documented
 on this reference page:
 
-- `GET /agents/:id/skills`
-- `POST /control/agents/:id/skills/install`
-- `POST /control/agents/:id/skills/uninstall`
+- `GET /api/agents/:id/skills`
+- `POST /api/control/agents/:id/skills/install`
+- `POST /api/control/agents/:id/skills/uninstall`
 - Default-agent aliases: `/status`, `/briefs`, `/state`, `/transcript`,
   `/worktree-summary`
 

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4589,7 +4589,7 @@
   },
   "openapi": "3.1.0",
   "paths": {
-    "/": {
+    "/api/": {
       "get": {
         "description": "Return the default agent id.",
         "operationId": "root",
@@ -4637,7 +4637,7 @@
         ]
       }
     },
-    "/agents/list": {
+    "/api/agents/list": {
       "get": {
         "description": "Return lightweight public agent entries.",
         "operationId": "listAgents",
@@ -4685,7 +4685,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/agents/{agent_id}/briefs": {
+    "/api/agents/{agent_id}/briefs": {
       "get": {
         "description": "Return recent user-facing delivery briefs. Query parameter: limit.",
         "operationId": "agentBriefs",
@@ -4745,7 +4745,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/agents/{agent_id}/briefs/{brief_id}": {
+    "/api/agents/{agent_id}/briefs/{brief_id}": {
       "get": {
         "description": "Return a persisted user-facing delivery brief by id.",
         "operationId": "agentBrief",
@@ -4812,7 +4812,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/enqueue": {
+    "/api/agents/{agent_id}/enqueue": {
       "post": {
         "description": "Enqueue a public channel/webhook message for the named agent.",
         "operationId": "enqueueAgent",
@@ -4880,7 +4880,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/events": {
+    "/api/agents/{agent_id}/events": {
       "get": {
         "description": "Return a bounded page of runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Event payloads are included in full; max_level filters event inclusion only. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.",
         "operationId": "agentEvents",
@@ -4938,7 +4938,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/events/stream": {
+    "/api/agents/{agent_id}/events/stream": {
       "get": {
         "description": "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.",
         "operationId": "agentEventsStream",
@@ -4986,7 +4986,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/messages/{message_id}": {
+    "/api/agents/{agent_id}/messages/{message_id}": {
       "get": {
         "description": "Return a persisted message envelope by id for the selected agent.",
         "operationId": "agentMessage",
@@ -5053,7 +5053,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/messages:batchGet": {
+    "/api/agents/{agent_id}/messages:batchGet": {
       "post": {
         "description": "Return persisted message envelopes for the selected agent. Missing or cross-agent ids are reported in missing_message_ids.",
         "operationId": "agentMessagesBatchGet",
@@ -5121,7 +5121,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/skills": {
+    "/api/agents/{agent_id}/skills": {
       "get": {
         "description": "Return skills enabled/effective for an agent.",
         "operationId": "agentSkills",
@@ -5179,7 +5179,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/state": {
+    "/api/agents/{agent_id}/state": {
       "get": {
         "description": "Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.",
         "operationId": "agentState",
@@ -5239,7 +5239,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/agents/{agent_id}/status": {
+    "/api/agents/{agent_id}/status": {
       "get": {
         "description": "Return the public AgentSummary read model.",
         "operationId": "agentStatus",
@@ -5299,7 +5299,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/agents/{agent_id}/tasks": {
+    "/api/agents/{agent_id}/tasks": {
       "get": {
         "description": "Return active task records. Query parameter: limit.",
         "operationId": "agentTasks",
@@ -5357,7 +5357,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/tasks/{task_id}": {
+    "/api/agents/{agent_id}/tasks/{task_id}": {
       "get": {
         "description": "Return a task lifecycle snapshot by id.",
         "operationId": "agentTaskStatus",
@@ -5424,7 +5424,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/tasks/{task_id}/output": {
+    "/api/agents/{agent_id}/tasks/{task_id}/output": {
       "get": {
         "description": "Return a task output snapshot. Query parameters: block, timeout_ms.",
         "operationId": "agentTaskOutput",
@@ -5491,7 +5491,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/timers": {
+    "/api/agents/{agent_id}/timers": {
       "get": {
         "description": "Return recent timer records. Query parameter: limit.",
         "operationId": "agentTimers",
@@ -5549,7 +5549,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/timers/{timer_id}": {
+    "/api/agents/{agent_id}/timers/{timer_id}": {
       "get": {
         "description": "Return a timer record by id.",
         "operationId": "agentTimer",
@@ -5616,7 +5616,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/tool-executions/{tool_execution_id}": {
+    "/api/agents/{agent_id}/tool-executions/{tool_execution_id}": {
       "get": {
         "description": "Return a persisted tool execution record by id.",
         "operationId": "agentToolExecution",
@@ -5683,7 +5683,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/transcript": {
+    "/api/agents/{agent_id}/transcript": {
       "get": {
         "description": "Return recent transcript entries. Query parameter: limit.",
         "operationId": "agentTranscript",
@@ -5743,7 +5743,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/agents/{agent_id}/transcript/{entry_id}": {
+    "/api/agents/{agent_id}/transcript/{entry_id}": {
       "get": {
         "description": "Return a persisted transcript entry by id for the selected agent.",
         "operationId": "agentTranscriptEntry",
@@ -5801,7 +5801,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/transcript:batchGet": {
+    "/api/agents/{agent_id}/transcript:batchGet": {
       "post": {
         "description": "Return persisted transcript entries for the selected agent. Missing or cross-agent ids are reported in missing_entry_ids.",
         "operationId": "agentTranscriptBatchGet",
@@ -5869,7 +5869,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/work-items": {
+    "/api/agents/{agent_id}/work-items": {
       "get": {
         "description": "Return latest work item records for the agent. Query parameter: limit.",
         "operationId": "agentWorkItems",
@@ -5927,7 +5927,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/work-items/{work_item_id}": {
+    "/api/agents/{agent_id}/work-items/{work_item_id}": {
       "get": {
         "description": "Return a work item record by id.",
         "operationId": "agentWorkItem",
@@ -5994,7 +5994,7 @@
         ]
       }
     },
-    "/agents/{agent_id}/worktree-summary": {
+    "/api/agents/{agent_id}/worktree-summary": {
       "get": {
         "description": "Return managed worktree summary for an agent.",
         "operationId": "agentWorktreeSummary",
@@ -6052,6 +6052,2652 @@
           "agents"
         ],
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
+      }
+    },
+    "/api/auth/codex/device/start": {
+      "post": {
+        "description": "Request an OpenAI Codex device code and start a background job that persists the OAuth credential profile after user authorization.",
+        "operationId": "startCodexDeviceLogin",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Start Codex device login",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/briefs": {
+      "get": {
+        "description": "Compatibility alias for the default agent briefs route. Query parameter: limit.",
+        "operationId": "defaultBriefs",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Default agent briefs alias",
+        "tags": [
+          "compat"
+        ],
+        "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
+      }
+    },
+    "/api/callbacks/enqueue/{callback_token}": {
+      "post": {
+        "description": "Capability-token callback ingress for enqueue delivery. The token is a secret path segment and examples intentionally use a placeholder.",
+        "operationId": "callbackEnqueue",
+        "parameters": [
+          {
+            "description": "Opaque callback capability token. This is a secret and must not be exposed in examples.",
+            "in": "path",
+            "name": "callback_token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallbackBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "CallbackToken": []
+          }
+        ],
+        "summary": "Callback enqueue ingress",
+        "tags": [
+          "callbacks"
+        ]
+      }
+    },
+    "/api/callbacks/wake/{callback_token}": {
+      "post": {
+        "description": "Capability-token callback ingress for wake delivery. The token is a secret path segment and examples intentionally use a placeholder.",
+        "operationId": "callbackWake",
+        "parameters": [
+          {
+            "description": "Opaque callback capability token. This is a secret and must not be exposed in examples.",
+            "in": "path",
+            "name": "callback_token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallbackBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "CallbackToken": []
+          }
+        ],
+        "summary": "Callback wake ingress",
+        "tags": [
+          "callbacks"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/control": {
+      "post": {
+        "description": "Submit a lifecycle control action.",
+        "operationId": "controlAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControlRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Control agent lifecycle",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/create": {
+      "post": {
+        "description": "Create a public named agent, optionally from a template.",
+        "operationId": "createAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create named agent",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/current-run/abort": {
+      "post": {
+        "description": "Request abort for the current agent run.",
+        "operationId": "abortCurrentRun",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AbortCurrentRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Abort current run",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/debug-prompt": {
+      "post": {
+        "description": "Render a diagnostic prompt preview.",
+        "operationId": "debugPrompt",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebugPromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Debug prompt",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/model": {
+      "post": {
+        "description": "Set an agent model override and optional reasoning effort.",
+        "operationId": "setAgentModel",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAgentModelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Set agent model override",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/model/clear": {
+      "post": {
+        "description": "Clear an agent model override.",
+        "operationId": "clearAgentModel",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClearAgentModelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Clear agent model override",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/operator-bindings": {
+      "post": {
+        "description": "Create or update a remote operator transport binding.",
+        "operationId": "createOperatorTransportBinding",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperatorTransportBindingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create operator binding",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/operator-ingress": {
+      "post": {
+        "description": "Deliver an authenticated remote operator prompt.",
+        "operationId": "operatorIngress",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperatorIngressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Operator ingress",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/prompt": {
+      "post": {
+        "description": "Submit a trusted operator prompt through the control plane.",
+        "operationId": "controlPrompt",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControlPromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Submit operator prompt",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/skills/disable": {
+      "post": {
+        "description": "Disable a skill for an agent.",
+        "operationId": "disableSkill",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Disable agent skill",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/skills/enable": {
+      "post": {
+        "description": "Enable a locally known skill for an agent.",
+        "operationId": "enableSkill",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnableSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Enable agent skill",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/skills/install": {
+      "post": {
+        "description": "Compatibility alias for older agent skill install behavior.",
+        "operationId": "installSkill",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Install skill compatibility alias",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/skills/uninstall": {
+      "post": {
+        "description": "Compatibility alias for disabling an agent skill.",
+        "operationId": "uninstallSkill",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UninstallSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Uninstall skill compatibility alias",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/tasks": {
+      "post": {
+        "description": "Schedule a command task for an agent.",
+        "operationId": "createCommandTask",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCommandTaskRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create command task",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/tasks/{task_id}/input": {
+      "post": {
+        "description": "Deliver text input to a managed task.",
+        "operationId": "taskInput",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Task id.",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskInputRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskInputResult"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Task input",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/tasks/{task_id}/stop": {
+      "post": {
+        "description": "Request cancellation for a managed task.",
+        "operationId": "taskStop",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Task id.",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskStopRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStopResult"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Task stop",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/timers": {
+      "post": {
+        "description": "Schedule a timer for an agent.",
+        "operationId": "createTimer",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTimerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimerRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create timer",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/timers/{timer_id}/cancel": {
+      "post": {
+        "description": "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.",
+        "operationId": "cancelTimer",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Timer id.",
+            "in": "path",
+            "name": "timer_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelTimerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimerRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Cancel timer",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/wake": {
+      "post": {
+        "description": "Submit a trusted wake hint.",
+        "operationId": "controlWake",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControlWakeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Wake agent",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/work-items": {
+      "post": {
+        "description": "Create or enqueue a public work item objective.",
+        "operationId": "createWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkItemRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/work-items/{work_item_id}": {
+      "patch": {
+        "description": "Mutate work item objective, plan status, todo list, or blocker fields.",
+        "operationId": "updateWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Work item id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkItemRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/work-items/{work_item_id}/complete": {
+      "post": {
+        "description": "Mark an open work item completed.",
+        "operationId": "completeWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Work item id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkItemRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Complete work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/work-items/{work_item_id}/pick": {
+      "post": {
+        "description": "Make an existing open work item the current focus for the agent.",
+        "operationId": "pickWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Work item id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PickWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PickWorkItemResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Pick work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/workspace/attach": {
+      "post": {
+        "description": "Attach a workspace path to an agent.",
+        "operationId": "attachWorkspace",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Attach workspace",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/workspace/detach": {
+      "post": {
+        "description": "Detach a workspace binding by workspace id.",
+        "operationId": "detachWorkspace",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetachWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Detach workspace",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/workspace/exit": {
+      "post": {
+        "description": "Return an agent to its default AgentHome workspace.",
+        "operationId": "exitWorkspace",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExitWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Exit workspace",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/runtime/config": {
+      "get": {
+        "description": "Return the daemon effective runtime configuration surface.",
+        "operationId": "runtimeConfig",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeConfigReadResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime config",
+        "tags": [
+          "runtime"
+        ]
+      },
+      "patch": {
+        "description": "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.",
+        "operationId": "runtimeConfigUpdate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeConfigUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeConfigUpdateResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update runtime config",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/credentials": {
+      "get": {
+        "description": "List credential profiles stored in the runtime credential store.",
+        "operationId": "runtimeCredentials",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime credential profiles",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/credentials/{profile}": {
+      "delete": {
+        "description": "Remove a credential profile from the runtime credential store.",
+        "operationId": "deleteRuntimeCredential",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete runtime credential",
+        "tags": [
+          "runtime"
+        ]
+      },
+      "put": {
+        "description": "Set an API key credential profile in the runtime credential store.",
+        "operationId": "setRuntimeCredential",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCredentialRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Set runtime credential",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/performance": {
+      "get": {
+        "description": "Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.",
+        "operationId": "runtimePerformance",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PerformanceDiagnosticsSnapshot"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime performance diagnostics",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/readiness": {
+      "get": {
+        "description": "Return daemon readiness metadata.",
+        "operationId": "runtimeReadiness",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime readiness",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/shutdown": {
+      "post": {
+        "description": "Request graceful runtime shutdown.",
+        "operationId": "runtimeShutdown",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime shutdown",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/status": {
+      "get": {
+        "description": "Return daemon status and runtime activity metadata.",
+        "operationId": "runtimeStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime status",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/enqueue": {
+      "post": {
+        "description": "Enqueue a public channel/webhook message for the default agent.",
+        "operationId": "enqueueDefault",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnqueueRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Enqueue default agent message",
+        "tags": [
+          "ingress"
+        ]
+      }
+    },
+    "/api/events/stream": {
+      "get": {
+        "description": "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor.",
+        "operationId": "eventsStream",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error before stream establishment."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Global event stream",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/handshake": {
+      "get": {
+        "description": "Return auth mode, protocol version, capabilities, and runtime hints.",
+        "operationId": "handshake",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Protocol handshake",
+        "tags": [
+          "discovery"
+        ]
       }
     },
     "/api/jobs": {
@@ -6157,6 +8803,170 @@
         "summary": "Job status",
         "tags": [
           "jobs"
+        ]
+      }
+    },
+    "/api/memory/get": {
+      "post": {
+        "description": "Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.",
+        "operationId": "runtimeMemoryGet",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemoryGetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryGetResult"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Fetch runtime memory source",
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/api/models": {
+      "get": {
+        "description": "Return model catalog entries and runtime availability.",
+        "operationId": "models",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List available models",
+        "tags": [
+          "discovery"
+        ]
+      }
+    },
+    "/api/search": {
+      "post": {
+        "description": "Search the same memory v2 index used by the agent MemorySearch tool.",
+        "operationId": "runtimeSearch",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Search runtime memory",
+        "tags": [
+          "search"
         ]
       }
     },
@@ -6614,2817 +9424,7 @@
         ]
       }
     },
-    "/auth/codex/device/start": {
-      "post": {
-        "description": "Request an OpenAI Codex device code and start a background job that persists the OAuth credential profile after user authorization.",
-        "operationId": "startCodexDeviceLogin",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Start Codex device login",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/briefs": {
-      "get": {
-        "description": "Compatibility alias for the default agent briefs route. Query parameter: limit.",
-        "operationId": "defaultBriefs",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Default agent briefs alias",
-        "tags": [
-          "compat"
-        ],
-        "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
-      }
-    },
-    "/callbacks/enqueue/{callback_token}": {
-      "post": {
-        "description": "Capability-token callback ingress for enqueue delivery. The token is a secret path segment and examples intentionally use a placeholder.",
-        "operationId": "callbackEnqueue",
-        "parameters": [
-          {
-            "description": "Opaque callback capability token. This is a secret and must not be exposed in examples.",
-            "in": "path",
-            "name": "callback_token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallbackBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "CallbackToken": []
-          }
-        ],
-        "summary": "Callback enqueue ingress",
-        "tags": [
-          "callbacks"
-        ]
-      }
-    },
-    "/callbacks/wake/{callback_token}": {
-      "post": {
-        "description": "Capability-token callback ingress for wake delivery. The token is a secret path segment and examples intentionally use a placeholder.",
-        "operationId": "callbackWake",
-        "parameters": [
-          {
-            "description": "Opaque callback capability token. This is a secret and must not be exposed in examples.",
-            "in": "path",
-            "name": "callback_token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallbackBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "CallbackToken": []
-          }
-        ],
-        "summary": "Callback wake ingress",
-        "tags": [
-          "callbacks"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/control": {
-      "post": {
-        "description": "Submit a lifecycle control action.",
-        "operationId": "controlAgent",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ControlRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Control agent lifecycle",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/create": {
-      "post": {
-        "description": "Create a public named agent, optionally from a template.",
-        "operationId": "createAgent",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAgentRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Create named agent",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/current-run/abort": {
-      "post": {
-        "description": "Request abort for the current agent run.",
-        "operationId": "abortCurrentRun",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AbortCurrentRunRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Abort current run",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/debug-prompt": {
-      "post": {
-        "description": "Render a diagnostic prompt preview.",
-        "operationId": "debugPrompt",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DebugPromptRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Debug prompt",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/model": {
-      "post": {
-        "description": "Set an agent model override and optional reasoning effort.",
-        "operationId": "setAgentModel",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetAgentModelRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Set agent model override",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/model/clear": {
-      "post": {
-        "description": "Clear an agent model override.",
-        "operationId": "clearAgentModel",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ClearAgentModelRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Clear agent model override",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/operator-bindings": {
-      "post": {
-        "description": "Create or update a remote operator transport binding.",
-        "operationId": "createOperatorTransportBinding",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OperatorTransportBindingRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Create operator binding",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/operator-ingress": {
-      "post": {
-        "description": "Deliver an authenticated remote operator prompt.",
-        "operationId": "operatorIngress",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OperatorIngressRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Operator ingress",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/prompt": {
-      "post": {
-        "description": "Submit a trusted operator prompt through the control plane.",
-        "operationId": "controlPrompt",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ControlPromptRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Submit operator prompt",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/skills/disable": {
-      "post": {
-        "description": "Disable a skill for an agent.",
-        "operationId": "disableSkill",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DisableSkillRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Disable agent skill",
-        "tags": [
-          "skills"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/skills/enable": {
-      "post": {
-        "description": "Enable a locally known skill for an agent.",
-        "operationId": "enableSkill",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EnableSkillRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Enable agent skill",
-        "tags": [
-          "skills"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/skills/install": {
-      "post": {
-        "description": "Compatibility alias for older agent skill install behavior.",
-        "operationId": "installSkill",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstallSkillRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Install skill compatibility alias",
-        "tags": [
-          "skills"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/skills/uninstall": {
-      "post": {
-        "description": "Compatibility alias for disabling an agent skill.",
-        "operationId": "uninstallSkill",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UninstallSkillRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Uninstall skill compatibility alias",
-        "tags": [
-          "skills"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/tasks": {
-      "post": {
-        "description": "Schedule a command task for an agent.",
-        "operationId": "createCommandTask",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateCommandTaskRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Create command task",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/tasks/{task_id}/input": {
-      "post": {
-        "description": "Deliver text input to a managed task.",
-        "operationId": "taskInput",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Task id.",
-            "in": "path",
-            "name": "task_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TaskInputRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaskInputResult"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Task input",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/tasks/{task_id}/stop": {
-      "post": {
-        "description": "Request cancellation for a managed task.",
-        "operationId": "taskStop",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Task id.",
-            "in": "path",
-            "name": "task_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TaskStopRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaskStopResult"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Task stop",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/timers": {
-      "post": {
-        "description": "Schedule a timer for an agent.",
-        "operationId": "createTimer",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateTimerRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimerRecord"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Create timer",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/timers/{timer_id}/cancel": {
-      "post": {
-        "description": "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.",
-        "operationId": "cancelTimer",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Timer id.",
-            "in": "path",
-            "name": "timer_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CancelTimerRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimerRecord"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Cancel timer",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/wake": {
-      "post": {
-        "description": "Submit a trusted wake hint.",
-        "operationId": "controlWake",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ControlWakeRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Wake agent",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/work-items": {
-      "post": {
-        "description": "Create or enqueue a public work item objective.",
-        "operationId": "createWorkItem",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateWorkItemRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkItemRecord"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Create work item",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/work-items/{work_item_id}": {
-      "patch": {
-        "description": "Mutate work item objective, plan status, todo list, or blocker fields.",
-        "operationId": "updateWorkItem",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Work item id.",
-            "in": "path",
-            "name": "work_item_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateWorkItemRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkItemRecord"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Update work item",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/work-items/{work_item_id}/complete": {
-      "post": {
-        "description": "Mark an open work item completed.",
-        "operationId": "completeWorkItem",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Work item id.",
-            "in": "path",
-            "name": "work_item_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CompleteWorkItemRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkItemRecord"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Complete work item",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/work-items/{work_item_id}/pick": {
-      "post": {
-        "description": "Make an existing open work item the current focus for the agent.",
-        "operationId": "pickWorkItem",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Work item id.",
-            "in": "path",
-            "name": "work_item_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PickWorkItemRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PickWorkItemResponse"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Pick work item",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/workspace/attach": {
-      "post": {
-        "description": "Attach a workspace path to an agent.",
-        "operationId": "attachWorkspace",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AttachWorkspaceRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Attach workspace",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/workspace/detach": {
-      "post": {
-        "description": "Detach a workspace binding by workspace id.",
-        "operationId": "detachWorkspace",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DetachWorkspaceRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Detach workspace",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/agents/{agent_id}/workspace/exit": {
-      "post": {
-        "description": "Return an agent to its default AgentHome workspace.",
-        "operationId": "exitWorkspace",
-        "parameters": [
-          {
-            "description": "Agent id.",
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExitWorkspaceRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Exit workspace",
-        "tags": [
-          "control"
-        ]
-      }
-    },
-    "/control/runtime/config": {
-      "get": {
-        "description": "Return the daemon effective runtime configuration surface.",
-        "operationId": "runtimeConfig",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RuntimeConfigReadResponse"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Runtime config",
-        "tags": [
-          "runtime"
-        ]
-      },
-      "patch": {
-        "description": "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.",
-        "operationId": "runtimeConfigUpdate",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RuntimeConfigUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RuntimeConfigUpdateResponse"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Update runtime config",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/control/runtime/credentials": {
-      "get": {
-        "description": "List credential profiles stored in the runtime credential store.",
-        "operationId": "runtimeCredentials",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Runtime credential profiles",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/control/runtime/credentials/{profile}": {
-      "delete": {
-        "description": "Remove a credential profile from the runtime credential store.",
-        "operationId": "deleteRuntimeCredential",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Delete runtime credential",
-        "tags": [
-          "runtime"
-        ]
-      },
-      "put": {
-        "description": "Set an API key credential profile in the runtime credential store.",
-        "operationId": "setRuntimeCredential",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetCredentialRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Set runtime credential",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/control/runtime/performance": {
-      "get": {
-        "description": "Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.",
-        "operationId": "runtimePerformance",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PerformanceDiagnosticsSnapshot"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Runtime performance diagnostics",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/control/runtime/readiness": {
-      "get": {
-        "description": "Return daemon readiness metadata.",
-        "operationId": "runtimeReadiness",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Runtime readiness",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/control/runtime/shutdown": {
-      "post": {
-        "description": "Request graceful runtime shutdown.",
-        "operationId": "runtimeShutdown",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Runtime shutdown",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/control/runtime/status": {
-      "get": {
-        "description": "Return daemon status and runtime activity metadata.",
-        "operationId": "runtimeStatus",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Runtime status",
-        "tags": [
-          "runtime"
-        ]
-      }
-    },
-    "/enqueue": {
-      "post": {
-        "description": "Enqueue a public channel/webhook message for the default agent.",
-        "operationId": "enqueueDefault",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EnqueueRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Enqueue default agent message",
-        "tags": [
-          "ingress"
-        ]
-      }
-    },
-    "/events/stream": {
-      "get": {
-        "description": "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor.",
-        "operationId": "eventsStream",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error before stream establishment."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Global event stream",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/handshake": {
-      "get": {
-        "description": "Return auth mode, protocol version, capabilities, and runtime hints.",
-        "operationId": "handshake",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Protocol handshake",
-        "tags": [
-          "discovery"
-        ]
-      }
-    },
-    "/memory/get": {
-      "post": {
-        "description": "Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.",
-        "operationId": "runtimeMemoryGet",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MemoryGetRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MemoryGetResult"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Fetch runtime memory source",
-        "tags": [
-          "search"
-        ]
-      }
-    },
-    "/models": {
-      "get": {
-        "description": "Return model catalog entries and runtime availability.",
-        "operationId": "models",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
-                }
-              }
-            },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "List available models",
-        "tags": [
-          "discovery"
-        ]
-      }
-    },
-    "/search": {
-      "post": {
-        "description": "Search the same memory v2 index used by the agent MemorySearch tool.",
-        "operationId": "runtimeSearch",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SearchRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchResponse"
-                }
-              }
-            },
-            "description": "Successful JSON response using a stable DTO schema."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Client error JSON response."
-          },
-          "5XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Server error JSON response."
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "summary": "Search runtime memory",
-        "tags": [
-          "search"
-        ]
-      }
-    },
-    "/state": {
+    "/api/state": {
       "get": {
         "description": "Compatibility alias for the default agent state route.",
         "operationId": "defaultState",
@@ -9472,7 +9472,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/status": {
+    "/api/status": {
       "get": {
         "description": "Compatibility alias for the default agent status route.",
         "operationId": "defaultStatus",
@@ -9520,7 +9520,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/transcript": {
+    "/api/transcript": {
       "get": {
         "description": "Compatibility alias for the default agent transcript route. Query parameter: limit.",
         "operationId": "defaultTranscript",
@@ -9568,7 +9568,7 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
-    "/webhooks/generic/{agent_id}": {
+    "/api/webhooks/generic/{agent_id}": {
       "post": {
         "description": "Convert an arbitrary JSON webhook body into a trusted integration message.",
         "operationId": "genericWebhook",
@@ -9631,7 +9631,7 @@
         ]
       }
     },
-    "/workspaces/{workspace_id}/files": {
+    "/api/workspaces/{workspace_id}/files": {
       "get": {
         "description": "List directory entries at the workspace root. Query parameters: execution_root_id.",
         "operationId": "workspaceFilesRoot",
@@ -9679,7 +9679,7 @@
         ]
       }
     },
-    "/workspaces/{workspace_id}/files/{path}": {
+    "/api/workspaces/{workspace_id}/files/{path}": {
       "get": {
         "description": "List a directory or read a file by path. Supports content negotiation: Accept: application/json returns structured metadata + content, other Accept values return raw body. Query parameters: execution_root_id, download, meta.",
         "operationId": "workspaceFiles",
@@ -9727,7 +9727,7 @@
         ]
       }
     },
-    "/worktree-summary": {
+    "/api/worktree-summary": {
       "get": {
         "description": "Compatibility alias for the default agent worktree summary route.",
         "operationId": "defaultWorktreeSummary",

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -187,7 +187,7 @@ projection facts and current turn facts to choose a `ClosureOutcome`,
 ## User-facing projection (`AgentSummary`)
 
 `AgentSummary` is the stable projection returned by `AgentGet` and
-`GET /agents`. It includes:
+`GET /api/agents`. It includes:
 
 - `identity` — agent identity badge (visibility/ownership/profile)
 - `agent` — core `AgentState` including status, pending count, turn index

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -24,7 +24,7 @@ pub(crate) fn build_callback_url(
         CallbackDeliveryMode::WakeHint => "wake",
     };
     format!(
-        "{}/callbacks/{}/{}",
+        "{}/api/callbacks/{}/{}",
         base_url.trim_end_matches('/'),
         mode,
         token

--- a/src/client.rs
+++ b/src/client.rs
@@ -695,7 +695,7 @@ impl LocalClient {
     }
 
     pub async fn skills_catalog(&self) -> Result<Value> {
-        let path = api_path("/api/skills/catalog");
+        let path = api_path("/skills/catalog");
         let body = self.send(RequestSpec::get(&path), false).await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for GET {}", path))
@@ -703,7 +703,7 @@ impl LocalClient {
 
     pub async fn add_skill(&self, kind: crate::types::SkillInstallKind) -> Result<Value> {
         self.post_control_json(
-            "/api/skills/catalog/add",
+            "/skills/catalog/add",
             &crate::types::AddSkillRequest { kind },
         )
         .await
@@ -711,7 +711,7 @@ impl LocalClient {
 
     pub async fn remove_skill(&self, name: &str) -> Result<Value> {
         self.post_control_json(
-            "/api/skills/catalog/remove",
+            "/skills/catalog/remove",
             &crate::types::RemoveSkillRequest {
                 name: name.to_string(),
             },

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -295,8 +295,8 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/briefs/{brief_id}", get(state::brief))
         .route("/agents/{agent_id}/state", get(state::agent_state))
         .route("/events/stream", get(events::global_events_stream))
-        .route("/api/jobs", post(jobs::create_job))
-        .route("/api/jobs/{job_id}", get(jobs::job_status))
+        .route("/jobs", post(jobs::create_job))
+        .route("/jobs/{job_id}", get(jobs::job_status))
         .route("/agents/{agent_id}/events", get(events::events))
         .route(
             "/agents/{agent_id}/events/stream",
@@ -475,32 +475,23 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/enqueue", post(state::enqueue_default))
         .route("/agents/{agent_id}/skills", get(skills::list_skills))
-        .route("/api/skills/catalog", get(skills::skills_catalog))
-        .route("/api/skills/catalog/{skill_id}", get(skills::skill_detail))
+        .route("/skills/catalog", get(skills::skills_catalog))
+        .route("/skills/catalog/{skill_id}", get(skills::skill_detail))
+        .route("/skills/catalog/add", post(skills::add_skill_to_catalog))
         .route(
-            "/api/skills/catalog/add",
-            post(skills::add_skill_to_catalog),
-        )
-        .route(
-            "/api/skills/catalog/remove",
+            "/skills/catalog/remove",
             post(skills::remove_skill_from_catalog),
         )
         .route(
-            "/api/skills/catalog/reconcile",
+            "/skills/catalog/reconcile",
             post(skills::reconcile_skill_catalog),
         )
         .route(
-            "/api/skills/catalog/refresh",
+            "/skills/catalog/refresh",
             post(skills::refresh_skill_catalog),
         )
-        .route(
-            "/api/skills/catalog/update",
-            post(skills::update_skill_catalog),
-        )
-        .route(
-            "/api/skills/catalog/check",
-            post(skills::check_skill_catalog),
-        )
+        .route("/skills/catalog/update", post(skills::update_skill_catalog))
+        .route("/skills/catalog/check", post(skills::check_skill_catalog))
         .route(
             "/control/agents/{agent_id}/skills/enable",
             post(skills::enable_skill),
@@ -532,16 +523,11 @@ pub fn router(state: AppState) -> Router {
             "/workspaces/{workspace_id}/files/{*path}",
             get(workspace_files::workspace_files),
         );
-    let root_routes = api_routes.clone().route(
-        "/search",
-        get(web::web_or_not_found_handler).post(agents::search),
-    );
     let api_routes = api_routes
         .route("/search", post(agents::search))
         .route("/memory/get", post(agents::memory_get));
 
     Router::new()
-        .merge(root_routes)
         .nest("/api", api_routes)
         .fallback(web::web_or_not_found_handler)
         .layer(api_cors_layer(&config.api_cors))

--- a/src/main.rs
+++ b/src/main.rs
@@ -2812,7 +2812,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
             print_json(&response)
         }
         SkillsCommands::Catalog => {
-            let response: serde_json::Value = get_json(config, "/api/skills/catalog").await?;
+            let response: serde_json::Value = get_json(config, "/skills/catalog").await?;
             print_json(&response)
         }
         SkillsCommands::Add {
@@ -2825,7 +2825,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
             let kind = build_skill_add_kind(&source, builtin, remote, skill, copy)?;
             post_control_json(
                 config,
-                "/api/skills/catalog/add",
+                "/skills/catalog/add",
                 &holon::types::AddSkillRequest { kind },
             )
             .await
@@ -2833,7 +2833,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Remove { name } => {
             post_control_json(
                 config,
-                "/api/skills/catalog/remove",
+                "/skills/catalog/remove",
                 &holon::types::RemoveSkillRequest { name },
             )
             .await
@@ -2841,7 +2841,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Reconcile { name } => {
             post_control_json(
                 config,
-                "/api/skills/catalog/reconcile",
+                "/skills/catalog/reconcile",
                 &holon::types::ReconcileSkillRequest { name },
             )
             .await
@@ -2849,7 +2849,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Refresh => {
             post_control_json(
                 config,
-                "/api/skills/catalog/refresh",
+                "/skills/catalog/refresh",
                 &holon::types::RefreshCatalogRequest {},
             )
             .await
@@ -2857,7 +2857,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Update { name } => {
             post_control_json(
                 config,
-                "/api/skills/catalog/update",
+                "/skills/catalog/update",
                 &holon::types::UpdateSkillRequest { name },
             )
             .await
@@ -2865,7 +2865,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Check { name } => {
             post_control_json(
                 config,
-                "/api/skills/catalog/check",
+                "/skills/catalog/check",
                 &holon::types::CheckSkillRequest { name },
             )
             .await

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -91,18 +91,18 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List agent skills", "Return skills enabled/effective for an agent.", None, AuthKind::RemoteAccess),
-    route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the global user Skill Library catalog. Query parameter: scope.", None, AuthKind::RemoteAccess),
-    route("get", "/api/skills/catalog/{skill_id}", "skillDetail", "skills", "Skill detail", "Return catalog metadata and SKILL.md content for a Global Skill Library skill.", None, AuthKind::RemoteAccess),
+    route("get", "/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the global user Skill Library catalog. Query parameter: scope.", None, AuthKind::RemoteAccess),
+    route("get", "/skills/catalog/{skill_id}", "skillDetail", "skills", "Skill detail", "Return catalog metadata and SKILL.md content for a Global Skill Library skill.", None, AuthKind::RemoteAccess),
     route("get", "/workspaces/{workspace_id}/files", "workspaceFilesRoot", "workspaces", "Browse workspace root", "List directory entries at the workspace root. Query parameters: execution_root_id.", None, AuthKind::RemoteAccess),
     route("get", "/workspaces/{workspace_id}/files/{path}", "workspaceFiles", "workspaces", "Browse workspace files", "List a directory or read a file by path. Supports content negotiation: Accept: application/json returns structured metadata + content, other Accept values return raw body. Query parameters: execution_root_id, download, meta.", None, AuthKind::RemoteAccess),
-    route_with_response("post", "/api/jobs", "createJob", "jobs", "Create job", "Create an asynchronous job. Currently supports kind=skill.install for Global Skill Library installation.", Some("CreateJobRequest"), "JobResponse", AuthKind::Control),
-    route_with_response("get", "/api/jobs/{job_id}", "jobStatus", "jobs", "Job status", "Return a generic asynchronous job snapshot by id.", None, "JobResponse", AuthKind::RemoteAccess),
-    route("post", "/api/skills/catalog/add", "addSkillToCatalog", "skills", "Add skill to library", "Add or import a skill into the local Skill Library.", Some("AddSkillRequest"), AuthKind::Control),
-    route("post", "/api/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
-    route("post", "/api/skills/catalog/reconcile", "reconcileSkillCatalog", "skills", "Reconcile skill library lock", "Reconcile local Skill Library contents with .skill-lock.json, then check consistency. This does not fetch remote updates.", Some("ReconcileSkillRequest"), AuthKind::Control),
-    route("post", "/api/skills/catalog/refresh", "refreshSkillCatalog", "skills", "Refresh runtime catalog", "Refresh runtime Skill Library catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates.", Some("RefreshCatalogRequest"), AuthKind::Control),
-    route("post", "/api/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Fetch supported remote Skill Library entries described by .skill-lock.json and update changed skills. Returns per-skill status.", Some("UpdateSkillRequest"), AuthKind::Control),
-    route("post", "/api/skills/catalog/check", "checkSkillCatalog", "skills", "Check skill library", "Check Skill Library and lock-file consistency.", Some("CheckSkillRequest"), AuthKind::Control),
+    route_with_response("post", "/jobs", "createJob", "jobs", "Create job", "Create an asynchronous job. Currently supports kind=skill.install for Global Skill Library installation.", Some("CreateJobRequest"), "JobResponse", AuthKind::Control),
+    route_with_response("get", "/jobs/{job_id}", "jobStatus", "jobs", "Job status", "Return a generic asynchronous job snapshot by id.", None, "JobResponse", AuthKind::RemoteAccess),
+    route("post", "/skills/catalog/add", "addSkillToCatalog", "skills", "Add skill to library", "Add or import a skill into the local Skill Library.", Some("AddSkillRequest"), AuthKind::Control),
+    route("post", "/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
+    route("post", "/skills/catalog/reconcile", "reconcileSkillCatalog", "skills", "Reconcile skill library lock", "Reconcile local Skill Library contents with .skill-lock.json, then check consistency. This does not fetch remote updates.", Some("ReconcileSkillRequest"), AuthKind::Control),
+    route("post", "/skills/catalog/refresh", "refreshSkillCatalog", "skills", "Refresh runtime catalog", "Refresh runtime Skill Library catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates.", Some("RefreshCatalogRequest"), AuthKind::Control),
+    route("post", "/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Fetch supported remote Skill Library entries described by .skill-lock.json and update changed skills. Returns per-skill status.", Some("UpdateSkillRequest"), AuthKind::Control),
+    route("post", "/skills/catalog/check", "checkSkillCatalog", "skills", "Check skill library", "Check Skill Library and lock-file consistency.", Some("CheckSkillRequest"), AuthKind::Control),
     route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime memory", "Search the same memory v2 index used by the agent MemorySearch tool.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
     route_with_response("post", "/memory/get", "runtimeMemoryGet", "search", "Fetch runtime memory source", "Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.", Some("MemoryGetRequest"), "MemoryGetResult", AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
@@ -263,7 +263,7 @@ fn openapi_value() -> Value {
         .filter(|spec| spec.metadata_source == MetadataSource::Manual)
     {
         let entry = paths
-            .entry(spec.path.to_string())
+            .entry(format!("/api{}", spec.path))
             .or_insert_with(|| json!({}));
         entry[spec.method] = operation(spec);
     }
@@ -336,7 +336,7 @@ fn aide_route_paths() -> serde_json::Map<String, Value> {
         .filter(|spec| spec.metadata_source == MetadataSource::Aide)
     {
         router = router.api_route_docs(
-            spec.path,
+            &format!("/api{}", spec.path),
             ApiMethodDocs::new(spec.method, aide_operation(spec)),
         );
     }
@@ -714,15 +714,16 @@ mod tests {
             .flat_map(|path| path.as_object().into_iter().flat_map(|ops| ops.keys()))
             .count();
         assert!(operation_count >= 40, "expected baseline coverage");
-        assert!(paths["/events/stream"]["get"].is_object());
-        assert!(paths["/agents/{agent_id}/events/stream"]["get"].is_object());
-        assert!(paths["/callbacks/wake/{callback_token}"]["post"].is_object());
+        assert!(paths["/api/events/stream"]["get"].is_object());
+        assert!(paths["/api/agents/{agent_id}/events/stream"]["get"].is_object());
+        assert!(paths["/api/callbacks/wake/{callback_token}"]["post"].is_object());
         assert_eq!(
-            paths["/agents/{agent_id}/status"]["get"]["x-holon-openapi-source"],
+            paths["/api/agents/{agent_id}/status"]["get"]["x-holon-openapi-source"],
             "aide::axum::ApiRouter::api_route_docs"
         );
         assert!(
-            paths["/control/agents/{agent_id}/tasks"]["post"]["x-holon-openapi-source"].is_null()
+            paths["/api/control/agents/{agent_id}/tasks"]["post"]["x-holon-openapi-source"]
+                .is_null()
         );
     }
 

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -78,10 +78,15 @@ fn render_live_inventory() -> String {
         .into_iter()
         .map(|mut route| {
             route.path = route.path.replace("{*", "{").replace(":path}", "}");
+            // All routes are nested under /api in the router, so prepend
+            // the prefix to match OpenAPI paths.
+            if !route.path.starts_with("/api") {
+                route.path = format!("/api{}", route.path);
+            }
             route
         })
         .collect();
-    assert_eq!(routes.len(), 87, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 86, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -353,7 +353,7 @@ fn sanitize_prompt_dump(rendered: &str) -> String {
     for token in rendered.split_inclusive(char::is_whitespace) {
         let token_body = token.trim_end_matches(char::is_whitespace);
         let trailing_whitespace = &token[token_body.len()..];
-        if token_body.contains("/callbacks/") {
+        if token_body.contains("/api/callbacks/") {
             sanitized.push_str("$CALLBACK_URL");
         } else {
             sanitized.push_str(token_body);
@@ -365,7 +365,7 @@ fn sanitize_prompt_dump(rendered: &str) -> String {
 
 #[test]
 fn sanitize_prompt_dump_preserves_formatting_and_redacts_callback_tokens() {
-    let rendered = "## default_external_ingress\n  - url: http://127.0.0.1:7878/callbacks/wake/wake-secret\n\t- enqueue: http://127.0.0.1:7878/callbacks/enqueue/enqueue-secret\n  - keep: http://127.0.0.1:7878/not-secret\n";
+    let rendered = "## default_external_ingress\n  - url: http://127.0.0.1:7878/api/callbacks/wake/wake-secret\n\t- enqueue: http://127.0.0.1:7878/api/callbacks/enqueue/enqueue-secret\n  - keep: http://127.0.0.1:7878/not-secret\n";
 
     let sanitized = sanitize_prompt_dump(rendered);
 

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -1,7 +1,7 @@
 [
   {
     "method": "delete",
-    "path": "/control/runtime/credentials/{profile}",
+    "path": "/api/control/runtime/credentials/{profile}",
     "handler": "delete_credential",
     "operation_id": "deleteRuntimeCredential",
     "tag": "runtime",
@@ -17,7 +17,7 @@
   },
   {
     "method": "get",
-    "path": "/",
+    "path": "/api/",
     "handler": "root",
     "operation_id": "root",
     "tag": "discovery",
@@ -33,7 +33,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/list",
+    "path": "/api/agents/list",
     "handler": "list_agent_entries",
     "operation_id": "listAgents",
     "tag": "agents",
@@ -49,7 +49,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/briefs",
+    "path": "/api/agents/{agent_id}/briefs",
     "handler": "briefs",
     "operation_id": "agentBriefs",
     "tag": "agents",
@@ -71,7 +71,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/briefs/{brief_id}",
+    "path": "/api/agents/{agent_id}/briefs/{brief_id}",
     "handler": "brief",
     "operation_id": "agentBrief",
     "tag": "agents",
@@ -98,7 +98,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/events",
+    "path": "/api/agents/{agent_id}/events",
     "handler": "events",
     "operation_id": "agentEvents",
     "tag": "events",
@@ -120,7 +120,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/events/stream",
+    "path": "/api/agents/{agent_id}/events/stream",
     "handler": "events_stream",
     "operation_id": "agentEventsStream",
     "tag": "events",
@@ -143,7 +143,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/messages/{message_id}",
+    "path": "/api/agents/{agent_id}/messages/{message_id}",
     "handler": "message",
     "operation_id": "agentMessage",
     "tag": "messages",
@@ -170,7 +170,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/skills",
+    "path": "/api/agents/{agent_id}/skills",
     "handler": "list_skills",
     "operation_id": "agentSkills",
     "tag": "skills",
@@ -192,7 +192,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/state",
+    "path": "/api/agents/{agent_id}/state",
     "handler": "agent_state",
     "operation_id": "agentState",
     "tag": "agents",
@@ -214,7 +214,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/status",
+    "path": "/api/agents/{agent_id}/status",
     "handler": "status",
     "operation_id": "agentStatus",
     "tag": "agents",
@@ -236,7 +236,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/tasks",
+    "path": "/api/agents/{agent_id}/tasks",
     "handler": "tasks",
     "operation_id": "agentTasks",
     "tag": "tasks",
@@ -258,7 +258,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/tasks/{task_id}",
+    "path": "/api/agents/{agent_id}/tasks/{task_id}",
     "handler": "task_status",
     "operation_id": "agentTaskStatus",
     "tag": "tasks",
@@ -285,7 +285,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/tasks/{task_id}/output",
+    "path": "/api/agents/{agent_id}/tasks/{task_id}/output",
     "handler": "task_output",
     "operation_id": "agentTaskOutput",
     "tag": "tasks",
@@ -312,7 +312,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/timers",
+    "path": "/api/agents/{agent_id}/timers",
     "handler": "timers",
     "operation_id": "agentTimers",
     "tag": "timers",
@@ -334,7 +334,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/timers/{timer_id}",
+    "path": "/api/agents/{agent_id}/timers/{timer_id}",
     "handler": "timer",
     "operation_id": "agentTimer",
     "tag": "timers",
@@ -361,7 +361,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/tool-executions/{tool_execution_id}",
+    "path": "/api/agents/{agent_id}/tool-executions/{tool_execution_id}",
     "handler": "tool_execution",
     "operation_id": "agentToolExecution",
     "tag": "tools",
@@ -388,7 +388,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/transcript",
+    "path": "/api/agents/{agent_id}/transcript",
     "handler": "transcript",
     "operation_id": "agentTranscript",
     "tag": "agents",
@@ -410,7 +410,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/transcript/{entry_id}",
+    "path": "/api/agents/{agent_id}/transcript/{entry_id}",
     "handler": "transcript_entry",
     "operation_id": "agentTranscriptEntry",
     "tag": "agents",
@@ -432,7 +432,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/work-items",
+    "path": "/api/agents/{agent_id}/work-items",
     "handler": "work_items",
     "operation_id": "agentWorkItems",
     "tag": "work-items",
@@ -454,7 +454,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/work-items/{work_item_id}",
+    "path": "/api/agents/{agent_id}/work-items/{work_item_id}",
     "handler": "work_item",
     "operation_id": "agentWorkItem",
     "tag": "work-items",
@@ -481,7 +481,7 @@
   },
   {
     "method": "get",
-    "path": "/agents/{agent_id}/worktree-summary",
+    "path": "/api/agents/{agent_id}/worktree-summary",
     "handler": "worktree_summary",
     "operation_id": "agentWorktreeSummary",
     "tag": "agents",
@@ -503,10 +503,155 @@
   },
   {
     "method": "get",
+    "path": "/api/briefs",
+    "handler": "briefs_default",
+    "operation_id": "defaultBriefs",
+    "tag": "compat",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/config",
+    "handler": "runtime_config",
+    "operation_id": "runtimeConfig",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/credentials",
+    "handler": "list_credentials",
+    "operation_id": "runtimeCredentials",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/performance",
+    "handler": "runtime_performance",
+    "operation_id": "runtimePerformance",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/readiness",
+    "handler": "runtime_readiness",
+    "operation_id": "runtimeReadiness",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/status",
+    "handler": "runtime_status",
+    "operation_id": "runtimeStatus",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/events/stream",
+    "handler": "global_events_stream",
+    "operation_id": "eventsStream",
+    "tag": "events",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json",
+      "text/event-stream"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/handshake",
+    "handler": "handshake",
+    "operation_id": "handshake",
+    "tag": "discovery",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/jobs/{job_id}",
     "handler": "job_status",
     "operation_id": "jobStatus",
     "tag": "jobs",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/models",
+    "handler": "models_handler",
+    "operation_id": "models",
+    "tag": "discovery",
     "parameters": [],
     "request_schema": null,
     "request_strict": null,
@@ -557,152 +702,7 @@
   },
   {
     "method": "get",
-    "path": "/briefs",
-    "handler": "briefs_default",
-    "operation_id": "defaultBriefs",
-    "tag": "compat",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/control/runtime/config",
-    "handler": "runtime_config",
-    "operation_id": "runtimeConfig",
-    "tag": "runtime",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/control/runtime/credentials",
-    "handler": "list_credentials",
-    "operation_id": "runtimeCredentials",
-    "tag": "runtime",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/control/runtime/performance",
-    "handler": "runtime_performance",
-    "operation_id": "runtimePerformance",
-    "tag": "runtime",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/control/runtime/readiness",
-    "handler": "runtime_readiness",
-    "operation_id": "runtimeReadiness",
-    "tag": "runtime",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/control/runtime/status",
-    "handler": "runtime_status",
-    "operation_id": "runtimeStatus",
-    "tag": "runtime",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/events/stream",
-    "handler": "global_events_stream",
-    "operation_id": "eventsStream",
-    "tag": "events",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json",
-      "text/event-stream"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/handshake",
-    "handler": "handshake",
-    "operation_id": "handshake",
-    "tag": "discovery",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/models",
-    "handler": "models_handler",
-    "operation_id": "models",
-    "tag": "discovery",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/state",
+    "path": "/api/state",
     "handler": "state_default",
     "operation_id": "defaultState",
     "tag": "compat",
@@ -718,7 +718,7 @@
   },
   {
     "method": "get",
-    "path": "/status",
+    "path": "/api/status",
     "handler": "status_default",
     "operation_id": "defaultStatus",
     "tag": "compat",
@@ -734,7 +734,7 @@
   },
   {
     "method": "get",
-    "path": "/transcript",
+    "path": "/api/transcript",
     "handler": "transcript_default",
     "operation_id": "defaultTranscript",
     "tag": "compat",
@@ -750,7 +750,7 @@
   },
   {
     "method": "get",
-    "path": "/workspaces/{workspace_id}/files",
+    "path": "/api/workspaces/{workspace_id}/files",
     "handler": "workspace_files_root",
     "operation_id": "workspaceFilesRoot",
     "tag": "workspaces",
@@ -766,7 +766,7 @@
   },
   {
     "method": "get",
-    "path": "/workspaces/{workspace_id}/files/{path}",
+    "path": "/api/workspaces/{workspace_id}/files/{path}",
     "handler": "workspace_files",
     "operation_id": "workspaceFiles",
     "tag": "workspaces",
@@ -782,7 +782,7 @@
   },
   {
     "method": "get",
-    "path": "/worktree-summary",
+    "path": "/api/worktree-summary",
     "handler": "worktree_summary_default",
     "operation_id": "defaultWorktreeSummary",
     "tag": "compat",
@@ -798,7 +798,7 @@
   },
   {
     "method": "patch",
-    "path": "/control/agents/{agent_id}/work-items/{work_item_id}",
+    "path": "/api/control/agents/{agent_id}/work-items/{work_item_id}",
     "handler": "update_work_item",
     "operation_id": "updateWorkItem",
     "tag": "control",
@@ -825,7 +825,7 @@
   },
   {
     "method": "patch",
-    "path": "/control/runtime/config",
+    "path": "/api/control/runtime/config",
     "handler": "runtime_config_update",
     "operation_id": "runtimeConfigUpdate",
     "tag": "runtime",
@@ -841,7 +841,7 @@
   },
   {
     "method": "post",
-    "path": "/agents/{agent_id}/enqueue",
+    "path": "/api/agents/{agent_id}/enqueue",
     "handler": "enqueue",
     "operation_id": "enqueueAgent",
     "tag": "ingress",
@@ -863,7 +863,7 @@
   },
   {
     "method": "post",
-    "path": "/agents/{agent_id}/messages:batchGet",
+    "path": "/api/agents/{agent_id}/messages:batchGet",
     "handler": "messages_batch_get",
     "operation_id": "agentMessagesBatchGet",
     "tag": "messages",
@@ -885,7 +885,7 @@
   },
   {
     "method": "post",
-    "path": "/agents/{agent_id}/transcript:batchGet",
+    "path": "/api/agents/{agent_id}/transcript:batchGet",
     "handler": "transcript_batch_get",
     "operation_id": "agentTranscriptBatchGet",
     "tag": "agents",
@@ -907,6 +907,673 @@
   },
   {
     "method": "post",
+    "path": "/api/auth/codex/device/start",
+    "handler": "start_codex_device_login",
+    "operation_id": "startCodexDeviceLogin",
+    "tag": "auth",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/callbacks/enqueue/{callback_token}",
+    "handler": "callback_ingress_enqueue",
+    "operation_id": "callbackEnqueue",
+    "tag": "callbacks",
+    "parameters": [
+      {
+        "name": "callback_token",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CallbackBody",
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "CallbackToken"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/callbacks/wake/{callback_token}",
+    "handler": "callback_ingress_wake",
+    "operation_id": "callbackWake",
+    "tag": "callbacks",
+    "parameters": [
+      {
+        "name": "callback_token",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CallbackBody",
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "CallbackToken"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/control",
+    "handler": "control",
+    "operation_id": "controlAgent",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "ControlRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/create",
+    "handler": "create_agent",
+    "operation_id": "createAgent",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CreateAgentRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/current-run/abort",
+    "handler": "abort_current_run",
+    "operation_id": "abortCurrentRun",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "AbortCurrentRunRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/debug-prompt",
+    "handler": "control_debug_prompt",
+    "operation_id": "debugPrompt",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "DebugPromptRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/model",
+    "handler": "set_agent_model",
+    "operation_id": "setAgentModel",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "SetAgentModelRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/model/clear",
+    "handler": "clear_agent_model",
+    "operation_id": "clearAgentModel",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "ClearAgentModelRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/operator-bindings",
+    "handler": "create_operator_transport_binding",
+    "operation_id": "createOperatorTransportBinding",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "OperatorTransportBindingRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/operator-ingress",
+    "handler": "operator_ingress",
+    "operation_id": "operatorIngress",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "OperatorIngressRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/prompt",
+    "handler": "control_prompt",
+    "operation_id": "controlPrompt",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "ControlPromptRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/skills/disable",
+    "handler": "disable_skill",
+    "operation_id": "disableSkill",
+    "tag": "skills",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "DisableSkillRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/skills/enable",
+    "handler": "enable_skill",
+    "operation_id": "enableSkill",
+    "tag": "skills",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "EnableSkillRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/skills/install",
+    "handler": "install_skill",
+    "operation_id": "installSkill",
+    "tag": "skills",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "InstallSkillRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/skills/uninstall",
+    "handler": "uninstall_skill",
+    "operation_id": "uninstallSkill",
+    "tag": "skills",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "UninstallSkillRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/tasks",
+    "handler": "create_command_task",
+    "operation_id": "createCommandTask",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CreateCommandTaskRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/tasks/{task_id}/input",
+    "handler": "task_input",
+    "operation_id": "taskInput",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "task_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "TaskInputRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/tasks/{task_id}/stop",
+    "handler": "task_stop",
+    "operation_id": "taskStop",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "task_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "TaskStopRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/timers",
+    "handler": "create_timer",
+    "operation_id": "createTimer",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CreateTimerRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/timers/{timer_id}/cancel",
+    "handler": "cancel_timer",
+    "operation_id": "cancelTimer",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "timer_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CancelTimerRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/wake",
+    "handler": "control_wake",
+    "operation_id": "controlWake",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "ControlWakeRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/work-items",
+    "handler": "create_work_item",
+    "operation_id": "createWorkItem",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CreateWorkItemRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/work-items/{work_item_id}/complete",
+    "handler": "complete_work_item",
+    "operation_id": "completeWorkItem",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "work_item_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CompleteWorkItemRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/work-items/{work_item_id}/pick",
+    "handler": "pick_work_item",
+    "operation_id": "pickWorkItem",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "work_item_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "PickWorkItemRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/workspace/attach",
+    "handler": "attach_workspace",
+    "operation_id": "attachWorkspace",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "AttachWorkspaceRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/workspace/detach",
+    "handler": "detach_workspace",
+    "operation_id": "detachWorkspace",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "DetachWorkspaceRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/agents/{agent_id}/workspace/exit",
+    "handler": "exit_workspace",
+    "operation_id": "exitWorkspace",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "ExitWorkspaceRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/runtime/shutdown",
+    "handler": "runtime_shutdown",
+    "operation_id": "runtimeShutdown",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/enqueue",
+    "handler": "enqueue_default",
+    "operation_id": "enqueueDefault",
+    "tag": "ingress",
+    "parameters": [],
+    "request_schema": "EnqueueRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/api/jobs",
     "handler": "create_job",
     "operation_id": "createJob",
@@ -914,6 +1581,38 @@
     "parameters": [],
     "request_schema": "CreateJobRequest",
     "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/memory/get",
+    "handler": "memory_get",
+    "operation_id": "runtimeMemoryGet",
+    "tag": "search",
+    "parameters": [],
+    "request_schema": "MemoryGetRequest",
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/search",
+    "handler": "search",
+    "operation_id": "runtimeSearch",
+    "tag": "search",
+    "parameters": [],
+    "request_schema": "SearchRequest",
+    "request_strict": null,
     "response_content_types": [
       "application/json"
     ],
@@ -1019,706 +1718,7 @@
   },
   {
     "method": "post",
-    "path": "/auth/codex/device/start",
-    "handler": "start_codex_device_login",
-    "operation_id": "startCodexDeviceLogin",
-    "tag": "auth",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/callbacks/enqueue/{callback_token}",
-    "handler": "callback_ingress_enqueue",
-    "operation_id": "callbackEnqueue",
-    "tag": "callbacks",
-    "parameters": [
-      {
-        "name": "callback_token",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CallbackBody",
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "CallbackToken"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/callbacks/wake/{callback_token}",
-    "handler": "callback_ingress_wake",
-    "operation_id": "callbackWake",
-    "tag": "callbacks",
-    "parameters": [
-      {
-        "name": "callback_token",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CallbackBody",
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "CallbackToken"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/control",
-    "handler": "control",
-    "operation_id": "controlAgent",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "ControlRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/create",
-    "handler": "create_agent",
-    "operation_id": "createAgent",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CreateAgentRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/current-run/abort",
-    "handler": "abort_current_run",
-    "operation_id": "abortCurrentRun",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "AbortCurrentRunRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/debug-prompt",
-    "handler": "control_debug_prompt",
-    "operation_id": "debugPrompt",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "DebugPromptRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/model",
-    "handler": "set_agent_model",
-    "operation_id": "setAgentModel",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "SetAgentModelRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/model/clear",
-    "handler": "clear_agent_model",
-    "operation_id": "clearAgentModel",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "ClearAgentModelRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/operator-bindings",
-    "handler": "create_operator_transport_binding",
-    "operation_id": "createOperatorTransportBinding",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "OperatorTransportBindingRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/operator-ingress",
-    "handler": "operator_ingress",
-    "operation_id": "operatorIngress",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "OperatorIngressRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/prompt",
-    "handler": "control_prompt",
-    "operation_id": "controlPrompt",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "ControlPromptRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/skills/disable",
-    "handler": "disable_skill",
-    "operation_id": "disableSkill",
-    "tag": "skills",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "DisableSkillRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/skills/enable",
-    "handler": "enable_skill",
-    "operation_id": "enableSkill",
-    "tag": "skills",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "EnableSkillRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/skills/install",
-    "handler": "install_skill",
-    "operation_id": "installSkill",
-    "tag": "skills",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "InstallSkillRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/skills/uninstall",
-    "handler": "uninstall_skill",
-    "operation_id": "uninstallSkill",
-    "tag": "skills",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "UninstallSkillRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/tasks",
-    "handler": "create_command_task",
-    "operation_id": "createCommandTask",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CreateCommandTaskRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/tasks/{task_id}/input",
-    "handler": "task_input",
-    "operation_id": "taskInput",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      },
-      {
-        "name": "task_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "TaskInputRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/tasks/{task_id}/stop",
-    "handler": "task_stop",
-    "operation_id": "taskStop",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      },
-      {
-        "name": "task_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "TaskStopRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/timers",
-    "handler": "create_timer",
-    "operation_id": "createTimer",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CreateTimerRequest",
-    "request_strict": true,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/timers/{timer_id}/cancel",
-    "handler": "cancel_timer",
-    "operation_id": "cancelTimer",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      },
-      {
-        "name": "timer_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CancelTimerRequest",
-    "request_strict": true,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/wake",
-    "handler": "control_wake",
-    "operation_id": "controlWake",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "ControlWakeRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/work-items",
-    "handler": "create_work_item",
-    "operation_id": "createWorkItem",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CreateWorkItemRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/work-items/{work_item_id}/complete",
-    "handler": "complete_work_item",
-    "operation_id": "completeWorkItem",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      },
-      {
-        "name": "work_item_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "CompleteWorkItemRequest",
-    "request_strict": true,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/work-items/{work_item_id}/pick",
-    "handler": "pick_work_item",
-    "operation_id": "pickWorkItem",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      },
-      {
-        "name": "work_item_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "PickWorkItemRequest",
-    "request_strict": true,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/workspace/attach",
-    "handler": "attach_workspace",
-    "operation_id": "attachWorkspace",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "AttachWorkspaceRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/workspace/detach",
-    "handler": "detach_workspace",
-    "operation_id": "detachWorkspace",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "DetachWorkspaceRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/agents/{agent_id}/workspace/exit",
-    "handler": "exit_workspace",
-    "operation_id": "exitWorkspace",
-    "tag": "control",
-    "parameters": [
-      {
-        "name": "agent_id",
-        "location": "path",
-        "required": true
-      }
-    ],
-    "request_schema": "ExitWorkspaceRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/control/runtime/shutdown",
-    "handler": "runtime_shutdown",
-    "operation_id": "runtimeShutdown",
-    "tag": "runtime",
-    "parameters": [],
-    "request_schema": null,
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/enqueue",
-    "handler": "enqueue_default",
-    "operation_id": "enqueueDefault",
-    "tag": "ingress",
-    "parameters": [],
-    "request_schema": "EnqueueRequest",
-    "request_strict": false,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/memory/get",
-    "handler": "memory_get",
-    "operation_id": "runtimeMemoryGet",
-    "tag": "search",
-    "parameters": [],
-    "request_schema": "MemoryGetRequest",
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/search",
-    "handler": "search",
-    "operation_id": "runtimeSearch",
-    "tag": "search",
-    "parameters": [],
-    "request_schema": "SearchRequest",
-    "request_strict": null,
-    "response_content_types": [
-      "application/json"
-    ],
-    "security": [
-      "BearerAuth"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/webhooks/generic/{agent_id}",
+    "path": "/api/webhooks/generic/{agent_id}",
     "handler": "generic_webhook",
     "operation_id": "genericWebhook",
     "tag": "ingress",
@@ -1738,7 +1738,7 @@
   },
   {
     "method": "put",
-    "path": "/control/runtime/credentials/{profile}",
+    "path": "/api/control/runtime/credentials/{profile}",
     "handler": "set_credential",
     "operation_id": "setRuntimeCredential",
     "tag": "runtime",

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -280,7 +280,7 @@ pub async fn unknown_callback_token_is_rejected() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/callbacks/enqueue/not-a-real-token"))
+        .post(format!("{base}/api/callbacks/enqueue/not-a-real-token"))
         .json(&serde_json::json!({ "hello": "world" }))
         .send()
         .await?;
@@ -307,7 +307,7 @@ pub async fn callback_mode_mismatch_is_rejected() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/callbacks/enqueue/{token}"))
+        .post(format!("{base}/api/callbacks/enqueue/{token}"))
         .json(&serde_json::json!({ "status": "checks_passed" }))
         .send()
         .await?;

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -92,12 +92,17 @@ pub async fn http_success_response_shapes_follow_route_class_policy() -> Result<
     let runtime = host.default_runtime().await?;
     let client = reqwest::Client::new();
 
-    let root: serde_json::Value = client.get(format!("{base}/")).send().await?.json().await?;
+    let root: serde_json::Value = client
+        .get(format!("{base}/api"))
+        .send()
+        .await?
+        .json()
+        .await?;
     assert_eq!(root["ok"], true, "discovery root should use ok envelope");
     assert_eq!(root["default_agent"], "default");
 
     let models: serde_json::Value = client
-        .get(format!("{base}/models"))
+        .get(format!("{base}/api/models"))
         .send()
         .await?
         .json()
@@ -109,7 +114,7 @@ pub async fn http_success_response_shapes_follow_route_class_policy() -> Result<
     assert!(models["available_models"].is_array());
 
     let agents: serde_json::Value = client
-        .get(format!("{base}/agents/list"))
+        .get(format!("{base}/api/agents/list"))
         .send()
         .await?
         .json()
@@ -120,7 +125,7 @@ pub async fn http_success_response_shapes_follow_route_class_policy() -> Result<
     );
 
     let prompt: serde_json::Value = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "success shape policy" }))
         .send()
         .await?
@@ -161,7 +166,7 @@ pub async fn http_success_response_shapes_follow_route_class_policy() -> Result<
     assert_eq!(callback["delivery_mode"], "wake_hint");
 
     let stream_response = client
-        .get(format!("{base}/agents/default/events/stream"))
+        .get(format!("{base}/api/agents/default/events/stream"))
         .header(reqwest::header::ACCEPT, "text/event-stream")
         .send()
         .await?;
@@ -204,7 +209,7 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
 
     let client = reqwest::Client::new();
     let payload: serde_json::Value = client
-        .get(format!("{base}/agents/list"))
+        .get(format!("{base}/api/agents/list"))
         .send()
         .await?
         .json()
@@ -246,7 +251,7 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
         );
     }
 
-    let removed_agents = client.get(format!("{base}/agents")).send().await?;
+    let removed_agents = client.get(format!("{base}/api/agents")).send().await?;
     assert_eq!(
         removed_agents.status(),
         reqwest::StatusCode::NOT_FOUND,
@@ -254,7 +259,7 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
     );
 
     let models_payload: serde_json::Value = client
-        .get(format!("{base}/models"))
+        .get(format!("{base}/api/models"))
         .send()
         .await?
         .json()
@@ -287,7 +292,7 @@ pub async fn json_responses_support_gzip_without_compressing_sse() -> Result<()>
     let client = reqwest::Client::builder().no_gzip().build()?;
 
     let response = client
-        .get(format!("{base}/agents/list"))
+        .get(format!("{base}/api/agents/list"))
         .header(reqwest::header::ACCEPT_ENCODING, "gzip")
         .send()
         .await?;
@@ -306,7 +311,7 @@ pub async fn json_responses_support_gzip_without_compressing_sse() -> Result<()>
     assert!(payload.as_array().is_some());
 
     let stream_response = client
-        .get(format!("{base}/agents/default/events/stream"))
+        .get(format!("{base}/api/agents/default/events/stream"))
         .header(reqwest::header::ACCEPT, "text/event-stream")
         .header(reqwest::header::ACCEPT_ENCODING, "gzip")
         .send()
@@ -364,7 +369,7 @@ pub async fn agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue(
     config.workspace_dir = tempdir()?.keep();
     let (_host, base, server) = spawn_server_with_config(config.clone()).await?;
     let response = reqwest::Client::new()
-        .get(format!("{base}/agents/list"))
+        .get(format!("{base}/api/agents/list"))
         .send()
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::OK);
@@ -435,7 +440,7 @@ pub async fn local_client_over_http_can_read_agent_state_snapshot() -> Result<()
         .any(|event| event.event_type == "operator_notification_requested"));
 
     let raw_state: serde_json::Value = reqwest::Client::new()
-        .get(format!("{base}/agents/default/state"))
+        .get(format!("{base}/api/agents/default/state"))
         .send()
         .await?
         .json()

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -43,7 +43,7 @@ pub async fn control_prompt_is_open_on_loopback_auto() -> Result<()> {
     let (_host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
     let response = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
@@ -59,7 +59,7 @@ pub async fn control_prompt_is_open_over_unix_socket_auto() -> Result<()> {
     let response = unix_request(
         &socket_path,
         "POST",
-        "/control/agents/default/prompt",
+        "/api/control/agents/default/prompt",
         &[("content-type", "application/json")],
         Some(br#"{ "text": "hello" }"#),
     )
@@ -75,14 +75,14 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "snapshot bootstrap" }))
         .send()
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
     let state_payload: serde_json::Value = client
-        .get(format!("{base}/agents/default/state"))
+        .get(format!("{base}/api/agents/default/state"))
         .send()
         .await?
         .json()
@@ -131,7 +131,7 @@ pub async fn runtime_search_route_returns_memory_search_results() -> Result<()> 
     runtime.storage().append_message(&message)?;
 
     let response = client
-        .post(format!("{base}/search"))
+        .post(format!("{base}/api/search"))
         .json(&serde_json::json!({
             "query": "issue1879",
             "limit": 5
@@ -218,7 +218,7 @@ pub async fn runtime_search_route_filters_memory_results_by_agent_ids() -> Resul
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/search"))
+        .post(format!("{base}/api/search"))
         .json(&serde_json::json!({
             "query": "agentfilter1879",
             "limit": 10,
@@ -235,7 +235,7 @@ pub async fn runtime_search_route_filters_memory_results_by_agent_ids() -> Resul
     assert!(results.iter().all(|result| result["agent_id"] == "alpha"));
 
     let response = client
-        .post(format!("{base}/search"))
+        .post(format!("{base}/api/search"))
         .json(&serde_json::json!({
             "query": "agentfilter1879",
             "limit": 10,
@@ -255,7 +255,7 @@ pub async fn runtime_search_route_filters_memory_results_by_agent_ids() -> Resul
     assert!(refs.contains(&"message:msg-http-search-beta"));
 
     let response = client
-        .post(format!("{base}/search"))
+        .post(format!("{base}/api/search"))
         .json(&serde_json::json!({
             "query": "agentfilter1879",
             "limit": 10
@@ -278,7 +278,7 @@ pub async fn agent_brief_route_returns_full_brief_by_id() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "brief detail route" }))
         .send()
         .await?;
@@ -300,7 +300,7 @@ pub async fn agent_brief_route_returns_full_brief_by_id() -> Result<()> {
         .expect("brief should be persisted");
 
     let detail = client
-        .get(format!("{base}/agents/default/briefs/{}", brief.id))
+        .get(format!("{base}/api/agents/default/briefs/{}", brief.id))
         .send()
         .await?;
     assert_eq!(detail.status(), reqwest::StatusCode::OK);
@@ -331,13 +331,13 @@ pub async fn agent_state_route_scopes_work_items_to_requested_agent() -> Result<
     let client = reqwest::Client::new();
 
     let alpha_state: serde_json::Value = client
-        .get(format!("{base}/agents/alpha/state"))
+        .get(format!("{base}/api/agents/alpha/state"))
         .send()
         .await?
         .json()
         .await?;
     let beta_state: serde_json::Value = client
-        .get(format!("{base}/agents/beta/state"))
+        .get(format!("{base}/api/agents/beta/state"))
         .send()
         .await?
         .json()
@@ -386,7 +386,7 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "bootstrap contract prompt" }))
         .send()
         .await?;
@@ -443,7 +443,7 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     );
 
     let raw_snapshot: serde_json::Value = client
-        .get(format!("{base}/agents/default/state"))
+        .get(format!("{base}/api/agents/default/state"))
         .send()
         .await?
         .json()
@@ -535,7 +535,7 @@ pub async fn list_skills_includes_all_agent_skill_roots() -> Result<()> {
     }
 
     let payload: serde_json::Value = Client::new()
-        .get(format!("{base}/agents/default/skills"))
+        .get(format!("{base}/api/agents/default/skills"))
         .send()
         .await?
         .json()
@@ -576,7 +576,7 @@ pub async fn agent_skills_endpoint_uses_effective_registry_snapshot() -> Result<
 
     let client = Client::new();
     let list_payload: serde_json::Value = client
-        .get(format!("{base}/agents/default/skills"))
+        .get(format!("{base}/api/agents/default/skills"))
         .send()
         .await?
         .json()
@@ -592,7 +592,7 @@ pub async fn agent_skills_endpoint_uses_effective_registry_snapshot() -> Result<
 
     std::fs::remove_dir_all(&agent_skill_dir)?;
     let list_payload: serde_json::Value = client
-        .get(format!("{base}/agents/default/skills"))
+        .get(format!("{base}/api/agents/default/skills"))
         .send()
         .await?
         .json()
@@ -632,7 +632,7 @@ pub async fn agent_skills_endpoint_does_not_leak_stale_roots_between_agents() ->
     let client = Client::new();
 
     let default_payload: serde_json::Value = client
-        .get(format!("{base}/agents/default/skills"))
+        .get(format!("{base}/api/agents/default/skills"))
         .send()
         .await?
         .json()
@@ -644,7 +644,7 @@ pub async fn agent_skills_endpoint_does_not_leak_stale_roots_between_agents() ->
         .any(|skill| skill["name"] == "default-only"));
 
     let alpha_payload: serde_json::Value = client
-        .get(format!("{base}/agents/alpha/skills"))
+        .get(format!("{base}/api/agents/alpha/skills"))
         .send()
         .await?
         .json()
@@ -812,14 +812,14 @@ pub async fn install_skill_existing_destination_returns_conflict() -> Result<()>
     });
 
     let first = client
-        .post(format!("{base}/control/agents/default/skills/install"))
+        .post(format!("{base}/api/control/agents/default/skills/install"))
         .json(&payload)
         .send()
         .await?;
     assert!(first.status().is_success());
 
     let second = client
-        .post(format!("{base}/control/agents/default/skills/install"))
+        .post(format!("{base}/api/control/agents/default/skills/install"))
         .json(&payload)
         .send()
         .await?;
@@ -1026,7 +1026,7 @@ pub async fn skill_library_add_remove_and_agent_enable_disable_are_separate() ->
     assert!(!agent_skill_path.exists());
 
     let enable = client
-        .post(format!("{base}/control/agents/default/skills/enable"))
+        .post(format!("{base}/api/control/agents/default/skills/enable"))
         .json(&serde_json::json!({
             "name": skill_name
         }))
@@ -1036,7 +1036,7 @@ pub async fn skill_library_add_remove_and_agent_enable_disable_are_separate() ->
     assert!(agent_skill_path.exists());
 
     let disable = client
-        .post(format!("{base}/control/agents/default/skills/disable"))
+        .post(format!("{base}/api/control/agents/default/skills/disable"))
         .json(&serde_json::json!({
             "name": skill_name
         }))
@@ -1140,7 +1140,7 @@ pub async fn control_agent_model_override_set_and_clear_updates_status() -> Resu
     let client = reqwest::Client::new();
 
     let set_response = client
-        .post(format!("{base}/control/agents/default/model"))
+        .post(format!("{base}/api/control/agents/default/model"))
         .json(&serde_json::json!({ "model": "anthropic/claude-haiku-4-5" }))
         .send()
         .await?;
@@ -1153,7 +1153,7 @@ pub async fn control_agent_model_override_set_and_clear_updates_status() -> Resu
     );
 
     let status_payload: serde_json::Value = client
-        .get(format!("{base}/agents/default/status"))
+        .get(format!("{base}/api/agents/default/status"))
         .send()
         .await?
         .json()
@@ -1165,7 +1165,7 @@ pub async fn control_agent_model_override_set_and_clear_updates_status() -> Resu
     );
 
     let clear_response = client
-        .post(format!("{base}/control/agents/default/model/clear"))
+        .post(format!("{base}/api/control/agents/default/model/clear"))
         .json(&serde_json::json!({}))
         .send()
         .await?;
@@ -1188,13 +1188,13 @@ pub async fn control_prompt_requires_bearer_token_when_required() -> Result<()> 
     let (_host, base, server) = spawn_server_with_config(config).await?;
     let client = reqwest::Client::new();
     let denied = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
     assert_eq!(denied.status(), reqwest::StatusCode::FORBIDDEN);
     let allowed = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .bearer_auth("secret")
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
@@ -1232,7 +1232,14 @@ pub async fn control_runtime_status_is_open_over_unix_socket_when_auth_required(
         Ok::<_, anyhow::Error>(())
     });
 
-    let response = unix_request(&socket_path, "GET", "/control/runtime/status", &[], None).await?;
+    let response = unix_request(
+        &socket_path,
+        "GET",
+        "/api/control/runtime/status",
+        &[],
+        None,
+    )
+    .await?;
     assert_eq!(response.status, 200);
 
     server.abort();
@@ -1267,8 +1274,14 @@ pub async fn control_runtime_readiness_is_open_over_unix_socket_when_auth_requir
         Ok::<_, anyhow::Error>(())
     });
 
-    let response =
-        unix_request(&socket_path, "GET", "/control/runtime/readiness", &[], None).await?;
+    let response = unix_request(
+        &socket_path,
+        "GET",
+        "/api/control/runtime/readiness",
+        &[],
+        None,
+    )
+    .await?;
     assert_eq!(response.status, 200);
 
     server.abort();
@@ -1301,22 +1314,22 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
     let client = reqwest::Client::new();
 
     for path in [
-        "/handshake",
-        "/",
-        "/control/runtime/status",
-        "/control/runtime/config",
-        "/agents/list",
-        "/agents/default/status",
-        "/agents/default/state",
-        "/agents/default/briefs",
-        "/agents/default/briefs/brief-test",
-        "/agents/default/transcript",
-        "/agents/default/tasks",
-        "/agents/default/timers",
-        "/agents/default/worktree-summary",
-        "/agents/default/skills",
-        "/agents/default/events",
-        "/agents/default/events/stream",
+        "/api/handshake",
+        "/api",
+        "/api/control/runtime/status",
+        "/api/control/runtime/config",
+        "/api/agents/list",
+        "/api/agents/default/status",
+        "/api/agents/default/state",
+        "/api/agents/default/briefs",
+        "/api/agents/default/briefs/brief-test",
+        "/api/agents/default/transcript",
+        "/api/agents/default/tasks",
+        "/api/agents/default/timers",
+        "/api/agents/default/worktree-summary",
+        "/api/agents/default/skills",
+        "/api/agents/default/events",
+        "/api/agents/default/events/stream",
     ] {
         let denied = client.get(format!("{base}{path}")).send().await?;
         assert_eq!(
@@ -1333,7 +1346,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
     }
 
     let handshake: serde_json::Value = client
-        .get(format!("{base}/handshake"))
+        .get(format!("{base}/api/handshake"))
         .bearer_auth("secret")
         .send()
         .await?
@@ -1344,14 +1357,14 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
     assert_eq!(handshake["runtime"]["default_agent"], "default");
 
     let agents = client
-        .get(format!("{base}/agents/list"))
+        .get(format!("{base}/api/agents/list"))
         .bearer_auth("secret")
         .send()
         .await?;
     assert!(agents.status().is_success());
 
     let removed_agents = client
-        .get(format!("{base}/agents"))
+        .get(format!("{base}/api/agents"))
         .bearer_auth("secret")
         .send()
         .await?;
@@ -1361,7 +1374,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
     assert_eq!(removed_body["error"], "Not Found");
 
     let invalid_runtime_status = client
-        .get(format!("{base}/control/runtime/status"))
+        .get(format!("{base}/api/control/runtime/status"))
         .bearer_auth("wrong")
         .send()
         .await?;
@@ -1377,14 +1390,14 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         .contains("invalid control token"));
 
     let runtime_status = client
-        .get(format!("{base}/control/runtime/status"))
+        .get(format!("{base}/api/control/runtime/status"))
         .bearer_auth("secret")
         .send()
         .await?;
     assert!(runtime_status.status().is_success());
 
     let denied_enqueue = client
-        .post(format!("{base}/enqueue"))
+        .post(format!("{base}/api/enqueue"))
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
@@ -1393,7 +1406,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
     assert_eq!(denied_enqueue_body["ok"], false);
     assert!(denied_enqueue_body["error"].is_string());
     let allowed_enqueue = client
-        .post(format!("{base}/enqueue"))
+        .post(format!("{base}/api/enqueue"))
         .bearer_auth("secret")
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
@@ -1419,7 +1432,7 @@ pub async fn control_wake_records_liveness_only_system_tick_on_loopback_auto() -
     .await?;
 
     let allowed = client
-        .post(format!("{base}/control/agents/default/wake"))
+        .post(format!("{base}/api/control/agents/default/wake"))
         .json(&serde_json::json!({
             "reason": "pr changed",
             "source": "github",
@@ -1461,14 +1474,14 @@ pub async fn control_prompt_requires_bearer_token_for_non_loopback_auto() -> Res
     let (_host, base, server) = spawn_server_with_config(config).await?;
     let client = reqwest::Client::new();
     let denied = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
     assert_eq!(denied.status(), reqwest::StatusCode::FORBIDDEN);
 
     let allowed = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .bearer_auth("secret")
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
@@ -1485,7 +1498,7 @@ pub async fn control_prompt_records_message_admission_fields() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
@@ -1520,7 +1533,7 @@ pub async fn control_prompt_records_message_admission_fields() -> Result<()> {
     .await?;
 
     let state_response = client
-        .get(format!("{base}/agents/default/state"))
+        .get(format!("{base}/api/agents/default/state"))
         .send()
         .await?;
     assert!(state_response.status().is_success());
@@ -1547,7 +1560,7 @@ pub async fn control_prompt_rejects_stopped_agent_without_queueing() -> Result<(
     .await?;
 
     let response = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "hello after stop" }))
         .send()
         .await?;
@@ -1588,7 +1601,7 @@ pub async fn stopped_status_includes_lifecycle_start_guidance() -> Result<()> {
     .await?;
 
     let payload: serde_json::Value = client
-        .get(format!("{base}/agents/default/status"))
+        .get(format!("{base}/api/agents/default/status"))
         .send()
         .await?
         .json()
@@ -1631,7 +1644,7 @@ pub async fn control_wake_rejects_stopped_agent_with_start_guidance() -> Result<
     .await?;
 
     let response = client
-        .post(format!("{base}/control/agents/default/wake"))
+        .post(format!("{base}/api/control/agents/default/wake"))
         .json(&serde_json::json!({ "reason": "check if alive" }))
         .send()
         .await?;
@@ -1673,21 +1686,21 @@ pub async fn control_start_restores_live_runtime_loop_for_stopped_agent() -> Res
     .await?;
 
     let rejected = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "before start" }))
         .send()
         .await?;
     assert_eq!(rejected.status(), reqwest::StatusCode::CONFLICT);
 
     let started = client
-        .post(format!("{base}/control/agents/default/control"))
+        .post(format!("{base}/api/control/agents/default/control"))
         .json(&serde_json::json!({ "action": "start" }))
         .send()
         .await?;
     assert!(started.status().is_success());
 
     let accepted = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "after start" }))
         .send()
         .await?;
@@ -1737,7 +1750,7 @@ pub async fn daemon_shutdown_restart_preserves_public_agent_http_runnability() -
     let client = reqwest::Client::new();
 
     let first = client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "before shutdown" }))
         .send()
         .await?;
@@ -1764,7 +1777,7 @@ pub async fn daemon_shutdown_restart_preserves_public_agent_http_runnability() -
     let (base2, server2) = spawn_server_for_host(host2.clone()).await?;
 
     let second = client
-        .post(format!("{base2}/control/agents/default/prompt"))
+        .post(format!("{base2}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "after restart" }))
         .send()
         .await?;
@@ -1814,7 +1827,7 @@ pub async fn runtime_status_route_reports_runtime_metadata() -> Result<()> {
 
     let client = reqwest::Client::new();
     let response = client
-        .get(format!("http://{addr}/control/runtime/status"))
+        .get(format!("http://{addr}/api/control/runtime/status"))
         .bearer_auth("secret")
         .send()
         .await?;
@@ -1902,7 +1915,7 @@ pub async fn runtime_readiness_route_omits_activity_summary() -> Result<()> {
 
     let client = reqwest::Client::new();
     let response = client
-        .get(format!("http://{addr}/control/runtime/readiness"))
+        .get(format!("http://{addr}/api/control/runtime/readiness"))
         .bearer_auth("secret")
         .send()
         .await?;
@@ -1945,7 +1958,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
 
     let client = reqwest::Client::new();
     let read_response = client
-        .get(format!("http://{addr}/control/runtime/config"))
+        .get(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .send()
         .await?;
@@ -1958,7 +1971,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     );
 
     let update_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -1985,7 +1998,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert_eq!(persisted.model.default, None);
 
     let valid_model_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -2011,7 +2024,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
 
     let provider_config_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -2047,7 +2060,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     );
 
     let provider_remove_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -2081,7 +2094,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
         .contains_key(&holon::config::ProviderId::parse("openai")?));
 
     let valid_cors_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -2125,7 +2138,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert_eq!(persisted.api.cors.max_age_seconds, Some(120));
 
     let valid_web_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -2145,7 +2158,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert_eq!(valid_web_payload["changed"], true);
 
     let invalid_web_response = client
-        .patch(format!("http://{addr}/control/runtime/config"))
+        .patch(format!("http://{addr}/api/control/runtime/config"))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "updates": [
@@ -2207,7 +2220,7 @@ pub async fn cors_preflight_allows_default_localhost_origins() -> Result<()> {
         let allowed = client
             .request(
                 reqwest::Method::OPTIONS,
-                format!("http://{addr}/control/runtime/status"),
+                format!("http://{addr}/api/control/runtime/status"),
             )
             .header("origin", origin)
             .header("access-control-request-method", "GET")
@@ -2227,7 +2240,7 @@ pub async fn cors_preflight_allows_default_localhost_origins() -> Result<()> {
     let denied = client
         .request(
             reqwest::Method::OPTIONS,
-            format!("http://{addr}/control/runtime/status"),
+            format!("http://{addr}/api/control/runtime/status"),
         )
         .header("origin", "http://evil.example")
         .header("access-control-request-method", "GET")
@@ -2259,7 +2272,7 @@ pub async fn cors_preflight_allows_default_put_credentials_route() -> Result<()>
     let allowed = reqwest::Client::new()
         .request(
             reqwest::Method::OPTIONS,
-            format!("http://{addr}/control/runtime/credentials/test-profile"),
+            format!("http://{addr}/api/control/runtime/credentials/test-profile"),
         )
         .header("origin", "http://localhost:5173")
         .header("access-control-request-method", "PUT")
@@ -2313,7 +2326,7 @@ pub async fn cors_preflight_respects_configured_origin() -> Result<()> {
     let allowed = client
         .request(
             reqwest::Method::OPTIONS,
-            format!("http://{addr}/control/runtime/status"),
+            format!("http://{addr}/api/control/runtime/status"),
         )
         .header("origin", "http://192.168.1.10:5173")
         .header("access-control-request-method", "GET")
@@ -2339,7 +2352,7 @@ pub async fn cors_preflight_respects_configured_origin() -> Result<()> {
     let denied = client
         .request(
             reqwest::Method::OPTIONS,
-            format!("http://{addr}/control/runtime/status"),
+            format!("http://{addr}/api/control/runtime/status"),
         )
         .header("origin", "http://evil.example")
         .header("access-control-request-method", "GET")
@@ -2404,7 +2417,7 @@ pub async fn runtime_status_route_reports_waiting_activity_summary() -> Result<(
     }
 
     let response = client
-        .get(format!("http://{addr}/control/runtime/status"))
+        .get(format!("http://{addr}/api/control/runtime/status"))
         .bearer_auth("secret")
         .send()
         .await?;
@@ -2464,7 +2477,7 @@ pub async fn runtime_status_route_reports_last_runtime_failure_summary() -> Resu
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         let response = client
-            .get(format!("http://{addr}/control/runtime/status"))
+            .get(format!("http://{addr}/api/control/runtime/status"))
             .bearer_auth("secret")
             .send()
             .await?;
@@ -2510,7 +2523,7 @@ pub async fn runtime_shutdown_route_requests_shutdown() -> Result<()> {
 
     let client = reqwest::Client::new();
     let response = client
-        .post(format!("http://{addr}/control/runtime/shutdown"))
+        .post(format!("http://{addr}/api/control/runtime/shutdown"))
         .bearer_auth("secret")
         .json(&serde_json::json!({}))
         .send()

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -59,7 +59,9 @@ async fn next_sse_event_kind(
 }
 
 async fn newest_event_seq(base: &str, client: &Client, token: Option<&str>) -> Result<u64> {
-    let mut request = client.get(format!("{base}/agents/default/events?limit=1&order=desc"));
+    let mut request = client.get(format!(
+        "{base}/api/agents/default/events?limit=1&order=desc"
+    ));
     if let Some(token) = token {
         request = request.bearer_auth(token);
     }
@@ -105,7 +107,9 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
         serde_json::json!({ "n": 3 }),
     ))?;
     let latest: serde_json::Value = client
-        .get(format!("{base}/agents/default/events?limit=2&order=desc"))
+        .get(format!(
+            "{base}/api/agents/default/events?limit=2&order=desc"
+        ))
         .send()
         .await?
         .json()
@@ -121,7 +125,7 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
 
     let older: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/events?before_seq={}&limit=2&order=desc",
+            "{base}/api/agents/default/events?before_seq={}&limit=2&order=desc",
             latest["oldest_seq"].as_u64().expect("oldest seq")
         ))
         .send()
@@ -141,7 +145,7 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
     let newer = fetch_events_page_until(
         &client,
         format!(
-            "{base}/agents/default/events?after_seq={}&limit=2&order=asc",
+            "{base}/api/agents/default/events?after_seq={}&limit=2&order=asc",
             older["newest_seq"].as_u64().expect("newest seq")
         ),
         |page| {
@@ -168,7 +172,7 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
 
     let bounded_newer: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/events?after_seq={latest_oldest}&before_seq={}&limit=10&order=desc",
+            "{base}/api/agents/default/events?after_seq={latest_oldest}&before_seq={}&limit=10&order=desc",
             latest_newest + 1
         ))
         .send()
@@ -181,7 +185,7 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
 
     let bounded_older: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/events?after_seq={older_newest}&before_seq={latest_newest}&limit=10&order=asc"
+            "{base}/api/agents/default/events?after_seq={older_newest}&before_seq={latest_newest}&limit=10&order=asc"
         ))
         .send()
         .await?
@@ -192,7 +196,9 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
     assert_eq!(bounded_older["has_newer"], false);
 
     let empty_cursor: serde_json::Value = client
-        .get(format!("{base}/agents/default/events?limit=2&order=desc"))
+        .get(format!(
+            "{base}/api/agents/default/events?limit=2&order=desc"
+        ))
         .send()
         .await?
         .json()
@@ -218,7 +224,7 @@ pub async fn events_route_supports_cursor_replay() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "first message" }))
         .send()
         .await?;
@@ -227,13 +233,13 @@ pub async fn events_route_supports_cursor_replay() -> Result<()> {
     let after_seq = newest_event_seq(&base, &client, None).await?;
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "second message" }))
         .send()
         .await?;
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -251,7 +257,7 @@ pub async fn events_stream_supports_cursor_and_rfc3339_ts() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "cursor bootstrap" }))
         .send()
         .await?;
@@ -260,14 +266,14 @@ pub async fn events_stream_supports_cursor_and_rfc3339_ts() -> Result<()> {
     let after_seq = newest_event_seq(&base, &client, None).await?;
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "cursor replay" }))
         .send()
         .await?;
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -296,7 +302,7 @@ pub async fn events_stream_receives_live_events_without_polling_replay() -> Resu
     let client = reqwest::Client::new();
 
     let mut stream = client
-        .get(format!("{base}/agents/default/events/stream"))
+        .get(format!("{base}/api/agents/default/events/stream"))
         .send()
         .await?;
     runtime.storage().append_event(&AuditEvent::new(
@@ -317,7 +323,10 @@ pub async fn global_events_stream_receives_live_agent_events() -> Result<()> {
     let runtime = host.default_runtime().await?;
     let client = reqwest::Client::new();
 
-    let mut stream = client.get(format!("{base}/events/stream")).send().await?;
+    let mut stream = client
+        .get(format!("{base}/api/events/stream"))
+        .send()
+        .await?;
     runtime.storage().append_event(&AuditEvent::new(
         "global_live_test_event",
         serde_json::json!({ "global": true }),
@@ -341,7 +350,7 @@ pub async fn events_route_preserves_replay_provenance() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "provenance bootstrap" }))
         .send()
         .await?;
@@ -350,14 +359,14 @@ pub async fn events_route_preserves_replay_provenance() -> Result<()> {
     let after_seq = newest_event_seq(&base, &client, None).await?;
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "provenance replay" }))
         .send()
         .await?;
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -385,7 +394,7 @@ pub async fn events_route_payload_includes_full_fields() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "stable operator event bootstrap" }))
         .send()
         .await?;
@@ -435,7 +444,7 @@ pub async fn events_route_payload_includes_full_fields() -> Result<()> {
 
     let page = fetch_events_page_until(
         &client,
-        format!("{base}/agents/default/events?after_seq={after_seq}&limit=10&order=asc"),
+        format!("{base}/api/agents/default/events?after_seq={after_seq}&limit=10&order=asc"),
         |page| {
             page["events"].as_array().is_some_and(|events| {
                 events
@@ -534,7 +543,7 @@ pub async fn events_route_max_level_filters_with_bounded_visible_pages() -> Resu
 
     let page = fetch_events_page_until(
         &client,
-        format!("{base}/agents/default/events?limit=2&order=desc&max_level=info"),
+        format!("{base}/api/agents/default/events?limit=2&order=desc&max_level=info"),
         |page| {
             page["events"].as_array().is_some_and(|events| {
                 events.len() == 2
@@ -552,7 +561,9 @@ pub async fn events_route_max_level_filters_with_bounded_visible_pages() -> Resu
     assert!(page["cursor_seq"].as_u64().is_some());
 
     let unfiltered: serde_json::Value = client
-        .get(format!("{base}/agents/default/events?limit=32&order=desc"))
+        .get(format!(
+            "{base}/api/agents/default/events?limit=32&order=desc"
+        ))
         .send()
         .await?
         .json()
@@ -573,7 +584,7 @@ pub async fn events_stream_includes_tool_payload() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "event stream bootstrap" }))
         .send()
         .await?;
@@ -596,7 +607,7 @@ pub async fn events_stream_includes_tool_payload() -> Result<()> {
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -650,7 +661,7 @@ pub async fn tool_execution_route_returns_canonical_output() -> Result<()> {
 
     let response = client
         .get(format!(
-            "{base}/agents/default/tool-executions/tool-http-detail"
+            "{base}/api/agents/default/tool-executions/tool-http-detail"
         ))
         .send()
         .await?;
@@ -661,7 +672,7 @@ pub async fn tool_execution_route_returns_canonical_output() -> Result<()> {
 
     let missing = client
         .get(format!(
-            "{base}/agents/default/tool-executions/missing-tool"
+            "{base}/api/agents/default/tool-executions/missing-tool"
         ))
         .send()
         .await?;
@@ -677,7 +688,7 @@ pub async fn events_stream_includes_assistant_round_payload() -> Result<()> {
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .json(&serde_json::json!({ "text": "assistant round stream bootstrap" }))
         .send()
         .await?;
@@ -707,7 +718,7 @@ pub async fn events_stream_includes_assistant_round_payload() -> Result<()> {
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -760,7 +771,7 @@ pub async fn events_stream_preserves_raw_payload_with_control_auth() -> Result<(
     let client = reqwest::Client::new();
 
     client
-        .post(format!("{base}/control/agents/default/prompt"))
+        .post(format!("{base}/api/control/agents/default/prompt"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "text": "workspace stream bootstrap" }))
         .send()
@@ -785,7 +796,7 @@ pub async fn events_stream_preserves_raw_payload_with_control_auth() -> Result<(
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .bearer_auth(token)
         .send()
@@ -829,7 +840,9 @@ pub async fn events_page_cursor_seq_seeds_stream_resume() -> Result<()> {
     ))?;
 
     let page: serde_json::Value = client
-        .get(format!("{base}/agents/default/events?limit=10&order=desc"))
+        .get(format!(
+            "{base}/api/agents/default/events?limit=10&order=desc"
+        ))
         .send()
         .await?
         .json()
@@ -862,7 +875,7 @@ pub async fn events_page_cursor_seq_seeds_stream_resume() -> Result<()> {
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?after_seq={after_seq}"
+            "{base}/api/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -885,7 +898,7 @@ pub async fn events_stream_requires_control_auth_when_configured() -> Result<()>
     let client = reqwest::Client::new();
 
     let response = client
-        .get(format!("{base}/agents/default/events/stream"))
+        .get(format!("{base}/api/agents/default/events/stream"))
         .send()
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
@@ -925,7 +938,7 @@ pub async fn state_snapshot_bounds_large_projection_fields() -> Result<()> {
     let (base, server) = spawn_server_for_host(host).await?;
 
     let snapshot: serde_json::Value = reqwest::Client::new()
-        .get(format!("{base}/agents/default/state"))
+        .get(format!("{base}/api/agents/default/state"))
         .send()
         .await?
         .json()
@@ -954,7 +967,9 @@ pub async fn events_stream_with_missing_cursor_returns_not_found() -> Result<()>
     let (_host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
     let response = client
-        .get(format!("{base}/agents/default/events/stream?after_seq=999"))
+        .get(format!(
+            "{base}/api/agents/default/events/stream?after_seq=999"
+        ))
         .send()
         .await?;
     let status = response.status();

--- a/tests/support/http_ingress.rs
+++ b/tests/support/http_ingress.rs
@@ -47,7 +47,7 @@ pub async fn generic_webhook_records_public_admission_fields() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/webhooks/generic/default"))
+        .post(format!("{base}/api/webhooks/generic/default"))
         .json(&serde_json::json!({ "status": "opened" }))
         .send()
         .await?;
@@ -85,7 +85,7 @@ pub async fn public_channel_enqueue_rejects_stopped_agent_without_queueing() -> 
     .await?;
 
     let response = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "channel_event",
             "text": "channel after stop",
@@ -134,7 +134,7 @@ pub async fn generic_webhook_rejects_stopped_public_agent_without_queueing() -> 
     .await?;
 
     let response = client
-        .post(format!("{base}/webhooks/generic/default"))
+        .post(format!("{base}/api/webhooks/generic/default"))
         .json(&serde_json::json!({ "status": "opened" }))
         .send()
         .await?;
@@ -161,14 +161,14 @@ pub async fn generic_webhook_and_multi_agent_listing_work() -> Result<()> {
     host.create_named_agent("alpha", None).await?;
 
     let response = client
-        .post(format!("{base}/webhooks/generic/alpha"))
+        .post(format!("{base}/api/webhooks/generic/alpha"))
         .json(&serde_json::json!({ "event": "push", "repo": "holon" }))
         .send()
         .await?;
     assert!(response.status().is_success());
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
-    let agents = client.get(format!("{base}/agents/list")).send().await?;
+    let agents = client.get(format!("{base}/api/agents/list")).send().await?;
     let agents_json: serde_json::Value = agents.json().await?;
     assert!(agents_json
         .as_array()
@@ -196,7 +196,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     let client = reqwest::Client::new();
 
     let privileged_origin = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "task_result",
             "origin": {
@@ -210,7 +210,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     assert_eq!(privileged_origin.status(), reqwest::StatusCode::FORBIDDEN);
 
     let trust_override = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "webhook_event",
             "origin": {
@@ -225,7 +225,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     assert_eq!(trust_override.status(), reqwest::StatusCode::FORBIDDEN);
 
     let interject_override = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "webhook_event",
             "origin": {
@@ -240,7 +240,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     assert_eq!(interject_override.status(), reqwest::StatusCode::FORBIDDEN);
 
     let forged_system_tick = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "system_tick",
             "origin": {
@@ -254,7 +254,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     assert_eq!(forged_system_tick.status(), reqwest::StatusCode::FORBIDDEN);
 
     let forged_callback = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "callback_event",
             "origin": {
@@ -268,7 +268,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     assert_eq!(forged_callback.status(), reqwest::StatusCode::FORBIDDEN);
 
     let authority_override = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "webhook_event",
             "origin": {
@@ -283,7 +283,7 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     assert_eq!(authority_override.status(), reqwest::StatusCode::FORBIDDEN);
 
     let channel_evidence = client
-        .post(format!("{base}/agents/default/enqueue"))
+        .post(format!("{base}/api/agents/default/enqueue"))
         .json(&serde_json::json!({
             "kind": "channel_event",
             "origin": {
@@ -323,7 +323,7 @@ pub async fn generic_webhook_requires_bearer_token_when_configured() -> Result<(
     let client = reqwest::Client::new();
 
     let denied = client
-        .post(format!("{base}/webhooks/generic/default"))
+        .post(format!("{base}/api/webhooks/generic/default"))
         .json(&serde_json::json!({ "status": "opened" }))
         .send()
         .await?;
@@ -333,7 +333,7 @@ pub async fn generic_webhook_requires_bearer_token_when_configured() -> Result<(
     assert!(runtime.storage().read_recent_messages(10)?.is_empty());
 
     let allowed = client
-        .post(format!("{base}/webhooks/generic/default"))
+        .post(format!("{base}/api/webhooks/generic/default"))
         .bearer_auth("secret")
         .json(&serde_json::json!({ "status": "opened" }))
         .send()

--- a/tests/support/http_operator_ingress.rs
+++ b/tests/support/http_operator_ingress.rs
@@ -56,7 +56,9 @@ pub async fn operator_ingress_records_remote_operator_provenance() -> Result<()>
     .await?;
 
     let response = client
-        .post(format!("{base}/control/agents/default/operator-ingress"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-ingress"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "text": "remote operator continue",
@@ -157,7 +159,9 @@ pub async fn operator_ingress_defaults_provider_provenance_from_binding() -> Res
     .await?;
 
     let response = client
-        .post(format!("{base}/control/agents/default/operator-ingress"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-ingress"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "text": "remote operator without provider",
@@ -207,7 +211,9 @@ pub async fn operator_ingress_requires_control_auth() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/operator-ingress"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-ingress"
+        ))
         .json(&serde_json::json!({
             "text": "unauthenticated remote operator",
             "actor_id": "operator:jolestar",
@@ -227,7 +233,9 @@ pub async fn operator_transport_binding_validates_delivery_auth_and_redacts_audi
     let client = reqwest::Client::new();
 
     let missing_bearer = client
-        .post(format!("{base}/control/agents/default/operator-bindings"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-bindings"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "binding_id": "opbind-missing-bearer-token",
@@ -247,7 +255,9 @@ pub async fn operator_transport_binding_validates_delivery_auth_and_redacts_audi
     assert_eq!(missing_bearer.status(), reqwest::StatusCode::BAD_REQUEST);
 
     let hmac = client
-        .post(format!("{base}/control/agents/default/operator-bindings"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-bindings"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "binding_id": "opbind-hmac",
@@ -303,7 +313,9 @@ pub async fn operator_ingress_validates_binding_and_actor() -> Result<()> {
     let client = reqwest::Client::new();
 
     let missing = client
-        .post(format!("{base}/control/agents/default/operator-ingress"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-ingress"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "text": "missing binding",
@@ -322,7 +334,9 @@ pub async fn operator_ingress_validates_binding_and_actor() -> Result<()> {
     )
     .await?;
     let wrong_actor = client
-        .post(format!("{base}/control/agents/default/operator-ingress"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-ingress"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "text": "wrong actor",
@@ -368,7 +382,9 @@ pub async fn operator_ingress_rejects_stopped_agent_without_queueing() -> Result
     .await?;
 
     let response = client
-        .post(format!("{base}/control/agents/default/operator-ingress"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-ingress"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "text": "remote after stop",

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -48,7 +48,7 @@ pub async fn create_command_task_route_rejects_legacy_kind_field() -> Result<()>
 
     for kind in ["subagent_task", "worktree_subagent_task"] {
         let response = client
-            .post(format!("{base}/control/agents/default/tasks"))
+            .post(format!("{base}/api/control/agents/default/tasks"))
             .json(&serde_json::json!({
                 "kind": kind,
                 "summary": "delegate through deprecated control task path",
@@ -71,7 +71,7 @@ pub async fn create_task_route_rejects_unknown_prompt_field() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "run route command",
             "cmd": "printf route_command_ok",
@@ -93,7 +93,7 @@ pub async fn create_command_task_route_rejects_continue_on_result_field() -> Res
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "run route command",
             "cmd": "printf route_command_ok",
@@ -115,7 +115,7 @@ pub async fn create_command_task_route_accepts_integration_authority() -> Result
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "integration can create task",
             "cmd": "printf integration_signal_ok",
@@ -145,7 +145,7 @@ pub async fn create_command_task_route_accepts_command_request() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "run route command",
             "cmd": "printf route_command_ok",
@@ -185,7 +185,7 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
 
     let create_task = |summary: &str, cmd: &str, yield_time_ms: u64| {
         client
-            .post(format!("{base}/control/agents/default/tasks"))
+            .post(format!("{base}/api/control/agents/default/tasks"))
             .json(&serde_json::json!({
                 "summary": summary,
                 "cmd": cmd,
@@ -229,7 +229,7 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
     .await?;
 
     let tasks: serde_json::Value = client
-        .get(format!("{base}/agents/default/tasks"))
+        .get(format!("{base}/api/agents/default/tasks"))
         .send()
         .await?
         .json()
@@ -244,7 +244,7 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
     assert!(task_ids.contains(&second_id.as_str()));
 
     let snapshot: serde_json::Value = client
-        .get(format!("{base}/agents/default/state"))
+        .get(format!("{base}/api/agents/default/state"))
         .send()
         .await?
         .json()
@@ -259,7 +259,7 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
 
     client
         .post(format!(
-            "{base}/control/agents/default/tasks/{first_id}/stop"
+            "{base}/api/control/agents/default/tasks/{first_id}/stop"
         ))
         .json(&serde_json::json!({}))
         .send()
@@ -267,7 +267,7 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
         .error_for_status()?;
     client
         .post(format!(
-            "{base}/control/agents/default/tasks/{second_id}/stop"
+            "{base}/api/control/agents/default/tasks/{second_id}/stop"
         ))
         .json(&serde_json::json!({}))
         .send()
@@ -283,7 +283,7 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "inspect task lifecycle",
             "cmd": "printf lifecycle_output",
@@ -307,7 +307,7 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
     .await?;
 
     let status: serde_json::Value = client
-        .get(format!("{base}/agents/default/tasks/{task_id}"))
+        .get(format!("{base}/api/agents/default/tasks/{task_id}"))
         .send()
         .await?
         .json()
@@ -318,7 +318,7 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
 
     let output: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/tasks/{task_id}/output?block=false"
+            "{base}/api/agents/default/tasks/{task_id}/output?block=false"
         ))
         .send()
         .await?
@@ -329,7 +329,7 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
     assert_eq!(output["task"]["output_preview"], "lifecycle_output");
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "inspect delayed task output",
             "cmd": "sleep 0.2; printf delayed_lifecycle_output",
@@ -347,7 +347,7 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
 
     let delayed_output: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/tasks/{delayed_task_id}/output?block=true"
+            "{base}/api/agents/default/tasks/{delayed_task_id}/output?block=true"
         ))
         .send()
         .await?
@@ -360,7 +360,7 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
     );
 
     let missing = client
-        .get(format!("{base}/agents/default/tasks/missing-task"))
+        .get(format!("{base}/api/agents/default/tasks/missing-task"))
         .send()
         .await?;
     assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
@@ -374,7 +374,7 @@ pub async fn create_work_item_route_persists_queued_item_without_message_ingress
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/work-items"))
+        .post(format!("{base}/api/control/agents/default/work-items"))
         .json(&serde_json::json!({
             "objective": "follow up on queued runtime cleanup"
         }))
@@ -419,7 +419,7 @@ pub async fn task_input_and_stop_routes_manage_task_lifecycle() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "accept task input",
             "cmd": "cat",
@@ -438,7 +438,7 @@ pub async fn task_input_and_stop_routes_manage_task_lifecycle() -> Result<()> {
 
     let input: serde_json::Value = client
         .post(format!(
-            "{base}/control/agents/default/tasks/{input_task_id}/input"
+            "{base}/api/control/agents/default/tasks/{input_task_id}/input"
         ))
         .json(&serde_json::json!({
             "text": "managed input\n"
@@ -451,7 +451,7 @@ pub async fn task_input_and_stop_routes_manage_task_lifecycle() -> Result<()> {
     assert_eq!(input["accepted_input"], true);
 
     let response = client
-        .post(format!("{base}/control/agents/default/tasks"))
+        .post(format!("{base}/api/control/agents/default/tasks"))
         .json(&serde_json::json!({
             "summary": "stop task through route",
             "cmd": "sleep 30",
@@ -469,7 +469,7 @@ pub async fn task_input_and_stop_routes_manage_task_lifecycle() -> Result<()> {
 
     let stop: serde_json::Value = client
         .post(format!(
-            "{base}/control/agents/default/tasks/{stop_task_id}/stop"
+            "{base}/api/control/agents/default/tasks/{stop_task_id}/stop"
         ))
         .json(&serde_json::json!({}))
         .send()
@@ -481,7 +481,7 @@ pub async fn task_input_and_stop_routes_manage_task_lifecycle() -> Result<()> {
 
     let missing = client
         .post(format!(
-            "{base}/control/agents/default/tasks/missing-task/stop"
+            "{base}/api/control/agents/default/tasks/missing-task/stop"
         ))
         .json(&serde_json::json!({}))
         .send()
@@ -497,7 +497,7 @@ pub async fn work_item_routes_list_and_return_work_item_detail() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/work-items"))
+        .post(format!("{base}/api/control/agents/default/work-items"))
         .json(&serde_json::json!({
             "objective": "inspect lifecycle work item"
         }))
@@ -511,7 +511,7 @@ pub async fn work_item_routes_list_and_return_work_item_detail() -> Result<()> {
         .to_string();
 
     let list: serde_json::Value = client
-        .get(format!("{base}/agents/default/work-items"))
+        .get(format!("{base}/api/agents/default/work-items"))
         .send()
         .await?
         .json()
@@ -523,7 +523,9 @@ pub async fn work_item_routes_list_and_return_work_item_detail() -> Result<()> {
         .any(|item| item["id"] == work_item_id));
 
     let detail: serde_json::Value = client
-        .get(format!("{base}/agents/default/work-items/{work_item_id}"))
+        .get(format!(
+            "{base}/api/agents/default/work-items/{work_item_id}"
+        ))
         .send()
         .await?
         .json()
@@ -532,7 +534,7 @@ pub async fn work_item_routes_list_and_return_work_item_detail() -> Result<()> {
     assert_eq!(detail["objective"], "inspect lifecycle work item");
 
     let missing = client
-        .get(format!("{base}/agents/default/work-items/missing-work"))
+        .get(format!("{base}/api/agents/default/work-items/missing-work"))
         .send()
         .await?;
     assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
@@ -556,7 +558,7 @@ pub async fn create_work_item_route_does_not_replace_existing_active_item() -> R
     .await?;
 
     let response = client
-        .post(format!("{base}/control/agents/default/work-items"))
+        .post(format!("{base}/api/control/agents/default/work-items"))
         .json(&serde_json::json!({
             "objective": "queued follow-up after active work",
             "summary": "queued from route"
@@ -586,7 +588,7 @@ pub async fn create_work_item_route_rejects_empty_objective_with_bad_request() -
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/control/agents/default/work-items"))
+        .post(format!("{base}/api/control/agents/default/work-items"))
         .json(&serde_json::json!({
             "objective": "   ",
             "summary": "queued from control plane"
@@ -618,7 +620,7 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
 
     let pick: serde_json::Value = client
         .post(format!(
-            "{base}/control/agents/default/work-items/{second_id}/pick",
+            "{base}/api/control/agents/default/work-items/{second_id}/pick",
             second_id = second.id
         ))
         .json(&serde_json::json!({
@@ -638,7 +640,7 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
 
     let update: serde_json::Value = client
         .patch(format!(
-            "{base}/control/agents/default/work-items/{second_id}",
+            "{base}/api/control/agents/default/work-items/{second_id}",
             second_id = second.id
         ))
         .json(&serde_json::json!({
@@ -665,7 +667,7 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
 
     let complete: serde_json::Value = client
         .post(format!(
-            "{base}/control/agents/default/work-items/{second_id}/complete",
+            "{base}/api/control/agents/default/work-items/{second_id}/complete",
             second_id = second.id
         ))
         .json(&serde_json::json!({
@@ -714,7 +716,7 @@ pub async fn work_item_mutation_routes_validate_bad_requests() -> Result<()> {
 
     let empty_update = client
         .patch(format!(
-            "{base}/control/agents/default/work-items/{}",
+            "{base}/api/control/agents/default/work-items/{}",
             work.id
         ))
         .json(&serde_json::json!({}))
@@ -729,7 +731,7 @@ pub async fn work_item_mutation_routes_validate_bad_requests() -> Result<()> {
 
     let recheck_without_blocker = client
         .patch(format!(
-            "{base}/control/agents/default/work-items/{}",
+            "{base}/api/control/agents/default/work-items/{}",
             work.id
         ))
         .json(&serde_json::json!({
@@ -745,7 +747,7 @@ pub async fn work_item_mutation_routes_validate_bad_requests() -> Result<()> {
 
     let missing = client
         .post(format!(
-            "{base}/control/agents/default/work-items/missing-work/complete"
+            "{base}/api/control/agents/default/work-items/missing-work/complete"
         ))
         .json(&serde_json::json!({}))
         .send()
@@ -766,7 +768,7 @@ pub async fn timer_detail_route_returns_latest_timer_record() -> Result<()> {
         .await?;
 
     let detail: serde_json::Value = client
-        .get(format!("{base}/agents/default/timers/{}", timer.id))
+        .get(format!("{base}/api/agents/default/timers/{}", timer.id))
         .send()
         .await?
         .json()
@@ -776,7 +778,7 @@ pub async fn timer_detail_route_returns_latest_timer_record() -> Result<()> {
     assert_eq!(detail["summary"], "inspect lifecycle timer");
 
     let missing = client
-        .get(format!("{base}/agents/default/timers/missing-timer"))
+        .get(format!("{base}/api/agents/default/timers/missing-timer"))
         .send()
         .await?;
     assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
@@ -796,7 +798,7 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
 
     let cancelled_response = client
         .post(format!(
-            "{base}/control/agents/default/timers/{}/cancel",
+            "{base}/api/control/agents/default/timers/{}/cancel",
             timer.id
         ))
         .json(&serde_json::json!({"authority_class": "integration_signal"}))
@@ -811,7 +813,7 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
 
     let idempotent: serde_json::Value = client
         .post(format!(
-            "{base}/control/agents/default/timers/{}/cancel",
+            "{base}/api/control/agents/default/timers/{}/cancel",
             timer.id
         ))
         .json(&serde_json::json!({}))
@@ -822,7 +824,7 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
     assert_eq!(idempotent["status"], "cancelled");
 
     let detail: serde_json::Value = client
-        .get(format!("{base}/agents/default/timers/{}", timer.id))
+        .get(format!("{base}/api/agents/default/timers/{}", timer.id))
         .send()
         .await?
         .json()
@@ -831,7 +833,7 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
 
     let missing = client
         .post(format!(
-            "{base}/control/agents/default/timers/missing-timer/cancel"
+            "{base}/api/control/agents/default/timers/missing-timer/cancel"
         ))
         .json(&serde_json::json!({}))
         .send()
@@ -851,7 +853,7 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
             let completed_id = completed_id.clone();
             async move {
                 let detail: serde_json::Value = client
-                    .get(format!("{base}/agents/default/timers/{completed_id}"))
+                    .get(format!("{base}/api/agents/default/timers/{completed_id}"))
                     .send()
                     .await?
                     .json()
@@ -863,7 +865,7 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
     .await?;
     let completed_cancel = client
         .post(format!(
-            "{base}/control/agents/default/timers/{}/cancel",
+            "{base}/api/control/agents/default/timers/{}/cancel",
             completed.id
         ))
         .json(&serde_json::json!({}))

--- a/tests/support/http_workspace.rs
+++ b/tests/support/http_workspace.rs
@@ -50,7 +50,7 @@ pub async fn workspace_enter_control_route_is_not_exposed() -> Result<()> {
     let response = unix_request(
         &socket_path,
         "POST",
-        "/control/agents/default/workspace/enter",
+        "/api/control/agents/default/workspace/enter",
         &[("Content-Type", "application/json")],
         Some(br#"{}"#),
     )
@@ -73,7 +73,9 @@ pub async fn detach_workspace_route_removes_stale_non_active_binding() -> Result
 
     let client = reqwest::Client::new();
     let response = client
-        .post(format!("{base}/control/agents/default/workspace/detach"))
+        .post(format!(
+            "{base}/api/control/agents/default/workspace/detach"
+        ))
         .json(&serde_json::json!({
             "workspace_id": stale_workspace.workspace_id.clone()
         }))
@@ -107,7 +109,9 @@ pub async fn detach_workspace_route_rejects_active_binding() -> Result<()> {
 
     let client = reqwest::Client::new();
     let response = client
-        .post(format!("{base}/control/agents/default/workspace/detach"))
+        .post(format!(
+            "{base}/api/control/agents/default/workspace/detach"
+        ))
         .json(&serde_json::json!({
             "workspace_id": active_workspace_id.clone()
         }))
@@ -154,7 +158,7 @@ pub async fn worktree_summary_route_returns_reviewable_candidate_summary() -> Re
     .await?;
 
     let response = client
-        .get(format!("{base}/agents/default/worktree-summary"))
+        .get(format!("{base}/api/agents/default/worktree-summary"))
         .send()
         .await?;
     assert!(response.status().is_success());
@@ -176,7 +180,7 @@ pub async fn workspace_files_lists_directory() -> Result<()> {
 
     let workspace_id = "agent_home:default";
     let response = client
-        .get(format!("{base}/workspaces/{workspace_id}/files"))
+        .get(format!("{base}/api/workspaces/{workspace_id}/files"))
         .send()
         .await?;
     assert_eq!(response.status(), 200);
@@ -200,7 +204,7 @@ pub async fn workspace_files_reads_text_file() -> Result<()> {
 
     let workspace_id = "agent_home:default";
     let listing: serde_json::Value = client
-        .get(format!("{base}/workspaces/{workspace_id}/files"))
+        .get(format!("{base}/api/workspaces/{workspace_id}/files"))
         .send()
         .await?
         .json()
@@ -213,7 +217,9 @@ pub async fn workspace_files_reads_text_file() -> Result<()> {
     let filename = target["name"].as_str().unwrap();
 
     let response = client
-        .get(format!("{base}/workspaces/{workspace_id}/files/{filename}"))
+        .get(format!(
+            "{base}/api/workspaces/{workspace_id}/files/{filename}"
+        ))
         .header("Accept", "application/json")
         .send()
         .await?;
@@ -236,7 +242,7 @@ pub async fn workspace_files_path_traversal_rejected() -> Result<()> {
     let workspace_id = "agent_home:default";
     let response = client
         .get(format!(
-            "{base}/workspaces/{workspace_id}/files/../../../etc/passwd"
+            "{base}/api/workspaces/{workspace_id}/files/../../../etc/passwd"
         ))
         .send()
         .await?;
@@ -253,7 +259,7 @@ pub async fn workspace_files_returns_404_for_missing_file() -> Result<()> {
     let workspace_id = "agent_home:default";
     let response = client
         .get(format!(
-            "{base}/workspaces/{workspace_id}/files/nonexistent_file_12345.txt"
+            "{base}/api/workspaces/{workspace_id}/files/nonexistent_file_12345.txt"
         ))
         .send()
         .await?;
@@ -269,7 +275,7 @@ pub async fn workspace_files_metadata_only() -> Result<()> {
 
     let workspace_id = "agent_home:default";
     let listing: serde_json::Value = client
-        .get(format!("{base}/workspaces/{workspace_id}/files"))
+        .get(format!("{base}/api/workspaces/{workspace_id}/files"))
         .send()
         .await?
         .json()
@@ -283,7 +289,7 @@ pub async fn workspace_files_metadata_only() -> Result<()> {
 
     let response = client
         .get(format!(
-            "{base}/workspaces/{workspace_id}/files/{filename}?meta=true"
+            "{base}/api/workspaces/{workspace_id}/files/{filename}?meta=true"
         ))
         .send()
         .await?;
@@ -307,7 +313,7 @@ pub async fn workspace_files_unknown_workspace_404() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .get(format!("{base}/workspaces/ws_nonexistent_12345/files"))
+        .get(format!("{base}/api/workspaces/ws_nonexistent_12345/files"))
         .send()
         .await?;
     assert_eq!(response.status(), 404);
@@ -336,7 +342,7 @@ pub async fn workspace_files_symlink_escape_rejected() -> Result<()> {
 
     let response = client
         .get(format!(
-            "{base}/workspaces/{workspace_id}/files/escape_link"
+            "{base}/api/workspaces/{workspace_id}/files/escape_link"
         ))
         .send()
         .await?;
@@ -355,7 +361,7 @@ pub async fn workspace_files_execution_root_id_rejected() -> Result<()> {
     let workspace_id = "agent_home:default";
     let response = client
         .get(format!(
-            "{base}/workspaces/{workspace_id}/files?execution_root_id=git_worktree_root:ws-1"
+            "{base}/api/workspaces/{workspace_id}/files?execution_root_id=git_worktree_root:ws-1"
         ))
         .send()
         .await?;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -727,9 +727,9 @@ pub fn callback_token(trigger_url: &str) -> &str {
 
 pub fn callback_path(trigger_url: &str) -> String {
     trigger_url
-        .split_once("/callbacks/")
+        .split_once("/api/callbacks/")
         .map(|(_, path)| path)
-        .map(|path| format!("/callbacks/{path}"))
+        .map(|path| format!("/api/callbacks/{path}"))
         .expect("callback url should contain /callbacks/")
 }
 
@@ -740,7 +740,9 @@ pub async fn create_operator_transport_binding(
     delivery_callback_url: &str,
 ) -> Result<serde_json::Value> {
     let response = client
-        .post(format!("{base}/control/agents/default/operator-bindings"))
+        .post(format!(
+            "{base}/api/control/agents/default/operator-bindings"
+        ))
         .bearer_auth("secret")
         .json(&serde_json::json!({
             "binding_id": binding_id,


### PR DESCRIPTION
## Summary

Previously, `src/http/mod.rs` cloned API routes and mounted them at both the root path and under `/api`. All first-party clients (Web GUI, TUI/CLI) already use the `/api` prefix exclusively. This PR removes the redundant root route mounting.

## Changes

- **Remove root routes**: Deleted `root_routes` clone + `.merge(root_routes)` from the router; only `.nest("/api", api_routes)` remains
- **Fix `/api/api/jobs` double-prefix**: Jobs routes inside `api_routes` now use `/jobs` instead of `/api/jobs`
- **Fix `/api/api/skills/catalog` double-prefix**: Same pattern for all skills catalog routes
- **Remove root `/search` handler**: Only `/api/search` remains
- **Migrate test support modules**: All `tests/support/*.rs` files updated to `/api`-prefixed paths
- **Update snapshots**: `openapi.json`, `http_route_inventory.json`, `prompt_context_snapshots.rs`
- **Update docs**: `http-control-plane.md`, `web-gui.md`, `skills.md`, `agent-state.md`

## Breaking change

External consumers using root paths (e.g. `GET /agents/list`) must now use the `/api` prefix (e.g. `GET /api/agents/list`).

All first-party clients are unaffected — they already use `/api`.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test` (full suite) ✅