### PR TITLE
feat(web-gui): fix file viewer auto-scroll and add markdown rendered/source toggle

### DIFF
--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -12,6 +12,7 @@ interface FileBrowserPanelProps {
   executionRootId?: string;
   initialFilePath?: string;
   initialPath?: string;
+  onClose?: () => void;
 }
 
 interface SelectedFile {
@@ -131,7 +132,7 @@ function useShikiHighlight(content: string | undefined, filePath: string | undef
   return highlighted;
 }
 
-export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, initialFilePath }: FileBrowserPanelProps) {
+export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, initialFilePath, onClose }: FileBrowserPanelProps) {
   const browseWorkspaceDir = useRuntimeStore((s) => s.browseWorkspaceDir);
   const readWorkspaceFile = useRuntimeStore((s) => s.readWorkspaceFile);
   const workspaceFileUrl = useRuntimeStore((s) => s.workspaceFileUrl);
@@ -201,6 +202,10 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   };
 
   const openEntry = async (entry: WorkspaceFileEntry) => {
+    if (entry.name === "..") {
+      void loadDir(parentPath);
+      return;
+    }
     if (entry.type === "directory") {
       const dirPath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
       void loadDir(dirPath);
@@ -239,6 +244,9 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
     }
   };
 
+  const parentPath = currentPath.split("/").filter(Boolean).slice(0, -1).join("/");
+  const atRoot = !currentPath;
+
   const markdownComponents: Components = {
     a: ({ href, children }) => <a href={href} target="_blank" rel="noreferrer">{children}</a>,
   };
@@ -250,6 +258,9 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const dirs = visibleEntries.filter((e) => e.type === "directory" || e.type === "symlink");
   const files = visibleEntries.filter((e) => e.type === "file");
   const sortedEntries = [...dirs, ...files];
+  if (!atRoot) {
+    sortedEntries.unshift({ name: "..", type: "directory" as const, size: 0, mimeType: undefined });
+  }
 
   return (
     <div className="file-browser">
@@ -306,6 +317,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
               <button
                 type="button"
                 className="file-browser-entry"
+                data-parent-dir={entry.name === ".." ? true : undefined}
                 data-selected={selectedFile?.path === (currentPath ? `${currentPath}/${entry.name}` : entry.name)}
                 onClick={() => void openEntry(entry)}
               >
@@ -343,7 +355,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
                   </button>
                 </div>
               ) : null}
