### PR TITLE
fix: web-gui model picker not showing Thinking selector after reasoning_summaries rename

### DIFF
--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -10,7 +10,7 @@ describe("projectModelOptions", () => {
           model: "openai-codex/gpt-5.5",
           provider: "openai-codex",
           capabilities: {
-            reasoning_summaries: true,
+            supports_reasoning: true,
           },
         },
       ],

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -363,12 +363,14 @@ interface RuntimeAvailableModelDto {
   capabilities?: {
     image_input?: boolean;
     reasoning_summaries?: boolean;
+    supports_reasoning?: boolean;
   };
   policy?: {
     supported_parameters?: string[];
     capabilities?: {
       image_input?: boolean;
       reasoning_summaries?: boolean;
+      supports_reasoning?: boolean;
     };
   };
   supported_parameters?: string[];
@@ -385,6 +387,7 @@ interface ModelAvailabilityDto {
     capabilities?: {
       image_input?: boolean;
       reasoning_summaries?: boolean;
+      supports_reasoning?: boolean;
     };
   };
 }
@@ -1748,7 +1751,9 @@ function supportsReasoningEffort(entry: ModelAvailabilityDto | RuntimeAvailableM
   return (
     entry.policy?.supported_parameters?.includes("reasoning_effort") ||
     ("supported_parameters" in entry && entry.supported_parameters?.includes("reasoning_effort")) ||
+    entry.policy?.capabilities?.supports_reasoning ||
     entry.policy?.capabilities?.reasoning_summaries ||
+    ("capabilities" in entry && entry.capabilities?.supports_reasoning) ||
     ("capabilities" in entry && entry.capabilities?.reasoning_summaries) ||
     false
   );


### PR DESCRIPTION
## 问题

PR #2055 在 `ModelCapabilityFlags` 中去掉了 `reasoning_summaries` 字段，推理模型现在只返回 `supports_reasoning: true`。但 web-gui 的 `supportsReasoningEffort()` 函数只检查旧的 `reasoning_summaries`，不认识新字段，导致所有模型都不显示 Thinking 选择器。

## 修复

在 DTO 接口中加入 `supports_reasoning` 字段，同时在 `supportsReasoningEffort()` 中检查该字段。保留对旧字段 `reasoning_summaries` 的兼容性检查。

## 改动

- `web-gui/app/src/runtime/client.ts` — DTO 接口和检查函数增加 `supports_reasoning`
- `web-gui/app/src/runtime/client.test.ts` — 测试用例更新为新字段名