### PR TITLE
feat: emit first-run intro when provider is configured

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -129,6 +129,19 @@ impl AppConfig {
         Ok(reloaded)
     }
 
+    /// Returns true when the default model provider has a usable credential,
+    /// indicating the agent can actually make model calls.
+    ///
+    /// Local providers with `CredentialSource::None` (e.g. vllm) are excluded
+    /// because their availability cannot be verified from config alone — they
+    /// exist in the builtin registry regardless of whether the service is running.
+    pub fn default_provider_ready(&self) -> bool {
+        self.providers
+            .get(&self.default_model.provider)
+            .map(provider_has_usable_auth)
+            .unwrap_or(false)
+    }
+
     fn load_with_home_and_mode(
         home_override: Option<PathBuf>,
         mode: ConfigLoadMode,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2524,3 +2524,56 @@ fn provider_doc_entries_are_sorted_and_populated() {
         );
     }
 }
+
+#[test]
+fn default_provider_ready_with_configured_credential() {
+    let fixture = test_app_config("openai/gpt-4o", &[]);
+    assert!(
+        fixture.config.default_provider_ready(),
+        "openai with a configured credential should be ready"
+    );
+}
+
+#[test]
+fn default_provider_ready_false_for_credential_source_none() {
+    let mut fixture = test_app_config("openai/gpt-4o", &[]);
+    // Simulate a local provider (e.g. vllm) with CredentialSource::None.
+    let vllm = ProviderId::parse("vllm").unwrap();
+    fixture.config.providers.insert(
+        vllm.clone(),
+        ProviderRuntimeConfig {
+            id: vllm.clone(),
+            transport: ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "http://127.0.0.1:8000/v1".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::None,
+                kind: CredentialKind::None,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        },
+    );
+    fixture.config.default_model = ModelRef::parse("vllm/test-model").unwrap();
+    assert!(
+        !fixture.config.default_provider_ready(),
+        "CredentialSource::None providers should not be considered ready"
+    );
+}
+
+#[test]
+fn default_provider_ready_false_when_provider_missing() {
+    let mut fixture = test_app_config("openai/gpt-4o", &[]);
+    fixture.config.default_model = ModelRef::parse("nonexistent/model").unwrap();
+    assert!(
+        !fixture.config.default_provider_ready(),
+        "missing provider should not be ready"
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,11 +39,15 @@ use holon::{
     onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
+    runtime::RuntimeHandle,
     runtime_db::RuntimeDb,
     solve::{run_solve, SolveRequest},
     storage::AppStorage,
     tui::run_tui,
-    types::{AuditEvent, AuthorityClass, ControlAction, TimerStatus},
+    types::{
+        AdmissionContext, AuditEvent, AuthorityClass, ControlAction, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority, TimerStatus,
+    },
 };
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
@@ -782,6 +786,51 @@ fn restart_serve_launch_options(
     Ok(serve_args_for_options(&options))
 }
 
+/// On the first run with a configured provider, enqueue a one-time prompt so
+/// the agent greets the user and explains what it can do.
+///
+/// First-run is detected via `total_message_count == 0`: the count is
+/// persisted and restored from DB on restart, so the intro fires exactly once
+/// per fresh agent state.
+async fn maybe_emit_first_run_intro(config: &AppConfig, runtime: &RuntimeHandle) {
+    if !config.default_provider_ready() {
+        return;
+    }
+    let state = match runtime.agent_state().await {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!("failed to read agent state for first-run intro: {error:#}");
+            return;
+        }
+    };
+    if state.total_message_count > 0 {
+        return;
+    }
+    let intro_prompt = "This is the first run of Holon with a model provider configured. \
+        Introduce yourself to the user: greet them, briefly explain what you can do as a Holon \
+        agent, and suggest a few starter actions they could try. Keep it friendly and concise — \
+        this is a one-time welcome, not a generic bot template.";
+    let message = MessageEnvelope::new(
+        state.id.clone(),
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("first_run_intro".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: intro_prompt.to_string(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    if let Err(error) = runtime.enqueue(message).await {
+        eprintln!("failed to enqueue first-run intro: {error:#}");
+    }
+}
+
 async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     let serve_args = serve_args_for_options(&options).args;
     let web_dist = options.web_dist.clone();
@@ -814,8 +863,9 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     }
 
     let host = RuntimeHost::new(config.clone())?;
-    host.default_runtime().await?;
+    let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
+    maybe_emit_first_run_intro(&config, &runtime).await;
     let runtime_service = RuntimeServiceHandle::new(&config)?;
 
     let tcp_router = http::router(


### PR DESCRIPTION
## Summary

Implements [#1993](https://github.com/holon-run/holon/issues/1993) Part 1: first-run intro message.

On the first run of Holon with a usable model provider, the runtime enqueues a one-time `OperatorPrompt` so the agent greets the user and explains what it can do.

## Design

**Trigger condition:** `default_provider_ready() && total_message_count == 0`

- **`default_provider_ready()`** (new method on `AppConfig`): uses `provider_has_usable_auth`, which correctly excludes `CredentialSource::None` providers (e.g. vllm) that exist in the builtin registry regardless of whether the service is actually running. This avoids the false-positive discussed in [#1993](https://github.com/holon-run/holon/issues/1993).
- **`total_message_count == 0`**: already persisted and restored from DB on restart — no separate `intro_sent` flag needed. Daemon restart, crash recovery, and DB reset all behave correctly.
- **Message construction**: `OperatorPrompt` with `actor_id: "first_run_intro"` — required by the message policy (`OperatorPrompt` must use `Operator` origin). The `actor_id` makes it traceable in audit logs.

## Changes

- `src/config/mod.rs`: `AppConfig::default_provider_ready()` — 4-line method delegating to `provider_has_usable_auth`
- `src/main.rs`: `maybe_emit_first_run_intro()` — checks readiness + first-run, enqueues intro prompt. Non-critical: failures log a warning and continue.
- `src/config/tests.rs`: 3 unit tests covering configured credential (true), `CredentialSource::None` (false), missing provider (false)

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib default_provider_ready` — 3/3 pass ✅

Closes #1993