### PR TITLE
feat: improve Agent Templates Web UI

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -97,6 +97,7 @@ export function App() {
   const templateCatalog = useRuntimeStore((state) => state.templateCatalog);
   const templateCatalogLoading = useRuntimeStore((state) => state.templateCatalogLoading);
   const templateCatalogError = useRuntimeStore((state) => state.templateCatalogError);
+ const templateSyncInProgress = useRuntimeStore((state) => state.templateSyncInProgress);
   const templateDetail = useRuntimeStore((state) =>
     selectedTemplateId ? state.templateDetailById[selectedTemplateId] : undefined,
   );
@@ -127,6 +128,8 @@ export function App() {
   const installTemplate = useRuntimeStore((state) => state.installTemplate);
   const removeTemplate = useRuntimeStore((state) => state.removeTemplate);
   const syncTemplateRemoteSources = useRuntimeStore((state) => state.syncTemplateRemoteSources);
+ const dismissTemplateDiagnostics = useRuntimeStore((state) => state.dismissTemplateDiagnostics);
+ const dismissTemplateError = useRuntimeStore((state) => state.dismissTemplateError);
   const createAgentFromTemplate = useRuntimeStore((state) => state.createAgentFromTemplate);
   const refreshAgentSkillCatalog = useRuntimeStore((state) => state.refreshAgentSkillCatalog);
   const enableAgentSkill = useRuntimeStore((state) => state.enableAgentSkill);
@@ -613,6 +616,7 @@ export function App() {
           <TemplatesPage
             catalog={templateCatalog}
             loading={templateCatalogLoading}
+           syncInProgress={templateSyncInProgress}
             error={templateCatalogError}
             onRefresh={refreshTemplateCatalog}
             onSyncSources={syncTemplateRemoteSources}
@@ -621,6 +625,8 @@ export function App() {
             onOpenTemplate={navigateTemplate}
             onAddRemoteSource={addTemplateRemoteSource}
             onRemoveRemoteSource={removeTemplateRemoteSource}
+           onDismissDiagnostics={dismissTemplateDiagnostics}
+           onDismissError={dismissTemplateError}
           />
         ) : null}
         {route === "templateDetail" ? (
@@ -632,6 +638,7 @@ export function App() {
             onBack={() => navigateRoute("templates")}
             onRefresh={() => refreshTemplateDetail(selectedTemplateId)}
             onRemoveTemplate={removeTemplate}
+           onCreateAgent={(template) => { setCreateAgentTemplate(template); setShowCreateAgentModal(true); }}
           />
         ) : null}
         {route === "settings" ? (

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -98,6 +98,7 @@ export function App() {
   const templateCatalogLoading = useRuntimeStore((state) => state.templateCatalogLoading);
   const templateCatalogError = useRuntimeStore((state) => state.templateCatalogError);
  const templateSyncInProgress = useRuntimeStore((state) => state.templateSyncInProgress);
+ const templateSyncMessage = useRuntimeStore((state) => state.templateSyncMessage);
   const templateDetail = useRuntimeStore((state) =>
     selectedTemplateId ? state.templateDetailById[selectedTemplateId] : undefined,
   );
@@ -617,6 +618,7 @@ export function App() {
             catalog={templateCatalog}
             loading={templateCatalogLoading}
            syncInProgress={templateSyncInProgress}
+           syncMessage={templateSyncMessage}
             error={templateCatalogError}
             onRefresh={refreshTemplateCatalog}
             onSyncSources={syncTemplateRemoteSources}

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -65,7 +65,6 @@ export function TemplatesPage({
   const [newSourceRef, setNewSourceRef] = useState("");
   const [sourceFormError, setSourceFormError] = useState<string | undefined>();
   const [sourceFormBusy, setSourceFormBusy] = useState(false);
-  const stats = useMemo(() => templateStats(templates), [templates]);
   const existingSourceIds = useMemo(() => catalog.sources.map((source) => source.sourceId), [catalog.sources]);
   const suggestedSourceId = useMemo(() => uniqueSourceId(deriveSourceId(newSourceUrl), existingSourceIds), [existingSourceIds, newSourceUrl]);
   const visibleTemplates = useMemo(() => {
@@ -152,15 +151,6 @@ export function TemplatesPage({
             {loading ? "Refreshing…" : "Refresh"}
           </Button>
         </div>
-      </section>
-
-      <section className="skills-summary" aria-label="Template library summary">
-        {stats.map((stat) => (
-          <Card className="skills-stat" key={stat.label}>
-            <strong>{stat.value}</strong>
-            <span>{stat.label}</span>
-          </Card>
-        ))}
       </section>
 
       {error ? (
@@ -504,14 +494,6 @@ function TemplateCard({
       </div>
     </li>
   );
-}
-
-function templateStats(templates: AgentTemplateCatalogEntry[]) {
-  return [
-    { label: "templates", value: String(templates.length) },
-    { label: "global", value: String(templates.filter((template) => template.source === "user_global").length) },
-    { label: "remote", value: String(templates.filter((template) => template.source === "remote").length) },
-  ];
 }
 
 function deriveSourceId(url: string): string {

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -16,6 +16,7 @@ interface TemplatesPageProps {
   catalog: AgentTemplateCatalogState;
   loading: boolean;
   syncInProgress: boolean;
+  syncMessage?: string;
   error?: string;
   onRefresh: () => void;
   onSyncSources: () => Promise<boolean>;
@@ -43,6 +44,7 @@ export function TemplatesPage({
   catalog,
   loading,
   syncInProgress,
+ syncMessage,
   error,
   onRefresh,
   onSyncSources,
@@ -166,6 +168,12 @@ export function TemplatesPage({
           <strong>Template operation failed</strong>
           <span>{error}</span>
           <button type="button" className="skills-error-dismiss" aria-label="Dismiss error" onClick={onDismissError}>×</button>
+        </div>
+      ) : null}
+
+      {syncMessage && !syncInProgress ? (
+        <div className="skills-success" role="status">
+          <span>{syncMessage}</span>
         </div>
       ) : null}
 

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -15,6 +15,7 @@ import type {
 interface TemplatesPageProps {
   catalog: AgentTemplateCatalogState;
   loading: boolean;
+  syncInProgress: boolean;
   error?: string;
   onRefresh: () => void;
   onSyncSources: () => Promise<boolean>;
@@ -23,6 +24,8 @@ interface TemplatesPageProps {
   onOpenTemplate: (catalogId: string) => void;
   onAddRemoteSource: (sourceId: string, url: string, gitRef?: string) => Promise<boolean>;
   onRemoveRemoteSource: (sourceId: string) => Promise<boolean>;
+  onDismissDiagnostics: () => void;
+  onDismissError: () => void;
 }
 
 interface TemplateDetailPageProps {
@@ -33,11 +36,13 @@ interface TemplateDetailPageProps {
   onBack: () => void;
   onRefresh: () => void;
   onRemoveTemplate: (templateId: string) => Promise<boolean>;
+  onCreateAgent: (template: string) => void;
 }
 
 export function TemplatesPage({
   catalog,
   loading,
+  syncInProgress,
   error,
   onRefresh,
   onSyncSources,
@@ -46,6 +51,8 @@ export function TemplatesPage({
   onOpenTemplate,
   onAddRemoteSource,
   onRemoveRemoteSource,
+  onDismissDiagnostics,
+  onDismissError,
 }: TemplatesPageProps) {
   const templates = catalog.catalog;
   const [query, setQuery] = useState("");
@@ -136,11 +143,11 @@ export function TemplatesPage({
           </p>
         </div>
         <div className="skills-actions" aria-label="Template library actions">
-          <Button type="button" variant="outline" disabled={loading} onClick={() => void onSyncSources()}>
-            Sync sources
+          <Button type="button" variant="outline" disabled={loading || syncInProgress} onClick={() => void onSyncSources()}>
+            {syncInProgress ? "Syncing…" : "Sync sources"}
           </Button>
-          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
-            {loading ? "Refreshing…" : "Refresh"}
+          <Button type="button" variant="outline" disabled={loading || syncInProgress} onClick={onRefresh}>
+            {syncInProgress ? "Syncing…" : loading ? "Refreshing…" : "Refresh"}
           </Button>
         </div>
       </section>
@@ -158,6 +165,7 @@ export function TemplatesPage({
         <div className="skills-error" role="alert">
           <strong>Template operation failed</strong>
           <span>{error}</span>
+          <button type="button" className="skills-error-dismiss" aria-label="Dismiss error" onClick={onDismissError}>×</button>
         </div>
       ) : null}
 
@@ -170,6 +178,7 @@ export function TemplatesPage({
               {diagnostic.message}
             </span>
           ))}
+          <button type="button" className="skills-error-dismiss" aria-label="Dismiss diagnostics" onClick={onDismissDiagnostics}>×</button>
         </div>
       ) : null}
 
@@ -228,9 +237,9 @@ export function TemplatesPage({
           </div>
 
           {visibleTemplates.length ? (
-            <ul className="skills-list templates-list">
+            <ul className="template-card-grid">
               {visibleTemplates.map((template) => (
-                <TemplateRow
+                <TemplateCard
                   key={template.catalogId}
                   template={template}
                   loading={loading}
@@ -253,13 +262,12 @@ export function TemplatesPage({
         </CardContent>
       </Card>
 
-      <Card className="skills-library-card">
-        <CardHeader className="skills-library-head">
-          <div>
-            <p>Remote sources</p>
-          </div>
+      <details className="template-remote-sources-collapse">
+        <summary className="template-remote-sources-toggle">
+          Remote sources ({catalog.sources.length})
           <StatusBadge className="state-chip" kind="connection" value={catalog.source} />
-        </CardHeader>
+        </summary>
+      <Card className="skills-library-card">
         <CardContent>
           <form className="skills-add-form template-remote-source-form" onSubmit={(event) => void handleAddSource(event)}>
             <label className="skills-add-source">
@@ -330,6 +338,7 @@ export function TemplatesPage({
           )}
         </CardContent>
       </Card>
+      </details>
     </div>
   );
 }
@@ -342,6 +351,7 @@ export function TemplateDetailPage({
   onBack,
   onRefresh,
   onRemoveTemplate,
+  onCreateAgent,
 }: TemplateDetailPageProps) {
   const template = detail?.detail;
   const [viewMode, setViewMode] = useState<"rendered" | "source">("rendered");
@@ -358,6 +368,11 @@ export function TemplateDetailPage({
           <p>{template?.summary || "Read-only template detail from the Holon daemon catalog."}</p>
         </div>
         <div className="skills-actions">
+          {template ? (
+            <Button type="button" variant="accent" onClick={() => onCreateAgent(template.template)}>
+              Create Agent
+            </Button>
+          ) : null}
           <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
             {loading ? "Refreshing…" : "Refresh"}
           </Button>
@@ -469,7 +484,7 @@ export function TemplateDetailPage({
   );
 }
 
-function TemplateRow({
+function TemplateCard({
   template,
   loading,
   onOpen,
@@ -482,21 +497,20 @@ function TemplateRow({
 }) {
   const canRemove = template.source === "user_global";
   return (
-    <li className="skills-row">
-      <button className="skills-row-open" type="button" onClick={() => onOpen(template.catalogId)}>
-        <span className="template-row-title">
+    <li className="template-card">
+      <button className="template-card-open" type="button" onClick={() => onOpen(template.catalogId)}>
+        <span className="template-card-title">
           <strong>{template.name}</strong>
           <StatusBadge className="state-chip" kind="connection" value={template.source} />
         </span>
-        <span className="template-row-description">{template.description || template.template}</span>
-        <span className="template-row-meta">
+        <span className="template-card-description">{template.description || template.template}</span>
+        <span className="template-card-meta">
           <span>{template.catalogId}</span>
           {template.includedSkills.length ? <span>{template.includedSkills.length} skills</span> : null}
           {template.sourceId ? <span>{template.sourceId}</span> : null}
         </span>
       </button>
-      <div className="skills-row-actions">
-
+      <div className="template-card-actions">
         {canRemove ? (
           <Button type="button" size="sm" variant="outline" disabled={loading} onClick={() => void onRemove(template.templateId)}>
             Remove

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -146,8 +146,8 @@ export function TemplatesPage({
           <Button type="button" variant="outline" disabled={loading || syncInProgress} onClick={() => void onSyncSources()}>
             {syncInProgress ? "Syncing…" : "Sync sources"}
           </Button>
-          <Button type="button" variant="outline" disabled={loading || syncInProgress} onClick={onRefresh}>
-            {syncInProgress ? "Syncing…" : loading ? "Refreshing…" : "Refresh"}
+          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
+            {loading ? "Refreshing…" : "Refresh"}
           </Button>
         </div>
       </section>
@@ -262,7 +262,7 @@ export function TemplatesPage({
         </CardContent>
       </Card>
 
-      <details className="template-remote-sources-collapse">
+      <details className="template-remote-sources-collapse" open>
         <summary className="template-remote-sources-toggle">
           Remote sources ({catalog.sources.length})
           <StatusBadge className="state-chip" kind="connection" value={catalog.source} />

--- a/web-gui/app/src/features/templates/TemplatesPage.tsx
+++ b/web-gui/app/src/features/templates/TemplatesPage.tsx
@@ -197,7 +197,6 @@ export function TemplatesPage({
               Showing {visibleTemplates.length} of {templates.length} templates
             </p>
           </div>
-          <StatusBadge className="state-chip" kind="connection" value={catalog.source} />
         </CardHeader>
         <CardContent>
           <div className="template-actions-grid">
@@ -273,7 +272,6 @@ export function TemplatesPage({
       <details className="template-remote-sources-collapse" open>
         <summary className="template-remote-sources-toggle">
           Remote sources ({catalog.sources.length})
-          <StatusBadge className="state-chip" kind="connection" value={catalog.source} />
         </summary>
       <Card className="skills-library-card">
         <CardContent>
@@ -371,9 +369,21 @@ export function TemplateDetailPage({
           <button className="text-button" type="button" onClick={onBack}>
             ← Agent Templates
           </button>
-          <span className="eyebrow">AgentTemplate</span>
+          <span className="eyebrow">{template?.schemaVersion ?? "AgentTemplate"}</span>
           <h1>{template?.name ?? catalogId}</h1>
           <p>{template?.summary || "Read-only template detail from the Holon daemon catalog."}</p>
+          {template ? (
+            <div className="template-detail-meta-bar">
+              <StatusBadge className="state-chip" kind="connection" value={template.source} />
+              <span className="template-detail-meta-id">{template.catalogId}</span>
+              {template.sourceLocation ? (
+                <span className="template-detail-meta-path">{template.sourceLocation}</span>
+              ) : null}
+              {template.skills.length ? (
+                <span className="template-detail-meta-skills">{template.skills.length} skills</span>
+              ) : null}
+            </div>
+          ) : null}
         </div>
         <div className="skills-actions">
           {template ? (
@@ -401,39 +411,6 @@ export function TemplateDetailPage({
 
       {template ? (
         <>
-          <Card className="skills-library-card">
-            <CardHeader className="skills-library-head">
-              <div>
-                <p>{template.template}</p>
-              </div>
-              <StatusBadge className="state-chip" kind="connection" value={template.source} />
-            </CardHeader>
-            <CardContent>
-              <dl className="skills-detail-meta">
-                <div>
-                  <dt>Catalog id</dt>
-                  <dd>{template.catalogId}</dd>
-                </div>
-                <div>
-                  <dt>Template id</dt>
-                  <dd>{template.templateId}</dd>
-                </div>
-                {template.schemaVersion ? (
-                  <div>
-                    <dt>Schema</dt>
-                    <dd>{template.schemaVersion}</dd>
-                  </div>
-                ) : null}
-                {template.sourceLocation ? (
-                  <div>
-                    <dt>Source</dt>
-                    <dd>{template.sourceLocation}</dd>
-                  </div>
-                ) : null}
-              </dl>
-            </CardContent>
-          </Card>
-
           <Card className="skills-library-card">
             <CardHeader className="skills-library-head">
               <div>

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -871,11 +871,16 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
       await postJson<unknown>(fetchImpl, baseUrl, "/control/templates/remove", { template_id: templateId }, requestHeaders);
     },
-    async syncTemplateRemoteSources(): Promise<void> {
+    async syncTemplateRemoteSources(): Promise<string> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
-      await postJson<unknown>(fetchImpl, baseUrl, "/templates/remote-sources/sync", {}, requestHeaders);
+      const response = await postJson<JobResponseDto>(fetchImpl, baseUrl, "/templates/remote-sources/sync", {}, requestHeaders);
+      const jobId = response.job?.id;
+      if (!jobId) {
+        throw new Error("Template sync response did not include a job id.");
+      }
+      return jobId;
     },
     async createAgentFromTemplate(agentId: string, template: string): Promise<void> {
       if (!baseUrl) {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -19,6 +19,7 @@ import {
 import type {
   AddSkillInput,
   AgentDetail,
+  AgentTemplateCatalogDiagnostic,
   AgentSummary,
   AgentTemplateCatalogState,
   AgentTemplateDetailState,
@@ -192,6 +193,7 @@ export interface RuntimeStoreState {
   templateCatalog: AgentTemplateCatalogState;
   templateCatalogLoading: boolean;
   templateCatalogError?: string;
+  dismissedTemplateDiagnostics: string[];
   templateSyncInProgress: boolean;
   templateDetailById: Record<string, AgentTemplateDetailState>;
   templateDetailLoadingById: Record<string, boolean>;
@@ -640,6 +642,26 @@ const emptyTemplateCatalog: AgentTemplateCatalogState = {
   diagnostics: [],
 };
 
+function diagnosticSignature(d: AgentTemplateCatalogDiagnostic): string {
+  return `${d.sourceId ?? "catalog"}:${d.message}`;
+}
+
+/**
+ * Filter out diagnostics the user has previously dismissed so they don't
+ * reappear on refresh when the server still has them stored.
+ */
+function filterDismissedDiagnostics(
+  catalog: AgentTemplateCatalogState,
+  dismissed: string[],
+): AgentTemplateCatalogState {
+  if (!dismissed.length || !catalog.diagnostics.length) return catalog;
+  const dismissedSet = new Set(dismissed);
+  return {
+    ...catalog,
+    diagnostics: catalog.diagnostics.filter((d) => !dismissedSet.has(diagnosticSignature(d))),
+  };
+}
+
 /**
  * Initialize session cache for the current remote and hydrate any cached
  * sessions into the store. Called on initial load and remote switch.
@@ -703,6 +725,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   templateCatalog: emptyTemplateCatalog,
   templateCatalogLoading: false,
   templateCatalogError: undefined,
+  dismissedTemplateDiagnostics: [],
   templateSyncInProgress: false,
   templateDetailById: {},
   templateDetailLoadingById: {},
@@ -907,6 +930,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       templateCatalog: emptyTemplateCatalog,
       templateCatalogLoading: false,
       templateCatalogError: undefined,
+      dismissedTemplateDiagnostics: [],
       templateSyncInProgress: false,
       templateDetailById: {},
       templateDetailLoadingById: {},
@@ -1090,7 +1114,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   refreshTemplateCatalog: async () => {
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
-      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      const templateCatalog = filterDismissedDiagnostics(
+        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+      );
       set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -1132,7 +1158,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
       await runtimeClient.installTemplate(githubUrl);
-      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      const templateCatalog = filterDismissedDiagnostics(
+        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+      );
       set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
       return true;
     } catch (error) {
@@ -1150,7 +1178,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
       await runtimeClient.removeTemplate(templateId);
-      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      const templateCatalog = filterDismissedDiagnostics(
+        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+      );
       set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
       return true;
     } catch (error) {
@@ -1170,7 +1200,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set({ templateSyncInProgress: true });
       const jobId = await runtimeClient.syncTemplateRemoteSources();
       await pollTemplateSyncJob(set, get, jobId);
-      const templateCatalog = await runtimeClient.getTemplateCatalog();
+      const templateCatalog = filterDismissedDiagnostics(
+        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+      );
       set({ templateCatalog, templateCatalogLoading: false, templateSyncInProgress: false, templateCatalogError: templateCatalog.error });
       return true;
     } catch (error) {
@@ -1200,6 +1232,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   dismissTemplateDiagnostics: () => {
     set((state) => ({
+      dismissedTemplateDiagnostics: [
+        ...state.dismissedTemplateDiagnostics,
+        ...state.templateCatalog.diagnostics.map(diagnosticSignature),
+      ],
       templateCatalog: { ...state.templateCatalog, diagnostics: [] },
     }));
   },

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -195,6 +195,7 @@ export interface RuntimeStoreState {
   templateCatalogError?: string;
   dismissedTemplateDiagnostics: string[];
   templateSyncInProgress: boolean;
+  templateSyncMessage?: string;
   templateDetailById: Record<string, AgentTemplateDetailState>;
   templateDetailLoadingById: Record<string, boolean>;
   templateDetailErrorById: Record<string, string | undefined>;
@@ -727,6 +728,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   templateCatalogError: undefined,
   dismissedTemplateDiagnostics: [],
   templateSyncInProgress: false,
+  templateSyncMessage: undefined,
   templateDetailById: {},
   templateDetailLoadingById: {},
   templateDetailErrorById: {},
@@ -932,6 +934,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       templateCatalogError: undefined,
       dismissedTemplateDiagnostics: [],
       templateSyncInProgress: false,
+      templateSyncMessage: undefined,
       templateDetailById: {},
       templateDetailLoadingById: {},
       templateDetailErrorById: {},
@@ -1195,7 +1198,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   syncTemplateRemoteSources: async () => {
-    set({ templateCatalogLoading: true, templateCatalogError: undefined });
+    set({ templateCatalogLoading: true, templateCatalogError: undefined, templateSyncMessage: undefined });
     try {
       set({ templateSyncInProgress: true });
       const jobId = await runtimeClient.syncTemplateRemoteSources();
@@ -1203,7 +1206,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       const templateCatalog = filterDismissedDiagnostics(
         await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
       );
-      set({ templateCatalog, templateCatalogLoading: false, templateSyncInProgress: false, templateCatalogError: templateCatalog.error });
+      const sourceCount = templateCatalog.sources.length;
+      const templateCount = templateCatalog.catalog.length;
+      set({ templateCatalog, templateCatalogLoading: false, templateSyncInProgress: false, templateCatalogError: templateCatalog.error, templateSyncMessage: `Synced ${sourceCount} source(s), ${templateCount} template(s).` });
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -1212,6 +1217,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         templateCatalogLoading: false,
         templateSyncInProgress: false,
         templateCatalogError: message,
+        templateSyncMessage: undefined,
       }));
       return false;
     }

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -192,6 +192,7 @@ export interface RuntimeStoreState {
   templateCatalog: AgentTemplateCatalogState;
   templateCatalogLoading: boolean;
   templateCatalogError?: string;
+  templateSyncInProgress: boolean;
   templateDetailById: Record<string, AgentTemplateDetailState>;
   templateDetailLoadingById: Record<string, boolean>;
   templateDetailErrorById: Record<string, string | undefined>;
@@ -241,6 +242,8 @@ export interface RuntimeStoreState {
   installTemplate: (githubUrl: string) => Promise<boolean>;
   removeTemplate: (templateId: string) => Promise<boolean>;
   syncTemplateRemoteSources: () => Promise<boolean>;
+  dismissTemplateDiagnostics: () => void;
+  dismissTemplateError: () => void;
   createAgentFromTemplate: (agentId: string, template: string) => Promise<boolean>;
   addSkillToCatalog: (input: AddSkillInput) => Promise<boolean>;
   removeSkillFromCatalog: (name: string) => Promise<boolean>;
@@ -700,6 +703,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   templateCatalog: emptyTemplateCatalog,
   templateCatalogLoading: false,
   templateCatalogError: undefined,
+  templateSyncInProgress: false,
   templateDetailById: {},
   templateDetailLoadingById: {},
   templateDetailErrorById: {},
@@ -903,6 +907,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       templateCatalog: emptyTemplateCatalog,
       templateCatalogLoading: false,
       templateCatalogError: undefined,
+      templateSyncInProgress: false,
       templateDetailById: {},
       templateDetailLoadingById: {},
       templateDetailErrorById: {},
@@ -1162,15 +1167,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   syncTemplateRemoteSources: async () => {
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
-      await runtimeClient.syncTemplateRemoteSources();
+      set({ templateSyncInProgress: true });
+      const jobId = await runtimeClient.syncTemplateRemoteSources();
+      await pollTemplateSyncJob(set, get, jobId);
       const templateCatalog = await runtimeClient.getTemplateCatalog();
-      set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
+      set({ templateCatalog, templateCatalogLoading: false, templateSyncInProgress: false, templateCatalogError: templateCatalog.error });
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         templateCatalog: { ...state.templateCatalog, error: message },
         templateCatalogLoading: false,
+        templateSyncInProgress: false,
         templateCatalogError: message,
       }));
       return false;
@@ -1188,6 +1196,19 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set({ templateCatalogError: message });
       return false;
     }
+  },
+
+  dismissTemplateDiagnostics: () => {
+    set((state) => ({
+      templateCatalog: { ...state.templateCatalog, diagnostics: [] },
+    }));
+  },
+
+  dismissTemplateError: () => {
+    set((state) => ({
+      templateCatalog: { ...state.templateCatalog, error: undefined },
+      templateCatalogError: undefined,
+    }));
   },
 
   addSkillToCatalog: async (input) => {
@@ -2464,6 +2485,34 @@ async function pollSkillInstallJob(
   }
   updateSkillInstallJob(set, jobId, "failed", "Timed out waiting for skill install.");
   removeSkillInstallJobAfterDelay(set, get, jobId, 10_000);
+}
+
+const TEMPLATE_SYNC_POLL_INTERVAL_MS = 1_000;
+const TEMPLATE_SYNC_POLL_TIMEOUT_MS = 120_000;
+
+/**
+ * Poll the daemon job created by `POST /templates/remote-sources/sync` until
+ * it completes, fails, or times out. Throws on failure so the caller can
+ * surface the error via `templateCatalogError`.
+ */
+async function pollTemplateSyncJob(
+  _set: StoreSet,
+  _get: () => RuntimeStoreState,
+  jobId: string,
+): Promise<void> {
+  const deadline = Date.now() + TEMPLATE_SYNC_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => globalThis.setTimeout(resolve, TEMPLATE_SYNC_POLL_INTERVAL_MS));
+    const job = await runtimeClient.getJob(jobId);
+    if (job.status === "completed") {
+      return;
+    }
+    if (job.status === "failed") {
+      throw new Error(job.error || job.summary || "Template remote source sync failed.");
+    }
+    // status is "queued" or "running" — continue polling
+  }
+  throw new Error("Timed out waiting for template remote source sync.");
 }
 
 function updateSkillInstallJob(set: StoreSet, jobId: string, status: SkillInstallJob["status"], error?: string): void {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3925,6 +3925,126 @@ code {
   }
 }
 
+/* --- Template card grid --- */
+
+.template-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.template-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.template-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+}
+
+.template-card-open {
+  display: grid;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.template-card-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.template-card-description {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.template-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.template-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* --- Template remote sources collapsible --- */
+
+.template-remote-sources-collapse {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.template-remote-sources-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  list-style: none;
+}
+
+.template-remote-sources-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.template-remote-sources-collapse[open] .template-remote-sources-toggle {
+  border-bottom: 1px solid var(--line);
+}
+
+/* --- Error dismiss button --- */
+
+.skills-error-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.skills-error-dismiss:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+}
+
 .settings-builtins {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2958,6 +2958,34 @@ code {
   min-width: fit-content;
 }
 
+.skill-detail-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 20px;
+}
+
+.skill-detail-hero > div:first-child {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.skill-detail-hero h1 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: clamp(28px, 4vw, 40px);
+  letter-spacing: -0.04em;
+}
+
+.skill-detail-hero p {
+  max-width: 820px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
 .skills-message {
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--success) 32%, var(--line));
@@ -3895,6 +3923,7 @@ code {
 
 @media (max-width: 920px) {
   .skills-hero,
+  .skill-detail-hero,
   .skills-library-head {
     display: grid;
   }
@@ -4014,26 +4043,39 @@ code {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
-  margin-top: 14px;
-  padding-top: 12px;
+  gap: 8px;
+  min-width: 0;
+  margin-top: 4px;
+  padding-top: 14px;
   border-top: 1px solid var(--line);
   font-size: 12px;
   color: var(--muted);
 }
 
+.template-detail-meta-bar > span {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-width: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  line-height: 1.35;
+}
+
 .template-detail-meta-id {
   font-family: var(--mono);
   color: var(--text);
+  overflow-wrap: anywhere;
 }
 
 .template-detail-meta-path {
   font-family: var(--mono);
   color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 380px;
+  max-width: min(100%, 560px);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .template-detail-meta-skills {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3192,6 +3192,7 @@ code {
 .skills-library-card {
   display: grid;
   gap: 0;
+  padding: 16px 18px;
 }
 
 .skills-library-head {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3178,6 +3178,7 @@ code {
 .skills-error {
   display: grid;
   gap: 4px;
+  position: relative;
   padding: 12px;
   border: 1px solid color-mix(in srgb, var(--danger) 42%, var(--line));
   border-radius: 12px;
@@ -4029,14 +4030,16 @@ code {
 /* --- Error dismiss button --- */
 
 .skills-error-dismiss {
-  flex-shrink: 0;
+  position: absolute;
+  top: 8px;
+  right: 8px;
   background: none;
   border: none;
   color: var(--muted);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
-  padding: 2px 6px;
+  padding: 4px 8px;
   border-radius: 6px;
 }
 

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -4008,6 +4008,38 @@ code {
   gap: 6px;
 }
 
+/* --- Template detail meta bar --- */
+
+.template-detail-meta-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.template-detail-meta-id {
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.template-detail-meta-path {
+  font-family: var(--mono);
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 380px;
+}
+
+.template-detail-meta-skills {
+  font-weight: 600;
+}
+
 /* --- Template remote sources collapsible --- */
 
 .template-remote-sources-collapse {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2986,6 +2986,17 @@ code {
   line-height: 1.55;
 }
 
+.text-button {
+  justify-self: start;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent);
+  font-size: 14px;
+  cursor: pointer;
+  text-align: left;
+}
+
 .skills-message {
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--success) 32%, var(--line));

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3190,6 +3190,16 @@ code {
   color: var(--text);
 }
 
+.skills-success {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--success) 42%, var(--line));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--success) 8%, var(--surface));
+  color: var(--muted);
+}
+
 .skills-library-card {
   display: grid;
   gap: 0;
@@ -4002,9 +4012,7 @@ code {
 
 .template-remote-sources-collapse {
   border: 1px solid var(--line);
-  border-radius: 14px;
-  background: var(--surface);
-  overflow: hidden;
+  border-radius: 12px;
 }
 
 .template-remote-sources-toggle {


### PR DESCRIPTION
## Summary

Optimize the Agent Templates Web UI with card grid layout, sync progress feedback, diagnostics management, and detail page redesign.

## Changes

- **Card grid layout** — Replace flat template list with responsive card grid; each card shows template name, description, source badge, and skills count
- **Sync progress feedback** — client.ts now returns jobId; runtime-store.ts polls getJob until completion; templateCatalogLoading stays true as progress indicator
- **Diagnostics dismiss** — Add dismiss button (top-right close icon); dismissed diagnostics persist in store and won't reappear on page refresh
- **Remote sources collapsible** — Wrap remote sources in collapsible details element; fix overflow:hidden bug that hid remote sources in grid layout
- **Detail page redesign** — Merge metadata into hero compact meta bar; add Create Agent CTA button; fix text crowding and back button alignment
- **Sync/Refresh button separation** — Only Sync sources button shows Syncing state; Refresh button is independent
- **Cleanup** — Remove redundant template count stats row and Live badges

## Verification

- npm run build passes
- Browser-verified across multiple template detail pages
