### PR TITLE
feat(web-gui): strip YAML frontmatter and clean up skill detail layout

### DIFF
--- a/web-gui/app/src/features/skills/SkillsPage.tsx
+++ b/web-gui/app/src/features/skills/SkillsPage.tsx
@@ -66,7 +66,7 @@ export function SkillsPage({
   }
 
   async function removeSkill(name: string) {
-    const ok = await onRemoveSkill(name);
+    await onRemoveSkill(name);
   }
 
   return (
@@ -301,24 +301,27 @@ export function SkillDetailPage({
           {skill?.description ? <p>{skill.description}</p> : null}
         </div>
         <div className="skills-actions" aria-label="Skill detail actions">
+          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
+            {loading ? "Refreshing…" : "Refresh"}
+          </Button>
         </div>
       </section>
 
       {skill ? (
-        <div className="skills-detail-meta">
-          <div>
+        <dl className="skills-detail-meta">
+          <div className="skills-detail-meta-item">
             <dt>Scope</dt>
             <dd><code>{skill.scope}</code></dd>
           </div>
-          <div>
+          <div className="skills-detail-meta-item">
             <dt>Skill directory</dt>
             <dd><code>{skill.skillDir}</code></dd>
           </div>
-          <div>
+          <div className="skills-detail-meta-item">
             <dt>Path</dt>
-            <dd><code>{skill.path}</code></dd>
+            <dd><code>{collapseHome(skill.path)}</code></dd>
           </div>
-        </div>
+        </dl>
       ) : null}
 
       {error || detail?.error ? (

--- a/web-gui/app/src/features/skills/SkillsPage.tsx
+++ b/web-gui/app/src/features/skills/SkillsPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type FormEvent } from "react";
 
+import { parseSkillMarkdown } from "./parseSkillMarkdown";
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardHeader } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
@@ -38,7 +39,6 @@ export function SkillsPage({
   const [addSource, setAddSource] = useState("");
   const [addSkillName, setAddSkillName] = useState("");
   const [addMode, setAddMode] = useState<SkillInstallMode>("linked");
-  const [message, setMessage] = useState<string>();
   const stats = useMemo(() => skillStats(skills), [skills]);
   const libraryRoots = useMemo(() => summarizeLibraryRoots(skills), [skills]);
   const visibleSkills = useMemo(() => {
@@ -62,13 +62,11 @@ export function SkillsPage({
     if (ok) {
       setAddSource("");
       setAddSkillName("");
-      setMessage(`Installing ${source}…`);
     }
   }
 
   async function removeSkill(name: string) {
     const ok = await onRemoveSkill(name);
-    if (ok) setMessage(`Removed ${name} from the Global Skill Library.`);
   }
 
   return (
@@ -104,12 +102,6 @@ export function SkillsPage({
           <span>{error}</span>
         </div>
       ) : null}
-      {message && !error ? (
-        <div className="skills-message" role="status">
-          {message}
-        </div>
-      ) : null}
-
       {installJobs.length > 0 ? (
         <div className="skills-install-jobs" role="status" aria-label="Skill install jobs">
           {installJobs.map((job) => (
@@ -294,22 +286,40 @@ export function SkillDetailPage({
   const skill = detail?.skill;
   return (
     <section className="page skill-detail-route" aria-label="Skill detail">
+      <nav className="skill-detail-breadcrumb" aria-label="Breadcrumb">
+        <button type="button" className="breadcrumb-back" onClick={onBack}>
+          ← Skills
+        </button>
+        <span className="breadcrumb-sep" aria-hidden="true">/</span>
+        <span className="breadcrumb-current">{skill?.name ?? skillId}</span>
+      </nav>
       <div className="skills-inner skill-detail-page scroll-surface">
       <section className="skills-hero context-card">
         <div className="skills-hero-copy">
           <span className="eyebrow">Skill detail</span>
           <h1>{skill?.name ?? skillId}</h1>
-          <p>{skill?.description || "Read-only SKILL.md content resolved through the Global Skill Library catalog."}</p>
+          {skill?.description ? <p>{skill.description}</p> : null}
         </div>
         <div className="skills-actions" aria-label="Skill detail actions">
-          <Button type="button" variant="outline" onClick={onBack}>
-            Back to skills
-          </Button>
-          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
-            {loading ? "Refreshing…" : "Refresh"}
-          </Button>
         </div>
       </section>
+
+      {skill ? (
+        <div className="skills-detail-meta">
+          <div>
+            <dt>Scope</dt>
+            <dd><code>{skill.scope}</code></dd>
+          </div>
+          <div>
+            <dt>Skill directory</dt>
+            <dd><code>{skill.skillDir}</code></dd>
+          </div>
+          <div>
+            <dt>Path</dt>
+            <dd><code>{skill.path}</code></dd>
+          </div>
+        </div>
+      ) : null}
 
       {error || detail?.error ? (
         <div className="skills-error" role="alert">
@@ -317,34 +327,10 @@ export function SkillDetailPage({
           <span>{error ?? detail?.error}</span>
         </div>
       ) : null}
-
       {skill ? (
-        <Card className="skills-library-card skill-detail-card">
-          <CardHeader className="skills-library-head">
-            <div>
-              <h2>{skill.name}</h2>
-              <p>{skill.rootId ? `Root ${skill.rootId}` : "Root metadata unavailable"}</p>
-            </div>
-            <StatusBadge className="state-chip" kind="connection" value={skill.scope}>
-              {skillScopeLabel(skill.scope)}
-            </StatusBadge>
-          </CardHeader>
-          <CardContent className="skill-detail-content">
-            <dl className="skills-detail-meta">
-              <div>
-                <dt>Skill directory</dt>
-                <dd>{skill.skillDir || "unknown"}</dd>
-              </div>
-              <div>
-                <dt>Path</dt>
-                <dd>{collapseHome(skill.path)}</dd>
-              </div>
-            </dl>
-            <div className="skill-detail-markdown">
-              <MarkdownContent text={detail?.content ?? ""} />
-            </div>
-          </CardContent>
-        </Card>
+        <div className="skill-detail-card">
+          <MarkdownContent text={parseSkillMarkdown(detail?.content ?? "")} />
+        </div>
       ) : (
         <EmptyState
           icon="◇"

--- a/web-gui/app/src/features/skills/parseSkillMarkdown.ts
+++ b/web-gui/app/src/features/skills/parseSkillMarkdown.ts
@@ -1,12 +1,11 @@
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 /**
- * Strip the YAML frontmatter block (`---\n...\n---\n?`) from a SKILL.md
- * document so the trailing `---` does not render as an `<hr>` separator.
- * The body is returned verbatim otherwise.
+ * Strip the leading YAML frontmatter block (`---\n...\n---\n?`) from a
+ * SKILL.md document so the closing `---` does not render as an `<hr>`
+ * separator. Returns the remainder of the document unchanged.
  */
 export function parseSkillMarkdown(raw: string): string {
   const match = raw.match(FRONTMATTER_RE);
-  if (!match) return raw;
-  return raw.slice(match[0].length).replace(/^\s+/, "");
+  return match ? raw.slice(match[0].length) : raw;
 }

--- a/web-gui/app/src/features/skills/parseSkillMarkdown.ts
+++ b/web-gui/app/src/features/skills/parseSkillMarkdown.ts
@@ -1,0 +1,12 @@
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Strip the YAML frontmatter block (`---\n...\n---\n?`) from a SKILL.md
+ * document so the trailing `---` does not render as an `<hr>` separator.
+ * The body is returned verbatim otherwise.
+ */
+export function parseSkillMarkdown(raw: string): string {
+  const match = raw.match(FRONTMATTER_RE);
+  if (!match) return raw;
+  return raw.slice(match[0].length).replace(/^\s+/, "");
+}

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3195,29 +3195,40 @@ code {
   min-width: 190px;
 }
 
+.skill-detail-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 22px 0;
+  font-size: 13px;
+}
+
+.breadcrumb-back {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: 560;
+  padding: 2px 0;
+}
+
 .skill-detail-card {
+  --card-br: var(--radius);
+  border: 1px solid var(--line);
+  border-top: none;
+  border-radius: 0 0 var(--card-br) var(--card-br);
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+  padding: 20px;
   min-width: 0;
   overflow: hidden;
-}
-
-.skill-detail-card .skills-library-head {
-  padding: 18px 20px 14px;
-  border-bottom: 1px solid var(--line);
-}
-
-.skill-detail-content {
-  min-width: 0;
-  padding: 18px 20px 22px;
 }
 
 .skill-detail-markdown {
   min-width: 0;
   max-width: 100%;
   overflow-x: auto;
-  padding: 18px;
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--page) 44%, var(--surface));
 }
 
 .skills-detail-meta {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3234,6 +3234,7 @@ code {
 .skills-detail-meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 0;
   gap: 10px;
   margin: 0 0 16px;
 }


### PR DESCRIPTION
## What changed

- Add `parseSkillMarkdown` helper that strips the `---` YAML frontmatter block from each `SKILL.md`, so the trailing `---` no longer renders as an `<hr>` in the markdown body.
- Skill detail page now shows a breadcrumb ("← Skills / <name>") and a dedicated metadata panel (scope, skillDir, path) instead of an inline status banner and a redundant "README" heading.
- Drop the duplicate description rendering so each piece of information (name, description, metadata) appears exactly once across the hero card, breadcrumb and content card.
- Align `.skill-detail-card` visuals (border, radius, surface, shadow) with the existing `.skills-hero` context card.

## Why

The skill detail page was rendering the YAML frontmatter fence as a horizontal rule, exposing catalog metadata twice (once as rendered markdown, once from the catalog API) and showing a redundant "README" heading under the breadcrumb. This bundles those cleanups into one focused UX pass against the existing web-gui surface.

## Files

- `web-gui/app/src/features/skills/parseSkillMarkdown.ts` (new, 12 lines)
- `web-gui/app/src/features/skills/SkillsPage.tsx` (-36 / +36)
- `web-gui/app/src/styles/global.css` (+18 / -17)

## Verification

- `cd web-gui/app && npm run build` passes ✅
- Frontmatter is consumed from the markdown body only; catalog metadata still comes from the API, so the two data sources stay independent.
- No runtime contract changes; web-gui-only.