### PR TITLE
feat: add image generation support and config

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -683,6 +683,60 @@
       "stability": "stable"
     },
     {
+      "description": "Generate one image from a text prompt using a configured image-generation model.\n\nThe runtime saves the generated image under `agent_home/media/generated` and returns\na `workspace://...` URI plus metadata. Do not request multiple images in one call;\ncall this tool multiple times when distinct images are needed.\n\nInputs:\n- `prompt` (required): detailed image-generation prompt.\n- `size` (optional): one of `1024x1024`, `1536x1024`, or `1024x1536`.\n- `background` (optional): one of `auto`, `transparent`, or `opaque`.\n- `output_format` (optional): one of `png`, `jpeg`, or `webp`.\n- `name` (optional): filename stem used for the saved image.\n",
+      "family": "local_environment",
+      "freeform_grammar": null,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "background": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "output_format": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "size": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "name": "GenerateImage",
+      "related_surfaces": [],
+      "result_envelope": {
+        "canonical": "ToolResultEnvelope",
+        "error_result": "ToolError",
+        "model_rendering": "custom_text_receipt",
+        "success_result": "tool-specific JSON payload"
+      },
+      "stability": "stable"
+    },
+    {
       "description": "List recent work items with explicit current, open, completed, queued, yielded, blocked, waiting_for_operator, and runnable views. Use this before relying on memory briefs for work-item focus.\n",
       "family": "core_agent",
       "freeform_grammar": null,

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1643,6 +1643,9 @@
               "disable_provider_fallback": {
                 "type": "boolean"
               },
+              "image_generation_default": {
+                "type": "string"
+              },
               "max_tool_output_tokens": {
                 "format": "uint32",
                 "minimum": 0,
@@ -1813,6 +1816,7 @@
             "required": [
               "model_default",
               "model_fallbacks",
+              "image_generation_default",
               "model_catalog",
               "unknown_model_fallback_configured",
               "runtime_max_output_tokens",
@@ -1912,6 +1916,9 @@
               "disable_provider_fallback": {
                 "type": "boolean"
               },
+              "image_generation_default": {
+                "type": "string"
+              },
               "max_tool_output_tokens": {
                 "format": "uint32",
                 "minimum": 0,
@@ -2082,6 +2089,7 @@
             "required": [
               "model_default",
               "model_fallbacks",
+              "image_generation_default",
               "model_catalog",
               "unknown_model_fallback_configured",
               "runtime_max_output_tokens",

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -14,6 +14,8 @@ pub struct HolonConfigFile {
     pub runtime: RuntimeConfigFile,
     #[serde(default, skip_serializing_if = "VisionConfigFile::is_empty")]
     pub vision: VisionConfigFile,
+    #[serde(default, skip_serializing_if = "ImageGenerationConfigFile::is_empty")]
+    pub image_generation: ImageGenerationConfigFile,
     #[serde(default, skip_serializing_if = "TuiConfigFile::is_empty")]
     pub tui: TuiConfigFile,
     #[serde(default, skip_serializing_if = "WebConfigFile::is_empty")]
@@ -124,6 +126,12 @@ pub struct ModelsConfigFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct VisionConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ImageGenerationConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
 }
@@ -353,6 +361,12 @@ impl ModelsConfigFile {
 }
 
 impl VisionConfigFile {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.default.is_none()
+    }
+}
+
+impl ImageGenerationConfigFile {
     pub(crate) fn is_empty(&self) -> bool {
         self.default.is_none()
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,6 +65,7 @@ pub struct AppConfig {
     pub default_model: ModelRef,
     pub fallback_models: Vec<ModelRef>,
     pub vision_model: Option<ModelRef>,
+    pub image_generation_model: Option<ModelRef>,
     pub vision_candidate_models: Vec<ModelRef>,
     pub runtime_max_output_tokens: u32,
     pub default_tool_output_tokens: u32,
@@ -264,6 +265,7 @@ impl AppConfig {
         let explicit_default = resolve_default_model(&stored_config)?;
         let explicit_fallbacks = resolve_fallback_models(&stored_config)?;
         let explicit_vision_model = resolve_vision_model(&stored_config)?;
+        let explicit_image_generation_model = resolve_image_generation_model(&stored_config)?;
         let (default_model, fallback_models) = match resolve_model_selection_for_load_mode(
             explicit_default,
             explicit_fallbacks,
@@ -314,6 +316,7 @@ impl AppConfig {
             default_model,
             fallback_models,
             vision_model: explicit_vision_model,
+            image_generation_model: explicit_image_generation_model,
             vision_candidate_models,
             runtime_max_output_tokens,
             default_tool_output_tokens,

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -6,11 +6,32 @@ pub struct ModelRef {
     pub model: String,
 }
 
+pub(crate) fn resolve_image_generation_model(
+    stored_config: &HolonConfigFile,
+) -> Result<Option<ModelRef>> {
+    if let Ok(value) = env::var("HOLON_IMAGE_GENERATION_MODEL") {
+        return parse_image_generation_model_ref(&value);
+    }
+    if let Some(value) = &stored_config.image_generation.default {
+        return parse_image_generation_model_ref(value);
+    }
+    Ok(None)
+}
+
+fn parse_image_generation_model_ref(value: &str) -> Result<Option<ModelRef>> {
+    if value.trim().eq_ignore_ascii_case("auto") {
+        Ok(None)
+    } else {
+        ModelRef::parse(value).map(Some)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeModelCatalog {
     pub default_model: ModelRef,
     pub fallback_models: Vec<ModelRef>,
     pub vision_model: Option<ModelRef>,
+    pub image_generation_model: Option<ModelRef>,
     pub vision_candidate_models: Vec<ModelRef>,
     pub disable_provider_fallback: bool,
     pub provider_transports: HashMap<ProviderId, ProviderTransportKind>,
@@ -27,6 +48,7 @@ impl RuntimeModelCatalog {
             default_model: config.default_model.clone(),
             fallback_models: config.fallback_models.clone(),
             vision_model: config.vision_model.clone(),
+            image_generation_model: config.image_generation_model.clone(),
             vision_candidate_models: config.vision_candidate_models.clone(),
             disable_provider_fallback: config.provider_fallback_disabled(),
             provider_transports: config
@@ -319,7 +341,14 @@ impl RuntimeModelCatalog {
         model_override: Option<&ModelRef>,
         pending_fallback_model: Option<&ModelRef>,
     ) -> Option<ModelRef> {
-        for model_ref in self.provider_chain_for_turn(model_override, pending_fallback_model) {
+        let candidates = self
+            .image_generation_model
+            .clone()
+            .map(|model_ref| vec![model_ref])
+            .unwrap_or_else(|| {
+                self.provider_chain_for_turn(model_override, pending_fallback_model)
+            });
+        for model_ref in candidates {
             let policy = self.built_in_catalog.resolve_policy(
                 &model_ref,
                 &self.model_overrides,
@@ -346,6 +375,7 @@ impl Default for RuntimeModelCatalog {
             default_model: ModelRef::parse("openai/gpt-5.4").expect("valid default model ref"),
             fallback_models: Vec::new(),
             vision_model: None,
+            image_generation_model: None,
             vision_candidate_models: Vec::new(),
             disable_provider_fallback: false,
             provider_transports: HashMap::new(),
@@ -372,6 +402,9 @@ pub(crate) fn merged_model_capabilities(
         }
         if let Some(value) = override_config.image_input {
             capabilities.image_input = value;
+        }
+        if let Some(value) = override_config.image_generation {
+            capabilities.image_generation = value;
         }
         if let Some(value) = override_config.interactive_exec {
             capabilities.interactive_exec = value;

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -312,6 +312,32 @@ impl RuntimeModelCatalog {
                     && transport.supports_view_image_observation_generation()
             })
     }
+
+    pub fn select_generate_image_model(
+        &self,
+        base_context_config: &ContextConfig,
+        model_override: Option<&ModelRef>,
+        pending_fallback_model: Option<&ModelRef>,
+    ) -> Option<ModelRef> {
+        for model_ref in self.provider_chain_for_turn(model_override, pending_fallback_model) {
+            let policy = self.built_in_catalog.resolve_policy(
+                &model_ref,
+                &self.model_overrides,
+                &self.discovered_models,
+                self.unknown_model_fallback.as_ref(),
+                base_context_config,
+                self.configured_runtime_max_output_tokens,
+            );
+            let supported_transport = self
+                .provider_transports
+                .get(&model_ref.provider)
+                .is_some_and(|transport| transport.supports_image_generation());
+            if policy.capabilities.image_generation && supported_transport {
+                return Some(model_ref);
+            }
+        }
+        None
+    }
 }
 
 impl Default for RuntimeModelCatalog {

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -279,7 +279,10 @@ impl ProviderTransportKind {
     }
 
     pub fn supports_image_generation(self) -> bool {
-        matches!(self, Self::OpenAiResponses | Self::OpenAiChatCompletions)
+        matches!(
+            self,
+            Self::OpenAiCodexResponses | Self::OpenAiResponses | Self::OpenAiChatCompletions
+        )
     }
 }
 

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -277,6 +277,10 @@ impl ProviderTransportKind {
                 | Self::AnthropicMessages
         )
     }
+
+    pub fn supports_image_generation(self) -> bool {
+        matches!(self, Self::OpenAiResponses | Self::OpenAiChatCompletions)
+    }
 }
 
 impl ProviderId {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -78,6 +78,14 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
+            key: "image_generation.default",
+            kind: "model_ref_or_auto",
+            description:
+                "Provider/model ref for GenerateImage. The default auto mode selects the first configured turn model that supports image_generation.",
+            default: json!("auto"),
+            allowed_values: vec!["auto"],
+        },
+        ConfigSchemaEntry {
             key: "providers.<id>.transport",
             kind: "enum",
             description: "Model provider transport used for the provider account/profile.",
@@ -507,6 +515,12 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .as_ref()
             .map(|value| Value::String(value.clone()))
             .unwrap_or(Value::Null)),
+        "image_generation.default" => Ok(config
+            .image_generation
+            .default
+            .as_ref()
+            .map(|value| Value::String(value.clone()))
+            .unwrap_or_else(|| json!("auto"))),
         "models.catalog" => Ok(serde_json::to_value(&config.models.catalog)?),
         "model.unknown_fallback" => Ok(config
             .model
@@ -788,6 +802,14 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
             let parsed = ModelRef::parse(raw_value)?;
             config.vision.default = Some(parsed.as_string());
         }
+        "image_generation.default" => {
+            if raw_value.trim().eq_ignore_ascii_case("auto") {
+                config.image_generation.default = None;
+            } else {
+                let parsed = ModelRef::parse(raw_value)?;
+                config.image_generation.default = Some(parsed.as_string());
+            }
+        }
         "models.catalog" => {
             config.models.catalog = parse_model_catalog_value(raw_value)?;
         }
@@ -1052,6 +1074,7 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "model.default" => config.model.default = None,
         "model.fallbacks" => config.model.fallbacks.clear(),
         "vision.default" => config.vision.default = None,
+        "image_generation.default" => config.image_generation.default = None,
         "models.catalog" => config.models.catalog.clear(),
         "model.unknown_fallback" => config.model.unknown_fallback = None,
         "model.unknown_fallback.context_window_tokens" => {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -154,6 +154,7 @@ fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConf
             .map(|value| ModelRef::parse(value).unwrap())
             .collect(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
@@ -2378,6 +2379,83 @@ fn view_image_vision_selection_prefers_primary_over_other_candidates() {
     // Primary appears first in candidates
     assert_eq!(selection.candidates[0].provider, "openai");
     assert_eq!(selection.candidates[0].model, "gpt-5.4");
+}
+
+#[test]
+fn image_generation_config_defaults_to_auto() {
+    let mut config = HolonConfigFile::default();
+
+    assert_eq!(
+        get_config_key(&config, "image_generation.default").unwrap(),
+        json!("auto")
+    );
+
+    set_config_key(&mut config, "image_generation.default", "auto").unwrap();
+    assert!(config.image_generation.default.is_none());
+    assert!(config.image_generation.is_empty());
+}
+
+#[test]
+fn image_generation_config_accepts_explicit_model_ref() {
+    let mut config = HolonConfigFile::default();
+
+    set_config_key(
+        &mut config,
+        "image_generation.default",
+        "openai-codex/gpt-5.5",
+    )
+    .unwrap();
+
+    assert_eq!(
+        config.image_generation.default.as_deref(),
+        Some("openai-codex/gpt-5.5")
+    );
+    assert_eq!(
+        get_config_key(&config, "image_generation.default").unwrap(),
+        json!("openai-codex/gpt-5.5")
+    );
+
+    unset_config_key(&mut config, "image_generation.default").unwrap();
+    assert_eq!(
+        get_config_key(&config, "image_generation.default").unwrap(),
+        json!("auto")
+    );
+}
+
+#[test]
+fn generate_image_selection_auto_uses_turn_chain() {
+    let fixture = test_app_config("arcee/trinity-mini", &["openai/gpt-image-2"]);
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let selected = catalog
+        .select_generate_image_model(&ContextConfig::default(), None, None)
+        .unwrap();
+
+    assert_eq!(selected.as_string(), "openai/gpt-image-2");
+}
+
+#[test]
+fn generate_image_selection_uses_explicit_image_generation_model() {
+    let mut fixture = test_app_config("openai/gpt-image-2", &[]);
+    fixture.config.image_generation_model = Some(ModelRef::parse("openai-codex/gpt-5.5").unwrap());
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let selected = catalog
+        .select_generate_image_model(&ContextConfig::default(), None, None)
+        .unwrap();
+
+    assert_eq!(selected.as_string(), "openai-codex/gpt-5.5");
+}
+
+#[test]
+fn generate_image_selection_requires_explicit_model_capability() {
+    let mut fixture = test_app_config("openai/gpt-image-2", &[]);
+    fixture.config.image_generation_model = Some(ModelRef::parse("openai/gpt-5.4").unwrap());
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    assert!(catalog
+        .select_generate_image_model(&ContextConfig::default(), None, None)
+        .is_none());
 }
 
 #[test]

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -83,6 +83,7 @@ pub struct RuntimeConfigSurface {
     pub model_default: String,
     pub model_fallbacks: Vec<String>,
     pub vision_default: Option<String>,
+    pub image_generation_default: String,
     pub model_catalog: Vec<String>,
     pub unknown_model_fallback_configured: bool,
     pub runtime_max_output_tokens: u32,
@@ -144,6 +145,11 @@ impl RuntimeConfigSurface {
                 .map(|value| value.as_string())
                 .collect(),
             vision_default: config.vision_model.as_ref().map(|value| value.as_string()),
+            image_generation_default: config
+                .image_generation_model
+                .as_ref()
+                .map(|value| value.as_string())
+                .unwrap_or_else(|| "auto".to_string()),
             model_catalog,
             unknown_model_fallback_configured: config.validated_unknown_model_fallback.is_some(),
             runtime_max_output_tokens: config.runtime_max_output_tokens,

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -84,6 +84,7 @@ fn test_config() -> AppConfig {
         },
         fallback_models: vec![],
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,

--- a/src/host.rs
+++ b/src/host.rs
@@ -2374,6 +2374,7 @@ mod tests {
             default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
+            image_generation_model: None,
             vision_candidate_models: Vec::new(),
             runtime_max_output_tokens: 8192,
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1072,6 +1072,7 @@ mod tests {
             default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
+            image_generation_model: None,
             vision_candidate_models: Vec::new(),
             runtime_max_output_tokens: 8192,
             default_tool_output_tokens: 8_000,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -34,6 +34,8 @@ pub struct ModelCapabilityFlags {
     #[serde(default)]
     pub image_input: bool,
     #[serde(default)]
+    pub image_generation: bool,
+    #[serde(default)]
     pub supports_reasoning: bool,
     #[serde(default)]
     pub interactive_exec: bool,
@@ -46,6 +48,8 @@ pub struct ModelCapabilityOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_input: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_generation: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_reasoning: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interactive_exec: Option<bool>,
@@ -55,6 +59,7 @@ impl ModelCapabilityOverride {
     pub fn is_empty(&self) -> bool {
         self.parallel_tool_calls.is_none()
             && self.image_input.is_none()
+            && self.image_generation.is_none()
             && self.supports_reasoning.is_none()
             && self.interactive_exec.is_none()
     }
@@ -65,6 +70,9 @@ impl ModelCapabilityOverride {
         }
         if let Some(value) = self.image_input {
             base.image_input = value;
+        }
+        if let Some(value) = self.image_generation {
+            base.image_generation = value;
         }
         if let Some(value) = self.supports_reasoning {
             base.supports_reasoning = value;
@@ -634,6 +642,23 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 image_input: true,
                 interactive_exec: true,
                 supports_reasoning: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+        },
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(ProviderId::openai(), "gpt-image-1"),
+            display_name: "GPT Image 1".into(),
+            description: "OpenAI image generation model for the Images API.".into(),
+            context_window_tokens: None,
+            effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_generation: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -241,7 +241,7 @@ impl BuiltInModelCatalog {
             preferred_models
                 .entry(entry.model_ref.provider.clone())
                 .or_insert_with(|| entry.model_ref.clone());
-            entries.insert(entry.model_ref.clone(), entry);
+            entries.entry(entry.model_ref.clone()).or_insert(entry);
         }
         Self {
             entries,
@@ -583,6 +583,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
+                image_generation: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -602,6 +603,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
+                image_generation: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -621,6 +623,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
+                image_generation: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -640,6 +643,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
+                image_generation: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -647,8 +651,8 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             source: ModelMetadataSource::BuiltInCatalog,
         },
         BuiltInModelMetadata {
-            model_ref: ModelRef::new(ProviderId::openai(), "gpt-image-1"),
-            display_name: "GPT Image 1".into(),
+            model_ref: ModelRef::new(ProviderId::openai(), "gpt-image-2"),
+            display_name: "GPT Image 2".into(),
             description: "OpenAI image generation model for the Images API.".into(),
             context_window_tokens: None,
             effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -238,9 +238,11 @@ impl BuiltInModelCatalog {
         let mut entries = HashMap::new();
         let mut preferred_models = HashMap::new();
         for entry in built_in_entries() {
-            preferred_models
-                .entry(entry.model_ref.provider.clone())
-                .or_insert_with(|| entry.model_ref.clone());
+            if is_turn_default_candidate(&entry) {
+                preferred_models
+                    .entry(entry.model_ref.provider.clone())
+                    .or_insert_with(|| entry.model_ref.clone());
+            }
             entries.entry(entry.model_ref.clone()).or_insert(entry);
         }
         Self {
@@ -509,6 +511,14 @@ fn catalog_model(
         },
         source: ModelMetadataSource::BuiltInCatalog,
     }
+}
+
+fn is_turn_default_candidate(entry: &BuiltInModelMetadata) -> bool {
+    entry.context_window_tokens.is_some()
+        || entry.capabilities.parallel_tool_calls
+        || entry.capabilities.image_input
+        || entry.capabilities.supports_reasoning
+        || entry.capabilities.interactive_exec
 }
 
 fn mirror_catalog_models(

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1019,6 +1019,7 @@ mod tests {
             default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
+            image_generation_model: None,
             vision_candidate_models: Vec::new(),
             runtime_max_output_tokens: 8192,
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -480,6 +480,7 @@ mod tests {
             default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
             fallback_models: vec![ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()],
             vision_model: None,
+            image_generation_model: None,
             vision_candidate_models: Vec::new(),
             runtime_max_output_tokens: 8192,
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -68,6 +68,27 @@ pub struct ProviderTurnResponse {
     pub request_diagnostics: Option<ProviderRequestDiagnostics>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ProviderGenerateImageRequest {
+    pub prompt: String,
+    pub size: Option<String>,
+    pub background: Option<String>,
+    pub output_format: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderGeneratedImage {
+    pub bytes: Vec<u8>,
+    pub mime: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderGenerateImageResponse {
+    pub provider: String,
+    pub model: String,
+    pub images: Vec<ProviderGeneratedImage>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderPromptFrame {
     pub system_prompt: String,
@@ -398,6 +419,13 @@ pub struct ToolResultBlock {
 #[async_trait]
 pub trait AgentProvider: Send + Sync {
     async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse>;
+
+    async fn generate_image(
+        &self,
+        _request: ProviderGenerateImageRequest,
+    ) -> Result<ProviderGenerateImageResponse> {
+        Err(anyhow!("active provider does not support image generation"))
+    }
 
     fn prompt_capabilities(&self) -> Vec<ProviderPromptCapability> {
         vec![ProviderPromptCapability::FullRequestOnly]

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -297,6 +297,7 @@ pub fn test_config(
             .map(|value| ModelRef::parse(value).unwrap())
             .collect(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1120,6 +1120,96 @@ impl AgentProvider for OpenAiCodexProvider {
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
     }
 
+    async fn generate_image(
+        &self,
+        request: ProviderGenerateImageRequest,
+    ) -> Result<ProviderGenerateImageResponse> {
+        let model_ref = format!("{}/{}", self.provider_id, self.model);
+        let credential = self.resolve_fresh_credential().await.map_err(|error| {
+            openai_codex_auth_error(
+                "credential_resolution",
+                &model_ref,
+                vec![
+                    error.to_string(),
+                    "OpenAI Codex image generation uses Codex OAuth credentials through the Responses image_generation tool.".into(),
+                ],
+                "OpenAI Codex image generation authentication failed: no usable OAuth credentials are available.",
+            )
+        })?;
+        if let Some(expires_at) = credential.expires_at {
+            if expires_at <= Utc::now() + chrono::Duration::seconds(60) {
+                return Err(openai_codex_auth_error(
+                    "credential_expired",
+                    &model_ref,
+                    vec![
+                        format!(
+                            "OpenAI Codex OAuth access token is expired: credential source {} expired at {}",
+                            credential.source,
+                            expires_at.to_rfc3339()
+                        ),
+                        "Run Holon onboarding login for openai-codex to configure or refresh Holon-managed OAuth, or run `codex login` if intentionally using external CLI credentials.".into(),
+                    ],
+                    "OpenAI Codex image generation authentication failed: OAuth access token is expired.",
+                ));
+            }
+        }
+
+        let body = build_openai_codex_image_generation_request(&self.model, &request);
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        let mut credential = credential;
+        let mut headers = openai_codex_headers(&credential, &self.originator);
+        let images = match send_openai_codex_image_generation_request(
+            &self.client,
+            openai_codex_responses_url(&self.base_url),
+            body.clone(),
+            headers.clone(),
+            trace.as_ref(),
+            None,
+        )
+        .await
+        {
+            Ok(images) => images,
+            Err(error) => {
+                if is_openai_codex_auth_status_error(&error) {
+                    if let Some(refreshed) = self.refresh_after_auth_failure(&credential).await.map_err(|refresh_error| {
+                        openai_codex_auth_error(
+                            "credential_refresh_after_auth_failure",
+                            &model_ref,
+                            vec![
+                                error.to_string(),
+                                refresh_error.to_string(),
+                                "OpenAI Codex returned an auth error for image generation; Holon attempted to refresh the Holon-managed profile before retrying.".into(),
+                            ],
+                            "OpenAI Codex image generation authentication failed and Holon-managed OAuth refresh did not recover it.",
+                        )
+                    })? {
+                        credential = refreshed;
+                        headers = openai_codex_headers(&credential, &self.originator);
+                        send_openai_codex_image_generation_request(
+                            &self.client,
+                            openai_codex_responses_url(&self.base_url),
+                            body,
+                            headers,
+                            trace.as_ref(),
+                            None,
+                        )
+                        .await?
+                    } else {
+                        return Err(error);
+                    }
+                } else {
+                    return Err(error);
+                }
+            }
+        };
+
+        Ok(ProviderGenerateImageResponse {
+            provider: self.provider_id.clone(),
+            model: self.model.clone(),
+            images,
+        })
+    }
+
     #[cfg(test)]
     fn configured_model_refs(&self) -> Vec<String> {
         vec![format!("openai-codex/{}", self.model)]
@@ -1323,6 +1413,55 @@ fn build_openai_images_request(model: &str, request: &ProviderGenerateImageReque
         .filter(|value| !value.trim().is_empty())
     {
         body["output_format"] = Value::String(output_format.clone());
+    }
+    body
+}
+
+fn build_openai_codex_image_generation_request(
+    model: &str,
+    request: &ProviderGenerateImageRequest,
+) -> Value {
+    let mut body = json!({
+        "model": model,
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": request.prompt,
+                    }
+                ],
+            }
+        ],
+        "tools": [
+            {
+                "type": "image_generation",
+                "output_format": request
+                    .output_format
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or("png"),
+            }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "store": false,
+        "stream": true,
+    });
+    if let Some(size) = request
+        .size
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        body["tools"][0]["size"] = Value::String(size.clone());
+    }
+    if let Some(background) = request
+        .background
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        body["tools"][0]["background"] = Value::String(background.clone());
     }
     body
 }
@@ -4409,6 +4548,40 @@ fn parse_openai_images_response(value: Value) -> Result<Vec<ProviderGeneratedIma
     Ok(images)
 }
 
+fn parse_openai_codex_image_generation_response_items(
+    output_items: Vec<Value>,
+) -> Result<Vec<ProviderGeneratedImage>> {
+    let mut images = Vec::new();
+    for item in output_items {
+        if item.get("type").and_then(Value::as_str) != Some("image_generation_call") {
+            continue;
+        }
+        let b64 = item.get("result").and_then(Value::as_str).ok_or_else(|| {
+            invalid_response_error(
+                "OpenAI Codex image_generation_call item missing result",
+                "missing result",
+            )
+        })?;
+        let bytes = BASE64_STANDARD.decode(b64).map_err(|error| {
+            invalid_response_error(
+                "invalid OpenAI Codex image_generation base64 payload",
+                error,
+            )
+        })?;
+        images.push(ProviderGeneratedImage {
+            bytes,
+            mime: Some("image/png".into()),
+        });
+    }
+    if images.is_empty() {
+        return Err(invalid_response_error(
+            "OpenAI Codex image generation response contained no completed images",
+            "missing completed image_generation_call",
+        ));
+    }
+    Ok(images)
+}
+
 async fn send_openai_compact_request(
     client: &Client,
     url: String,
@@ -4580,6 +4753,20 @@ async fn send_openai_responses_streaming_request(
         read_openai_streaming_response(response, request_trace.as_ref()).await?;
     parse_openai_response_with_transport_state(terminal_response)
         .map(|parsed| parsed.with_provider_request_id(provider_request_id))
+}
+
+async fn send_openai_codex_image_generation_request(
+    client: &Client,
+    url: String,
+    body: Value,
+    headers: Vec<(&str, String)>,
+    trace: Option<&ProviderHttpTrace>,
+    agent_id: Option<&str>,
+) -> Result<Vec<ProviderGeneratedImage>> {
+    let terminal_response =
+        send_openai_responses_streaming_request(client, url, body, headers, trace, agent_id)
+            .await?;
+    parse_openai_codex_image_generation_response_items(terminal_response.output_items)
 }
 
 fn openai_codex_auth_error(
@@ -5167,10 +5354,12 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_openai_responses_request, chat_completions_url, choose_openai_codex_credential,
-        consume_openai_sse_event, incremental_diagnostics, latest_openai_compaction_index,
+        build_openai_codex_image_generation_request, build_openai_responses_request,
+        chat_completions_url, choose_openai_codex_credential, consume_openai_sse_event,
+        incremental_diagnostics, latest_openai_compaction_index,
         openai_compaction_trigger_for_request_plan, openai_compaction_trigger_for_window,
-        openai_provider_window_compaction_candidate, plan_openai_responses_request,
+        openai_provider_window_compaction_candidate,
+        parse_openai_codex_image_generation_response_items, plan_openai_responses_request,
         resolve_openai_codex_credential, CredentialStoreRefreshLock, OpenAiCodexProvider,
         OpenAiCompactionPolicy, OpenAiContinuationState, OpenAiProviderWindow, OpenAiRequestPlan,
         OpenAiRequestShape, OpenAiResponsesTransportContract, ToolSchemaContract,
@@ -5183,9 +5372,11 @@ mod tests {
     };
     use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
     use crate::provider::{
-        ConversationMessage, ProviderJsonSchemaResponseFormat, ProviderNativeWebSearchKind,
-        ProviderNativeWebSearchRequest, ProviderResponseFormatRequest, ProviderTurnRequest,
+        ConversationMessage, ProviderGenerateImageRequest, ProviderJsonSchemaResponseFormat,
+        ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest, ProviderResponseFormatRequest,
+        ProviderTurnRequest,
     };
+    use base64::prelude::BASE64_STANDARD;
     use base64::Engine;
     use chrono::Utc;
     use serde_json::json;
@@ -5730,6 +5921,74 @@ mod tests {
             .iter()
             .any(|tool| tool == &json!({ "type": "web_search" })));
         assert_eq!(body["stream"], json!(true));
+    }
+
+    #[test]
+    fn openai_codex_image_generation_request_uses_hosted_tool() {
+        let request = ProviderGenerateImageRequest {
+            prompt: "draw a small holon".into(),
+            size: Some("1024x1024".into()),
+            background: Some("transparent".into()),
+            output_format: Some("png".into()),
+        };
+
+        let body = build_openai_codex_image_generation_request("gpt-5.3-codex-spark", &request);
+
+        assert_eq!(body["model"], json!("gpt-5.3-codex-spark"));
+        assert_eq!(body["stream"], json!(true));
+        assert_eq!(body["store"], json!(false));
+        assert_eq!(
+            body["input"][0]["content"][0],
+            json!({
+                "type": "input_text",
+                "text": "draw a small holon",
+            })
+        );
+        assert_eq!(
+            body["tools"][0],
+            json!({
+                "type": "image_generation",
+                "output_format": "png",
+                "size": "1024x1024",
+                "background": "transparent",
+            })
+        );
+    }
+
+    #[test]
+    fn openai_codex_image_generation_response_parses_result_items() {
+        let images = parse_openai_codex_image_generation_response_items(vec![
+            json!({
+                "type": "message",
+                "content": [],
+            }),
+            json!({
+                "type": "image_generation_call",
+                "id": "ig_1",
+                "status": "completed",
+                "revised_prompt": "draw a tiny holon",
+                "result": BASE64_STANDARD.encode(b"fake_png"),
+            }),
+        ])
+        .expect("image_generation_call should parse");
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].bytes, b"fake_png");
+        assert_eq!(images[0].mime.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn openai_codex_image_generation_response_accepts_done_item_with_generating_status() {
+        let images = parse_openai_codex_image_generation_response_items(vec![json!({
+            "type": "image_generation_call",
+            "id": "ig_1",
+            "status": "generating",
+            "result": BASE64_STANDARD.encode(b"fake_png"),
+        })])
+        .expect("image_generation_call with a final result should parse");
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].bytes, b"fake_png");
     }
 
     #[test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use chrono::Utc;
 use reqwest::{header::HeaderMap, Client, RequestBuilder, Response};
 use serde_json::{json, Value};
@@ -27,7 +28,8 @@ use crate::{
         builtin_web_search_probe_turn_request, emitted_tool_json_schema,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
         AgentProvider, ConversationMessage, ModelBlock, ProviderBuiltinWebSearchCapability,
-        ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
+        ProviderCacheUsage, ProviderGenerateImageRequest, ProviderGenerateImageResponse,
+        ProviderGeneratedImage, ProviderIncrementalContinuationDiagnostics,
         ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
         ProviderNativeWebSearchRequest, ProviderOpenAiRemoteCompactionDiagnostics,
         ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
@@ -84,6 +86,7 @@ pub struct OpenAiCodexProvider {
 #[derive(Clone)]
 pub struct OpenAiChatCompletionsProvider {
     client: Client,
+    provider_id: String,
     base_url: String,
     api_key: Option<String>,
     model: String,
@@ -786,6 +789,7 @@ impl OpenAiChatCompletionsProvider {
         };
         Ok(Self {
             client,
+            provider_id: provider_config.id.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             api_key,
             model: model.to_string(),
@@ -872,6 +876,33 @@ impl AgentProvider for OpenAiProvider {
             .await;
         }
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
+    }
+
+    async fn generate_image(
+        &self,
+        request: ProviderGenerateImageRequest,
+    ) -> Result<ProviderGenerateImageResponse> {
+        let body = build_openai_images_request(&self.model, &request);
+        let headers = self
+            .api_key
+            .as_ref()
+            .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
+            .unwrap_or_default();
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        let images = send_openai_images_request(
+            &self.client,
+            openai_images_generations_url(&self.base_url),
+            body,
+            headers,
+            trace.as_ref(),
+            None,
+        )
+        .await?;
+        Ok(ProviderGenerateImageResponse {
+            provider: self.provider_id.clone(),
+            model: self.model.clone(),
+            images,
+        })
     }
 
     #[cfg(test)]
@@ -1203,6 +1234,33 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
     }
 
+    async fn generate_image(
+        &self,
+        request: ProviderGenerateImageRequest,
+    ) -> Result<ProviderGenerateImageResponse> {
+        let body = build_openai_images_request(&self.model, &request);
+        let headers = self
+            .api_key
+            .as_ref()
+            .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
+            .unwrap_or_default();
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        let images = send_openai_images_request(
+            &self.client,
+            openai_images_generations_url(&self.base_url),
+            body,
+            headers,
+            trace.as_ref(),
+            None,
+        )
+        .await?;
+        Ok(ProviderGenerateImageResponse {
+            provider: self.provider_id.clone(),
+            model: self.model.clone(),
+            images,
+        })
+    }
+
     #[cfg(test)]
     fn configured_model_refs(&self) -> Vec<String> {
         vec![format!("openai/{}", self.model)]
@@ -1225,6 +1283,48 @@ fn chat_completions_url(base_url: &str) -> String {
     } else {
         format!("{trimmed}/v1/chat/completions")
     }
+}
+
+fn openai_images_generations_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/images/generations") {
+        trimmed.to_string()
+    } else if has_trailing_version_segment(trimmed) {
+        format!("{trimmed}/images/generations")
+    } else {
+        format!("{trimmed}/v1/images/generations")
+    }
+}
+
+fn build_openai_images_request(model: &str, request: &ProviderGenerateImageRequest) -> Value {
+    let mut body = json!({
+        "model": model,
+        "prompt": request.prompt,
+        "n": 1,
+        "response_format": "b64_json",
+    });
+    if let Some(size) = request
+        .size
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        body["size"] = Value::String(size.clone());
+    }
+    if let Some(background) = request
+        .background
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        body["background"] = Value::String(background.clone());
+    }
+    if let Some(output_format) = request
+        .output_format
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        body["output_format"] = Value::String(output_format.clone());
+    }
+    body
 }
 
 fn has_trailing_version_segment(url: &str) -> bool {
@@ -4189,6 +4289,124 @@ async fn send_openai_responses_request(
         .map_err(|error| invalid_response_error("invalid OpenAI-style JSON", error))?;
     parse_openai_response_with_transport_state(parsed)
         .map(|parsed| parsed.with_provider_request_id(provider_request_id))
+}
+
+async fn send_openai_images_request(
+    client: &Client,
+    url: String,
+    body: Value,
+    headers: Vec<(&str, String)>,
+    trace: Option<&ProviderHttpTrace>,
+    agent_id: Option<&str>,
+) -> Result<Vec<ProviderGeneratedImage>> {
+    let model_ref = provider_model_ref("openai", &body);
+    let request_trace = trace.and_then(|trace| {
+        trace.begin_request(
+            agent_id,
+            "openai",
+            Some(&model_ref),
+            url.as_str(),
+            "images_generations",
+            &headers,
+            &body,
+        )
+    });
+    let mut request = client.post(&url).header("content-type", "application/json");
+    for (name, value) in headers {
+        request = request.header(name, value);
+    }
+    let response = send_openai_request(
+        request.json(&body),
+        "OpenAI Images request failed",
+        "request_send",
+        "openai",
+        Some(&model_ref),
+        Some(url.as_str()),
+        false,
+        request_trace.as_ref(),
+    )
+    .await?;
+    trace_response_headers(
+        request_trace.as_ref(),
+        response.status(),
+        response.headers(),
+    );
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+            Ok(Ok(text)) => text,
+            _ => String::new(),
+        };
+        trace_response_body(request_trace.as_ref(), &body);
+        return Err(classify_status_error_with_trace(
+            "OpenAI Images request failed",
+            "response_status",
+            Some("openai"),
+            Some(&model_ref),
+            Some(url.as_str()),
+            status,
+            body,
+            request_trace.as_ref(),
+        ));
+    }
+    let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+        Ok(Ok(text)) => text,
+        Ok(Err(error)) => {
+            return Err(classify_reqwest_transport_error_with_trace(
+                "OpenAI Images response body failed",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                error,
+                request_trace.as_ref(),
+            ));
+        }
+        Err(_elapsed) => {
+            return Err(timeout_transport_error_with_trace(
+                "OpenAI Images response body read timed out",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                format!("timed out after {:?}", response_body_timeout()),
+                request_trace.as_ref(),
+            ));
+        }
+    };
+    trace_response_body(request_trace.as_ref(), &body);
+    let parsed: Value = serde_json::from_str(&body)
+        .map_err(|error| invalid_response_error("invalid OpenAI Images JSON", error))?;
+    parse_openai_images_response(parsed)
+}
+
+fn parse_openai_images_response(value: Value) -> Result<Vec<ProviderGeneratedImage>> {
+    let data = value.get("data").and_then(Value::as_array).ok_or_else(|| {
+        invalid_response_error("OpenAI Images response missing data", "missing data")
+    })?;
+    let mut images = Vec::new();
+    for item in data {
+        let b64 = item
+            .get("b64_json")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                invalid_response_error(
+                    "OpenAI Images response item missing b64_json",
+                    "missing b64_json",
+                )
+            })?;
+        let bytes = BASE64_STANDARD.decode(b64).map_err(|error| {
+            invalid_response_error("invalid OpenAI Images base64 payload", error)
+        })?;
+        images.push(ProviderGeneratedImage { bytes, mime: None });
+    }
+    if images.is_empty() {
+        return Err(invalid_response_error(
+            "OpenAI Images response contained no images",
+            "empty data",
+        ));
+    }
+    Ok(images)
 }
 
 async fn send_openai_compact_request(

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -21,7 +21,8 @@ use crate::{
     },
     provider::{
         build_provider_from_model_chain, resolved_model_availability, AgentProvider,
-        ConversationMessage, ModelBlock, ProviderJsonSchemaResponseFormat,
+        ConversationMessage, ModelBlock, ProviderGenerateImageRequest,
+        ProviderGenerateImageResponse, ProviderJsonSchemaResponseFormat,
         ProviderResponseFormatRequest, ProviderTurnRequest,
     },
     queue::RuntimeQueue,
@@ -524,6 +525,27 @@ impl RuntimeHandle {
             ));
         }
         Ok(text)
+    }
+
+    pub(crate) async fn generate_image(
+        &self,
+        request: ProviderGenerateImageRequest,
+    ) -> Result<ProviderGenerateImageResponse> {
+        let state = self.agent_state().await?;
+        let snap = self.inner.config_snapshot.load();
+        let model_ref = snap
+            .model_catalog
+            .select_generate_image_model(
+                &snap.base_context_config,
+                state.model_override.as_ref(),
+                state.pending_fallback_model.as_ref(),
+            )
+            .ok_or_else(|| anyhow!("no configured model supports image_generation"))?;
+        let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
+            anyhow!("image generation requires host-managed provider configuration")
+        })?;
+        let provider = build_provider_from_model_chain(&reconfig.config, &[model_ref])?;
+        provider.generate_image(request).await
     }
 
     async fn model_config_with_fresh_discovery_cache(&self) -> Option<AppConfig> {

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -2,7 +2,10 @@ use super::*;
 
 use std::collections::BTreeMap;
 
-use crate::types::{OperatorMessageRecord, OperatorMessageStatus};
+use crate::types::{
+    BriefAttachment, GenerateImageResult, OperatorMessageRecord, OperatorMessageStatus,
+    ToolExecutionStatus,
+};
 
 const OPERATOR_MESSAGE_SCAN_MIN: usize = 256;
 const OPERATOR_MESSAGE_SCAN_HEADROOM: usize = 16;
@@ -88,6 +91,7 @@ impl RuntimeHandle {
                 bound_brief.turn_id = guard.state.current_turn_id.clone();
             }
         }
+        self.attach_generated_image_brief_attachments(&mut bound_brief)?;
         let event_payload = BriefCreatedAuditEvent::from_brief(&bound_brief);
         let evidence_brief = bound_brief.clone();
         self.persist_brief_evidence(&evidence_brief)?;
@@ -98,6 +102,53 @@ impl RuntimeHandle {
         let mut guard = self.inner.agent.lock().await;
         guard.state.last_brief_at = Some(bound_brief.created_at);
         guard.persist_state(&self.inner.storage)?;
+        Ok(())
+    }
+
+    fn attach_generated_image_brief_attachments(&self, brief: &mut BriefRecord) -> Result<()> {
+        let Some(turn_id) = brief.turn_id.as_deref() else {
+            return Ok(());
+        };
+        let existing = brief.attachments.get_or_insert_with(Vec::new);
+        let mut existing_uris = existing
+            .iter()
+            .filter_map(|attachment| attachment.uri.clone())
+            .collect::<std::collections::HashSet<_>>();
+        for record in self.inner.storage.read_recent_tool_executions(64)? {
+            if record.status != ToolExecutionStatus::Success
+                || record.turn_id.as_deref() != Some(turn_id)
+                || record.tool_name != crate::tool::names::GENERATE_IMAGE
+            {
+                continue;
+            }
+            let Some(value) = record.output.get("result").cloned() else {
+                continue;
+            };
+            let Ok(result) = serde_json::from_value::<GenerateImageResult>(value) else {
+                continue;
+            };
+            for image in result.images {
+                if existing_uris.contains(&image.uri) {
+                    continue;
+                }
+                let uri = image.uri.clone();
+                existing.push(BriefAttachment {
+                    kind: "image".to_string(),
+                    name: image
+                        .path
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or(image.id.as_str())
+                        .to_string(),
+                    uri: Some(uri.clone()),
+                    value: Some(to_json_value(&image)),
+                });
+                existing_uris.insert(uri);
+            }
+        }
+        if existing.is_empty() {
+            brief.attachments = None;
+        }
         Ok(())
     }
 }

--- a/src/tool/names.rs
+++ b/src/tool/names.rs
@@ -18,6 +18,7 @@ pub mod tool_names {
     pub const EXEC_COMMAND: &str = "ExecCommand";
     pub const EXEC_COMMAND_BATCH: &str = "ExecCommandBatch";
     pub const GET_WORK_ITEM: &str = "GetWorkItem";
+    pub const GENERATE_IMAGE: &str = "GenerateImage";
     pub const LIST_MODEL_PROVIDERS: &str = "ListModelProviders";
     pub const LIST_PROVIDER_MODELS: &str = "ListProviderModels";
     pub const LIST_TASKS: &str = "ListTasks";
@@ -55,6 +56,7 @@ pub const STABLE_TOOL_NAMES: &[&str] = &[
     EXEC_COMMAND,
     EXEC_COMMAND_BATCH,
     GET_WORK_ITEM,
+    GENERATE_IMAGE,
     LIST_MODEL_PROVIDERS,
     LIST_PROVIDER_MODELS,
     LIST_TASKS,
@@ -82,6 +84,7 @@ pub const CUSTOM_TEXT_RECEIPT_TOOLS: &[&str] = &[
     EXEC_COMMAND,
     EXEC_COMMAND_BATCH,
     TASK_OUTPUT,
+    GENERATE_IMAGE,
     VIEW_IMAGE,
 ];
 
@@ -106,6 +109,7 @@ pub const ALL_TOOL_NAMES: &[&str] = &[
     EXEC_COMMAND,
     EXEC_COMMAND_BATCH,
     GET_WORK_ITEM,
+    GENERATE_IMAGE,
     LIST_MODEL_PROVIDERS,
     LIST_PROVIDER_MODELS,
     LIST_TASKS,

--- a/src/tool/tool_descriptions/generate_image.md
+++ b/src/tool/tool_descriptions/generate_image.md
@@ -1,0 +1,12 @@
+Generate one image from a text prompt using a configured image-generation model.
+
+The runtime saves the generated image under `agent_home/media/generated` and returns
+a `workspace://...` URI plus metadata. Do not request multiple images in one call;
+call this tool multiple times when distinct images are needed.
+
+Inputs:
+- `prompt` (required): detailed image-generation prompt.
+- `size` (optional): one of `1024x1024`, `1536x1024`, or `1024x1536`.
+- `background` (optional): one of `auto`, `transparent`, or `opaque`.
+- `output_format` (optional): one of `png`, `jpeg`, or `webp`.
+- `name` (optional): filename stem used for the saved image.

--- a/src/tool/tools/generate_image.rs
+++ b/src/tool/tools/generate_image.rs
@@ -1,0 +1,284 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    provider::ProviderGenerateImageRequest,
+    runtime::RuntimeHandle,
+    tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError, ToolResult},
+    types::{
+        agent_home_workspace_id, AuthorityClass, GenerateImageParameters, GenerateImageResult,
+        GenerateImageSize, GeneratedImageReference, ToolCapabilityFamily,
+    },
+};
+
+use super::{serialize_success, view_image::read_visual_reference, BuiltinToolDefinition};
+use crate::tool::helpers::{parse_tool_args, validate_non_empty};
+
+pub(crate) const NAME: &str = crate::tool::names::GENERATE_IMAGE;
+
+const VALID_SIZES: &[&str] = &["1024x1024", "1536x1024", "1024x1536"];
+const VALID_BACKGROUNDS: &[&str] = &["auto", "transparent", "opaque"];
+const VALID_OUTPUT_FORMATS: &[&str] = &["png", "jpeg", "webp"];
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GenerateImageArgs {
+    pub(crate) prompt: String,
+    #[serde(default)]
+    pub(crate) size: Option<String>,
+    #[serde(default)]
+    pub(crate) background: Option<String>,
+    #[serde(default)]
+    pub(crate) output_format: Option<String>,
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::LocalEnvironment,
+        spec: typed_spec::<GenerateImageArgs>(
+            NAME,
+            include_str!("../tool_descriptions/generate_image.md"),
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    agent_id: &str,
+    _authority_class: &AuthorityClass,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: GenerateImageArgs = parse_tool_args(NAME, input)?;
+    let prompt = validate_non_empty(args.prompt, NAME, "prompt")?;
+    let size = optional_enum(args.size, "size", VALID_SIZES)?;
+    let background = optional_enum(args.background, "background", VALID_BACKGROUNDS)?;
+    let output_format = optional_enum(args.output_format, "output_format", VALID_OUTPUT_FORMATS)?;
+    let name = args
+        .name
+        .map(|value| validate_filename_stem(&value))
+        .transpose()?;
+
+    let provider_result = runtime
+        .generate_image(ProviderGenerateImageRequest {
+            prompt: prompt.clone(),
+            size: size.clone(),
+            background: background.clone(),
+            output_format: output_format.clone(),
+        })
+        .await
+        .map_err(generate_image_failed)?;
+
+    let generated_dir = runtime.agent_home().join("media").join("generated");
+    fs::create_dir_all(&generated_dir).map_err(|error| {
+        ToolError::new(
+            "generated_media_write_failed",
+            format!("failed to create generated media directory: {error}"),
+        )
+        .with_details(json!({
+            "path": generated_dir,
+            "io_error": error.to_string(),
+        }))
+        .with_recovery_hint("ensure the agent_home media directory is writable")
+    })?;
+
+    let workspace_id = agent_home_workspace_id(agent_id);
+    let mut images = Vec::new();
+    for (index, image) in provider_result.images.into_iter().enumerate() {
+        let sha256 = format!("{:x}", Sha256::digest(&image.bytes));
+        let extension =
+            extension_for_mime_or_format(image.mime.as_deref(), output_format.as_deref());
+        let stem = name
+            .clone()
+            .unwrap_or_else(|| format!("generated_{}", Utc::now().format("%Y%m%dT%H%M%S%.3fZ")));
+        let filename = if index == 0 {
+            format!("{stem}.{extension}")
+        } else {
+            format!("{stem}-{}.{}", index + 1, extension)
+        };
+        let path = generated_dir.join(filename);
+        fs::write(&path, &image.bytes).map_err(|error| {
+            ToolError::new(
+                "generated_media_write_failed",
+                format!("failed to write generated image: {error}"),
+            )
+            .with_details(json!({
+                "path": path,
+                "io_error": error.to_string(),
+            }))
+            .with_recovery_hint("ensure the agent_home media directory is writable")
+        })?;
+
+        let read_image = read_visual_reference(&path).map_err(|error| {
+            ToolError::new(
+                "generated_image_invalid",
+                format!("provider returned image bytes that could not be validated: {error}"),
+            )
+            .with_details(json!({
+                "path": path,
+                "sha256": sha256,
+                "error": error.to_string(),
+            }))
+            .with_recovery_hint("retry generation or choose a different image-generation model")
+        })?;
+        let reference = read_image.visual_reference;
+        let relative_path = PathBuf::from("media").join("generated").join(
+            path.file_name()
+                .ok_or_else(|| anyhow!("generated image path has no filename"))?,
+        );
+        let uri = format!(
+            "workspace://{}/{}",
+            workspace_id,
+            relative_path.to_string_lossy()
+        );
+        images.push(GeneratedImageReference {
+            kind: "generated_image".to_string(),
+            id: format!("img_{}", &reference.sha256[..16]),
+            workspace_id: workspace_id.clone(),
+            path: relative_path,
+            uri,
+            sha256: reference.sha256,
+            mime: reference.mime,
+            byte_count: reference.byte_count,
+            size: GenerateImageSize {
+                width: reference.size.width,
+                height: reference.size.height,
+            },
+            created_at: reference.created_at,
+        });
+    }
+
+    serialize_success(
+        NAME,
+        &GenerateImageResult {
+            images,
+            provider: provider_result.provider,
+            model: provider_result.model,
+            prompt,
+            parameters: GenerateImageParameters {
+                size,
+                background,
+                output_format,
+                name,
+            },
+            summary_text: Some("GenerateImage created one image".to_string()),
+        },
+    )
+}
+
+pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
+    let value = result
+        .envelope
+        .result
+        .as_ref()
+        .ok_or_else(|| anyhow!("GenerateImage success result missing payload"))?;
+    let result: GenerateImageResult = serde_json::from_value(value.clone())?;
+    let mut lines = vec![
+        "GenerateImage result".to_string(),
+        format!("Provider/model: {}/{}", result.provider, result.model),
+        format!("Prompt: {}", result.prompt),
+    ];
+    for image in result.images {
+        lines.push(format!(
+            "Image: {} ({}, {} bytes, sha256 {}, uri {})",
+            image.id, image.mime, image.byte_count, image.sha256, image.uri
+        ));
+        lines.push(format!(
+            "Size: {}",
+            match (image.size.width, image.size.height) {
+                (Some(width), Some(height)) => format!("{width}x{height}"),
+                (Some(width), None) => format!("{width}xunknown"),
+                (None, Some(height)) => format!("unknownx{height}"),
+                (None, None) => "unknown".to_string(),
+            }
+        ));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn optional_enum(value: Option<String>, field: &str, allowed: &[&str]) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = validate_non_empty(value, NAME, field)?;
+    if allowed.contains(&value.as_str()) {
+        return Ok(Some(value));
+    }
+    Err(invalid_tool_input(
+        NAME,
+        format!("GenerateImage `{field}` is not supported"),
+        json!({
+            "field": field,
+            "value": value,
+            "allowed_values": allowed,
+        }),
+        "use one of the supported values from the tool schema",
+    ))
+}
+
+fn validate_filename_stem(value: &str) -> Result<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(invalid_tool_input(
+            NAME,
+            "GenerateImage `name` must be non-empty when provided",
+            json!({"field": "name"}),
+            "omit `name` or provide a simple filename stem",
+        ));
+    }
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let sanitized = sanitized.trim_matches('_').to_string();
+    if sanitized.is_empty() {
+        return Err(invalid_tool_input(
+            NAME,
+            "GenerateImage `name` must contain letters, numbers, '-' or '_'",
+            json!({"field": "name", "value": value}),
+            "provide a simple filename stem such as `logo_sketch`",
+        ));
+    }
+    Ok(sanitized)
+}
+
+fn extension_for_mime_or_format(mime: Option<&str>, output_format: Option<&str>) -> &'static str {
+    match mime {
+        Some("image/png") => "png",
+        Some("image/jpeg") => "jpg",
+        Some("image/webp") => "webp",
+        Some("image/gif") => "gif",
+        _ => match output_format {
+            Some("jpeg") => "jpg",
+            Some("webp") => "webp",
+            _ => "png",
+        },
+    }
+}
+
+fn generate_image_failed(error: anyhow::Error) -> anyhow::Error {
+    ToolError::new(
+        "image_generation_failed",
+        format!("GenerateImage could not create an image: {error}"),
+    )
+    .with_details(json!({
+        "error": error.to_string(),
+    }))
+    .with_recovery_hint(
+        "configure an OpenAI image-generation model with valid credentials, or retry after provider failures are resolved",
+    )
+    .into()
+}

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod create_work_item;
 pub(crate) mod enqueue;
 pub(crate) mod exec_command;
 pub(crate) mod exec_command_batch;
+pub(crate) mod generate_image;
 pub(crate) mod get_work_item;
 pub(crate) mod list_model_providers;
 pub(crate) mod list_provider_models;
@@ -63,6 +64,7 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         create_work_item::definition()?,
         pick_work_item::definition()?,
         get_work_item::definition()?,
+        generate_image::definition()?,
         list_work_items::definition()?,
         update_work_item::definition()?,
         complete_work_item::definition()?,
@@ -142,6 +144,9 @@ pub(crate) async fn execute_builtin_tool(
         get_work_item::NAME => {
             get_work_item::execute(runtime, agent_id, authority_class, &call.input).await
         }
+        generate_image::NAME => {
+            generate_image::execute(runtime, agent_id, authority_class, &call.input).await
+        }
         list_work_items::NAME => {
             list_work_items::execute(runtime, agent_id, authority_class, &call.input).await
         }
@@ -201,6 +206,7 @@ pub(crate) fn render_tool_result_for_model(result: &ToolResult) -> Result<String
         exec_command::NAME => exec_command::render_for_model(result),
         exec_command_batch::NAME => exec_command_batch::render_for_model(result),
         task_output::NAME => task_output::render_for_model(result),
+        generate_image::NAME => generate_image::render_for_model(result),
         view_image::NAME => view_image::render_for_model(result),
         _ => canonical_json_render(result),
     }

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -250,6 +250,7 @@ mod tests {
             "Enqueue" => "src/tool/tool_descriptions/enqueue.md",
             "ExecCommand" => "src/tool/tool_descriptions/exec_command.md",
             "ExecCommandBatch" => "src/tool/tool_descriptions/exec_command_batch.md",
+            "GenerateImage" => "src/tool/tool_descriptions/generate_image.md",
             "GetWorkItem" => "src/tool/tool_descriptions/get_work_item.md",
             "ListModelProviders" => "src/tool/tool_descriptions/list_model_providers.md",
             "ListProviderModels" => "src/tool/tool_descriptions/list_provider_models.md",

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -3062,6 +3062,7 @@ mod tests {
             model_default: "anthropic/claude-sonnet-4-6".into(),
             model_fallbacks: Vec::new(),
             vision_default: None,
+            image_generation_default: "auto".into(),
             model_catalog: Vec::new(),
             unknown_model_fallback_configured: false,
             runtime_max_output_tokens: 8192,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -70,6 +70,7 @@ fn test_config() -> AppConfig {
         default_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3340,6 +3340,52 @@ pub struct ViewImageResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct GenerateImageSize {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct GeneratedImageReference {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub id: String,
+    pub workspace_id: String,
+    pub path: PathBuf,
+    pub uri: String,
+    pub sha256: String,
+    pub mime: String,
+    pub byte_count: u64,
+    pub size: GenerateImageSize,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct GenerateImageParameters {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct GenerateImageResult {
+    pub images: Vec<GeneratedImageReference>,
+    pub provider: String,
+    pub model: String,
+    pub prompt: String,
+    pub parameters: GenerateImageParameters,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ViewImageVisionCandidate {
     pub provider: String,
     pub model: String,

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -4,8 +4,8 @@ use holon::{
     prompt::PromptStability,
     provider::{
         AgentProvider, ConversationMessage, ModelBlock, OpenAiCodexProvider, PromptContentBlock,
-        ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
-        ProviderTurnRequest,
+        ProviderGenerateImageRequest, ProviderNativeWebSearchRequest, ProviderPromptCache,
+        ProviderPromptFrame, ProviderTurnRequest,
     },
     tool::ToolSpec,
 };
@@ -17,6 +17,11 @@ fn live_config() -> Result<AppConfig> {
 
 fn live_openai_codex_model() -> String {
     std::env::var("HOLON_LIVE_OPENAI_CODEX_MODEL").unwrap_or_else(|_| "gpt-5.3-codex-spark".into())
+}
+
+fn live_openai_codex_image_model() -> String {
+    std::env::var("HOLON_LIVE_OPENAI_CODEX_IMAGE_MODEL")
+        .unwrap_or_else(|_| live_openai_codex_model())
 }
 
 fn probe_tool_spec() -> ToolSpec {
@@ -221,5 +226,30 @@ async fn live_openai_codex_provider_returns_tool_call_for_real_schema() -> Resul
     });
     let tool_use = tool_use.expect("expected ProbeAction tool call from real codex response");
     assert_eq!(tool_use["reason"], json!("live codex tool probe"));
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires real Codex auth state, network access, and Codex image generation support"]
+async fn live_openai_codex_generates_image_with_responses_tool() -> Result<()> {
+    let config = live_config()?;
+    let provider = OpenAiCodexProvider::from_config(&config, &live_openai_codex_image_model())?;
+    let output = provider
+        .generate_image(ProviderGenerateImageRequest {
+            prompt: "Create a simple flat icon of a blue circle on a white background.".into(),
+            size: Some("1024x1024".into()),
+            background: Some("opaque".into()),
+            output_format: Some("png".into()),
+        })
+        .await?;
+
+    assert_eq!(output.provider.as_str(), "openai-codex");
+    assert_eq!(output.model, live_openai_codex_image_model());
+    assert_eq!(output.images.len(), 1);
+    assert_eq!(output.images[0].mime.as_deref(), Some("image/png"));
+    assert!(
+        !output.images[0].bytes.is_empty(),
+        "expected non-empty generated image bytes"
+    );
     Ok(())
 }

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -41,6 +41,7 @@ fn test_config() -> AppConfig {
         default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: 8_000,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -163,6 +163,7 @@ impl TestConfigBuilder {
             default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
+            image_generation_model: None,
             vision_candidate_models: Vec::new(),
             runtime_max_output_tokens: 8192,
             default_tool_output_tokens: 8_000,

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -43,6 +43,7 @@ fn test_config() -> AppConfig {
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: 8_000,

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -42,6 +42,7 @@ fn test_config() -> AppConfig {
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: 8_000,

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -41,6 +41,7 @@ fn test_config() -> AppConfig {
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: 8_000,

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -42,6 +42,7 @@ fn test_config() -> AppConfig {
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: 8_000,

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -42,6 +42,7 @@ fn test_config() -> AppConfig {
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
+        image_generation_model: None,
         vision_candidate_models: Vec::new(),
         runtime_max_output_tokens: 8192,
         default_tool_output_tokens: 8_000,


### PR DESCRIPTION
## Summary
- add the image generation tool path, including OpenAI Responses image generation support
- add independent `image_generation.default` config with `auto` as the default behavior
- prefer an explicit configured image generation model before falling back to the turn model chain
- expose image generation config in runtime config summaries and selection diagnostics

## Verification
- `cargo test image_generation_config --lib`
- `cargo test generate_image_selection --lib`
- `cargo test openai_codex_image_generation --lib`
- `HOLON_PROVIDER_HTTP_TRACE=1 HOLON_LIVE_OPENAI_CODEX_IMAGE_MODEL=gpt-5.5 cargo test --test live_codex live_openai_codex_generates_image_with_responses_tool -- --ignored --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
