### PR TITLE
fix: resolve omitted template skill refs via HEAD

### DIFF
--- a/agent_templates/holon-developer/skills.toml
+++ b/agent_templates/holon-developer/skills.toml
@@ -1,12 +1,15 @@
 [[skills]]
-kind = "builtin"
-name = "ghx"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/ghx"
 
 [[skills]]
-kind = "builtin"
-name = "github-issue-solve"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-issue-solve"
 
 [[skills]]
-kind = "builtin"
-name = "github-pr-fix"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-pr-fix"
 

--- a/agent_templates/holon-github-solve/skills.toml
+++ b/agent_templates/holon-github-solve/skills.toml
@@ -1,16 +1,20 @@
 [[skills]]
-kind = "builtin"
-name = "ghx"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/ghx"
 
 [[skills]]
-kind = "builtin"
-name = "github-issue-solve"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-issue-solve"
 
 [[skills]]
-kind = "builtin"
-name = "github-pr-fix"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-pr-fix"
 
 [[skills]]
-kind = "builtin"
-name = "github-review"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-review"
 

--- a/agent_templates/holon-release/skills.toml
+++ b/agent_templates/holon-release/skills.toml
@@ -1,4 +1,5 @@
 [[skills]]
-kind = "builtin"
-name = "ghx"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/ghx"
 

--- a/agent_templates/holon-reviewer/skills.toml
+++ b/agent_templates/holon-reviewer/skills.toml
@@ -1,8 +1,10 @@
 [[skills]]
-kind = "builtin"
-name = "ghx"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/ghx"
 
 [[skills]]
-kind = "builtin"
-name = "github-review"
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/github-review"
 

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1963,7 +1963,7 @@ fn template_github_skill_package(
             path,
             git_ref,
         } => {
-            let git_ref = git_ref.as_deref().unwrap_or("main");
+            let git_ref = git_ref.as_deref().unwrap_or("HEAD");
             format!("https://github.com/{repo}/tree/{git_ref}/{path}")
         }
         TemplateGithubSkillRef::LegacyPackage { package } => {
@@ -3942,6 +3942,24 @@ name = "ghx"
                 skill: None,
                 mode: SkillInstallMode::Linked,
             } if package == "https://github.com/holon-run/holon/tree/main/skills/ghx"
+        ));
+    }
+
+    #[test]
+    fn template_github_skill_install_kind_uses_head_for_omitted_ref() {
+        let kind = template_github_skill_install_kind(&TemplateGithubSkillRef::Structured {
+            repo: "holon-run/holon".into(),
+            path: "skills/ghx".into(),
+            git_ref: None,
+        })
+        .unwrap();
+        assert!(matches!(
+            kind,
+            SkillInstallKind::Remote {
+                package,
+                skill: None,
+                mode: SkillInstallMode::Linked,
+            } if package == "https://github.com/holon-run/holon/tree/HEAD/skills/ghx"
         ));
     }
 

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -948,10 +948,8 @@ struct GithubTreeResponse {
 }
 
 /// Resolve the effective Git reference for a remote skill source.
-/// If the reference is empty or `"main"` (the pre-fix hardcoded default),
-/// queries the repository's actual default branch via `GET /repos/{o}/{r}`.
-/// Treating `"main"` as a sentinel ensures legacy lock files benefit from the
-/// fix instead of 404-ing on master-default repos.
+/// If the reference is empty or `"HEAD"`, queries the repository's actual
+/// default branch via `GET /repos/{o}/{r}`.
 fn resolve_effective_reference(
     client: &reqwest::blocking::Client,
     owner: &str,
@@ -959,7 +957,7 @@ fn resolve_effective_reference(
     reference: &str,
     package: &str,
 ) -> Result<String> {
-    if !reference.is_empty() && reference != "main" {
+    if !reference.is_empty() && reference != "HEAD" {
         return Ok(reference.to_string());
     }
     resolve_default_branch(client, owner, repo, package)
@@ -3310,6 +3308,26 @@ mod tests {
                 owner: "user".into(),
                 repo: "repo".into(),
                 reference: "main".into(),
+                path: "skills/my-skill".into(),
+                skill_name: "my-skill".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn remote_skill_source_preserves_head_default_ref_sentinel() {
+        let source = RemoteSkillSource::parse(
+            "https://github.com/user/repo/tree/HEAD/skills/my-skill",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            source,
+            RemoteSkillSource {
+                owner: "user".into(),
+                repo: "repo".into(),
+                reference: "HEAD".into(),
                 path: "skills/my-skill".into(),
                 skill_name: "my-skill".into(),
             }


### PR DESCRIPTION
## Summary

- use `HEAD` as the template GitHub skill URL sentinel when `ref` is omitted
- resolve empty/`HEAD` remote skill refs through the repository default branch lookup
- add regression coverage for omitted template refs and `HEAD` tree URLs

## Verification

- `cargo test template_github_skill_install_kind_ -- --nocapture`
- `cargo test remote_skill_source_ -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Follow-up to #2107 review note about omitted refs hardcoding `main`.
