### PR TITLE
refactor: simplify agent template sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ a new agent:
 - Or create one through the CLI:
 
 ```bash
-holon agent create builder --template holon-developer
+holon agent create builder
 holon agent list
 ```
 

--- a/docs/rfcs/agent-initialization-and-template.md
+++ b/docs/rfcs/agent-initialization-and-template.md
@@ -274,26 +274,10 @@ agent_templates/
 collisions with prompt templates, UI templates, workflow templates, and other
 future template-like assets.
 
-A repository may optionally include a small repository index:
-
-```text
-holon-index.toml
-```
-
-Example:
-
-```toml
-schema = "holon.repository.v1"
-
-[collections]
-skills = "skills"
-agent_templates = "agent_templates"
-```
-
-The index is an optimization and capability declaration, not the source of the
-template body. The source of truth remains the per-template directory.
-Implementations may scan the default `skills/` and `agent_templates/`
-directories when `holon-index.toml` is absent.
+Template repositories use the top-level `agent_templates/` directory for
+repository-level discovery. `holon-index.toml` is not part of v1 template
+discovery; keeping one conventional path avoids a second source of truth for
+remote sync.
 
 ### GitHub URL format
 
@@ -328,26 +312,21 @@ template URL application. A daemon discovers templates in configured remote
 sources by scanning the `agent_templates/` directory and exposes the catalog
 through API responses.
 
-### Builtin templates
+### Builtin default template
 
-Holon should ship a small builtin template set for common roles.
+Holon ships exactly one hidden built-in `holon-default` template as the
+zero-config and offline fallback. It is not exposed as a normal catalog entry
+and is not seeded into the user-visible template root on startup.
 
-Builtin templates should be exposed through the same catalog model as other
-templates.
+Creating an agent without an explicit template selector uses this hidden
+default. Creating an agent with a selector resolves only visible local
+templates, catalog-qualified local templates, explicit paths, and explicit
+GitHub template URLs. Compatibility selectors for the hidden default may remain
+available, but they should not create duplicate visible catalog entries.
 
-If builtin templates are materialized into the user-visible local root, that
-materialization should be idempotent:
-
-- builtin templates are installed only when the target template directory does
-  not already exist
-- startup should not overwrite or silently rewrite an existing user template
-- after materialization, normal `template_id` resolution uses the standard
-  `agent_templates` directory
-
-Builtin templates should not be special caller-provided inline prompts. They
-may still be materialized locally for inspectability, but their target
-user-visible root should follow the same `agent_templates` convention as
-user-authored templates.
+Common role templates such as developer, reviewer, release, or GitHub issue
+solver should be delivered through the official remote template source and
+materialized into `~/.agents/agent_templates` by sync/install operations.
 
 ### `skills.toml` format
 
@@ -431,8 +410,8 @@ daemon should expose templates as first-class catalog and lifecycle resources.
 
 The API surface should be able to:
 
-- list visible template catalog entries across builtin, user, agent-local, and
-  configured remote sources
+- list visible template catalog entries across user, agent-local, and managed
+  templates materialized from configured remote sources
 - return template details, including metadata, source, package path, rendered
   `AGENTS.md` preview, and declared skill references
 - validate a local or remote template package without applying it
