### PR TITLE
fix(web-gui): workspace image rendering, file browser integration, and drag-and-drop attachment

### DIFF
--- a/web-gui/app/src/components/MarkdownContent.test.ts
+++ b/web-gui/app/src/components/MarkdownContent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseWorkspaceImageRef, resolveWorkspaceRelativePath } from "./MarkdownContent";
+import { markdownUrlTransform, parseWorkspaceImageRef, resolveWorkspaceRelativePath } from "./MarkdownContent";
 
 describe("parseWorkspaceImageRef", () => {
   it("parses workspace image URIs", () => {
@@ -35,5 +35,16 @@ describe("resolveWorkspaceRelativePath", () => {
     expect(resolveWorkspaceRelativePath("docs/report.md", "https://example.com/chart.png")).toBeUndefined();
     expect(resolveWorkspaceRelativePath("docs/report.md", "data:image/png;base64,abc")).toBeUndefined();
     expect(resolveWorkspaceRelativePath("report.md", "../secret.png")).toBeUndefined();
+  });
+});
+
+describe("markdownUrlTransform", () => {
+  it("keeps workspace image sources while preserving default URL sanitization", () => {
+    const src = "workspace://agent_home:holon-pm/media/inbox/screenshot.png";
+
+    expect(markdownUrlTransform(src, "src")).toBe(src);
+    expect(markdownUrlTransform(src, "href")).toBe("");
+    expect(markdownUrlTransform("javascript:alert(1)", "src")).toBe("");
+    expect(markdownUrlTransform("https://example.com/chart.png", "src")).toBe("https://example.com/chart.png");
   });
 });

--- a/web-gui/app/src/components/MarkdownContent.test.ts
+++ b/web-gui/app/src/components/MarkdownContent.test.ts
@@ -8,6 +8,10 @@ describe("parseWorkspaceImageRef", () => {
       workspaceId: "ws_123",
       path: "outputs/chart.png",
     });
+    expect(parseWorkspaceImageRef("workspace://agent_home:holon-pm/media/inbox/screenshot.png")).toEqual({
+      workspaceId: "agent_home:holon-pm",
+      path: "media/inbox/screenshot.png",
+    });
   });
 
   it("decodes path segments without accepting non-workspace URLs", () => {
@@ -16,6 +20,7 @@ describe("parseWorkspaceImageRef", () => {
       path: "out dir/chart 1.png",
     });
     expect(parseWorkspaceImageRef("https://example.com/chart.png")).toBeUndefined();
+    expect(parseWorkspaceImageRef("workspace://agent_home:holon-pm/../secret.png")).toBeUndefined();
   });
 });
 

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { memo, useEffect, useState, type ImgHTMLAttributes } from "react";
 
@@ -39,6 +39,11 @@ export function parseWorkspaceImageRef(src: string | undefined): WorkspaceImageR
   } catch {
     return undefined;
   }
