### PR TITLE
fix: remove suppress_normal_brief mechanism (now unnecessary with multi-brief support)

### DIFF
--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -112,30 +112,19 @@ impl RuntimeHandle {
             );
             self.persist_brief(&brief).await?;
         } else {
-            if !outcome.terminal_delivery.suppress_normal_brief {
-                let mut brief =
-                    brief::make_result(&message.agent_id, message, outcome.final_text.clone());
-                brief.turn_index = Some(outcome.turn_index);
-                bind_brief_to_assistant_round(
-                    &mut brief,
-                    outcome.final_text_source_assistant_round_id.as_deref(),
-                );
-                self.persist_brief(&brief).await?;
-            }
-            for promotion in &outcome.terminal_delivery.promoted_completion_reports {
-                if outcome.terminal_delivery.suppress_normal_brief {
-                    self.inner.storage.append_event(&AuditEvent::new(
-                        "turn_terminal_brief_suppressed",
-                        serde_json::json!({
-                            "agent_id": message.agent_id.clone(),
-                            "message_id": message.id.clone(),
-                            "reason": "work_item_completion_report_promoted",
-                            "work_item_id": &promotion.work_item_id,
-                            "brief_id": &promotion.brief_id,
-                        }),
-                    ))?;
-                }
-            }
+            // Always generate the normal result brief (no longer suppressed for
+            // promoted completion reports). The same turn supports multiple briefs,
+            // and the normal brief and promoted completion reports serve different
+            // purposes — the former records the turn-level result, the latter records
+            // the work-item-level completion.
+            let mut brief =
+                brief::make_result(&message.agent_id, message, outcome.final_text.clone());
+            brief.turn_index = Some(outcome.turn_index);
+            bind_brief_to_assistant_round(
+                &mut brief,
+                outcome.final_text_source_assistant_round_id.as_deref(),
+            );
+            self.persist_brief(&brief).await?;
         }
         self.persist_turn_record(&outcome.terminal).await?;
         self.promote_turn_active_skills().await?;

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1986,7 +1986,10 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         brief.kind == BriefKind::Result
             && brief.related_message_id.as_deref() == Some(message.id.as_str())
     });
-    assert!(normal_brief.is_some(), "normal terminal result brief should exist");
+    assert!(
+        normal_brief.is_some(),
+        "normal terminal result brief should exist"
+    );
     let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
     let complete_tool = tools
         .iter()

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1980,13 +1980,13 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         .latest_delivery_summary(&work_item.id)
         .unwrap()
         .is_none());
-    assert!(
-        !briefs.iter().any(|brief| {
-            brief.kind == BriefKind::Result
-                && brief.related_message_id.as_deref() == Some(message.id.as_str())
-        }),
-        "normal terminal result brief should be suppressed after completion promotion"
-    );
+    // The normal result brief is no longer suppressed — it coexists with the
+    // promoted completion report brief.
+    let normal_brief = briefs.iter().find(|brief| {
+        brief.kind == BriefKind::Result
+            && brief.related_message_id.as_deref() == Some(message.id.as_str())
+    });
+    assert!(normal_brief.is_some(), "normal terminal result brief should exist");
     let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
     let complete_tool = tools
         .iter()
@@ -2024,12 +2024,6 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         tool_result["result"]["completion_report_promoted"].as_bool(),
         Some(true)
     );
-    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
-    assert!(events.iter().any(|event| {
-        event.kind == "turn_terminal_brief_suppressed"
-            && event.data["reason"].as_str() == Some("work_item_completion_report_promoted")
-            && event.data["work_item_id"].as_str() == Some(work_item.id.as_str())
-    }));
 }
 
 #[tokio::test]
@@ -2504,13 +2498,6 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
             })
             .count(),
         0
-    );
-    assert_eq!(
-        events
-            .iter()
-            .filter(|event| event.kind == "turn_terminal_brief_suppressed")
-            .count(),
-        2
     );
 }
 

--- a/src/runtime/turn/completion.rs
+++ b/src/runtime/turn/completion.rs
@@ -148,7 +148,6 @@ pub(super) fn completion_report_texts_by_tool_id(
     reports
 }
 
