### PR TITLE
feat(web-gui): Agent Templates page with Create Agent entry, remote sources, and cache fix

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -996,6 +996,34 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
             let provider = web_provider_config_mut(config, key, ".limits.max_output_bytes")?;
             provider.limits.max_output_bytes = Some(parse_positive_usize_key(key, raw_value)?);
         }
+        "agent_templates.remote_sources" => {
+            let sources: std::collections::BTreeMap<
+                String,
+                crate::config::file::AgentTemplateRemoteSourceConfigFile,
+            > = serde_json::from_str(raw_value).with_context(|| {
+                format!("invalid agent_templates.remote_sources JSON: {}", raw_value)
+            })?;
+            config.agent_templates.remote_sources = sources;
+        }
+        key if key.starts_with("agent_templates.remote_sources.") => {
+            let source_id = key.strip_prefix("agent_templates.remote_sources.").unwrap();
+            if source_id.is_empty() {
+                return Err(anyhow!(
+                    "agent_templates.remote_sources.<id> requires a non-empty source id"
+                ));
+            }
+            let source: crate::config::file::AgentTemplateRemoteSourceConfigFile =
+                serde_json::from_str(raw_value).with_context(|| {
+                    format!(
+                        "invalid agent template source config for {}: {}",
+                        source_id, raw_value
+                    )
+                })?;
+            config
+                .agent_templates
+                .remote_sources
+                .insert(source_id.to_string(), source);
+        }
         _ => return Err(unknown_config_key(key)),
     }
     validate_api_cors_config(&config.api.cors)?;
@@ -1139,6 +1167,18 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
                 return Err(anyhow!("web provider {name} not found"));
             }
             return Ok(());
+        }
+        "agent_templates.remote_sources" => {
+            config.agent_templates.remote_sources.clear();
+        }
+        key if key.starts_with("agent_templates.remote_sources.") => {
+            let source_id = key.strip_prefix("agent_templates.remote_sources.").unwrap();
+            if source_id.is_empty() {
+                return Err(anyhow!(
+                    "agent_templates.remote_sources.<id> requires a non-empty source id"
+                ));
+            }
+            config.agent_templates.remote_sources.remove(source_id);
         }
         _ => return Err(unknown_config_key(key)),
     }

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -266,6 +266,7 @@ fn is_runtime_mutable_config_key(key: &str) -> bool {
             | "runtime.max_tool_output_tokens"
             | "runtime.disable_provider_fallback"
     ) || key.starts_with("providers.")
+        || key.starts_with("agent_templates.")
         || key.starts_with("web.")
 }
 

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -11,6 +11,7 @@ import { RightSidePanel } from "../features/right-panel/RightSidePanel";
 import { SearchPage } from "../features/search/SearchPage";
 import { SettingsPage } from "../features/settings/SettingsPage";
 import { SkillDetailPage, SkillsPage } from "../features/skills/SkillsPage";
+import { TemplateDetailPage, TemplatesPage } from "../features/templates/TemplatesPage";
 import { deriveAgentDisplayStatus } from "../runtime/agent-status";
 import { selectSelectedAgent } from "../runtime/runtime-selectors";
 import { canUseRemoteRuntimeConnections, readStoredRemoteConnectionProfiles, useRuntimeStore } from "../runtime/runtime-store";
@@ -23,6 +24,7 @@ const globalRoutes: Array<{ key: RouteKey; label: string; icon: string }> = [
   { key: "dashboard", label: "Dashboard", icon: "◎" },
   { key: "search", label: "Search", icon: "⌕" },
   { key: "skills", label: "Skills", icon: "◇" },
+  { key: "templates", label: "Templates", icon: "▣" },
   { key: "settings", label: "Settings", icon: "⚙" },
 ];
 
