### PR TITLE
feat: derive template remote source IDs with install & home_dir fixes

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -2317,26 +2317,46 @@ pub fn install_template_from_github(user_home: &Path, github_url: &str) -> Resul
         .build()
         .context("failed to create HTTP client for template install")?;
 
-    let tarball_url = format!(
-        "https://api.github.com/repos/{}/{}/tarball/{}",
-        source.owner, source.repo, source.reference
-    );
-    // Forward GITHUB_TOKEN / GH_TOKEN when available so private repos work and
-    // the 60 req/hr unauthenticated rate limit is avoided.
-    let mut request = client
-        .get(&tarball_url)
-        .header("Accept", "application/vnd.github+json");
-    if let Ok(token) = env::var("GITHUB_TOKEN").or_else(|_| env::var("GH_TOKEN")) {
-        request = request.bearer_auth(&token);
-    }
+    // GitHub refs (branch/tag names) can contain slashes, making the
+    // ref/path boundary in a tree URL ambiguous.  Try candidate splits
+    // from longest ref to shortest; the first tarball download that
+    // succeeds identifies the correct ref.
+    let segments: Vec<&str> = source.all_after_tree.split('/').collect();
+    let mut bytes = None;
+    let mut resolved_path = String::new();
 
-    let response = request.send().context("failed to request GitHub tarball")?;
-    if !response.status().is_success() {
-        bail!("GitHub tarball download failed: HTTP {}", response.status());
+    for i in (1..=segments.len()).rev() {
+        let candidate_ref = segments[..i].join("/");
+        let candidate_path = if i < segments.len() {
+            segments[i..].join("/")
+        } else {
+            String::new()
+        };
+        let tarball_url = format!(
+            "https://api.github.com/repos/{}/{}/tarball/{}",
+            source.owner, source.repo, candidate_ref
+        );
+        // Forward GITHUB_TOKEN / GH_TOKEN when available so private repos work and
+        // the 60 req/hr unauthenticated rate limit is avoided.
+        let mut request = client
+            .get(&tarball_url)
+            .header("Accept", "application/vnd.github+json");
+        if let Ok(token) = env::var("GITHUB_TOKEN").or_else(|_| env::var("GH_TOKEN")) {
+            request = request.bearer_auth(&token);
+        }
+        let response = request.send().context("failed to request GitHub tarball")?;
+        if response.status().is_success() {
+            resolved_path = candidate_path;
+            bytes = Some(response.bytes().context("failed to read GitHub tarball body")?);
+            break;
+        }
     }
-    let bytes = response
-        .bytes()
-        .context("failed to read GitHub tarball body")?;
+    let bytes = bytes.ok_or_else(|| {
+        anyhow!(
+            "GitHub tarball download failed: no valid ref found for '{}'",
+            source.all_after_tree
+        )
+    })?;
     let tarball_path = tmp.join("archive.tar.gz");
     fs::write(&tarball_path, &bytes)
         .with_context(|| format!("failed to write tarball to {}", tarball_path.display()))?;
@@ -2351,13 +2371,13 @@ pub fn install_template_from_github(user_home: &Path, github_url: &str) -> Resul
     if entries.len() == 1 && entries[0].path().is_dir() {
         search_dir = entries[0].path();
     }
-    if !source.path.is_empty() {
-        search_dir = search_dir.join(&source.path);
+    if !resolved_path.is_empty() {
+        search_dir = search_dir.join(&resolved_path);
     }
     if !search_dir.is_dir() {
         bail!(
             "template directory not found at '{}' in the downloaded archive",
-            source.path
+            resolved_path
         );
     }
 
@@ -2402,8 +2422,9 @@ impl Drop for TmpDirGuard<'_> {
 struct ParsedGithubTemplateUrl {
     owner: String,
     repo: String,
-    reference: String,
-    path: String,
+    /// All segments after `tree/`, preserved verbatim so the caller can
+    /// resolve refs that contain slashes (e.g. `feat/branch-name`).
+    all_after_tree: String,
 }
 
 impl ParsedGithubTemplateUrl {
@@ -2422,17 +2443,11 @@ impl ParsedGithubTemplateUrl {
         if parts.len() < 4 || parts[2] != "tree" {
             bail!("invalid GitHub URL: expected .../tree/<ref>[/<path>]");
         }
-        let reference = parts[3].to_string();
-        let path = if parts.len() > 4 {
-            parts[4..].join("/")
-        } else {
-            String::new()
-        };
+        let all_after_tree = parts[3..].join("/");
         Ok(Self {
             owner,
             repo,
-            reference,
-            path,
+            all_after_tree,
         })
     }
 }
@@ -2459,15 +2474,10 @@ fn extract_tarball(tarball_path: &Path, dest: &Path) -> Result<()> {
 pub fn validate_github_template_url(url: &str) -> Result<String> {
     let parsed = ParsedGithubTemplateUrl::parse(url)?;
     Ok(format!(
-        "{}/{}/tree/{}{}",
+        "{}/{}/tree/{}",
         parsed.owner,
         parsed.repo,
-        parsed.reference,
-        if parsed.path.is_empty() {
-            String::new()
-        } else {
-            format!("/{}", parsed.path)
-        }
+        parsed.all_after_tree,
     ))
 }
 
@@ -4012,8 +4022,7 @@ name = "Versioned"
         .unwrap();
         assert_eq!(url.owner, "holon-run");
         assert_eq!(url.repo, "templates");
-        assert_eq!(url.reference, "main");
-        assert_eq!(url.path, "my-template");
+        assert_eq!(url.all_after_tree, "main/my-template");
     }
 
     #[test]
@@ -4024,8 +4033,7 @@ name = "Versioned"
         .unwrap();
         assert_eq!(url.owner, "owner");
         assert_eq!(url.repo, "repo");
-        assert_eq!(url.reference, "v1.0.0");
-        assert_eq!(url.path, "nested/path/to/template");
+        assert_eq!(url.all_after_tree, "v1.0.0/nested/path/to/template");
     }
 
     #[test]
@@ -4034,8 +4042,7 @@ name = "Versioned"
             ParsedGithubTemplateUrl::parse("https://github.com/owner/repo/tree/main").unwrap();
         assert_eq!(url.owner, "owner");
         assert_eq!(url.repo, "repo");
-        assert_eq!(url.reference, "main");
-        assert!(url.path.is_empty());
+        assert_eq!(url.all_after_tree, "main");
     }
 
     #[test]