-
 pub(super) fn result_work_item_id(envelope: &ToolResultEnvelope) -> Option<String> {
     envelope
         .result

--- a/src/runtime/turn/completion.rs
+++ b/src/runtime/turn/completion.rs
@@ -148,22 +148,6 @@ pub(super) fn completion_report_texts_by_tool_id(
     reports
 }
 
-pub(super) fn round_has_post_completion_non_completion_tool_call(
-    assistant_blocks: &[ModelBlock],
-) -> bool {
-    let mut saw_completion = false;
-    for block in assistant_blocks {
-        if let ModelBlock::ToolUse { name, .. } = block {
-            if saw_completion && name != "CompleteWorkItem" {
-                return true;
-            }
-            if name == "CompleteWorkItem" {
-                saw_completion = true;
-            }
-        }
-    }
-    false
-}
 
 pub(super) fn result_work_item_id(envelope: &ToolResultEnvelope) -> Option<String> {
     envelope

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -35,7 +35,7 @@ use super::completion::{
     command_batch_preview_field, command_cost_field, command_display_field, command_preview_field,
     envelope_completes_work_item, exec_command_disposition_field, exec_command_exit_status_field,
     exec_command_task_handle_field, rejects_truncated_mutation_tool_call, result_work_item_id,
-    round_has_post_completion_non_completion_tool_call, truncated_mutation_recovery_hint,
+    truncated_mutation_recovery_hint,
 };
 use super::context_management::context_management_diagnostic;
 use super::projection::{
@@ -50,7 +50,7 @@ use super::reminders::{
 };
 use super::{
     append_follow_up_user_texts, render_operator_interjection_text, AgentLoopOutcome,
-    LoopControlOptions, TurnPromotedCompletionReport, TurnRoundRecord, TurnTerminalDelivery,
+    LoopControlOptions, TurnRoundRecord,
     MAX_OUTPUT_RECOVERY_ATTEMPTS, ROUND_TEXT_PREVIEW_LIMIT,
     WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
 };
@@ -101,7 +101,6 @@ impl RuntimeHandle {
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
             terminal_kind: TurnTerminalKind::Aborted,
-            terminal_delivery: TurnTerminalDelivery::normal(),
         }))
     }
 
@@ -268,7 +267,6 @@ impl RuntimeHandle {
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
             terminal_kind,
-            terminal_delivery: TurnTerminalDelivery::normal(),
         }))
     }
     pub(super) async fn complete_turn_with_abort(
@@ -491,8 +489,6 @@ impl TurnExecution<'_> {
         let mut completed_rounds = Vec::<TurnRoundRecord>::new();
         let turn_started_at = Instant::now();
         let mut sleep_duration_ms = None;
-        let mut promoted_completion_reports = Vec::<TurnPromotedCompletionReport>::new();
-        let mut post_completion_continuation_action = false;
         let mut completed_work_item_this_turn = false;
         let mut round = 0usize;
         let mut truncated_text_history = Vec::new();
@@ -583,7 +579,6 @@ impl TurnExecution<'_> {
                         sleep_duration_ms: None,
                         allow_sleep_runnable_work_override: false,
                         terminal_kind: TurnTerminalKind::Aborted,
-                        terminal_delivery: TurnTerminalDelivery::normal(),
                     });
                 }
             }
@@ -820,7 +815,6 @@ impl TurnExecution<'_> {
                             sleep_duration_ms: None,
                             allow_sleep_runnable_work_override: false,
                             terminal_kind: TurnTerminalKind::BaselineOverBudget,
-                            terminal_delivery: TurnTerminalDelivery::normal(),
                         });
                     }
                 };
@@ -1340,20 +1334,9 @@ impl TurnExecution<'_> {
                     sleep_duration_ms,
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
-                    terminal_delivery: if !promoted_completion_reports.is_empty() {
-                        TurnTerminalDelivery::completion_reports(
-                            promoted_completion_reports,
-                            !post_completion_continuation_action,
-                        )
-                    } else {
-                        TurnTerminalDelivery::normal()
-                    },
                 });
             }
 
-            if !promoted_completion_reports.is_empty() && !tool_calls.is_empty() {
-                post_completion_continuation_action = true;
-            }
             let round_tool_calls = tool_calls.clone();
             let mut tool_results = Vec::new();
             let mut tool_result_envelopes = Vec::new();
