### PR TITLE
fix: coerce_string now parses JSON-string arrays/objects

### DIFF
--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -127,6 +127,18 @@ fn coerce_string(s: &str) -> Option<Value> {
             return Some(Value::Number(serde_json::Number::from_f64(f)?));
         }
     }
+
+    // If the string looks like a JSON array or object, try parsing it.
+    // This recovers the common LLM mistake of serializing a structured
+    // field as a JSON string instead of inline JSON.
+    let trimmed = s.trim_start();
+    if trimmed.starts_with('[') || trimmed.starts_with('{') {
+        if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+            if parsed.is_array() || parsed.is_object() {
+                return Some(parsed);
+            }
+        }
+    }
     None
 }
 
@@ -591,5 +603,49 @@ mod tests {
     fn coerce_string_scalars_returns_none_when_no_change() {
         let input = json!({"name": "test", "cmd": "echo"});
         assert!(coerce_string_scalars(&input).is_none());
+    }
+
+    #[test]
+    fn coerce_string_json_array() {
+        let s = r#"[{"text":"do something","state":"pending"}]"#;
+        let result = coerce_string(s).expect("should parse JSON array");
+        assert_eq!(
+            result,
+            json!([{"text": "do something", "state": "pending"}])
+        );
+    }
+
+    #[test]
+    fn coerce_string_json_object() {
+        let s = r#"{"key":"value","num":42}"#;
+        let result = coerce_string(s).expect("should parse JSON object");
+        assert_eq!(result, json!({"key": "value", "num": 42}));
+    }
+
+    #[test]
+    fn coerce_string_invalid_json_left_untouched() {
+        // Starts with [ but is not valid JSON — should return None.
+        assert_eq!(coerce_string("[invalid"), None);
+        assert_eq!(coerce_string("{not json"), None);
+    }
+
+    #[test]
+    fn coerce_string_plain_text_with_brace_untouched() {
+        // Text that merely starts with { or [ but is not JSON should be preserved.
+        assert_eq!(coerce_string("{placeholder}"), None);
+        assert_eq!(coerce_string("[link]"), None);
+    }
+
+    #[test]
+    fn coerce_string_scalars_json_string_field() {
+        // Simulates the LLM mistake: todo_list serialized as a JSON string.
+        let input = json!({
+            "todo_list": "[{\"text\":\"step 1\",\"state\":\"pending\"}]"
+        });
+        let result = coerce_string_scalars(&input).expect("should have coerced");
+        assert_eq!(
+            result,
+            json!({"todo_list": [{"text": "step 1", "state": "pending"}]})
+        );
     }
 }


### PR DESCRIPTION
Closes #1937

## Summary

Extend `coerce_string` in `src/tool/helpers.rs` to attempt JSON parsing when a string value starts with `[` or `{`. This recovers the common LLM mistake of serializing structured fields (e.g. `todo_list`) as JSON strings instead of inline JSON.

## Problem

Multiple agents using `dashscope/qwen3.7-max` serialize `todo_list` as a JSON string instead of an array, causing ~93 `invalid_tool_input` errors. Example:

```json
"todo_list": "[{\"text\":\"xxx\", \"state\":\"pending\"}]"
```

should be:

```json
"todo_list": [{"text":"xxx", "state":"pending"}]
```

## Change

In `coerce_string`, after the existing bool/int/float checks, add a JSON-string parse attempt when the trimmed string starts with `[` or `{`:

- Only valid JSON arrays/objects are adopted (bare scalars already handled above)
- Invalid JSON or text that merely starts with `{`/`[` is left untouched
- All tools benefit automatically since `coerce_string_scalars` is the unified entry point for tool input parsing

## Tests

5 new unit tests added covering: JSON array parsing, JSON object parsing, invalid JSON left untouched, plain text with braces untouched, and the `todo_list` JSON-string field scenario.

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets`
- [x] `cargo test --lib coerce_string` (12 passed)