### PR TITLE
fix: persist TUI display state

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -72,9 +72,18 @@ impl TuiApp {
     pub(crate) fn new(client: LocalClient, log_writer: TuiLogWriter) -> Self {
         let connection_summary = client.connection_summary();
         let state_path = tui_state_path(&client);
-        let preferred_agent_id = TuiClientState::load(&state_path)
-            .ok()
-            .map(|state| state.last_selected_agent_id);
+        let tui_state = TuiClientState::load(&state_path).ok();
+        let preferred_agent_id = tui_state
+            .as_ref()
+            .map(|state| state.last_selected_agent_id.clone());
+        let display_mode = preferred_agent_id
+            .as_deref()
+            .and_then(|agent_id| {
+                tui_state
+                    .as_ref()
+                    .map(|state| state.effective_display_mode(agent_id))
+            })
+            .unwrap_or(OperatorDisplayMode::DEFAULT);
         let (runtime_tx, runtime_messages) = mpsc::unbounded_channel();
         Self {
             client,
@@ -121,7 +130,7 @@ impl TuiApp {
             overlay: OverlayState::None,
             last_refresh_at: None,
             last_event_at: None,
-            display_mode: OperatorDisplayMode::DEFAULT,
+            display_mode,
             status_line: format!("Connecting to {connection_summary}..."),
             should_quit: false,
             chat_text_cache: std::cell::RefCell::new(None),

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -96,7 +96,7 @@ pub(super) struct SlashCommandSpec {
     command: SlashCommand,
 }
 
-const DISPLAY_MODE_ARGS: &[&str] = &["info", "verbose", "debug", "3", "4", "5"];
+const DISPLAY_MODE_ARGS: &[&str] = &["info", "verbose", "debug", "3", "4", "5", "reset"];
 
 const SLASH_COMMAND_SPECS: [SlashCommandSpec; 22] = [
     SlashCommandSpec {
@@ -200,8 +200,8 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 22] = [
     },
     SlashCommandSpec {
         name: "/display",
-        description: "set chat display mode",
-        usage: "/display <info|verbose|debug|3|4|5>",
+        description: "set or reset selected agent display mode",
+        usage: "/display <info|verbose|debug|3|4|5|reset>",
         arg_hint: SlashArgHint::Values(DISPLAY_MODE_ARGS),
         category: SlashCommandCategory::Runtime,
         arg_rule: SlashArgRule::ExactlyOne,
@@ -952,22 +952,41 @@ impl TuiApp {
                     .into_iter()
                     .next()
                     .expect("slash command /display requires one argument");
-                let display_mode = OperatorDisplayMode::parse(&level)
-                    .ok_or_else(|| anyhow!("/display expects info, verbose, debug, or 3, 4, 5"))?;
+                let agent_id = self
+                    .selected_agent_id()
+                    .ok_or_else(|| anyhow!("No agent selected"))?
+                    .to_string();
+                let reset = level.trim().eq_ignore_ascii_case("reset");
+                let display_mode = if reset {
+                    self.clear_agent_display_mode(&agent_id)
+                } else {
+                    OperatorDisplayMode::parse(&level).ok_or_else(|| {
+                        anyhow!("/display expects info, verbose, debug, 3, 4, 5, or reset")
+                    })?
+                };
                 self.display_mode = display_mode;
+                if !reset {
+                    self.persist_agent_display_mode(&agent_id, display_mode);
+                }
                 if let Some(projection) = self.projection.as_mut() {
                     projection.clear_event_history();
                 }
                 self.chat_text_cache.borrow_mut().take();
                 self.overlay = OverlayState::None;
-                self.status_line = format!(
-                    "Display mode set to {} ({})",
-                    display_mode.name(),
-                    display_mode.display_level()
-                );
-                if self.selected_agent_id().is_some() {
-                    self.begin_bootstrap_selected_agent();
-                }
+                self.status_line = if reset {
+                    format!(
+                        "Display mode reset to {} ({}) for {agent_id}",
+                        display_mode.name(),
+                        display_mode.display_level()
+                    )
+                } else {
+                    format!(
+                        "Display mode set to {} ({}) for {agent_id}",
+                        display_mode.name(),
+                        display_mode.display_level()
+                    )
+                };
+                self.begin_bootstrap_selected_agent();
             }
             SlashCommand::Abort => {
                 let agent_id = match self.selected_agent_id() {
@@ -2942,7 +2961,7 @@ mod tests {
             "/refresh",
             "/clear-status",
             "/debug-prompt",
-            "/display <info|verbose|debug|3|4|5>",
+            "/display <info|verbose|debug|3|4|5|reset>",
             "/abort",
             "/vim",
             "/agent switch <agent-id>|create <name>|start [agent-id]|stop [agent-id]",

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -296,6 +296,9 @@ impl TuiApp {
             .or_else(|| find_agent_index(&agents, self.client.default_agent_id()))
             .unwrap_or_else(|| self.selected_agent.min(agents.len().saturating_sub(1)));
         self.agents = agents;
+        if let Some(agent_id) = self.selected_agent_id().map(ToString::to_string) {
+            self.apply_persisted_display_mode_for(&agent_id);
+        }
 
         if selected_missing {
             self.clear_projection_view();
@@ -442,7 +445,10 @@ impl TuiApp {
         self.status_line = format!("Loading agent state for {agent_id}");
         let client = self.client.clone();
         let tx = self.runtime_tx.clone();
-        let display_mode = self.display_mode.name().to_string();
+        let display_mode = self
+            .persisted_display_mode_for(&agent_id)
+            .name()
+            .to_string();
         tokio::spawn({
             let agent_id = agent_id.clone();
             async move {
@@ -538,6 +544,7 @@ impl TuiApp {
         self.stop_stream_task();
         self.selected_agent = target_index;
         self.record_selected_agent(&agent_id);
+        self.apply_persisted_display_mode_for(&agent_id);
         self.projection = Some(projection);
         self.apply_projection_view();
         self.last_refresh_at = Some(Local::now());
@@ -645,12 +652,58 @@ impl TuiApp {
 
     pub(super) fn record_selected_agent(&mut self, agent_id: &str) {
         self.preferred_agent_id = Some(agent_id.to_string());
-        if let Err(err) = TuiClientState::new(agent_id).save(&self.state_path) {
+        let mut state = TuiClientState::load_or_new(&self.state_path, agent_id);
+        state.set_selected_agent(agent_id);
+        if let Err(err) = state.save(&self.state_path) {
             tracing::warn!(
                 error = %err,
                 path = %self.state_path.display(),
                 "failed to persist TUI selected agent"
             );
+        }
+    }
+
+    pub(super) fn persist_agent_display_mode(
+        &mut self,
+        agent_id: &str,
+        display_mode: OperatorDisplayMode,
+    ) {
+        let mut state = TuiClientState::load_or_new(&self.state_path, agent_id);
+        state.set_selected_agent(agent_id);
+        state.set_agent_display_mode(agent_id, display_mode);
+        if let Err(err) = state.save(&self.state_path) {
+            tracing::warn!(
+                error = %err,
+                path = %self.state_path.display(),
+                "failed to persist TUI display mode"
+            );
+        }
+    }
+
+    pub(super) fn clear_agent_display_mode(&mut self, agent_id: &str) -> OperatorDisplayMode {
+        let mut state = TuiClientState::load_or_new(&self.state_path, agent_id);
+        state.set_selected_agent(agent_id);
+        state.clear_agent_display_mode(agent_id);
+        let display_mode = state.effective_display_mode(agent_id);
+        if let Err(err) = state.save(&self.state_path) {
+            tracing::warn!(
+                error = %err,
+                path = %self.state_path.display(),
+                "failed to persist TUI display reset"
+            );
+        }
+        display_mode
+    }
+
+    pub(super) fn apply_persisted_display_mode_for(&mut self, agent_id: &str) {
+        self.display_mode = self.persisted_display_mode_for(agent_id);
+    }
+
+    pub(super) fn persisted_display_mode_for(&self, agent_id: &str) -> OperatorDisplayMode {
+        if let Ok(state) = TuiClientState::load(&self.state_path) {
+            state.effective_display_mode(agent_id)
+        } else {
+            OperatorDisplayMode::DEFAULT
         }
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -8,18 +9,27 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-use crate::client::LocalClient;
+use crate::{client::LocalClient, operator_event::OperatorDisplayMode};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct TuiClientState {
     pub(super) last_selected_agent_id: String,
+    #[serde(default)]
+    pub(super) display: TuiDisplayState,
     pub(super) updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct TuiDisplayState {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(super) per_agent: BTreeMap<String, OperatorDisplayMode>,
 }
 
 impl TuiClientState {
     pub(super) fn new(last_selected_agent_id: impl Into<String>) -> Self {
         Self {
             last_selected_agent_id: last_selected_agent_id.into(),
+            display: TuiDisplayState::default(),
             updated_at: Utc::now(),
         }
     }
@@ -39,6 +49,37 @@ impl TuiClientState {
         let bytes = serde_json::to_vec_pretty(self)?;
         fs::write(path, bytes)
             .with_context(|| format!("failed to write TUI state {}", path.display()))
+    }
+
+    pub(super) fn load_or_new(path: &Path, last_selected_agent_id: impl Into<String>) -> Self {
+        Self::load(path).unwrap_or_else(|_| Self::new(last_selected_agent_id))
+    }
+
+    pub(super) fn effective_display_mode(&self, agent_id: &str) -> OperatorDisplayMode {
+        self.display
+            .per_agent
+            .get(agent_id)
+            .copied()
+            .unwrap_or(OperatorDisplayMode::DEFAULT)
+    }
+
+    pub(super) fn set_selected_agent(&mut self, agent_id: impl Into<String>) {
+        self.last_selected_agent_id = agent_id.into();
+        self.updated_at = Utc::now();
+    }
+
+    pub(super) fn set_agent_display_mode(
+        &mut self,
+        agent_id: impl Into<String>,
+        display_mode: OperatorDisplayMode,
+    ) {
+        self.display.per_agent.insert(agent_id.into(), display_mode);
+        self.updated_at = Utc::now();
+    }
+
+    pub(super) fn clear_agent_display_mode(&mut self, agent_id: &str) {
+        self.display.per_agent.remove(agent_id);
+        self.updated_at = Utc::now();
     }
 }
 
@@ -67,11 +108,38 @@ mod tests {
     fn state_round_trip_preserves_selected_agent() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("state").join("tui").join("local.json");
-        let state = TuiClientState::new("agent-beta");
+        let mut state = TuiClientState::new("agent-beta");
+        state.set_agent_display_mode("agent-beta", OperatorDisplayMode::Verbose);
 
         state.save(&path).unwrap();
         let loaded = TuiClientState::load(&path).unwrap();
 
         assert_eq!(loaded.last_selected_agent_id, "agent-beta");
+        assert_eq!(
+            loaded.effective_display_mode("agent-beta"),
+            OperatorDisplayMode::Verbose
+        );
+    }
+
+    #[test]
+    fn state_loads_legacy_selected_agent_only_json() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("local.json");
+        fs::write(
+            &path,
+            r#"{
+  "last_selected_agent_id": "agent-beta",
+  "updated_at": "2026-01-02T03:04:05Z"
+}"#,
+        )
+        .unwrap();
+
+        let loaded = TuiClientState::load(&path).unwrap();
+
+        assert_eq!(loaded.last_selected_agent_id, "agent-beta");
+        assert_eq!(
+            loaded.effective_display_mode("agent-beta"),
+            OperatorDisplayMode::DEFAULT
+        );
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -91,7 +91,9 @@ fn test_config() -> AppConfig {
 fn local_tui_restores_persisted_selected_agent_on_initial_agent_list() {
     let config = test_config();
     let state_path = config.home_dir.join("state").join("tui").join("local.json");
-    TuiClientState::new("beta").save(&state_path).unwrap();
+    let mut state = TuiClientState::new("beta");
+    state.set_agent_display_mode("beta", OperatorDisplayMode::Verbose);
+    state.save(&state_path).unwrap();
     let client = LocalClient::new(config).unwrap();
     let mut app = TuiApp::new(
         client,
@@ -105,6 +107,7 @@ fn local_tui_restores_persisted_selected_agent_on_initial_agent_list() {
 
     assert_eq!(change, AgentListChange::RequiresBootstrap);
     assert_eq!(app.selected_agent_id(), Some("beta"));
+    assert_eq!(app.display_mode, OperatorDisplayMode::Verbose);
 }
 
 #[test]
@@ -148,6 +151,29 @@ fn remote_tui_state_scope_uses_hashed_connect_target_without_token() {
     assert!(raw.contains("beta"));
     assert!(!raw.contains("top-secret-token"));
     assert!(!raw.contains("example.test"));
+}
+
+#[test]
+fn recording_selected_agent_preserves_display_preferences() {
+    let config = test_config();
+    let state_path = config.home_dir.join("state").join("tui").join("local.json");
+    let mut state = TuiClientState::new("alpha");
+    state.set_agent_display_mode("alpha", OperatorDisplayMode::Debug);
+    state.save(&state_path).unwrap();
+    let client = LocalClient::new(config).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+
+    app.record_selected_agent("beta");
+
+    let loaded = TuiClientState::load(&state_path).unwrap();
+    assert_eq!(loaded.last_selected_agent_id, "beta");
+    assert_eq!(
+        loaded.effective_display_mode("alpha"),
+        OperatorDisplayMode::Debug
+    );
 }
 
 fn sample_agent_summary(agent_id: &str) -> AgentSummary {
@@ -1911,10 +1937,12 @@ async fn agent_state_overlay_scrolls_and_esc_closes() {
 #[tokio::test]
 async fn slash_display_sets_chat_display_mode() {
     let client = LocalClient::new(test_config()).unwrap();
+    let state_path = tui_state_path(&client);
     let mut app = TuiApp::new(
         client,
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
+    app.apply_agent_list(vec![sample_agent_summary("default")]);
     app.composer = ComposerState::from("/display 5");
 
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
@@ -1924,7 +1952,12 @@ async fn slash_display_sets_chat_display_mode() {
     assert_eq!(app.display_mode, OperatorDisplayMode::Debug);
     assert_eq!(app.overlay, OverlayState::None);
     assert_eq!(app.composer.as_str(), "");
-    assert_eq!(app.status_line, "Display mode set to debug (5)");
+    assert_eq!(app.status_line, "Loading agent state for default");
+    let loaded = TuiClientState::load(&state_path).unwrap();
+    assert_eq!(
+        loaded.effective_display_mode("default"),
+        OperatorDisplayMode::Debug
+    );
 }
 
 #[tokio::test]
@@ -1934,6 +1967,7 @@ async fn slash_display_accepts_named_modes() {
         client,
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
+    app.apply_agent_list(vec![sample_agent_summary("default")]);
     app.composer = ComposerState::from("/display VERBOSE");
 
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
@@ -1941,7 +1975,34 @@ async fn slash_display_accepts_named_modes() {
         .unwrap();
 
     assert_eq!(app.display_mode, OperatorDisplayMode::Verbose);
-    assert_eq!(app.status_line, "Display mode set to verbose (4)");
+    assert_eq!(app.status_line, "Loading agent state for default");
+}
+
+#[tokio::test]
+async fn slash_display_reset_clears_selected_agent_override() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let state_path = tui_state_path(&client);
+    let mut state = TuiClientState::new("default");
+    state.set_agent_display_mode("default", OperatorDisplayMode::Debug);
+    state.save(&state_path).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.apply_agent_list(vec![sample_agent_summary("default")]);
+    app.composer = ComposerState::from("/display reset");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(app.display_mode, OperatorDisplayMode::Info);
+    let loaded = TuiClientState::load(&state_path).unwrap();
+    assert_eq!(
+        loaded.effective_display_mode("default"),
+        OperatorDisplayMode::Info
+    );
+    assert!(loaded.display.per_agent.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- persist TUI display preferences in the existing per-connection client state file
- store display mode as per-agent overrides and restore the effective mode on startup/agent switch
- add `/display reset` to clear the selected agent override without adding connection-level defaults

## Tests
- cargo test tui::state -- --nocapture
- cargo test local_tui_restores_persisted_selected_agent_on_initial_agent_list -- --nocapture
- cargo test missing_persisted_agent_falls_back_to_default_agent -- --nocapture
- cargo test recording_selected_agent_preserves_display_preferences -- --nocapture
- cargo test slash_display -- --nocapture
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets

Closes #1502
