### PR TITLE
fix: repair stray characters and missing brace in agent_template.rs breaking main CI

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -3435,7 +3435,6 @@ name = "Worker"
             Some("https://github.com/owner/repo/tree/main/agent_templates/worker")
         );
     }
-D
     #[tokio::test]
     async fn provenance_records_schema_version_from_template_toml() {
         let _lock = crate::test_env::lock_env();
@@ -3548,8 +3547,9 @@ name = "Versioned"
             .await
             .unwrap_err();
         assert!(err.to_string().contains("already exists"));
+    }
 
-#[test]
+    #[test]
     fn parsed_github_template_url_parses_tree_url() {
         let url = ParsedGithubTemplateUrl::parse(
             "https://github.com/holon-run/templates/tree/main/my-template",
@@ -3606,10 +3606,7 @@ name = "Versioned"
         let err = remove_user_template(tmp.path(), "my-test-template").unwrap_err();
         assert!(!template_dir.exists());
 
-D
-        assert!(err.to_string().contains("not found"));    }
-
-assert!(err.to_string().contains("not found"));
+        assert!(err.to_string().contains("not found"));
     }
 
     #[cfg(unix)]
@@ -3639,4 +3636,5 @@ assert!(err.to_string().contains("not found"));
         assert_eq!(result, "owner/repo/tree/main/templates/dev");
 
         assert!(validate_github_template_url("https://gitlab.com/owner/repo").is_err());
-    }}
+    }
+}


### PR DESCRIPTION
## Problem

The squash merge of PR #2079 (commit `a044428c`) corrupted `src/agent_template.rs`, breaking `cargo fmt` and `cargo check` on `main`:

- Two stray `D` characters on standalone lines
- A missing closing `}` for `reapplying_template_on_existing_home_fails` (the diff "moved" it to close a new function)
- A duplicated `assert!` line and misplaced `}` in `remove_user_template_removes_existing_and_reports_missing`
- `}}` on a single line at end of file

## Fix

- Removed both stray `D` lines
- Restored the missing `}` to close `reapplying_template_on_existing_home_fails`
- Removed the duplicate `assert!` and fixed brace placement
- Ran `cargo fmt --all` to normalize indentation and split `}}` into separate lines

## Verification

```
cargo fmt --all -- --check   ✅
RUSTFLAGS="-D warnings" cargo check --all-targets   ✅
```