### PR TITLE
docs: update for v0.26.0 — Agent Templates, Bing Search, skill uses, trigger security, CLI refresh

### DIFF
--- a/docs/website/concepts/external-triggers.md
+++ b/docs/website/concepts/external-triggers.md
@@ -92,9 +92,20 @@ is for the agent's own tracking; the runtime does not interpret it.
 
 ## Security model
 
-Callback tokens are capability secrets.  Tokens can be revoked with
-`CancelExternalTrigger`.  Revoking a trigger invalidates its URL immediately;
-future requests to that URL are rejected.
+Callback tokens are capability secrets. The runtime stores only the hashed
+token, not the raw value — once a token is issued, the raw token is returned
+to the agent's execution context and is never persisted to logs or storage.
+Store it securely on the caller side.
+
+Tokens can be revoked with `CancelExternalTrigger`. Revoking a trigger
+invalidates its URL immediately; future requests to that URL are rejected.
+
+### Reset callback token
+
+The `POST /control/agents/:agent_id/external-triggers/:id/reset-callback`
+endpoint rotates the callback token for an existing trigger. The old token
+is invalidated immediately and a new token is returned. Use this when a
+token has been exposed or as a periodic security rotation.
 
 ## Default ingress capability
 
@@ -120,6 +131,13 @@ CancelExternalTrigger { external_trigger_id: "trigger_abc123" }
 
 This invalidates the callback URLs immediately. Any future requests to those
 URLs will be rejected.
+
+### Agent stop auto-revocation
+
+When an agent is stopped (`holon agent stop`), all of its external triggers
+are automatically revoked. This prevents orphaned callback URLs from
+remaining active after the agent is no longer running. If you restart the
+agent later, new triggers with fresh tokens are provisioned.
 
 ## Integration patterns
 

--- a/docs/website/guides/skills.md
+++ b/docs/website/guides/skills.md
@@ -99,6 +99,10 @@ holon skills check
 holon skills check my-skill
 ```
 
+> **Note:** Installing an already-installed global skill is idempotent —
+> `holon skills add` skips the install and reports the existing entry without
+> error. This is safe to repeat in scripts and automation.
+
 #### Reconcile library with lock file
 
 ```bash
@@ -165,6 +169,22 @@ holon skills disable my-skill --agent reviewer
 > add/enable and remove/disable model. Prefer the new commands for
 > clarity.
 
+### Skill `uses` shorthand
+
+When adding a GitHub-hosted skill, you can use the `uses` shorthand syntax
+instead of the repository URL:
+
+```bash
+# Full URL form
+holon skills add https://github.com/holon-run/holon/tree/main/skills/ghx --remote
+
+# uses shorthand — same result
+holon skills add holon-run/holon/skills/ghx@main
+```
+
+The `uses` form (`owner/repo/path@ref`) is normalized to the full GitHub URL
+internally. It also accepts `owner/repo/path#ref` as a compatible input.
+
 ### Skill source types
 
 | Source | Flag | Example |
@@ -186,6 +206,10 @@ holon skills disable my-skill --agent reviewer
 | Agent | `holon skills list [--agent]` | List enabled skills |
 | Agent | `holon skills enable <name>` | Enable for an agent |
 | Agent | `holon skills disable <name>` | Disable for an agent |
+
+> **Note:** The `--builtin` flag and `kind = "builtin"` in template manifests
+> have been removed in v0.26.0. Official Holon skills are referenced the same
+> way as any other GitHub-hosted skill.
 
 ## Managing skills via HTTP
 

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -67,6 +67,25 @@ Results include:
 - **Agent filtering** — Scope results to one or more agent IDs.
 - **Full-text search** — Query the runtime memory index across agents.
 
+### Agent Templates
+
+Browse, install, and create agents from templates directly in the Web GUI.
+Available at `/app/templates`:
+
+- **Template catalog** — Browse installed templates with display name,
+  description, and source information (local, remote URL, or synced source).
+- **Create Agent** — Click a template to open the Create Agent dialog
+  pre-filled with the template selector. The agent is initialized with the
+  template's role contract and pre-installed skills.
+- **Remote sources** — View and manage configured remote template sources
+  (GitHub repositories). The daemon syncs templates from these sources at
+  startup.
+- **Template detail** — Click a template to view its full metadata including
+  the template manifest, pre-installed skills, and source provenance.
+
+For CLI-based template management, see
+[Agent Templates Guide](/guides/agent-templates.md).
+
 ### Skill Management
 
 Manage the Skill Library and agent skills from the browser:
