### PR TITLE
fix: limit control prompt request body

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -218,6 +218,7 @@ impl HttpErrorEnvelope {
 }
 
 pub(crate) const CALLBACK_BODY_LIMIT_BYTES: usize = 256 * 1024;
+pub(crate) const CONTROL_PROMPT_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 pub(crate) const DEFAULT_EVENT_STREAM_WINDOW: usize = 128;
 pub(crate) const MAX_EVENT_STREAM_WINDOW: usize = 512;
 pub(crate) const EVENT_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
@@ -420,7 +421,8 @@ pub fn router(state: AppState) -> Router {
         )
         .route(
             "/control/agents/{agent_id}/prompt",
-            post(control::control_prompt),
+            post(control::control_prompt)
+                .layer(DefaultBodyLimit::max(CONTROL_PROMPT_BODY_LIMIT_BYTES)),
         )
         .route(
             "/control/agents/{agent_id}/operator-bindings",

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -31,6 +31,7 @@ http_async_tests!(
     skill_library_reconcile_and_check_lock_file,
     control_agent_model_override_set_and_clear_updates_status,
     control_prompt_requires_bearer_token_when_required,
+    control_prompt_rejects_oversized_body,
     remote_tcp_surfaces_require_bearer_token_when_required,
     control_wake_records_liveness_only_system_tick_on_loopback_auto,
     control_prompt_requires_bearer_token_for_non_loopback_auto,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1296,6 +1296,20 @@ pub async fn control_runtime_readiness_is_open_over_unix_socket_when_auth_requir
     Ok(())
 }
 
+pub async fn control_prompt_rejects_oversized_body() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::new();
+    let oversized_text = "x".repeat(33 * 1024 * 1024);
+    let response = client
+        .post(format!("{base}/api/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": oversized_text }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+    server.abort();
+    Ok(())
+}
+
 pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<()> {
     let config = test_config_with_paths(
         tempdir().unwrap().keep(),


### PR DESCRIPTION
## Summary
- add a size cap for control prompt request bodies before JSON parsing
- return an explicit 413 response when the request body is too large
- cover oversized control prompt requests with a regression test

## Verification
- cargo fmt --all -- --check
- cargo test -q control_prompt_rejects_oversized_body
- RUSTFLAGS="-D warnings" cargo check --all-targets