### PR TITLE
feat: add agent template tui flows

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -592,11 +592,19 @@ impl LocalClient {
     }
 
     pub async fn create_agent(&self, agent_id: &str) -> Result<Value> {
+        self.create_agent_with_template(agent_id, None).await
+    }
+
+    pub async fn create_agent_with_template(
+        &self,
+        agent_id: &str,
+        template: Option<String>,
+    ) -> Result<Value> {
         self.post_control_json(
             &format!("/control/agents/{agent_id}/create"),
             &CreateAgentRequest {
                 authority_class: Some(AuthorityClass::OperatorInstruction),
-                template: None,
+                template,
             },
         )
         .await
@@ -699,6 +707,44 @@ impl LocalClient {
         let body = self.send(RequestSpec::get(&path), false).await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for GET {}", path))
+    }
+
+    pub async fn templates_catalog(&self) -> Result<Value> {
+        let path = api_path("/templates/catalog");
+        let body = self.send(RequestSpec::get(&path), false).await?;
+        serde_json::from_slice(&body)
+            .with_context(|| format!("failed to decode response body for GET {}", path))
+    }
+
+    pub async fn install_template(&self, github_url: impl Into<String>) -> Result<Value> {
+        self.post_control_json(
+            "/control/templates/install",
+            &crate::types::InstallTemplateRequest {
+                github_url: github_url.into(),
+            },
+        )
+        .await
+    }
+
+    pub async fn remove_template(&self, template_id: &str) -> Result<Value> {
+        self.post_control_json(
+            "/control/templates/remove",
+            &crate::types::RemoveTemplateRequest {
+                template_id: template_id.to_string(),
+            },
+        )
+        .await
+    }
+
+    pub async fn sync_template_remote_sources(&self) -> Result<Value> {
+        self.post_json(
+            "/templates/remote-sources/sync",
+            &crate::types::SyncTemplateRemoteSourcesRequest {
+                source_id: None,
+                force: false,
+            },
+        )
+        .await
     }
 
     pub async fn add_skill(&self, kind: crate::types::SkillInstallKind) -> Result<Value> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -10,9 +10,9 @@ use crate::{
     system::{workspace_access_mode_label, workspace_projection_label},
     tui_markdown::{render_markdown_text, render_markdown_text_spaced},
     types::{
-        AgentListEntry, AgentSummary, AuthorityClass, MessageBody, OperatorMessageRecord,
-        OperatorMessageStatus, ResolvedModelAvailability, SkillCatalogEntry, SkillScope,
-        TaskRecord,
+        AgentListEntry, AgentSummary, AgentTemplateCatalogEntry, AgentTemplateSourceKind,
+        AuthorityClass, MessageBody, OperatorMessageRecord, OperatorMessageStatus,
+        ResolvedModelAvailability, SkillCatalogEntry, SkillScope, TaskRecord,
     },
 };
 use anyhow::{anyhow, Result};

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -3,6 +3,7 @@ use crate::tui::app::ComposerEditMode;
 use crate::tui::keymap::{
     resolve_key, ComposerAction, KeyContext, ScrollAction, SlashMenuAction, TuiKeyAction,
 };
+use crate::tui::overlay::{TemplateCatalogMode, TemplateUrlInputMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,6 +24,7 @@ enum SlashCommand {
     Agent,
     Skills,
     SkillCatalog,
+    Templates,
     SkillAdd,
     SkillRemove,
     SkillEnable,
@@ -96,7 +98,7 @@ pub(super) struct SlashCommandSpec {
 
 const DISPLAY_MODE_ARGS: &[&str] = &["info", "verbose", "debug", "3", "4", "5"];
 
-const SLASH_COMMAND_SPECS: [SlashCommandSpec; 21] = [
+const SLASH_COMMAND_SPECS: [SlashCommandSpec; 22] = [
     SlashCommandSpec {
         name: "/help",
         description: "show slash command help",
@@ -249,6 +251,15 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 21] = [
         category: SlashCommandCategory::Skills,
         arg_rule: SlashArgRule::None,
         command: SlashCommand::SkillCatalog,
+    },
+    SlashCommandSpec {
+        name: "/templates",
+        description: "show agent template catalog",
+        usage: "/templates",
+        arg_hint: SlashArgHint::None,
+        category: SlashCommandCategory::Agent,
+        arg_rule: SlashArgRule::None,
+        command: SlashCommand::Templates,
     },
     SlashCommandSpec {
         name: "/skill-add",
@@ -527,6 +538,12 @@ fn parse_skill_catalog_entries(value: &serde_json::Value) -> Option<Vec<SkillCat
     serde_json::from_value(value.get("catalog")?.clone()).ok()
 }
 
+fn parse_template_catalog_entries(
+    value: &serde_json::Value,
+) -> Option<Vec<AgentTemplateCatalogEntry>> {
+    serde_json::from_value(value.get("catalog")?.clone()).ok()
+}
+
 fn skill_install_mode_label(mode: &crate::types::SkillInstallMode) -> &'static str {
     match mode {
         crate::types::SkillInstallMode::Linked => "linked",
@@ -752,6 +769,9 @@ impl TuiApp {
                 );
             }
             OverlayState::DebugPromptInput { composer } => {
+                composer.insert_str(&paste_single_line_text(text));
+            }
+            OverlayState::TemplateUrlInput { composer, .. } => {
                 composer.insert_str(&paste_single_line_text(text));
             }
             _ => {}
@@ -982,10 +1002,11 @@ impl TuiApp {
                     self.status_line = format!("Switching to agent {requested_agent_id}");
                 }
                 AgentSlashAction::Create(agent_id) => {
-                    self.client.create_agent(&agent_id).await?;
-                    self.overlay = OverlayState::None;
-                    self.status_line = format!("Created agent {agent_id}");
-                    self.schedule_agent_list_refresh();
+                    self.open_template_catalog(
+                        TemplateCatalogMode::SelectForAgentCreate,
+                        Some(agent_id),
+                    )
+                    .await?;
                 }
                 AgentSlashAction::Control { action, agent_id } => {
                     let agent_id = agent_id
@@ -1055,6 +1076,10 @@ impl TuiApp {
                         true,
                     );
                 }
+            }
+            SlashCommand::Templates => {
+                self.open_template_catalog(TemplateCatalogMode::Manage, None)
+                    .await?;
             }
             SlashCommand::SkillAdd => {
                 let kind = parse_skill_add_kind(&args)?;
@@ -1298,6 +1323,63 @@ impl TuiApp {
                             catalog,
                             selected,
                             detail_scroll,
+                        };
+                    }
+                }
+                Ok(())
+            }
+            OverlayState::TemplateCatalog {
+                catalog,
+                selected,
+                detail_scroll,
+                mode,
+                pending_agent_id,
+            } => {
+                self.handle_template_catalog_overlay_key(
+                    key,
+                    catalog,
+                    selected,
+                    detail_scroll,
+                    mode,
+                    pending_agent_id,
+                )
+                .await
+            }
+            OverlayState::TemplateUrlInput {
+                mut composer,
+                mode,
+                pending_agent_id,
+            } => {
+                let action = resolve_key(KeyContext::Composer, key);
+                match apply_composer_key_action(action, &mut composer) {
+                    Some(BufferAction::Submit) => {
+                        let url = composer.as_str().trim().to_string();
+                        if url.is_empty() {
+                            self.status_line = "Template URL is empty".into();
+                            self.overlay = OverlayState::TemplateUrlInput {
+                                composer,
+                                mode,
+                                pending_agent_id,
+                            };
+                        } else {
+                            self.apply_template_url_input(mode, pending_agent_id, url)
+                                .await?;
+                        }
+                    }
+                    Some(BufferAction::Cancel) => {
+                        if let Some(agent_id) = pending_agent_id {
+                            self.open_template_catalog(
+                                TemplateCatalogMode::SelectForAgentCreate,
+                                Some(agent_id),
+                            )
+                            .await?;
+                        }
+                    }
+                    None => {
+                        self.overlay = OverlayState::TemplateUrlInput {
+                            composer,
+                            mode,
+                            pending_agent_id,
                         };
                     }
                 }
@@ -1923,6 +2005,33 @@ impl TuiApp {
         }
     }
 
+    async fn open_template_catalog(
+        &mut self,
+        mode: TemplateCatalogMode,
+        pending_agent_id: Option<String>,
+    ) -> Result<()> {
+        let response = self.client.templates_catalog().await?;
+        let Some(catalog) = parse_template_catalog_entries(&response) else {
+            self.status_line = "Failed to list agent templates".into();
+            self.append_command_output(
+                "Agent Templates",
+                "Failed to list agent templates: response did not include a catalog array.",
+                true,
+            );
+            return Ok(());
+        };
+        let count = catalog.len();
+        self.overlay = OverlayState::TemplateCatalog {
+            catalog,
+            selected: 0,
+            detail_scroll: 0,
+            mode,
+            pending_agent_id,
+        };
+        self.status_line = format!("Opened agent template catalog: {count} templates");
+        Ok(())
+    }
+
     async fn handle_agents_overlay_key(&mut self, key: KeyEvent, selected: usize) -> Result<()> {
         match resolve_key(KeyContext::AgentsOverlay, key) {
             TuiKeyAction::OverlayClose => Ok(()),
@@ -2255,6 +2364,211 @@ fn scroll_action_key_code(action: ScrollAction) -> KeyCode {
 }
 
 impl TuiApp {
+    async fn handle_template_catalog_overlay_key(
+        &mut self,
+        key: KeyEvent,
+        catalog: Vec<AgentTemplateCatalogEntry>,
+        selected: usize,
+        detail_scroll: u16,
+        mode: TemplateCatalogMode,
+        pending_agent_id: Option<String>,
+    ) -> Result<()> {
+        let mut selected = selected;
+        let mut detail_scroll = detail_scroll;
+        match resolve_key(KeyContext::TemplatesOverlay, key) {
+            TuiKeyAction::OverlayClose => {}
+            TuiKeyAction::OverlayAccept => {
+                if mode == TemplateCatalogMode::SelectForAgentCreate {
+                    let agent_id = pending_agent_id
+                        .ok_or_else(|| anyhow!("no pending agent id for template selection"))?;
+                    let template = catalog
+                        .get(selected)
+                        .ok_or_else(|| anyhow!("no template selected"))?
+                        .template
+                        .clone();
+                    self.create_agent_with_template(agent_id, Some(template))
+                        .await?;
+                } else {
+                    self.overlay = OverlayState::TemplateCatalog {
+                        catalog,
+                        selected,
+                        detail_scroll,
+                        mode,
+                        pending_agent_id,
+                    };
+                }
+            }
+            TuiKeyAction::Template(action) => {
+                self.handle_template_overlay_action(
+                    catalog,
+                    selected,
+                    detail_scroll,
+                    mode,
+                    pending_agent_id,
+                    action,
+                )
+                .await?;
+            }
+            TuiKeyAction::OverlayMoveUp => {
+                selected = selected.saturating_sub(1);
+                self.overlay = OverlayState::TemplateCatalog {
+                    catalog,
+                    selected,
+                    detail_scroll: 0,
+                    mode,
+                    pending_agent_id,
+                };
+            }
+            TuiKeyAction::OverlayMoveDown => {
+                let max = catalog.len().saturating_sub(1);
+                selected = (selected + 1).min(max);
+                self.overlay = OverlayState::TemplateCatalog {
+                    catalog,
+                    selected,
+                    detail_scroll: 0,
+                    mode,
+                    pending_agent_id,
+                };
+            }
+            TuiKeyAction::OverlayScroll(action) => {
+                detail_scroll = adjust_scroll_for_action(detail_scroll, action);
+                self.overlay = OverlayState::TemplateCatalog {
+                    catalog,
+                    selected,
+                    detail_scroll,
+                    mode,
+                    pending_agent_id,
+                };
+            }
+            _ => {
+                self.overlay = OverlayState::TemplateCatalog {
+                    catalog,
+                    selected,
+                    detail_scroll,
+                    mode,
+                    pending_agent_id,
+                };
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_template_overlay_action(
+        &mut self,
+        catalog: Vec<AgentTemplateCatalogEntry>,
+        selected: usize,
+        detail_scroll: u16,
+        mode: TemplateCatalogMode,
+        pending_agent_id: Option<String>,
+        action: crate::tui::keymap::TemplateOverlayAction,
+    ) -> Result<()> {
+        match action {
+            crate::tui::keymap::TemplateOverlayAction::UrlInput => {
+                self.overlay = OverlayState::TemplateUrlInput {
+                    composer: ComposerState::new(),
+                    mode: match mode {
+                        TemplateCatalogMode::Manage => TemplateUrlInputMode::Install,
+                        TemplateCatalogMode::SelectForAgentCreate => {
+                            TemplateUrlInputMode::CreateAgent
+                        }
+                    },
+                    pending_agent_id,
+                };
+            }
+            crate::tui::keymap::TemplateOverlayAction::Install => {
+                self.overlay = OverlayState::TemplateUrlInput {
+                    composer: ComposerState::new(),
+                    mode: TemplateUrlInputMode::Install,
+                    pending_agent_id,
+                };
+            }
+            crate::tui::keymap::TemplateOverlayAction::Remove => {
+                if let Some(template) = catalog.get(selected) {
+                    if template.source != AgentTemplateSourceKind::UserGlobal {
+                        self.status_line =
+                            "Only user_global templates can be removed from the TUI".into();
+                        self.overlay = OverlayState::TemplateCatalog {
+                            catalog,
+                            selected,
+                            detail_scroll,
+                            mode,
+                            pending_agent_id,
+                        };
+                    } else {
+                        let template_id = template.template_id.clone();
+                        self.client.remove_template(&template_id).await?;
+                        self.status_line = format!("Removed agent template: {template_id}");
+                        self.open_template_catalog(mode, pending_agent_id).await?;
+                    }
+                }
+            }
+            crate::tui::keymap::TemplateOverlayAction::Sync => {
+                self.client.sync_template_remote_sources().await?;
+                self.status_line = "Synced agent template remote sources".into();
+                self.open_template_catalog(mode, pending_agent_id).await?;
+            }
+            crate::tui::keymap::TemplateOverlayAction::CreateWithoutTemplate => {
+                if mode == TemplateCatalogMode::SelectForAgentCreate {
+                    let agent_id = pending_agent_id
+                        .ok_or_else(|| anyhow!("no pending agent id for agent create"))?;
+                    self.create_agent_with_template(agent_id, None).await?;
+                } else {
+                    self.overlay = OverlayState::TemplateCatalog {
+                        catalog,
+                        selected,
+                        detail_scroll,
+                        mode,
+                        pending_agent_id,
+                    };
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn apply_template_url_input(
+        &mut self,
+        mode: TemplateUrlInputMode,
+        pending_agent_id: Option<String>,
+        url: String,
+    ) -> Result<()> {
+        match mode {
+            TemplateUrlInputMode::CreateAgent => {
+                let agent_id = pending_agent_id
+                    .ok_or_else(|| anyhow!("no pending agent id for template URL"))?;
+                self.create_agent_with_template(agent_id, Some(url)).await?;
+            }
+            TemplateUrlInputMode::Install => {
+                let response = self.client.install_template(url).await?;
+                let template_id = response
+                    .get("template_id")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("template");
+                self.status_line = format!("Installed agent template: {template_id}");
+                self.open_template_catalog(TemplateCatalogMode::Manage, pending_agent_id)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn create_agent_with_template(
+        &mut self,
+        agent_id: String,
+        template: Option<String>,
+    ) -> Result<()> {
+        self.client
+            .create_agent_with_template(&agent_id, template.clone())
+            .await?;
+        self.overlay = OverlayState::None;
+        self.status_line = match template {
+            Some(template) => format!("Created agent {agent_id} with template {template}"),
+            None => format!("Created agent {agent_id} without template"),
+        };
+        self.schedule_agent_list_refresh();
+        Ok(())
+    }
+
     async fn handle_task_overlay_action(
         &mut self,
         selected: usize,

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -3,6 +3,42 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use super::render::TaskOverlayAction;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TemplateOverlayAction {
+    Install,
+    Remove,
+    Sync,
+    UrlInput,
+    CreateWithoutTemplate,
+}
+
+fn resolve_templates_overlay_key(key: KeyEvent) -> TuiKeyAction {
+    match key.code {
+        KeyCode::Esc => TuiKeyAction::OverlayClose,
+        KeyCode::Enter => TuiKeyAction::OverlayAccept,
+        KeyCode::Up | KeyCode::Char('k') => TuiKeyAction::OverlayMoveUp,
+        KeyCode::Down | KeyCode::Char('j') => TuiKeyAction::OverlayMoveDown,
+        KeyCode::Char('g') | KeyCode::Char('G') => {
+            TuiKeyAction::Template(TemplateOverlayAction::UrlInput)
+        }
+        KeyCode::Char('i') | KeyCode::Char('I') => {
+            TuiKeyAction::Template(TemplateOverlayAction::Install)
+        }
+        KeyCode::Char('r') | KeyCode::Char('R') => {
+            TuiKeyAction::Template(TemplateOverlayAction::Remove)
+        }
+        KeyCode::Char('s') | KeyCode::Char('S') => {
+            TuiKeyAction::Template(TemplateOverlayAction::Sync)
+        }
+        KeyCode::Char('n') | KeyCode::Char('N') => {
+            TuiKeyAction::Template(TemplateOverlayAction::CreateWithoutTemplate)
+        }
+        _ => scroll_action_for_key(key.code)
+            .map(TuiKeyAction::OverlayScroll)
+            .unwrap_or(TuiKeyAction::Ignore),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum KeyContext {
     Global,
     Main,
@@ -12,6 +48,7 @@ pub(super) enum KeyContext {
     EventsOverlay,
     ScrollOverlay,
     TasksOverlay,
+    TemplatesOverlay,
     ModelPicker,
     ModelEffortPicker,
     DebugPromptInput,
@@ -28,6 +65,7 @@ impl KeyContext {
             KeyContext::EventsOverlay => "events overlay",
             KeyContext::ScrollOverlay => "scroll overlays",
             KeyContext::TasksOverlay => "tasks overlay",
+            KeyContext::TemplatesOverlay => "templates overlay",
             KeyContext::ModelPicker => "model picker",
             KeyContext::ModelEffortPicker => "reasoning effort picker",
             KeyContext::DebugPromptInput => "debug prompt",
@@ -50,6 +88,7 @@ pub(super) enum TuiKeyAction {
     OverlayMoveDown,
     OverlayScroll(ScrollAction),
     Task(TaskOverlayAction),
+    Template(TemplateOverlayAction),
     ModelFilterBackspace,
     InsertChar(char),
     Ignore,
@@ -175,6 +214,7 @@ pub(super) fn resolve_key(context: KeyContext, key: KeyEvent) -> TuiKeyAction {
         KeyContext::EventsOverlay => resolve_events_overlay_key(key),
         KeyContext::ScrollOverlay => resolve_scroll_overlay_key(key),
         KeyContext::TasksOverlay => resolve_tasks_overlay_key(key),
+        KeyContext::TemplatesOverlay => resolve_templates_overlay_key(key),
         KeyContext::ModelPicker => resolve_model_picker_key(key),
         KeyContext::ModelEffortPicker => resolve_list_overlay_key(key),
     }
@@ -193,6 +233,9 @@ pub(super) fn status_hint(context: KeyContext, slash_menu_visible: bool) -> &'st
         KeyContext::EventsOverlay => "Events: Up/Down, PgUp/PgDn, Home/End, Esc",
         KeyContext::ScrollOverlay => "Up/Down, PgUp/PgDn, Home/End, Esc",
         KeyContext::TasksOverlay => "Tasks: Up/Down, PgUp/PgDn, Home/End, f/l/x/i actions, Esc",
+        KeyContext::TemplatesOverlay => {
+            "Templates: Up/Down, Enter select, g URL, i install, r remove, s sync, n no template, Esc"
+        }
         KeyContext::ModelPicker => {
             "Model: type filter, Backspace edit, Up/Down move, Enter select, Esc cancel"
         }

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -30,6 +30,18 @@ pub(super) enum OverlayState {
         selected: usize,
         detail_scroll: u16,
     },
+    TemplateCatalog {
+        catalog: Vec<AgentTemplateCatalogEntry>,
+        selected: usize,
+        detail_scroll: u16,
+        mode: TemplateCatalogMode,
+        pending_agent_id: Option<String>,
+    },
+    TemplateUrlInput {
+        composer: ComposerState,
+        mode: TemplateUrlInputMode,
+        pending_agent_id: Option<String>,
+    },
     ModelPicker {
         provider: Option<String>,
         filter: String,
@@ -54,6 +66,18 @@ pub(super) enum OverlayState {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TemplateCatalogMode {
+    Manage,
+    SelectForAgentCreate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TemplateUrlInputMode {
+    CreateAgent,
+    Install,
+}
+
 pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
     match &app.overlay {
         OverlayState::None => {}
@@ -73,6 +97,48 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
             selected,
             detail_scroll,
         } => draw_skill_catalog_overlay(frame, catalog, *selected, *detail_scroll),
+        OverlayState::TemplateCatalog {
+            catalog,
+            selected,
+            detail_scroll,
+            mode,
+            pending_agent_id,
+        } => draw_template_catalog_overlay(
+            frame,
+            catalog,
+            *selected,
+            *detail_scroll,
+            *mode,
+            pending_agent_id.as_deref(),
+        ),
+        OverlayState::TemplateUrlInput {
+            composer,
+            mode,
+            pending_agent_id,
+        } => {
+            let help = match mode {
+                TemplateUrlInputMode::CreateAgent => pending_agent_id
+                    .as_deref()
+                    .map(|agent_id| {
+                        format!("Enter a GitHub template URL to create agent `{agent_id}` with.")
+                    })
+                    .unwrap_or_else(|| "Enter a GitHub template URL.".into()),
+                TemplateUrlInputMode::Install => {
+                    "Enter a GitHub template URL to install into the user_global library.".into()
+                }
+            };
+            draw_input_modal(
+                frame,
+                match mode {
+                    TemplateUrlInputMode::CreateAgent => "Template URL",
+                    TemplateUrlInputMode::Install => "Install Template",
+                },
+                &help,
+                composer,
+                82,
+                7,
+            )
+        }
         OverlayState::ModelPicker {
             provider,
             filter,
@@ -398,6 +464,115 @@ fn render_skill_catalog_detail(skill: &SkillCatalogEntry) -> String {
             "Use /skill-remove {} to remove it from the Skill Library.",
             skill.name
         ),
+    ]);
+    lines.join("\n")
+}
+
+fn draw_template_catalog_overlay(
+    frame: &mut Frame<'_>,
+    catalog: &[AgentTemplateCatalogEntry],
+    selected: usize,
+    detail_scroll: u16,
+    mode: TemplateCatalogMode,
+    pending_agent_id: Option<&str>,
+) {
+    let popup = centered_rect(94, 82, frame.area());
+    let layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(44), Constraint::Min(0)])
+        .split(popup);
+    frame.render_widget(Clear, popup);
+
+    let items = if catalog.is_empty() {
+        vec![ListItem::new("No agent templates in catalog")]
+    } else {
+        catalog
+            .iter()
+            .map(|template| {
+                ListItem::new(format!(
+                    "[{}] {}\n  {}",
+                    template.source.label(),
+                    template.template_id,
+                    render::trim(&template.description, 64)
+                ))
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut state = ListState::default();
+    if !catalog.is_empty() {
+        state.select(Some(selected.min(catalog.len().saturating_sub(1))));
+    }
+    let title = match mode {
+        TemplateCatalogMode::Manage => format!("Agent Templates ({})", catalog.len()),
+        TemplateCatalogMode::SelectForAgentCreate => pending_agent_id
+            .map(|agent_id| format!("Create Agent `{agent_id}` · Select Template"))
+            .unwrap_or_else(|| "Create Agent · Select Template".into()),
+    };
+    let list = List::new(items)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, layout[0], &mut state);
+
+    let detail_text = catalog
+        .get(selected)
+        .map(render_template_catalog_detail)
+        .unwrap_or_else(|| "No template selected.".to_string());
+    let help = match mode {
+        TemplateCatalogMode::Manage => {
+            "Template Detail · Up/Down select · PgUp/PgDn scroll · g URL · i install · r remove · s sync · Esc close"
+        }
+        TemplateCatalogMode::SelectForAgentCreate => {
+            "Template Detail · Enter create · g URL · n no template · i install · r remove · s sync · Esc cancel"
+        }
+    };
+    let detail = Paragraph::new(detail_text)
+        .block(Block::default().title(help).borders(Borders::ALL))
+        .scroll((detail_scroll, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(detail, layout[1]);
+}
+
+fn render_template_catalog_detail(template: &AgentTemplateCatalogEntry) -> String {
+    let mut lines = vec![
+        format!("Template: {}", template.template),
+        format!("Template id: {}", template.template_id),
+        format!("Catalog id: {}", template.catalog_id),
+        format!("Source: {}", template.source.label()),
+    ];
+    if !template.name.trim().is_empty() {
+        lines.push(format!("Name: {}", template.name));
+    }
+    if let Some(path) = &template.path {
+        lines.push(format!("Path: {}", path.display()));
+    }
+    if let Some(source_id) = &template.source_id {
+        lines.push(format!("Source id: {source_id}"));
+    }
+    if let Some(source_url) = &template.source_url {
+        lines.push(format!("Source URL: {source_url}"));
+    }
+    if let Some(resolved_ref) = &template.resolved_ref {
+        lines.push(format!("Resolved ref: {resolved_ref}"));
+    }
+    if let Some(revision) = &template.resolved_revision {
+        lines.push(format!("Revision: {revision}"));
+    }
+    if !template.included_skills.is_empty() {
+        lines.push(format!("Skills: {}", template.included_skills.join(", ")));
+    }
+    if !template.description.trim().is_empty() {
+        lines.extend([
+            "".into(),
+            "Description:".into(),
+            template.description.clone(),
+        ]);
+    }
+    lines.extend([
+        "".into(),
+        "Enter selects this template when creating an agent.".into(),
+        "Use g to paste a GitHub template URL directly.".into(),
+        "Use i/r/s to install, remove user_global templates, or sync remote sources.".into(),
     ]);
     lines.join("\n")
 }

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -179,9 +179,12 @@ fn overlay_hint(app: &TuiApp, slash_visible: bool) -> Option<&'static str> {
         | OverlayState::DebugPromptView { .. }
         | OverlayState::HelpView { .. } => KeyContext::ScrollOverlay,
         OverlayState::Tasks { .. } | OverlayState::SkillCatalog { .. } => KeyContext::TasksOverlay,
+        OverlayState::TemplateCatalog { .. } => KeyContext::TemplatesOverlay,
         OverlayState::ModelPicker { .. } => KeyContext::ModelPicker,
         OverlayState::ModelEffortPicker { .. } => KeyContext::ModelEffortPicker,
-        OverlayState::DebugPromptInput { .. } => KeyContext::DebugPromptInput,
+        OverlayState::DebugPromptInput { .. } | OverlayState::TemplateUrlInput { .. } => {
+            KeyContext::DebugPromptInput
+        }
     };
     Some(status_hint(context, false))
 }


### PR DESCRIPTION
## Summary
- add a `/templates` TUI entry with catalog/selector support
- route `agent create` through template selection first, including remote GitHub template URL input
- expose minimal install/remove/sync operations for templates in the TUI

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