-              <button type="button" aria-label="Back to directory listing" onClick={() => setSelectedFile(null)}>← Back</button>
+              <button type="button" aria-label="Back to previous page" onClick={() => onClose?.()}>← Back</button>
             </div>
           </div>
           {selectedFile.loading ? (

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createHighlighter, type Highlighter } from "shiki";
+import Markdown from "react-markdown";
+import type { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import type { WorkspaceDirectoryListing, WorkspaceFileEntry } from "../../runtime/types";
 import { useRuntimeStore } from "../../runtime/runtime-store";
@@ -142,6 +145,19 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
   const [showHidden, setShowHidden] = useState(false);
   const autoOpenedRef = useRef(false);
+  const contentScrollRef = useRef<HTMLDivElement>(null);
+  const [showRendered, setShowRendered] = useState(true);
+
+  // Determine whether the selected file is markdown.
+  const isMarkdownFile = selectedFile?.path?.toLowerCase().endsWith(".md") ?? false;
+
+  // Reset scroll position and toggle state when a new file is opened.
+  useEffect(() => {
+    if (contentScrollRef.current) {
+      contentScrollRef.current.scrollTop = 0;
+    }
+    setShowRendered(true);
+  }, [selectedFile?.path]);
 
   const highlightedHtml = useShikiHighlight(selectedFile?.content, selectedFile?.path);
 
@@ -221,6 +237,10 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  };
+
+  const markdownComponents: Components = {
+    a: ({ href, children }) => <a href={href} target="_blank" rel="noreferrer">{children}</a>,
   };
 
   const entries = listing?.entries ?? [];
@@ -304,13 +324,27 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
         <div className="file-browser-viewer">
           <div className="file-browser-viewer-head">
             <strong>{selectedFile.path.split("/").pop()}</strong>
-            <button
-              type="button"
-              aria-label="Back to directory listing"
-              onClick={() => setSelectedFile(null)}
-            >
-              ← Back
-            </button>
+            <div className="file-browser-viewer-actions">
+              {isMarkdownFile ? (
+                <div className="file-browser-md-toggle" role="group" aria-label="Markdown view mode">
+                  <button
+                    type="button"
+                    className={showRendered ? "active" : ""}
+                    onClick={() => setShowRendered(true)}
+                  >
+                    Rendered
+                  </button>
+                  <button
+                    type="button"
+                    className={!showRendered ? "active" : ""}
+                    onClick={() => setShowRendered(false)}
+                  >
+                    Source
+                  </button>
+                </div>
+              ) : null}
+              <button type="button" aria-label="Back to directory listing" onClick={() => setSelectedFile(null)}>← Back</button>
+            </div>
           </div>
           {selectedFile.loading ? (
             <p className="inspector-muted">Loading file…</p>
@@ -330,13 +364,16 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
                   {selectedFile.totalSize ? ` (${formatSize(selectedFile.totalSize)} total)` : ""}.
                 </p>
               ) : null}
-              {highlightedHtml ? (
-                <div
-                  className="file-browser-code"
-                  dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-                />
+              {isMarkdownFile && showRendered ? (
+                <div className="file-browser-markdown" ref={contentScrollRef}>
+                  <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                    {selectedFile.content}
+                  </Markdown>
+                </div>
+              ) : highlightedHtml ? (
+                <div className="file-browser-code" ref={contentScrollRef} dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
               ) : (
-                <pre className="file-browser-text">
+                <pre className="file-browser-text" ref={contentScrollRef as React.Ref<HTMLPreElement>}>
                   <code>{selectedFile.content}</code>
                 </pre>
               )}

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -182,7 +182,7 @@ export function RightSidePanel({
             <TaskDetailPanel task={activeView.task} detailState={taskDetailState} />
           </div>
         ) : activeView.kind === "file_browser" ? (
-          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} />
+          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} onClose={onShowAgentOverview} />
         ) : (
           <AgentOverviewPanel
             agent={agent}

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3645,6 +3645,72 @@ code {
   height: auto;
   border-radius: 4px;
 }
+
+.file-browser-viewer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-browser-md-toggle {
+  display: flex;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 5px;
+  overflow: hidden;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.file-browser-md-toggle button {
+  background: none;
+  border: none;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: inherit;
+  color: var(--text-muted, #666);
+  transition: background 0.15s, color 0.15s;
+}
+
+.file-browser-md-toggle button:hover {
+  background: var(--hover-bg, #f0f0f0);
+}
+
+.file-browser-md-toggle button.active {
+  background: var(--accent, #4a9eff);
+  color: #fff;
+}
+
+.file-browser-markdown {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px 16px;
+  border-radius: 6px;
+  background: var(--surface);
+  line-height: 1.7;
+  font-size: 0.875rem;
+}
+
+.file-browser-markdown h1,
+.file-browser-markdown h2,
+.file-browser-markdown h3,
+.file-browser-markdown h4 {
+  margin: 1em 0 0.5em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.file-browser-markdown p {
+  margin: 0 0 0.75em;
+}
+
+.file-browser-markdown code {
+  background: var(--code-bg, #f5f5f5);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.8125em;
+}
+
 .agent-skill-manager-head {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## 变更内容

### 1. 修复打开文件后自动滚动的问题

- 添加 `contentScrollRef` (`useRef`) 和 `useEffect`，在切换文件时重置 `scrollTop = 0`
- 滚动容器（代码高亮区、纯文本区、markdown 区）均绑定同一 ref
- 避免异步 shiki 高亮加载后 scroll 位置跳跃

### 2. Markdown 文件支持 Rendered / Source 双视图

- 使用已有的 `react-markdown` + `remark-gfm` 渲染 markdown
- 默认 Rendered 视图；点击 Source 切换回语法高亮/纯文本视图
- 切换按钮在文件查看器头部，紧挨 ←Back 按钮
- 外部链接自动 `target="_blank"`

### 演示

| Rendered | Source |
|----------|--------|
| 渲染后的 Markdown（默认） | 源码（shiki 高亮或纯文本） |

Closes: #N/A