@@ -1645,7 +1628,7 @@ impl TurnExecution<'_> {
                     }
                 }
             }
-            let completion_promotions = runtime
+            let _completion_promotions = runtime
                 .promote_round_completion_report_if_present(
                     agent_id,
                     round,
@@ -1660,13 +1643,6 @@ impl TurnExecution<'_> {
                 .any(envelope_completes_work_item)
             {
                 completed_work_item_this_turn = true;
-            }
-            if !completion_promotions.is_empty()
-                && round_has_post_completion_non_completion_tool_call(
-                    &completed_round_assistant_blocks,
-                )
-            {
-                post_completion_continuation_action = true;
             }
             // Build ref-backed tool result metadata for transcript
             use crate::types::{ToolResultData, ToolResultRef};
@@ -1703,11 +1679,6 @@ impl TurnExecution<'_> {
             let mut interjections = before_tool_execution_interjections;
             interjections.extend(after_tool_results_interjections);
             let has_operator_interjections = !interjections.is_empty();
-            if (!promoted_completion_reports.is_empty() || !completion_promotions.is_empty())
-                && has_operator_interjections
-            {
-                post_completion_continuation_action = true;
-            }
             let round_record = TurnRoundRecord {
                 round,
                 estimated_tokens: build_round_estimated_tokens(
@@ -1735,12 +1706,6 @@ impl TurnExecution<'_> {
             }
             completed_rounds.push(round_record);
 
-            promoted_completion_reports.extend(completion_promotions.into_iter().map(
-                |promotion| TurnPromotedCompletionReport {
-                    work_item_id: promotion.record.id,
-                    brief_id: promotion.brief_id,
-                },
-            ));
 
             if all_tool_results_should_sleep && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
@@ -1761,14 +1726,6 @@ impl TurnExecution<'_> {
                     sleep_duration_ms: sleep_duration_ms.or(legacy_sleep_duration_ms),
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
-                    terminal_delivery: if !promoted_completion_reports.is_empty() {
-                        TurnTerminalDelivery::completion_reports(
-                            promoted_completion_reports,
-                            !post_completion_continuation_action,
-                        )
-                    } else {
-                        TurnTerminalDelivery::normal()
-                    },
                 });
             }
         }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -50,8 +50,7 @@ use super::reminders::{
 };
 use super::{
     append_follow_up_user_texts, render_operator_interjection_text, AgentLoopOutcome,
-    LoopControlOptions, TurnRoundRecord,
-    MAX_OUTPUT_RECOVERY_ATTEMPTS, ROUND_TEXT_PREVIEW_LIMIT,
+    LoopControlOptions, TurnRoundRecord, MAX_OUTPUT_RECOVERY_ATTEMPTS, ROUND_TEXT_PREVIEW_LIMIT,
     WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
 };
 use super::{truncate_preview, CHECKPOINT_RESUME_PROMPT};
@@ -1705,7 +1704,6 @@ impl TurnExecution<'_> {
                 rounds_since_work_item_reminder = rounds_since_work_item_reminder.saturating_add(1);
             }
             completed_rounds.push(round_record);
-
 
             if all_tool_results_should_sleep && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -43,42 +43,8 @@ pub(crate) struct AgentLoopOutcome {
     pub(super) sleep_duration_ms: Option<u64>,
     pub(super) allow_sleep_runnable_work_override: bool,
     pub(super) terminal_kind: TurnTerminalKind,
-    pub(super) terminal_delivery: TurnTerminalDelivery,
 }
 
