### PR TITLE
fix: remove legacy message fallback

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,9 +7,8 @@ use budget::{estimate_text_tokens, reserve_current_input_budget, truncate_sectio
 #[cfg(test)]
 use render::trust_label;
 use render::{
-    body_preview, bounded_inline, enum_label, estimate_message_tokens, include_in_prompt_context,
-    indent_block, message_body_text, message_header, push_budgeted_section, sanitize_inline,
-    section, turn_section,
+    body_preview, bounded_inline, enum_label, indent_block, message_body_text, message_header,
+    push_budgeted_section, sanitize_inline, section, turn_section,
 };
 
 use std::cmp::Ordering;
@@ -32,7 +31,7 @@ use crate::{
         ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         SkillsRuntimeView, TaskRecord, TodoItemState, ToolExecutionRecord, ToolExecutionStatus,
         TranscriptEntry, TranscriptEntryKind, TurnRecord, WaitConditionRecord, WorkItemRecord,
-        WorkItemRefStatus, WorkingMemorySnapshot,
+        WorkItemRefStatus,
     },
 };
 
@@ -128,20 +127,11 @@ pub fn build_context_with_default_external_ingress(
     agent_home: &Path,
     default_external_ingress_override: Option<&ExternalTriggerRecord>,
 ) -> Result<BuiltContext> {
-    let mut messages =
-        storage.read_messages_from(agent.compacted_message_count, config.recent_messages)?;
+    let mut messages = Vec::new();
     let continuation_anchor_messages = storage.read_all_messages()?;
     let mut briefs = storage.read_recent_briefs(config.recent_briefs)?;
     let mut tools = storage.read_recent_tool_executions(config.recent_messages)?;
-    let mut turn_records = storage.read_recent_turns(config.recent_messages)?;
-    if turn_records.is_empty() {
-        turn_records = synthesize_legacy_recent_turn_records(
-            &messages,
-            &briefs,
-            &tools,
-            config.recent_messages,
-        );
-    }
+    let turn_records = storage.read_recent_turns(config.recent_messages)?;
     hydrate_recent_turn_references(
         storage,
         &turn_records,
@@ -209,19 +199,6 @@ pub fn build_context_with_default_external_ingress(
                 render_active_tasks(&active_tasks, active_task_count),
             ),
         );
-    }
-
-    if let Some(summary) = &agent.context_summary {
-        if !summary.trim().is_empty() {
-            push_budgeted_section(
-                &mut sections,
-                &mut remaining_budget,
-                section(
-                    "compacted_summary",
-                    format!("Compacted agent summary:\n{summary}"),
-                ),
-            );
-        }
     }
 
     if let Some(work_item) = current_work_item {
@@ -601,106 +578,6 @@ fn hydrate_recent_turn_references(
     Ok(())
 }
 
-fn synthesize_legacy_recent_turn_records(
-    messages: &[MessageEnvelope],
-    briefs: &[BriefRecord],
-    tools: &[ToolExecutionRecord],
-    limit: usize,
-) -> Vec<TurnRecord> {
-    let mut records = messages
-        .iter()
-        .filter(|message| !matches!(message.kind, MessageKind::SystemTick))
-        .filter_map(|message| {
-            let message_turn_id = message.turn_id.as_deref().map(str::trim);
-            let message_seq = message.message_seq.filter(|seq| *seq != 0);
-            let produced_brief_ids = briefs
-                .iter()
-                .filter(|brief| {
-                    legacy_brief_matches_message(brief, message, message_turn_id, message_seq)
-                })
-                .map(|brief| brief.id.clone())
-                .collect::<Vec<_>>();
-
-            let tool_execution_ids = tools
-                .iter()
-                .filter(|tool| legacy_tool_matches_message(tool, message_turn_id, message_seq))
-                .map(|tool| tool.id.clone())
-                .collect::<Vec<_>>();
-
-            if produced_brief_ids.is_empty() && tool_execution_ids.is_empty() {
-                return None;
-            }
-
-            let turn_index = message_seq.unwrap_or(0);
-            let turn_id = message_seq
-                .map(|seq| format!("legacy-message-seq-{seq}"))
-                .or_else(|| {
-                    message_turn_id
-                        .filter(|turn_id| !turn_id.is_empty())
-                        .map(|turn_id| format!("legacy-turn-id-{turn_id}"))
-                })
-                .unwrap_or_else(|| format!("legacy-message-{}", message.id));
-            let mut record = TurnRecord::new(&message.agent_id, turn_id, turn_index);
-            record.trigger = Some(crate::types::TurnTriggerSummary::from_message(message));
-            record.input_message_ids = vec![message.id.clone()];
-            record.produced_brief_ids = produced_brief_ids;
-            record.tool_execution_ids = tool_execution_ids;
-            record.created_at = message.created_at;
-            Some(record)
-        })
-        .collect::<Vec<_>>();
-
-    if records.len() > limit {
-        records = records.split_off(records.len() - limit);
-    }
-    records
-}
-
-fn legacy_brief_matches_message(
-    brief: &BriefRecord,
-    message: &MessageEnvelope,
-    message_turn_id: Option<&str>,
-    message_seq: Option<u64>,
-) -> bool {
-    brief.related_message_id.as_deref() == Some(message.id.as_str())
-        || legacy_turn_identity_matches(
-            brief.turn_id.as_deref(),
-            brief.turn_index,
-            message_turn_id,
-            message_seq,
-        )
-}
-
-fn legacy_tool_matches_message(
-    tool: &ToolExecutionRecord,
-    message_turn_id: Option<&str>,
-    message_seq: Option<u64>,
-) -> bool {
-    legacy_turn_identity_matches(
-        tool.turn_id.as_deref(),
-        Some(tool.turn_index),
-        message_turn_id,
-        message_seq,
-    )
-}
-
-fn legacy_turn_identity_matches(
-    evidence_turn_id: Option<&str>,
-    evidence_turn_index: Option<u64>,
-    message_turn_id: Option<&str>,
-    message_seq: Option<u64>,
-) -> bool {
-    evidence_turn_id
-        .map(str::trim)
-        .filter(|turn_id| !turn_id.is_empty())
-        .zip(message_turn_id.filter(|turn_id| !turn_id.is_empty()))
-        .is_some_and(|(evidence_turn_id, message_turn_id)| evidence_turn_id == message_turn_id)
-        || evidence_turn_index
-            .filter(|turn_index| *turn_index != 0)
-            .zip(message_seq)
-            .is_some_and(|(evidence_turn_index, message_seq)| evidence_turn_index == message_seq)
-}
-
 fn default_external_ingress(
     storage: &AppStorage,
     agent_id: &str,
@@ -743,80 +620,11 @@ fn render_default_external_ingress(
     )
 }
 
-pub fn maybe_compact_agent(
-    storage: &AppStorage,
-    agent: &mut AgentState,
-    config: &ContextConfig,
-) -> Result<bool> {
-    let all_messages = storage.read_all_messages()?;
+pub fn sync_agent_message_count(storage: &AppStorage, agent: &mut AgentState) -> Result<bool> {
+    let total_message_count = storage.count_messages()?;
     let previous_total_message_count = agent.total_message_count;
-    agent.total_message_count = all_messages.len();
-    let mut changed = agent.total_message_count != previous_total_message_count;
-    let has_working_memory = !working_memory_is_empty(&agent.working_memory.current_working_memory);
-    if has_working_memory && agent.context_summary.is_some() {
-        agent.context_summary = None;
-        changed = true;
-    }
-    let visible_messages = all_messages
-        .iter()
-        .filter(|message| include_in_prompt_context(message))
-        .collect::<Vec<_>>();
-    let visible_estimated_tokens = visible_messages
-        .iter()
-        .map(|message| estimate_message_tokens(message))
-        .sum::<usize>();
-    if visible_estimated_tokens <= config.compaction_trigger_estimated_tokens {
-        return Ok(changed);
-    }
-
-    let mut split_at = all_messages.len();
-    let mut kept_visible_messages = 0usize;
-    let mut kept_estimated_tokens = 0usize;
-    for (idx, message) in all_messages.iter().enumerate().rev() {
-        if !include_in_prompt_context(message) {
-            continue;
-        }
-        let message_tokens = estimate_message_tokens(message);
-        if kept_visible_messages >= config.compaction_keep_recent_messages
-            && kept_estimated_tokens + message_tokens
-                > config.compaction_keep_recent_estimated_tokens
-        {
-            split_at = idx + 1;
-            break;
-        }
-        kept_visible_messages += 1;
-        kept_estimated_tokens += message_tokens;
-        split_at = idx;
-    }
-
-    if split_at == 0 || split_at <= agent.compacted_message_count {
-        return Ok(changed);
-    }
-
-    if has_working_memory {
-        agent.context_summary = None;
-    } else {
-        let compacted_slice = &all_messages[..split_at];
-        let summary = compacted_slice
-            .iter()
-            .filter(|message| include_in_prompt_context(message))
-            .map(|message| {
-                format!(
-                    "- {} {}",
-                    message_header(message),
-                    body_preview(&message.body)
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        agent.context_summary = Some(summary);
-    }
-    agent.compacted_message_count = split_at;
-    if !has_working_memory {
-        agent.working_memory.compression_epoch =
-            agent.working_memory.compression_epoch.saturating_add(1);
-    }
-    Ok(true)
+    agent.total_message_count = total_message_count;
+    Ok(agent.total_message_count != previous_total_message_count)
 }
 
 fn render_active_tasks(tasks: &[TaskRecord], total_count: usize) -> String {
@@ -1355,10 +1163,6 @@ fn render_work_item_plan_ref(
     crate::work_item_plan::ensure_plan_artifact(agent_home, work_item, None)
         .ok()
         .map(|artifact| format!("Plan ref: {}", artifact.path.display()))
-}
-
-fn working_memory_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
-    snapshot == &WorkingMemorySnapshot::default()
 }
 
 fn scope_label(scope: &crate::types::SkillScope) -> &'static str {
@@ -2037,7 +1841,6 @@ fn render_turn_record_projection(
     mode: RecentTurnProjectionMode,
     budget: usize,
 ) -> Option<String> {
-    let is_legacy_synthetic_record = record.turn_id.starts_with("legacy-");
     let trigger_message = record
         .input_message_ids
         .iter()
@@ -2051,17 +1854,13 @@ fn render_turn_record_projection(
         });
     let mut lines = vec![format!(
         "- Turn {}:",
-        if is_legacy_synthetic_record && record.turn_index != 0 {
-            format!("message_seq {}", record.turn_index)
-        } else if record.turn_index != 0 {
+        if record.turn_index != 0 {
             format!("turn_index {}", record.turn_index)
         } else {
             record.turn_id.clone()
         }
     )];
-    if !is_legacy_synthetic_record {
-        lines.push(format!("  - turn_id: {}", sanitize_inline(&record.turn_id)));
-    }
+    lines.push(format!("  - turn_id: {}", sanitize_inline(&record.turn_id)));
     if let Some(trigger_message) = trigger_message {
         lines.push(format!(
             "  - trigger: {}",
@@ -2190,9 +1989,7 @@ fn turn_record_matches_message(record: &TurnRecord, message: &MessageEnvelope) -
             if turn_id == record.turn_id.trim() {
                 return true;
             }
-            if !record.turn_id.starts_with("legacy-") {
-                return false;
-            }
+            return false;
         }
     }
 
@@ -2973,7 +2770,7 @@ mod tests {
             MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
             ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
             WaitConditionKind, WaitConditionStatus, WakeSource, WorkItemRef, WorkItemRefKind,
-            WorkItemRefStatus, WorkItemState,
+            WorkItemRefStatus, WorkItemState, WorkingMemorySnapshot,
         },
     };
 
@@ -3549,7 +3346,7 @@ mod tests {
     }
 
     #[test]
-    fn compaction_adds_summary_when_message_count_exceeds_threshold() {
+    fn sync_agent_message_count_updates_total_without_compaction() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..6 {
@@ -3567,70 +3364,10 @@ mod tests {
         }
 
         let mut session = AgentState::new("default");
-        let changed = maybe_compact_agent(
-            &storage,
-            &mut session,
-            &ContextConfig {
-                recent_messages: 4,
-                recent_briefs: 4,
-                compaction_trigger_messages: 4,
-                compaction_keep_recent_messages: 2,
-                compaction_trigger_estimated_tokens: 4,
-                compaction_keep_recent_estimated_tokens: 2,
-                ..ContextConfig::default()
-            },
-        )
-        .unwrap();
+        let changed = sync_agent_message_count(&storage, &mut session).unwrap();
         assert!(changed);
-        assert!(session.context_summary.unwrap().contains("message-0"));
-        assert_eq!(session.working_memory.compression_epoch, 1);
-    }
-
-    #[test]
-    fn structured_working_memory_keeps_compression_epoch_stable_during_legacy_compaction() {
-        let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_test(dir.path()).unwrap();
-        for idx in 0..6 {
-            let msg = MessageEnvelope::new(
-                "default",
-                MessageKind::OperatorPrompt,
-                MessageOrigin::Operator { actor_id: None },
-                AuthorityClass::OperatorInstruction,
-                Priority::Normal,
-                MessageBody::Text {
-                    text: format!("message-{idx}"),
-                },
-            );
-            storage.append_message(&msg).unwrap();
-        }
-
-        let mut session = AgentState::new("default");
-        session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            objective: Some("ship working memory".into()),
-            plan: Some(vec!["[InProgress] keep cache identity stable"].join("\n")),
-            ..WorkingMemorySnapshot::default()
-        };
-        session.working_memory.compression_epoch = 7;
-
-        let changed = maybe_compact_agent(
-            &storage,
-            &mut session,
-            &ContextConfig {
-                recent_messages: 4,
-                recent_briefs: 4,
-                compaction_trigger_messages: 4,
-                compaction_keep_recent_messages: 2,
-                compaction_trigger_estimated_tokens: 4,
-                compaction_keep_recent_estimated_tokens: 2,
-                ..ContextConfig::default()
-            },
-        )
-        .unwrap();
-
-        assert!(changed);
-        assert_eq!(session.context_summary, None);
-        assert_eq!(session.compacted_message_count, 4);
-        assert_eq!(session.working_memory.compression_epoch, 7);
+        assert_eq!(session.total_message_count, 6);
+        assert_eq!(session.working_memory.compression_epoch, 0);
     }
 
     #[test]
@@ -3691,7 +3428,7 @@ mod tests {
             delegated_from_task_id: None,
         };
 
-        maybe_compact_agent(&storage, &mut session, &config).unwrap();
+        sync_agent_message_count(&storage, &mut session).unwrap();
         let first_prompt = build_effective_prompt(
             &storage,
             &session,
@@ -3709,21 +3446,20 @@ mod tests {
         )
         .unwrap();
 
-        storage
-            .append_message(&MessageEnvelope::new(
-                "default",
-                MessageKind::OperatorPrompt,
-                MessageOrigin::Operator { actor_id: None },
-                AuthorityClass::OperatorInstruction,
-                Priority::Normal,
-                MessageBody::Text {
-                    text: "message-6".into(),
-                },
-            ))
-            .unwrap();
+        let new_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "message-6".into(),
+            },
+        );
+        storage.append_message(&new_message).unwrap();
+        append_turn_for_message(&storage, &new_message, "turn-message-6", 7);
 
-        let previous_compacted_message_count = session.compacted_message_count;
-        maybe_compact_agent(&storage, &mut session, &config).unwrap();
+        sync_agent_message_count(&storage, &mut session).unwrap();
         let second_prompt = build_effective_prompt(
             &storage,
             &session,
@@ -3741,12 +3477,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(session.context_summary, None);
-        assert_ne!(
-            session.compacted_message_count,
-            previous_compacted_message_count
-        );
-        assert_eq!(session.compacted_message_count, 5);
         assert_eq!(
             first_prompt.cache_identity.agent_id,
             second_prompt.cache_identity.agent_id
@@ -4587,7 +4317,7 @@ mod tests {
     }
 
     #[test]
-    fn build_context_skips_messages_covered_by_compacted_summary() {
+    fn build_context_uses_turn_records_without_legacy_message_fallback() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..20 {
@@ -4611,6 +4341,17 @@ mod tests {
                 );
             }
         }
+        let legacy_without_turn = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "legacy-message-without-turn-record".to_string(),
+            },
+        );
+        storage.append_message(&legacy_without_turn).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -4622,10 +4363,7 @@ mod tests {
                 text: "continue".to_string(),
             },
         );
-        let mut session = AgentState::new("default");
-        session.compacted_message_count = 12;
-        session.context_summary =
-            Some("Compacted messages include message-8 and message-11".into());
+        let session = AgentState::new("default");
 
         let built = build_context(
             &storage,
@@ -4649,14 +4387,21 @@ mod tests {
             .iter()
             .find(|section| section.name == "recent_turns")
             .expect("recent_turns section should be present");
+        assert!(!built
+            .sections
+            .iter()
+            .any(|section| section.name == "compacted_summary"));
         assert!(!recent_turns.content.contains("message-8"));
         assert!(!recent_turns.content.contains("message-11"));
         assert!(recent_turns.content.contains("message-12"));
         assert!(recent_turns.content.contains("message-19"));
+        assert!(!recent_turns
+            .content
+            .contains("legacy-message-without-turn-record"));
     }
 
     #[test]
-    fn maybe_compact_agent_persists_message_count_without_compaction() {
+    fn sync_agent_message_count_persists_message_count_without_compaction() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
@@ -4673,62 +4418,10 @@ mod tests {
             .unwrap();
 
         let mut session = AgentState::new("default");
-        let changed = maybe_compact_agent(
-            &storage,
-            &mut session,
-            &ContextConfig {
-                compaction_trigger_estimated_tokens: 10_000,
-                ..ContextConfig::default()
-            },
-        )
-        .unwrap();
+        let changed = sync_agent_message_count(&storage, &mut session).unwrap();
 
         assert!(changed);
         assert_eq!(session.total_message_count, 1);
-        assert_eq!(session.context_summary, None);
-        assert_eq!(session.compacted_message_count, 0);
-    }
-
-    #[test]
-    fn maybe_compact_agent_clears_legacy_summary_when_working_memory_is_active() {
-        let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_test(dir.path()).unwrap();
-        for idx in 0..6 {
-            storage
-                .append_message(&MessageEnvelope::new(
-                    "default",
-                    MessageKind::OperatorPrompt,
-                    MessageOrigin::Operator { actor_id: None },
-                    AuthorityClass::OperatorInstruction,
-                    Priority::Normal,
-                    MessageBody::Text {
-                        text: format!("message-{idx}"),
-                    },
-                ))
-                .unwrap();
-        }
-
-        let mut session = AgentState::new("default");
-        session.context_summary = Some("stale compacted summary".into());
-        session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            objective: Some("active work".into()),
-            ..WorkingMemorySnapshot::default()
-        };
-        let changed = maybe_compact_agent(
-            &storage,
-            &mut session,
-            &ContextConfig {
-                compaction_trigger_estimated_tokens: 4,
-                compaction_keep_recent_messages: 2,
-                compaction_keep_recent_estimated_tokens: 2,
-                ..ContextConfig::default()
-            },
-        )
-        .unwrap();
-
-        assert!(changed);
-        assert_eq!(session.context_summary, None);
-        assert!(session.compacted_message_count > 0);
     }
 
     #[test]
@@ -4748,7 +4441,6 @@ mod tests {
         );
 
         let mut session = AgentState::new("default");
-        session.context_summary = Some("legacy summary".into());
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             objective: Some("ship working memory".into()),
             plan: Some(vec!["[InProgress] wire post-turn refresh"].join("\n")),
@@ -4781,7 +4473,7 @@ mod tests {
             .sections
             .iter()
             .any(|section| section.name == "working_memory_delta"));
-        assert!(built
+        assert!(!built
             .sections
             .iter()
             .any(|section| section.name == "compacted_summary"));
@@ -6682,8 +6374,7 @@ mod tests {
         );
         recovery.trigger_kind = Some(ContinuationTriggerKind::SystemTick);
 
-        let mut session = AgentState::new("default");
-        session.compacted_message_count = 4;
+        let session = AgentState::new("default");
         let built = build_context(
             &storage,
             &session,

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -4,10 +4,10 @@ use crate::prompt::{PromptSection, PromptStability};
 use crate::tool::helpers::truncate_text;
 use crate::types::{
     AdmissionContext, AuthorityClass, MessageBody, MessageDeliverySurface, MessageEnvelope,
-    MessageKind, MessageOrigin,
+    MessageOrigin,
 };
 
-use super::budget::{estimate_section_tokens, estimate_text_tokens};
+use super::budget::estimate_section_tokens;
 
 /// Create a section with `AgentScoped` stability.
 pub(super) fn section(name: &'static str, content: String) -> PromptSection {
@@ -93,20 +93,6 @@ pub(super) fn message_body_text(body: &MessageBody) -> String {
         MessageBody::Json { value } => value.to_string(),
         MessageBody::Brief { text, .. } => text.clone(),
     }
-}
-
-/// Render a message as a single-line bullet with header and body preview.
-pub(super) fn render_message(message: &MessageEnvelope) -> String {
-    format!(
-        "- {} {}",
-        message_header(message),
-        body_preview(&message.body)
-    )
-}
-
-/// Estimate token count for a single message by rendering it first.
-pub(super) fn estimate_message_tokens(message: &MessageEnvelope) -> usize {
-    estimate_text_tokens(&render_message(message))
 }
 
 /// Build the bracketed header label for a message (origin, surface, trust, etc.).
@@ -209,9 +195,4 @@ pub(super) fn enum_label<T: serde::Serialize + std::fmt::Debug>(value: &T) -> St
         .ok()
         .and_then(|value| value.as_str().map(ToString::to_string))
         .unwrap_or_else(|| format!("{value:?}"))
-}
-
-/// Filter: include messages eligible for prompt context.
-pub(super) fn include_in_prompt_context(message: &MessageEnvelope) -> bool {
-    !matches!(message.kind, MessageKind::SystemTick)
 }

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -321,11 +321,6 @@ fn slim_state_agent_summary(agent: &mut AgentSummary) {
     agent.active_wait_conditions.clear();
     agent.active_external_triggers.clear();
     agent.recent_operator_notifications.clear();
-    agent.agent.context_summary = agent
-        .agent
-        .context_summary
-        .take()
-        .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
     agent.agent.tool_latency.clear();
     agent.agent.working_memory.active_episode_builder = None;
     agent.agent.active_skills.clear();

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -27,12 +27,8 @@ pub fn refresh_working_memory(
     if scrubbed_legacy_fields || previous_snapshot != next_snapshot {
         agent.working_memory.current_working_memory = next_snapshot.clone();
     }
-    let cleared_stale_summary =
-        !working_memory_snapshot_is_empty(&next_snapshot) && agent.context_summary.take().is_some();
-
-    let working_memory_updated = cleared_stale_summary
-        || scrubbed_legacy_fields
-        || agent.working_memory.current_working_memory != previous_snapshot;
+    let working_memory_updated =
+        scrubbed_legacy_fields || agent.working_memory.current_working_memory != previous_snapshot;
 
     Ok(WorkingMemoryRefresh {
         previous_snapshot,
@@ -45,10 +41,6 @@ fn normalize_working_memory_snapshot(mut snapshot: WorkingMemorySnapshot) -> Wor
     snapshot.scope_hints.clear();
     snapshot.recent_decisions.clear();
     snapshot
-}
-
-fn working_memory_snapshot_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
-    snapshot == &WorkingMemorySnapshot::default()
 }
 
 pub fn derive_working_memory_snapshot(

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -513,7 +513,6 @@ fn prompt_context_fingerprint(
 ) -> String {
     let payload = json!({
         "agent_id": session.id,
-        "compacted_message_count": session.compacted_message_count,
         "compression_epoch": session.working_memory.compression_epoch,
         "execution_semantics": execution_semantic_cache_payload(execution),
         "system_sections": system_sections,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -59,7 +59,7 @@ use crate::{
     agents_md::load_agents_md,
     brief,
     config::RuntimeModelCatalog,
-    context::{maybe_compact_agent, ContextConfig},
+    context::{sync_agent_message_count, ContextConfig},
     host::RuntimeHostBridge,
     ingress::WakeDisposition,
     memory::{refresh_episode_memory, refresh_working_memory},

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -34,8 +34,7 @@ impl RuntimeHandle {
 
         let built = {
             let mut guard = self.inner.agent.lock().await;
-            let agent_changed =
-                maybe_compact_agent(&self.inner.storage, &mut guard.state, &context_config)?;
+            let agent_changed = sync_agent_message_count(&self.inner.storage, &mut guard.state)?;
             if agent_changed {
                 guard.persist_state(&self.inner.storage)?;
             }
@@ -192,8 +191,7 @@ impl RuntimeHandle {
             AdmissionContext::LocalProcess,
         );
         let mut agent = self.agent_state().await?;
-        let context_config = self.current_context_config().await;
-        let _ = maybe_compact_agent(&self.inner.storage, &mut agent, &context_config)?;
+        let _ = sync_agent_message_count(&self.inner.storage, &mut agent)?;
         let prior_closure = self.current_closure_decision().await?;
         let continuation = ContinuationTrigger::from_message(&message, None)
             .map(|trigger| resolve_continuation(&prior_closure, &trigger, None));
@@ -215,6 +213,7 @@ impl RuntimeHandle {
         let skills = self
             .skills_runtime_view_for_state(&agent, &identity)
             .await?;
+        let context_config = self.current_context_config().await;
         build_effective_prompt_with_apply_patch_surface_and_default_external_ingress(
             &self.inner.storage,
             &agent,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -74,7 +74,6 @@ fn append_state_changed_events_emits_single_lightweight_agent_event() {
     state.status = AgentStatus::AwakeRunning;
     state.current_run_id = Some("run-1".into());
     state.pending = 2;
-    state.context_summary = Some("large summary must not be copied".into());
     state.working_memory.archived_episode_count = 4;
 
     runtime.append_state_changed_events(&state).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1815,8 +1815,6 @@ pub struct AgentState {
     pub last_brief_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub working_memory: WorkingMemoryState,
-    pub context_summary: Option<String>,
-    pub compacted_message_count: usize,
     pub total_message_count: usize,
     #[serde(default)]
     pub total_input_tokens: u64,
@@ -1981,8 +1979,6 @@ impl AgentState {
             last_wake_reason: None,
             last_brief_at: None,
             working_memory: WorkingMemoryState::default(),
-            context_summary: None,
-            compacted_message_count: 0,
             total_message_count: 0,
             total_input_tokens: 0,
             total_output_tokens: 0,
@@ -5030,7 +5026,6 @@ mod tests {
         state.current_turn_id = Some("turn-42".into());
         state.current_turn_work_item_id = Some("turn-work".into());
         state.current_work_item_id = Some("work-current".into());
-        state.context_summary = Some("large summary that must stay out of the event".into());
         state.working_memory.archived_episode_count = 9;
         state.attached_workspaces = vec!["ws-a".into(), "ws-b".into()];
         state.active_workspace_entry = Some(ActiveWorkspaceEntry {

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -17,7 +17,8 @@ use holon::{
         ContinuationClass, ContinuationResolution, ContinuationTriggerKind, LoadedAgentMemory,
         LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
         MessageOrigin, Priority, SkillsRuntimeView, TodoItem, TodoItemState, ToolExecutionRecord,
-        ToolExecutionStatus, WaitingReason, WorkItemRecord, WorkItemState, WorkingMemorySnapshot,
+        ToolExecutionStatus, TurnRecord, TurnTriggerSummary, WaitingReason, WorkItemRecord,
+        WorkItemState, WorkingMemorySnapshot,
     },
 };
 use serde_json::{json, Value};
@@ -389,6 +390,19 @@ fn append_work_item_todo(
     Ok(())
 }
 
+fn append_turn_for_message(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+    turn_id: &str,
+    turn_index: u64,
+) -> Result<TurnRecord> {
+    let mut turn = TurnRecord::new(&message.agent_id, turn_id, turn_index);
+    turn.input_message_ids = vec![message.id.clone()];
+    turn.trigger = Some(TurnTriggerSummary::from_message(message));
+    storage.append_turn(&turn)?;
+    Ok(turn)
+}
+
 #[test]
 fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
     let dir = tempdir()?;
@@ -421,6 +435,9 @@ fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
     );
     result_brief.id = "brief_focused_prompt_projection".into();
     storage.append_brief(&result_brief)?;
+    let mut turn = append_turn_for_message(&storage, &previous_operator, "turn-focused-prompt", 1)?;
+    turn.produced_brief_ids = vec![result_brief.id.clone()];
+    storage.append_turn(&turn)?;
 
     let current_message = MessageEnvelope::new(
         "default",
@@ -466,7 +483,8 @@ Current input relation: current_input is the latest trusted operator input.
 
 ## recent_turns
 Recent turns:
-- Turn message_seq 1:
+- Turn turn_index 1:
+  - turn_id: turn-focused-prompt
   - trigger: trusted operator input
   - operator input full: Run the focused prompt projection test. message_ref=message:msg_focused_prompt_projection
   - produced briefs:
@@ -535,6 +553,11 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
         summary: "Run command: cargo test runtime_flow".into(),
         invocation_surface: Some("commentary".into()),
     })?;
+    let mut turn =
+        append_turn_for_message(&storage, &operator_message_with_turn, "turn_op_test", 1)?;
+    turn.produced_brief_ids = vec![turn_index_brief.id.clone()];
+    turn.tool_execution_ids = vec!["tool_exec_1".into()];
+    storage.append_turn(&turn)?;
 
     let mut work_item = WorkItemRecord::new("default", "Track\nruntime flow", WorkItemState::Open);
     work_item.id = "work_runtime_flow".into();
@@ -606,7 +629,8 @@ Current input relation: current_input is a task-result continuation, not a new o
 
 ## recent_turns
 Recent turns:
-- Turn message_seq 1:
+- Turn turn_index 1:
+  - turn_id: turn_op_test
   - trigger: trusted operator input
   - continues input: message_seq 1
   - continuation trigger: a task-result continuation
@@ -1685,13 +1709,15 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         AdmissionContext::LocalProcess,
     );
     storage.append_message(&first_operator)?;
-    storage.append_brief(&BriefRecord::new(
+    let mut first_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
         "Started deterministic fixture construction.",
         Some(first_operator.id.clone()),
         None,
-    ))?;
+    );
+    first_brief.id = "brief_context_eval_started".into();
+    storage.append_brief(&first_brief)?;
 
     storage.append_tool_execution(&ToolExecutionRecord {
         id: "tool_context_eval".into(),
@@ -1710,6 +1736,10 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         summary: "Run command: cargo test -q --test prompt_context_snapshots".into(),
         invocation_surface: Some("commentary".into()),
     })?;
+    let mut first_turn =
+        append_turn_for_message(&storage, &first_operator, "turn_context_eval_start", 1)?;
+    first_turn.produced_brief_ids = vec![first_brief.id.clone()];
+    storage.append_turn(&first_turn)?;
 
     let task_result = MessageEnvelope::new(
         "default",
@@ -1728,13 +1758,20 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         AdmissionContext::RuntimeOwned,
     );
     storage.append_message(&task_result)?;
-    storage.append_brief(&BriefRecord::new(
+    let mut task_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
         "Diagnostics helper reports stable section sizes.",
         Some(task_result.id.clone()),
         Some("task_context_eval".into()),
-    ))?;
+    );
+    task_brief.id = "brief_context_eval_diagnostics".into();
+    storage.append_brief(&task_brief)?;
+    let mut task_turn =
+        append_turn_for_message(&storage, &task_result, "turn_context_eval_tool", 2)?;
+    task_turn.produced_brief_ids = vec![task_brief.id.clone()];
+    task_turn.tool_execution_ids = vec!["tool_context_eval".into()];
+    storage.append_turn(&task_turn)?;
 
     let current_message = MessageEnvelope::new(
         "default",
@@ -1899,13 +1936,20 @@ fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_disc
         summary: "Inspected prompt projection and produced a five-item issue list.".into(),
         invocation_surface: Some("commentary".into()),
     })?;
-    storage.append_brief(&BriefRecord::new(
+    let mut first_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
         "Initial issue list was promoted into the active work item and working memory.",
         Some(first_operator.id.clone()),
         None,
-    ))?;
+    );
+    first_brief.id = "brief_issue_list_initial".into();
+    storage.append_brief(&first_brief)?;
+    let mut first_turn =
+        append_turn_for_message(&storage, &first_operator, "turn_issue_list_analysis", 1)?;
+    first_turn.produced_brief_ids = vec![first_brief.id.clone()];
+    first_turn.tool_execution_ids = vec!["tool_issue_list_analysis".into()];
+    storage.append_turn(&first_turn)?;
 
     for (turn_index, (prompt, result)) in [
         (
@@ -1950,6 +1994,14 @@ fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_disc
         );
         brief.turn_index = Some((turn_index + 2) as u64);
         storage.append_brief(&brief)?;
+        let mut turn = append_turn_for_message(
+            &storage,
+            &operator,
+            &format!("turn_issue_list_discussion_{}", turn_index + 1),
+            (turn_index + 2) as u64,
+        )?;
+        turn.produced_brief_ids = vec![brief.id.clone()];
+        storage.append_turn(&turn)?;
     }
 
     let current_message = MessageEnvelope::new(
@@ -2044,13 +2096,15 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
         AdmissionContext::LocalProcess,
     );
     storage.append_message(&stale_operator)?;
-    storage.append_brief(&BriefRecord::new(
+    let mut stale_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
         "Compaction summary should carry only the preserved budget decision.",
         Some(stale_operator.id.clone()),
         None,
-    ))?;
+    );
+    stale_brief.id = "brief_stale_compaction".into();
+    storage.append_brief(&stale_brief)?;
 
     let recent_operator = MessageEnvelope::new(
         "default",
@@ -2069,13 +2123,19 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
         AdmissionContext::LocalProcess,
     );
     storage.append_message(&recent_operator)?;
-    storage.append_brief(&BriefRecord::new(
+    let mut recent_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
         "Active work resumed after compaction.",
         Some(recent_operator.id.clone()),
         None,
-    ))?;
+    );
+    recent_brief.id = "brief_active_resume".into();
+    storage.append_brief(&recent_brief)?;
+    let mut recent_turn =
+        append_turn_for_message(&storage, &recent_operator, "turn_active_resume", 2)?;
+    recent_turn.produced_brief_ids = vec![recent_brief.id.clone()];
+    storage.append_turn(&recent_turn)?;
 
     let mut active_work = WorkItemRecord::new(
         "default",
@@ -2139,9 +2199,6 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
     );
 
     let mut session = AgentState::new("default");
-    session.compacted_message_count = 1;
-    session.context_summary =
-        Some("Compacted summary: preserved budget decision and fact omega.".into());
     session.current_work_item_id = Some(active_work.id.clone());
 
     let rendered = render_context_snapshot_named(
@@ -2152,8 +2209,6 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
         Some("multi_turn_context_compacted_interleaving"),
     )?;
     let diagnostics = analyze_context(&rendered);
-    let compacted_summary =
-        section_content(&rendered, "compacted_summary").expect("compacted summary section");
     let current_work_item =
         section_content(&rendered, "current_work_item").expect("current work section");
     let queued_blocked =
@@ -2161,7 +2216,7 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
     let recent_turns = section_content(&rendered, "recent_turns").expect("recent turns section");
     let current_input = section_content(&rendered, "current_input").expect("current input");
 
-    assert!(compacted_summary.contains("preserved budget decision and fact omega"));
+    assert!(section_content(&rendered, "compacted_summary").is_none());
     assert!(current_work_item.contains("work_active_eval"));
     assert!(current_work_item.contains("Ship compacted interleaving eval"));
     assert!(queued_blocked.contains("work_queued_eval"));

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -153,8 +153,6 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
         )
         .await?;
 
-    assert!(prompt.cache_identity.compression_epoch > 0);
-
     let active_section = prompt
         .context_sections
         .iter()
@@ -275,7 +273,6 @@ pub async fn task_result_rejoin_after_compaction_preserves_current_work_truth() 
 
     let requests = provider.captured_requests().await;
     let task_rejoin = &requests[1];
-    assert!(task_rejoin.compression_epoch > 0);
     assert!(task_rejoin
         .prompt_text
         .contains("Close the compaction regression gap"));
@@ -400,7 +397,6 @@ pub async fn contentful_wake_hint_after_compaction_keeps_active_work_truth() -> 
 
     let requests = provider.captured_requests().await;
     let wake_follow_up = &requests[1];
-    assert!(wake_follow_up.compression_epoch > 0);
     assert!(wake_follow_up
         .prompt_text
         .contains("Keep active compaction work in focus"));
@@ -482,7 +478,6 @@ pub async fn queued_notification_after_compaction_keeps_queued_work_visible() ->
 
     let requests = provider.captured_requests().await;
     let queued_follow_up = &requests[1];
-    assert!(queued_follow_up.compression_epoch > 0);
     assert!(queued_follow_up
         .prompt_text
         .contains("Resume queued compaction validation"));


### PR DESCRIPTION
## Summary
- remove legacy message compaction fallback state and prompt rendering
- drop synthesized legacy recent_turns from raw messages/briefs/tools
- keep context continuity on persisted recent_turns, episode memory, and retrieval surfaces

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test --all-targets
