### PR TITLE
fix: make solve default template distributable

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -34,6 +34,7 @@ const TEMPLATE_PROVENANCE_FILENAME: &str = "template-provenance.json";
 const MANAGED_TEMPLATE_STATE_FILENAME: &str = ".holon-template.json";
 const TEMPLATE_REGISTRY_FILENAME: &str = ".registry.json";
 pub const DEFAULT_AGENT_TEMPLATE_ID: &str = "holon-default";
+pub const GITHUB_SOLVE_AGENT_TEMPLATE_ID: &str = "holon-github-solve";
 pub const OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_ID: &str = "official";
 pub const OFFICIAL_AGENT_TEMPLATE_REMOTE_SOURCE_URL: &str = "https://github.com/holon-run/holon";
 const GITHUB_TEMPLATE_API_BASE_ENV: &str = "HOLON_TEMPLATE_GITHUB_API_BASE";
@@ -65,7 +66,19 @@ const DEFAULT_BUILTIN_TEMPLATE: BuiltinTemplate = BuiltinTemplate {
     template_toml: include_str!("../builtin_templates/holon-default/template.toml"),
     skill_names: &[],
 };
-const BUILTIN_TEMPLATES: &[BuiltinTemplate] = &[DEFAULT_BUILTIN_TEMPLATE];
+const GITHUB_SOLVE_BUILTIN_TEMPLATE: BuiltinTemplate = BuiltinTemplate {
+    template_id: GITHUB_SOLVE_AGENT_TEMPLATE_ID,
+    agents_md: include_str!("../agent_templates/holon-github-solve/AGENTS.md"),
+    template_toml: include_str!("../agent_templates/holon-github-solve/template.toml"),
+    skill_names: &[
+        "ghx",
+        "github-issue-solve",
+        "github-pr-fix",
+        "github-review",
+    ],
+};
+const BUILTIN_TEMPLATES: &[BuiltinTemplate] =
+    &[DEFAULT_BUILTIN_TEMPLATE, GITHUB_SOLVE_BUILTIN_TEMPLATE];
 
 struct BuiltinTemplate {
     template_id: &'static str,
@@ -1713,9 +1726,16 @@ fn resolve_template_catalog_entry(
 
     validate_template_install_id(template)?;
     let catalog = discover_agent_templates_catalog(Some(home_dir), catalog_agent_home);
-    catalog
+    if let Some(entry) = catalog
         .into_iter()
         .find(|entry| entry.template_id == template || entry.template == template)
+    {
+        return Ok(entry);
+    }
+    BUILTIN_TEMPLATES
+        .iter()
+        .find(|builtin| builtin.template_id == template)
+        .map(builtin_template_catalog_entry)
         .ok_or_else(|| unknown_template_error(template, home_dir, catalog_agent_home))
 }
 
@@ -1785,11 +1805,10 @@ async fn resolve_catalog_template(
 }
 
 fn resolve_builtin_template(template_id: &str, home_dir: &Path) -> Result<ResolvedTemplate> {
-    let builtin = if template_id == DEFAULT_AGENT_TEMPLATE_ID {
-        &DEFAULT_BUILTIN_TEMPLATE
-    } else {
-        bail!("unknown builtin template id {template_id}");
-    };
+    let builtin = BUILTIN_TEMPLATES
+        .iter()
+        .find(|template| template.template_id == template_id)
+        .ok_or_else(|| anyhow!("unknown builtin template id {template_id}"))?;
     let skill_refs: Vec<TemplateSkillRef> = builtin
         .skill_names
         .iter()
@@ -3561,6 +3580,35 @@ mod tests {
         assert!(!catalog
             .iter()
             .any(|entry| entry.catalog_id == "builtin:holon-default"));
+    }
+
+    #[test]
+    fn github_solve_builtin_template_resolves_without_user_catalog() {
+        let user_home = tempdir().unwrap();
+        let agent_home = tempdir().unwrap();
+
+        let entry = resolve_template_catalog_entry(
+            GITHUB_SOLVE_AGENT_TEMPLATE_ID,
+            user_home.path(),
+            agent_home.path(),
+        )
+        .unwrap();
+        assert_eq!(entry.catalog_id, "builtin:holon-github-solve");
+        assert_eq!(entry.source, AgentTemplateSourceKind::Builtin);
+        assert_eq!(
+            entry.included_skills,
+            vec![
+                "ghx",
+                "github-issue-solve",
+                "github-pr-fix",
+                "github-review"
+            ]
+        );
+
+        let resolved =
+            resolve_builtin_template(GITHUB_SOLVE_AGENT_TEMPLATE_ID, user_home.path()).unwrap();
+        assert!(resolved.agents_md.contains("Holon GitHub Solve"));
+        assert_eq!(resolved.skill_refs.len(), 4);
     }
 
     #[tokio::test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -22,7 +22,8 @@ use crate::{
     agent_template::{
         discover_agent_templates_catalog, ensure_agent_home_agents_md_without_template_with_home,
         initialize_agent_home_from_template_with_catalog,
-        initialize_agent_home_from_template_with_home, initialize_agent_home_without_template,
+        initialize_agent_home_from_template_with_home,
+        initialize_agent_home_without_template_with_home,
     },
     agents_md::load_agents_md,
     callbacks::hash_callback_token,
@@ -636,7 +637,7 @@ impl RuntimeHost {
         }
         if let Some(template) = template {
             let agent_home = self.agent_data_dir(agent_id);
-            let user_home = crate::agent_template::user_home_dir()?;
+            let user_home = self.config().home_dir.clone();
             if let Some(catalog_agent_home) = catalog_agent_home {
                 initialize_agent_home_from_template_with_catalog(
                     &agent_home,
@@ -650,7 +651,12 @@ impl RuntimeHost {
                     .await?;
             }
         } else {
-            initialize_agent_home_without_template(&self.agent_data_dir(agent_id)).await?;
+            let user_home = self.config().home_dir.clone();
+            initialize_agent_home_without_template_with_home(
+                &self.agent_data_dir(agent_id),
+                &user_home,
+            )
+            .await?;
         }
         let record = AgentIdentityRecord::new(
             agent_id,
@@ -1057,20 +1063,20 @@ impl RuntimeHost {
         .snapshot();
         let agent_home = self.agent_data_dir(&identity.agent_id);
         let loaded_agents_md = load_agents_md(
-            std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+            Some(self.config().home_dir.as_path()),
             agent_home.as_path(),
             crate::runtime::workspace::workspace_anchor_for_state_ref(&state),
         )?;
         let loaded_agent_memory = load_agent_memory(agent_home.as_path())?;
         let skill_visibility = skill_visibility(&identity_view);
-        let user_home = std::env::var_os("HOME").map(PathBuf::from);
+        let user_home = self.config().home_dir.clone();
         let workspace_anchor = state
             .active_workspace_entry
             .as_ref()
             .map(|entry| entry.workspace_anchor.as_path());
         let skill_roots = effective_skill_root_registrations(
             skill_visibility,
-            user_home.as_deref(),
+            Some(user_home.as_path()),
             &state.id,
             agent_home.as_path(),
             workspace_anchor,
@@ -1083,7 +1089,7 @@ impl RuntimeHost {
             &state.active_skills,
         );
         skills.agent_templates_catalog = discover_agent_templates_catalog(
-            std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+            Some(self.config().home_dir.as_path()),
             agent_home.as_path(),
         );
         let config = self.config();
@@ -1247,7 +1253,7 @@ impl RuntimeHost {
 
     async fn ensure_default_agent_home_initialized(&self) -> Result<()> {
         let agent_home = self.agent_data_dir(&self.config().default_agent_id);
-        let user_home = crate::agent_template::user_home_dir()?;
+        let user_home = self.config().home_dir.clone();
         let _ =
             ensure_agent_home_agents_md_without_template_with_home(&agent_home, &user_home).await?;
         Ok(())
@@ -1263,7 +1269,7 @@ impl RuntimeHost {
         let child_agent_id = ids::runtime_id(TEMP_CHILD_AGENT_PREFIX.trim_end_matches('_'));
         self.validate_agent_id(&child_agent_id)?;
         if let Some(template) = template {
-            let user_home = crate::agent_template::user_home_dir()?;
+            let user_home = self.config().home_dir.clone();
             initialize_agent_home_from_template_with_catalog(
                 &self.agent_data_dir(&child_agent_id),
                 &user_home,
@@ -1272,7 +1278,12 @@ impl RuntimeHost {
             )
             .await?;
         } else {
-            initialize_agent_home_without_template(&self.agent_data_dir(&child_agent_id)).await?;
+            let user_home = self.config().home_dir.clone();
+            initialize_agent_home_without_template_with_home(
+                &self.agent_data_dir(&child_agent_id),
+                &user_home,
+            )
+            .await?;
         }
         let record = AgentIdentityRecord::new(
             child_agent_id,
@@ -2446,6 +2457,50 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(listed.contains(&host.config().default_agent_id));
         assert!(listed.contains(&"release-bot".to_string()));
+    }
+
+    #[tokio::test]
+    async fn named_agent_template_resolution_uses_config_home_not_os_home() {
+        struct HomeGuard(Option<String>);
+
+        impl Drop for HomeGuard {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+
+        let config_home = tempdir().unwrap();
+        let os_home = tempdir().unwrap();
+        write_test_model_config(config_home.path());
+
+        let worker = config_home
+            .path()
+            .join(".agents")
+            .join("agent_templates")
+            .join("worker");
+        fs::create_dir_all(&worker).unwrap();
+        fs::write(
+            worker.join("AGENTS.md"),
+            "# Config worker\n\nfrom config home\n",
+        )
+        .unwrap();
+
+        let _home_guard = HomeGuard(std::env::var("HOME").ok());
+        std::env::set_var("HOME", os_home.path());
+        let config = AppConfig::load_with_home(Some(config_home.path().to_path_buf())).unwrap();
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+
+        host.create_named_agent("worker-bot", Some("worker"))
+            .await
+            .unwrap();
+
+        let agents_md =
+            fs::read_to_string(host.agent_data_dir("worker-bot").join("AGENTS.md")).unwrap();
+        assert!(agents_md.starts_with("# Config worker\n\nfrom config home\n"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -947,17 +947,8 @@ fn spawn_stale_agent_template_remote_source_sync(config: &AppConfig, host: &Runt
     }
 
     let db = host.runtime_db().clone();
+    let user_home = config.home_dir.clone();
     tokio::spawn(async move {
-        let user_home = match holon::agent_template::user_home_dir() {
-            Ok(path) => path,
-            Err(error) => {
-                warn!(
-                    error = %error,
-                    "failed to resolve user home for agent template remote source startup sync"
-                );
-                return;
-            }
-        };
         for (source_id, source_config) in sync_candidates {
             if let Err(error) = holon::agent_template::sync_agent_template_remote_source(
                 &db,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -834,6 +834,11 @@ impl RuntimeHandle {
     }
 
     fn user_home(&self) -> Option<PathBuf> {
+        if let Some(provider_reconfig) =
+            self.inner.config_snapshot.load().provider_reconfig.as_ref()
+        {
+            return Some(provider_reconfig.config.home_dir.clone());
+        }
         std::env::var_os("HOME").map(PathBuf::from)
     }
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -87,7 +87,7 @@ impl ConfigSnapshot {
 
 #[derive(Debug, Clone)]
 pub(super) struct ProviderReconfigurator {
-    config: AppConfig,
+    pub(super) config: AppConfig,
 }
 
 impl RuntimeHandle {

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -7,13 +7,14 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
 
 use crate::{
+    agent_template::GITHUB_SOLVE_AGENT_TEMPLATE_ID,
     config::AppConfig,
     run_once::{run_once, RunFinalStatus, RunOnceRequest, RunOnceResponse},
     types::AuthorityClass,
 };
 
 pub const DEFAULT_SOLVE_AGENT_ID: &str = "github-solve";
-pub const DEFAULT_SOLVE_TEMPLATE_ID: &str = "holon-github-solve";
+pub const DEFAULT_SOLVE_TEMPLATE_ID: &str = GITHUB_SOLVE_AGENT_TEMPLATE_ID;
 
 #[derive(Debug, Clone)]
 pub struct SolveRequest {


### PR DESCRIPTION
## Summary
- add `holon-github-solve` as a distributable builtin template so `holon solve` works on fresh release runners without a pre-synced user template catalog
- make template/catalog discovery use `AppConfig.home_dir` instead of OS `HOME` in runtime host paths
- cover builtin solve template resolution and config-home template lookup with regression tests

## Verification
- `cargo test --lib github_solve_builtin_template_resolves_without_user_catalog`
- `cargo test --lib named_agent_template_resolution_uses_config_home_not_os_home`
- `cargo test --lib solve::tests`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