+}
+
+export function markdownUrlTransform(url: string, key: string): string {
+  if (key === "src" && parseWorkspaceImageRef(url)) return url;
+  return defaultUrlTransform(url);
 }
 
 export function resolveWorkspaceRelativePath(baseFilePath: string, src: string | undefined): string | undefined {
@@ -121,6 +126,7 @@ function MarkdownContentView({ text, compact = false }: MarkdownContentProps) {
     <div className={`markdown-content${compact ? " compact" : ""}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        urlTransform={markdownUrlTransform}
         components={{
           a: ({ children, ...props }) => (
             <a {...props} rel="noreferrer" target="_blank">

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -1,6 +1,6 @@
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { memo, useEffect, useState, type ImgHTMLAttributes } from "react";
+import { memo, useCallback, useEffect, useState, useRef, type ImgHTMLAttributes } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useRuntimeStore } from "../runtime/runtime-store";
@@ -76,17 +76,29 @@ interface WorkspaceImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 
   workspaceId: string;
   path: string;
   executionRootId?: string;
+  showOpenInBrowser?: boolean;
 }
 
-export function WorkspaceImage({ workspaceId, path, executionRootId, alt, ...props }: WorkspaceImageProps) {
+export function WorkspaceImage({
+  workspaceId,
+  path,
+  executionRootId,
+  alt,
+  showOpenInBrowser = true,
+  ...props
+}: WorkspaceImageProps) {
   const { t } = useTranslation();
   const fetchWorkspaceFileBlob = useRuntimeStore((s) => s.fetchWorkspaceFileBlob);
   const selectedAgentId = useRuntimeStore((s) => s.selectedAgentId);
   const showFileBrowser = useRuntimeStore((s) => s.showFileBrowser);
   const [objectUrl, setObjectUrl] = useState<string>();
   const [error, setError] = useState<string>();
+  const [showContextMenu, setShowContextMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const openInFileBrowser = () => {
+    setShowContextMenu(false);
     if (!selectedAgentId) return;
     showFileBrowser(selectedAgentId, workspaceId, undefined, executionRootId, path);
   };
@@ -117,6 +129,26 @@ export function WorkspaceImage({ workspaceId, path, executionRootId, alt, ...pro
     };
   }, [fetchWorkspaceFileBlob, workspaceId, path, executionRootId]);
 
+  // Close context menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setShowContextMenu(false);
+      }
+    };
+    if (showContextMenu) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showContextMenu]);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    if (!showOpenInBrowser || !selectedAgentId) return;
+    e.preventDefault();
+    setMenuPosition({ x: e.clientX, y: e.clientY });
+    setShowContextMenu(true);
+  }, [showOpenInBrowser, selectedAgentId]);
+
   if (error) {
     return (
       <span className="workspace-image-error" title={error}>
@@ -129,11 +161,26 @@ export function WorkspaceImage({ workspaceId, path, executionRootId, alt, ...pro
   }
   return (
     <span className="workspace-image-frame">
-      <img {...props} src={objectUrl} alt={alt ?? path} />
-      {selectedAgentId ? (
-        <button type="button" className="workspace-image-open" onClick={openInFileBrowser}>
-          {t("fileBrowser.openInFileBrowser")}
-        </button>
+      <img
+        {...props}
+        src={objectUrl}
+        alt={alt ?? path}
+        onContextMenu={handleContextMenu}
+      />
+      {showContextMenu && menuPosition && showOpenInBrowser ? (
+        <div
+          ref={menuRef}
+          className="workspace-image-context-menu"
+          style={{ position: "fixed", left: menuPosition.x, top: menuPosition.y, zIndex: 1000 }}
+        >
+          <button
+            type="button"
+            className="workspace-image-context-menu-item"
+            onClick={openInFileBrowser}
+          >
+            {t("fileBrowser.openInFileBrowser")}
+          </button>
+        </div>
       ) : null}
     </span>
   );

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -1,7 +1,6 @@
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { memo, useCallback, useEffect, useState, useRef, type ImgHTMLAttributes } from "react";
-import { useTranslation } from "react-i18next";
+import { memo, useEffect, useState, type ImgHTMLAttributes } from "react";
 
 import { useRuntimeStore } from "../runtime/runtime-store";
 
@@ -87,21 +86,10 @@ export function WorkspaceImage({
   showOpenInBrowser = true,
   ...props
 }: WorkspaceImageProps) {
-  const { t } = useTranslation();
+  void showOpenInBrowser;
   const fetchWorkspaceFileBlob = useRuntimeStore((s) => s.fetchWorkspaceFileBlob);
-  const selectedAgentId = useRuntimeStore((s) => s.selectedAgentId);
-  const showFileBrowser = useRuntimeStore((s) => s.showFileBrowser);
   const [objectUrl, setObjectUrl] = useState<string>();
   const [error, setError] = useState<string>();
-  const [showContextMenu, setShowContextMenu] = useState(false);
-  const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const openInFileBrowser = () => {
-    setShowContextMenu(false);
-    if (!selectedAgentId) return;
-    showFileBrowser(selectedAgentId, workspaceId, undefined, executionRootId, path);
-  };
 
   useEffect(() => {
     let cancelled = false;
@@ -129,26 +117,6 @@ export function WorkspaceImage({
     };
   }, [fetchWorkspaceFileBlob, workspaceId, path, executionRootId]);
 
-  // Close context menu when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setShowContextMenu(false);
-      }
-    };
-    if (showContextMenu) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [showContextMenu]);
-
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    if (!showOpenInBrowser || !selectedAgentId) return;
-    e.preventDefault();
-    setMenuPosition({ x: e.clientX, y: e.clientY });
-    setShowContextMenu(true);
-  }, [showOpenInBrowser, selectedAgentId]);
-
   if (error) {
     return (
       <span className="workspace-image-error" title={error}>
@@ -165,23 +133,7 @@ export function WorkspaceImage({
         {...props}
         src={objectUrl}
         alt={alt ?? path}
-        onContextMenu={handleContextMenu}
       />
-      {showContextMenu && menuPosition && showOpenInBrowser ? (
-        <div
-          ref={menuRef}
-          className="workspace-image-context-menu"
-          style={{ position: "fixed", left: menuPosition.x, top: menuPosition.y, zIndex: 1000 }}
-        >
-          <button
-            type="button"
-            className="workspace-image-context-menu-item"
-            onClick={openInFileBrowser}
-          >
-            {t("fileBrowser.openInFileBrowser")}
-          </button>
-        </div>
-      ) : null}
     </span>
   );
 }

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -75,7 +75,6 @@ interface WorkspaceImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 
   workspaceId: string;
   path: string;
   executionRootId?: string;
-  showOpenInBrowser?: boolean;
 }
 
 export function WorkspaceImage({
@@ -83,10 +82,8 @@ export function WorkspaceImage({
   path,
   executionRootId,
   alt,
-  showOpenInBrowser = true,
   ...props
 }: WorkspaceImageProps) {
-  void showOpenInBrowser;
   const fetchWorkspaceFileBlob = useRuntimeStore((s) => s.fetchWorkspaceFileBlob);
   const [objectUrl, setObjectUrl] = useState<string>();
   const [error, setError] = useState<string>();

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { memo, useEffect, useState, type ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useRuntimeStore } from "../runtime/runtime-store";
 
@@ -78,9 +79,17 @@ interface WorkspaceImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 
 }
 
 export function WorkspaceImage({ workspaceId, path, executionRootId, alt, ...props }: WorkspaceImageProps) {
+  const { t } = useTranslation();
   const fetchWorkspaceFileBlob = useRuntimeStore((s) => s.fetchWorkspaceFileBlob);
+  const selectedAgentId = useRuntimeStore((s) => s.selectedAgentId);
+  const showFileBrowser = useRuntimeStore((s) => s.showFileBrowser);
   const [objectUrl, setObjectUrl] = useState<string>();
   const [error, setError] = useState<string>();
+
+  const openInFileBrowser = () => {
+    if (!selectedAgentId) return;
+    showFileBrowser(selectedAgentId, workspaceId, undefined, executionRootId, path);
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -118,7 +127,16 @@ export function WorkspaceImage({ workspaceId, path, executionRootId, alt, ...pro
   if (!objectUrl) {
     return <span className="workspace-image-loading">Loading image…</span>;
   }
-  return <img {...props} src={objectUrl} alt={alt ?? path} />;
+  return (
+    <span className="workspace-image-frame">
+      <img {...props} src={objectUrl} alt={alt ?? path} />
+      {selectedAgentId ? (
+        <button type="button" className="workspace-image-open" onClick={openInFileBrowser}>
+          {t("fileBrowser.openInFileBrowser")}
+        </button>
+      ) : null}
+    </span>
+  );
 }
 
 function MarkdownContentView({ text, compact = false }: MarkdownContentProps) {

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -16,15 +16,25 @@ export interface WorkspaceImageRef {
 
 export function parseWorkspaceImageRef(src: string | undefined): WorkspaceImageRef | undefined {
   if (!src?.startsWith("workspace://")) return undefined;
+  const value = src.slice("workspace://".length);
+  const pathStart = value.indexOf("/");
+  if (pathStart <= 0) return undefined;
+
+  const workspaceId = value.slice(0, pathStart);
+  const rawPath = value.slice(pathStart + 1).split(/[?#]/, 1)[0];
+  if (!workspaceId || !rawPath) return undefined;
+
   try {
-    const url = new URL(src);
-    const workspaceId = url.hostname;
-    const path = url.pathname
+    const path = rawPath
       .split("/")
       .filter(Boolean)
-      .map((part) => decodeURIComponent(part))
+      .map((part) => {
+        const decoded = decodeURIComponent(part);
+        if (decoded === "..") throw new Error("workspace image path escapes workspace");
+        return decoded;
+      })
       .join("/");
-    if (!workspaceId || !path) return undefined;
+    if (!path) return undefined;
     return { workspaceId, path };
   } catch {
     return undefined;

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -15,7 +15,10 @@ import {
   User,
   Zap,
 } from "lucide-react";
-import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent, type ReactNode } from "react";
+import {
+  memo, useEffect, useLayoutEffect, useMemo, useRef, useState,
+  type DragEvent, type FormEvent, type KeyboardEvent, type ReactNode,
+} from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { MarkdownContent, parseWorkspaceImageRef, type WorkspaceImageRef } from "../../components/MarkdownContent";
@@ -144,6 +147,7 @@ export function AgentPage({
   const { t } = useTranslation();
   const [prompt, setPrompt] = useState(() => readStoredComposerDraft(agent.id));
   const [attachments, setAttachments] = useState<OperatorPromptAttachment[]>([]);
+  const [composerDragActive, setComposerDragActive] = useState(false);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [changingModel, setChangingModel] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
@@ -153,6 +157,7 @@ export function AgentPage({
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const dragCounterRef = useRef(0);
   const preserveScrollRef = useRef<{ height: number; top: number } | null>(null);
   const stickToBottomRef = useRef(true);
   const autoStickToBottomRef = useRef(false);
@@ -357,6 +362,43 @@ export function AgentPage({
     }
   }
 
+  function composerDragHasFiles(event: DragEvent<HTMLFormElement>): boolean {
+    const items = event.dataTransfer?.items;
+    return Boolean(items && Array.from(items).some((item) => item.kind === "file"));
+  }
+
+  function handleComposerDragEnter(event: DragEvent<HTMLFormElement>) {
+    if (sendingPrompt || !composerDragHasFiles(event)) return;
+    event.preventDefault();
+    dragCounterRef.current += 1;
+    setComposerDragActive(true);
+  }
+
+  function handleComposerDragOver(event: DragEvent<HTMLFormElement>) {
+    if (sendingPrompt || !composerDragHasFiles(event)) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "copy";
+    }
+  }
+
+  function handleComposerDragLeave(event: DragEvent<HTMLFormElement>) {
+    if (sendingPrompt || !composerDragHasFiles(event)) return;
+    event.preventDefault();
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+    if (dragCounterRef.current === 0) {
+      setComposerDragActive(false);
+    }
+  }
+
+  async function handleComposerDrop(event: DragEvent<HTMLFormElement>) {
+    if (sendingPrompt || !composerDragHasFiles(event)) return;
+    event.preventDefault();
+    dragCounterRef.current = 0;
+    setComposerDragActive(false);
+    await handleAttachmentFiles(event.dataTransfer?.files ?? null);
+  }
+
   function handleMessageListScroll() {
     const list = messageListRef.current;
     if (!list) return;
@@ -524,7 +566,20 @@ export function AgentPage({
             </div>
           ) : null}
 
-          <form className="composer" aria-label={t("agent.sendInputAria", { id: activeAgent.id })} onSubmit={handleSubmit}>
+          <form
+            className={composerDragActive ? "composer composer--drag" : "composer"}
+            aria-label={t("agent.sendInputAria", { id: activeAgent.id })}
+            onSubmit={handleSubmit}
+            onDragEnter={handleComposerDragEnter}
+            onDragOver={handleComposerDragOver}
+            onDragLeave={handleComposerDragLeave}
+            onDrop={handleComposerDrop}
+          >
+            {composerDragActive ? (
+              <div className="composer-drop-overlay" aria-hidden="true">
+                <span>{t("agent.dropImageHint")}</span>
+              </div>
+            ) : null}
             <textarea
               ref={composerTextareaRef}
               rows={2}

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -4,6 +4,7 @@ import {
   CircleAlert,
   Clock,
   Diamond,
+  ImageIcon,
   ChevronRight,
   Equal,
   LoaderCircle,
@@ -17,10 +18,11 @@ import {
 import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent, type ReactNode } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
-import { MarkdownContent } from "../../components/MarkdownContent";
+import { MarkdownContent, parseWorkspaceImageRef, type WorkspaceImageRef } from "../../components/MarkdownContent";
 import { Button } from "../../components/ui/Button";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { deriveAgentDisplayStatus } from "../../runtime/agent-status";
+import { useRuntimeStore } from "../../runtime/runtime-store";
 import { debugAgentSessionEvents, filterTimelineByDisplayLevel } from "../../runtime/session-reducer";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
@@ -970,6 +972,8 @@ const TimelineMessage = memo(function TimelineMessage({
 }) {
   const { t } = useTranslation();
   const isRuntimeItem = isRuntimeActivityItem(item);
+  const selectedAgentId = useRuntimeStore((s) => s.selectedAgentId);
+  const showFileBrowser = useRuntimeStore((s) => s.showFileBrowser);
   const activities =
     isRuntimeItem && item.meta === "activity"
       ? (item.activities ?? [])
@@ -997,7 +1001,15 @@ const TimelineMessage = memo(function TimelineMessage({
 
   const timelineMeta = formatTimelineMeta(item.meta, displayLevel);
   const inspectItem = () => onInspectActivity(timelineItemToWorkingActivity(item));
-
+  const workspaceImageRefs = useMemo(
+    () => extractWorkspaceImageRefs(item.body),
+    [item.body],
+  );
+  const openFirstImage = () => {
+    const first = workspaceImageRefs[0];
+    if (!first || !selectedAgentId) return;
+    showFileBrowser(selectedAgentId, first.workspaceId, undefined, undefined, first.path);
+  };
   return (
     <article
       className={`message ${item.kind}${compactAssistant ? " is-compact" : ""}${targetTimelineItemId === item.id ? " is-targeted" : ""}`}
@@ -1011,6 +1023,11 @@ const TimelineMessage = memo(function TimelineMessage({
         <button className="message-action" type="button" title={t("agent.copyMessage")} onClick={() => copyMessageText(item.body)}>
           ⧉
         </button>
+        {workspaceImageRefs.length > 0 ? (
+          <button className="message-action" type="button" title={t("fileBrowser.openInFileBrowser")} onClick={openFirstImage}>
+            <ImageIcon size={14} />
+          </button>
+        ) : null}
         <button className="message-action" type="button" title={t("agent.inspectMessage")} onClick={inspectItem}>
           ⓘ
         </button>
@@ -1037,7 +1054,16 @@ function copyMessageText(text: string): void {
   if (!navigator.clipboard) return;
   void navigator.clipboard.writeText(text);
 }
-
+function extractWorkspaceImageRefs(text: string): WorkspaceImageRef[] {
+  const refs: WorkspaceImageRef[] = [];
+  const re = /workspace:\/\/[^\s"')\]]+/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const ref = parseWorkspaceImageRef(match[0]);
+    if (ref) refs.push(ref);
+  }
+  return refs;
+}
 function TimelineItemContent({ item }: { item: AgentTimelineItem }) {
   return <MarkdownContent text={item.body} compact={false} />;
 }

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -68,6 +68,7 @@ const TOP_SCROLL_THRESHOLD = 16;
 const BOTTOM_SCROLL_THRESHOLD = 96;
 const COMPOSER_DRAFT_STORAGE_PREFIX = "holon.webGui.composerDraft.v1";
 const COMPOSER_TEXTAREA_MAX_HEIGHT = 320;
+const MESSAGE_LIST_BOTTOM_SAFE_SPACE = 96;
 
 export function storedComposerDraftKey(agentId: string): string {
   return `${COMPOSER_DRAFT_STORAGE_PREFIX}:${encodeURIComponent(agentId)}`;
@@ -178,6 +179,7 @@ export function AgentPage({
     count: timelineTurns.length,
     getScrollElement: () => messageListRef.current,
     estimateSize: () => 320,
+    paddingEnd: MESSAGE_LIST_BOTTOM_SAFE_SPACE,
     overscan: 4,
     getItemKey: (index) => timelineTurns[index]?.id ?? `empty:${index}`,
   });

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -307,6 +307,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
             workspaceId={workspaceRef.workspaceId}
             path={workspaceRef.path}
             alt={alt ?? workspaceRef.path}
+            showOpenInBrowser={false}
           />
         );
       }
@@ -322,6 +323,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
           path={relativePath}
           executionRootId={executionRootId}
           alt={alt ?? relativePath}
+          showOpenInBrowser={false}
         />
       );
     },
@@ -448,9 +450,10 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
             <WorkspaceImage
               className="file-browser-image"
               workspaceId={workspaceId}
-              path={selectedFile.path}
-              executionRootId={executionRootId}
-              alt={selectedFile.path}
+            path={selectedFile.path}
+            executionRootId={executionRootId}
+            alt={selectedFile.path}
+            showOpenInBrowser={false}
             />
           ) : selectedFile.content != null ? (
             <>

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -307,7 +307,6 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
             workspaceId={workspaceRef.workspaceId}
             path={workspaceRef.path}
             alt={alt ?? workspaceRef.path}
-            showOpenInBrowser={false}
           />
         );
       }
@@ -323,7 +322,6 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
           path={relativePath}
           executionRootId={executionRootId}
           alt={alt ?? relativePath}
-          showOpenInBrowser={false}
         />
       );
     },
@@ -450,10 +448,9 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
             <WorkspaceImage
               className="file-browser-image"
               workspaceId={workspaceId}
-            path={selectedFile.path}
-            executionRootId={executionRootId}
-            alt={selectedFile.path}
-            showOpenInBrowser={false}
+              path={selectedFile.path}
+              executionRootId={executionRootId}
+              alt={selectedFile.path}
             />
           ) : selectedFile.content != null ? (
             <>

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -186,7 +186,7 @@ export function RightSidePanel({
             <TaskDetailPanel task={activeView.task} detailState={taskDetailState} />
           </div>
         ) : activeView.kind === "file_browser" ? (
-          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} onClose={onNavigateBack} />
+          <FileBrowserPanel key={`${activeView.workspaceId}:${activeView.initialFilePath ?? ""}`} workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} onClose={onNavigateBack} />
         ) : (
           <AgentOverviewPanel
             agent={agent}

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -609,6 +609,7 @@ const en = {
     binaryFile: "Binary file ({{type}}).",
     binaryFileUnknown: "Binary file (unknown type).",
     download: "Download",
+    openInFileBrowser: "Open in file browser",
     markdownView: "Markdown view mode",
     pathBreadcrumb: "Path breadcrumb",
   },

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -707,6 +707,7 @@ const en = {
     // Composer
     sendInputAria: "Send operator input to {{id}}",
     sendInputPlaceholder: "Send operator input to {{id}}…",
+    dropImageHint: "Drop images to attach",
     // Thinking
     thinkingAria: "Thinking: {{level}}",
     thinkingLevelValue: "Thinking level: {{level}}",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -709,6 +709,7 @@ const zh: Record<string, any> = {
     // 输入框
     sendInputAria: "向 {{id}} 发送操作者消息",
     sendInputPlaceholder: "向 {{id}} 发送操作者消息…",
+    dropImageHint: "拖放图片以添加附件",
     // 思考级别
     thinkingAria: "思考：{{level}}",
     thinkingLevelValue: "思考级别：{{level}}",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -611,6 +611,7 @@ const zh: Record<string, any> = {
     binaryFile: "二进制文件（{{type}}）。",
     binaryFileUnknown: "二进制文件（未知类型）。",
     download: "下载",
+    openInFileBrowser: "在文件浏览器中打开",
     markdownView: "Markdown 查看模式",
     pathBreadcrumb: "路径面包屑导航",
   },

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1118,6 +1118,28 @@ code {
   height: auto;
 }
 
+.workspace-image-frame {
+  display: inline-flex;
+  max-width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.workspace-image-open {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.82em;
+  cursor: pointer;
+}
+
+.workspace-image-open:hover {
+  text-decoration: underline;
+}
+
 .markdown-content th,
 .markdown-content td {
   padding: 6px 8px;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1123,35 +1123,6 @@ code {
 .workspace-image-frame img {
   max-width: 100%;
   height: auto;
-  cursor: context-menu;
-}
-
-.workspace-image-context-menu {
-  position: fixed;
-  min-width: 180px;
-  padding: 4px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  z-index: 1000;
-}
-
-.workspace-image-context-menu-item {
-  width: 100%;
-  padding: 8px 12px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text);
-  font: inherit;
-  font-size: 13px;
-  text-align: left;
-  cursor: pointer;
-}
-
-.workspace-image-context-menu-item:hover {
-  background: var(--surface-soft);
 }
 .markdown-content th,
 .markdown-content td {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2289,6 +2289,7 @@ code {
 .composer {
   width: min(var(--conversation-content-max), calc(100% - 60px));
   margin: 0 auto 18px;
+  position: relative;
   border: 1px solid var(--line);
   border-radius: 16px;
   background: var(--surface);
@@ -2301,6 +2302,26 @@ code {
 .composer:focus-within {
   border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
   box-shadow: 0 18px 54px rgba(8, 126, 164, 0.12);
+}
+
+.composer--drag {
+  border-color: var(--accent);
+  box-shadow: 0 18px 54px rgba(8, 126, 164, 0.2);
+}
+
+.composer-drop-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .composer textarea {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1118,28 +1118,41 @@ code {
   height: auto;
 }
 
-.workspace-image-frame {
-  display: inline-flex;
+
+
+.workspace-image-frame img {
   max-width: 100%;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
+  height: auto;
+  cursor: context-menu;
 }
 
-.workspace-image-open {
-  padding: 0;
+.workspace-image-context-menu {
+  position: fixed;
+  min-width: 180px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+}
+
+.workspace-image-context-menu-item {
+  width: 100%;
+  padding: 8px 12px;
   border: 0;
+  border-radius: 6px;
   background: transparent;
-  color: var(--accent);
+  color: var(--text);
   font: inherit;
-  font-size: 0.82em;
+  font-size: 13px;
+  text-align: left;
   cursor: pointer;
 }
 
-.workspace-image-open:hover {
-  text-decoration: underline;
+.workspace-image-context-menu-item:hover {
+  background: var(--surface-soft);
 }
-
 .markdown-content th,
 .markdown-content td {
   padding: 6px 8px;


### PR DESCRIPTION
## Summary

Bundles a series of Web GUI improvements for workspace image handling and message interaction.

### Changes

- b77ca73e — Keep latest message above the composer (scroll position fix)
- 8c0c8970 — Render workspace image attachments in message markdown
- 0b0f60bf — Preserve workspace image markdown URLs during rendering
- b2c1b93e — Link workspace images to open in file browser
- 6d280abf — Move open in file browser to image context menu
- dfdbbc3c — Move open in file browser to message action bar icon
- 4e0c89cf — Support drag-and-drop image attachment in composer

### Verification

- typecheck passes
- MarkdownContent tests 5/5 pass
- make web build passes

Related: #2125