### PR TITLE
feat: expose AgentTemplate catalog and lifecycle daemon APIs (#1983)

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -323,6 +323,11 @@
         "title": "CancelTimerRequest",
         "type": "object"
       },
+      "CheckTemplateRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
       "ClearAgentModelRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -511,6 +516,11 @@
         "type": "object"
       },
       "InstallSkillRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "InstallTemplateRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
@@ -1622,6 +1632,11 @@
         "type": "object"
       },
       "RemoveSkillRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "RemoveTemplateRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
@@ -8614,6 +8629,122 @@
         ]
       }
     },
+    "/api/control/templates/install": {
+      "post": {
+        "description": "Install a template package from a GitHub tree URL into the user global library.",
+        "operationId": "installTemplate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Install template",
+        "tags": [
+          "templates"
+        ]
+      }
+    },
+    "/api/control/templates/remove": {
+      "post": {
+        "description": "Remove a template from the user global library.",
+        "operationId": "removeTemplate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remove template",
+        "tags": [
+          "templates"
+        ]
+      }
+    },
     "/api/enqueue": {
       "post": {
         "description": "Enqueue a public channel/webhook message for the default agent.",
@@ -9578,6 +9709,160 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
+    "/api/templates/catalog": {
+      "get": {
+        "description": "Return the global AgentTemplate catalog (builtin + user global library).",
+        "operationId": "templatesCatalog",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Template catalog",
+        "tags": [
+          "templates"
+        ]
+      }
+    },
+    "/api/templates/catalog/check": {
+      "post": {
+        "description": "Validate a local template directory without applying it.",
+        "operationId": "checkTemplate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Check template",
+        "tags": [
+          "templates"
+        ]
+      }
+    },
+    "/api/templates/catalog/{catalog_id}": {
+      "get": {
+        "description": "Return template detail with full AGENTS.md content, manifest, and skill dependencies.",
+        "operationId": "templateDetail",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Template detail",
+        "tags": [
+          "templates"
+        ]
+      }
+    },
     "/api/transcript": {
       "get": {
         "description": "Compatibility alias for the default agent transcript route. Query parameter: limit.",
@@ -9873,6 +10158,9 @@
     },
     {
       "name": "skills"
+    },
+    {
+      "name": "templates"
     },
     {
       "name": "jobs"

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1864,6 +1864,216 @@ fn create_directory_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::os::windows::fs::symlink_dir(src, dst)
 }
 
+// ---------------------------------------------------------------------------
+// Public API helpers for HTTP handlers
+// ---------------------------------------------------------------------------
+
+/// Parse `template.toml` from a local template directory and return it as a
+/// JSON value for API responses.
+pub fn parse_template_manifest_for_api(template_dir: &Path) -> Option<serde_json::Value> {
+    parse_local_template_manifest(template_dir).map(|manifest| {
+        serde_json::json!({
+            "schema": manifest.schema,
+            "id": manifest.id,
+            "name": manifest.name,
+            "summary": manifest.summary,
+        })
+    })
+}
+
+/// Remove a template from the user global library.
+pub fn remove_user_template(user_home: &Path, template_id: &str) -> Result<()> {
+    validate_template_id(template_id)?;
+    let templates_root = templates_root_for_home(user_home);
+    let target = templates_root.join(template_id);
+    if !target.is_dir() {
+        bail!(
+            "template '{}' not found in user global library at {}",
+            template_id,
+            templates_root.display()
+        );
+    }
+    fs::remove_dir_all(&target)
+        .with_context(|| format!("failed to remove {}", target.display()))?;
+    tracing::info!(template_id, "removed user global template");
+    Ok(())
+}
+
+/// Install a template package from a GitHub tree URL into the user global
+/// library.
+///
+/// Expected URL: `https://github.com/<owner>/<repo>/tree/<ref>[/<path>]`
+pub fn install_template_from_github(user_home: &Path, github_url: &str) -> Result<String> {
+    let source = ParsedGithubTemplateUrl::parse(github_url)?;
+    let templates_root = templates_root_for_home(user_home);
+    fs::create_dir_all(&templates_root)
+        .with_context(|| format!("failed to create {}", templates_root.display()))?;
+
+    let tmp = templates_root.join(format!(
+        ".tmp-holon-template-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let _guard = TmpDirGuard(&tmp);
+
+    fs::create_dir_all(&tmp).with_context(|| format!("failed to create {}", tmp.display()))?;
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .user_agent(format!("holon/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("failed to create HTTP client for template install")?;
+
+    let tarball_url = format!(
+        "https://api.github.com/repos/{}/{}/tarball/{}",
+        source.owner, source.repo, source.reference
+    );
+    let response = client
+        .get(&tarball_url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .context("failed to request GitHub tarball")?;
+    if !response.status().is_success() {
+        bail!("GitHub tarball download failed: HTTP {}", response.status());
+    }
+    let bytes = response
+        .bytes()
+        .context("failed to read GitHub tarball body")?;
+    let tarball_path = tmp.join("archive.tar.gz");
+    fs::write(&tarball_path, &bytes)
+        .with_context(|| format!("failed to write tarball to {}", tarball_path.display()))?;
+
+    let extract_dir = tmp.join("extracted");
+    fs::create_dir_all(&extract_dir)?;
+    extract_tarball(&tarball_path, &extract_dir)?;
+
+    // GitHub tarballs contain a single top-level directory.
+    let mut search_dir = extract_dir.clone();
+    let entries: Vec<_> = fs::read_dir(&search_dir)?.collect::<Result<_, _>>()?;
+    if entries.len() == 1 && entries[0].path().is_dir() {
+        search_dir = entries[0].path();
+    }
+    if !source.path.is_empty() {
+        search_dir = search_dir.join(&source.path);
+    }
+    if !search_dir.is_dir() {
+        bail!(
+            "template directory not found at '{}' in the downloaded archive",
+            source.path
+        );
+    }
+
+    if !search_dir.join(TEMPLATE_MANIFEST_FILENAME).exists()
+        && !search_dir.join("AGENTS.md").exists()
+    {
+        bail!(
+            "the specified path does not contain template.toml or AGENTS.md; \
+             not a valid template directory"
+        );
+    }
+
+    let template_id = parse_local_template_manifest(&search_dir)
+        .map(|m| m.id)
+        .unwrap_or_else(|| {
+            search_dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("imported")
+                .to_string()
+        });
+    validate_template_id(&template_id)?;
+
+    let destination = templates_root.join(&template_id);
+    if destination.exists() {
+        fs::remove_dir_all(&destination)
+            .with_context(|| format!("failed to clear existing {}", destination.display()))?;
+    }
+    copy_template_dir(&search_dir, &destination)?;
+
+    tracing::info!(template_id = %template_id, "installed user global template from GitHub");
+    Ok(template_id)
+}
+
+struct TmpDirGuard<'a>(&'a Path);
+impl Drop for TmpDirGuard<'_> {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(self.0);
+    }
+}
+
+struct ParsedGithubTemplateUrl {
+    owner: String,
+    repo: String,
+    reference: String,
+    path: String,
+}
+
+impl ParsedGithubTemplateUrl {
+    fn parse(url: &str) -> Result<Self> {
+        let url = url.trim();
+        let rest = url
+            .strip_prefix("https://github.com/")
+            .or_else(|| url.strip_prefix("http://github.com/"))
+            .ok_or_else(|| anyhow!("github_url must be a https://github.com/ URL"))?;
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() < 2 {
+            bail!("invalid GitHub URL: expected owner/repo/tree/ref[/path]");
+        }
+        let owner = parts[0].to_string();
+        let repo = parts[1].trim_end_matches(".git").to_string();
+        if parts.len() < 4 || parts[2] != "tree" {
+            bail!("invalid GitHub URL: expected .../tree/<ref>[/<path>]");
+        }
+        let reference = parts[3].to_string();
+        let path = if parts.len() > 4 {
+            parts[4..].join("/")
+        } else {
+            String::new()
+        };
+        Ok(Self {
+            owner,
+            repo,
+            reference,
+            path,
+        })
+    }
+}
+
+fn extract_tarball(tarball_path: &Path, dest: &Path) -> Result<()> {
+    let output = std::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(tarball_path)
+        .arg("-C")
+        .arg(dest)
+        .output()
+        .context("failed to run tar")?;
+    if !output.status.success() {
+        bail!(
+            "tar extraction failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn copy_template_dir(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            if from.file_name().is_some_and(|n| n == ".git") {
+                continue;
+            }
+            copy_template_dir(&from, &to)?;
+        } else if from.is_file() {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -3197,6 +3407,7 @@ name = "Worker"
             Some("https://github.com/owner/repo/tree/main/agent_templates/worker")
         );
     }
+D
     #[tokio::test]
     async fn provenance_records_schema_version_from_template_toml() {
         let _lock = crate::test_env::lock_env();
@@ -3309,5 +3520,62 @@ name = "Versioned"
             .await
             .unwrap_err();
         assert!(err.to_string().contains("already exists"));
+
+#[test]
+    fn parsed_github_template_url_parses_tree_url() {
+        let url = ParsedGithubTemplateUrl::parse(
+            "https://github.com/holon-run/templates/tree/main/my-template",
+        )
+        .unwrap();
+        assert_eq!(url.owner, "holon-run");
+        assert_eq!(url.repo, "templates");
+        assert_eq!(url.reference, "main");
+        assert_eq!(url.path, "my-template");
     }
+
+    #[test]
+    fn parsed_github_template_url_parses_nested_path() {
+        let url = ParsedGithubTemplateUrl::parse(
+            "https://github.com/owner/repo/tree/v1.0.0/nested/path/to/template",
+        )
+        .unwrap();
+        assert_eq!(url.owner, "owner");
+        assert_eq!(url.repo, "repo");
+        assert_eq!(url.reference, "v1.0.0");
+        assert_eq!(url.path, "nested/path/to/template");
+    }
+
+    #[test]
+    fn parsed_github_template_url_parses_without_subpath() {
+        let url =
+            ParsedGithubTemplateUrl::parse("https://github.com/owner/repo/tree/main").unwrap();
+        assert_eq!(url.owner, "owner");
+        assert_eq!(url.repo, "repo");
+        assert_eq!(url.reference, "main");
+        assert!(url.path.is_empty());
+    }
+
+    #[test]
+    fn parsed_github_template_url_rejects_non_github_url() {
+        assert!(ParsedGithubTemplateUrl::parse("https://gitlab.com/owner/repo").is_err());
+        assert!(ParsedGithubTemplateUrl::parse("not-a-url").is_err());
+    }
+
+    #[test]
+    fn parsed_github_template_url_rejects_missing_tree_segment() {
+        assert!(ParsedGithubTemplateUrl::parse("https://github.com/owner/repo").is_err());
+    }
+
+    #[test]
+    fn remove_user_template_removes_existing_and_reports_missing() {
+        let tmp = tempdir().unwrap();
+        let templates_root = templates_root_for_home(tmp.path());
+        let template_dir = templates_root.join("my-test-template");
+        fs::create_dir_all(&template_dir).unwrap();
+        fs::write(template_dir.join("AGENTS.md"), "# test").unwrap();
+
+        let err = remove_user_template(tmp.path(), "my-test-template").unwrap_err();
+        assert!(!template_dir.exists());
+
+        assert!(err.to_string().contains("not found"));    }
 }

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1928,11 +1928,16 @@ pub fn install_template_from_github(user_home: &Path, github_url: &str) -> Resul
         "https://api.github.com/repos/{}/{}/tarball/{}",
         source.owner, source.repo, source.reference
     );
-    let response = client
+    // Forward GITHUB_TOKEN / GH_TOKEN when available so private repos work and
+    // the 60 req/hr unauthenticated rate limit is avoided.
+    let mut request = client
         .get(&tarball_url)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .context("failed to request GitHub tarball")?;
+        .header("Accept", "application/vnd.github+json");
+    if let Ok(token) = env::var("GITHUB_TOKEN").or_else(|_| env::var("GH_TOKEN")) {
+        request = request.bearer_auth(&token);
+    }
+
+    let response = request.send().context("failed to request GitHub tarball")?;
     if !response.status().is_success() {
         bail!("GitHub tarball download failed: HTTP {}", response.status());
     }
@@ -2056,19 +2061,42 @@ fn extract_tarball(tarball_path: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Validate a GitHub template URL format without downloading anything.
+/// Returns a canonical path string (owner/repo/tree/ref[/path]).
+pub fn validate_github_template_url(url: &str) -> Result<String> {
+    let parsed = ParsedGithubTemplateUrl::parse(url)?;
+    Ok(format!(
+        "{}/{}/tree/{}{}",
+        parsed.owner,
+        parsed.repo,
+        parsed.reference,
+        if parsed.path.is_empty() {
+            String::new()
+        } else {
+            format!("/{}", parsed.path)
+        }
+    ))
+}
+
 fn copy_template_dir(src: &Path, dst: &Path) -> Result<()> {
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
+        let file_type = entry.file_type()?;
         let from = entry.path();
         let to = dst.join(entry.file_name());
-        if from.is_dir() {
+        if file_type.is_dir() {
             if from.file_name().is_some_and(|n| n == ".git") {
                 continue;
             }
             copy_template_dir(&from, &to)?;
-        } else if from.is_file() {
+        } else if file_type.is_file() {
             fs::copy(&from, &to)?;
+        } else {
+            bail!(
+                "template contains unsupported file type (e.g. symlink): {}",
+                from.display()
+            );
         }
     }
     Ok(())
@@ -3577,5 +3605,37 @@ name = "Versioned"
         let err = remove_user_template(tmp.path(), "my-test-template").unwrap_err();
         assert!(!template_dir.exists());
 
+D
         assert!(err.to_string().contains("not found"));    }
-}
+
+assert!(err.to_string().contains("not found"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_template_dir_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("AGENTS.md"), "# test").unwrap();
+        // Create a symlink pointing outside the template directory.
+        symlink("/etc/hostname", src.join("evil")).unwrap();
+
+        let err = copy_template_dir(&src, &dst).unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_github_template_url_parses_and_reports() {
+        let result =
+            validate_github_template_url("https://github.com/owner/repo/tree/main/templates/dev")
+                .unwrap();
+        assert_eq!(result, "owner/repo/tree/main/templates/dev");
+
+        assert!(validate_github_template_url("https://gitlab.com/owner/repo").is_err());
+    }}

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -3602,6 +3602,7 @@ name = "Versioned"
         fs::create_dir_all(&template_dir).unwrap();
         fs::write(template_dir.join("AGENTS.md"), "# test").unwrap();
 
+        remove_user_template(tmp.path(), "my-test-template").unwrap();
         let err = remove_user_template(tmp.path(), "my-test-template").unwrap_err();
         assert!(!template_dir.exists());
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -96,6 +96,7 @@ mod jobs;
 mod skills;
 mod state;
 mod tasks;
+mod templates;
 mod types;
 mod web;
 mod workspace_files;
@@ -496,6 +497,20 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/skills/catalog/update", post(skills::update_skill_catalog))
         .route("/skills/catalog/check", post(skills::check_skill_catalog))
+        .route("/templates/catalog", get(templates::templates_catalog))
+        .route(
+            "/templates/catalog/{catalog_id}",
+            get(templates::template_detail),
+        )
+        .route("/templates/catalog/check", post(templates::check_template))
+        .route(
+            "/control/templates/install",
+            post(templates::install_template),
+        )
+        .route(
+            "/control/templates/remove",
+            post(templates::remove_template),
+        )
         .route(
             "/control/agents/{agent_id}/skills/enable",
             post(skills::enable_skill),

--- a/src/http/templates.rs
+++ b/src/http/templates.rs
@@ -1,0 +1,229 @@
+use super::*;
+use std::path::Path as FsPath;
+
+const USER_GLOBAL_LIBRARY_LABEL: &str = "user_global";
+
+/// `GET /templates/catalog`
+///
+/// List all globally visible templates (builtin + user global library).
+/// Agent-scoped templates are excluded from this global catalog endpoint.
+pub async fn templates_catalog(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let user_home = crate::agent_template::user_home_dir().ok();
+    // Use a non-existent agent_home path so the global catalog shows only
+    // builtin + user_global entries, parallel to /skills/catalog.
+    let catalog = crate::agent_template::discover_agent_templates_catalog(
+        user_home.as_deref(),
+        FsPath::new("/nonexistent-agent-home"),
+    );
+    Ok(Json(json!({
+        "ok": true,
+        "catalog": catalog,
+    })))
+}
+
+/// `GET /templates/catalog/{catalog_id}`
+///
+/// Return template detail with full AGENTS.md content, manifest summary,
+/// and skill dependencies.
+pub async fn template_detail(
+    Path(catalog_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let user_home = crate::agent_template::user_home_dir().ok();
+    let catalog = crate::agent_template::discover_agent_templates_catalog(
+        user_home.as_deref(),
+        FsPath::new("/nonexistent-agent-home"),
+    );
+    let Some(entry) = catalog
+        .iter()
+        .find(|entry| entry.catalog_id == catalog_id || entry.template == catalog_id)
+    else {
+        return Err(not_found(format!("template {catalog_id} not found")));
+    };
+
+    let Some(detail) = crate::agent_template::resolve_agent_template_detail(entry) else {
+        return Err(not_found(format!(
+            "template {catalog_id} detail could not be resolved"
+        )));
+    };
+
+    Ok(Json(json!({
+        "ok": true,
+        "detail": detail,
+    })))
+}
+
+/// `POST /templates/catalog/check`
+///
+/// Validate a local template directory without applying it.
+pub async fn check_template(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::CheckTemplateRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let Some(path_str) = request.path.as_deref().filter(|s| !s.is_empty()) else {
+        return Err(error_response(anyhow!(
+            "path is required (github_url validation is not yet supported)"
+        )));
+    };
+
+    let template_dir = std::path::PathBuf::from(path_str);
+    let result = tokio::task::spawn_blocking(move || {
+        let canonical = std::fs::canonicalize(&template_dir)
+            .map_err(|e| anyhow!("failed to resolve path: {e}"))?;
+        if !canonical.is_dir() {
+            return Err(anyhow!("path is not a directory: {}", canonical.display()));
+        }
+        check_template_dir(&canonical)
+    })
+    .await
+    .map_err(|err| error_response(anyhow!("check worker failed: {err}")))?
+    .map_err(error_response)?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "valid": result.valid,
+        "errors": result.errors,
+        "warnings": result.warnings,
+        "manifest": result.manifest,
+    })))
+}
+
+/// `POST /control/templates/install`
+///
+/// Install a template package from a GitHub tree URL into the user global
+/// library.
+pub async fn install_template(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::InstallTemplateRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let github_url = request.github_url.trim().to_string();
+    if github_url.is_empty() {
+        return Err(error_response(anyhow!("github_url must not be empty")));
+    }
+
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
+    let url = github_url.clone();
+    let template_id = tokio::task::spawn_blocking(move || {
+        crate::agent_template::install_template_from_github(&user_home, &url)
+    })
+    .await
+    .map_err(|err| error_response(anyhow!("install worker failed: {err}")))?
+    .map_err(template_install_error_response)?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "template_id": template_id,
+        "library": USER_GLOBAL_LIBRARY_LABEL,
+    })))
+}
+
+/// `POST /control/templates/remove`
+///
+/// Remove a template from the user global library.
+pub async fn remove_template(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::RemoveTemplateRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let template_id = request.template_id.trim().to_string();
+    if template_id.is_empty() {
+        return Err(error_response(anyhow!("template_id must not be empty")));
+    }
+
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
+    let id = template_id.clone();
+    tokio::task::spawn_blocking(move || {
+        crate::agent_template::remove_user_template(&user_home, &id)
+    })
+    .await
+    .map_err(|err| error_response(anyhow!("remove worker failed: {err}")))?
+    .map_err(error_response)?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "template_id": template_id,
+        "library": USER_GLOBAL_LIBRARY_LABEL,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+struct TemplateCheckResult {
+    valid: bool,
+    errors: Vec<String>,
+    warnings: Vec<String>,
+    manifest: Option<Value>,
+}
+
+fn check_template_dir(template_dir: &FsPath) -> anyhow::Result<TemplateCheckResult> {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    // Check for AGENTS.md.
+    let agents_md_path = template_dir.join("AGENTS.md");
+    if !agents_md_path.exists() {
+        errors.push("AGENTS.md not found".to_string());
+    } else {
+        match std::fs::read_to_string(&agents_md_path) {
+            Ok(content) if content.trim().is_empty() => {
+                warnings.push("AGENTS.md is empty".to_string());
+            }
+            Ok(_) => {}
+            Err(e) => errors.push(format!("failed to read AGENTS.md: {e}")),
+        }
+    }
+
+    // Check for template.toml.
+    let manifest = crate::agent_template::parse_template_manifest_for_api(template_dir);
+    match &manifest {
+        Some(m) => {
+            if m.get("schema")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .is_empty()
+            {
+                warnings.push("template.toml schema field is empty".to_string());
+            }
+        }
+        None => {
+            warnings.push("template.toml not found or invalid".to_string());
+        }
+    }
+
+    let valid = errors.is_empty();
+    Ok(TemplateCheckResult {
+        valid,
+        errors,
+        warnings,
+        manifest,
+    })
+}
+
+fn template_install_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "ok": false,
+            "error": error.to_string(),
+            "code": "template_install_failed",
+        })),
+    )
+}

