### PR TITLE
feat: preinstall skills for agent templates

### DIFF
--- a/agent_templates/holon-developer/AGENTS.md
+++ b/agent_templates/holon-developer/AGENTS.md
@@ -5,8 +5,15 @@ You are a long-lived implementation-focused agent.
 ## Responsibilities
 
 - turn accepted requirements into concrete code changes
+- use GitHub issue and PR remediation workflows when the task starts from GitHub
 - run the smallest verification that meaningfully checks the change
 - keep edits narrow, explicit, and easy to review
+
+## Available Skills
+
+- `ghx`: safe GitHub CLI and API command patterns
+- `github-issue-solve`: issue-to-PR implementation workflow
+- `github-pr-fix`: PR feedback and CI remediation workflow
 
 ## Working Style
 

--- a/agent_templates/holon-developer/skills.toml
+++ b/agent_templates/holon-developer/skills.toml
@@ -1,0 +1,12 @@
+[[skills]]
+kind = "builtin"
+name = "ghx"
+
+[[skills]]
+kind = "builtin"
+name = "github-issue-solve"
+
+[[skills]]
+kind = "builtin"
+name = "github-pr-fix"
+

--- a/agent_templates/holon-github-solve/AGENTS.md
+++ b/agent_templates/holon-github-solve/AGENTS.md
@@ -15,6 +15,16 @@ You are a GitHub task agent created by `holon solve`.
 - Assume the caller has already checked out the repository.
 - Do not clone a fresh copy of the repository unless the prompt explicitly asks.
 - Use `GITHUB_TOKEN` or `GH_TOKEN` for GitHub operations.
+
+## Available Skills
+
+- `github-issue-solve`: use for issue implementation and PR publishing
+- `github-pr-fix`: use for existing PR feedback or CI remediation
+- `github-review`: use for review-only tasks
+- `ghx`: use for raw GitHub CLI/API safety and payload handling
+
+## Skill Selection
+
 - For issue implementation, prefer `github-issue-solve`.
 - For pull request remediation, prefer `github-pr-fix`.
 - For review-only tasks, prefer `github-review`.

--- a/agent_templates/holon-github-solve/AGENTS.md
+++ b/agent_templates/holon-github-solve/AGENTS.md
@@ -15,6 +15,7 @@ You are a GitHub task agent created by `holon solve`.
 - Assume the caller has already checked out the repository.
 - Do not clone a fresh copy of the repository unless the prompt explicitly asks.
 - Use `GITHUB_TOKEN` or `GH_TOKEN` for GitHub operations.
+- Do not report success until required publish actions are complete.
 
 ## Available Skills
 
@@ -22,11 +23,3 @@ You are a GitHub task agent created by `holon solve`.
 - `github-pr-fix`: use for existing PR feedback or CI remediation
 - `github-review`: use for review-only tasks
 - `ghx`: use for raw GitHub CLI/API safety and payload handling
-
-## Skill Selection
-
-- For issue implementation, prefer `github-issue-solve`.
-- For pull request remediation, prefer `github-pr-fix`.
-- For review-only tasks, prefer `github-review`.
-- Use `ghx` guidance for raw GitHub CLI and API commands.
-- Do not report success until required publish actions are complete.

--- a/agent_templates/holon-github-solve/skills.toml
+++ b/agent_templates/holon-github-solve/skills.toml
@@ -1,0 +1,16 @@
+[[skills]]
+kind = "builtin"
+name = "ghx"
+
+[[skills]]
+kind = "builtin"
+name = "github-issue-solve"
+
+[[skills]]
+kind = "builtin"
+name = "github-pr-fix"
+
+[[skills]]
+kind = "builtin"
+name = "github-review"
+

--- a/agent_templates/holon-release/AGENTS.md
+++ b/agent_templates/holon-release/AGENTS.md
@@ -5,8 +5,13 @@ You are a long-lived release and delivery agent.
 ## Responsibilities
 
 - prepare release changesets, version bumps, and release notes
+- use safe GitHub CLI/API patterns for release PRs, tags, and published notes
 - verify release prerequisites before publishing
 - keep operator-visible state, tags, and follow-up actions explicit
+
+## Available Skills
+
+- `ghx`: safe GitHub CLI and API command patterns for release operations
 
 ## Working Style
 

--- a/agent_templates/holon-release/skills.toml
+++ b/agent_templates/holon-release/skills.toml
@@ -1,0 +1,4 @@
+[[skills]]
+kind = "builtin"
+name = "ghx"
+

--- a/agent_templates/holon-reviewer/AGENTS.md
+++ b/agent_templates/holon-reviewer/AGENTS.md
@@ -5,8 +5,14 @@ You are a long-lived review-focused agent.
 ## Responsibilities
 
 - inspect pull requests for correctness, regressions, and contract drift
+- use the GitHub review workflow when publishing PR reviews
 - prioritize concrete findings with clear severity and file references
 - keep summaries short after findings are stated
+
+## Available Skills
+
+- `github-review`: structured PR review workflow and publish contract
+- `ghx`: safe GitHub CLI and API command patterns
 
 ## Working Style
 

