### PR TITLE
fix: make global skill install idempotent for already-installed skills

### DIFF
--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -759,7 +759,18 @@ fn install_github_remote_skill(
     let skills_root = user_library_skills_root(user_home);
     fs::create_dir_all(&skills_root)
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
-    let destination = install_destination(&skills_root, &source.skill_name)?;
+    let destination = match install_destination(&skills_root, &source.skill_name) {
+        Ok(dest) => dest,
+        Err(err) if err.downcast_ref::<SkillInstallConflict>().is_some() => {
+            tracing::info!(
+                skill_name = %source.skill_name,
+                destination = %skills_root.join(&source.skill_name).display(),
+                "skill already installed globally; skipping re-install"
+            );
+            return Ok(());
+        }
+        Err(err) => return Err(err),
+    };
     let tmp = skills_root.join(format!(
         ".tmp-holon-skill-{}-{}",
         std::process::id(),


### PR DESCRIPTION
## Summary

Creating an agent with a template that declares skills already present in the global skills directory (`~/.agents/skills/`) failed with `Failed to create agent` (HTTP 500).

## Root cause

`install_github_remote_skill` treats an existing target directory as `SkillInstallConflict` and errors out. When the same skill (e.g. `ghx`, `github-issue-solve`) is shared by multiple templates and is already installed globally, subsequent agent creation attempts trigger the conflict and abort template initialization.

## Fix

Make global skill install idempotent: if the skill already exists in the global directory, skip download and return success directly. The downstream resolve + link-to-agent logic is unaffected.

## Verification

- `cargo build` passes
- `cargo test` passes