### PR TITLE
feat(web-gui): add navigation stack, file-level refresh, and toolbar improvements

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -49,6 +49,7 @@ export function App() {
   const showWorkItemDetail = useRuntimeStore((state) => state.showWorkItemDetail);
   const showTaskDetail = useRuntimeStore((state) => state.showTaskDetail);
   const showFileBrowser = useRuntimeStore((state) => state.showFileBrowser);
+  const navigateBack = useRuntimeStore((state) => state.navigateBack);
   const toggleRightPanel = useRuntimeStore((state) => state.toggleRightPanel);
   const toggleNavCollapsed = useRuntimeStore((state) => state.toggleNavCollapsed);
   const setRuntimeConnection = useRuntimeStore((state) => state.setRuntimeConnection);
@@ -548,6 +549,7 @@ export function App() {
           }}
           onOpenSkill={navigateSkill}
           onShowAgentOverview={showAgentOverview}
+          onNavigateBack={navigateBack}
           onBrowseFiles={(workspaceId: string, executionRootId?: string) => {
             showFileBrowser(selectedAgent.id, workspaceId, undefined, executionRootId);
           }}

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -180,6 +180,34 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
     [workspaceId, executionRootId, browseWorkspaceDir],
   );
 
+  const reloadFile = useCallback(async () => {
+    if (!selectedFile?.path) return;
+    const filePath = selectedFile.path;
+    if (isImageFile(selectedFile.mimeType)) {
+      // Image files are served via URL, force re-render by re-setting state
+      setSelectedFile({ path: filePath, loading: false, mimeType: selectedFile.mimeType });
+      return;
+    }
+    setSelectedFile({ path: filePath, loading: true });
+    try {
+      const content = await readWorkspaceFile(workspaceId, filePath, executionRootId);
+      setSelectedFile({
+        path: filePath,
+        content: content.content,
+        mimeType: content.mimeType,
+        truncated: content.truncated,
+        totalSize: content.totalSize ?? content.size,
+        loading: false,
+      });
+    } catch (err) {
+      setSelectedFile({
+        path: filePath,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [selectedFile, workspaceId, executionRootId, readWorkspaceFile]);
+
   useEffect(() => {
     void loadDir(effectiveInitialPath);
   }, [loadDir, effectiveInitialPath]);
@@ -265,6 +293,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   return (
     <div className="file-browser">
       <div className="file-browser-toolbar">
+        <button type="button" className="file-browser-back-btn" onClick={() => onClose?.()}>← Back</button>
         <nav className="file-browser-breadcrumb" aria-label="Path breadcrumb">
           <button
             type="button"
@@ -286,6 +315,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
             </span>
           ))}
         </nav>
+        {!selectedFile ? (
         <label className="file-browser-hidden-toggle">
           <input
             type="checkbox"
@@ -294,11 +324,12 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
           />
           <small>hidden</small>
         </label>
+        ) : null}
         <button
           type="button"
           className="file-browser-refresh"
-          aria-label="Refresh directory"
-          onClick={() => void loadDir(currentPath)}
+          aria-label={selectedFile ? "Refresh file content" : "Refresh directory"}
+          onClick={() => void (selectedFile ? reloadFile() : loadDir(currentPath))}
         >
           ↻
         </button>
@@ -355,7 +386,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
                   </button>
                 </div>
               ) : null}
