### PR TITLE
refactor: remove user-facing builtin skills

### DIFF
--- a/docs/rfcs/agent-initialization-and-template.md
+++ b/docs/rfcs/agent-initialization-and-template.md
@@ -336,8 +336,10 @@ It should contain an array of typed skill references:
 
 ```toml
 [[skills]]
-kind = "builtin"
-name = "ghx"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/ghx"
+ref = "main"
 
 [[skills]]
 kind = "local"
@@ -345,16 +347,14 @@ path = "/absolute/path/to/local-skill"
 
 [[skills]]
 kind = "github"
-package = "vercel-labs/agent-skills@react-best-practices"
+repo = "owner/repo"
+path = "skills/react-best-practices"
+ref = "v1.0.0"
 ```
 
 The rules are:
 
 - `skills` is an array of typed skill references
-- built-in references use:
-  - `kind = "builtin"`
-  - `name = "ghx"`
-  - the name must match a skill shipped with the runtime
 - local references use:
   - `kind = "local"`
   - `path = "/absolute/path/to/skill"`
@@ -363,11 +363,19 @@ The rules are:
 - a local path points to a skill directory whose entrypoint is `SKILL.md`
 - GitHub references use:
   - `kind = "github"`
-  - `package = "<owner>/<repo>@<skill>"`
-- the GitHub package string should follow the same package-style convention used
-  by `npx skills add`
-- this RFC does not require the manifest to expose lower-level installer fields
-  such as separate repo and path keys
+  - `repo = "<owner>/<repo>"`
+  - `path = "<relative/path/to/skill>"`
+  - optional `ref = "<branch-or-tag-or-commit>"`
+- GitHub `repo` must be in `owner/repo` form
+- GitHub `path` must be a repository-relative directory path and must not
+  contain empty, `.`, or `..` segments
+- GitHub `ref` is optional; when omitted, the installer resolves the default
+  branch according to its remote-source behavior
+- `kind = "builtin"` is not part of the manifest format; official Holon skills
+  are referenced through `repo = "holon-run/holon"` and `path = "skills/<name>"`
+- legacy manifests that use `kind = "github"` with `package = "..."`
+  may be parsed for compatibility, but new manifests and write-back should use
+  the structured `repo`/`path`/`ref` fields
 - invalid, unreadable, or unresolvable entries should cause template
   application to fail rather than silently produce a partially initialized
   agent

--- a/docs/website/guides/agent-templates.md
+++ b/docs/website/guides/agent-templates.md
@@ -114,27 +114,37 @@ An optional manifest that lists skills to pre-install when the agent is created:
 
 ```toml
 [[skills]]
-kind = "builtin"
-name = "github-issue-solve"
-
-[[skills]]
-kind = "builtin"
-name = "github-pr-fix"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-issue-solve"
+ref = "main"
 
 [[skills]]
 kind = "github"
-package = "owner/skills@custom-skill"
+repo = "holon-run/holon"
+path = "skills/github-pr-fix"
+ref = "main"
+
+[[skills]]
+kind = "github"
+repo = "owner/skills"
+path = "skills/custom-skill"
+ref = "v1.2.3"
 
 [[skills]]
 kind = "local"
-path = "/path/to/custom-skill"
+path = "/absolute/path/to/custom-skill"
 ```
 
-Three skill reference kinds are supported:
+Two skill reference kinds are supported:
 
-- **`builtin`** — A skill shipped with Holon (e.g. `ghx`, `github-issue-solve`)
-- **`github`** — A skill fetched from a GitHub package reference
+- **`github`** — A skill fetched from a GitHub repository path. Use
+  `repo = "owner/repo"`, `path = "path/to/skill"`, and optional `ref`.
 - **`local`** — An absolute path to a skill directory on disk
+
+`kind = "builtin"` is no longer part of the template manifest format. Official
+Holon skills are referenced the same way as any other GitHub-hosted skill, for
+example `repo = "holon-run/holon"` and `path = "skills/ghx"`.
 
 ## Creating Custom Templates
 

--- a/docs/website/guides/skills.md
+++ b/docs/website/guides/skills.md
@@ -79,9 +79,6 @@ holon skills add /path/to/skill-dir
 # Add from a remote source
 holon skills add https://github.com/user/repo/tree/main/skills/my-skill --remote
 
-# Add a built-in skill by name
-holon skills add my-skill --builtin
-
 # Copy the skill into the user directory instead of referencing it
 holon skills add /path/to/skill --copy
 ```
@@ -174,7 +171,6 @@ holon skills disable my-skill --agent reviewer
 |--------|------|---------|
 | Local path | (default) | `holon skills add ./skills/my-skill` |
 | Remote URL | `--remote` | `holon skills add https://... --remote` |
-| Built-in | `--builtin` | `holon skills add ghx --builtin` |
 
 ### Command summary
 

--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -145,14 +145,14 @@ Skill management is split into library operations and agent enablement:
 |---|---|---|---|---:|---|
 | `holon skills catalog` | none | none | JSON catalog response | `experimental` | Lists all skills in the local Skill Library. |
 | `holon skills refresh` | none | none | JSON catalog response | `experimental` | Refresh runtime catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates. |
