### PR TITLE
fix: make default callback trigger updates atomic

### DIFF
--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -42,60 +42,39 @@ impl RuntimeHandle {
         let delivery_mode = CallbackDeliveryMode::WakeHint;
         let agent_id = self.agent_id().await?;
         let now = Utc::now();
-        if let Some(descriptor) = self
+        let external_trigger_id = crate::ids::external_trigger_id();
+        let token = generate_callback_token();
+        let (descriptor, revoked, created) = self
             .inner
             .runtime_db
             .external_triggers()
-            .active_default_for_agent(&agent_id)?
-        {
-            if descriptor.token.is_some() {
-                return capability_from_record(&self.inner.callback_base_url, &descriptor);
-            }
-            let mut revoked = descriptor;
-            revoked.status = ExternalTriggerStatus::Revoked;
-            revoked.revoked_at = Some(now);
-            self.inner.runtime_db.external_triggers().upsert(&revoked)?;
+            .ensure_default_for_agent(
+                &agent_id,
+                delivery_mode.clone(),
+                now,
+                external_trigger_id,
+                token,
+            )?;
+
+        if !created {
+            return capability_from_record(&self.inner.callback_base_url, &descriptor);
+        }
+        if let Some(revoked) = revoked {
             self.cache_external_trigger_projection(&revoked).await;
         }
 
-        let external_trigger_id = crate::ids::external_trigger_id();
-        let token = generate_callback_token();
-        let descriptor = ExternalTriggerRecord {
-            external_trigger_id: external_trigger_id.clone(),
-            target_agent_id: agent_id.clone(),
-            scope: ExternalTriggerScope::Agent,
-            delivery_mode: delivery_mode.clone(),
-            token: Some(token.clone()),
-            token_hash: crate::callbacks::hash_callback_token(&token),
-            status: ExternalTriggerStatus::Active,
-            created_at: now,
-            revoked_at: None,
-            last_delivered_at: None,
-            delivery_count: 0,
-        };
-
-        self.inner
-            .runtime_db
-            .external_triggers()
-            .upsert(&descriptor)?;
         self.cache_external_trigger_projection(&descriptor).await;
         self.inner.storage.append_event(&AuditEvent::new(
             "external_trigger_created",
             serde_json::json!({
-                "external_trigger_id": descriptor.external_trigger_id,
-                "agent_id": agent_id,
-                "scope": descriptor.scope,
-                "delivery_mode": descriptor.delivery_mode,
+                "external_trigger_id": &descriptor.external_trigger_id,
+                "agent_id": &agent_id,
+                "scope": &descriptor.scope,
+                "delivery_mode": &descriptor.delivery_mode,
             }),
         ))?;
 
-        Ok(ExternalTriggerCapability {
-            external_trigger_id,
-            trigger_url: build_callback_url(&self.inner.callback_base_url, &delivery_mode, &token),
-            target_agent_id: agent_id,
-            delivery_mode,
-            status: ExternalTriggerStatus::Active,
-        })
+        capability_from_record(&self.inner.callback_base_url, &descriptor)
     }
 
     pub async fn deliver_callback(
@@ -220,17 +199,21 @@ impl RuntimeHandle {
         let agent_id = self.agent_id().await?;
         let now = Utc::now();
 
-        // Revoke existing active default trigger if present.
-        if let Some(descriptor) = self
+        let external_trigger_id = crate::ids::external_trigger_id();
+        let token = generate_callback_token();
+        let (descriptor, revoked) = self
             .inner
             .runtime_db
             .external_triggers()
-            .active_default_for_agent(&agent_id)?
-        {
-            let mut revoked = descriptor;
-            revoked.status = ExternalTriggerStatus::Revoked;
-            revoked.revoked_at = Some(now);
-            self.inner.runtime_db.external_triggers().upsert(&revoked)?;
+            .reset_default_for_agent(
+                &agent_id,
+                delivery_mode.clone(),
+                now,
+                external_trigger_id,
+                token,
+            )?;
+
+        if let Some(revoked) = revoked {
             self.cache_external_trigger_projection(&revoked).await;
             self.inner.storage.append_event(&AuditEvent::new(
                 "external_trigger_revoked",
@@ -243,45 +226,19 @@ impl RuntimeHandle {
             ))?;
         }
 
-        // Provision a new trigger with a fresh token.
-        let external_trigger_id = crate::ids::external_trigger_id();
-        let token = generate_callback_token();
-        let descriptor = ExternalTriggerRecord {
-            external_trigger_id: external_trigger_id.clone(),
-            target_agent_id: agent_id.clone(),
-            scope: ExternalTriggerScope::Agent,
-            delivery_mode: delivery_mode.clone(),
-            token: Some(token.clone()),
-            token_hash: crate::callbacks::hash_callback_token(&token),
-            status: ExternalTriggerStatus::Active,
-            created_at: now,
-            revoked_at: None,
-            last_delivered_at: None,
-            delivery_count: 0,
-        };
-        self.inner
-            .runtime_db
-            .external_triggers()
-            .upsert(&descriptor)?;
         self.cache_external_trigger_projection(&descriptor).await;
         self.inner.storage.append_event(&AuditEvent::new(
             "external_trigger_created",
             serde_json::json!({
-                "external_trigger_id": &external_trigger_id,
+                "external_trigger_id": &descriptor.external_trigger_id,
                 "agent_id": &agent_id,
-                "scope": descriptor.scope,
+                "scope": &descriptor.scope,
                 "delivery_mode": &delivery_mode,
                 "reason": "reset_callback",
             }),
         ))?;
 
-        Ok(ExternalTriggerCapability {
-            external_trigger_id,
-            trigger_url: build_callback_url(&self.inner.callback_base_url, &delivery_mode, &token),
-            target_agent_id: agent_id,
-            delivery_mode,
-            status: ExternalTriggerStatus::Active,
-        })
+        capability_from_record(&self.inner.callback_base_url, &descriptor)
     }
 }
 

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -727,6 +727,79 @@ impl ExternalTriggerRepository<'_> {
             .transaction(|tx| upsert_external_trigger_tx(tx, record))
     }
 
+    pub fn ensure_default_for_agent(
+        &self,
+        agent_id: &str,
+        delivery_mode: CallbackDeliveryMode,
+        now: DateTime<Utc>,
+        external_trigger_id: String,
+        token: String,
+    ) -> Result<(ExternalTriggerRecord, Option<ExternalTriggerRecord>, bool)> {
+        self.db.transaction(|tx| {
+            if let Some(descriptor) = active_default_for_agent_tx(tx, agent_id)? {
+                if descriptor.token.is_some() {
+                    return Ok((descriptor, None, false));
+                }
+
+                let mut revoked = descriptor;
+                revoked.status = ExternalTriggerStatus::Revoked;
+                revoked.revoked_at = Some(now);
+                upsert_external_trigger_tx(tx, &revoked)?;
+
+                let descriptor = default_external_trigger_record(
+                    agent_id,
+                    delivery_mode.clone(),
+                    now,
+                    external_trigger_id.clone(),
+                    token.clone(),
+                );
+                upsert_external_trigger_tx(tx, &descriptor)?;
+                return Ok((descriptor, Some(revoked), true));
+            }
+
+            let descriptor = default_external_trigger_record(
+                agent_id,
+                delivery_mode.clone(),
+                now,
+                external_trigger_id.clone(),
+                token.clone(),
+            );
+            upsert_external_trigger_tx(tx, &descriptor)?;
+            Ok((descriptor, None, true))
+        })
+    }
+
+    pub fn reset_default_for_agent(
+        &self,
+        agent_id: &str,
+        delivery_mode: CallbackDeliveryMode,
+        now: DateTime<Utc>,
+        external_trigger_id: String,
+        token: String,
+    ) -> Result<(ExternalTriggerRecord, Option<ExternalTriggerRecord>)> {
+        self.db.transaction(|tx| {
+            let revoked = if let Some(descriptor) = active_default_for_agent_tx(tx, agent_id)? {
+                let mut revoked = descriptor;
+                revoked.status = ExternalTriggerStatus::Revoked;
+                revoked.revoked_at = Some(now);
+                upsert_external_trigger_tx(tx, &revoked)?;
+                Some(revoked)
+            } else {
+                None
+            };
+
+            let descriptor = default_external_trigger_record(
+                agent_id,
+                delivery_mode.clone(),
+                now,
+                external_trigger_id.clone(),
+                token.clone(),
+            );
+            upsert_external_trigger_tx(tx, &descriptor)?;
+            Ok((descriptor, revoked))
+        })
+    }
+
     pub fn latest(&self, external_trigger_id: &str) -> Result<Option<ExternalTriggerRecord>> {
         let connection = self.db.connection()?;
         connection
@@ -2560,6 +2633,46 @@ fn upsert_external_trigger_tx(tx: &Transaction<'_>, record: &ExternalTriggerReco
         ],
     )?;
     Ok(())
+}
+
+fn active_default_for_agent_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+) -> Result<Option<ExternalTriggerRecord>> {
+    tx.query_row(
+        "SELECT payload_json
+         FROM external_triggers
+         WHERE target_agent_id = ?1 AND status = 'active'
+         ORDER BY created_at DESC, external_trigger_id ASC
+         LIMIT 1",
+        [agent_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|payload| decode_external_trigger_payload(&payload))
+    .transpose()
+}
+
+fn default_external_trigger_record(
+    agent_id: &str,
+    delivery_mode: CallbackDeliveryMode,
+    now: DateTime<Utc>,
+    external_trigger_id: String,
+    token: String,
+) -> ExternalTriggerRecord {
+    ExternalTriggerRecord {
+        external_trigger_id,
+        target_agent_id: agent_id.to_string(),
+        scope: ExternalTriggerScope::Agent,
+        delivery_mode,
+        token: Some(token.clone()),
+        token_hash: crate::callbacks::hash_callback_token(&token),
+        status: ExternalTriggerStatus::Active,
+        created_at: now,
+        revoked_at: None,
+        last_delivered_at: None,
+        delivery_count: 0,
+    }
 }
 
 fn insert_operator_notification_tx(


### PR DESCRIPTION
## Summary
- move default callback trigger ensure/reset into runtime DB transactions
- preserve projection/audit updates after the DB state transition commits
- fixes the callback route coverage failure surfaced by PR #2131

## Verification
- cargo fmt --all -- --check
- cargo test http_success_response_shapes_follow_route_class_policy --test http_client -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets