### PR TITLE
perf: SQLite PRAGMA tuning — add wal_autocheckpoint, synchronous, mmap_size to connection init

### DIFF
--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -505,6 +505,9 @@ impl MemoryIndex {
             r#"
             PRAGMA journal_mode = WAL;
             PRAGMA busy_timeout = 5000;
+            PRAGMA synchronous = NORMAL;
+            PRAGMA wal_autocheckpoint = 10000;
+            PRAGMA mmap_size = 268435456;
             "#,
         )?;
         index.ensure_schema()?;

--- a/src/runtime_db/connection.rs
+++ b/src/runtime_db/connection.rs
@@ -48,6 +48,9 @@ pub(crate) fn configure_persistent_database(connection: &Connection) -> Result<(
     connection.execute_batch(
         r#"
 PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA wal_autocheckpoint = 10000;
+PRAGMA mmap_size = 268435456;
 "#,
     )?;
     Ok(())


### PR DESCRIPTION
## Summary

Closes #2063

Add three SQLite PRAGMAs to both connection initialization paths (`src/runtime_db/connection.rs` and `src/memory/index.rs`):

| PRAGMA | Value | Rationale |
|--------|-------|-----------|
| `wal_autocheckpoint` | 10000 (~40MB) | Reduces checkpoint frequency ~10x, cutting exclusive lock contention under high-concurrency workloads (20+ agents) |
| `synchronous` | NORMAL | Safe under WAL mode, significantly reduces fsync overhead vs default FULL |
| `mmap_size` | 268435456 (256MB) | Enables memory-mapped reads for the 5.5GB database, reducing read() syscall overhead |

## Context

From 2026-06-29 patrol data: `runtime.sqlite` is 5.5GB with 1.65M `audit_events` rows. Default `wal_autocheckpoint = 1000` (~4MB) triggers frequent checkpoints that hold exclusive locks, contributing to 30K+ "database is locked" errors.

This is a **mitigation**, not a root-cause fix. The primary CPU/lock issue is tracked in #2061 (memory indexer busy-loop). This PR is complementary — low-risk, well-understood PRAGMAs.

## Verification

- `cargo fmt --all -- --check` pass
- `RUSTFLAGS="-D warnings" cargo check --all-targets` pass

## Scope

6 lines added across 2 files. No logic changes, no new dependencies.