-| `holon skills add` | `<SOURCE>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy` | pretty JSON control-plane response | `experimental` | Adds a skill to the local Skill Library. Local paths resolved relative to cwd when directories. |
+| `holon skills add` | `<SOURCE>` | `--remote`; `--skill <SKILL>`; `--copy` | pretty JSON control-plane response | `experimental` | Adds a skill to the local Skill Library. Local paths resolved relative to cwd when directories. |
 | `holon skills remove` | `<NAME>` | none | pretty JSON control-plane response | `experimental` | Removes a skill from the local Skill Library. |
 | `holon skills check` | `[NAME]` | none | pretty JSON control-plane response | `experimental` | Checks Skill Library consistency against `.skill-lock.json`. |
 | `holon skills reconcile` | `[NAME]` | none | pretty JSON control-plane response | `experimental` | Reconciles library entries with lock file. |
 | `holon skills list` | none | `--agent <AGENT>` | JSON agent skills response | `experimental` | Lists skills enabled/effective for an agent. |
 | `holon skills enable` | `<NAME>` | `--agent <AGENT>`; `--copy` | pretty JSON control-plane response | `experimental` | Enables a locally known skill for an agent. |
 | `holon skills disable` | `<NAME>` | `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Disables a skill for an agent. |
-| `holon skills install` | `<NAME_OR_PATH>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy`; `--agent <AGENT>` | pretty JSON control-plane response | `deprecated` | Compatibility alias. Prefer `skills add` for library or `skills enable` for agents. |
+| `holon skills install` | `<NAME_OR_PATH>` | `--remote`; `--skill <SKILL>`; `--copy`; `--agent <AGENT>` | pretty JSON control-plane response | `deprecated` | Compatibility alias. Prefer `skills add` for library or `skills enable` for agents. |
 | `holon skills uninstall` | `<NAME>` | `--agent <AGENT>` | pretty JSON control-plane response | `deprecated` | Compatibility alias. Prefer `skills remove` for library or `skills disable` for agents. |
 
 ### One-shot and solve workflows

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -13,22 +13,6 @@
               {
                 "properties": {
                   "kind": {
-                    "const": "builtin",
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "kind",
-                  "name"
-                ],
-                "type": "object"
-              },
-              {
-                "properties": {
-                  "kind": {
                     "const": "named",
                     "type": "string"
                   },

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -155,14 +155,28 @@ pub struct TemplateProvenanceRecord {
 }
 
 /// File-format skill reference as defined in `skills.toml`.
-/// `builtin` references install skills shipped with Holon without a network
-/// fetch. `local` and `github` references allow custom skill packages.
+/// Template-authored manifests expose only `local` and `github` skill
+/// references. The legacy `package` field is accepted for old manifests, but
+/// new GitHub references should use structured `repo` + `path` fields.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum TemplateSkillFileRef {
-    Builtin { name: String },
-    Local { path: PathBuf },
-    Github { package: String },
+    Builtin {
+        name: String,
+    },
+    Local {
+        path: PathBuf,
+    },
+    Github {
+        #[serde(default)]
+        repo: Option<String>,
+        #[serde(default)]
+        path: Option<String>,
+        #[serde(default, rename = "ref")]
+        git_ref: Option<String>,
+        #[serde(default)]
+        package: Option<String>,
+    },
 }
 
 /// Parsed `skills.toml` manifest.
@@ -173,21 +187,36 @@ struct TemplateSkillsManifest {
 }
 
 /// Internal skill reference used throughout template resolution and materialization.
-/// The `Builtin` variant installs compiled-in skills referenced either by
-/// hidden built-in templates or by on-disk `skills.toml` manifests.
 #[derive(Debug, Clone)]
 enum TemplateSkillRef {
     Local { path: PathBuf },
-    Github { package: String },
-    Builtin { name: String },
+    Github(TemplateGithubSkillRef),
 }
 
-impl From<TemplateSkillFileRef> for TemplateSkillRef {
-    fn from(file_ref: TemplateSkillFileRef) -> Self {
-        match file_ref {
-            TemplateSkillFileRef::Builtin { name } => TemplateSkillRef::Builtin { name },
-            TemplateSkillFileRef::Local { path } => TemplateSkillRef::Local { path },
-            TemplateSkillFileRef::Github { package } => TemplateSkillRef::Github { package },
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TemplateGithubSkillRef {
+    Structured {
+        repo: String,
+        path: String,
+        git_ref: Option<String>,
+    },
+    LegacyPackage {
+        package: String,
+    },
+}
+
+impl TemplateGithubSkillRef {
+    fn display_reference(&self) -> String {
+        match self {
+            TemplateGithubSkillRef::Structured {
+                repo,
+                path,
+                git_ref,
+            } => match git_ref {
+                Some(git_ref) => format!("{repo}/{path}@{git_ref}"),
+                None => format!("{repo}/{path}"),
+            },
+            TemplateGithubSkillRef::LegacyPackage { package } => package.clone(),
         }
     }
 }
@@ -1302,7 +1331,7 @@ pub(crate) fn resolve_agent_template_detail(
                 .skill_names
                 .iter()
                 .map(|&name| AgentTemplateSkillDependency {
-                    kind: "builtin".to_string(),
+                    kind: "github".to_string(),
                     reference: name.to_string(),
                 })
                 .collect::<Vec<_>>();
@@ -1331,13 +1360,9 @@ pub(crate) fn resolve_agent_template_detail(
                         kind: "local".to_string(),
                         reference: path.display().to_string(),
                     },
-                    TemplateSkillRef::Github { package } => AgentTemplateSkillDependency {
+                    TemplateSkillRef::Github(github_ref) => AgentTemplateSkillDependency {
                         kind: "github".to_string(),
-                        reference: package,
-                    },
-                    TemplateSkillRef::Builtin { name } => AgentTemplateSkillDependency {
-                        kind: "builtin".to_string(),
-                        reference: name,
+                        reference: github_ref.display_reference(),
                     },
                 })
                 .collect::<Vec<_>>();
@@ -1375,13 +1400,9 @@ pub(crate) async fn resolve_remote_agent_template_detail(
                 kind: "local".to_string(),
                 reference: path.display().to_string(),
             },
-            TemplateSkillRef::Github { package } => AgentTemplateSkillDependency {
+            TemplateSkillRef::Github(github_ref) => AgentTemplateSkillDependency {
                 kind: "github".to_string(),
-                reference: package,
-            },
-            TemplateSkillRef::Builtin { name } => AgentTemplateSkillDependency {
-                kind: "builtin".to_string(),
-                reference: name,
+                reference: github_ref.display_reference(),
             },
         })
         .collect::<Vec<_>>();
@@ -1557,13 +1578,20 @@ fn skill_ref_names(skill_refs: Vec<TemplateSkillRef>) -> Vec<String> {
         .into_iter()
         .map(|skill_ref| match skill_ref {
             TemplateSkillRef::Local { path } => path.display().to_string(),
-            TemplateSkillRef::Github { package } => package,
-            TemplateSkillRef::Builtin { name } => name,
+            TemplateSkillRef::Github(github_ref) => github_ref.display_reference(),
         })
         .collect::<Vec<_>>();
     names.sort();
     names.dedup();
     names
+}
+
+fn official_template_skill_ref(name: &str) -> TemplateGithubSkillRef {
+    TemplateGithubSkillRef::Structured {
+        repo: "holon-run/holon".to_string(),
+        path: format!("skills/{name}"),
+        git_ref: Some("main".to_string()),
+    }
 }
 
 pub fn user_home_dir() -> Result<PathBuf> {
@@ -1761,9 +1789,7 @@ fn resolve_builtin_template(template_id: &str, home_dir: &Path) -> Result<Resolv
     let skill_refs: Vec<TemplateSkillRef> = builtin
         .skill_names
         .iter()
-        .map(|&name| TemplateSkillRef::Builtin {
-            name: name.to_string(),
-        })
+        .map(|&name| TemplateSkillRef::Github(official_template_skill_ref(name)))
         .collect();
     Ok(ResolvedTemplate {
         provenance: TemplateProvenanceSource::TemplateId {
@@ -1853,16 +1879,16 @@ fn parse_skill_refs(path: PathBuf) -> Result<Vec<TemplateSkillRef>> {
         fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
     let manifest: TemplateSkillsManifest =
         toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))?;
-    let skill_refs: Vec<TemplateSkillRef> = manifest.skills.into_iter().map(Into::into).collect();
+    let skill_refs: Vec<TemplateSkillRef> = manifest
+        .skills
+        .into_iter()
+        .map(parse_template_skill_file_ref)
+        .collect::<Result<Vec<_>>>()
+        .with_context(|| format!("failed to parse {}", path.display()))?;
     for skill_ref in &skill_refs {
         match skill_ref {
-            TemplateSkillRef::Github { package } => {
-                template_github_skill_install_kind(package)?;
-            }
-            TemplateSkillRef::Builtin { name } => {
-                if builtin_skill(name).is_none() {
-                    bail!("unknown builtin skill ref: {name}");
-                }
+            TemplateSkillRef::Github(github_ref) => {
+                template_github_skill_install_kind(github_ref)?;
             }
             TemplateSkillRef::Local { .. } => {}
         }
@@ -1870,14 +1896,83 @@ fn parse_skill_refs(path: PathBuf) -> Result<Vec<TemplateSkillRef>> {
     Ok(skill_refs)
 }
 
-fn template_github_skill_install_kind(package: &str) -> Result<SkillInstallKind> {
-    validate_template_github_skill_package(package)?;
-    let (remote_package, skill) = split_template_github_skill_package(package)?;
+fn parse_template_skill_file_ref(file_ref: TemplateSkillFileRef) -> Result<TemplateSkillRef> {
+    match file_ref {
+        TemplateSkillFileRef::Builtin { name } => {
+            bail!(
+                "skills.toml no longer supports kind = \"builtin\" for '{name}'; \
+                 use kind = \"github\" with repo = \"holon-run/holon\" and path = \"skills/{name}\""
+            )
+        }
+        TemplateSkillFileRef::Local { path } => Ok(TemplateSkillRef::Local { path }),
+        TemplateSkillFileRef::Github {
+            repo,
+            path,
+            git_ref,
+            package,
+        } => parse_template_github_skill_ref(repo, path, git_ref, package)
+            .map(TemplateSkillRef::Github),
+    }
+}
+
+fn parse_template_github_skill_ref(
+    repo: Option<String>,
+    path: Option<String>,
+    git_ref: Option<String>,
+    package: Option<String>,
+) -> Result<TemplateGithubSkillRef> {
+    if let Some(package) = package {
+        if repo.is_some() || path.is_some() || git_ref.is_some() {
+            bail!("github skill ref must use either legacy package or structured repo/path/ref fields, not both");
+        }
+        validate_template_github_skill_package(&package)?;
+        return Ok(TemplateGithubSkillRef::LegacyPackage { package });
+    }
+
+    let repo = repo.context("github skill ref requires repo")?;
+    let path = path.context("github skill ref requires path")?;
+    validate_template_github_skill_repo(&repo)?;
+    validate_template_github_skill_path(&path)?;
+    if let Some(git_ref) = &git_ref {
+        validate_template_github_skill_ref(git_ref)?;
+    }
+    Ok(TemplateGithubSkillRef::Structured {
+        repo,
+        path,
+        git_ref,
+    })
+}
+
+fn template_github_skill_install_kind(
+    github_ref: &TemplateGithubSkillRef,
+) -> Result<SkillInstallKind> {
+    let (package, skill) = template_github_skill_package(github_ref)?;
     Ok(SkillInstallKind::Remote {
-        package: remote_package.to_string(),
-        skill: skill.map(str::to_string),
+        package,
+        skill,
         mode: SkillInstallMode::Linked,
     })
+}
+
+fn template_github_skill_package(
+    github_ref: &TemplateGithubSkillRef,
+) -> Result<(String, Option<String>)> {
+    let package = match github_ref {
+        TemplateGithubSkillRef::Structured {
+            repo,
+            path,
+            git_ref,
+        } => {
+            let git_ref = git_ref.as_deref().unwrap_or("main");
+            format!("https://github.com/{repo}/tree/{git_ref}/{path}")
+        }
+        TemplateGithubSkillRef::LegacyPackage { package } => {
+            validate_template_github_skill_package(package)?;
+            let (remote_package, skill) = split_template_github_skill_package(package)?;
+            return Ok((remote_package.to_string(), skill.map(str::to_string)));
+        }
+    };
+    Ok((package, None))
 }
 
 fn split_template_github_skill_package(package: &str) -> Result<(&str, Option<&str>)> {
@@ -1910,6 +2005,47 @@ fn validate_template_github_skill_package(package: &str) -> Result<()> {
         .any(|ch| ch.is_control() || ch.is_ascii_whitespace())
     {
         bail!("github skill ref package must not contain whitespace or control characters");
+    }
+    Ok(())
+}
+
+fn validate_template_github_skill_repo(repo: &str) -> Result<()> {
+    validate_template_github_skill_package(repo)?;
+    let mut parts = repo.split('/');
+    let owner = parts.next().unwrap_or_default();
+    let name = parts.next().unwrap_or_default();
+    if owner.is_empty() || name.is_empty() || parts.next().is_some() {
+        bail!("github skill ref repo must be in owner/repo form");
+    }
+    Ok(())
+}
+
+fn validate_template_github_skill_path(path: &str) -> Result<()> {
+    validate_template_github_skill_package(path)?;
+    if path.starts_with('/') || path.starts_with('-') {
+        bail!("github skill ref path must be a relative repository path");
+    }
+    if path
+        .split('/')
+        .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        bail!("github skill ref path must not contain empty, '.' or '..' segments");
+    }
+    Ok(())
+}
+
+fn validate_template_github_skill_ref(git_ref: &str) -> Result<()> {
+    if git_ref.trim().is_empty() {
+        bail!("github skill ref ref must not be empty");
+    }
+    if git_ref.trim() != git_ref {
+        bail!("github skill ref ref must not contain leading or trailing whitespace");
+    }
+    if git_ref
+        .chars()
+        .any(|ch| ch.is_control() || ch.is_ascii_whitespace())
+    {
+        bail!("github skill ref ref must not contain whitespace or control characters");
     }
     Ok(())
 }
@@ -1967,13 +2103,9 @@ fn resolved_template_content_hash(resolved: &ResolvedTemplate) -> String {
                 hasher.update(b"local:");
                 hasher.update(path.display().to_string().as_bytes());
             }
-            TemplateSkillRef::Github { package } => {
+            TemplateSkillRef::Github(github_ref) => {
                 hasher.update(b"github:");
-                hasher.update(package.as_bytes());
-            }
-            TemplateSkillRef::Builtin { name } => {
-                hasher.update(b"builtin:");
-                hasher.update(name.as_bytes());
+                hasher.update(github_ref.display_reference().as_bytes());
             }
         }
     }
@@ -2116,16 +2248,30 @@ fn write_template_skills_file(template_dir: &Path, skill_refs: &[TemplateSkillRe
                 content.push_str(&toml_escape(&path.display().to_string()));
                 content.push_str("\"\n\n");
             }
-            TemplateSkillRef::Github { package } => {
-                content.push_str("[[skills]]\nkind = \"github\"\npackage = \"");
-                content.push_str(&toml_escape(package));
-                content.push_str("\"\n\n");
-            }
-            TemplateSkillRef::Builtin { name } => {
-                content.push_str("[[skills]]\nkind = \"builtin\"\nname = \"");
-                content.push_str(&toml_escape(name));
-                content.push_str("\"\n\n");
-            }
+            TemplateSkillRef::Github(github_ref) => match github_ref {
+                TemplateGithubSkillRef::Structured {
+                    repo,
+                    path,
+                    git_ref,
+                } => {
+                    content.push_str("[[skills]]\nkind = \"github\"\nrepo = \"");
+                    content.push_str(&toml_escape(repo));
+                    content.push_str("\"\npath = \"");
+                    content.push_str(&toml_escape(path));
+                    content.push('"');
+                    if let Some(git_ref) = git_ref {
+                        content.push_str("\nref = \"");
+                        content.push_str(&toml_escape(git_ref));
+                        content.push('"');
+                    }
+                    content.push_str("\n\n");
+                }
+                TemplateGithubSkillRef::LegacyPackage { package } => {
+                    content.push_str("[[skills]]\nkind = \"github\"\npackage = \"");
+                    content.push_str(&toml_escape(package));
+                    content.push_str("\"\n\n");
+                }
+            },
         }
     }
     write_file_atomically(
@@ -2218,7 +2364,14 @@ async fn resolve_github_template_with_client(
                     toml::from_str(&content).with_context(|| {
                         format!("failed to parse {template}::{TEMPLATE_SKILLS_FILENAME}")
                     })?;
-                manifest.skills.into_iter().map(Into::into).collect()
+                manifest
+                    .skills
+                    .into_iter()
+                    .map(parse_template_skill_file_ref)
+                    .collect::<Result<Vec<_>>>()
+                    .with_context(|| {
+                        format!("failed to parse {template}::{TEMPLATE_SKILLS_FILENAME}")
+                    })?
             }
             None => Vec::new(),
         };
@@ -2720,13 +2873,17 @@ async fn materialize_skill_ref(
 ) -> Result<PathBuf> {
     match skill_ref {
         TemplateSkillRef::Local { path } => materialize_local_skill_ref(skills_root, path),
-        TemplateSkillRef::Builtin { name } => materialize_builtin_skill_ref(skills_root, name),
-        TemplateSkillRef::Github { package } => materialize_github_skill_ref(agent_home, package),
+        TemplateSkillRef::Github(github_ref) => {
+            materialize_github_skill_ref(agent_home, github_ref)
+        }
     }
 }
 
-fn materialize_github_skill_ref(agent_home: &Path, package: &str) -> Result<PathBuf> {
-    let install_kind = template_github_skill_install_kind(package)?;
+fn materialize_github_skill_ref(
+    agent_home: &Path,
+    github_ref: &TemplateGithubSkillRef,
+) -> Result<PathBuf> {
+    let install_kind = template_github_skill_install_kind(github_ref)?;
     let user_home = user_home_dir()?;
     let skill_name = crate::skills::install_skill_with_user_home(
         agent_home,
@@ -3680,7 +3837,47 @@ path = "relative/path"
     }
 
     #[test]
-    fn parse_skill_refs_accepts_github_skill_refs() {
+    fn parse_skill_refs_accepts_structured_github_skill_refs() {
+        let home = tempdir().unwrap();
+        let manifest_path = home.path().join(TEMPLATE_SKILLS_FILENAME);
+        fs::write(
+            &manifest_path,
+            r#"[[skills]]
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/ghx"
+ref = "main"
+
+[[skills]]
+kind = "github"
+repo = "owner/repo"
+path = "nested/skills/demo"
+"#,
+        )
+        .unwrap();
+
+        let refs = parse_skill_refs(manifest_path).unwrap();
+        assert_eq!(refs.len(), 2);
+        assert!(matches!(
+            &refs[0],
+            TemplateSkillRef::Github(TemplateGithubSkillRef::Structured {
+                repo,
+                path,
+                git_ref: Some(git_ref),
+            }) if repo == "holon-run/holon" && path == "skills/ghx" && git_ref == "main"
+        ));
+        assert!(matches!(
+            &refs[1],
+            TemplateSkillRef::Github(TemplateGithubSkillRef::Structured {
+                repo,
+                path,
+                git_ref: None,
+            }) if repo == "owner/repo" && path == "nested/skills/demo"
+        ));
+    }
+
+    #[test]
+    fn parse_skill_refs_accepts_legacy_github_package_refs() {
         let home = tempdir().unwrap();
         let manifest_path = home.path().join(TEMPLATE_SKILLS_FILENAME);
         fs::write(
@@ -3698,16 +3895,20 @@ package = "@scope/package"
 
         let refs = parse_skill_refs(manifest_path).unwrap();
         assert_eq!(refs.len(), 2);
-        assert!(
-            matches!(&refs[0], TemplateSkillRef::Github { package } if package == "owner/repo@skill")
-        );
-        assert!(
-            matches!(&refs[1], TemplateSkillRef::Github { package } if package == "@scope/package")
-        );
+        assert!(matches!(
+            &refs[0],
+            TemplateSkillRef::Github(TemplateGithubSkillRef::LegacyPackage { package })
+                if package == "owner/repo@skill"
+        ));
+        assert!(matches!(
+            &refs[1],
+            TemplateSkillRef::Github(TemplateGithubSkillRef::LegacyPackage { package })
+                if package == "@scope/package"
+        ));
     }
 
     #[test]
-    fn parse_skill_refs_accepts_builtin_skill_refs() {
+    fn parse_skill_refs_rejects_builtin_skill_refs_with_migration_hint() {
         let home = tempdir().unwrap();
         let manifest_path = home.path().join(TEMPLATE_SKILLS_FILENAME);
         fs::write(
@@ -3719,31 +3920,37 @@ name = "ghx"
         )
         .unwrap();
 
-        let refs = parse_skill_refs(manifest_path).unwrap();
-        assert_eq!(refs.len(), 1);
-        assert!(matches!(&refs[0], TemplateSkillRef::Builtin { name } if name == "ghx"));
-    }
-
-    #[test]
-    fn parse_skill_refs_rejects_unknown_builtin_skill_refs() {
-        let home = tempdir().unwrap();
-        let manifest_path = home.path().join(TEMPLATE_SKILLS_FILENAME);
-        fs::write(
-            &manifest_path,
-            r#"[[skills]]
-kind = "builtin"
-name = "missing-skill"
-"#,
-        )
-        .unwrap();
-
         let err = parse_skill_refs(manifest_path).unwrap_err();
-        assert!(err.to_string().contains("unknown builtin skill ref"));
+        let message = format!("{err:?}");
+        assert!(message.contains("no longer supports kind = \"builtin\""));
+        assert!(message.contains("repo = \"holon-run/holon\""));
+        assert!(message.contains("path = \"skills/ghx\""));
     }
 
     #[test]
-    fn template_github_skill_install_kind_splits_skill_selector() {
-        let kind = template_github_skill_install_kind("owner/repo@skill").unwrap();
+    fn template_github_skill_install_kind_uses_structured_tree_url() {
+        let kind = template_github_skill_install_kind(&TemplateGithubSkillRef::Structured {
+            repo: "holon-run/holon".into(),
+            path: "skills/ghx".into(),
+            git_ref: Some("main".into()),
+        })
+        .unwrap();
+        assert!(matches!(
+            kind,
+            SkillInstallKind::Remote {
+                package,
+                skill: None,
+                mode: SkillInstallMode::Linked,
+            } if package == "https://github.com/holon-run/holon/tree/main/skills/ghx"
+        ));
+    }
+
+    #[test]
+    fn template_github_skill_install_kind_splits_legacy_skill_selector() {
+        let kind = template_github_skill_install_kind(&TemplateGithubSkillRef::LegacyPackage {
+            package: "owner/repo@skill".into(),
+        })
+        .unwrap();
         assert!(matches!(
             kind,
             SkillInstallKind::Remote {
@@ -3753,7 +3960,10 @@ name = "missing-skill"
             } if package == "owner/repo" && skill == "skill"
         ));
 
-        let scoped = template_github_skill_install_kind("@scope/package").unwrap();
+        let scoped = template_github_skill_install_kind(&TemplateGithubSkillRef::LegacyPackage {
+            package: "@scope/package".into(),
+        })
+        .unwrap();
         assert!(matches!(
             scoped,
             SkillInstallKind::Remote {
@@ -4403,7 +4613,7 @@ name = "Worker"
                 "/repos/owner/repo/contents/agent_templates/worker/skills.toml",
                 200,
                 github_file_response(
-                    "[[skills]]\nkind = \"github\"\npackage = \"owner/skills/ghx\"\n",
+                    "[[skills]]\nkind = \"github\"\nrepo = \"holon-run/holon\"\npath = \"skills/ghx\"\nref = \"main\"\n",
                 ),
             ),
             (
@@ -4430,7 +4640,7 @@ name = "Worker"
             name: "Worker".into(),
             schema_version: None,
             description: "Does worker things".into(),
-            included_skills: vec!["owner/skills/ghx".into()],
+            included_skills: vec!["holon-run/holon/skills/ghx@main".into()],
             source_id: Some("community".into()),
             resolved_ref: Some("main".into()),
             resolved_revision: None,
@@ -4449,7 +4659,10 @@ name = "Worker"
         assert!(detail.agents_md.contains("Does worker things"));
         assert_eq!(detail.skills.len(), 1);
         assert_eq!(detail.skills[0].kind, "github");
-        assert_eq!(detail.skills[0].reference, "owner/skills/ghx");
+        assert_eq!(
+            detail.skills[0].reference,
+            "holon-run/holon/skills/ghx@main"
+        );
     }
 
     #[tokio::test]
@@ -4487,7 +4700,7 @@ summary = "Implementation agent"
                 "/repos/owner/repo/contents/agent_templates/worker/skills.toml",
                 200,
                 github_file_response(
-                    "[[skills]]\nkind = \"github\"\npackage = \"owner/skills/ghx\"\n",
+                    "[[skills]]\nkind = \"github\"\nrepo = \"holon-run/holon\"\npath = \"skills/ghx\"\nref = \"main\"\n",
                 ),
             ),
             (
@@ -4525,7 +4738,7 @@ summary = "Implementation agent"
         );
         assert_eq!(
             fs::read_to_string(template_dir.join(TEMPLATE_SKILLS_FILENAME)).unwrap(),
-            "[[skills]]\nkind = \"github\"\npackage = \"owner/skills/ghx\"\n\n"
+            "[[skills]]\nkind = \"github\"\nrepo = \"holon-run/holon\"\npath = \"skills/ghx\"\nref = \"main\"\n\n"
         );
         let state = read_managed_template_state(&template_dir)
             .unwrap()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -624,8 +624,6 @@ pub enum SkillsCommands {
     Add {
         source: String,
         #[arg(long)]
-        builtin: bool,
-        #[arg(long)]
         remote: bool,
         #[arg(long)]
         skill: Option<String>,
@@ -659,8 +657,6 @@ pub enum SkillsCommands {
     #[command(about = "Compatibility alias for enabling or importing a skill for an agent")]
     Install {
         name_or_path: String,
-        #[arg(long)]
-        builtin: bool,
         #[arg(long)]
         remote: bool,
         #[arg(long)]

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -568,7 +568,6 @@ fn fail_codex_device_login_job(jobs: &JobRegistry, job_id: &str, summary: &str, 
 
 fn skill_install_summary(kind: &crate::types::SkillInstallKind) -> String {
     match kind {
-        crate::types::SkillInstallKind::Builtin { name } => format!("Install builtin skill {name}"),
         crate::types::SkillInstallKind::Named { name, .. } => format!("Install named skill {name}"),
         crate::types::SkillInstallKind::Local { path, .. } => {
             format!("Install local skill {}", path.display())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1947,7 +1947,6 @@ mod tests {
             command:
                 SkillsCommands::Install {
                     name_or_path,
-                    builtin,
                     remote,
                     skill,
                     copy,
@@ -1959,7 +1958,6 @@ mod tests {
         };
 
         assert_eq!(name_or_path, "vercel-labs/agent-skills");
-        assert!(!builtin);
         assert!(remote);
         assert_eq!(skill.as_deref(), Some("pr-review"));
         assert!(!copy);
@@ -2988,12 +2986,11 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         }
         SkillsCommands::Add {
             source,
-            builtin,
             remote,
             skill,
             copy,
         } => {
-            let kind = build_skill_add_kind(&source, builtin, remote, skill, copy)?;
+            let kind = build_skill_add_kind(&source, remote, skill, copy)?;
             post_control_json(
                 config,
                 "/skills/catalog/add",
@@ -3066,19 +3063,13 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         }
         SkillsCommands::Install {
             name_or_path,
-            builtin,
             remote,
             skill,
             copy,
             agent,
         } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-            let kind = if builtin {
-                if remote || skill.is_some() {
-                    anyhow::bail!("--builtin cannot be combined with --remote or --skill");
-                }
-                holon::types::SkillInstallKind::Builtin { name: name_or_path }
-            } else if remote {
+            let kind = if remote {
                 let mode = if copy {
                     holon::types::SkillInstallMode::Copied
                 } else {
@@ -3116,19 +3107,11 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
 
 fn build_skill_add_kind(
     source: &str,
-    builtin: bool,
     remote: bool,
     skill: Option<String>,
     copy: bool,
 ) -> Result<holon::types::SkillInstallKind> {
-    if builtin {
-        if remote || skill.is_some() {
-            anyhow::bail!("--builtin cannot be combined with --remote or --skill");
-        }
-        Ok(holon::types::SkillInstallKind::Builtin {
-            name: source.to_string(),
-        })
-    } else if remote {
+    if remote {
         let mode = if copy {
             holon::types::SkillInstallMode::Copied
         } else {

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -1301,26 +1301,10 @@ fn install_skill_with_user_home_and_remote_installer(
     fs::create_dir_all(&skills_root)
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
     let name = match kind {
-        crate::types::SkillInstallKind::Builtin { name } => {
-            validate_skill_name(name)?;
-            let _ = install_destination(&skills_root, name)?;
-            let destination =
-                crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
-            record_install_metadata(&destination, "builtin")?;
-            name.clone()
-        }
         crate::types::SkillInstallKind::Named { name, mode } => {
             validate_skill_name(name)?;
-            if crate::agent_template::builtin_skill_names().contains(&name.as_str()) {
-                let _ = install_destination(&skills_root, name)?;
-                let destination =
-                    crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
-                record_install_metadata(&destination, "builtin")?;
-                name.clone()
-            } else {
-                let path = resolve_user_skill_by_name(user_home, name)?;
-                materialize_local_skill(&skills_root, &path, mode)?
-            }
+            let path = resolve_user_skill_by_name(user_home, name)?;
+            materialize_local_skill(&skills_root, &path, mode)?
         }
         crate::types::SkillInstallKind::Local { path, mode } => {
             materialize_local_skill(&skills_root, path, mode)?
@@ -1365,26 +1349,10 @@ fn add_library_skill_with_remote_installer(
     fs::create_dir_all(&skills_root)
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
     let name = match kind {
-        crate::types::SkillInstallKind::Builtin { name } => {
-            validate_skill_name(name)?;
-            let _ = install_destination(&skills_root, name)?;
-            let destination =
-                crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
-            record_install_metadata(&destination, "builtin")?;
-            name.clone()
-        }
         crate::types::SkillInstallKind::Named { name, mode } => {
-            if crate::agent_template::builtin_skill_names().contains(&name.as_str()) {
-                validate_skill_name(name)?;
-                let _ = install_destination(&skills_root, name)?;
-                let destination =
-                    crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
-                record_install_metadata(&destination, "builtin")?;
-                name.clone()
-            } else {
-                let path = resolve_user_skill_by_name(Some(user_home), name)?;
-                materialize_local_skill(&skills_root, &path, mode)?
-            }
+            validate_skill_name(name)?;
+            let path = resolve_user_skill_by_name(Some(user_home), name)?;
+            materialize_local_skill(&skills_root, &path, mode)?
         }
         crate::types::SkillInstallKind::Local { path, mode } => {
             materialize_local_skill(&skills_root, path, mode)?
@@ -1539,7 +1507,7 @@ fn resolve_user_skill_by_name(user_home: Option<&Path>, name: &str) -> Result<Pa
         }
     }
     bail!(
-        "skill '{}' is not a builtin skill and was not found in the user-global skill catalog; use an explicit path",
+        "skill '{}' was not found in the user-global skill catalog; use an explicit path or add it to the skill library first",
         name
     )
 }
@@ -2297,11 +2265,6 @@ fn upsert_skill_lock_entry(
     };
     let source = if metadata.file_type().is_symlink() {
         "linked"
-    } else if read_install_metadata(skill_dir)
-        .as_ref()
-        .is_some_and(|metadata| metadata.install_mode == "builtin")
-    {
-        "builtin"
     } else {
         "local"
     };
@@ -2500,20 +2463,9 @@ fn installed_skill_view(catalog: SkillCatalogEntry) -> Result<InstalledSkillView
             install_metadata
                 .as_ref()
                 .map(|metadata| metadata.install_mode.as_str()),
-            Some("builtin")
-        ) {
-            "builtin".into()
-        } else if matches!(
-            install_metadata
-                .as_ref()
-                .map(|metadata| metadata.install_mode.as_str()),
             Some("copied")
         ) {
             "copied".into()
-        } else if crate::agent_template::builtin_skill_names()
-            .contains(&catalog.skill_id.trim_start_matches("agent:"))
-        {
-            "builtin".into()
         } else {
             "copied".into()
         },
@@ -3009,6 +2961,26 @@ mod tests {
     }
 
     #[test]
+    fn named_install_does_not_fallback_to_builtin_skill() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        let agent_home = dir.path().join("agent");
+
+        let error = install_skill_with_user_home(
+            &agent_home,
+            Some(&user_home),
+            &crate::types::SkillInstallKind::Named {
+                name: "ghx".into(),
+                mode: SkillInstallMode::Linked,
+            },
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:?}").contains("was not found in the user-global skill catalog"));
+        assert!(!agent_home.join("skills/ghx").exists());
+    }
+
+    #[test]
     fn local_install_can_copy_skill_directory() {
         let dir = tempdir().unwrap();
         let source = dir.path().join("source/demo");
@@ -3097,26 +3069,6 @@ mod tests {
     }
 
     #[test]
-    fn list_installed_skills_reports_builtin_mode() {
-        let dir = tempdir().unwrap();
-        let agent_home = dir.path().join("agent");
-        install_skill_with_user_home(
-            &agent_home,
-            None,
-            &crate::types::SkillInstallKind::Builtin { name: "ghx".into() },
-        )
-        .unwrap();
-
-        let installed = list_installed_skills(&agent_home).unwrap();
-
-        assert_eq!(installed.len(), 1);
-        assert_eq!(installed[0].catalog.name, "ghx");
-        assert_eq!(installed[0].install_mode, "builtin");
-        assert!(installed[0].link_target.is_none());
-        assert!(installed[0].warning.is_none());
-    }
-
-    #[test]
     fn list_installed_skills_merges_compatible_agent_roots() {
         let dir = tempdir().unwrap();
         let agent_home = dir.path().join("agent");
@@ -3143,21 +3095,27 @@ mod tests {
     fn install_existing_destination_returns_structured_conflict() {
         let dir = tempdir().unwrap();
         let agent_home = dir.path().join("agent");
-        let destination = agent_home.join("skills/ghx");
+        let source = dir.path().join("source/demo");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join(SKILL_ENTRYPOINT), "# Demo").unwrap();
+        let destination = agent_home.join("skills/demo");
         fs::create_dir_all(&destination).unwrap();
-        fs::write(destination.join(SKILL_ENTRYPOINT), "# Existing ghx").unwrap();
+        fs::write(destination.join(SKILL_ENTRYPOINT), "# Existing demo").unwrap();
 
         let error = install_skill_with_user_home(
             &agent_home,
             None,
-            &crate::types::SkillInstallKind::Builtin { name: "ghx".into() },
+            &crate::types::SkillInstallKind::Local {
+                path: source,
+                mode: SkillInstallMode::Linked,
+            },
         )
         .unwrap_err();
         let conflict = error
             .downcast_ref::<SkillInstallConflict>()
             .expect("existing destination should return a structured conflict");
 
-        assert_eq!(conflict.skill_name, "ghx");
+        assert_eq!(conflict.skill_name, "demo");
         assert_eq!(conflict.destination, destination);
     }
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -253,7 +253,7 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 21] = [
     SlashCommandSpec {
         name: "/skill-add",
         description: "add or import a skill into the Skill Library",
-        usage: "/skill-add <source> [--builtin|--remote] [--skill <name>] [--copy]",
+        usage: "/skill-add <source> [--remote] [--skill <name>] [--copy]",
         arg_hint: SlashArgHint::SkillName,
         category: SlashCommandCategory::Skills,
         arg_rule: SlashArgRule::AtLeastOne,
@@ -420,18 +420,16 @@ fn parse_skill_add_kind(args: &[String]) -> Result<crate::types::SkillInstallKin
         .ok_or_else(|| anyhow!("/skill-add requires a source"))?;
     if source.starts_with("--") {
         return Err(anyhow!(
-            "/skill-add requires the source before flags; usage: /skill-add <source> [--builtin|--remote] [--skill <name>] [--copy]"
+            "/skill-add requires the source before flags; usage: /skill-add <source> [--remote] [--skill <name>] [--copy]"
         ));
     }
 
-    let mut builtin = false;
     let mut remote = false;
     let mut copy = false;
     let mut skill = None;
     let mut index = 1;
     while index < args.len() {
         match args[index].as_str() {
-            "--builtin" => builtin = true,
             "--remote" => remote = true,
             "--copy" => copy = true,
             "--skill" => {
@@ -446,22 +444,11 @@ fn parse_skill_add_kind(args: &[String]) -> Result<crate::types::SkillInstallKin
             }
             other => {
                 return Err(anyhow!(
-                    "unexpected /skill-add argument '{other}'; usage: /skill-add <source> [--builtin|--remote] [--skill <name>] [--copy]"
+                    "unexpected /skill-add argument '{other}'; usage: /skill-add <source> [--remote] [--skill <name>] [--copy]"
                 ));
             }
         }
         index += 1;
-    }
-
-    if builtin {
-        if remote || skill.is_some() {
-            return Err(anyhow!(
-                "--builtin cannot be combined with --remote or --skill"
-            ));
-        }
-        return Ok(crate::types::SkillInstallKind::Builtin {
-            name: source.clone(),
-        });
     }
 
     let mode = if copy {
@@ -2647,7 +2634,7 @@ mod tests {
             "/agent switch <agent-id>|create <name>|start [agent-id]|stop [agent-id]",
             "/skills",
             "/skill-catalog",
-            "/skill-add <source> [--builtin|--remote] [--skill <name>] [--copy]",
+            "/skill-add <source> [--remote] [--skill <name>] [--copy]",
             "/skill-remove <name>",
             "/skill-enable <name> [--copy]",
             "/skill-disable <name>",

--- a/src/types.rs
+++ b/src/types.rs
@@ -1036,9 +1036,6 @@ impl Default for SkillInstallMode {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SkillInstallKind {
-    Builtin {
-        name: String,
-    },
     Named {
         name: String,
         #[serde(default)]

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -49,7 +49,14 @@ fn control_plane_post_commands_pretty_print_json_stdout() {
         ),
         (&["skills", "catalog"], "/api/skills/catalog"),
         (
-            &["skills", "add", "ghx", "--builtin"],
+            &[
+                "skills",
+                "add",
+                "holon-run/holon",
+                "--remote",
+                "--skill",
+                "ghx",
+            ],
             "/api/skills/catalog/add",
         ),
         (&["skills", "remove", "ghx"], "/api/skills/catalog/remove"),

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1071,16 +1071,6 @@
     ],
     "flags": [
       {
-        "long": "builtin",
-        "short": null,
-        "default_value": null,
-        "possible_values": [
-          "true",
-          "false"
-        ],
-        "required": false
-      },
-      {
         "long": "copy",
         "short": null,
         "default_value": null,
@@ -1197,16 +1187,6 @@
         "short": null,
         "default_value": null,
         "possible_values": null,
-        "required": false
-      },
-      {
-        "long": "builtin",
-        "short": null,
-        "default_value": null,
-        "possible_values": [
-          "true",
-          "false"
-        ],
         "required": false
       },
       {

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -804,10 +804,18 @@ pub async fn skill_detail_returns_catalog_skill_markdown() -> Result<()> {
 pub async fn install_skill_existing_destination_returns_conflict() -> Result<()> {
     let (_host, base, server) = spawn_server().await?;
     let client = Client::new();
+    let skill_name = format!("http-install-conflict-{}", std::process::id());
+    let local_skill_root = tempdir()?;
+    let local_skill_path = local_skill_root.path().join(&skill_name);
+    std::fs::create_dir_all(&local_skill_path)?;
+    std::fs::write(
+        local_skill_path.join("SKILL.md"),
+        format!("---\nname: {skill_name}\ndescription: test skill\n---\n# Test skill\n"),
+    )?;
     let payload = serde_json::json!({
         "kind": {
-            "kind": "builtin",
-            "name": "ghx"
+            "kind": "local",
+            "path": local_skill_path
         }
     });
 


### PR DESCRIPTION
## Summary
- remove user-facing builtin skill install/config paths from CLI, TUI, control API, and OpenAPI
- make template `skills.toml` expose only `github` and `local`, with structured `repo`/`path`/optional `ref` GitHub refs
- document the `skills.toml` spec and reject legacy `kind = "builtin"` manifests with a migration hint

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test parse_skill_refs_ -- --nocapture`
- `cargo test template_github_skill_install_kind_ -- --nocapture`
- `cargo test cli_snapshot -- --nocapture`
- `cargo test openapi_snapshot -- --nocapture`
- `cargo test control_plane_post_commands_pretty_print_json_stdout -- --nocapture`
- `cargo test named_install_does_not_fallback_to_builtin_skill -- --nocapture`
- `cargo test install_existing_destination_returns_structured_conflict -- --nocapture`
