### PR TITLE
fix: use source solve template in action builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -601,6 +601,14 @@ runs:
         fi
         mkdir -p "$input_dir" "$output_dir" "$state_dir"
 
+        template=""
+        if [ -n "${HOLON_SOURCE_DIR:-}" ]; then
+          source_template="$HOLON_SOURCE_DIR/agent_templates/holon-github-solve"
+          if [ -f "$source_template/AGENTS.md" ]; then
+            template="$source_template"
+          fi
+        fi
+
         args=("$INPUT_REF" --home "$state_dir" --workspace "$workspace" --cwd "$cwd" --input "$input_dir" --output "$output_dir" --max-turns "$INPUT_MAX_TURNS" --json)
         if [ -n "$INPUT_REPO" ]; then
           args+=(--repo "$INPUT_REPO")
@@ -613,6 +621,9 @@ runs:
         fi
         if [ -n "$INPUT_ROLE" ]; then
           args+=(--role "$INPUT_ROLE")
+        fi
+        if [ -n "$template" ]; then
+          args+=(--template "$template")
         fi
         if [ -n "$INPUT_MODEL" ]; then
           args+=(--model "$INPUT_MODEL")


### PR DESCRIPTION
## Summary
- pass the checked-out source `agent_templates/holon-github-solve` directory as `--template` when the composite action builds Holon from source
- keep `--role` as a prompt hint instead of using it for template selection

## Why
PR #2100 moved `holon-github-solve` out of `builtin_templates/`. The source-built Holon action runs in a clean home before remote template sync is available, so `holon solve` could not resolve the default template selector.

## Verification
- parsed `action.yml` as composite action metadata
- `bash -n` for all 10 composite action run blocks
- `cargo test --lib agent_template::tests::checked_in_templates_split_hidden_builtin_from_syncable_official_templates -- --nocapture`