### PR TITLE
fix: address review feedback on memory indexer (#2061 follow-up)

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -4,7 +4,7 @@ use std::{
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{Arc, Weak},
+    sync::{Arc, Mutex, Weak},
     time::Duration,
 };
 
@@ -14,6 +14,7 @@ use tokio::{
     sync::{Notify, RwLock},
     task::{spawn_blocking, JoinHandle},
 };
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::{
@@ -105,6 +106,8 @@ struct HostInner {
     runtime_db: RuntimeDb,
     event_bus: EventBus,
     memory_index_notify: Arc<Notify>,
+    daemon_indexer_token: CancellationToken,
+    daemon_indexer_handle: Mutex<Option<JoinHandle<()>>>,
     skills_registry: Arc<RwLock<SkillsRegistry>>,
     static_provider: Option<Arc<dyn AgentProvider>>,
     agents: RwLock<HashMap<String, AgentEntry>>,
@@ -204,6 +207,8 @@ impl RuntimeHost {
                 runtime_db,
                 event_bus: EventBus::new(1024),
                 memory_index_notify: Arc::new(Notify::new()),
+                daemon_indexer_token: CancellationToken::new(),
+                daemon_indexer_handle: Mutex::new(None),
                 skills_registry: Arc::new(RwLock::new(SkillsRegistry::new())),
                 static_provider,
                 agents: RwLock::new(HashMap::new()),
@@ -275,9 +280,22 @@ impl RuntimeHost {
             return;
         }
         let host = self.clone();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             host.run_daemon_memory_indexer().await;
         });
+        *self.inner.daemon_indexer_handle.lock().unwrap() = Some(handle);
+    }
+
+    /// Signal the daemon memory indexer to stop and await its exit.
+    ///
+    /// Called during graceful shutdown so the indexer does not outlive the
+    /// process servers.
+    pub async fn shutdown_daemon_memory_indexer(&self) {
+        self.inner.daemon_indexer_token.cancel();
+        let handle = self.inner.daemon_indexer_handle.lock().unwrap().take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
     }
 
     const DAEMON_INDEXER_BATCH: usize = 500;
@@ -286,6 +304,9 @@ impl RuntimeHost {
     async fn run_daemon_memory_indexer(self) {
         use crate::memory::refresh_memory_index_bounded;
         loop {
+            if self.inner.daemon_indexer_token.is_cancelled() {
+                break;
+            }
             let agent_ids = match self
                 .inner
                 .runtime_db
@@ -356,6 +377,7 @@ impl RuntimeHost {
 
     async fn wait_daemon_indexer_round(&self) {
         tokio::select! {
+            _ = self.inner.daemon_indexer_token.cancelled() => {}
             _ = self.inner.memory_index_notify.notified() => {}
             _ = tokio::time::sleep(Self::DAEMON_INDEXER_FALLBACK_POLL) => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -879,6 +879,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
                 .context("runtime servers failed")
         };
         let _ = runtime_service.cleanup_state_files(&config);
+        host.shutdown_daemon_memory_indexer().await;
         return result;
     }
 
@@ -905,6 +906,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
                 .context("HTTP server failed")?;
         }
         let _ = runtime_service.cleanup_state_files(&config);
+        host.shutdown_daemon_memory_indexer().await;
         Ok(())
     }
 }

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -3630,6 +3630,57 @@ mod tests {
     }
 
     #[test]
+    fn consume_runtime_outbox_deletes_consumed_rows() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+
+        let changes: Vec<_> = (0..5)
+            .map(|i| RuntimeIndexChange {
+                agent_id: "default".into(),
+                source_kind: "brief".into(),
+                source_id: format!("test-{i}"),
+                source_ref: format!("brief:test-{i}"),
+                operation: RuntimeIndexOperation::Upsert,
+                source_updated_at: Some(Utc::now()),
+                reason: "test_consume_delete".into(),
+            })
+            .collect();
+        runtime_db
+            .runtime_index_outbox()
+            .append_changes(&changes)
+            .unwrap();
+
+        // Outbox has rows before consumption.
+        assert_eq!(
+            runtime_db
+                .runtime_index_outbox()
+                .high_watermark_for_agent("default")
+                .unwrap(),
+            5
+        );
+
+        // Consume all rows via the full refresh path.
+        let status = refresh_memory_index_bounded(&storage, None, 100).unwrap();
+        assert_eq!(status.lag, 0);
+        assert!(!status.consumption_was_limited);
+
+        // All consumed rows should have been deleted.
+        assert_eq!(
+            runtime_db
+                .runtime_index_outbox()
+                .high_watermark_for_agent("default")
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
     fn memory_get_hydrates_transcript_backed_brief_content() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -209,7 +209,6 @@ pub async fn run_once(config: AppConfig, request: RunOnceRequest) -> Result<RunO
     std::fs::create_dir_all(config.agent_root_dir())?;
     std::fs::create_dir_all(config.run_dir())?;
     let host = RuntimeHost::new(config)?;
-    host.spawn_daemon_memory_indexer();
     run_once_with_host(host, request).await
 }
 

--- a/src/runtime_db/index_outbox.rs
+++ b/src/runtime_db/index_outbox.rs
@@ -84,7 +84,8 @@ impl RuntimeIndexOutboxRepository<'_> {
     /// Return distinct agent ids that have at least one pending outbox row,
     /// ordered for deterministic processing.
     ///
-    /// Uses the `idx_runtime_index_outbox_agent_seq` index for efficiency.
+    /// Can be served by the `idx_runtime_index_outbox_agent_seq` covering index,
+    /// though the planner ultimately decides the access path.
     pub fn agent_ids_with_pending(&self) -> Result<Vec<String>> {
         let connection = self.db.connection()?;
         let mut statement = connection


### PR DESCRIPTION
## Summary

Addresses review feedback from holonbot on PR #2065 (merged).

### Changes

1. **Daemon indexer shutdown path (should-fix):** Added `CancellationToken` + retained `JoinHandle` + `shutdown_daemon_memory_indexer()` method. The indexer loop now checks `is_cancelled()` at the top of each iteration, and `wait_daemon_indexer_round` has a `token.cancelled()` arm. `serve()` calls shutdown after servers complete.

2. **Remove unnecessary spawn from `run_once` (nit):** Single-turn path does not need the daemon indexer; removed the spawn.

3. **Soften doc comment (nit):** Changed `agent_ids_with_pending` doc from "Uses the `idx_runtime_index_outbox_agent_seq` index for efficiency" to "Can be served by the ... covering index, though the planner ultimately decides the access path."

4. **Integration test for DELETE-after-consume:** Added `consume_runtime_outbox_deletes_consumed_rows` test that appends 5 outbox rows, runs `refresh_memory_index_bounded`, and asserts `high_watermark_for_agent` returns to 0.

### Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib memory::index::tests` (35 tests) ✅