-#[derive(Debug, Clone)]
-pub(super) struct TurnTerminalDelivery {
-    /// Completion reports already promoted during this turn.
-    pub(super) promoted_completion_reports: Vec<TurnPromotedCompletionReport>,
-    /// Whether the terminal result brief should be suppressed because it would
-    /// only duplicate a promoted completion report.
-    pub(super) suppress_normal_brief: bool,
-}
-
-#[derive(Debug, Clone)]
-pub(super) struct TurnPromotedCompletionReport {
-    pub(super) work_item_id: String,
-    pub(super) brief_id: String,
-}
-
-impl TurnTerminalDelivery {
-    fn normal() -> Self {
-        Self {
-            promoted_completion_reports: Vec::new(),
-            suppress_normal_brief: false,
-        }
-    }
-
-    fn completion_reports(
-        promoted_completion_reports: Vec<TurnPromotedCompletionReport>,
-        suppress_normal_brief: bool,
-    ) -> Self {
-        Self {
-            promoted_completion_reports,
-            suppress_normal_brief,
-        }
-    }
-}
 
 pub(crate) struct LoopControlOptions {
     pub(super) max_tool_rounds: Option<usize>,

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -45,7 +45,6 @@ pub(crate) struct AgentLoopOutcome {
     pub(super) terminal_kind: TurnTerminalKind,
 }
 
-
 pub(crate) struct LoopControlOptions {
     pub(super) max_tool_rounds: Option<usize>,
 }

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -2184,65 +2184,6 @@ fn completion_report_texts_empty_when_no_text_precedes() {
 }
 
 // -----------------------------------------------------------------------
-// round_has_post_completion_non_completion_tool_call tests
-// -----------------------------------------------------------------------
-
-#[test]
-fn post_completion_false_when_no_tools() {
-    let blocks = vec![ModelBlock::Text {
-        text: "hello".to_string(),
-    }];
-    assert!(!round_has_post_completion_non_completion_tool_call(&blocks));
-}
-
-#[test]
-fn post_completion_false_when_only_complete_work_item() {
-    let blocks = vec![
-        ModelBlock::Text {
-            text: "report".to_string(),
-        },
-        ModelBlock::ToolUse {
-            id: "call_1".to_string(),
-            name: "CompleteWorkItem".to_string(),
-            input: serde_json::json!({}),
-        },
-    ];
-    assert!(!round_has_post_completion_non_completion_tool_call(&blocks));
-}
-
-#[test]
-fn post_completion_true_when_tool_after_complete() {
-    let blocks = vec![
-        ModelBlock::ToolUse {
-            id: "call_1".to_string(),
-            name: "CompleteWorkItem".to_string(),
-            input: serde_json::json!({}),
-        },
-        ModelBlock::ToolUse {
-            id: "call_2".to_string(),
-            name: "ExecCommand".to_string(),
-            input: serde_json::json!({"cmd": "echo hi"}),
-        },
-    ];
-    assert!(round_has_post_completion_non_completion_tool_call(&blocks));
-}
-
-#[test]
-fn post_completion_false_when_multiple_completes_no_other() {
-    let blocks = vec![
-        ModelBlock::ToolUse {
-            id: "call_1".to_string(),
-            name: "CompleteWorkItem".to_string(),
-            input: serde_json::json!({}),
-        },
-        ModelBlock::ToolUse {
-            id: "call_2".to_string(),
-            name: "CompleteWorkItem".to_string(),
-            input: serde_json::json!({}),
-        },
-    ];
-    assert!(!round_has_post_completion_non_completion_tool_call(&blocks));
-}
 
 // -----------------------------------------------------------------------
 // tool_result_invalidates_checkpoint_anchor tests


### PR DESCRIPTION
## 背景

 最初是为了避免 CompleteWorkItem promote completion report 时产生重复 brief。现在同一个 turn 已经支持多条 brief，抑制机制不再必要——normal result brief 是 turn 级别结果，promoted completion report 是 work item 级别完成记录，两者用途不同。

## 改动

| 文件 | 改动 |
|---|---|
| `src/runtime/turn/mod.rs` | 删除 `TurnTerminalDelivery` 结构体和 `AgentLoopOutcome.terminal_delivery` 字段 |
| `src/runtime/turn/execution.rs` | 删除 6 处 `terminal_delivery` 赋值、`promoted_completion_reports` 累积、`post_completion_continuation_action` 及赋值 |
| `src/runtime/operator_dispatch.rs` | 无条件生成 result brief，移除 `suppress_normal_brief` 判断和审计事件 |
| `src/runtime/turn/completion.rs` | 删除 `round_has_post_completion_non_completion_tool_call`（无调用者） |
| `src/runtime/turn/tests.rs` | 删除对应测试 |
| `src/runtime/tests/work_items.rs` | 更新断言：expect normal brief after promotion |

## 验证

- `RUSTFLAGS="-D warnings" cargo check --all-targets` 通过，零错误零警告
- 实际行为不变：正常 turn 结束时仍然生成 result brief；CompleteWorkItem 仍然 promote completion report