@@ -465,8 +444,8 @@ Remote template sources are configured explicitly in daemon-level config:
 {
   "agent_templates": {
     "remote_sources": {
-      "community": {
-        "url": "https://github.com/holon-run/agent-templates",
+      "official": {
+        "url": "https://github.com/holon-run/holon",
         "ref": "main",
         "enabled": true
       }
@@ -493,9 +472,14 @@ v1 non-goals:
   or ad-hoc URLs
 - no configurable remote repo layout path
 
+If config does not explicitly define `official`, Holon registers the official
+`https://github.com/holon-run/holon` source by default. Startup must not require
+network access: missing, stale, or failed source sync state is surfaced as
+source status and diagnostics, not as an agent creation blocker.
+
 ### Remote source sync
 
-Sync is explicit, not automatic:
+Sync can be requested explicitly:
 
 ```
 POST /templates/remote-sources/sync
@@ -505,7 +489,7 @@ Request body (optional):
 
 ```json
 {
-  "source_id": "community",
+  "source_id": "official",
   "force": false
 }
 ```
@@ -516,14 +500,29 @@ Request body (optional):
 Sync runs as a daemon job (`kind = "agent_template.remote_sources.sync"`) through
 the existing `/jobs` infrastructure. Jobs are asynchronous and trackable.
 
+The daemon may also start a non-blocking background sync for enabled sources
+that have never synced or whose last successful sync is stale. That work must
+not block startup, default agent creation, or explicit agent creation.
+
 Sync results are persisted in DB table `agent_template_remote_source_syncs` with
 fields: `source_id`, `kind`, `url`, `requested_ref`, `enabled`, `status`,
 `last_synced_at`, `resolved_ref`, nullable `resolved_revision`, `catalog_json`,
 `diagnostics_json`, and `error`.
 
-Cache policy: conservative. Each source has its own cache directory. Last-good
-cache is preserved on sync failure. Disabled or removed source caches are not
-automatically cleaned up.
+Sync materializes each discovered template into:
+
+```text
+~/.agents/agent_templates/<template_id>/
+```
+
+This is intentionally the same root used for user-authored templates and
+explicit installs. Managed metadata records the owning remote source and content
+hash. A later sync may update templates it owns, but it must refuse to overwrite
+a user-owned template directory or a template managed by another source.
+
+The DB row remains source status metadata for APIs and diagnostics. It is not
+the live catalog source for synced templates; after materialization, normal
+local template discovery exposes the synced templates.
 
 ### Catalog API response
 
@@ -533,19 +532,19 @@ automatically cleaned up.
 {
   "catalog": [
     {
-      "catalog_id": "builtin:holon-developer",
+      "catalog_id": "user_global:holon-developer",
       "template": "holon-developer",
       "template_id": "holon-developer",
-      "source": "builtin",
+      "source": "user_global",
       "name": "Holon Developer",
       "description": "A long-lived implementation-focused agent.",
       "included_skills": []
     }
   ],
   "sources": [
-    { "source_id": "community", "kind": "github", "enabled": true,
+    { "source_id": "official", "kind": "github", "enabled": true,
       "status": "synced",
-      "url": "https://github.com/holon-run/agent-templates",
+      "url": "https://github.com/holon-run/holon",
       "resolved_ref": "main", "resolved_revision": null,
       "last_synced_at": "2026-01-01T00:00:00Z" }
   ],
@@ -556,9 +555,9 @@ automatically cleaned up.
 `resolved_ref` is the configured or default branch name. `resolved_revision` is
 nullable in v1 because GitHub contents discovery currently resolves branch
 names for request stability but does not require an additional commit SHA
-lookup. Remote entries include `source_id`, `resolved_ref`, and `source_url`;
-`GET /templates/catalog/{catalog_id}` can resolve remote details by fetching the
-template tree from `source_url`.
+lookup. The visible catalog is local: user-authored templates, explicit
+installs, agent-home templates, and managed templates materialized by remote
+sync. Hidden built-in defaults are not returned as normal catalog entries.
 
 ## Evolving `AGENTS.md`
 
@@ -640,7 +639,7 @@ The intended direction is:
 3. user-authored template packages live under
    `~/.agents/agent_templates/<template_id>/`
 4. package repositories use top-level `agent_templates/` convention;
-   no index file required
+   no index file supported
 5. each template package uses `template.toml`, `AGENTS.md`, and optional
    `skills.toml`
 6. templates materialize an initial `agent_home/AGENTS.md`

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -31,7 +31,7 @@
 | Original section | Current home |
 |------------------|--------------|
 | Agent State | [Agent state spec](./website/spec/agent-state.md) |
-| Agent Initialization Contract | Implementation detail; see `src/runtime/agent_init.rs` and `builtin_templates/` |
+| Agent Initialization Contract | Implementation detail; see `src/runtime/agent_init.rs` and `src/agent_template.rs` |
 | Agent Identity And Visibility Contract | [Agent state spec](./website/spec/agent-state.md) — lifecycle, identity, visibility, ownership, profile presets |
 | Agent Model Selection | [Agent state spec](./website/spec/agent-state.md) |
 | Agent Inspection Surface Contract | Control-plane API; see `/agents/list`, `/agents/:id/status`, `/agents/:id/state` |
@@ -121,7 +121,7 @@ focused spec page. They remain in source code, RFCs, or CLI reference:
 - **Failure artifact envelope** (operator-facing failure normalization):
   `src/types.rs` `FailureArtifact`
 - **Agent initialization** (template selection, agent_home materialization):
-  `src/runtime/agent_init.rs`, `builtin_templates/`
+  `src/runtime/agent_init.rs`, `src/agent_template.rs`
 - **Memory search index** (FTS indexing, CJK, rebuild markers):
   `src/memory/`, tool schema inventory
 - **Local operator console** (TUI contract):

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -62,7 +62,7 @@ holon tui
 ```
 
 Holon automatically provides a default main agent. You can also create a more
-specialized agent from a template:
+specialized agent after syncing or installing templates:
 
 ```bash
 holon agent create builder --template holon-developer

--- a/docs/website/getting-started/README.md
+++ b/docs/website/getting-started/README.md
@@ -70,7 +70,7 @@ This is a short orientation for contributors. End users don't need to know the r
 - `tests/` contains Rust integration tests and shared support.
 - `docs/` contains runtime contracts, design records, and current architecture
   notes.
-- `builtin_templates/` contains runtime-managed agent templates.
+- `agent_templates/` contains remote-syncable agent templates.
 - `docs/website/` contains this mdorigin documentation site.
 
 

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -174,17 +174,17 @@ When you start Holon, it automatically creates a **default agent** in `~/.holon/
 Create a specialized agent for a specific role:
 
 ```bash
-holon agent create reviewer --template holon-reviewer
+holon agent create reviewer
 ```
 
-This creates a new agent in `~/.holon/agents/reviewer/` initialized with the holon-reviewer template.
+This creates a new agent in `~/.holon/agents/reviewer/` initialized with the default role contract.
 
 ### Use a template
 
 Templates provide reusable agent configurations:
 
 ```bash
-# Use a builtin template by ID
+# Use an installed or synced template by ID
 holon agent create docs-helper --template holon-developer
 
 # Use a local template path

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -88,7 +88,7 @@ Edit and build the Holon documentation website.
   <!-- mdorigin:index kind=article -->
 
 - [Agent templates](./agent-templates.md)
-  What agent templates are, available built-in templates, how to use --template, and how to create custom templates.
+  What agent templates are, how to sync or install them, how to use --template, and how to create custom templates.
   <!-- mdorigin:index kind=article -->
 
 - [Documentation workflow](./documentation-workflow.md)

--- a/docs/website/guides/agent-templates.md
+++ b/docs/website/guides/agent-templates.md
@@ -1,6 +1,6 @@
 ---
 title: Agent templates
-summary: What agent templates are, available built-in templates, how to use --template, and how to create custom templates.
+summary: What agent templates are, how to sync or install them, how to use --template, and how to create custom templates.
 order: 18
 ---
 
@@ -17,61 +17,31 @@ capabilities. Without a template, agents start with a generic default contract.
 
 Common scenarios:
 
-- **Creating a reviewer agent** — `holon agent create reviewer --template holon-reviewer`
+- **Creating a synced reviewer agent** — `holon agent create reviewer --template holon-reviewer`
 - **One-shot tasks with a role** — `holon run --template holon-developer "Fix the null check in handler.rs"`
 - **Solving GitHub issues** — `holon solve --template holon-github-solve https://github.com/owner/repo/issues/42`
 
-## Built-in Templates
+## Template library and default bootstrap
 
-Holon ships with these built-in templates. The repository source lives under
-`builtin_templates/`, and at runtime templates resolve from
-`~/.agents/templates/<template_id>/` (built-in templates are seeded there
-during initialization).
+Holon keeps visible templates in the user template library:
 
-| Template ID | Purpose | Includes Skills |
-|-------------|---------|----------------|
-| `holon-default` | Generic agent with fill-in-the-blank role contract | None |
-| `holon-developer` | Implementation-focused agent for code changes | None |
-| `holon-reviewer` | Review-focused agent for PR inspection | None |
-| `holon-release` | Release and delivery agent for versioning/publishing | None |
-| `holon-github-solve` | GitHub task agent for issues and PRs | `ghx`, `github-issue-solve`, `github-pr-fix`, `github-review` |
+```text
+~/.agents/agent_templates/<template_id>/
+```
 
-### `holon-default`
+User-authored templates, explicit installs, and remote-source sync results all
+use this same root. Remote-source sync is equivalent to a batch install/update
+of managed templates into that library; Holon writes managed metadata so later
+syncs can update their own templates without overwriting user-owned directories.
 
-The default template. Provides a fill-in-the-blank `AGENTS.md` structure with
-sections for Role, Responsibilities, Authority, Escalation Boundary, and
-Operating Conventions. Use this as a starting point for custom roles.
+Holon also carries one hidden built-in `holon-default` template for zero-config
+and offline startup. It is not seeded into `~/.agents/agent_templates`, and it
+is not shown as a catalog entry. It is used only when creating an agent without
+an explicit template selector.
 
-### `holon-developer`
-
-Pre-configured for implementation work:
-
-- Turn requirements into concrete code changes
-- Run minimal verification that meaningfully checks the change
-- Keep edits narrow, explicit, and easy to review
-- Report blockers with concrete technical evidence
-
-### `holon-reviewer`
-
-Pre-configured for code review:
-
-- Inspect pull requests for correctness, regressions, and contract drift
-- Prioritize concrete findings with clear severity and file references
-- Distinguish proven issues from open questions
-
-### `holon-release`
-
-Pre-configured for release work:
-
-- Prepare release changesets, version bumps, and release notes
-- Verify release prerequisites before publishing
-- Surface irreversible steps before executing them
-
-### `holon-github-solve`
-
-The most feature-rich template. Pre-configures the agent for GitHub workflows
-and pre-installs four skills for issue solving, PR fixing, code review, and
-GitHub CLI operations.
+The official template source is the Holon repository. When synced, templates
+under its top-level `agent_templates/` directory become normal local catalog
+entries from `~/.agents/agent_templates`.
 
 ## Using `--template`
 
@@ -81,9 +51,10 @@ GitHub CLI operations.
 holon agent create reviewer --template holon-reviewer
 ```
 
-This initializes `~/.holon/agents/reviewer/AGENTS.md` with the reviewer role
-contract. If the agent home already exists and is non-empty, template
-initialization refuses to overwrite it.
+This initializes `~/.holon/agents/reviewer/AGENTS.md` from the local
+`holon-reviewer` template after that template has been installed or synced. If
+the agent home already exists and is non-empty, template initialization refuses
+to overwrite it.
 
 ### One-Shot Run
 

--- a/docs/website/guides/durable-agent-workflow.md
+++ b/docs/website/guides/durable-agent-workflow.md
@@ -43,14 +43,15 @@ local Unix socket.
 
 ### 2. Create a specialized agent
 
-For focused durable work, create a named agent with a template:
+For focused durable work, create a named agent with an installed or synced
+template:
 
 ```bash
 holon agent create builder --template holon-developer
 ```
 
-This creates `~/.holon/agents/builder/` initialized with the developer
-template, which includes code-editing skills.
+This creates `~/.holon/agents/builder/` initialized from the local developer
+template.
 
 ### 3. Start a WorkItem-backed piece of work
 

--- a/docs/website/guides/quick-examples.md
+++ b/docs/website/guides/quick-examples.md
@@ -30,7 +30,7 @@ Create a named agent that persists across sessions:
 holon agent create reviewer
 ```
 
-Create an agent from a built-in template:
+Create an agent from an installed or synced template:
 
 ```bash
 holon agent create reviewer --template holon-reviewer

--- a/docs/website/guides/solve.md
+++ b/docs/website/guides/solve.md
@@ -130,8 +130,8 @@ When you run `holon solve`, these steps happen inside the runtime:
    `$TMPDIR/holon-output-<uuid>`) and a `github-context/` subdirectory holds
    input metadata.
 
-3. **Create the agent** — Holon creates an agent from the built-in
-   `holon-github-solve` template, which includes the `github-issue-solve`,
+3. **Create the agent** — Holon creates an agent from the configured solve
+   template, normally `holon-github-solve`, which includes the `github-issue-solve`,
    `github-pr-fix`, `github-review`, and `ghx` skills.
 
 4. **Run the prompt** — The runtime constructs a prompt describing the target
@@ -181,7 +181,7 @@ serve different purposes:
 |---|---|---|
 | Use case | General headless tasks | GitHub issues and PRs |
 | Input | Free-text prompt | GitHub target ref |
-| Agent template | `holon-default` | `holon-github-solve` (GitHub skills pre-loaded) |
+| Agent template | hidden default when no selector is provided | `holon-github-solve` (GitHub skills pre-loaded) |
 | Output | Text or JSON to stdout | Structured artifacts in output directory |
 | GitHub integration | Manual (`gh` CLI) | Automatic context collection and skill dispatch |
 | Pipeline-friendly | Use `--json` for structured output | Built-in manifest and summary files |

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1,10 +1,11 @@
 use std::{
+    collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
 };
 
 use crate::{
-    config::AgentTemplateRemoteSourceConfigFile,
+    config::{AgentTemplateRemoteSourceConfigFile, AgentTemplatesConfigFile},
     runtime_db::RuntimeDb,
     types::{
         AgentTemplateCatalogEntry, AgentTemplateDetail, AgentTemplateSkillDependency,
@@ -23,8 +24,10 @@ const TEMPLATE_AGENTS_FILENAME: &str = "AGENTS.md";
 const TEMPLATE_SKILLS_FILENAME: &str = "skills.toml";
 const TEMPLATE_MANIFEST_FILENAME: &str = "template.toml";
 const TEMPLATE_PROVENANCE_FILENAME: &str = "template-provenance.json";
-const BUILTIN_TEMPLATE_STATE_FILENAME: &str = ".holon-builtin-template.json";
+const MANAGED_TEMPLATE_STATE_FILENAME: &str = ".holon-template.json";
 pub const DEFAULT_AGENT_TEMPLATE_ID: &str = "holon-default";
+pub const OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_ID: &str = "official";
+pub const OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_URL: &str = "https://github.com/holon-run/holon";
 const MEMORY_SELF_INITIAL: &str = "# Self Memory\n\n";
 const MEMORY_OPERATOR_INITIAL: &str = r#"# Operator Memory
 
@@ -44,62 +47,38 @@ pub const REQUIRED_AGENT_HOME_GUIDANCE: &str = r#"## Holon Agent Home
 - `.holon/` is runtime-owned state, ledger, index, and cache storage. Do not edit it as ordinary agent-authored files.
 "#;
 
-const BUILTIN_TEMPLATES: &[BuiltinTemplate] = &[
-    BuiltinTemplate {
-        template_id: "holon-default",
-        version: 1,
-        agents_md: include_str!("../builtin_templates/holon-default/AGENTS.md"),
-        template_toml: include_str!("../builtin_templates/holon-default/template.toml"),
-        skill_names: &[],
-    },
-    BuiltinTemplate {
-        template_id: "holon-developer",
-        version: 1,
-        agents_md: include_str!("../builtin_templates/holon-developer/AGENTS.md"),
-        template_toml: include_str!("../builtin_templates/holon-developer/template.toml"),
-        skill_names: &[],
-    },
-    BuiltinTemplate {
-        template_id: "holon-reviewer",
-        version: 1,
-        agents_md: include_str!("../builtin_templates/holon-reviewer/AGENTS.md"),
-        template_toml: include_str!("../builtin_templates/holon-reviewer/template.toml"),
-        skill_names: &[],
-    },
-    BuiltinTemplate {
-        template_id: "holon-release",
-        version: 1,
-        agents_md: include_str!("../builtin_templates/holon-release/AGENTS.md"),
-        template_toml: include_str!("../builtin_templates/holon-release/template.toml"),
-        skill_names: &[],
-    },
-    BuiltinTemplate {
-        template_id: "holon-github-solve",
-        version: 1,
-        agents_md: include_str!("../builtin_templates/holon-github-solve/AGENTS.md"),
-        template_toml: include_str!("../builtin_templates/holon-github-solve/template.toml"),
-        skill_names: &[
-            "ghx",
-            "github-issue-solve",
-            "github-pr-fix",
-            "github-review",
-        ],
-    },
-];
+const DEFAULT_BUILTIN_TEMPLATE: BuiltinTemplate = BuiltinTemplate {
+    template_id: "holon-default",
+    agents_md: include_str!("../builtin_templates/holon-default/AGENTS.md"),
+    template_toml: include_str!("../builtin_templates/holon-default/template.toml"),
+    skill_names: &[],
+};
+const BUILTIN_TEMPLATES: &[BuiltinTemplate] = &[DEFAULT_BUILTIN_TEMPLATE];
 
 struct BuiltinTemplate {
     template_id: &'static str,
-    version: u32,
     agents_md: &'static str,
     template_toml: &'static str,
     skill_names: &'static [&'static str],
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct BuiltinTemplateState {
+struct ManagedTemplateState {
     template_id: String,
-    version: u32,
     content_hash: String,
+    owner: ManagedTemplateOwner,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ManagedTemplateOwner {
+    RemoteSource {
+        source_id: String,
+        url: String,
+        resolved_ref: String,
+        source_url: String,
+        synced_at: DateTime<Utc>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -251,26 +230,6 @@ struct GitHubContentsDirEntry {
     kind: String,
 }
 
-/// Parsed `holon-index.toml` repository manifest.
-///
-/// Present at a remote repository root to declare the collection layout.
-/// When absent, discovery falls back to the conventional `agent_templates/` directory.
-#[allow(dead_code)]
-#[derive(Debug, Deserialize)]
-struct HolonIndexManifest {
-    #[serde(default)]
-    schema: String,
-    #[serde(default)]
-    collections: HolonIndexCollections,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Default, Deserialize)]
-struct HolonIndexCollections {
-    skills: Option<String>,
-    agent_templates: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTemplateRemoteSourceSyncStatus {
@@ -317,6 +276,7 @@ pub struct AgentTemplateRemoteCatalogSnapshot {
 struct ResolvedTemplate {
     provenance: TemplateProvenanceSource,
     agents_md: String,
+    template_toml: Option<String>,
     skill_refs: Vec<TemplateSkillRef>,
     schema_version: Option<String>,
 }
@@ -337,42 +297,15 @@ pub fn agent_memory_operator_path(agent_home: &Path) -> PathBuf {
 }
 
 fn builtin_template_state_path(template_dir: &Path) -> PathBuf {
-    template_dir.join(BUILTIN_TEMPLATE_STATE_FILENAME)
+    template_dir.join(MANAGED_TEMPLATE_STATE_FILENAME)
 }
 
 pub fn seed_builtin_templates() -> Result<()> {
-    let home_dir = user_home_dir()?;
-    seed_builtin_templates_for_home(&home_dir)
+    Ok(())
 }
 
 pub fn seed_builtin_templates_for_home(home_dir: &Path) -> Result<()> {
-    let templates_root = templates_root_for_home(home_dir);
-    fs::create_dir_all(&templates_root)
-        .with_context(|| format!("failed to create {}", templates_root.display()))?;
-
-    for builtin in BUILTIN_TEMPLATES {
-        let template_dir = templates_root.join(builtin.template_id);
-        let existed_before = template_dir.exists();
-        let was_empty_before = if existed_before {
-            fs::read_dir(&template_dir)?.next().is_none()
-        } else {
-            false
-        };
-        let existing_state = read_builtin_template_state(&template_dir)?;
-        let should_write = if !existed_before || was_empty_before {
-            true
-        } else if let Some(state) = existing_state.as_ref() {
-            builtin_template_is_managed(&template_dir, state)?
-                && (state.version != builtin.version
-                    || state.content_hash != builtin_template_content_hash(builtin))
-        } else {
-            false
-        };
-        if should_write {
-            write_builtin_template(&template_dir, builtin)?;
-        }
-    }
-
+    let _ = home_dir;
     Ok(())
 }
 
@@ -399,13 +332,18 @@ pub async fn initialize_agent_home_from_template_with_catalog(
     .await
 }
 
-pub fn initialize_agent_home_without_template(agent_home: &Path) -> Result<()> {
-    ensure_agent_home_layout(agent_home)?;
-    let agents_md_path = agent_home.join(TEMPLATE_AGENTS_FILENAME);
-    create_file_if_missing(
-        &agents_md_path,
-        render_agent_home_agents_md("", None).as_bytes(),
-    )
+pub async fn initialize_agent_home_without_template(
+    agent_home: &Path,
+) -> Result<TemplateProvenanceRecord> {
+    let home_dir = user_home_dir()?;
+    initialize_agent_home_without_template_with_home(agent_home, &home_dir).await
+}
+
+pub async fn initialize_agent_home_without_template_with_home(
+    agent_home: &Path,
+    home_dir: &Path,
+) -> Result<TemplateProvenanceRecord> {
+    initialize_agent_home_from_builtin_default(agent_home, home_dir).await
 }
 
 pub async fn initialize_agent_home_from_template_with_home(
@@ -486,6 +424,68 @@ async fn initialize_agent_home_from_template_with_home_and_catalog(
     result
 }
 
+async fn initialize_agent_home_from_builtin_default(
+    agent_home: &Path,
+    home_dir: &Path,
+) -> Result<TemplateProvenanceRecord> {
+    let agent_home = agent_home.to_path_buf();
+    let existed_before = agent_home.exists();
+    let was_empty_before = if existed_before {
+        fs::read_dir(&agent_home)?.next().is_none()
+    } else {
+        false
+    };
+    if existed_before && !was_empty_before {
+        bail!(
+            "agent home {} already exists and is not empty; template initialization refuses to overwrite existing agent state",
+            agent_home.display()
+        );
+    }
+
+    if !existed_before {
+        fs::create_dir_all(&agent_home)
+            .with_context(|| format!("failed to create {}", agent_home.display()))?;
+    }
+
+    let result = async {
+        ensure_agent_home_layout(&agent_home)?;
+        let resolved = resolve_builtin_template(DEFAULT_AGENT_TEMPLATE_ID, home_dir)?;
+        materialize_template(&agent_home, &resolved).await?;
+        let record = TemplateProvenanceRecord {
+            selector: DEFAULT_AGENT_TEMPLATE_ID.to_string(),
+            source: resolved.provenance,
+            applied_at: Utc::now(),
+            schema_version: resolved.schema_version,
+        };
+        tracing::info!(
+            template = %record.selector,
+            schema_version = ?record.schema_version,
+            agent_home = %agent_home.display(),
+            "template_applied: agent initialized from hidden builtin default template"
+        );
+        let content = serde_json::to_vec_pretty(&record)?;
+        fs::write(template_provenance_path(&agent_home), content).with_context(|| {
+            format!(
+                "failed to write {}",
+                template_provenance_path(&agent_home).display()
+            )
+        })?;
+        Ok(record)
+    }
+    .await;
+
+    if result.is_err() && agent_home.exists() {
+        if !existed_before {
+            let _ = fs::remove_dir_all(&agent_home);
+        } else if was_empty_before {
+            let _ = fs::remove_dir_all(&agent_home);
+            let _ = fs::create_dir_all(&agent_home);
+        }
+    }
+
+    result
+}
+
 pub async fn ensure_agent_home_agents_md_from_template(
     agent_home: &Path,
     template: &str,
@@ -518,6 +518,13 @@ pub async fn ensure_agent_home_agents_md_from_template_with_home(
         agent_home, home_dir, None, template,
     )
     .await
+}
+
+pub async fn ensure_agent_home_agents_md_without_template_with_home(
+    agent_home: &Path,
+    home_dir: &Path,
+) -> Result<Option<TemplateProvenanceRecord>> {
+    ensure_agent_home_agents_md_from_builtin_default(agent_home, home_dir).await
 }
 
 async fn ensure_agent_home_agents_md_from_template_with_home_and_catalog(
@@ -581,6 +588,60 @@ async fn ensure_agent_home_agents_md_from_template_with_home_and_catalog(
     }
 }
 
+async fn ensure_agent_home_agents_md_from_builtin_default(
+    agent_home: &Path,
+    home_dir: &Path,
+) -> Result<Option<TemplateProvenanceRecord>> {
+    let agent_home = agent_home.to_path_buf();
+    fs::create_dir_all(&agent_home)
+        .with_context(|| format!("failed to create {}", agent_home.display()))?;
+    ensure_agent_home_layout(&agent_home)?;
+    let agents_md_path = agent_home.join(TEMPLATE_AGENTS_FILENAME);
+    if agents_md_path.exists() {
+        return Ok(None);
+    }
+    let resolved = resolve_builtin_template(DEFAULT_AGENT_TEMPLATE_ID, home_dir)?;
+    let skills_root = agent_home.join("skills");
+    let mut created_skill_destinations = Vec::new();
+
+    let result: Result<TemplateProvenanceRecord> = async {
+        let agents_md = render_agent_home_agents_md(&resolved.agents_md, None);
+        write_file_atomically(&agents_md_path, agents_md.as_bytes())?;
+        for skill_ref in &resolved.skill_refs {
+            let destination = materialize_skill_ref(&agent_home, &skills_root, skill_ref).await?;
+            created_skill_destinations.push(destination);
+        }
+        let record = TemplateProvenanceRecord {
+            selector: DEFAULT_AGENT_TEMPLATE_ID.to_string(),
+            source: resolved.provenance,
+            applied_at: Utc::now(),
+            schema_version: resolved.schema_version,
+        };
+        tracing::info!(
+            template = %record.selector,
+            schema_version = ?record.schema_version,
+            agent_home = %agent_home.display(),
+            "template_applied: agent initialized from hidden builtin default template"
+        );
+        let content = serde_json::to_vec_pretty(&record)?;
+        write_file_atomically(&template_provenance_path(&agent_home), &content)?;
+        Ok(record)
+    }
+    .await;
+
+    match result {
+        Ok(record) => Ok(Some(record)),
+        Err(err) => {
+            let _ = fs::remove_file(&agents_md_path);
+            let _ = fs::remove_file(template_provenance_path(&agent_home));
+            for destination in created_skill_destinations.into_iter().rev() {
+                let _ = remove_materialized_skill_destination(&destination);
+            }
+            Err(err)
+        }
+    }
+}
+
 #[cfg(test)]
 fn templates_root() -> Result<PathBuf> {
     Ok(templates_root_for_home(&user_home_dir()?))
@@ -588,6 +649,20 @@ fn templates_root() -> Result<PathBuf> {
 
 fn templates_root_for_home(home_dir: &Path) -> PathBuf {
     home_dir.join(".agents").join("agent_templates")
+}
+
+pub fn effective_agent_template_remote_sources(
+    config: &AgentTemplatesConfigFile,
+) -> BTreeMap<String, AgentTemplateRemoteSourceConfigFile> {
+    let mut sources = config.remote_sources.clone();
+    sources
+        .entry(OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_ID.to_string())
+        .or_insert_with(|| AgentTemplateRemoteSourceConfigFile {
+            url: OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_URL.to_string(),
+            git_ref: None,
+            enabled: Some(true),
+        });
+    sources
 }
 
 pub(crate) fn discover_agent_templates_catalog(
@@ -614,20 +689,6 @@ pub(crate) fn discover_agent_templates_catalog(
         .into_iter()
         .filter(|entry| !agent_home_template_ids.contains(&entry.template_id))
         .collect::<Vec<_>>();
-    let user_template_ids = entries
-        .iter()
-        .map(|entry| entry.template_id.clone())
-        .collect::<std::collections::BTreeSet<_>>();
-
-    for builtin in BUILTIN_TEMPLATES {
-        if user_template_ids.contains(builtin.template_id)
-            || agent_home_template_ids.contains(builtin.template_id)
-        {
-            continue;
-        }
-        entries.push(builtin_template_catalog_entry(builtin));
-    }
-
     entries.extend(agent_home_entries);
     entries.sort_by(|left, right| {
         (
@@ -690,11 +751,6 @@ fn discover_local_templates(
         if validate_template_id(template_id).is_err() {
             continue;
         }
-        if source == AgentTemplateSourceKind::UserGlobal
-            && is_managed_seeded_builtin_template(&path, template_id)
-        {
-            continue;
-        }
         let agents_md_path = path.join(TEMPLATE_AGENTS_FILENAME);
         let Ok(agents_md) = fs::read_to_string(&agents_md_path) else {
             continue;
@@ -736,10 +792,10 @@ fn discover_local_templates(
 
 pub fn load_remote_template_catalog_snapshot(
     db: &RuntimeDb,
-    configured_sources: &std::collections::BTreeMap<String, AgentTemplateRemoteSourceConfigFile>,
+    configured_sources: &BTreeMap<String, AgentTemplateRemoteSourceConfigFile>,
 ) -> Result<AgentTemplateRemoteCatalogSnapshot> {
     let connection = db.connection()?;
-    let mut catalog = Vec::new();
+    let catalog = Vec::new();
     let mut sources = Vec::new();
     let mut diagnostics = Vec::new();
 
@@ -765,9 +821,6 @@ pub fn load_remote_template_catalog_snapshot(
             });
             continue;
         };
-        if enabled {
-            catalog.extend(row.catalog.iter().cloned());
-        }
         diagnostics.extend(row.diagnostics.iter().cloned());
         let mut status = row.status;
         if !enabled {
@@ -792,6 +845,24 @@ pub fn load_remote_template_catalog_snapshot(
         sources,
         diagnostics,
     })
+}
+
+pub fn agent_template_remote_source_needs_sync(
+    db: &RuntimeDb,
+    source_id: &str,
+    stale_after: chrono::Duration,
+) -> Result<bool> {
+    let connection = db.connection()?;
+    let Some(row) = load_remote_source_row(&connection, source_id)? else {
+        return Ok(true);
+    };
+    if row.status != AgentTemplateRemoteSourceSyncStatus::Synced {
+        return Ok(true);
+    }
+    let Some(last_synced_at) = row.last_synced_at else {
+        return Ok(true);
+    };
+    Ok(Utc::now().signed_duration_since(last_synced_at) >= stale_after)
 }
 
 #[derive(Debug)]
@@ -884,6 +955,7 @@ fn remote_source_sync_status_label(status: &AgentTemplateRemoteSourceSyncStatus)
 
 pub async fn sync_agent_template_remote_source(
     db: &RuntimeDb,
+    user_home: &Path,
     source_id: &str,
     config: &AgentTemplateRemoteSourceConfigFile,
 ) -> Result<AgentTemplateRemoteSourceStatus> {
@@ -928,6 +1000,17 @@ pub async fn sync_agent_template_remote_source(
         entry.template = entry.catalog_id.clone();
     }
     let now = Utc::now();
+    for entry in &catalog {
+        install_remote_template_catalog_entry(
+            user_home,
+            source_id,
+            &config.url,
+            &resolved_ref,
+            now,
+            entry,
+        )
+        .await?;
+    }
     let status = AgentTemplateRemoteSourceStatus {
         source_id: source_id.to_string(),
         kind: "github".into(),
@@ -1023,34 +1106,6 @@ fn upsert_remote_source_sync(
         )?;
         Ok(())
     })
-}
-
-fn is_managed_seeded_builtin_template(path: &Path, template_id: &str) -> bool {
-    let Some(builtin) = BUILTIN_TEMPLATES
-        .iter()
-        .find(|builtin| builtin.template_id == template_id)
-    else {
-        return false;
-    };
-    let state = match read_builtin_template_state(path) {
-        Ok(Some(state)) => state,
-        Ok(None) => return false,
-        Err(error) => {
-            tracing::debug!(
-                template_path = %path.display(),
-                %error,
-                "failed to read seeded builtin template state while building catalog"
-            );
-            return false;
-        }
-    };
-    if state.template_id != builtin.template_id
-        || state.version != builtin.version
-        || state.content_hash != builtin_template_content_hash(builtin)
-    {
-        return false;
-    }
-    builtin_template_is_managed(path, &state).unwrap_or(false)
 }
 
 fn template_description(agents_md: &str) -> String {
@@ -1227,6 +1282,43 @@ pub(crate) async fn resolve_remote_agent_template_detail(
     })
 }
 
+async fn install_remote_template_catalog_entry(
+    user_home: &Path,
+    source_id: &str,
+    source_url: &str,
+    resolved_ref: &str,
+    synced_at: DateTime<Utc>,
+    entry: &AgentTemplateCatalogEntry,
+) -> Result<()> {
+    let template_url = entry
+        .source_url
+        .as_deref()
+        .ok_or_else(|| anyhow!("remote template {} has no source URL", entry.catalog_id))?;
+    let resolved = resolve_github_template(template_url).await?;
+    let templates_root = templates_root_for_home(user_home);
+    fs::create_dir_all(&templates_root)
+        .with_context(|| format!("failed to create {}", templates_root.display()))?;
+    let destination = templates_root.join(&entry.template_id);
+    let state = ManagedTemplateState {
+        template_id: entry.template_id.clone(),
+        content_hash: resolved_template_content_hash(&resolved),
+        owner: ManagedTemplateOwner::RemoteSource {
+            source_id: source_id.to_string(),
+            url: source_url.to_string(),
+            resolved_ref: resolved_ref.to_string(),
+            source_url: template_url.to_string(),
+            synced_at,
+        },
+    };
+    if let Err(error) = write_managed_template_dir(&destination, &resolved, &state) {
+        bail!(
+            "failed to install remote template {}: {error:#}",
+            entry.template_id
+        );
+    }
+    Ok(())
+}
+
 fn local_template_skills(path: &Path) -> Vec<String> {
     match parse_skill_refs(path.join(TEMPLATE_SKILLS_FILENAME)) {
         Ok(skill_refs) => skill_ref_names(skill_refs),
@@ -1266,7 +1358,7 @@ fn skill_ref_names(skill_refs: Vec<TemplateSkillRef>) -> Vec<String> {
     names
 }
 
-pub(crate) fn user_home_dir() -> Result<PathBuf> {
+pub fn user_home_dir() -> Result<PathBuf> {
     env::var_os("HOME")
         .map(PathBuf::from)
         .filter(|path| !path.as_os_str().is_empty())
@@ -1407,10 +1499,7 @@ async fn resolve_catalog_template(
     match entry.source {
         AgentTemplateSourceKind::Builtin => resolve_builtin_template(&entry.template_id, home_dir),
         AgentTemplateSourceKind::Remote => {
-            let source_url = entry
-                .source_url
-                .ok_or_else(|| anyhow!("remote template {} has no source URL", entry.catalog_id))?;
-            resolve_github_template(&source_url).await
+            unreachable!("remote templates are materialized locally")
         }
         AgentTemplateSourceKind::UserGlobal | AgentTemplateSourceKind::AgentHome => {
             let path = entry.path.clone().ok_or_else(|| {
@@ -1419,35 +1508,24 @@ async fn resolve_catalog_template(
                     entry.catalog_id
                 )
             })?;
-            let mut resolved = resolve_local_template(
+            let resolved = resolve_local_template(
                 path.clone(),
                 TemplateProvenanceSource::TemplateId {
                     template_id: entry.template_id.clone(),
                     path,
                 },
             )?;
-            // Seeded builtin templates carry compiled-in skills that cannot be
-            // expressed in skills.toml. Merge them so they are materialized.
-            if let Some(builtin) = BUILTIN_TEMPLATES
-                .iter()
-                .find(|t| t.template_id == entry.template_id)
-            {
-                for &name in builtin.skill_names {
-                    resolved.skill_refs.push(TemplateSkillRef::Builtin {
-                        name: name.to_string(),
-                    });
-                }
-            }
             Ok(resolved)
         }
     }
 }
 
 fn resolve_builtin_template(template_id: &str, home_dir: &Path) -> Result<ResolvedTemplate> {
-    let builtin = BUILTIN_TEMPLATES
-        .iter()
-        .find(|builtin| builtin.template_id == template_id)
-        .ok_or_else(|| anyhow!("unknown builtin template id {template_id}"))?;
+    let builtin = if template_id == DEFAULT_AGENT_TEMPLATE_ID {
+        &DEFAULT_BUILTIN_TEMPLATE
+    } else {
+        bail!("unknown builtin template id {template_id}");
+    };
     let skill_refs: Vec<TemplateSkillRef> = builtin
         .skill_names
         .iter()
@@ -1461,6 +1539,7 @@ fn resolve_builtin_template(template_id: &str, home_dir: &Path) -> Result<Resolv
             path: templates_root_for_home(home_dir).join(template_id),
         },
         agents_md: builtin.agents_md.to_string(),
+        template_toml: Some(builtin.template_toml.to_string()),
         skill_refs,
         schema_version: parse_template_manifest(builtin.template_toml).map(|m| m.schema),
     })
@@ -1518,14 +1597,19 @@ fn resolve_local_template(
     Ok(ResolvedTemplate {
         provenance,
         agents_md,
+        template_toml: read_template_manifest_content(&path),
         skill_refs,
         schema_version: read_template_schema_version(&path),
     })
 }
 
-fn read_template_schema_version(template_dir: &Path) -> Option<String> {
+fn read_template_manifest_content(template_dir: &Path) -> Option<String> {
     let manifest_path = template_dir.join(TEMPLATE_MANIFEST_FILENAME);
-    let content = fs::read_to_string(&manifest_path).ok()?;
+    fs::read_to_string(&manifest_path).ok()
+}
+
+fn read_template_schema_version(template_dir: &Path) -> Option<String> {
+    let content = read_template_manifest_content(template_dir)?;
     parse_template_manifest(&content).map(|m| m.schema)
 }
 
@@ -1611,7 +1695,7 @@ fn validate_template_github_skill_name(skill: &str) -> Result<()> {
     Ok(())
 }
 
-fn read_builtin_template_state(template_dir: &Path) -> Result<Option<BuiltinTemplateState>> {
+fn read_managed_template_state(template_dir: &Path) -> Result<Option<ManagedTemplateState>> {
     let path = builtin_template_state_path(template_dir);
     if !path.is_file() {
         return Ok(None);
@@ -1621,79 +1705,141 @@ fn read_builtin_template_state(template_dir: &Path) -> Result<Option<BuiltinTemp
     if content.trim().is_empty() {
         return Ok(None);
     }
-    let state = serde_json::from_str(&content).ok();
-    Ok(state)
+    serde_json::from_str(&content)
+        .map(Some)
+        .with_context(|| format!("failed to parse {}", path.display()))
 }
 
-fn builtin_template_content_hash(template: &BuiltinTemplate) -> String {
+fn resolved_template_content_hash(resolved: &ResolvedTemplate) -> String {
     use sha2::{Digest as _, Sha256};
 
     let mut hasher = Sha256::new();
     hasher.update(TEMPLATE_AGENTS_FILENAME.as_bytes());
     hasher.update(b"\n");
-    hasher.update(template.agents_md.as_bytes());
-    hasher.update(b"\n");
-    hasher.update(TEMPLATE_MANIFEST_FILENAME.as_bytes());
-    hasher.update(b"\n");
-    hasher.update(template.template_toml.as_bytes());
-    if !template.skill_names.is_empty() {
+    hasher.update(resolved.agents_md.as_bytes());
+    if let Some(schema_version) = resolved.schema_version.as_deref() {
         hasher.update(b"\n");
-        hasher.update(b"skill_names\n");
-        for &name in template.skill_names {
-            hasher.update(name.as_bytes());
-            hasher.update(b"\n");
+        hasher.update(b"schema_version\n");
+        hasher.update(schema_version.as_bytes());
+    }
+    if let Some(template_toml) = resolved.template_toml.as_deref() {
+        hasher.update(b"\n");
+        hasher.update(TEMPLATE_MANIFEST_FILENAME.as_bytes());
+        hasher.update(b"\n");
+        hasher.update(template_toml.as_bytes());
+    }
+    for skill_ref in &resolved.skill_refs {
+        hasher.update(b"\n");
+        match skill_ref {
+            TemplateSkillRef::Local { path } => {
+                hasher.update(b"local:");
+                hasher.update(path.display().to_string().as_bytes());
+            }
+            TemplateSkillRef::Github { package } => {
+                hasher.update(b"github:");
+                hasher.update(package.as_bytes());
+            }
+            TemplateSkillRef::Builtin { name } => {
+                hasher.update(b"builtin:");
+                hasher.update(name.as_bytes());
+            }
         }
     }
     format!("{:x}", hasher.finalize())
 }
 
-fn current_builtin_template_content_hash(template_dir: &Path) -> Result<String> {
-    use sha2::{Digest as _, Sha256};
-
-    let agents_md_path = template_dir.join(TEMPLATE_AGENTS_FILENAME);
-    let agents_md = fs::read_to_string(&agents_md_path)
-        .with_context(|| format!("failed to read {}", agents_md_path.display()))?;
-    let mut hasher = Sha256::new();
-    hasher.update(TEMPLATE_AGENTS_FILENAME.as_bytes());
-    hasher.update(b"\n");
-    hasher.update(agents_md.as_bytes());
-    let manifest_path = template_dir.join(TEMPLATE_MANIFEST_FILENAME);
-    if manifest_path.exists() {
-        let manifest = fs::read_to_string(&manifest_path)
-            .with_context(|| format!("failed to read {}", manifest_path.display()))?;
-        hasher.update(b"\n");
-        hasher.update(TEMPLATE_MANIFEST_FILENAME.as_bytes());
-        hasher.update(b"\n");
-        hasher.update(manifest.as_bytes());
+fn write_managed_template_dir(
+    template_dir: &Path,
+    resolved: &ResolvedTemplate,
+    state: &ManagedTemplateState,
+) -> Result<()> {
+    if template_dir.exists() {
+        let existing_state = read_managed_template_state(template_dir)?;
+        match existing_state {
+            Some(existing)
+                if matches!(
+                    (&existing.owner, &state.owner),
+                    (
+                        ManagedTemplateOwner::RemoteSource {
+                            source_id: existing_source,
+                            ..
+                        },
+                        ManagedTemplateOwner::RemoteSource {
+                            source_id: new_source,
+                            ..
+                        }
+                    ) if existing_source == new_source
+                ) =>
+            {
+                fs::remove_dir_all(template_dir)
+                    .with_context(|| format!("failed to clear {}", template_dir.display()))?;
+            }
+            Some(existing) => {
+                bail!(
+                    "template '{}' at {} is managed by {:?}; refusing to overwrite from another source",
+                    existing.template_id,
+                    template_dir.display(),
+                    existing.owner
+                );
+            }
+            None => {
+                bail!(
+                    "template directory {} already exists without managed metadata; refusing to overwrite user-owned template",
+                    template_dir.display()
+                );
+            }
+        }
     }
-    Ok(format!("{:x}", hasher.finalize()))
-}
 
-fn builtin_template_is_managed(template_dir: &Path, state: &BuiltinTemplateState) -> Result<bool> {
-    let current_hash = current_builtin_template_content_hash(template_dir)?;
-    Ok(current_hash == state.content_hash)
-}
-
-fn write_builtin_template(template_dir: &Path, builtin: &BuiltinTemplate) -> Result<()> {
     fs::create_dir_all(template_dir)
         .with_context(|| format!("failed to create {}", template_dir.display()))?;
-    let agents_md_path = template_dir.join(TEMPLATE_AGENTS_FILENAME);
-    write_file_atomically(&agents_md_path, builtin.agents_md.as_bytes())?;
-    let manifest_path = template_dir.join(TEMPLATE_MANIFEST_FILENAME);
-    write_file_atomically(&manifest_path, builtin.template_toml.as_bytes())?;
-    // Remove any leftover skills.json from the old format.
-    let old_skills_path = template_dir.join("skills.json");
-    if old_skills_path.exists() {
-        let _ = fs::remove_file(&old_skills_path);
+    write_file_atomically(
+        &template_dir.join(TEMPLATE_AGENTS_FILENAME),
+        resolved.agents_md.as_bytes(),
+    )?;
+    if let Some(manifest) = resolved.template_toml.as_deref() {
+        write_file_atomically(
+            &template_dir.join(TEMPLATE_MANIFEST_FILENAME),
+            manifest.as_bytes(),
+        )?;
     }
-    let state = BuiltinTemplateState {
-        template_id: builtin.template_id.to_string(),
-        version: builtin.version,
-        content_hash: builtin_template_content_hash(builtin),
-    };
-    let content = serde_json::to_vec_pretty(&state)?;
+    if !resolved.skill_refs.is_empty() {
+        write_template_skills_file(template_dir, &resolved.skill_refs)?;
+    }
+    let content = serde_json::to_vec_pretty(state)?;
     write_file_atomically(&builtin_template_state_path(template_dir), &content)?;
     Ok(())
+}
+
+fn write_template_skills_file(template_dir: &Path, skill_refs: &[TemplateSkillRef]) -> Result<()> {
+    let mut content = String::new();
+    for skill_ref in skill_refs {
+        match skill_ref {
+            TemplateSkillRef::Local { path } => {
+                content.push_str("[[skills]]\nkind = \"local\"\npath = \"");
+                content.push_str(&toml_escape(&path.display().to_string()));
+                content.push_str("\"\n\n");
+            }
+            TemplateSkillRef::Github { package } => {
+                content.push_str("[[skills]]\nkind = \"github\"\npackage = \"");
+                content.push_str(&toml_escape(package));
+                content.push_str("\"\n\n");
+            }
+            TemplateSkillRef::Builtin { name } => {
+                content.push_str("[[skills]]\nkind = \"builtin\"\nname = \"");
+                content.push_str(&toml_escape(name));
+                content.push_str("\"\n\n");
+            }
+        }
+    }
+    write_file_atomically(
+        &template_dir.join(TEMPLATE_SKILLS_FILENAME),
+        content.as_bytes(),
+    )
+}
+
+fn toml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
@@ -1786,6 +1932,7 @@ async fn resolve_github_template(template: &str) -> Result<ResolvedTemplate> {
                 template_path,
             },
             agents_md,
+            template_toml: manifest_content,
             skill_refs,
             schema_version,
         });
@@ -1988,10 +2135,8 @@ pub(crate) async fn discover_github_repo_templates(
     repo: &str,
     git_ref: &str,
 ) -> Result<Vec<AgentTemplateCatalogEntry>> {
-    let template_dir = resolve_remote_template_collection_dir(owner, repo, git_ref).await?;
-
     // List subdirectories under the template collection.
-    let entries = match fetch_github_dir(owner, repo, git_ref, &template_dir).await? {
+    let entries = match fetch_github_dir(owner, repo, git_ref, DEFAULT_REMOTE_TEMPLATE_DIR).await? {
         Some(entries) => entries,
         None => return Ok(Vec::new()),
     };
@@ -2002,7 +2147,8 @@ pub(crate) async fn discover_github_repo_templates(
             continue;
         }
         let template_id = entry.name;
-        let manifest_path = format!("{template_dir}/{template_id}/{TEMPLATE_MANIFEST_FILENAME}");
+        let manifest_path =
+            format!("{DEFAULT_REMOTE_TEMPLATE_DIR}/{template_id}/{TEMPLATE_MANIFEST_FILENAME}");
         let manifest = match fetch_github_file(owner, repo, git_ref, &manifest_path).await {
             Ok(Some(content)) => parse_template_manifest(&content),
             Ok(None) => None,
@@ -2036,33 +2182,11 @@ pub(crate) async fn discover_github_repo_templates(
             resolved_ref: Some(git_ref.to_string()),
             resolved_revision: None,
             source_url: Some(format!(
-                "https://github.com/{owner}/{repo}/tree/{git_ref}/{template_dir}/{template_id}"
+                "https://github.com/{owner}/{repo}/tree/{git_ref}/{DEFAULT_REMOTE_TEMPLATE_DIR}/{template_id}"
             )),
         });
     }
     Ok(catalog_entries)
-}
-
-/// Resolve the template collection directory for a remote GitHub repository.
-///
-/// Tries `holon-index.toml` at the repo root first; when present and parseable,
-/// uses its `collections.agent_templates` value. Falls back to
-/// [`DEFAULT_REMOTE_TEMPLATE_DIR`] when the index is absent, unreadable, or
-/// does not declare a custom collection path.
-async fn resolve_remote_template_collection_dir(
-    owner: &str,
-    repo: &str,
-    git_ref: &str,
-) -> Result<String> {
-    match fetch_github_file(owner, repo, git_ref, "holon-index.toml").await? {
-        Some(content) => match toml::from_str::<HolonIndexManifest>(&content) {
-            Ok(manifest) if manifest.collections.agent_templates.as_deref().is_some() => {
-                Ok(manifest.collections.agent_templates.unwrap())
-            }
-            _ => Ok(DEFAULT_REMOTE_TEMPLATE_DIR.to_string()),
-        },
-        None => Ok(DEFAULT_REMOTE_TEMPLATE_DIR.to_string()),
-    }
 }
 
 /// Discover AgentTemplates from a GitHub repository URL.
@@ -2413,8 +2537,19 @@ pub fn install_template_from_github(user_home: &Path, github_url: &str) -> Resul
 
     let destination = templates_root.join(&template_id);
     if destination.exists() {
-        fs::remove_dir_all(&destination)
-            .with_context(|| format!("failed to clear existing {}", destination.display()))?;
+        if let Some(state) = read_managed_template_state(&destination)? {
+            bail!(
+                "template '{}' at {} is managed by {:?}; refusing to overwrite it with an explicit install",
+                state.template_id,
+                destination.display(),
+                state.owner
+            );
+        }
+        bail!(
+            "template '{}' already exists at {}; refusing to overwrite existing user-owned template",
+            template_id,
+            destination.display()
+        );
     }
     copy_template_dir(&search_dir, &destination)?;
 
@@ -2549,75 +2684,20 @@ mod tests {
     }
 
     #[test]
-    fn seed_builtin_templates_is_idempotent() {
+    fn seed_builtin_templates_is_noop() {
         let home = tempdir().unwrap();
         let templates = templates_root_for_home(home.path());
 
         seed_builtin_templates_for_home(home.path()).unwrap();
-        let developer_agents = templates.join("holon-developer/AGENTS.md");
-        assert!(developer_agents.is_file());
 
-        fs::write(&developer_agents, "custom").unwrap();
-        seed_builtin_templates_for_home(home.path()).unwrap();
-        assert_eq!(fs::read_to_string(&developer_agents).unwrap(), "custom");
+        assert!(!templates.exists());
     }
 
     #[test]
-    fn seed_builtin_templates_writes_prefixed_default_template() {
-        let home = tempdir().unwrap();
-        let templates = templates_root_for_home(home.path());
-
-        seed_builtin_templates_for_home(home.path()).unwrap();
-        let agents_md = templates.join("holon-default/AGENTS.md");
-        assert!(agents_md.is_file());
-        assert!(fs::read_to_string(agents_md)
-            .unwrap()
-            .contains("Holon Default Agent"));
-    }
-
-    #[test]
-    fn seed_builtin_templates_upgrades_managed_builtin_content() {
-        let home = tempdir().unwrap();
-        let templates = templates_root_for_home(home.path());
-
-        seed_builtin_templates_for_home(home.path()).unwrap();
-        let template_dir = templates.join("holon-reviewer");
-        let agents_md = template_dir.join("AGENTS.md");
-        let state_path = builtin_template_state_path(&template_dir);
-        let original = fs::read_to_string(&agents_md).unwrap();
-        let mut state: BuiltinTemplateState =
-            serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
-        state.version = 0;
-        fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
-
-        seed_builtin_templates_for_home(home.path()).unwrap();
-
-        assert_eq!(fs::read_to_string(&agents_md).unwrap(), original);
-        let upgraded: BuiltinTemplateState =
-            serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
-        assert_eq!(upgraded.version, 1);
-    }
-
-    #[test]
-    fn seed_builtin_templates_tolerates_empty_builtin_state_file() {
-        let home = tempdir().unwrap();
-        let templates = templates_root_for_home(home.path());
-
-        seed_builtin_templates_for_home(home.path()).unwrap();
-        let template_dir = templates.join("holon-default");
-        fs::write(builtin_template_state_path(&template_dir), "").unwrap();
-
-        seed_builtin_templates_for_home(home.path()).unwrap();
-
-        assert!(template_dir.join("AGENTS.md").is_file());
-    }
-
-    #[test]
-    fn discover_agent_templates_catalog_lists_stable_selectors_and_shadowing() {
+    fn discover_agent_templates_catalog_lists_local_templates_without_builtin_entries() {
         let user_home = tempdir().unwrap();
         let agent_home = tempdir().unwrap();
         let user_templates = templates_root_for_home(user_home.path());
-        seed_builtin_templates_for_home(user_home.path()).unwrap();
         let worker = user_templates.join("worker");
         fs::create_dir_all(&worker).unwrap();
         fs::write(
@@ -2627,26 +2707,13 @@ mod tests {
         .unwrap();
         let source_skill = user_home.path().join("source-skill");
         fs::create_dir_all(&source_skill).unwrap();
-        fs::write(
-            source_skill.join("SKILL.md"),
-            "# Source
-",
-        )
-        .unwrap();
+        fs::write(source_skill.join("SKILL.md"), "# Source\n").unwrap();
         fs::write(
             worker.join(TEMPLATE_SKILLS_FILENAME),
             format!(
                 "[[skills]]\nkind = \"local\"\npath = \"{}\"\n",
                 source_skill.display()
             ),
-        )
-        .unwrap();
-
-        let shadowed_default = user_templates.join("holon-default");
-        fs::create_dir_all(&shadowed_default).unwrap();
-        fs::write(
-            shadowed_default.join(TEMPLATE_AGENTS_FILENAME),
-            "# Custom default\n",
         )
         .unwrap();
 
@@ -2665,16 +2732,10 @@ mod tests {
 
         assert!(catalog
             .iter()
-            .any(|entry| entry.catalog_id == "user_global:holon-default"));
+            .all(|entry| entry.source != AgentTemplateSourceKind::Builtin));
         assert!(!catalog
             .iter()
             .any(|entry| entry.catalog_id == "builtin:holon-default"));
-        assert!(catalog
-            .iter()
-            .any(|entry| entry.catalog_id == "builtin:holon-developer"));
-        assert!(!catalog
-            .iter()
-            .any(|entry| entry.catalog_id == "user_global:holon-developer"));
 
         let worker_entry = catalog
             .iter()
@@ -2698,11 +2759,45 @@ mod tests {
     }
 
     #[test]
-    fn discover_agent_templates_catalog_prefers_agent_home_over_other_sources() {
+    fn effective_remote_sources_include_official_source_by_default() {
+        let config = AgentTemplatesConfigFile::default();
+
+        let sources = effective_agent_template_remote_sources(&config);
+
+        let official = sources
+            .get(OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_ID)
+            .expect("official remote source should be registered by default");
+        assert_eq!(official.url, OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_URL);
+        assert!(official.enabled());
+    }
+
+    #[test]
+    fn effective_remote_sources_preserve_explicit_official_override() {
+        let mut config = AgentTemplatesConfigFile::default();
+        config.remote_sources.insert(
+            OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_ID.to_string(),
+            AgentTemplateRemoteSourceConfigFile {
+                url: "https://github.com/example/custom".into(),
+                git_ref: Some("dev".into()),
+                enabled: Some(false),
+            },
+        );
+
+        let sources = effective_agent_template_remote_sources(&config);
+
+        let official = sources
+            .get(OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_ID)
+            .expect("explicit official remote source should be preserved");
+        assert_eq!(official.url, "https://github.com/example/custom");
+        assert_eq!(official.git_ref.as_deref(), Some("dev"));
+        assert!(!official.enabled());
+    }
+
+    #[test]
+    fn discover_agent_templates_catalog_prefers_agent_home_over_user_global() {
         let user_home = tempdir().unwrap();
         let agent_home = tempdir().unwrap();
         let user_templates = templates_root_for_home(user_home.path());
-        seed_builtin_templates_for_home(user_home.path()).unwrap();
 
         let user_worker = user_templates.join("worker");
         fs::create_dir_all(&user_worker).unwrap();
@@ -2742,9 +2837,6 @@ mod tests {
         assert!(!catalog
             .iter()
             .any(|entry| entry.catalog_id == "builtin:holon-default"));
-        assert!(!catalog
-            .iter()
-            .any(|entry| entry.catalog_id == "user_global:holon-default"));
     }
 
     #[tokio::test]
@@ -2752,18 +2844,6 @@ mod tests {
         let user_home = tempdir().unwrap();
         let agent_home = tempdir().unwrap();
         let user_templates = templates_root_for_home(user_home.path());
-        seed_builtin_templates_for_home(user_home.path()).unwrap();
-
-        let agent_default = agent_home
-            .path()
-            .join("agent_templates")
-            .join("holon-default");
-        fs::create_dir_all(&agent_default).unwrap();
-        fs::write(
-            agent_default.join(TEMPLATE_AGENTS_FILENAME),
-            "# Agent default\n\nAgent-home default\n",
-        )
-        .unwrap();
 
         let user_worker = user_templates.join("worker");
         fs::create_dir_all(&user_worker).unwrap();
@@ -2785,7 +2865,7 @@ mod tests {
             resolve_template("builtin:holon-default", user_home.path(), agent_home.path())
                 .await
                 .unwrap();
-        assert!(builtin.agents_md.contains("## Role"));
+        assert!(builtin.agents_md.contains("Holon Default Agent"));
 
         let user = resolve_template("user_global:worker", user_home.path(), agent_home.path())
             .await
@@ -2805,65 +2885,6 @@ mod tests {
             "Visible description"
         );
         assert_eq!(template_description("<!-- hidden --> Visible\n"), "Visible");
-    }
-
-    #[test]
-    fn builtin_template_is_managed_accounts_for_template_manifest() {
-        let home = tempdir().unwrap();
-        let template_dir = home.path().join("template");
-        fs::create_dir_all(&template_dir).unwrap();
-        fs::write(template_dir.join(TEMPLATE_AGENTS_FILENAME), "agents").unwrap();
-        fs::write(
-            template_dir.join(TEMPLATE_MANIFEST_FILENAME),
-            "schema = \"holon.agent_template.v1\"\nid = \"test\"\nname = \"Test\"\nsummary = \"test\"\n",
-        )
-        .unwrap();
-
-        let builtin = BuiltinTemplate {
-            template_id: "holon-test",
-            version: 1,
-            agents_md: "agents",
-            template_toml: "schema = \"holon.agent_template.v1\"\nid = \"test\"\nname = \"Test\"\nsummary = \"test\"\n",
-            skill_names: &[],
-        };
-        let state = BuiltinTemplateState {
-            template_id: builtin.template_id.to_string(),
-            version: builtin.version,
-            content_hash: builtin_template_content_hash(&builtin),
-        };
-
-        assert!(builtin_template_is_managed(&template_dir, &state).unwrap());
-    }
-
-    #[tokio::test]
-    async fn github_solve_template_materializes_builtin_skills() {
-        let _lock = crate::test_env::lock_env();
-        let home = tempdir().unwrap();
-        let _guard = EnvGuard::set("HOME", home.path().display().to_string());
-        seed_builtin_templates().unwrap();
-
-        let agent_home = home.path().join("agent");
-        initialize_agent_home_from_template(&agent_home, "holon-github-solve")
-            .await
-            .unwrap();
-
-        let agents_md = fs::read_to_string(agent_home.join("AGENTS.md")).unwrap();
-        assert!(agents_md.contains("Holon GitHub Solve Agent"));
-        assert!(agent_home
-            .join("skills/github-issue-solve/SKILL.md")
-            .is_file());
-        assert!(agent_home
-            .join("skills/github-issue-solve/references/issue-solve-workflow.md")
-            .is_file());
-        assert!(agent_home.join("skills/github-pr-fix/SKILL.md").is_file());
-        assert!(agent_home
-            .join("skills/github-pr-fix/references/diagnostics.md")
-            .is_file());
-        assert!(agent_home
-            .join("skills/github-pr-fix/references/pr-fix-workflow.md")
-            .is_file());
-        assert!(agent_home.join("skills/github-review/SKILL.md").is_file());
-        assert!(agent_home.join("skills/ghx/SKILL.md").is_file());
     }
 
     #[tokio::test]
@@ -3062,7 +3083,7 @@ mod tests {
         fs::write(agent_home.join(".holon/state/agent.json"), "{}").unwrap();
 
         let record =
-            ensure_agent_home_agents_md_from_template(&agent_home, DEFAULT_AGENT_TEMPLATE_ID)
+            ensure_agent_home_agents_md_without_template_with_home(&agent_home, home.path())
                 .await
                 .unwrap()
                 .expect("missing AGENTS.md should be materialized");
@@ -3379,12 +3400,13 @@ package = "owner/repo@../bad"
 
     #[test]
     fn resolve_agent_template_detail_builtin() {
-        let catalog = discover_agent_templates_catalog(None, std::path::Path::new("/nonexistent"));
-        let entry = catalog
-            .iter()
-            .find(|e| e.catalog_id == "builtin:holon-default")
-            .unwrap();
-        let detail = resolve_agent_template_detail(entry).unwrap();
+        let entry = builtin_template_catalog_entry(
+            BUILTIN_TEMPLATES
+                .iter()
+                .find(|template| template.template_id == DEFAULT_AGENT_TEMPLATE_ID)
+                .unwrap(),
+        );
+        let detail = resolve_agent_template_detail(&entry).unwrap();
         assert_eq!(detail.template_id, "holon-default");
         assert_eq!(detail.source, AgentTemplateSourceKind::Builtin);
         assert!(!detail.agents_md.is_empty());
@@ -3467,27 +3489,6 @@ package = "owner/repo@../bad"
         assert!(parse_github_repo_url("https://github.com/owner/repo#section").is_err());
     }
 
-    #[test]
-    fn holon_index_manifest_parses_collections() {
-        let toml_str = r#"schema = "holon.repository.v1"
-[collections]
-skills = "my-skills"
-agent_templates = "my-templates"
-"#;
-        let index: HolonIndexManifest = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            index.collections.agent_templates.as_deref(),
-            Some("my-templates")
-        );
-    }
-
-    #[test]
-    fn holon_index_manifest_missing_collections_defaults() {
-        let toml_str = r#"schema = "holon.repository.v1""#;
-        let index: HolonIndexManifest = toml::from_str(toml_str).unwrap();
-        assert!(index.collections.agent_templates.is_none());
-    }
-
     /// Build a mock GitHub API server that serves configured responses.
     struct MockGithubServer {
         addr: std::net::SocketAddr,
@@ -3554,23 +3555,11 @@ agent_templates = "my-templates"
     }
 
     #[tokio::test]
-    async fn discover_github_repo_templates_with_index() {
+    async fn discover_github_repo_templates_uses_default_agent_templates_dir() {
         let _lock = crate::test_env::lock_env();
         let server = MockGithubServer::start(vec![
-            // holon-index.toml at repo root
             (
-                "/repos/owner/repo/contents/holon-index.toml",
-                200,
-                github_file_response(
-                    r#"schema = "holon.repository.v1"
-[collections]
-agent_templates = "custom-templates"
-"#,
-                ),
-            ),
-            // Directory listing of custom-templates/
-            (
-                "/repos/owner/repo/contents/custom-templates",
+                "/repos/owner/repo/contents/agent_templates",
                 200,
                 github_dir_response(&[
                     ("worker", "dir"),
@@ -3578,9 +3567,8 @@ agent_templates = "custom-templates"
                     ("README.md", "file"),
                 ]),
             ),
-            // worker/template.toml
             (
-                "/repos/owner/repo/contents/custom-templates/worker/template.toml",
+                "/repos/owner/repo/contents/agent_templates/worker/template.toml",
                 200,
                 github_file_response(
                     r#"schema = "holon.agent_template.v1"
@@ -3590,9 +3578,8 @@ summary = "Implementation agent"
 "#,
                 ),
             ),
-            // reviewer/template.toml
             (
-                "/repos/owner/repo/contents/custom-templates/reviewer/template.toml",
+                "/repos/owner/repo/contents/agent_templates/reviewer/template.toml",
                 200,
                 github_file_response(
                     r#"schema = "holon.agent_template.v1"
@@ -3627,12 +3614,6 @@ name = "Reviewer"
     async fn discover_github_repo_templates_fallback_default_dir() {
         let _lock = crate::test_env::lock_env();
         let server = MockGithubServer::start(vec![
-            // No holon-index.toml → 404
-            (
-                "/repos/owner/repo/contents/holon-index.toml",
-                404,
-                "{\"message\":\"not found\"}".to_string(),
-            ),
             // Default agent_templates/ directory listing
             (
                 "/repos/owner/repo/contents/agent_templates",
@@ -3667,12 +3648,6 @@ name = "Simple"
     async fn discover_github_repo_templates_skips_invalid_template() {
         let _lock = crate::test_env::lock_env();
         let server = MockGithubServer::start(vec![
-            // No holon-index.toml
-            (
-                "/repos/owner/repo/contents/holon-index.toml",
-                404,
-                "{\"message\":\"not found\"}".to_string(),
-            ),
             // Directory with two templates
             (
                 "/repos/owner/repo/contents/agent_templates",
@@ -3714,12 +3689,6 @@ name = "Good"
     async fn discover_github_repo_templates_empty_when_no_dir() {
         let _lock = crate::test_env::lock_env();
         let server = MockGithubServer::start(vec![
-            // No holon-index.toml
-            (
-                "/repos/owner/repo/contents/holon-index.toml",
-                404,
-                "{\"message\":\"not found\"}".to_string(),
-            ),
             // No agent_templates/ directory either
             (
                 "/repos/owner/repo/contents/agent_templates",
@@ -3743,11 +3712,6 @@ name = "Good"
         let _lock = crate::test_env::lock_env();
         let rt = tokio::runtime::Runtime::new().unwrap();
         let server = MockGithubServer::start(vec![
-            (
-                "/repos/owner/repo/contents/holon-index.toml",
-                404,
-                "{\"message\":\"not found\"}".to_string(),
-            ),
             (
                 "/repos/owner/repo/contents/agent_templates",
                 200,
@@ -3805,12 +3769,6 @@ name = "Worker"
                 "/repos/owner/repo",
                 200,
                 serde_json::json!({"default_branch": "main"}).to_string(),
-            ),
-            // No holon-index.toml
-            (
-                "/repos/owner/repo/contents/holon-index.toml",
-                404,
-                "{\"message\":\"not found\"}".to_string(),
             ),
             // Directory listing
             (
@@ -3908,6 +3866,216 @@ name = "Worker"
         assert_eq!(detail.skills[0].kind, "github");
         assert_eq!(detail.skills[0].reference, "owner/skills/ghx");
     }
+
+    #[tokio::test]
+    async fn sync_remote_source_installs_templates_into_user_library() {
+        let _lock = crate::test_env::lock_env();
+        let home = tempdir().unwrap();
+        let db = RuntimeDb::open_and_migrate(
+            home.path().join("runtime.sqlite"),
+            home.path().join("runtime.sqlite.lock"),
+        )
+        .unwrap();
+        let server = MockGithubServer::start(vec![
+            (
+                "/repos/owner/repo/contents/agent_templates",
+                200,
+                github_dir_response(&[("worker", "dir")]),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/template.toml",
+                200,
+                github_file_response(
+                    r#"schema = "holon.agent_template.v1"
+id = "worker"
+name = "Worker"
+summary = "Implementation agent"
+"#,
+                ),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/AGENTS.md",
+                200,
+                github_file_response("# Worker\n\nDoes worker things\n"),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/skills.toml",
+                200,
+                github_file_response(
+                    "[[skills]]\nkind = \"github\"\npackage = \"owner/skills/ghx\"\n",
+                ),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/template.toml",
+                200,
+                github_file_response(
+                    r#"schema = "holon.agent_template.v1"
+id = "worker"
+name = "Worker"
+summary = "Implementation agent"
+"#,
+                ),
+            ),
+        ]);
+        let _api_guard = EnvGuard::set(
+            "HOLON_TEMPLATE_GITHUB_API_BASE",
+            format!("http://{}", server.addr),
+        );
+        let config = AgentTemplateRemoteSourceConfigFile {
+            url: "https://github.com/owner/repo".into(),
+            git_ref: Some("main".into()),
+            enabled: Some(true),
+        };
+
+        let status = sync_agent_template_remote_source(&db, home.path(), "official", &config)
+            .await
+            .unwrap();
+
+        assert_eq!(status.status, AgentTemplateRemoteSourceSyncStatus::Synced);
+        let template_dir = templates_root_for_home(home.path()).join("worker");
+        assert_eq!(
+            fs::read_to_string(template_dir.join(TEMPLATE_AGENTS_FILENAME)).unwrap(),
+            "# Worker\n\nDoes worker things\n"
+        );
+        assert_eq!(
+            fs::read_to_string(template_dir.join(TEMPLATE_SKILLS_FILENAME)).unwrap(),
+            "[[skills]]\nkind = \"github\"\npackage = \"owner/skills/ghx\"\n\n"
+        );
+        let state = read_managed_template_state(&template_dir)
+            .unwrap()
+            .expect("remote sync should write managed metadata");
+        assert_eq!(state.template_id, "worker");
+        assert!(matches!(
+            state.owner,
+            ManagedTemplateOwner::RemoteSource {
+                ref source_id,
+                ref url,
+                ref resolved_ref,
+                ..
+            } if source_id == "official" && url == "https://github.com/owner/repo" && resolved_ref == "main"
+        ));
+
+        let catalog = discover_agent_templates_catalog(Some(home.path()), home.path());
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "user_global:worker"));
+    }
+
+    #[tokio::test]
+    async fn remote_source_needs_sync_when_never_synced_but_not_after_recent_success() {
+        let _lock = crate::test_env::lock_env();
+        let home = tempdir().unwrap();
+        let db = RuntimeDb::open_and_migrate(
+            home.path().join("runtime.sqlite"),
+            home.path().join("runtime.sqlite.lock"),
+        )
+        .unwrap();
+        let source_id = "official";
+        let config = AgentTemplateRemoteSourceConfigFile {
+            url: "https://github.com/owner/repo".into(),
+            git_ref: Some("main".into()),
+            enabled: Some(true),
+        };
+
+        assert!(agent_template_remote_source_needs_sync(
+            &db,
+            source_id,
+            chrono::Duration::hours(24)
+        )
+        .unwrap());
+
+        let status = AgentTemplateRemoteSourceStatus {
+            source_id: source_id.into(),
+            kind: "github".into(),
+            url: config.url.clone(),
+            requested_ref: config.git_ref.clone(),
+            enabled: config.enabled(),
+            status: AgentTemplateRemoteSourceSyncStatus::Synced,
+            last_synced_at: Some(Utc::now()),
+            resolved_ref: Some("main".into()),
+            resolved_revision: Some("abc123".into()),
+            error: None,
+        };
+        upsert_remote_source_sync(&db, &status, &[], &[]).unwrap();
+
+        assert!(!agent_template_remote_source_needs_sync(
+            &db,
+            source_id,
+            chrono::Duration::hours(24)
+        )
+        .unwrap());
+    }
+
+    #[tokio::test]
+    async fn sync_remote_source_refuses_to_overwrite_user_owned_template() {
+        let _lock = crate::test_env::lock_env();
+        let home = tempdir().unwrap();
+        let db = RuntimeDb::open_and_migrate(
+            home.path().join("runtime.sqlite"),
+            home.path().join("runtime.sqlite.lock"),
+        )
+        .unwrap();
+        let existing = templates_root_for_home(home.path()).join("worker");
+        fs::create_dir_all(&existing).unwrap();
+        fs::write(existing.join(TEMPLATE_AGENTS_FILENAME), "user-owned").unwrap();
+        let server = MockGithubServer::start(vec![
+            (
+                "/repos/owner/repo/contents/agent_templates",
+                200,
+                github_dir_response(&[("worker", "dir")]),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/template.toml",
+                200,
+                github_file_response(
+                    r#"schema = "holon.agent_template.v1"
+id = "worker"
+name = "Worker"
+"#,
+                ),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/AGENTS.md",
+                200,
+                github_file_response("remote-owned"),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/skills.toml",
+                404,
+                "{\"message\":\"not found\"}".to_string(),
+            ),
+            (
+                "/repos/owner/repo/contents/agent_templates/worker/template.toml",
+                200,
+                github_file_response(
+                    r#"schema = "holon.agent_template.v1"
+id = "worker"
+name = "Worker"
+"#,
+                ),
+            ),
+        ]);
+        let _api_guard = EnvGuard::set(
+            "HOLON_TEMPLATE_GITHUB_API_BASE",
+            format!("http://{}", server.addr),
+        );
+        let config = AgentTemplateRemoteSourceConfigFile {
+            url: "https://github.com/owner/repo".into(),
+            git_ref: Some("main".into()),
+            enabled: Some(true),
+        };
+
+        let err = sync_agent_template_remote_source(&db, home.path(), "official", &config)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("user-owned template"), "{err:#}");
+        assert_eq!(
+            fs::read_to_string(existing.join(TEMPLATE_AGENTS_FILENAME)).unwrap(),
+            "user-owned"
+        );
+    }
+
     #[tokio::test]
     async fn provenance_records_schema_version_from_template_toml() {
         let _lock = crate::test_env::lock_env();
@@ -3963,7 +4131,7 @@ name = "Versioned"
         seed_builtin_templates().unwrap();
 
         let agent_home = home.path().join("agent-builtin");
-        let provenance = initialize_agent_home_from_template(&agent_home, "holon-default")
+        let provenance = initialize_agent_home_without_template(&agent_home)
             .await
             .unwrap();
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -20,10 +20,9 @@ use tracing::warn;
 use crate::{
     agent_memory::load_agent_memory,
     agent_template::{
-        discover_agent_templates_catalog, ensure_agent_home_agents_md_from_template_with_home,
+        discover_agent_templates_catalog, ensure_agent_home_agents_md_without_template_with_home,
         initialize_agent_home_from_template_with_catalog,
         initialize_agent_home_from_template_with_home, initialize_agent_home_without_template,
-        seed_builtin_templates_for_home, DEFAULT_AGENT_TEMPLATE_ID,
     },
     agents_md::load_agents_md,
     callbacks::hash_callback_token,
@@ -197,7 +196,6 @@ impl RuntimeHost {
         config: AppConfig,
         static_provider: Option<Arc<dyn AgentProvider>>,
     ) -> Result<Self> {
-        seed_builtin_templates_for_home(&config.home_dir)?;
         let runtime_db =
             RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
         let registry = RuntimeRegistry::new(config, runtime_db.clone())?;
@@ -652,7 +650,7 @@ impl RuntimeHost {
                     .await?;
             }
         } else {
-            initialize_agent_home_without_template(&self.agent_data_dir(agent_id))?;
+            initialize_agent_home_without_template(&self.agent_data_dir(agent_id)).await?;
         }
         let record = AgentIdentityRecord::new(
             agent_id,
@@ -1250,12 +1248,8 @@ impl RuntimeHost {
     async fn ensure_default_agent_home_initialized(&self) -> Result<()> {
         let agent_home = self.agent_data_dir(&self.config().default_agent_id);
         let user_home = crate::agent_template::user_home_dir()?;
-        let _ = ensure_agent_home_agents_md_from_template_with_home(
-            &agent_home,
-            &user_home,
-            DEFAULT_AGENT_TEMPLATE_ID,
-        )
-        .await?;
+        let _ =
+            ensure_agent_home_agents_md_without_template_with_home(&agent_home, &user_home).await?;
         Ok(())
     }
 
@@ -1278,7 +1272,7 @@ impl RuntimeHost {
             )
             .await?;
         } else {
-            initialize_agent_home_without_template(&self.agent_data_dir(&child_agent_id))?;
+            initialize_agent_home_without_template(&self.agent_data_dir(&child_agent_id)).await?;
         }
         let record = AgentIdentityRecord::new(
             child_agent_id,
@@ -2557,7 +2551,10 @@ mod tests {
             &std::fs::read(crate::agent_template::template_provenance_path(&agent_home)).unwrap(),
         )
         .unwrap();
-        assert_eq!(provenance.selector, DEFAULT_AGENT_TEMPLATE_ID);
+        assert_eq!(
+            provenance.selector,
+            crate::agent_template::DEFAULT_AGENT_TEMPLATE_ID
+        );
         assert_eq!(
             runtime.agent_summary().await.unwrap().identity.agent_id,
             host.config().default_agent_id

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -273,13 +273,9 @@ pub(super) async fn create_template_remote_source_sync_job(
     let jobs = state.jobs.clone();
     let sync_jobs = state.template_remote_source_sync_jobs.clone();
     let db = state.host.runtime_db().clone();
-    let configured_sources = state
-        .host
-        .config()
-        .stored_config
-        .agent_templates
-        .remote_sources
-        .clone();
+    let configured_sources = crate::agent_template::effective_agent_template_remote_sources(
+        &state.host.config().stored_config.agent_templates,
+    );
     let job_id = id.clone();
     tokio::spawn(async move {
         let selected_sources = configured_sources
@@ -349,6 +345,24 @@ pub(super) async fn create_template_remote_source_sync_job(
         };
         let _permit = permit;
 
+        let user_home = match crate::agent_template::user_home_dir() {
+            Ok(path) => path,
+            Err(error) => {
+                let message = error.to_string();
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.summary = "Remote source sync failed".into();
+                    job.error = Some(message.clone());
+                    for item in &mut job.items {
+                        item.status = JobStatus::Failed;
+                        item.error = Some(message.clone());
+                    }
+                });
+                return;
+            }
+        };
+
         let mut completed = 0usize;
         let mut failed = 0usize;
         let mut source_results = Vec::new();
@@ -360,8 +374,10 @@ pub(super) async fn create_template_remote_source_sync_job(
                     item.error = None;
                 }
             });
-            match crate::agent_template::sync_agent_template_remote_source(&db, &source_id, &config)
-                .await
+            match crate::agent_template::sync_agent_template_remote_source(
+                &db, &user_home, &source_id, &config,
+            )
+            .await
             {
                 Ok(status) => {
                     completed += 1;

--- a/src/http/templates.rs
+++ b/src/http/templates.rs
@@ -21,9 +21,12 @@ pub async fn templates_catalog(
         user_home.as_deref(),
         FsPath::new("/nonexistent-agent-home"),
     );
+    let remote_sources = crate::agent_template::effective_agent_template_remote_sources(
+        &config.stored_config.agent_templates,
+    );
     let remote = crate::agent_template::load_remote_template_catalog_snapshot(
         state.host.runtime_db(),
-        &config.stored_config.agent_templates.remote_sources,
+        &remote_sources,
     )
     .map_err(error_response)?;
     let mut catalog = catalog;
@@ -65,9 +68,12 @@ pub async fn template_detail(
         FsPath::new("/nonexistent-agent-home"),
     );
     let config = state.host.config();
+    let remote_sources = crate::agent_template::effective_agent_template_remote_sources(
+        &config.stored_config.agent_templates,
+    );
     let remote = crate::agent_template::load_remote_template_catalog_snapshot(
         state.host.runtime_db(),
-        &config.stored_config.agent_templates.remote_sources,
+        &remote_sources,
     )
     .map_err(error_response)?;
     let mut catalog = catalog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use holon::{
         AppConfig, ControlAuthMode, CredentialKind, CredentialSource, ProviderAuthConfig,
         ProviderConfigFile, ProviderId, ProviderTransportKind,
     },
+    config::{AgentTemplateRemoteSourceConfigFile, AgentTemplatesConfigFile},
     daemon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
         ensure_serve_preflight, prepare_runtime_before_server, RuntimeServiceHandle,
@@ -47,6 +48,7 @@ use holon::{
     types::{AuditEvent, AuthorityClass, ControlAction, TimerStatus},
 };
 use tokio::net::TcpListener;
+use tracing::warn;
 use tracing_subscriber::EnvFilter;
 
 use holon::cli::{
@@ -823,6 +825,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     let host = RuntimeHost::new(config.clone())?;
     let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
+    spawn_stale_agent_template_remote_source_sync(&config, &host);
     emit_first_run_intro(&config, &runtime).await;
     let runtime_service = RuntimeServiceHandle::new(&config)?;
 
@@ -932,6 +935,91 @@ fn ensure_socket_parent(socket_path: &Path) -> Result<()> {
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
     Ok(())
+}
+
+fn spawn_stale_agent_template_remote_source_sync(config: &AppConfig, host: &RuntimeHost) {
+    let sync_candidates = stale_agent_template_remote_source_sync_candidates(
+        &config.stored_config.agent_templates,
+        host.runtime_db(),
+    );
+    if sync_candidates.is_empty() {
+        return;
+    }
+
+    let db = host.runtime_db().clone();
+    tokio::spawn(async move {
+        let user_home = match holon::agent_template::user_home_dir() {
+            Ok(path) => path,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "failed to resolve user home for agent template remote source startup sync"
+                );
+                return;
+            }
+        };
+        for (source_id, source_config) in sync_candidates {
+            if let Err(error) = holon::agent_template::sync_agent_template_remote_source(
+                &db,
+                &user_home,
+                &source_id,
+                &source_config,
+            )
+            .await
+            {
+                let message = error.to_string();
+                if let Err(record_error) =
+                    holon::agent_template::record_agent_template_remote_source_sync_failure(
+                        &db,
+                        &source_id,
+                        &source_config,
+                        &message,
+                    )
+                {
+                    warn!(
+                        source_id = %source_id,
+                        error = %record_error,
+                        "failed to persist agent template remote source startup sync failure"
+                    );
+                }
+                warn!(
+                    source_id = %source_id,
+                    error = %error,
+                    "agent template remote source startup sync failed"
+                );
+            }
+        }
+    });
+}
+
+fn stale_agent_template_remote_source_sync_candidates(
+    config: &AgentTemplatesConfigFile,
+    db: &RuntimeDb,
+) -> Vec<(String, AgentTemplateRemoteSourceConfigFile)> {
+    holon::agent_template::effective_agent_template_remote_sources(config)
+        .into_iter()
+        .filter_map(|(source_id, source_config)| {
+            if !source_config.enabled() {
+                return None;
+            }
+            match holon::agent_template::agent_template_remote_source_needs_sync(
+                db,
+                &source_id,
+                chrono::Duration::hours(24),
+            ) {
+                Ok(true) => Some((source_id, source_config)),
+                Ok(false) => None,
+                Err(error) => {
+                    warn!(
+                        source_id = %source_id,
+                        error = %error,
+                        "failed to inspect agent template remote source sync state"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
 }
 
 async fn wait_for_shutdown(mut shutdown: tokio::sync::watch::Receiver<bool>) {
@@ -1093,6 +1181,59 @@ mod tests {
             ]
         );
         assert_eq!(serve_launch.control_token_env, None);
+    }
+
+    #[test]
+    fn stale_template_remote_source_startup_sync_candidates_include_official_when_needed() {
+        let home = tempfile::tempdir().unwrap();
+        let db = RuntimeDb::open_and_migrate(
+            home.path().join("runtime.sqlite"),
+            home.path().join("runtime.sqlite.lock"),
+        )
+        .unwrap();
+        let config = AgentTemplatesConfigFile::default();
+
+        let candidates = stale_agent_template_remote_source_sync_candidates(&config, &db);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].0, "official");
+        assert_eq!(candidates[0].1.url, "https://github.com/holon-run/holon");
+    }
+
+    #[test]
+    fn stale_template_remote_source_startup_sync_candidates_skip_recent_and_disabled_sources() {
+        let home = tempfile::tempdir().unwrap();
+        let db = RuntimeDb::open_and_migrate(
+            home.path().join("runtime.sqlite"),
+            home.path().join("runtime.sqlite.lock"),
+        )
+        .unwrap();
+        db.connection()
+            .unwrap()
+            .execute(
+                "INSERT INTO agent_template_remote_source_syncs \
+                 (source_id, kind, url, requested_ref, enabled, status, last_synced_at, resolved_ref, resolved_revision, catalog_json, diagnostics_json, error, created_at, updated_at) \
+                 VALUES (?1, 'github', ?2, 'main', 1, 'synced', ?3, 'main', NULL, '[]', '[]', NULL, ?3, ?3)",
+                (
+                    "official",
+                    "https://github.com/holon-run/holon",
+                    chrono::Utc::now().to_rfc3339(),
+                ),
+            )
+            .unwrap();
+        let mut config = AgentTemplatesConfigFile::default();
+        config.remote_sources.insert(
+            "disabled".into(),
+            AgentTemplateRemoteSourceConfigFile {
+                url: "https://github.com/example/templates".into(),
+                git_ref: Some("main".into()),
+                enabled: Some(false),
+            },
+        );
+
+        let candidates = stale_agent_template_remote_source_sync_candidates(&config, &db);
+
+        assert!(candidates.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- simplify agent template handling around a hidden built-in `holon-default` fallback instead of visible bundled catalog entries
- materialize remote-source sync results into `~/.agents/agent_templates` with managed ownership metadata and conflict protection
- register the official `holon-run/holon` template source by default and add non-blocking stale-source startup sync candidates
- update template docs/RFC guidance for the new hidden-default plus remote-sync model

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib agent_template::tests:: -- --nocapture`
- `cargo test --bin holon stale_template_remote_source_startup_sync_candidates -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
