### PR TITLE
fix: make first-run intro runtime-owned

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,15 +39,12 @@ use holon::{
     onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
-    runtime::RuntimeHandle,
+    runtime::maybe_enqueue_first_run_intro,
     runtime_db::RuntimeDb,
     solve::{run_solve, SolveRequest},
     storage::AppStorage,
     tui::run_tui,
-    types::{
-        AdmissionContext, AuditEvent, AuthorityClass, ControlAction, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority, TimerStatus,
-    },
+    types::{AuditEvent, AuthorityClass, ControlAction, TimerStatus},
 };
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
@@ -786,47 +783,8 @@ fn restart_serve_launch_options(
     Ok(serve_args_for_options(&options))
 }
 
-/// On the first run with a configured provider, enqueue a one-time prompt so
-/// the agent greets the user and explains what it can do.
-///
-/// First-run is detected via `total_message_count == 0`: the count is
-/// persisted and restored from DB on restart, so the intro fires exactly once
-/// per fresh agent state.
-async fn maybe_emit_first_run_intro(config: &AppConfig, runtime: &RuntimeHandle) {
-    if !config.default_provider_ready() {
-        return;
-    }
-    let state = match runtime.agent_state().await {
-        Ok(state) => state,
-        Err(error) => {
-            eprintln!("failed to read agent state for first-run intro: {error:#}");
-            return;
-        }
-    };
-    if state.total_message_count > 0 {
-        return;
-    }
-    let intro_prompt = "This is the first run of Holon with a model provider configured. \
-        Introduce yourself to the user: greet them, briefly explain what you can do as a Holon \
-        agent, and suggest a few starter actions they could try. Keep it friendly and concise — \
-        this is a one-time welcome, not a generic bot template.";
-    let message = MessageEnvelope::new(
-        state.id.clone(),
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator {
-            actor_id: Some("first_run_intro".into()),
-        },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: intro_prompt.to_string(),
-        },
-    )
-    .with_admission(
-        MessageDeliverySurface::RuntimeSystem,
-        AdmissionContext::RuntimeOwned,
-    );
-    if let Err(error) = runtime.enqueue(message).await {
+async fn emit_first_run_intro(config: &AppConfig, runtime: &holon::runtime::RuntimeHandle) {
+    if let Err(error) = maybe_enqueue_first_run_intro(config, runtime).await {
         eprintln!("failed to enqueue first-run intro: {error:#}");
     }
 }
@@ -865,7 +823,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     let host = RuntimeHost::new(config.clone())?;
     let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
-    maybe_emit_first_run_intro(&config, &runtime).await;
+    emit_first_run_intro(&config, &runtime).await;
     let runtime_service = RuntimeServiceHandle::new(&config)?;
 
     let tcp_router = http::router(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,6 +5,7 @@ mod command_task;
 mod continuation;
 mod delivery;
 mod failure;
+mod first_run_intro;
 mod lifecycle;
 mod memory_refresh;
 mod message_dispatch;
@@ -24,6 +25,7 @@ mod waiting;
 pub(crate) mod workspace;
 mod worktree;
 
+pub use first_run_intro::maybe_enqueue_first_run_intro;
 pub use tasks::{
     PickedWorkItem, WorkItemContinuationSummary, WorkItemFocusTransition,
     WorkItemFocusTransitionWarning,

--- a/src/runtime/first_run_intro.rs
+++ b/src/runtime/first_run_intro.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use serde_json::json;
+
+use crate::{
+    config::AppConfig,
+    types::{
+        AdmissionContext, AuthorityClass, MessageBody, MessageDeliverySurface, MessageEnvelope,
+        MessageKind, MessageOrigin, Priority,
+    },
+};
+
+use super::RuntimeHandle;
+
+const FIRST_RUN_INTRO_SUBSYSTEM: &str = "first_run_intro";
+
+pub async fn maybe_enqueue_first_run_intro(
+    config: &AppConfig,
+    runtime: &RuntimeHandle,
+) -> Result<()> {
+    if !config.default_provider_ready() {
+        return Ok(());
+    }
+    let state = runtime.agent_state().await?;
+    if state.total_message_count > 0 {
+        return Ok(());
+    }
+    runtime
+        .enqueue(first_run_intro_message(state.id.clone()))
+        .await?;
+    Ok(())
+}
+
+fn first_run_intro_message(agent_id: impl Into<String>) -> MessageEnvelope {
+    let mut message = MessageEnvelope::new(
+        agent_id,
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: FIRST_RUN_INTRO_SUBSYSTEM.into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: first_run_intro_prompt().to_string(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.metadata = Some(json!({
+        "first_run_intro": true,
+        "reason": "provider_configured",
+        "one_time": true,
+    }));
+    message
+}
+
+fn first_run_intro_prompt() -> &'static str {
+    "This is the first run of Holon with a model provider configured. \
+        Introduce yourself to the user: greet them, briefly explain what you can do as a Holon \
+        agent, and suggest a few starter actions they could try. Keep it friendly and concise — \
+        this is a one-time welcome, not a generic bot template. Choose the user's most likely \
+        language from trusted preferences and environment hints such as locale or timezone; do not \
+        claim certainty, and adapt if the user replies in another language."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ContinuationTriggerKind, MessageBody};
+
+    #[test]
+    fn first_run_intro_is_runtime_owned_internal_followup() {
+        let mut message = first_run_intro_message("default");
+        message.normalize_admission_fields();
+
+        assert_eq!(message.kind, MessageKind::InternalFollowup);
+        assert_eq!(
+            message.origin,
+            MessageOrigin::System {
+                subsystem: FIRST_RUN_INTRO_SUBSYSTEM.into()
+            }
+        );
+        assert_eq!(message.authority_class, AuthorityClass::RuntimeInstruction);
+        assert_eq!(
+            message.delivery_surface,
+            Some(MessageDeliverySurface::RuntimeSystem)
+        );
+        assert_eq!(
+            message.admission_context,
+            Some(AdmissionContext::RuntimeOwned)
+        );
+        assert_eq!(
+            message.trigger_kind,
+            Some(ContinuationTriggerKind::InternalFollowup)
+        );
+        assert_eq!(
+            message
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("first_run_intro"))
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn first_run_intro_prompt_includes_language_hint() {
+        let MessageBody::Text { text } = first_run_intro_message("default").body else {
+            panic!("first-run intro should be text");
+        };
+
+        assert!(text.contains("most likely language"));
+        assert!(text.contains("locale or timezone"));
+        assert!(text.contains("adapt if the user replies in another language"));
+    }
+}

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -861,6 +861,58 @@ Current input:
 }
 
 #[test]
+fn first_run_intro_snapshot_is_runtime_owned_internal_followup() -> Result<()> {
+    let dir = tempdir()?;
+    let storage = AppStorage::new_for_test(dir.path())?;
+
+    let intro = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "first_run_intro".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "This is the first run of Holon with a model provider configured.".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+
+    let rendered = render_context_snapshot(&storage, &AgentState::new("default"), &intro, None)?;
+    let expected = format!(
+        r#"## agent
+Agent id: default
+
+## execution_environment
+{EXECUTION_ENVIRONMENT}
+
+## current_work_item
+Current work item: none.
+No focused WorkItem is attached to this turn.
+
+## context_contract
+{CONTEXT_CONTRACT}
+
+## continuation_anchor
+Continuation anchor:
+Current input relation: current_input is an internal-followup continuation, not a trusted operator request.
+
+## current_input
+Current input:
+- [system][runtime_system][runtime_owned][runtime_instruction][InternalFollowup]
+  This is the first run of Holon with a model provider configured."#
+    );
+    assert_snapshot(&rendered, &expected);
+    assert!(!rendered.contains("[operator]"));
+    assert!(!rendered.contains("operator input full"));
+    Ok(())
+}
+
+#[test]
 fn callback_turn_context_snapshot_preserves_provenance_labels() -> Result<()> {
     let dir = tempdir()?;
     let storage = AppStorage::new_for_test(dir.path())?;


### PR DESCRIPTION
## Summary
- move first-run intro construction out of `main.rs` into a runtime module
- enqueue the intro as a runtime-owned `InternalFollowup` from `System(first_run_intro)` instead of an operator prompt
- add metadata, language-selection guidance, and prompt snapshot coverage for the internal follow-up projection

## Verification
- `cargo fmt --all -- --check`
- `cargo test first_run_intro --tests --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