@@ -4091,5 +4098,31 @@ name = "Versioned"
         assert_eq!(result, "owner/repo/tree/main/templates/dev");
 
         assert!(validate_github_template_url("https://gitlab.com/owner/repo").is_err());
+    }
+
+    #[test]
+    fn parsed_github_template_url_preserves_slash_in_ref() {
+        let url = ParsedGithubTemplateUrl::parse(
+            "https://github.com/holon-run/holon-test/tree/feat/seed-test-templates/agent_templates/test-developer",
+        )
+        .unwrap();
+        assert_eq!(url.owner, "holon-run");
+        assert_eq!(url.repo, "holon-test");
+        // all_after_tree preserves the full ref+path for downstream resolution
+        assert_eq!(
+            url.all_after_tree,
+            "feat/seed-test-templates/agent_templates/test-developer"
+        );
+    }
+
+    #[test]
+    fn validate_github_template_url_preserves_slash_in_ref() {
+        let result = validate_github_template_url(
+            "https://github.com/owner/repo/tree/feat/branch-name/templates/dev",
+        )
+        .unwrap();
+        // Canonical form preserves the full ref+path since we can't resolve
+        // the ref/path boundary without an API call.
+        assert_eq!(result, "owner/repo/tree/feat/branch-name/templates/dev");
     }
 }

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1471,6 +1471,12 @@ fn unknown_template_error(
     home_dir: &Path,
     catalog_agent_home: &Path,
 ) -> anyhow::Error {
+    tracing::warn!(
+        template = %template,
+        home_dir = %home_dir.display(),
+        catalog_agent_home = %catalog_agent_home.display(),
+        "unknown template selector — diagnosing home_dir mismatch",
+    );
     let catalog = discover_agent_templates_catalog(Some(home_dir), catalog_agent_home);
     let known = if catalog.is_empty() {
         "none".to_string()
@@ -2347,7 +2353,11 @@ pub fn install_template_from_github(user_home: &Path, github_url: &str) -> Resul
         let response = request.send().context("failed to request GitHub tarball")?;
         if response.status().is_success() {
             resolved_path = candidate_path;
-            bytes = Some(response.bytes().context("failed to read GitHub tarball body")?);
+            bytes = Some(
+                response
+                    .bytes()
+                    .context("failed to read GitHub tarball body")?,
+            );
             break;
         }
     }
@@ -2475,9 +2485,7 @@ pub fn validate_github_template_url(url: &str) -> Result<String> {
     let parsed = ParsedGithubTemplateUrl::parse(url)?;
     Ok(format!(
         "{}/{}/tree/{}",
-        parsed.owner,
-        parsed.repo,
-        parsed.all_after_tree,
+        parsed.owner, parsed.repo, parsed.all_after_tree,
     ))
 }
 

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -236,7 +236,6 @@ const BUILTIN_SKILLS: &[BuiltinSkill] = &[
 ];
 
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct GitHubContentsFileResponse {
     #[serde(rename = "type")]
     kind: String,

--- a/src/host.rs
+++ b/src/host.rs
@@ -638,21 +638,18 @@ impl RuntimeHost {
         }
         if let Some(template) = template {
             let agent_home = self.agent_data_dir(agent_id);
+            let user_home = crate::agent_template::user_home_dir()?;
             if let Some(catalog_agent_home) = catalog_agent_home {
                 initialize_agent_home_from_template_with_catalog(
                     &agent_home,
-                    &self.config().home_dir,
+                    &user_home,
                     catalog_agent_home,
                     template,
                 )
                 .await?;
             } else {
-                initialize_agent_home_from_template_with_home(
-                    &agent_home,
-                    &self.config().home_dir,
-                    template,
-                )
-                .await?;
+                initialize_agent_home_from_template_with_home(&agent_home, &user_home, template)
+                    .await?;
             }
         } else {
             initialize_agent_home_without_template(&self.agent_data_dir(agent_id))?;
@@ -1252,9 +1249,10 @@ impl RuntimeHost {
 
     async fn ensure_default_agent_home_initialized(&self) -> Result<()> {
         let agent_home = self.agent_data_dir(&self.config().default_agent_id);
+        let user_home = crate::agent_template::user_home_dir()?;
         let _ = ensure_agent_home_agents_md_from_template_with_home(
             &agent_home,
-            &self.config().home_dir,
+            &user_home,
             DEFAULT_AGENT_TEMPLATE_ID,
         )
         .await?;
@@ -1271,9 +1269,10 @@ impl RuntimeHost {
         let child_agent_id = ids::runtime_id(TEMP_CHILD_AGENT_PREFIX.trim_end_matches('_'));
         self.validate_agent_id(&child_agent_id)?;
         if let Some(template) = template {
+            let user_home = crate::agent_template::user_home_dir()?;
             initialize_agent_home_from_template_with_catalog(
                 &self.agent_data_dir(&child_agent_id),
-                &self.config().home_dir,
+                &user_home,
                 catalog_agent_home,
                 template,
             )

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -263,7 +263,7 @@ export function TemplatesPage({
           <StatusBadge className="state-chip" kind="connection" value={catalog.source} />
         </CardHeader>
         <CardContent>
-          <form className="skills-add-form" onSubmit={(event) => void handleAddSource(event)}>
+          <form className="skills-add-form template-remote-source-form" onSubmit={(event) => void handleAddSource(event)}>
             <label className="skills-add-source">
               <span>GitHub URL</span>
               <input
@@ -273,9 +273,6 @@ export function TemplatesPage({
                 disabled={sourceFormBusy}
               />
             </label>
-            <span className="template-source-id-preview">
-              Source ID: <strong>{customSourceId.trim() || suggestedSourceId || "generated from GitHub URL"}</strong>
-            </span>
             <label>
               <span>Ref (optional)</span>
               <input
@@ -285,6 +282,10 @@ export function TemplatesPage({
                 disabled={sourceFormBusy}
               />
             </label>
+            <div className="template-source-id-preview">
+              <span>Generated source id</span>
+              <strong>{customSourceId.trim() || suggestedSourceId || "generated from GitHub URL"}</strong>
+            </div>
             <details className="template-source-advanced">
               <summary>Advanced: custom source id</summary>
               <label>

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -51,12 +51,14 @@ export function TemplatesPage({
   const [query, setQuery] = useState("");
   const [sourceFilter, setSourceFilter] = useState<"all" | AgentTemplateSourceKind>("all");
   const [githubUrl, setGithubUrl] = useState("");
-  const [newSourceId, setNewSourceId] = useState("");
+  const [customSourceId, setCustomSourceId] = useState("");
   const [newSourceUrl, setNewSourceUrl] = useState("");
   const [newSourceRef, setNewSourceRef] = useState("");
   const [sourceFormError, setSourceFormError] = useState<string | undefined>();
   const [sourceFormBusy, setSourceFormBusy] = useState(false);
   const stats = useMemo(() => templateStats(templates), [templates]);
+  const existingSourceIds = useMemo(() => catalog.sources.map((source) => source.sourceId), [catalog.sources]);
+  const suggestedSourceId = useMemo(() => uniqueSourceId(deriveSourceId(newSourceUrl), existingSourceIds), [existingSourceIds, newSourceUrl]);
   const visibleTemplates = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return templates.filter((template) => {
@@ -88,15 +90,28 @@ export function TemplatesPage({
 
   async function handleAddSource(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const id = newSourceId.trim();
     const url = newSourceUrl.trim();
-    if (!id || !url) return;
+    if (!url) return;
+    const customId = customSourceId.trim();
+    const id = customId ? sanitizeSourceId(customId) : suggestedSourceId;
+    if (!id) {
+      setSourceFormError("Enter a GitHub URL so Holon can generate a source id.");
+      return;
+    }
+    if (customId && id !== customId) {
+      setSourceFormError(`Custom source id was normalized to "${id}". Use that value or leave custom id empty.`);
+      return;
+    }
+    if (existingSourceIds.includes(id)) {
+      setSourceFormError(`Remote source "${id}" already exists.`);
+      return;
+    }
     setSourceFormBusy(true);
     setSourceFormError(undefined);
     try {
       const ok = await onAddRemoteSource(id, url, newSourceRef.trim() || undefined);
       if (ok) {
-        setNewSourceId("");
+        setCustomSourceId("");
         setNewSourceUrl("");
         setNewSourceRef("");
       } else {
@@ -249,15 +264,6 @@ export function TemplatesPage({
         </CardHeader>
         <CardContent>
           <form className="skills-add-form" onSubmit={(event) => void handleAddSource(event)}>
-            <label>
-              <span>Source ID</span>
-              <input
-                value={newSourceId}
-                placeholder="my-templates"
-                onChange={(event) => setNewSourceId(event.target.value)}
-                disabled={sourceFormBusy}
-              />
-            </label>
             <label className="skills-add-source">
               <span>GitHub URL</span>
               <input
@@ -267,6 +273,9 @@ export function TemplatesPage({
                 disabled={sourceFormBusy}
               />
             </label>
+            <span className="template-source-id-preview">
+              Source ID: <strong>{customSourceId.trim() || suggestedSourceId || "generated from GitHub URL"}</strong>
+            </span>
             <label>
               <span>Ref (optional)</span>
               <input
@@ -276,7 +285,19 @@ export function TemplatesPage({
                 disabled={sourceFormBusy}
               />
             </label>
-            <Button type="submit" variant="accent" disabled={sourceFormBusy || !newSourceId.trim() || !newSourceUrl.trim()}>
+            <details className="template-source-advanced">
+              <summary>Advanced: custom source id</summary>
+              <label>
+                <span>Custom source id</span>
+                <input
+                  value={customSourceId}
+                  placeholder="org-repo"
+                  onChange={(event) => setCustomSourceId(event.target.value)}
+                  disabled={sourceFormBusy}
+                />
+              </label>
+            </details>
+            <Button type="submit" variant="accent" disabled={sourceFormBusy || !newSourceUrl.trim()}>
               Add
             </Button>
           </form>
@@ -494,4 +515,53 @@ function templateStats(templates: AgentTemplateCatalogEntry[]) {
     { label: "global", value: String(templates.filter((template) => template.source === "user_global" || template.source === "user").length) },
     { label: "remote", value: String(templates.filter((template) => template.source === "remote").length) },
   ];
+}
+
+function deriveSourceId(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+  const githubRepo = githubRepoSlug(trimmed);
+  if (githubRepo) return githubRepo;
+  return sanitizeSourceId(trimmed.split("/").filter(Boolean).slice(-2).join("-")) || "remote-source";
+}
+
+function githubRepoSlug(url: string): string | undefined {
+  const parsed = parseGitHubUrl(url);
+  if (!parsed) return undefined;
+  return sanitizeSourceId(`${parsed.owner}-${parsed.repo}`);
+}
+
+function parseGitHubUrl(url: string): { owner: string; repo: string } | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "github.com") return undefined;
+    const [owner, repo] = parsed.pathname.split("/").filter(Boolean);
+    if (!owner || !repo) return undefined;
+    return { owner, repo: repo.replace(/\.git$/, "") };
+  } catch {
+    const match = url.match(/github\.com[:/](?<owner>[^/:\s]+)\/(?<repo>[^/\s]+?)(?:\.git)?(?:[/?#].*)?$/);
+    const owner = match?.groups?.owner;
+    const repo = match?.groups?.repo;
+    return owner && repo ? { owner, repo } : undefined;
+  }
+}
+
+function sanitizeSourceId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\.git$/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+function uniqueSourceId(sourceId: string, existingSourceIds: string[]): string {
+  if (!sourceId) return "";
+  const existing = new Set(existingSourceIds);
+  if (!existing.has(sourceId)) return sourceId;
+  for (let index = 2; ; index += 1) {
+    const candidate = `${sourceId}-${index}`;
+    if (!existing.has(candidate)) return candidate;
+  }
 }

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3033,38 +3033,63 @@ code {
   grid-template-columns: minmax(140px, 0.6fr) minmax(180px, 1fr) auto;
 }
 
+.template-remote-source-form {
+  grid-template-columns: minmax(260px, 1fr) minmax(140px, 180px) auto;
+  align-items: start;
+}
+
+.template-remote-source-form .skills-add-source {
+  min-width: 0;
+}
+
+.template-remote-source-form .template-source-id-preview,
+.template-remote-source-form .template-source-advanced {
+  grid-column: 1 / -1;
+}
+
+.template-remote-source-form .template-source-id-preview {
+  margin-top: -2px;
+}
+
+.template-remote-source-form > button {
+  align-self: end;
+}
+
 .template-source-id-preview {
-  align-self: center;
+  display: grid;
+  gap: 5px;
+  align-self: stretch;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--line) 82%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
   color: var(--muted);
-  font-size: 12px;
   line-height: 1.4;
   overflow-wrap: anywhere;
 }
 
-.skills-add-form .template-source-id-preview {
-  font-weight: 640;
-  letter-spacing: normal;
-  text-transform: none;
-}
-
 .template-source-id-preview strong {
   color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
   font-weight: 760;
 }
 
 .template-source-advanced {
+  border-top: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
   color: var(--muted);
   font-size: 12px;
 }
 
 .template-source-advanced summary {
   cursor: pointer;
-  min-height: 40px;
-  padding-top: 12px;
+  padding-top: 10px;
+  width: fit-content;
 }
 
 .template-source-advanced label {
   margin-top: 8px;
+  max-width: 360px;
 }
 
 .template-row-title,

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3033,6 +3033,40 @@ code {
   grid-template-columns: minmax(140px, 0.6fr) minmax(180px, 1fr) auto;
 }
 
+.template-source-id-preview {
+  align-self: center;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.skills-add-form .template-source-id-preview {
+  font-weight: 640;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.template-source-id-preview strong {
+  color: var(--text);
+  font-weight: 760;
+}
+
+.template-source-advanced {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.template-source-advanced summary {
+  cursor: pointer;
+  min-height: 40px;
+  padding-top: 12px;
+}
+
+.template-source-advanced label {
+  margin-top: 8px;
+}
+
 .template-row-title,
 .template-row-meta {
   display: flex;


### PR DESCRIPTION
## Summary

Improve agent template remote source identification, plus several fixes discovered during end-to-end testing with the `holon-test` repository.

## Changes

- **feat: derive template remote source ids** (`7d08b860`)
  - Derive stable source IDs for templates fetched from remote sources so the catalog can distinguish provenance.
- **style: refine template remote source form** (`01541fe0`)
  - Refine the remote source form UI in the Templates page.
- **fix: remove `deny_unknown_fields` from GitHub contents response struct** (`2a9c9ae9`)
  - The GitHub contents API returns extra fields that caused deserialization failures when `deny_unknown_fields` was set.
- **fix: handle slashes in GitHub refs for template install** (`9efd8d15`)
  - GitHub refs containing slashes (e.g. `feat/branch-name`) were parsed incorrectly during template install.
- **fix: use `user_home_dir()` instead of config `home_dir` for template initialization** (`e0739c49`)
  - Template initialization used the wrong `home_dir` value, causing agent home directories to be created without copying `AGENTS.md` and memory files from the template.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo build --release` ✅
- `cargo test --lib agent_template` ✅
- End-to-end test: sync → detail → install → create agent from template, all passing with the `holon-test` repo.

## Known Limitation

The Remote selector in `resolve_template` requires runtime DB access that is not currently available in that context. This needs a larger refactor and is tracked separately.