### PR TITLE
docs: update for v0.27.0 — i18n, UI icons, TUI template flows, overlay shortcuts, persistent display state

### DIFF
--- a/docs/website/guides/tui.md
+++ b/docs/website/guides/tui.md
@@ -158,6 +158,50 @@ holon tui --connect https://your-server:8787 --token "your-token"
 The daemon must be started with an access mode that accepts remote connections
 (`tunnel` or `public`). Use `--access local` for local-only TUI connections.
 
+## Agent Templates
+
+The TUI supports browsing, installing, and creating agents from templates
+directly within the terminal. This avoids switching to the Web GUI or CLI
+for common template workflows.
+
+- **Browse templates** — Press `Ctrl+O` then `T` to open the template catalog
+  overlay. Navigate installed templates with `↑`/`↓` and press `Enter` to
+  select a template for agent creation.
+- **Install from URL** — Press `g` inside the templates overlay to enter a
+  GitHub template URL and install it into the user-global template library.
+- **Remove** — Press `r` to remove a selected template.
+- **Sync** — Press `s` to sync templates from configured remote sources.
+- **Create without template** — Press `n` to skip template selection and
+  create an agent with the default configuration.
+
+## Overlay Shortcut Prefix
+
+All overlay shortcuts now use a common `Ctrl+O` prefix, replacing the
+previous single-key bindings. This prevents accidental overlay openings
+during normal typing.
+
+After pressing `Ctrl+O`, a short hint appears in the status line. Press a
+target key to open the corresponding overlay:
+
+| Key | Overlay |
+|-----|---------|
+| `H` | Help |
+| `A` | Agent picker |
+| `E` | Event log |
+| `M` | Model picker |
+| `T` | Template catalog |
+| `R` | Transcript |
+| `S` | Agent state |
+
+Press `Esc` to cancel the prefix and continue typing.
+
+## Persistent Display State
+
+The TUI remembers your last display mode and restores it on restart. Display
+mode is stored per agent in `~/.holon/tui_state.json`, so each agent
+maintains its own preference. This applies to the chat display mode (info,
+verbose, debug) set via `/display <mode>`.
+
 ## Troubleshooting
 
 See the [Troubleshooting guide](/guides/troubleshooting#tui-issues) for common

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -161,8 +161,28 @@ Configure Holon from the browser:
   automatically determines the right credential method for each provider
   (API key input for api_key providers, device login link for OAuth
   providers like Codex).
+- **Language** — switch the Web GUI display language. Supported languages are
+  English (EN) and Simplified Chinese (ZH-CN). All UI text — navigation,
+  buttons, labels, and status messages — updates in real time without a
+  page reload.
 - **Runtime configuration** — view the current execution environment,
   attached workspaces, and policy snapshot.
+
+### Internationalization (i18n)
+
+The Web GUI uses react-i18next for full internationalization. A language
+selector in the Settings page lets you switch between English and Simplified
+Chinese. All interface text — including navigation items, button labels, form
+hints, status messages, and error pages — translates instantly on selection.
+Translation resources are compiled into the embedded build alongside the UI
+assets, so no external files or network access are required.
+
+### UI Icons
+
+Status indicators, navigation icons, and file browser icons now use lucide
+icons (via lucide-react) throughout the Web GUI, replacing the previous
+Unicode symbol approach. Tooltips have been streamlined for clarity, and
+panel titles use a consistent `label(N)` format.
 
 ### Inspector (Right Panel)
 

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,9 +1,9 @@
 ---
 title: CLI reference
-summary: Holon's command-line interface — verified against holon --help (v0.26.0).
+summary: Holon's command-line interface — verified against holon --help (v0.27.0).
 order: 10
 ---
-<!-- maintenance: regenerate from `holon --help` output when commands change -->
+<!-- maintenance: regenerate from `holon --help` output when commands change. Last regenerated against v0.27.0. -->
 
 # CLI Reference
 
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.26.0)
+holon (v0.27.0)
 ├── serve        Start HTTP control plane server
 ├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle


### PR DESCRIPTION
## Summary

Updates documentation for the v0.27.0 release.

## Changes

| File | Change |
|------|--------|
|  | Added i18n section (EN/ZH-CN language switching with react-i18next), Language setting in Settings, UI Icons section (Unicode → lucide icons, tooltip improvements,  panel titles) |
|  | Added Agent Templates TUI flows (browse, install from URL, remove, sync, create without template), Overlay Shortcut Prefix (Ctrl+O prefix to prevent accidental triggers), Persistent Display State (per-agent display mode restore from ) |
|  | Updated version label from v0.26.0 → v0.27.0 |

## Excluded

- Agent Media Path Markdown — not yet released (will be in a future version)