@@ -74,7 +93,7 @@ Manage the Skill Library and agent skills from the browser:
 - **Library catalog** — Browse all skills registered in the local Skill
   Library with name, description, and source information.
 - **Add skill** — Import a skill from a local path, remote URL, or
-  built-in catalog.
+  GitHub `uses` shorthand.
 - **Remove skill** — Remove a skill from the library.
 - **Enable/disable** — Enable or disable individual skills per agent
   with a toggle. View which skills are active for each agent.
@@ -112,6 +131,24 @@ The file browser uses the workspace file browsing API
 (`GET /api/workspaces/{id}/files` and `GET /api/workspaces/{id}/files/{path}`).
 Path traversal and symlink escapes are blocked; file reads are capped
 at 1 MB.
+
+### Navigation improvements
+
+The Web GUI includes several navigation and usability enhancements:
+
+- **Navigation stack** — Pages maintain a history stack so the Back button
+  returns to the previous view with its scroll position and state preserved,
+  rather than resetting to the Dashboard.
+- **File-level refresh** — The file browser supports per-file refresh
+  without reloading the entire page. A refresh button in the file toolbar
+  re-fetches the selected file's content.
+- **Toolbar** — File viewer pages include a toolbar with actions including
+  refresh and markdown source/rendered toggle.
+- **Auto-scroll** — The file viewer auto-scrolls to the bottom when new
+  content arrives (e.g., streaming log output).
+- **Markdown rendered view** — When viewing a `.md` file, a toggle switches
+  between rendered HTML and raw markdown source. The rendered view supports
+  syntax-highlighted code blocks, tables, and links.
 
 ### Settings
 

--- a/docs/website/guides/webfetch-websearch.md
+++ b/docs/website/guides/webfetch-websearch.md
@@ -77,6 +77,9 @@ Holon uses a provider-based search model:
 - **DuckDuckGo (managed)** — Holon's built-in managed search provider. No
   API key required. Enabled during onboarding with "Managed DuckDuckGo" or
   "Auto" mode.
+- **Bing** — Microsoft Bing Web Search API. Requires an API key set via
+  credential profile. Configure with
+  `holon config providers set bing --kind bing --credential-profile <profile>`.
 - **Model-native search** — Some model providers (OpenAI, Anthropic) support
   native web search through their own APIs. In "Auto" mode, Holon prefers
   these when available.

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-summary: Holon's current command-line interface — verified against holon --help (v0.16.0).
+summary: Holon's command-line interface — verified against holon --help (v0.26.0).
 order: 10
 ---
 <!-- maintenance: regenerate from `holon --help` output when commands change -->
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.16.0)
+holon (v0.26.0)
 ├── serve        Start HTTP control plane server
 ├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle
@@ -80,15 +80,30 @@ holon (v0.16.0)
 │   ├── list       List agent enabled skills
 │   ├── enable     Enable a skill for an agent
 │   ├── disable    Disable a skill for an agent
+│   ├── update     Fetch and update skills from remote sources
+│   ├── refresh    Rescan local roots
 │   ├── install    [deprecated] Compatibility alias
 │   └── uninstall  [deprecated] Compatibility alias
 ├── run          One-shot agent interaction
 ├── solve        Solve a GitHub issue or similar target
+├── template     Agent template management
+│   ├── catalog  List installed templates
+│   ├── install  Install a template from a source
+│   ├── remove   Remove an installed template
+│   ├── info     Show template detail
+│   ├── sources  Remote template source management
+│   │   ├── list List configured remote sources
+│   │   ├── add  Add a remote source
+│   │   └── remove Remove a remote source
+│   └── sync     Sync templates from remote sources
 ├── workspace    Workspace management (attach, exit, detach)
 │   ├── attach   Attach to an existing workspace
 │   ├── exit     Exit current workspace
 │   └── detach   Detach from a workspace
 ├── tui          Launch interactive terminal UI