--- a/src/http/templates.rs
+++ b/src/http/templates.rs
@@ -71,9 +71,34 @@ pub async fn check_template(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
 
+    // Handle github_url validation (URL format check only, no download).
+    if let Some(url) = request.github_url.as_deref().filter(|s| !s.is_empty()) {
+        let url_owned = url.to_string();
+        let result = tokio::task::spawn_blocking(move || {
+            let canonical = crate::agent_template::validate_github_template_url(&url_owned)?;
+            Ok::<_, anyhow::Error>(TemplateCheckResult {
+                valid: true,
+                errors: vec![],
+                warnings: vec![format!("URL validated as: {canonical}")],
+                manifest: None,
+            })
+        })
+        .await
+        .map_err(|err| error_response(anyhow!("check worker failed: {err}")))?
+        .map_err(error_response)?;
+
+        return Ok(Json(json!({
+            "ok": true,
+            "valid": result.valid,
+            "errors": result.errors,
+            "warnings": result.warnings,
+            "manifest": result.manifest,
+        })));
+    }
+
     let Some(path_str) = request.path.as_deref().filter(|s| !s.is_empty()) else {
         return Err(error_response(anyhow!(
-            "path is required (github_url validation is not yet supported)"
+            "either path or github_url is required"
         )));
     };
 

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -103,6 +103,11 @@ const ROUTES: &[RouteSpec] = &[
     route("post", "/skills/catalog/refresh", "refreshSkillCatalog", "skills", "Refresh runtime catalog", "Refresh runtime Skill Library catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates.", Some("RefreshCatalogRequest"), AuthKind::Control),
     route("post", "/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Fetch supported remote Skill Library entries described by .skill-lock.json and update changed skills. Returns per-skill status.", Some("UpdateSkillRequest"), AuthKind::Control),
     route("post", "/skills/catalog/check", "checkSkillCatalog", "skills", "Check skill library", "Check Skill Library and lock-file consistency.", Some("CheckSkillRequest"), AuthKind::Control),
+    route("get", "/templates/catalog", "templatesCatalog", "templates", "Template catalog", "Return the global AgentTemplate catalog (builtin + user global library).", None, AuthKind::RemoteAccess),
+    route("get", "/templates/catalog/{catalog_id}", "templateDetail", "templates", "Template detail", "Return template detail with full AGENTS.md content, manifest, and skill dependencies.", None, AuthKind::RemoteAccess),
+    route("post", "/templates/catalog/check", "checkTemplate", "templates", "Check template", "Validate a local template directory without applying it.", Some("CheckTemplateRequest"), AuthKind::RemoteAccess),
+    route("post", "/control/templates/install", "installTemplate", "templates", "Install template", "Install a template package from a GitHub tree URL into the user global library.", Some("InstallTemplateRequest"), AuthKind::Control),
+    route("post", "/control/templates/remove", "removeTemplate", "templates", "Remove template", "Remove a template from the user global library.", Some("RemoveTemplateRequest"), AuthKind::Control),
     route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime memory", "Search the same memory v2 index used by the agent MemorySearch tool.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
     route_with_response("post", "/memory/get", "runtimeMemoryGet", "search", "Fetch runtime memory source", "Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.", Some("MemoryGetRequest"), "MemoryGetResult", AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
@@ -290,6 +295,7 @@ fn openapi_value() -> Value {
             { "name": "work-items" },
             { "name": "timers" },
             { "name": "skills" },
+            { "name": "templates" },
             { "name": "jobs" },
             { "name": "search" },
             { "name": "callbacks", "description": "Capability-token callback ingress. Never publish real callback_token values." },
@@ -682,6 +688,9 @@ fn component_schemas() -> Value {
         "DisableSkillRequest",
         "InstallSkillRequest",
         "UninstallSkillRequest",
+        "CheckTemplateRequest",
+        "InstallTemplateRequest",
+        "RemoveTemplateRequest",
     ] {
         schemas.insert(name.into(), request_schema.clone());
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1098,6 +1098,28 @@ pub struct UninstallSkillRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckTemplateRequest {
+    /// Local filesystem path to a template directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// GitHub tree URL for a template package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstallTemplateRequest {
+    /// GitHub tree URL for the template package to install.
+    pub github_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoveTemplateRequest {
+    /// Template id within the user global library.
+    pub template_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillOperationResponse {
     pub ok: bool,
     pub agent_id: String,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -86,7 +86,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 87, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 92, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -734,6 +734,38 @@
   },
   {
     "method": "get",
+    "path": "/api/templates/catalog",
+    "handler": "templates_catalog",
+    "operation_id": "templatesCatalog",
+    "tag": "templates",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/templates/catalog/{catalog_id}",
+    "handler": "template_detail",
+    "operation_id": "templateDetail",
+    "tag": "templates",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/transcript",
     "handler": "transcript_default",
     "operation_id": "defaultTranscript",
@@ -1580,6 +1612,38 @@
   },
   {
     "method": "post",
+    "path": "/api/control/templates/install",
+    "handler": "install_template",
+    "operation_id": "installTemplate",
+    "tag": "templates",
+    "parameters": [],
+    "request_schema": "InstallTemplateRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/control/templates/remove",
+    "handler": "remove_template",
+    "operation_id": "removeTemplate",
+    "tag": "templates",
+    "parameters": [],
+    "request_schema": "RemoveTemplateRequest",
+    "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/api/enqueue",
     "handler": "enqueue_default",
     "operation_id": "enqueueDefault",
@@ -1731,6 +1795,22 @@
     "parameters": [],
     "request_schema": "UpdateSkillRequest",
     "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/templates/catalog/check",
+    "handler": "check_template",
+    "operation_id": "checkTemplate",
+    "tag": "templates",
+    "parameters": [],
+    "request_schema": "CheckTemplateRequest",
+    "request_strict": false,
     "response_content_types": [
       "application/json"
     ],


### PR DESCRIPTION
## Summary

Add HTTP daemon endpoints for AgentTemplate management, parallel to the existing skills API.

Closes #1983

## Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/templates/catalog` | remote_access | List global catalog (builtin + user global) |
| GET | `/templates/catalog/{catalog_id}` | remote_access | Template detail with full AGENTS.md |
| POST | `/templates/catalog/check` | remote_access | Validate local template directory |
| POST | `/control/templates/install` | control | Install from GitHub tree URL |
| POST | `/control/templates/remove` | control | Remove from user global library |

## Implementation

- **`src/http/templates.rs`**: 5 handlers with auth guards
- **`src/agent_template.rs`**: `install_template_from_github`, `remove_user_template`, `parse_template_manifest_for_api`
- **`src/types.rs`**: Request DTOs
- **`src/openapi.rs`**: Route specs, tags, component schemas

## Tests

6 new unit tests: GitHub URL parsing (4 cases), template removal (2 cases).

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib agent_template` — 40 passed (6 new) ✅
- `openapi_snapshot` ✅

Stacked on #1982 (PR #2078).