### PR TITLE
fix: revoke external triggers when agent is stopped

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -259,6 +259,29 @@ impl RuntimeHandle {
                 .latest_active_task_records_for_agent(&agent_id, usize::MAX)?;
             self.interrupt_active_tasks_for_lifecycle_stop(active_tasks)
                 .await?;
+
+            // Revoke all active external triggers to prevent capability
+            // secret leakage and unexpected wake after the agent is stopped.
+            let triggers = self.latest_external_triggers().await?;
+            for trigger in triggers
+                .iter()
+                .filter(|t| t.status == ExternalTriggerStatus::Active)
+            {
+                match self
+                    .revoke_external_trigger(&trigger.external_trigger_id)
+                    .await
+                {
+                    Ok(_) => tracing::info!(
+                        external_trigger_id = %trigger.external_trigger_id,
+                        "revoked external trigger during agent stop"
+                    ),
+                    Err(err) => tracing::warn!(
+                        external_trigger_id = %trigger.external_trigger_id,
+                        error = %err,
+                        "failed to revoke external trigger during agent stop"
+                    ),
+                }
+            }
         }
         self.inner.storage.append_event(&AuditEvent::new(
             "control_applied",

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3340,3 +3340,48 @@ async fn register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits() {
         .unwrap();
     assert_eq!(first_record.status, WaitConditionStatus::Cancelled);
 }
+
+#[tokio::test]
+async fn stop_agent_revokes_active_external_triggers() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(CountingProvider {
+        calls: Mutex::new(0),
+        reply: "unused",
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    // Create a default external trigger.
+    let capability = runtime
+        .default_external_trigger(CallbackDeliveryMode::WakeHint)
+        .await
+        .unwrap();
+    let triggers = runtime.latest_external_triggers().await.unwrap();
+    assert_eq!(triggers.len(), 1);
+    assert_eq!(
+        triggers[0].status,
+        crate::types::ExternalTriggerStatus::Active
+    );
+
+    // Stop the agent — should revoke all active triggers.
+    runtime
+        .control(crate::types::ControlAction::Stop)
+        .await
+        .unwrap();
+
+    let triggers = runtime.latest_external_triggers().await.unwrap();
+    let revoked = triggers
+        .iter()
+        .find(|t| t.external_trigger_id == capability.external_trigger_id)
+        .expect("trigger should still exist");
+    assert_eq!(revoked.status, crate::types::ExternalTriggerStatus::Revoked);
+}

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -256,13 +256,11 @@ pub async fn callback_wake_hint_rejects_stopped_public_agent_without_side_effect
         }))
         .send()
         .await?;
-    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
-    let payload: serde_json::Value = response.json().await?;
-    assert_eq!(payload["code"], "agent_stopped");
+    // After stop, the external trigger is revoked, so the token is no
+    // longer valid and the callback is rejected at the token level.
+    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
 
-    let waiting: Vec<()> = vec![];
     let descriptors = runtime.latest_external_triggers().await?;
-    assert!(waiting.is_empty());
     assert_eq!(descriptors[0].delivery_count, 0);
 
     let events = runtime.storage().read_recent_events(20)?;
@@ -489,13 +487,9 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
         .json(&serde_json::json!({ "status": "still_works" }))
         .send()
         .await?;
-    assert_eq!(second.status(), reqwest::StatusCode::CONFLICT);
-    let second_payload: serde_json::Value = second.json().await?;
-    assert_eq!(second_payload["code"], "agent_stopped");
-    assert!(second_payload["error"]
-        .as_str()
-        .unwrap_or_default()
-        .contains("start first"));
+    // After stop, the external trigger is revoked, so the token is no
+    // longer valid and the callback is rejected at the token level.
+    assert_eq!(second.status(), reqwest::StatusCode::FORBIDDEN);
 
     let runtime_for_wait = runtime2.clone();
     wait_until_async(move || {
@@ -513,10 +507,6 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
         }
     })
     .await?;
-
-    runtime2
-        .revoke_external_trigger(&capability.external_trigger_id)
-        .await?;
 
     server2.abort();
     Ok(())


### PR DESCRIPTION
Closes #1963

## Summary

When `ControlAction::Stop` is applied, enumerate and revoke all active external triggers for the agent. This prevents capability secret leakage and unexpected wake calls after the agent is stopped.

## Problem

Stopped agents retained active external triggers with plaintext capability tokens (`cb_<hex>`) in their callback URLs. Patrol data showed 15 stopped `tmp_child` agents each retaining 1 active trigger with `delivery_count=0` — the triggers were never used but remained callable, creating a security risk and orphaned trigger accumulation.

## Change

In `src/runtime/lifecycle.rs`, the `ControlAction::Stop` branch now:
1. Enumerates all external triggers for the agent via `latest_external_triggers()`
2. Filters for `Active` status
3. Calls `revoke_external_trigger()` for each — this updates status to `Revoked`, sets `revoked_at`, persists to DB, updates projection cache, and emits an audit event

On agent restart, `ensure_default_external_ingress` will create a fresh trigger as needed.

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets`
- [x] `cargo test --lib stop_agent_revokes` (1 passed)