--- a/agent_templates/holon-reviewer/skills.toml
+++ b/agent_templates/holon-reviewer/skills.toml
@@ -1,0 +1,8 @@
+[[skills]]
+kind = "builtin"
+name = "ghx"
+
+[[skills]]
+kind = "builtin"
+name = "github-review"
+

--- a/docs/rfcs/agent-initialization-and-template.md
+++ b/docs/rfcs/agent-initialization-and-template.md
@@ -336,6 +336,10 @@ It should contain an array of typed skill references:
 
 ```toml
 [[skills]]
+kind = "builtin"
+name = "ghx"
+
+[[skills]]
 kind = "local"
 path = "/absolute/path/to/local-skill"
 
@@ -347,6 +351,10 @@ package = "vercel-labs/agent-skills@react-best-practices"
 The rules are:
 
 - `skills` is an array of typed skill references
+- built-in references use:
+  - `kind = "builtin"`
+  - `name = "ghx"`
+  - the name must match a skill shipped with the runtime
 - local references use:
   - `kind = "local"`
   - `path = "/absolute/path/to/skill"`

--- a/docs/website/guides/agent-templates.md
+++ b/docs/website/guides/agent-templates.md
@@ -122,13 +122,18 @@ kind = "builtin"
 name = "github-pr-fix"
 
 [[skills]]
+kind = "github"
+package = "owner/skills@custom-skill"
+
+[[skills]]
 kind = "local"
 path = "/path/to/custom-skill"
 ```
 
-Two skill reference kinds are supported:
+Three skill reference kinds are supported:
 
 - **`builtin`** — A skill shipped with Holon (e.g. `ghx`, `github-issue-solve`)
+- **`github`** — A skill fetched from a GitHub package reference
 - **`local`** — An absolute path to a skill directory on disk
 
 ## Creating Custom Templates

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -155,10 +155,12 @@ pub struct TemplateProvenanceRecord {
 }
 
 /// File-format skill reference as defined in `skills.toml`.
-/// Only `local` and `github` are valid in the on-disk format.
+/// `builtin` references install skills shipped with Holon without a network
+/// fetch. `local` and `github` references allow custom skill packages.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum TemplateSkillFileRef {
+    Builtin { name: String },
     Local { path: PathBuf },
     Github { package: String },
 }
@@ -171,8 +173,8 @@ struct TemplateSkillsManifest {
 }
 
 /// Internal skill reference used throughout template resolution and materialization.
-/// The `Builtin` variant exists only for compiled-in skills referenced via
-/// `BuiltinTemplate::skill_names`, not in the on-disk `skills.toml` format.
+/// The `Builtin` variant installs compiled-in skills referenced either by
+/// hidden built-in templates or by on-disk `skills.toml` manifests.
 #[derive(Debug, Clone)]
 enum TemplateSkillRef {
     Local { path: PathBuf },
@@ -183,6 +185,7 @@ enum TemplateSkillRef {
 impl From<TemplateSkillFileRef> for TemplateSkillRef {
     fn from(file_ref: TemplateSkillFileRef) -> Self {
         match file_ref {
+            TemplateSkillFileRef::Builtin { name } => TemplateSkillRef::Builtin { name },
             TemplateSkillFileRef::Local { path } => TemplateSkillRef::Local { path },
             TemplateSkillFileRef::Github { package } => TemplateSkillRef::Github { package },
         }
@@ -3701,6 +3704,41 @@ package = "@scope/package"
         assert!(
             matches!(&refs[1], TemplateSkillRef::Github { package } if package == "@scope/package")
         );
+    }
+
+    #[test]
+    fn parse_skill_refs_accepts_builtin_skill_refs() {
+        let home = tempdir().unwrap();
+        let manifest_path = home.path().join(TEMPLATE_SKILLS_FILENAME);
+        fs::write(
+            &manifest_path,
+            r#"[[skills]]
+kind = "builtin"
+name = "ghx"
+"#,
+        )
+        .unwrap();
+
+        let refs = parse_skill_refs(manifest_path).unwrap();
+        assert_eq!(refs.len(), 1);
+        assert!(matches!(&refs[0], TemplateSkillRef::Builtin { name } if name == "ghx"));
+    }
+
+    #[test]
+    fn parse_skill_refs_rejects_unknown_builtin_skill_refs() {
+        let home = tempdir().unwrap();
+        let manifest_path = home.path().join(TEMPLATE_SKILLS_FILENAME);
+        fs::write(
+            &manifest_path,
+            r#"[[skills]]
+kind = "builtin"
+name = "missing-skill"
+"#,
+        )
+        .unwrap();
+
+        let err = parse_skill_refs(manifest_path).unwrap_err();
+        assert!(err.to_string().contains("unknown builtin skill ref"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add built-in skill manifests for the four visible agent templates
- document each template's available workflow skills in its AGENTS.md
- allow on-disk template `skills.toml` manifests to reference shipped skills with `kind = "builtin"`

## Validation

- `cargo fmt --all -- --check`
- `cargo test parse_skill_refs_ -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