@@ -33,6 +35,7 @@ export function App() {
   const route = useRuntimeStore((state) => state.route);
   const selectedAgentId = useRuntimeStore((state) => state.selectedAgentId);
   const selectedSkillId = useRuntimeStore((state) => state.selectedSkillId);
+  const selectedTemplateId = useRuntimeStore((state) => state.selectedTemplateId);
   const displayLevel = useRuntimeStore((state) =>
     state.displayLevelsByAgentId[selectedAgentId] ?? "info",
   );
@@ -42,6 +45,7 @@ export function App() {
   const setRoute = useRuntimeStore((state) => state.setRoute);
   const openAgent = useRuntimeStore((state) => state.openAgent);
   const openSkill = useRuntimeStore((state) => state.openSkill);
+  const openTemplate = useRuntimeStore((state) => state.openTemplate);
   const setDisplayLevel = useRuntimeStore((state) => state.setDisplayLevel);
   const setRightPanelOpen = useRuntimeStore((state) => state.setRightPanelOpen);
   const inspectActivity = useRuntimeStore((state) => state.inspectActivity);
@@ -85,6 +89,18 @@ export function App() {
   const skillDetailError = useRuntimeStore((state) =>
     selectedSkillId ? state.skillDetailErrorById[selectedSkillId] : undefined,
   );
+  const templateCatalog = useRuntimeStore((state) => state.templateCatalog);
+  const templateCatalogLoading = useRuntimeStore((state) => state.templateCatalogLoading);
+  const templateCatalogError = useRuntimeStore((state) => state.templateCatalogError);
+  const templateDetail = useRuntimeStore((state) =>
+    selectedTemplateId ? state.templateDetailById[selectedTemplateId] : undefined,
+  );
+  const templateDetailLoading = useRuntimeStore((state) =>
+    selectedTemplateId ? state.templateDetailLoadingById[selectedTemplateId] ?? false : false,
+  );
+  const templateDetailError = useRuntimeStore((state) =>
+    selectedTemplateId ? state.templateDetailErrorById[selectedTemplateId] : undefined,
+  );
   const addSkillToCatalog = useRuntimeStore((state) => state.addSkillToCatalog);
   const removeSkillFromCatalog = useRuntimeStore((state) => state.removeSkillFromCatalog);
   const skillInstallJobs = useRuntimeStore((state) => state.skillInstallJobs);
@@ -101,6 +117,12 @@ export function App() {
   const loadSearchResultContent = useRuntimeStore((state) => state.loadSearchResultContent);
   const refreshSkillCatalog = useRuntimeStore((state) => state.refreshSkillCatalog);
   const refreshSkillDetail = useRuntimeStore((state) => state.refreshSkillDetail);
+  const refreshTemplateCatalog = useRuntimeStore((state) => state.refreshTemplateCatalog);
+  const refreshTemplateDetail = useRuntimeStore((state) => state.refreshTemplateDetail);
+  const installTemplate = useRuntimeStore((state) => state.installTemplate);
+  const removeTemplate = useRuntimeStore((state) => state.removeTemplate);
+  const syncTemplateRemoteSources = useRuntimeStore((state) => state.syncTemplateRemoteSources);
+  const createAgentFromTemplate = useRuntimeStore((state) => state.createAgentFromTemplate);
   const refreshAgentSkillCatalog = useRuntimeStore((state) => state.refreshAgentSkillCatalog);
   const enableAgentSkill = useRuntimeStore((state) => state.enableAgentSkill);
   const disableAgentSkill = useRuntimeStore((state) => state.disableAgentSkill);
@@ -196,13 +218,17 @@ export function App() {
         openSkill(nextRoute.skillId);
         return;
       }
+      if (nextRoute.route === "templateDetail" && nextRoute.templateId) {
+        openTemplate(nextRoute.templateId);
+        return;
+      }
       setRoute(nextRoute.route);
     };
 
     applyBrowserRoute();
     window.addEventListener("popstate", applyBrowserRoute);
     return () => window.removeEventListener("popstate", applyBrowserRoute);
-  }, [openAgent, openSkill, setRoute]);
+  }, [openAgent, openSkill, openTemplate, setRoute]);
 
   useEffect(() => {
     if ((route !== "agent" && route !== "settings") || modelCatalogLoading || modelCatalog.options.length > 0) return;
@@ -225,6 +251,16 @@ export function App() {
   }, [refreshSkillDetail, route, selectedSkillId, skillDetail, skillDetailLoading]);
 
   useEffect(() => {
+    if ((route !== "templates" && route !== "templateDetail") || templateCatalogLoading || templateCatalog.source !== "fixture") return;
+    void refreshTemplateCatalog();
+  }, [refreshTemplateCatalog, route, templateCatalog.source, templateCatalogLoading]);
+
+  useEffect(() => {
+    if (route !== "templateDetail" || !selectedTemplateId || templateDetailLoading || templateDetail) return;
+    void refreshTemplateDetail(selectedTemplateId);
+  }, [refreshTemplateDetail, route, selectedTemplateId, templateDetail, templateDetailLoading]);
+
+  useEffect(() => {
     if (!sidePanelAgentId || agentSkillCatalogLoading || agentSkillCatalog) return;
     void refreshAgentSkillCatalog(sidePanelAgentId);
   }, [agentSkillCatalog, agentSkillCatalogLoading, refreshAgentSkillCatalog, sidePanelAgentId]);
@@ -243,9 +279,20 @@ export function App() {
     pushBrowserRoute("skillDetail", skillId);
   }
 
+  function navigateTemplate(catalogId: string) {
+    openTemplate(catalogId);
+    pushBrowserRoute("templateDetail", catalogId);
+  }
+
   function navigateAgent(agentId: string, eventSeq?: number) {
     openAgent(agentId, eventSeq);
     pushBrowserRoute("agent", agentId, eventSeq == null ? undefined : { event_seq: eventSeq });
+  }
+
+  async function createTemplateAgent(agentId: string, template: string): Promise<boolean> {
+    const ok = await createAgentFromTemplate(agentId, template);
+    if (ok) navigateAgent(agentId);
+    return ok;
   }
 
   if (isInitialBootstrapping) {
@@ -489,6 +536,31 @@ export function App() {
             error={skillDetailError}
             onBack={() => navigateRoute("skills")}
             onRefresh={() => refreshSkillDetail(selectedSkillId)}
+          />
+        ) : null}
+        {route === "templates" ? (
+          <TemplatesPage
+            catalog={templateCatalog}
+            loading={templateCatalogLoading}
+            error={templateCatalogError}
+            onRefresh={refreshTemplateCatalog}
+            onSyncSources={syncTemplateRemoteSources}
+            onInstallTemplate={installTemplate}
+            onRemoveTemplate={removeTemplate}
+            onCreateAgent={createTemplateAgent}
+            onOpenTemplate={navigateTemplate}
+          />
+        ) : null}
+        {route === "templateDetail" ? (
+          <TemplateDetailPage
+            catalogId={selectedTemplateId}
+            detail={templateDetail}
+            loading={templateDetailLoading}
+            error={templateDetailError}
+            onBack={() => navigateRoute("templates")}
+            onRefresh={() => refreshTemplateDetail(selectedTemplateId)}
+            onCreateAgent={createTemplateAgent}
+            onRemoveTemplate={removeTemplate}
           />
         ) : null}
         {route === "settings" ? (
@@ -857,6 +929,7 @@ function agentStatusIcon(tone: string): string {
 function pageTitle(route: RouteKey): string {
   if (route === "search") return "Search";
   if (route === "skills" || route === "skillDetail") return "Skills";
+  if (route === "templates" || route === "templateDetail") return "Templates";
   if (route === "settings") return "Settings";
   return "Dashboard";
 }
@@ -864,6 +937,7 @@ function pageTitle(route: RouteKey): string {
 function pageSubtitle(route: RouteKey, attentionCount: number, agentCount: number): string {
   if (route === "search") return "cross-agent lookup · messages · briefs · work evidence";
   if (route === "skills" || route === "skillDetail") return "global library · catalog · daemon-managed skills";
+  if (route === "templates" || route === "templateDetail") return "agent templates · sources · create agents";
   if (route === "settings") return "local connection · providers · model defaults";
   return attentionCount > 0 ? `${agentCount} agents · ${attentionCount} need attention` : `${agentCount} agents · all clear`;
 }

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -24,7 +24,7 @@ const globalRoutes: Array<{ key: RouteKey; label: string; icon: string }> = [
   { key: "dashboard", label: "Dashboard", icon: "◎" },
   { key: "search", label: "Search", icon: "⌕" },
   { key: "skills", label: "Skills", icon: "◇" },
-  { key: "templates", label: "Templates", icon: "▣" },
+  { key: "templates", label: "Agent Templates", icon: "▣" },
   { key: "settings", label: "Settings", icon: "⚙" },
 ];
 
@@ -32,6 +32,11 @@ const APP_WINDOW_TITLE = "Holon";
 
 export function App() {
   const { bootstrap, loading, refresh } = useRuntimeDashboard();
+  const [showCreateAgentModal, setShowCreateAgentModal] = useState(false);
+  const [createAgentId, setCreateAgentId] = useState("");
+  const [createAgentTemplate, setCreateAgentTemplate] = useState("");
+  const [createAgentError, setCreateAgentError] = useState<string | undefined>();
+  const [createAgentBusy, setCreateAgentBusy] = useState(false);
   const route = useRuntimeStore((state) => state.route);
   const selectedAgentId = useRuntimeStore((state) => state.selectedAgentId);
   const selectedSkillId = useRuntimeStore((state) => state.selectedSkillId);
@@ -289,6 +294,58 @@ export function App() {
     pushBrowserRoute("agent", agentId, eventSeq == null ? undefined : { event_seq: eventSeq });
   }
 
+  async function handleCreateAgentSubmit(): Promise<void> {
+    const id = createAgentId.trim();
+    const tmpl = createAgentTemplate.trim();
+    if (!id || !tmpl) return;
+    setCreateAgentBusy(true);
+    setCreateAgentError(undefined);
+    try {
+      const ok = await createTemplateAgent(id, tmpl);
+      if (ok) {
+        setCreateAgentId("");
+        setCreateAgentTemplate("");
+        setShowCreateAgentModal(false);
+      } else {
+        setCreateAgentError("Failed to create agent.");
+      }
+    } catch (error) {
+      setCreateAgentError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setCreateAgentBusy(false);
+    }
+  }
+
+  async function addTemplateRemoteSource(sourceId: string, url: string, gitRef?: string): Promise<boolean> {
+    try {
+      const configValue = JSON.stringify({ url, ref: gitRef ?? null });
+      const result = await updateRuntimeConfig([{ key: `agent_templates.remote_sources.${sourceId}`, value: configValue }]);
+      if (result) {
+        void refreshRuntimeConfig();
+        void syncTemplateRemoteSources();
+        void refreshTemplateCatalog();
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async function removeTemplateRemoteSource(sourceId: string): Promise<boolean> {
+    try {
+      const result = await updateRuntimeConfig([{ key: `agent_templates.remote_sources.${sourceId}`, unset: true }]);
+      if (result) {
+        void refreshRuntimeConfig();
+        void refreshTemplateCatalog();
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
   async function createTemplateAgent(agentId: string, template: string): Promise<boolean> {
     const ok = await createAgentFromTemplate(agentId, template);
     if (ok) navigateAgent(agentId);
@@ -368,6 +425,15 @@ export function App() {
           <div className="side-heading">
             <span>Active agents</span>
             <strong>{bootstrap.agents.length}</strong>
+            <button
+              className="side-heading-add"
+              type="button"
+              aria-label="Create agent from template"
+              title="Create agent from template"
+              onClick={() => setShowCreateAgentModal(true)}
+            >
+              +
+            </button>
           </div>
           {bootstrap.agents.length === 0 ? (
             <div className="agent-list-state" role="status">
@@ -547,8 +613,9 @@ export function App() {
             onSyncSources={syncTemplateRemoteSources}
             onInstallTemplate={installTemplate}
             onRemoveTemplate={removeTemplate}
-            onCreateAgent={createTemplateAgent}
             onOpenTemplate={navigateTemplate}
+            onAddRemoteSource={addTemplateRemoteSource}
+            onRemoveRemoteSource={removeTemplateRemoteSource}
           />
         ) : null}
         {route === "templateDetail" ? (
@@ -559,7 +626,6 @@ export function App() {
             error={templateDetailError}
             onBack={() => navigateRoute("templates")}
             onRefresh={() => refreshTemplateDetail(selectedTemplateId)}
-            onCreateAgent={createTemplateAgent}
             onRemoveTemplate={removeTemplate}
           />
         ) : null}
@@ -630,6 +696,53 @@ export function App() {
           }}
           onClose={() => setRightPanelOpen(false)}
         />
+      ) : null}
+
+      {showCreateAgentModal ? (
+        <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Create agent from template" onClick={(e) => { if (e.target === e.currentTarget) setShowCreateAgentModal(false); }}>
+          <div className="modal-card">
+            <div className="modal-head">
+              <strong>Create agent from template</strong>
+              <button type="button" className="modal-close" aria-label="Close" onClick={() => setShowCreateAgentModal(false)}>×</button>
+            </div>
+            <form className="modal-body" onSubmit={(e) => { e.preventDefault(); void handleCreateAgentSubmit(); }}>
+              <label>
+                <span>Agent ID</span>
+                <input
+                  value={createAgentId}
+                  onChange={(e) => setCreateAgentId(e.target.value)}
+                  placeholder="new-agent-id"
+                  autoFocus
+                  disabled={createAgentBusy}
+                />
+              </label>
+              <label>
+                <span>Template</span>
+                <select
+                  value={createAgentTemplate}
+                  onChange={(e) => setCreateAgentTemplate(e.target.value)}
+                  disabled={createAgentBusy}
+                >
+                  <option value="">Choose a template…</option>
+                  {templateCatalog.catalog.map((t) => (
+                    <option key={t.catalogId} value={t.template}>
+                      {t.name} ({t.source})
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {createAgentError ? <span className="connection-error" role="alert">{createAgentError}</span> : null}
+              <div className="modal-actions">
+                <Button type="button" variant="outline" disabled={createAgentBusy} onClick={() => setShowCreateAgentModal(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="accent" disabled={createAgentBusy || !createAgentId.trim() || !createAgentTemplate.trim()}>
+                  {createAgentBusy ? "Creating…" : "Create"}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
       ) : null}
     </div>
   );
@@ -929,7 +1042,7 @@ function agentStatusIcon(tone: string): string {
 function pageTitle(route: RouteKey): string {
   if (route === "search") return "Search";
   if (route === "skills" || route === "skillDetail") return "Skills";
-  if (route === "templates" || route === "templateDetail") return "Templates";
+  if (route === "templates" || route === "templateDetail") return "Agent Templates";
   if (route === "settings") return "Settings";
   return "Dashboard";
 }
@@ -937,7 +1050,7 @@ function pageTitle(route: RouteKey): string {
 function pageSubtitle(route: RouteKey, attentionCount: number, agentCount: number): string {
   if (route === "search") return "cross-agent lookup · messages · briefs · work evidence";
   if (route === "skills" || route === "skillDetail") return "global library · catalog · daemon-managed skills";
-  if (route === "templates" || route === "templateDetail") return "agent templates · sources · create agents";
+  if (route === "templates" || route === "templateDetail") return "agent templates · remote sources · catalog";
   if (route === "settings") return "local connection · providers · model defaults";
   return attentionCount > 0 ? `${agentCount} agents · ${attentionCount} need attention` : `${agentCount} agents · all clear`;
 }

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -430,7 +430,12 @@ export function App() {
               type="button"
               aria-label="Create agent from template"
               title="Create agent from template"
-              onClick={() => setShowCreateAgentModal(true)}
+              onClick={async () => {
+                if (templateCatalog.source === "fixture" && !templateCatalogLoading) {
+                  await refreshTemplateCatalog();
+                }
+                setShowCreateAgentModal(true);
+              }}
             >
               +
             </button>

--- a/web-gui/app/src/app/routes.ts
+++ b/web-gui/app/src/app/routes.ts
@@ -4,6 +4,7 @@ interface BrowserRoute {
   route: RouteKey;
   agentId?: string;
   skillId?: string;
+  templateId?: string;
   eventSeq?: number;
 }
 
@@ -27,6 +28,14 @@ export function routeFromLocation(location: Pick<Location, "pathname" | "search"
       skillId: safeDecodeURIComponent(skillMatch[1]),
     };
   }
+  if (path === "/templates") return { route: "templates" };
+  const templateMatch = path.match(/^\/templates\/([^/]+)$/);
+  if (templateMatch) {
+    return {
+      route: "templateDetail",
+      templateId: safeDecodeURIComponent(templateMatch[1]),
+    };
+  }
   if (path === "/settings") return { route: "settings" };
 
   const agentMatch = path.match(/^\/agents\/([^/]+)(?:\/conversation)?$/);
@@ -46,6 +55,8 @@ export function pathForRoute(route: RouteKey, agentId?: string, query?: Record<s
   if (route === "search") return "/search";
   if (route === "skills") return "/skills";
   if (route === "skillDetail" && agentId) return `/skills/${encodeURIComponent(agentId)}`;
+  if (route === "templates") return "/templates";
+  if (route === "templateDetail" && agentId) return `/templates/${encodeURIComponent(agentId)}`;
   if (route === "settings") return "/settings";
   if (route === "agent" && agentId) return `/agents/${encodeURIComponent(agentId)}/conversation${queryString ? `?${queryString}` : ""}`;
   return "/";

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -1,0 +1,491 @@
+import { useMemo, useState, type FormEvent } from "react";
+
+import { MarkdownContent } from "../../components/MarkdownContent";
+import { Button } from "../../components/ui/Button";
+import { Card, CardContent, CardHeader } from "../../components/ui/Card";
+import { EmptyState } from "../../components/ui/EmptyState";
+import { StatusBadge } from "../../components/ui/StatusChip";
+import type {
+  AgentTemplateCatalogEntry,
+  AgentTemplateCatalogState,
+  AgentTemplateDetailState,
+  AgentTemplateSourceKind,
+} from "../../runtime/types";
+
+interface TemplatesPageProps {
+  catalog: AgentTemplateCatalogState;
+  loading: boolean;
+  error?: string;
+  onRefresh: () => void;
+  onSyncSources: () => Promise<boolean>;
+  onInstallTemplate: (githubUrl: string) => Promise<boolean>;
+  onRemoveTemplate: (templateId: string) => Promise<boolean>;
+  onCreateAgent: (agentId: string, template: string) => Promise<boolean>;
+  onOpenTemplate: (catalogId: string) => void;
+}
+
+interface TemplateDetailPageProps {
+  catalogId: string;
+  detail?: AgentTemplateDetailState;
+  loading: boolean;
+  error?: string;
+  onBack: () => void;
+  onRefresh: () => void;
+  onCreateAgent: (agentId: string, template: string) => Promise<boolean>;
+  onRemoveTemplate: (templateId: string) => Promise<boolean>;
+}
+
+export function TemplatesPage({
+  catalog,
+  loading,
+  error,
+  onRefresh,
+  onSyncSources,
+  onInstallTemplate,
+  onRemoveTemplate,
+  onCreateAgent,
+  onOpenTemplate,
+}: TemplatesPageProps) {
+  const templates = catalog.catalog;
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<"all" | AgentTemplateSourceKind>("all");
+  const [githubUrl, setGithubUrl] = useState("");
+  const [agentId, setAgentId] = useState("");
+  const [createTemplate, setCreateTemplate] = useState("");
+  const stats = useMemo(() => templateStats(templates), [templates]);
+  const visibleTemplates = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return templates.filter((template) => {
+      if (sourceFilter !== "all" && template.source !== sourceFilter) return false;
+      if (!normalizedQuery) return true;
+      return [
+        template.name,
+        template.description,
+        template.catalogId,
+        template.template,
+        template.templateId,
+        template.sourceId,
+        template.sourceUrl,
+        ...template.includedSkills,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(normalizedQuery));
+    });
+  }, [query, sourceFilter, templates]);
+
+  async function handleInstall(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const source = githubUrl.trim();
+    if (!source) return;
+    const ok = await onInstallTemplate(source);
+    if (ok) setGithubUrl("");
+  }
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const id = agentId.trim();
+    const template = createTemplate.trim();
+    if (!id || !template) return;
+    const ok = await onCreateAgent(id, template);
+    if (ok) setAgentId("");
+  }
+
+  return (
+    <div className="templates-inner skills-inner scroll-surface">
+      <section className="skills-hero context-card">
+        <div className="skills-hero-copy">
+          <span className="eyebrow">AgentTemplate Library</span>
+          <h1>Templates</h1>
+          <p>
+            Browse read-only AgentTemplate definitions from builtin, global, and remote sources. Install/remove user templates
+            through daemon APIs; source configuration can follow in a later settings phase.
+          </p>
+        </div>
+        <div className="skills-actions" aria-label="Template library actions">
+          <Button type="button" variant="outline" disabled={loading} onClick={() => void onSyncSources()}>
+            Sync sources
+          </Button>
+          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
+            {loading ? "Refreshing…" : "Refresh"}
+          </Button>
+        </div>
+      </section>
+
+      <section className="skills-summary" aria-label="Template library summary">
+        {stats.map((stat) => (
+          <Card className="skills-stat" key={stat.label}>
+            <strong>{stat.value}</strong>
+            <span>{stat.label}</span>
+          </Card>
+        ))}
+      </section>
+
+      {error ? (
+        <div className="skills-error" role="alert">
+          <strong>Template operation failed</strong>
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      {catalog.diagnostics.length > 0 ? (
+        <div className="skills-error" role="status">
+          <strong>Catalog diagnostics</strong>
+          {catalog.diagnostics.map((diagnostic, index) => (
+            <span key={`${diagnostic.sourceId ?? "catalog"}-${index}`}>
+              {diagnostic.sourceId ? `${diagnostic.sourceId}: ` : ""}
+              {diagnostic.message}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <Card className="skills-library-card">
+        <CardHeader className="skills-library-head">
+          <div>
+            <p>
+              Showing {visibleTemplates.length} of {templates.length} templates
+            </p>
+          </div>
+          <StatusBadge className="state-chip" kind="connection" value={catalog.source} />
+        </CardHeader>
+        <CardContent>
+          <div className="template-actions-grid">
+            <form className="skills-add-form" onSubmit={(event) => void handleCreate(event)}>
+              <label>
+                <span>Create agent</span>
+                <input
+                  value={agentId}
+                  placeholder="new-agent-id"
+                  onChange={(event) => setAgentId(event.target.value)}
+                  disabled={loading}
+                />
+              </label>
+              <label className="skills-add-source">
+                <span>Template</span>
+                <select value={createTemplate} onChange={(event) => setCreateTemplate(event.target.value)} disabled={loading}>
+                  <option value="">Choose template</option>
+                  {templates.map((template) => (
+                    <option key={template.catalogId} value={template.template}>
+                      {template.name} · {template.template}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Button type="submit" variant="accent" disabled={loading || !agentId.trim() || !createTemplate.trim()}>
+                +
+              </Button>
+            </form>
+
+            <form className="skills-add-form" onSubmit={(event) => void handleInstall(event)}>
+              <label className="skills-add-source">
+                <span>Install template</span>
+                <input
+                  value={githubUrl}
+                  placeholder="https://github.com/org/repo/tree/main/agent_templates/name"
+                  onChange={(event) => setGithubUrl(event.target.value)}
+                  disabled={loading}
+                />
+              </label>
+              <Button type="submit" variant="accent" disabled={loading || !githubUrl.trim()}>
+                Install
+              </Button>
+            </form>
+          </div>
+          <p className="skills-add-help">
+            Template content is read-only in the Web GUI. Removal targets user/global templates; builtin and remote entries remain
+            owned by their source.
+          </p>
+
+          <div className="skills-toolbar" role="search">
+            <label className="skills-search">
+              <span>Search templates</span>
+              <input
+                id="templates-search"
+                name="templates-search"
+                type="search"
+                value={query}
+                placeholder="Name, description, template id, or skill"
+                onChange={(event) => setQuery(event.target.value)}
+              />
+            </label>
+            <label className="skills-scope-filter">
+              <span>Source</span>
+              <select value={sourceFilter} onChange={(event) => setSourceFilter(event.target.value as typeof sourceFilter)}>
+                <option value="all">All sources</option>
+                <option value="builtin">Builtin</option>
+                <option value="user_global">Global</option>
+                <option value="remote">Remote</option>
+                <option value="agent">Agent</option>
+              </select>
+            </label>
+          </div>
+
+          {visibleTemplates.length ? (
+            <ul className="skills-list templates-list">
+              {visibleTemplates.map((template) => (
+                <TemplateRow
+                  key={template.catalogId}
+                  template={template}
+                  loading={loading}
+                  onUse={(selectedTemplate) => setCreateTemplate(selectedTemplate.template)}
+                  onOpen={onOpenTemplate}
+                  onRemove={onRemoveTemplate}
+                />
+              ))}
+            </ul>
+          ) : (
+            <EmptyState
+              icon="▣"
+              title={loading ? "Loading templates…" : templates.length ? "No templates match the current filters" : "No templates in the catalog"}
+              description={
+                templates.length
+                  ? "Try a different query or source filter."
+                  : "Refresh after installing templates or syncing remote sources."
+              }
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="skills-library-card">
+        <CardHeader className="skills-library-head">
+          <div>
+            <p>Template sources</p>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {catalog.sources.length ? (
+            <ul className="skills-list">
+              {catalog.sources.map((source) => (
+                <li className="skills-row" key={source.sourceId}>
+                  <div className="skills-row-open">
+                    <span className="template-row-title">
+                      <strong>{source.sourceId}</strong>
+                      <StatusBadge className="state-chip" kind="connection" value={source.status ?? (source.enabled ? "enabled" : "disabled")} />
+                    </span>
+                    <span className="template-row-description">{source.url ?? source.kind}</span>
+                    <span className="template-row-meta">
+                      {source.resolvedRef ? <span>ref {source.resolvedRef}</span> : null}
+                      {source.lastSyncedAt ? <span>synced {source.lastSyncedAt}</span> : null}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState icon="⇄" title="No configured remote template sources" description="Source configuration will be added in a later phase." />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function TemplateDetailPage({
+  catalogId,
+  detail,
+  loading,
+  error,
+  onBack,
+  onRefresh,
+  onCreateAgent,
+  onRemoveTemplate,
+}: TemplateDetailPageProps) {
+  const template = detail?.detail;
+  const [agentId, setAgentId] = useState("");
+  const [viewMode, setViewMode] = useState<"rendered" | "source">("rendered");
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!template || !agentId.trim()) return;
+    const ok = await onCreateAgent(agentId.trim(), template.template);
+    if (ok) setAgentId("");
+  }
+
+  return (
+    <div className="skills-inner scroll-surface">
+      <section className="skill-detail-hero context-card">
+        <div>
+          <button className="text-button" type="button" onClick={onBack}>
+            ← Templates
+          </button>
+          <span className="eyebrow">AgentTemplate</span>
+          <h1>{template?.name ?? catalogId}</h1>
+          <p>{template?.summary || "Read-only template detail from the Holon daemon catalog."}</p>
+        </div>
+        <div className="skills-actions">
+          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
+            {loading ? "Refreshing…" : "Refresh"}
+          </Button>
+          {template?.source === "user_global" || template?.source === "user" ? (
+            <Button type="button" variant="outline" disabled={loading} onClick={() => void onRemoveTemplate(template.templateId)}>
+              Remove
+            </Button>
+          ) : null}
+        </div>
+      </section>
+
+      {error || detail?.error ? (
+        <div className="skills-error" role="alert">
+          <strong>Template detail failed</strong>
+          <span>{error ?? detail?.error}</span>
+        </div>
+      ) : null}
+
+      {template ? (
+        <>
+          <Card className="skills-library-card">
+            <CardHeader className="skills-library-head">
+              <div>
+                <p>{template.template}</p>
+              </div>
+              <StatusBadge className="state-chip" kind="connection" value={template.source} />
+            </CardHeader>
+            <CardContent>
+              <form className="skills-add-form" onSubmit={(event) => void handleCreate(event)}>
+                <label className="skills-add-source">
+                  <span>Create agent from this template</span>
+                  <input
+                    value={agentId}
+                    placeholder="new-agent-id"
+                    onChange={(event) => setAgentId(event.target.value)}
+                    disabled={loading}
+                  />
+                </label>
+                <Button type="submit" variant="accent" disabled={loading || !agentId.trim()}>
+                  +
+                </Button>
+              </form>
+              <dl className="skills-detail-meta">
+                <div>
+                  <dt>Catalog id</dt>
+                  <dd>{template.catalogId}</dd>
+                </div>
+                <div>
+                  <dt>Template id</dt>
+                  <dd>{template.templateId}</dd>
+                </div>
+                {template.schemaVersion ? (
+                  <div>
+                    <dt>Schema</dt>
+                    <dd>{template.schemaVersion}</dd>
+                  </div>
+                ) : null}
+                {template.sourceLocation ? (
+                  <div>
+                    <dt>Source</dt>
+                    <dd>{template.sourceLocation}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card className="skills-library-card">
+            <CardHeader className="skills-library-head">
+              <div>
+                <p>AGENTS.md</p>
+              </div>
+              <div className="skills-actions">
+                <Button type="button" size="sm" variant={viewMode === "rendered" ? "accent" : "outline"} onClick={() => setViewMode("rendered")}>
+                  Rendered
+                </Button>
+                <Button type="button" size="sm" variant={viewMode === "source" ? "accent" : "outline"} onClick={() => setViewMode("source")}>
+                  Source
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {viewMode === "rendered" ? (
+                <MarkdownContent text={template.agentsMd} />
+              ) : (
+                <pre className="skill-source">
+                  <code>{template.agentsMd}</code>
+                </pre>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="skills-library-card">
+            <CardHeader className="skills-library-head">
+              <div>
+                <p>Included skills</p>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {template.skills.length ? (
+                <ul className="skills-list">
+                  {template.skills.map((skill) => (
+                    <li className="skills-row" key={`${skill.kind}:${skill.reference}`}>
+                      <div className="skills-row-open">
+                        <span className="template-row-title">
+                          <strong>{skill.reference}</strong>
+                          <StatusBadge className="state-chip" kind="connection" value={skill.kind} />
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState icon="◇" title="No declared skill dependencies" description="This template does not declare extra skills." />
+              )}
+            </CardContent>
+          </Card>
+        </>
+      ) : (
+        <EmptyState icon="▣" title={loading ? "Loading template…" : "Template not found"} description={catalogId} />
+      )}
+    </div>
+  );
+}
+
+function TemplateRow({
+  template,
+  loading,
+  onUse,
+  onOpen,
+  onRemove,
+}: {
+  template: AgentTemplateCatalogEntry;
+  loading: boolean;
+  onUse: (template: AgentTemplateCatalogEntry) => void;
+  onOpen: (catalogId: string) => void;
+  onRemove: (templateId: string) => Promise<boolean>;
+}) {
+  const canRemove = template.source === "user_global" || template.source === "user";
+  return (
+    <li className="skills-row">
+      <button className="skills-row-open" type="button" onClick={() => onOpen(template.catalogId)}>
+        <span className="template-row-title">
+          <strong>{template.name}</strong>
+          <StatusBadge className="state-chip" kind="connection" value={template.source} />
+        </span>
+        <span className="template-row-description">{template.description || template.template}</span>
+        <span className="template-row-meta">
+          <span>{template.catalogId}</span>
+          {template.includedSkills.length ? <span>{template.includedSkills.length} skills</span> : null}
+          {template.sourceId ? <span>{template.sourceId}</span> : null}
+        </span>
+      </button>
+      <div className="skills-row-actions">
+        <Button type="button" size="sm" variant="outline" disabled={loading} onClick={() => onUse(template)}>
+          Use
+        </Button>
+        {canRemove ? (
+          <Button type="button" size="sm" variant="outline" disabled={loading} onClick={() => void onRemove(template.templateId)}>
+            Remove
+          </Button>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function templateStats(templates: AgentTemplateCatalogEntry[]) {
+  return [
+    { label: "templates", value: String(templates.length) },
+    { label: "builtin", value: String(templates.filter((template) => template.source === "builtin").length) },
+    { label: "global", value: String(templates.filter((template) => template.source === "user_global" || template.source === "user").length) },
+    { label: "remote", value: String(templates.filter((template) => template.source === "remote").length) },
+  ];
+}

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -20,8 +20,9 @@ interface TemplatesPageProps {
   onSyncSources: () => Promise<boolean>;
   onInstallTemplate: (githubUrl: string) => Promise<boolean>;
   onRemoveTemplate: (templateId: string) => Promise<boolean>;
-  onCreateAgent: (agentId: string, template: string) => Promise<boolean>;
   onOpenTemplate: (catalogId: string) => void;
+  onAddRemoteSource: (sourceId: string, url: string, gitRef?: string) => Promise<boolean>;
+  onRemoveRemoteSource: (sourceId: string) => Promise<boolean>;
 }
 
 interface TemplateDetailPageProps {
@@ -31,7 +32,6 @@ interface TemplateDetailPageProps {
   error?: string;
   onBack: () => void;
   onRefresh: () => void;
-  onCreateAgent: (agentId: string, template: string) => Promise<boolean>;
   onRemoveTemplate: (templateId: string) => Promise<boolean>;
 }
 
@@ -43,15 +43,19 @@ export function TemplatesPage({
   onSyncSources,
   onInstallTemplate,
   onRemoveTemplate,
-  onCreateAgent,
   onOpenTemplate,
+  onAddRemoteSource,
+  onRemoveRemoteSource,
 }: TemplatesPageProps) {
   const templates = catalog.catalog;
   const [query, setQuery] = useState("");
   const [sourceFilter, setSourceFilter] = useState<"all" | AgentTemplateSourceKind>("all");
   const [githubUrl, setGithubUrl] = useState("");
-  const [agentId, setAgentId] = useState("");
-  const [createTemplate, setCreateTemplate] = useState("");
+  const [newSourceId, setNewSourceId] = useState("");
+  const [newSourceUrl, setNewSourceUrl] = useState("");
+  const [newSourceRef, setNewSourceRef] = useState("");
+  const [sourceFormError, setSourceFormError] = useState<string | undefined>();
+  const [sourceFormBusy, setSourceFormBusy] = useState(false);
   const stats = useMemo(() => templateStats(templates), [templates]);
   const visibleTemplates = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -81,21 +85,36 @@ export function TemplatesPage({
     if (ok) setGithubUrl("");
   }
 
-  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+
+  async function handleAddSource(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const id = agentId.trim();
-    const template = createTemplate.trim();
-    if (!id || !template) return;
-    const ok = await onCreateAgent(id, template);
-    if (ok) setAgentId("");
+    const id = newSourceId.trim();
+    const url = newSourceUrl.trim();
+    if (!id || !url) return;
+    setSourceFormBusy(true);
+    setSourceFormError(undefined);
+    try {
+      const ok = await onAddRemoteSource(id, url, newSourceRef.trim() || undefined);
+      if (ok) {
+        setNewSourceId("");
+        setNewSourceUrl("");
+        setNewSourceRef("");
+      } else {
+        setSourceFormError("Failed to add remote source.");
+      }
+    } catch (error) {
+      setSourceFormError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSourceFormBusy(false);
+    }
   }
 
   return (
     <div className="templates-inner skills-inner scroll-surface">
       <section className="skills-hero context-card">
         <div className="skills-hero-copy">
-          <span className="eyebrow">AgentTemplate Library</span>
-          <h1>Templates</h1>
+          <span className="eyebrow">Agent Template Library</span>
+          <h1>Agent Templates</h1>
           <p>
             Browse read-only AgentTemplate definitions from builtin, global, and remote sources. Install/remove user templates
             through daemon APIs; source configuration can follow in a later settings phase.
@@ -150,31 +169,6 @@ export function TemplatesPage({
         </CardHeader>
         <CardContent>
           <div className="template-actions-grid">
-            <form className="skills-add-form" onSubmit={(event) => void handleCreate(event)}>
-              <label>
-                <span>Create agent</span>
-                <input
-                  value={agentId}
-                  placeholder="new-agent-id"
-                  onChange={(event) => setAgentId(event.target.value)}
-                  disabled={loading}
-                />
-              </label>
-              <label className="skills-add-source">
-                <span>Template</span>
-                <select value={createTemplate} onChange={(event) => setCreateTemplate(event.target.value)} disabled={loading}>
-                  <option value="">Choose template</option>
-                  {templates.map((template) => (
-                    <option key={template.catalogId} value={template.template}>
-                      {template.name} · {template.template}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <Button type="submit" variant="accent" disabled={loading || !agentId.trim() || !createTemplate.trim()}>
-                +
-              </Button>
-            </form>
 
             <form className="skills-add-form" onSubmit={(event) => void handleInstall(event)}>
               <label className="skills-add-source">
@@ -192,8 +186,7 @@ export function TemplatesPage({
             </form>
           </div>
           <p className="skills-add-help">
-            Template content is read-only in the Web GUI. Removal targets user/global templates; builtin and remote entries remain
-            owned by their source.
+            Template content is read-only. Use the + button in Active Agents to create an agent from a template. Removal targets user/global templates; builtin and remote entries remain owned by their source.
           </p>
 
           <div className="skills-toolbar" role="search">
@@ -227,7 +220,6 @@ export function TemplatesPage({
                   key={template.catalogId}
                   template={template}
                   loading={loading}
-                  onUse={(selectedTemplate) => setCreateTemplate(selectedTemplate.template)}
                   onOpen={onOpenTemplate}
                   onRemove={onRemoveTemplate}
                 />
@@ -250,10 +242,45 @@ export function TemplatesPage({
       <Card className="skills-library-card">
         <CardHeader className="skills-library-head">
           <div>
-            <p>Template sources</p>
+            <p>Remote sources</p>
           </div>
+          <StatusBadge className="state-chip" kind="connection" value={catalog.source} />
         </CardHeader>
         <CardContent>
+          <form className="skills-add-form" onSubmit={(event) => void handleAddSource(event)}>
+            <label>
+              <span>Source ID</span>
+              <input
+                value={newSourceId}
+                placeholder="my-templates"
+                onChange={(event) => setNewSourceId(event.target.value)}
+                disabled={sourceFormBusy}
+              />
+            </label>
+            <label className="skills-add-source">
+              <span>GitHub URL</span>
+              <input
+                value={newSourceUrl}
+                placeholder="https://github.com/org/repo/tree/main/agent_templates"
+                onChange={(event) => setNewSourceUrl(event.target.value)}
+                disabled={sourceFormBusy}
+              />
+            </label>
+            <label>
+              <span>Ref (optional)</span>
+              <input
+                value={newSourceRef}
+                placeholder="main"
+                onChange={(event) => setNewSourceRef(event.target.value)}
+                disabled={sourceFormBusy}
+              />
+            </label>
+            <Button type="submit" variant="accent" disabled={sourceFormBusy || !newSourceId.trim() || !newSourceUrl.trim()}>
+              Add
+            </Button>
+          </form>
+          {sourceFormError ? <span className="connection-error" role="alert">{sourceFormError}</span> : null}
+
           {catalog.sources.length ? (
             <ul className="skills-list">
               {catalog.sources.map((source) => (
@@ -269,11 +296,16 @@ export function TemplatesPage({
                       {source.lastSyncedAt ? <span>synced {source.lastSyncedAt}</span> : null}
                     </span>
                   </div>
+                  <div className="skills-row-actions">
+                    <Button type="button" size="sm" variant="outline" disabled={loading} onClick={() => void onRemoveRemoteSource(source.sourceId)}>
+                      Remove
+                    </Button>
+                  </div>
                 </li>
               ))}
             </ul>
           ) : (
-            <EmptyState icon="⇄" title="No configured remote template sources" description="Source configuration will be added in a later phase." />
+            <EmptyState icon="⇄" title="No configured remote template sources" description="Add a GitHub remote source above to sync agent templates." />
           )}
         </CardContent>
       </Card>
@@ -288,26 +320,17 @@ export function TemplateDetailPage({
   error,
   onBack,
   onRefresh,
-  onCreateAgent,
   onRemoveTemplate,
 }: TemplateDetailPageProps) {
   const template = detail?.detail;
-  const [agentId, setAgentId] = useState("");
   const [viewMode, setViewMode] = useState<"rendered" | "source">("rendered");
-
-  async function handleCreate(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!template || !agentId.trim()) return;
-    const ok = await onCreateAgent(agentId.trim(), template.template);
-    if (ok) setAgentId("");
-  }
 
   return (
     <div className="skills-inner scroll-surface">
       <section className="skill-detail-hero context-card">
         <div>
           <button className="text-button" type="button" onClick={onBack}>
-            ← Templates
+            ← Agent Templates
           </button>
           <span className="eyebrow">AgentTemplate</span>
           <h1>{template?.name ?? catalogId}</h1>
@@ -342,20 +365,6 @@ export function TemplateDetailPage({
               <StatusBadge className="state-chip" kind="connection" value={template.source} />
             </CardHeader>
             <CardContent>
-              <form className="skills-add-form" onSubmit={(event) => void handleCreate(event)}>
-                <label className="skills-add-source">
-                  <span>Create agent from this template</span>
-                  <input
-                    value={agentId}
-                    placeholder="new-agent-id"
-                    onChange={(event) => setAgentId(event.target.value)}
-                    disabled={loading}
-                  />
-                </label>
-                <Button type="submit" variant="accent" disabled={loading || !agentId.trim()}>
-                  +
-                </Button>
-              </form>
               <dl className="skills-detail-meta">
                 <div>
                   <dt>Catalog id</dt>
@@ -442,13 +451,11 @@ export function TemplateDetailPage({
 function TemplateRow({
   template,
   loading,
-  onUse,
   onOpen,
   onRemove,
 }: {
   template: AgentTemplateCatalogEntry;
   loading: boolean;
-  onUse: (template: AgentTemplateCatalogEntry) => void;
   onOpen: (catalogId: string) => void;
   onRemove: (templateId: string) => Promise<boolean>;
 }) {
@@ -468,9 +475,7 @@ function TemplateRow({
         </span>
       </button>
       <div className="skills-row-actions">
-        <Button type="button" size="sm" variant="outline" disabled={loading} onClick={() => onUse(template)}>
-          Use
-        </Button>
+
         {canRemove ? (
           <Button type="button" size="sm" variant="outline" disabled={loading} onClick={() => void onRemove(template.templateId)}>
             Remove

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -4,6 +4,12 @@ import type {
   AddSkillInput,
   AgentDetail,
   AgentSummary,
+  AgentTemplateCatalogDiagnostic,
+  AgentTemplateCatalogEntry,
+  AgentTemplateCatalogState,
+  AgentTemplateDetail,
+  AgentTemplateDetailState,
+  AgentTemplateRemoteSource,
   CredentialProfileStatus,
   CredentialStoreState,
   CodexDeviceLoginResponse,
@@ -562,6 +568,62 @@ interface SkillDetailResponseDto {
   content?: string;
 }
 
+interface AgentTemplateCatalogEntryDto {
+  catalog_id?: string;
+  template?: string;
+  template_id?: string;
+  source?: AgentTemplateCatalogEntry["source"];
+  path?: string;
+  name?: string;
+  schema_version?: string;
+  description?: string;
+  included_skills?: string[];
+  source_id?: string;
+  resolved_ref?: string;
+  resolved_revision?: string;
+  source_url?: string;
+}
+
+interface AgentTemplateRemoteSourceDto {
+  source_id?: string;
+  kind?: string;
+  enabled?: boolean;
+  status?: string;
+  url?: string;
+  resolved_ref?: string;
+  resolved_revision?: string | null;
+  last_synced_at?: string;
+}
+
+interface AgentTemplateCatalogDiagnosticDto {
+  level?: string;
+  message?: string;
+  source_id?: string;
+}
+
+interface AgentTemplateCatalogResponseDto {
+  catalog?: AgentTemplateCatalogEntryDto[];
+  sources?: AgentTemplateRemoteSourceDto[];
+  diagnostics?: AgentTemplateCatalogDiagnosticDto[];
+}
+
+interface AgentTemplateDetailDto {
+  catalog_id?: string;
+  template?: string;
+  template_id?: string;
+  source?: AgentTemplateCatalogEntry["source"];
+  source_location?: string;
+  name?: string;
+  summary?: string;
+  schema_version?: string;
+  agents_md?: string;
+  skills?: Array<{ kind?: string; reference?: string }>;
+}
+
+interface AgentTemplateDetailResponseDto {
+  detail?: AgentTemplateDetailDto;
+}
+
 interface AgentSkillsResponseDto {
   skills?: SkillCatalogEntryDto[];
 }
@@ -774,6 +836,58 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         skill: response.skill ? projectSkillCatalogEntry(response.skill) : undefined,
         content: response.content ?? "",
       };
+    },
+    async getTemplateCatalog(): Promise<AgentTemplateCatalogState> {
+      if (!baseUrl) {
+        return { source: "fixture", catalog: [], sources: [], diagnostics: [] };
+      }
+      const response = await getJson<AgentTemplateCatalogResponseDto>(fetchImpl, baseUrl, "/templates/catalog", { headers: requestHeaders });
+      return projectTemplateCatalog(response);
+    },
+    async getTemplateDetail(catalogId: string): Promise<AgentTemplateDetailState> {
+      if (!baseUrl) {
+        return { source: "fixture", error: "Holon API base URL is not configured." };
+      }
+      const response = await getJson<AgentTemplateDetailResponseDto>(
+        fetchImpl,
+        baseUrl,
+        `/templates/catalog/${encodeURIComponent(catalogId)}`,
+        { headers: requestHeaders },
+      );
+      return {
+        source: "http",
+        detail: response.detail ? projectTemplateDetail(response.detail) : undefined,
+      };
+    },
+    async installTemplate(githubUrl: string): Promise<void> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      await postJson<unknown>(fetchImpl, baseUrl, "/control/templates/install", { github_url: githubUrl }, requestHeaders);
+    },
+    async removeTemplate(templateId: string): Promise<void> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      await postJson<unknown>(fetchImpl, baseUrl, "/control/templates/remove", { template_id: templateId }, requestHeaders);
+    },
+    async syncTemplateRemoteSources(): Promise<void> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      await postJson<unknown>(fetchImpl, baseUrl, "/templates/remote-sources/sync", {}, requestHeaders);
+    },
+    async createAgentFromTemplate(agentId: string, template: string): Promise<void> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      await postJson<unknown>(
+        fetchImpl,
+        baseUrl,
+        `/control/agents/${encodeURIComponent(agentId)}/create`,
+        { template },
+        requestHeaders,
+      );
     },
     async addSkillToCatalog(input: AddSkillInput): Promise<string> {
       if (!baseUrl) {
@@ -1314,6 +1428,76 @@ function projectSkillCatalogEntry(entry: SkillCatalogEntryDto) {
     description: entry.description ?? "",
     path: entry.path ?? "",
     scope: entry.scope ?? "user",
+  };
+}
+
+function projectTemplateCatalog(response: AgentTemplateCatalogResponseDto): AgentTemplateCatalogState {
+  return {
+    source: "http",
+    catalog: (response.catalog ?? [])
+      .filter((entry) => Boolean(entry.catalog_id || entry.template))
+      .map(projectTemplateCatalogEntry),
+    sources: (response.sources ?? []).map(projectTemplateRemoteSource),
+    diagnostics: (response.diagnostics ?? []).map(projectTemplateDiagnostic),
+  };
+}
+
+function projectTemplateCatalogEntry(entry: AgentTemplateCatalogEntryDto): AgentTemplateCatalogEntry {
+  const catalogId = entry.catalog_id ?? entry.template ?? entry.template_id ?? "unknown";
+  return {
+    catalogId,
+    template: entry.template ?? catalogId,
+    templateId: entry.template_id ?? entry.template ?? catalogId,
+    source: entry.source ?? "builtin",
+    path: entry.path,
+    name: entry.name ?? entry.template_id ?? catalogId,
+    schemaVersion: entry.schema_version,
+    description: entry.description ?? "",
+    includedSkills: entry.included_skills ?? [],
+    sourceId: entry.source_id,
+    resolvedRef: entry.resolved_ref,
+    resolvedRevision: entry.resolved_revision,
+    sourceUrl: entry.source_url,
+  };
+}
+
+function projectTemplateRemoteSource(source: AgentTemplateRemoteSourceDto): AgentTemplateRemoteSource {
+  return {
+    sourceId: source.source_id ?? "unknown",
+    kind: source.kind ?? "unknown",
+    enabled: source.enabled ?? false,
+    status: source.status,
+    url: source.url,
+    resolvedRef: source.resolved_ref,
+    resolvedRevision: source.resolved_revision ?? undefined,
+    lastSyncedAt: source.last_synced_at,
+  };
+}
+
+function projectTemplateDiagnostic(diagnostic: AgentTemplateCatalogDiagnosticDto): AgentTemplateCatalogDiagnostic {
+  return {
+    level: diagnostic.level,
+    message: diagnostic.message ?? "Template catalog diagnostic",
+    sourceId: diagnostic.source_id,
+  };
+}
+
+function projectTemplateDetail(detail: AgentTemplateDetailDto): AgentTemplateDetail {
+  const catalogId = detail.catalog_id ?? detail.template ?? detail.template_id ?? "unknown";
+  return {
+    catalogId,
+    template: detail.template ?? catalogId,
+    templateId: detail.template_id ?? detail.template ?? catalogId,
+    source: detail.source ?? "builtin",
+    sourceLocation: detail.source_location,
+    name: detail.name ?? detail.template_id ?? catalogId,
+    summary: detail.summary ?? "",
+    schemaVersion: detail.schema_version,
+    agentsMd: detail.agents_md ?? "",
+    skills: (detail.skills ?? []).map((skill) => ({
+      kind: skill.kind ?? "unknown",
+      reference: skill.reference ?? "",
+    })),
   };
 }
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -20,6 +20,8 @@ import type {
   AddSkillInput,
   AgentDetail,
   AgentSummary,
+  AgentTemplateCatalogState,
+  AgentTemplateDetailState,
   AgentTimelineActivity,
   AgentTimelineItem,
   DisplayLevel,
@@ -163,6 +165,7 @@ export interface RuntimeStoreState {
   route: RouteKey;
   selectedAgentId: string;
   selectedSkillId: string;
+  selectedTemplateId: string;
   displayLevel: DisplayLevel;
   displayLevelsByAgentId: Record<string, DisplayLevel>;
   rightPanelViewStack: RightPanelView[];
@@ -186,6 +189,12 @@ export interface RuntimeStoreState {
   skillDetailById: Record<string, SkillDetailState>;
   skillDetailLoadingById: Record<string, boolean>;
   skillDetailErrorById: Record<string, string | undefined>;
+  templateCatalog: AgentTemplateCatalogState;
+  templateCatalogLoading: boolean;
+  templateCatalogError?: string;
+  templateDetailById: Record<string, AgentTemplateDetailState>;
+  templateDetailLoadingById: Record<string, boolean>;
+  templateDetailErrorById: Record<string, string | undefined>;
   agentSkillCatalogByAgentId: Record<string, SkillCatalogState>;
   agentSkillCatalogLoadingByAgentId: Record<string, boolean>;
   agentSkillCatalogErrorByAgentId: Record<string, string | undefined>;
@@ -206,6 +215,7 @@ export interface RuntimeStoreState {
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string, targetEventSeq?: number) => void;
   openSkill: (skillId: string) => void;
+  openTemplate: (catalogId: string) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
   setRightPanelOpen: (open: boolean) => void;
   showAgentOverview: (agentId?: string) => void;
@@ -226,6 +236,12 @@ export interface RuntimeStoreState {
   updateRuntimeConfig: (updates: Array<{ key: string; value?: unknown; unset?: boolean }>) => Promise<RuntimeConfigState | undefined>;
   refreshSkillCatalog: () => Promise<void>;
   refreshSkillDetail: (skillId: string | undefined) => Promise<void>;
+  refreshTemplateCatalog: () => Promise<void>;
+  refreshTemplateDetail: (catalogId: string | undefined) => Promise<void>;
+  installTemplate: (githubUrl: string) => Promise<boolean>;
+  removeTemplate: (templateId: string) => Promise<boolean>;
+  syncTemplateRemoteSources: () => Promise<boolean>;
+  createAgentFromTemplate: (agentId: string, template: string) => Promise<boolean>;
   addSkillToCatalog: (input: AddSkillInput) => Promise<boolean>;
   removeSkillFromCatalog: (name: string) => Promise<boolean>;
   updateSkillCatalog: (name?: string) => Promise<boolean>;
@@ -614,6 +630,13 @@ const emptySkillCatalog: SkillCatalogState = {
   catalog: [],
 };
 
+const emptyTemplateCatalog: AgentTemplateCatalogState = {
+  source: "fixture",
+  catalog: [],
+  sources: [],
+  diagnostics: [],
+};
+
 /**
  * Initialize session cache for the current remote and hydrate any cached
  * sessions into the store. Called on initial load and remote switch.
@@ -654,6 +677,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   route: "dashboard",
   selectedAgentId: "",
   selectedSkillId: "",
+  selectedTemplateId: "",
   displayLevel: "info",
   displayLevelsByAgentId: readStoredDisplayLevels(),
   rightPanelOpen: true,
@@ -673,6 +697,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   skillDetailById: {},
   skillDetailLoadingById: {},
   skillDetailErrorById: {},
+  templateCatalog: emptyTemplateCatalog,
+  templateCatalogLoading: false,
+  templateCatalogError: undefined,
+  templateDetailById: {},
+  templateDetailLoadingById: {},
+  templateDetailErrorById: {},
   agentSkillCatalogByAgentId: {},
   agentSkillCatalogLoadingByAgentId: {},
   agentSkillCatalogErrorByAgentId: {},
@@ -691,6 +721,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   setRoute: (route) => set({ route }),
   openSkill: (skillId) => set({ route: "skillDetail", selectedSkillId: skillId }),
+  openTemplate: (catalogId) => set({ route: "templateDetail", selectedTemplateId: catalogId }),
   openAgent: (agentId, targetEventSeq) =>
     set((state) => {
       const currentSession = state.sessionsByAgentId[agentId];
@@ -869,6 +900,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       skillDetailById: {},
       skillDetailLoadingById: {},
       skillDetailErrorById: {},
+      templateCatalog: emptyTemplateCatalog,
+      templateCatalogLoading: false,
+      templateCatalogError: undefined,
+      templateDetailById: {},
+      templateDetailLoadingById: {},
+      templateDetailErrorById: {},
       agentSkillCatalogByAgentId: {},
       agentSkillCatalogLoadingByAgentId: {},
       agentSkillCatalogErrorByAgentId: {},
@@ -882,6 +919,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(normalizedConfig)),
       selectedAgentId: "",
       selectedSkillId: "",
+      selectedTemplateId: "",
       route: "dashboard",
     });
     await get().refreshBootstrap();
@@ -1041,6 +1079,114 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: false },
         skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: message },
       }));
+    }
+  },
+
+  refreshTemplateCatalog: async () => {
+    set({ templateCatalogLoading: true, templateCatalogError: undefined });
+    try {
+      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        templateCatalog: { ...state.templateCatalog, source: "http", error: message },
+        templateCatalogLoading: false,
+        templateCatalogError: message,
+      }));
+    }
+  },
+
+  refreshTemplateDetail: async (catalogId) => {
+    if (!catalogId) return;
+    set((state) => ({
+      templateDetailLoadingById: { ...state.templateDetailLoadingById, [catalogId]: true },
+      templateDetailErrorById: { ...state.templateDetailErrorById, [catalogId]: undefined },
+    }));
+    try {
+      const detail = await runtimeClient.getTemplateDetail(catalogId);
+      set((state) => ({
+        templateDetailById: { ...state.templateDetailById, [catalogId]: detail },
+        templateDetailLoadingById: { ...state.templateDetailLoadingById, [catalogId]: false },
+        templateDetailErrorById: { ...state.templateDetailErrorById, [catalogId]: detail.error },
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        templateDetailById: {
+          ...state.templateDetailById,
+          [catalogId]: { source: "http", error: message },
+        },
+        templateDetailLoadingById: { ...state.templateDetailLoadingById, [catalogId]: false },
+        templateDetailErrorById: { ...state.templateDetailErrorById, [catalogId]: message },
+      }));
+    }
+  },
+
+  installTemplate: async (githubUrl) => {
+    set({ templateCatalogLoading: true, templateCatalogError: undefined });
+    try {
+      await runtimeClient.installTemplate(githubUrl);
+      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        templateCatalog: { ...state.templateCatalog, error: message },
+        templateCatalogLoading: false,
+        templateCatalogError: message,
+      }));
+      return false;
+    }
+  },
+
+  removeTemplate: async (templateId) => {
+    set({ templateCatalogLoading: true, templateCatalogError: undefined });
+    try {
+      await runtimeClient.removeTemplate(templateId);
+      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        templateCatalog: { ...state.templateCatalog, error: message },
+        templateCatalogLoading: false,
+        templateCatalogError: message,
+      }));
+      return false;
+    }
+  },
+
+  syncTemplateRemoteSources: async () => {
+    set({ templateCatalogLoading: true, templateCatalogError: undefined });
+    try {
+      await runtimeClient.syncTemplateRemoteSources();
+      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        templateCatalog: { ...state.templateCatalog, error: message },
+        templateCatalogLoading: false,
+        templateCatalogError: message,
+      }));
+      return false;
+    }
+  },
+
+  createAgentFromTemplate: async (agentId, template) => {
+    set({ templateCatalogError: undefined });
+    try {
+      await runtimeClient.createAgentFromTemplate(agentId, template);
+      await get().refreshBootstrap({ background: true });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set({ templateCatalogError: message });
+      return false;
     }
   },
 

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -1,6 +1,6 @@
 export type DisplayLevel = "info" | "verbose" | "debug";
 
-export type RouteKey = "dashboard" | "agent" | "search" | "skills" | "skillDetail" | "settings";
+export type RouteKey = "dashboard" | "agent" | "search" | "skills" | "skillDetail" | "templates" | "templateDetail" | "settings";
 
 export interface RuntimeConnection {
   mode: "local" | "remote";
@@ -46,6 +46,73 @@ export interface SkillCatalogState {
   source: "http" | "fixture";
   agentId?: string;
   catalog: SkillCatalogEntry[];
+  error?: string;
+}
+
+export type AgentTemplateSourceKind = "builtin" | "user" | "user_global" | "agent" | "remote";
+
+export interface AgentTemplateCatalogEntry {
+  catalogId: string;
+  template: string;
+  templateId: string;
+  source: AgentTemplateSourceKind;
+  path?: string;
+  name: string;
+  schemaVersion?: string;
+  description: string;
+  includedSkills: string[];
+  sourceId?: string;
+  resolvedRef?: string;
+  resolvedRevision?: string;
+  sourceUrl?: string;
+}
+
+export interface AgentTemplateRemoteSource {
+  sourceId: string;
+  kind: string;
+  enabled: boolean;
+  status?: string;
+  url?: string;
+  resolvedRef?: string;
+  resolvedRevision?: string;
+  lastSyncedAt?: string;
+}
+
+export interface AgentTemplateCatalogDiagnostic {
+  level?: string;
+  message: string;
+  sourceId?: string;
+}
+
+export interface AgentTemplateCatalogState {
+  source: "http" | "fixture";
+  catalog: AgentTemplateCatalogEntry[];
+  sources: AgentTemplateRemoteSource[];
+  diagnostics: AgentTemplateCatalogDiagnostic[];
+  error?: string;
+}
+
+export interface AgentTemplateSkillDependency {
+  kind: string;
+  reference: string;
+}
+
+export interface AgentTemplateDetail {
+  catalogId: string;
+  template: string;
+  templateId: string;
+  source: AgentTemplateSourceKind;
+  sourceLocation?: string;
+  name: string;
+  summary: string;
+  schemaVersion?: string;
+  agentsMd: string;
+  skills: AgentTemplateSkillDependency[];
+}
+
+export interface AgentTemplateDetailState {
+  source: "http" | "fixture";
+  detail?: AgentTemplateDetail;
   error?: string;
 }
 

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3022,6 +3022,36 @@ code {
   line-height: 1.45;
 }
 
+.template-actions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.template-actions-grid .skills-add-form {
+  grid-template-columns: minmax(140px, 0.6fr) minmax(180px, 1fr) auto;
+}
+
+.template-row-title,
+.template-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.template-row-description {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.template-row-meta {
+  color: var(--faint);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
 .skills-add-form label,
 .skills-search,
 .skills-scope-filter {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -4735,3 +4735,104 @@ code {
   max-width: 680px;
   color: var(--muted);
 }
+
+/* Modal overlay */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+.modal-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  min-width: 360px;
+  max-width: 480px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-head strong {
+  font-size: 14px;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--fg);
+}
+
+.modal-body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modal-body label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.modal-body input,
+.modal-body select {
+  font-size: 13px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-alt);
+  color: var(--fg);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+/* Sidebar + button */
+.side-heading-add {
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 14px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.side-heading-add:hover {
+  color: var(--fg);
+  border-color: var(--fg-dim);
+}

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -509,6 +509,7 @@ button {
 
 .side-heading strong {
   color: var(--muted);
+  margin-left: 6px;
   font-size: 11px;
 }
 


### PR DESCRIPTION
## 改动内容

### 1. Agent Templates 页面
- 新增 **Agent Templates** 导航标签和独立页面（只读展示模板 catalog）
- 模板详情页展示模板的 AGENTS.md、skills、描述等信息
- 安装/删除/同步入口（UI 入口，后端同步逻辑在之前的 #2086 中已实现）

### 2. Create Agent 入口 → Active Agents + 按钮
- Sidebar 的 **Active agents** 标题行右侧增加 `+` 按钮
- 点击弹出创建 modal：填写 Agent ID + 选择 Template
- 创建成功后自动导航到新 agent
- 点击 `+` 时若 catalog 未加载先行 await 刷新，避免模板列表为空（修复）

### 3. Remote source 配置
- Templates 页面底部新增 **Remote sources** 卡片
- 支持添加（source ID + GitHub URL + 可选 ref）和删除
- 后端通过 `set_config_key` API 支持 `agent_templates.remote_sources.<id>` 配置路径
- `is_runtime_mutable_config_key` 放行了 `agent_templates.*` 前缀

### 4. 样式优化
- Active agents 数字与标签之间增加间距

## 提交历史
- `738306c7` feat(web-gui): add Templates page with catalog, detail, create agent, install/remove/sync
- `bf996e5e` feat: Web GUI - Agent Templates page with remote sources and Create Agent modal
- `95acf9e3` fix: await catalog refresh before opening Create Agent modal; add spacing between Active agents label and count

## 验证
- TypeScript 编译通过 (`npx tsc --noEmit`)
- Rust 编译通过 (`RUSTFLAGS="-D warnings" cargo check --all-targets`)
- `cargo fmt --all -- --check` 通过

Closes #2087