### PR TITLE
feat: add Volcengine Seedream image provider

### DIFF
--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -618,6 +618,18 @@ pub(crate) fn built_in_provider_registry_with_settings(
     )?;
     insert_openai_compatible_provider(
         &mut registry,
+        "volcengine-image-openai",
+        "https://ark.cn-beijing.volces.com/api/plan/v3",
+        &[
+            "VOLCENGINE_IMAGE_OPENAI_API_KEY",
+            "VOLCENGINE_AGENT_API_KEY",
+            "VOLCENGINE_API_KEY",
+            "ARK_API_KEY",
+        ],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
         "xiaomi",
         "https://api.xiaomimimo.com/v1",
         &["XIAOMI_API_KEY"],

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1723,6 +1723,7 @@ fn config_inspection_loads_provider_state_without_resolved_model() {
             "TOGETHER_API_KEY",
             "VENICE_API_KEY",
             "VOLCENGINE_API_KEY",
+            "VOLCENGINE_IMAGE_OPENAI_API_KEY",
             "VOLCENGINE_AGENT_API_KEY",
             "VOLCENGINE_CODING_API_KEY",
             "ARK_API_KEY",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1267,6 +1267,14 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         "HOLON_GEMINI_BASE_URL".to_string(),
         "https://gemini.example/v1beta".to_string(),
     );
+    settings_env.insert(
+        "VOLCENGINE_IMAGE_OPENAI_API_KEY".to_string(),
+        "volcengine-image-key".to_string(),
+    );
+    settings_env.insert(
+        "HOLON_VOLCENGINE_IMAGE_OPENAI_BASE_URL".to_string(),
+        "https://ark.example/api/v3".to_string(),
+    );
 
     let providers = super::built_in_provider_registry_with_settings(&settings_env).unwrap();
 
@@ -1348,6 +1356,44 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
     assert_eq!(
         dashscope_coding_plan.credential.as_deref(),
         Some("dashscope-coding-plan-key")
+    );
+
+    let volcengine_image_openai = providers
+        .get(&ProviderId::parse("volcengine-image-openai").unwrap())
+        .unwrap();
+    assert_eq!(
+        volcengine_image_openai.transport,
+        ProviderTransportKind::OpenAiChatCompletions
+    );
+    assert_eq!(
+        volcengine_image_openai.base_url,
+        "https://ark.example/api/v3"
+    );
+    assert_eq!(
+        volcengine_image_openai.auth.env.as_deref(),
+        Some("VOLCENGINE_IMAGE_OPENAI_API_KEY")
+    );
+    assert_eq!(
+        volcengine_image_openai.credential.as_deref(),
+        Some("volcengine-image-key")
+    );
+    let mut volcengine_agent_only_env = HashMap::new();
+    volcengine_agent_only_env.insert(
+        "VOLCENGINE_AGENT_API_KEY".to_string(),
+        "volcengine-agent-key".to_string(),
+    );
+    let volcengine_agent_only_providers =
+        super::built_in_provider_registry_with_settings(&volcengine_agent_only_env).unwrap();
+    let volcengine_image_openai = volcengine_agent_only_providers
+        .get(&ProviderId::parse("volcengine-image-openai").unwrap())
+        .unwrap();
+    assert_eq!(
+        volcengine_image_openai.auth.env.as_deref(),
+        Some("VOLCENGINE_AGENT_API_KEY")
+    );
+    assert_eq!(
+        volcengine_image_openai.credential.as_deref(),
+        Some("volcengine-agent-key")
     );
 
     let nearai = providers
@@ -1677,6 +1723,7 @@ fn config_inspection_loads_provider_state_without_resolved_model() {
             "TOGETHER_API_KEY",
             "VENICE_API_KEY",
             "VOLCENGINE_API_KEY",
+            "VOLCENGINE_AGENT_API_KEY",
             "VOLCENGINE_CODING_API_KEY",
             "ARK_API_KEY",
             "XIAOMI_API_KEY",
@@ -2456,6 +2503,39 @@ fn generate_image_selection_requires_explicit_model_capability() {
     assert!(catalog
         .select_generate_image_model(&ContextConfig::default(), None, None)
         .is_none());
+}
+
+#[test]
+fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
+    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
+    fixture.config.image_generation_model =
+        Some(ModelRef::parse("volcengine-image-openai/doubao-seedream-5.0-lite").unwrap());
+    fixture.config.providers.insert(
+        ProviderId::parse("volcengine-image-openai").unwrap(),
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("volcengine-image-openai").unwrap(),
+            transport: ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://ark.cn-beijing.volces.com/api/plan/v3".into(),
+            auth: ProviderAuthConfig::default(),
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        },
+    );
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let selected = catalog
+        .select_generate_image_model(&ContextConfig::default(), None, None)
+        .unwrap();
+
+    assert_eq!(
+        selected.as_string(),
+        "volcengine-image-openai/doubao-seedream-5.0-lite"
+    );
 }
 
 #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2335,6 +2335,28 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             false,
         ),
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(
+                provider_id("volcengine-image-openai"),
+                "doubao-seedream-5.0-lite",
+            ),
+            display_name: "Doubao Seedream 5.0 Lite".into(),
+            description: "Volcengine Ark Seedream image generation model for the OpenAI Images-compatible API.".into(),
+            context_window_tokens: None,
+            effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(
+                DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+            ),
+            capabilities: ModelCapabilityFlags {
+                image_generation: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+        },
         catalog_model(
             "xiaomi",
             "mimo-v2.5-pro",

--- a/tests/live_volcengine_image.rs
+++ b/tests/live_volcengine_image.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use holon::{
+    config::{AppConfig, ProviderId},
+    provider::{AgentProvider, OpenAiChatCompletionsProvider, ProviderGenerateImageRequest},
+};
+
+fn live_volcengine_image_model() -> String {
+    std::env::var("HOLON_LIVE_VOLCENGINE_IMAGE_MODEL")
+        .unwrap_or_else(|_| "doubao-seedream-5.0-lite".into())
+}
+
+#[tokio::test]
+#[ignore = "requires a Volcengine Ark image generation credential profile and network access"]
+async fn live_volcengine_ark_seedream_generates_image_with_openai_images_api() -> Result<()> {
+    let config = AppConfig::load()?;
+    let provider_id = ProviderId::parse("volcengine-image-openai")?;
+    let provider_config = config
+        .providers
+        .get(&provider_id)
+        .ok_or_else(|| anyhow::anyhow!("missing volcengine-image-openai provider config"))?;
+    let model = live_volcengine_image_model();
+    let provider = OpenAiChatCompletionsProvider::from_runtime_config(
+        provider_config,
+        &model,
+        config.runtime_max_output_tokens,
+        &config.home_dir,
+    )?;
+    let output = provider
+        .generate_image(ProviderGenerateImageRequest {
+            prompt: "Create a simple flat icon of a red kite on a white background.".into(),
+            size: Some("1920x1920".into()),
+            background: None,
+            output_format: None,
+        })
+        .await?;
+
+    assert_eq!(output.provider.as_str(), "volcengine-image-openai");
+    assert_eq!(output.model, model);
+    assert_eq!(output.images.len(), 1);
+    assert!(
+        !output.images[0].bytes.is_empty(),
+        "expected non-empty generated image bytes"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add the built-in `volcengine-image-openai` OpenAI-compatible image provider
- add built-in metadata for `doubao-seedream-5.0-lite` with `image_generation` capability
- add config selection coverage and an ignored live test for Ark Seedream image generation

## Notes

The provider defaults to the Volcengine Ark plan OpenAI Images endpoint prefix:

`https://ark.cn-beijing.volces.com/api/plan/v3`

The OpenAI transport then derives `/images/generations` from that versioned base URL.

## Verification

- `cargo test built_in_provider_registry_includes_compatible_provider_defaults --lib`
- `cargo test generate_image_selection_accepts_volcengine_image_openai_seedream --lib`
- `cargo test --test live_volcengine_image live_volcengine_ark_seedream_generates_image_with_openai_images_api -- --ignored --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