-              <button type="button" aria-label="Back to previous page" onClick={() => onClose?.()}>← Back</button>
+              <button type="button" className="file-browser-close-btn" aria-label="Close file" onClick={() => setSelectedFile(null)}>× Close</button>
             </div>
           </div>
           {selectedFile.loading ? (

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -26,6 +26,7 @@ interface RightSidePanelProps {
   onDisableAgentSkill: (name: string) => void;
   onOpenSkill: (skillId: string) => void;
   onShowAgentOverview: () => void;
+  onNavigateBack: () => void;
   onBrowseFiles: (workspaceId: string, executionRootId?: string) => void;
   onOpenPlanFile?: (workspaceId: string, filePath: string) => void;
   onClose: () => void;
@@ -51,6 +52,7 @@ export function RightSidePanel({
   onDisableAgentSkill,
   onOpenSkill,
   onShowAgentOverview,
+  onNavigateBack,
   onBrowseFiles,
   onOpenPlanFile,
   onClose,
@@ -182,7 +184,7 @@ export function RightSidePanel({
             <TaskDetailPanel task={activeView.task} detailState={taskDetailState} />
           </div>
         ) : activeView.kind === "file_browser" ? (
-          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} onClose={onShowAgentOverview} />
+          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} onClose={onNavigateBack} />
         ) : (
           <AgentOverviewPanel
             agent={agent}

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -165,6 +165,7 @@ export interface RuntimeStoreState {
   selectedSkillId: string;
   displayLevel: DisplayLevel;
   displayLevelsByAgentId: Record<string, DisplayLevel>;
+  rightPanelViewStack: RightPanelView[];
   rightPanelOpen: boolean;
   rightPanelView?: RightPanelView;
   navCollapsed: boolean;
@@ -214,6 +215,7 @@ export interface RuntimeStoreState {
   showFileBrowser: (agentId: string, workspaceId: string, initialPath?: string, executionRootId?: string, initialFilePath?: string) => void;
   browseWorkspaceDir: (workspaceId: string, path?: string, executionRootId?: string) => Promise<WorkspaceDirectoryListing>;
   readWorkspaceFile: (workspaceId: string, path: string, executionRootId?: string) => Promise<WorkspaceFileContent>;
+  navigateBack: () => void;
   workspaceFileUrl: (workspaceId: string, path: string, download?: boolean, executionRootId?: string) => string;
   toggleRightPanel: () => void;
   toggleNavCollapsed: () => void;
@@ -656,6 +658,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   displayLevelsByAgentId: readStoredDisplayLevels(),
   rightPanelOpen: true,
   rightPanelView: undefined,
+  rightPanelViewStack: [],
   navCollapsed: false,
 
   bootstrap: pendingBootstrap(runtimeConnectionConfig),
@@ -731,35 +734,70 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }),
   setRightPanelOpen: (open) => set({ rightPanelOpen: open }),
   showAgentOverview: (agentId) =>
-    set((state) => ({
+    set((state) => {
+      const stack = state.rightPanelView ? [...state.rightPanelViewStack, state.rightPanelView] : state.rightPanelViewStack;
+      return {
+      rightPanelViewStack: stack,
       rightPanelOpen: true,
       rightPanelView: { kind: "agent_overview", agentId: agentId ?? state.selectedAgentId },
-    })),
+      };
+    }),
   showWorkItemDetail: (agentId, workItem) =>
-    set({
+    set((state) => {
+      const stack = state.rightPanelView ? [...state.rightPanelViewStack, state.rightPanelView] : state.rightPanelViewStack;
+      return {
+      rightPanelViewStack: stack,
       rightPanelOpen: true,
       rightPanelView: { kind: "work_item_detail", agentId, workItem },
+      };
     }),
   showTaskDetail: (agentId, task) =>
-    set({
+    set((state) => {
+      const stack = state.rightPanelView ? [...state.rightPanelViewStack, state.rightPanelView] : state.rightPanelViewStack;
+      return {
+      rightPanelViewStack: stack,
       rightPanelOpen: true,
       rightPanelView: { kind: "task_detail", agentId, task },
+      };
     }),
   showFileBrowser: (agentId, workspaceId, initialPath, executionRootId, initialFilePath) =>
-    set({
+    set((state) => {
+      const stack = state.rightPanelView ? [...state.rightPanelViewStack, state.rightPanelView] : state.rightPanelViewStack;
+      return {
+      rightPanelViewStack: stack,
       rightPanelOpen: true,
       rightPanelView: { kind: "file_browser", agentId, workspaceId, initialPath, executionRootId, initialFilePath },
+      };
     }),
   browseWorkspaceDir: (workspaceId, path, executionRootId) => runtimeClient.browseWorkspaceDir(workspaceId, path, executionRootId),
   readWorkspaceFile: (workspaceId, path, executionRootId) => runtimeClient.readWorkspaceFile(workspaceId, path, executionRootId),
   workspaceFileUrl: (workspaceId, path, download, executionRootId) => runtimeClient.workspaceFileUrl(workspaceId, path, download, executionRootId),
   inspectActivity: (agentId, activity) => {
-    set({
+    set((state) => {
+      const stack = state.rightPanelView ? [...state.rightPanelViewStack, state.rightPanelView] : state.rightPanelViewStack;
+      return {
+      rightPanelViewStack: stack,
       rightPanelOpen: true,
       rightPanelView: { kind: "activity_inspector", agentId, activity },
+      };
     });
     hydrateInspectorActivityDetail(get, set, agentId, activity);
   },
+  navigateBack: () =>
+    set((state) => {
+      if (state.rightPanelViewStack.length === 0) {
+        return {
+          rightPanelView: { kind: "agent_overview", agentId: state.selectedAgentId },
+          rightPanelViewStack: [],
+        };
+      }
+      const newStack = [...state.rightPanelViewStack];
+      const previous = newStack.pop()!;
+      return {
+        rightPanelView: previous,
+        rightPanelViewStack: newStack,
+      };
+    }),
   toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),
   toggleNavCollapsed: () => set((state) => ({ navCollapsed: !state.navCollapsed })),
 

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3440,7 +3440,7 @@ code {
   grid-template-rows: minmax(0, 1fr);
 }
 
-.file-browser:has(> .file-browser-viewer) > :not(.file-browser-viewer) {
+.file-browser:has(> .file-browser-viewer) > .file-browser-list {
   display: none;
 }
 
@@ -3449,6 +3449,16 @@ code {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.file-browser-back-btn {
+  background: none;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  line-height: 1;
 }
 
 .file-browser-breadcrumb {
@@ -3658,6 +3668,16 @@ code {
   border-radius: 5px;
   overflow: hidden;
   font-size: 0.75rem;
+  line-height: 1;
+}
+
+.file-browser-close-btn {
+  background: none;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 4px 10px;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary

在文件浏览器中引入导航栈机制，修复 Back 按钮语义，并改进文件查看时的工具栏体验。

## Changes

### Navigation Stack (方案 B)
- 新增 `rightPanelViewStack` 状态，每次切换 view 时自动压栈
- 新增 `navigateBack()` action，从栈中弹出前一个 view
- 文件浏览器的 `← Back` 按钮改为调用 `navigateBack()`，回到前一个页面（如 work_item_detail）而非硬编码到 agent_overview

### Toolbar Improvements
- 查看文件时保留 toolbar（← Back + breadcrumb + ↻ refresh），仅隐藏 hidden toggle
- 更新 CSS：`.file-browser:has(> .file-browser-viewer) > .file-browser-list` 只隐藏目录列表，不影响 toolbar

### File-Level Refresh
- 新增 `reloadFile()` 函数，复用 `readWorkspaceFile` 重新读取当前文件内容
- refresh 按钮根据是否有已选文件，条件调用 `reloadFile()` 或 `loadDir(currentPath)`
- aria-label 区分 "Refresh file content" / "Refresh directory"

### Close Button
- viewer-head 的 `← Back` 改为 `× Close`，语义为关闭文件回到目录列表

## Related
- 基于之前已合并的 PR #2090 的后续改进
- 之前的讨论和设计确认在 #2090 的对话中