+├── memory-index Memory indexing management
+│   ├── status   Show indexing status
+│   └── rebuild  Rebuild the memory search index
 ├── debug        Debug utilities
 │   ├── prompt   Debug-mode prompt
 │   ├── latency  Show latency metrics

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -294,10 +294,47 @@ TUI debug instrumentation is controlled by environment variables:
 | `web.search.providers` | string_list | `[]` | Explicit auto-mode provider attempt order |
 | `web.search.max_results` | integer | `5` | Max results returned |
 | `web.search.max_provider_attempts` | integer | `3` | Max providers attempted by fallback/aggregate routing |
-| `web.providers.<name>.kind` | string | required | Provider kind: `duck_duck_go`, `searxng`, `brave`, `tavily`, `exa`, `perplexity`, `firecrawl`, `open_ai_native`, `anthropic_native`, or `gemini_native` |
+| `web.providers.<name>.kind` | string | required | Provider kind: `duck_duck_go`, `bing`, `searxng`, `brave`, `tavily`, `exa`, `perplexity`, `firecrawl`, `open_ai_native`, `anthropic_native`, or `gemini_native` |
 | `web.providers.<name>.base_url` | string | unset | Custom provider endpoint |
 | `web.providers.<name>.credential_profile` | string | unset | Credential profile for API-backed providers |
 | `web.providers.<name>.capabilities` | json_object | derived | Read-only capability metadata surfaced by `holon config get` and routing diagnostics |
+
+## Agent Template Remote Sources
+
+Configure remote Git repositories that Holon syncs to populate the agent
+template catalog:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `agent_templates.remote_sources` | json_object | `{}` | Map of source IDs to remote source configs |
+| `agent_templates.remote_sources.<id>.url` | string | required | Git repository URL (HTTPS) |
+| `agent_templates.remote_sources.<id>.ref` | string | unset | Git ref (branch, tag, or commit); defaults to repository default branch |
+| `agent_templates.remote_sources.<id>.enabled` | boolean | `true` | Whether this source is enabled for sync |
+| `agent_templates.remote_sources.<id>.credential_profile` | string | unset | Credential profile for private repositories |
+
+The daemon runs a sync job at startup to fetch remote source templates into
+the local template library (`~/.agents/agent_templates`). Re-syncs reuse
+recorded install mappings and refuse to overwrite locally-edited templates.
+
+## HTTP Addressing
+
+Holon separates the **listen address** from the **advertised address**:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `http_addr` | string | `127.0.0.1:7878` | TCP listen address for the HTTP/control API |
+| `advertise_url` | string | unset | Publicly reachable URL advertised to clients (e.g., `https://holon.example.com`) |
+| `callback_base_url` | string | derived | Local loopback URL for same-host webhook callbacks |
+
+`advertise_url` is the URL remote clients (CLI, Web GUI) use to reach the
+daemon. Set it when the daemon is behind a reverse proxy, tunnel, or on a
+different network interface than the default localhost address.
+
+`callback_base_url` is always derived from the listen port as
+`http://127.0.0.1:<port>` unless overridden via the
+`HOLON_CALLBACK_BASE_URL` environment variable. This keeps same-host
+webhook callbacks working even when `advertise_url` is set to a remote
+address.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Updates documentation for v0.26.0 features across 6 files.

## Changes

| # | File | Change |
|---|------|--------|
| 1 | `web-gui.md` | New Agent Templates Web UI section (browse, create, remote sources), navigation improvements (nav stack, file-level refresh, toolbar, auto-scroll, markdown toggle), update built-in→uses reference |
| 2 | `webfetch-websearch.md` | Add Bing Web Search provider |
| 3 | `skills.md` | Document `uses` shorthand, note builtin removal, add idempotent global install note |
| 4 | `configuration.md` | Add Bing in web providers list, Agent Template Remote Sources section, HTTP Addressing (advertise_url / callback_base_url decoupling) |
| 5 | `external-triggers.md` | Document token-only storage, reset-callback API, agent stop auto-revocation |
| 6 | `cli.md` | Bump version to v0.26.0, add template/memory-index/skills update+refresh to command tree |

## Related

- #2040 (previous v0.23.0 docs update)