### PR TITLE
refactor: introduce model route resolution

### DIFF
--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -6,6 +6,81 @@ pub struct ModelRef {
     pub model: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProviderEndpointId(String);
+
+impl ProviderEndpointId {
+    pub const DEFAULT: &'static str = "default";
+
+    pub fn default_endpoint() -> Self {
+        Self(Self::DEFAULT.to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelRouteCapability {
+    Turn,
+    VisionObservation,
+    ImageGeneration,
+}
+
+impl ModelRouteCapability {
+    pub fn model_supports(self, policy: &ResolvedRuntimeModelPolicy) -> bool {
+        match self {
+            Self::Turn => true,
+            Self::VisionObservation => policy.capabilities.image_input,
+            Self::ImageGeneration => policy.capabilities.image_generation,
+        }
+    }
+
+    pub fn transport_supports(self, transport: ProviderTransportKind) -> bool {
+        match self {
+            Self::Turn => true,
+            Self::VisionObservation => transport.supports_view_image_observation_generation(),
+            Self::ImageGeneration => transport.supports_image_generation(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedProviderEndpointConfig {
+    pub provider: ProviderId,
+    pub endpoint: ProviderEndpointId,
+    pub runtime_config: ProviderRuntimeConfig,
+}
+
+impl ResolvedProviderEndpointConfig {
+    pub fn from_provider_runtime_config(runtime_config: ProviderRuntimeConfig) -> Self {
+        Self {
+            provider: runtime_config.id.clone(),
+            endpoint: ProviderEndpointId::default_endpoint(),
+            runtime_config,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedModelRoute {
+    pub model_ref: ModelRef,
+    pub endpoint: ResolvedProviderEndpointConfig,
+    pub policy: ResolvedRuntimeModelPolicy,
+    pub requested_capability: ModelRouteCapability,
+}
+
+impl ResolvedModelRoute {
+    pub fn provider_config(&self) -> &ProviderRuntimeConfig {
+        &self.endpoint.runtime_config
+    }
+
+    pub fn provider_name(&self) -> &str {
+        self.endpoint.provider.as_str()
+    }
+}
+
 pub(crate) fn resolve_image_generation_model(
     stored_config: &HolonConfigFile,
 ) -> Result<Option<ModelRef>> {
@@ -34,7 +109,7 @@ pub struct RuntimeModelCatalog {
     pub image_generation_model: Option<ModelRef>,
     pub vision_candidate_models: Vec<ModelRef>,
     pub disable_provider_fallback: bool,
-    pub provider_transports: HashMap<ProviderId, ProviderTransportKind>,
+    pub provider_endpoints: HashMap<ProviderId, ResolvedProviderEndpointConfig>,
     pub built_in_catalog: BuiltInModelCatalog,
     pub discovered_models: HashMap<ModelRef, BuiltInModelMetadata>,
     pub model_overrides: HashMap<ModelRef, ModelRuntimeOverride>,
@@ -51,10 +126,17 @@ impl RuntimeModelCatalog {
             image_generation_model: config.image_generation_model.clone(),
             vision_candidate_models: config.vision_candidate_models.clone(),
             disable_provider_fallback: config.provider_fallback_disabled(),
-            provider_transports: config
+            provider_endpoints: config
                 .providers
                 .iter()
-                .map(|(provider, config)| (provider.clone(), config.transport))
+                .map(|(provider, config)| {
+                    (
+                        provider.clone(),
+                        ResolvedProviderEndpointConfig::from_provider_runtime_config(
+                            config.clone(),
+                        ),
+                    )
+                })
                 .collect(),
             built_in_catalog: BuiltInModelCatalog::default(),
             discovered_models: config
@@ -66,6 +148,34 @@ impl RuntimeModelCatalog {
             unknown_model_fallback: config.validated_unknown_model_fallback.clone(),
             configured_runtime_max_output_tokens: config.runtime_max_output_tokens,
         }
+    }
+
+    pub fn resolve_model_route(
+        &self,
+        base_context_config: &ContextConfig,
+        model_ref: &ModelRef,
+        requested_capability: ModelRouteCapability,
+    ) -> Option<ResolvedModelRoute> {
+        let endpoint = self.provider_endpoints.get(&model_ref.provider)?;
+        let policy = self.built_in_catalog.resolve_policy(
+            model_ref,
+            &self.model_overrides,
+            &self.discovered_models,
+            self.unknown_model_fallback.as_ref(),
+            base_context_config,
+            self.configured_runtime_max_output_tokens,
+        );
+        if !requested_capability.model_supports(&policy)
+            || !requested_capability.transport_supports(endpoint.runtime_config.transport)
+        {
+            return None;
+        }
+        Some(ResolvedModelRoute {
+            model_ref: model_ref.clone(),
+            endpoint: endpoint.clone(),
+            policy,
+            requested_capability,
+        })
     }
 
     pub fn provider_chain(&self, model_override: Option<&ModelRef>) -> Vec<ModelRef> {
@@ -271,9 +381,12 @@ impl RuntimeModelCatalog {
             );
             let image_input = policy.capabilities.image_input;
             let supported_transport = self
-                .provider_transports
+                .provider_endpoints
                 .get(&model_ref.provider)
-                .is_some_and(|transport| transport.supports_view_image_observation_generation());
+                .is_some_and(|endpoint| {
+                    ModelRouteCapability::VisionObservation
+                        .transport_supports(endpoint.runtime_config.transport)
+                });
             let reason = if !image_input {
                 "model_lacks_image_input"
             } else if supported_transport {
@@ -288,7 +401,15 @@ impl RuntimeModelCatalog {
                 image_input,
                 reason: reason.to_string(),
             });
-            if image_input && supported_transport && selected.is_none() {
+            if self
+                .resolve_model_route(
+                    base_context_config,
+                    model_ref,
+                    ModelRouteCapability::VisionObservation,
+                )
+                .is_some()
+                && selected.is_none()
+            {
                 selected = Some(model_ref.clone());
             }
         }
@@ -327,12 +448,35 @@ impl RuntimeModelCatalog {
     }
 
     pub fn provider_supports_view_image_observation(&self, provider: &str) -> bool {
-        self.provider_transports
+        self.provider_endpoints
             .iter()
-            .any(|(provider_id, transport)| {
+            .any(|(provider_id, endpoint)| {
                 provider_id.as_str() == provider
-                    && transport.supports_view_image_observation_generation()
+                    && ModelRouteCapability::VisionObservation
+                        .transport_supports(endpoint.runtime_config.transport)
             })
+    }
+
+    pub fn select_generate_image_route(
+        &self,
+        base_context_config: &ContextConfig,
+        model_override: Option<&ModelRef>,
+        pending_fallback_model: Option<&ModelRef>,
+    ) -> Option<ResolvedModelRoute> {
+        let candidates = self
+            .image_generation_model
+            .clone()
+            .map(|model_ref| vec![model_ref])
+            .unwrap_or_else(|| {
+                self.provider_chain_for_turn(model_override, pending_fallback_model)
+            });
+        candidates.into_iter().find_map(|model_ref| {
+            self.resolve_model_route(
+                base_context_config,
+                &model_ref,
+                ModelRouteCapability::ImageGeneration,
+            )
+        })
     }
 
     pub fn select_generate_image_model(
@@ -341,31 +485,12 @@ impl RuntimeModelCatalog {
         model_override: Option<&ModelRef>,
         pending_fallback_model: Option<&ModelRef>,
     ) -> Option<ModelRef> {
-        let candidates = self
-            .image_generation_model
-            .clone()
-            .map(|model_ref| vec![model_ref])
-            .unwrap_or_else(|| {
-                self.provider_chain_for_turn(model_override, pending_fallback_model)
-            });
-        for model_ref in candidates {
-            let policy = self.built_in_catalog.resolve_policy(
-                &model_ref,
-                &self.model_overrides,
-                &self.discovered_models,
-                self.unknown_model_fallback.as_ref(),
-                base_context_config,
-                self.configured_runtime_max_output_tokens,
-            );
-            let supported_transport = self
-                .provider_transports
-                .get(&model_ref.provider)
-                .is_some_and(|transport| transport.supports_image_generation());
-            if policy.capabilities.image_generation && supported_transport {
-                return Some(model_ref);
-            }
-        }
-        None
+        self.select_generate_image_route(
+            base_context_config,
+            model_override,
+            pending_fallback_model,
+        )
+        .map(|route| route.model_ref)
     }
 }
 
@@ -378,7 +503,7 @@ impl Default for RuntimeModelCatalog {
             image_generation_model: None,
             vision_candidate_models: Vec::new(),
             disable_provider_fallback: false,
-            provider_transports: HashMap::new(),
+            provider_endpoints: HashMap::new(),
             built_in_catalog: BuiltInModelCatalog::default(),
             discovered_models: HashMap::new(),
             model_overrides: HashMap::new(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -23,9 +23,10 @@ use crate::config::{
     save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
     validate_provider_config, AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig,
     ControlAuthMode, CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile,
-    ModelConfigFile, ModelRef, ProviderAuthConfig, ProviderBuiltinWebSearchConfig,
-    ProviderConfigFile, ProviderId, ProviderRegistry, ProviderRuntimeConfig, ProviderTransportKind,
-    RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID, OPENAI_CODEX_CREDENTIAL_PROFILE,
+    ModelConfigFile, ModelRef, ModelRouteCapability, ProviderAuthConfig,
+    ProviderBuiltinWebSearchConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
+    ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
+    OPENAI_CODEX_CREDENTIAL_PROFILE,
 };
 
 struct EnvVarSnapshot {
@@ -2427,6 +2428,46 @@ fn view_image_vision_selection_prefers_primary_over_other_candidates() {
     // Primary appears first in candidates
     assert_eq!(selection.candidates[0].provider, "openai");
     assert_eq!(selection.candidates[0].model, "gpt-5.4");
+}
+
+#[test]
+fn runtime_model_catalog_materializes_legacy_provider_as_default_route_endpoint() {
+    let fixture = test_app_config("openai/gpt-5.4", &[]);
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let route = catalog
+        .resolve_model_route(
+            &ContextConfig::default(),
+            &ModelRef::parse("openai/gpt-5.4").unwrap(),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+
+    assert_eq!(route.model_ref.as_string(), "openai/gpt-5.4");
+    assert_eq!(route.endpoint.provider.as_str(), "openai");
+    assert_eq!(route.endpoint.endpoint.as_str(), "default");
+    assert_eq!(
+        route.endpoint.runtime_config.transport,
+        ProviderTransportKind::OpenAiResponses
+    );
+}
+
+#[test]
+fn runtime_model_catalog_resolves_image_generation_route() {
+    let fixture = test_app_config("arcee/trinity-mini", &["openai/gpt-image-2"]);
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let route = catalog
+        .select_generate_image_route(&ContextConfig::default(), None, None)
+        .unwrap();
+
+    assert_eq!(route.model_ref.as_string(), "openai/gpt-image-2");
+    assert_eq!(
+        route.requested_capability,
+        ModelRouteCapability::ImageGeneration
+    );
+    assert_eq!(route.endpoint.provider.as_str(), "openai");
+    assert_eq!(route.endpoint.endpoint.as_str(), "default");
 }
 
 #[test]

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 
 use crate::{
-    config::{AppConfig, ModelRef, ProviderTransportKind},
+    config::{
+        AppConfig, ModelRef, ModelRouteCapability, ProviderTransportKind, ResolvedModelRoute,
+        ResolvedProviderEndpointConfig,
+    },
     context::ContextConfig,
     model_catalog::BuiltInModelCatalog,
     provider::fallback::FallbackProvider,
@@ -67,14 +70,17 @@ pub(crate) fn build_candidate(
     config: &AppConfig,
     model_ref: &ModelRef,
 ) -> Result<ProviderCandidate> {
-    let provider_config = config.providers.get(&model_ref.provider).ok_or_else(|| {
-        anyhow!(
-            "unknown provider {}; configure providers.{}",
-            model_ref.provider.as_str(),
-            model_ref.provider.as_str()
-        )
-    })?;
-    let resolved_policy = resolved_model_policy_for_candidate(config, model_ref);
+    let route = resolve_model_route_for_candidate(config, model_ref, ModelRouteCapability::Turn)?;
+    build_candidate_from_model_route(config, &route)
+}
+
+pub(crate) fn build_candidate_from_model_route(
+    config: &AppConfig,
+    route: &ResolvedModelRoute,
+) -> Result<ProviderCandidate> {
+    let model_ref = &route.model_ref;
+    let provider_config = route.provider_config();
+    let resolved_policy = &route.policy;
     let openai_compaction_policy = OpenAiCompactionPolicy {
         trigger_input_tokens: resolved_policy.compaction_trigger_estimated_tokens as u64,
     };
@@ -130,8 +136,46 @@ pub(crate) fn build_candidate(
     };
     Ok(ProviderCandidate {
         model_ref: model_ref.as_string(),
-        provider_name: model_ref.provider.as_str().to_string(),
+        provider_name: route.provider_name().to_string(),
         provider,
+    })
+}
+
+pub(crate) fn resolve_model_route_for_candidate(
+    config: &AppConfig,
+    model_ref: &ModelRef,
+    requested_capability: ModelRouteCapability,
+) -> Result<ResolvedModelRoute> {
+    let provider_config = config.providers.get(&model_ref.provider).ok_or_else(|| {
+        anyhow!(
+            "unknown provider {}; configure providers.{}",
+            model_ref.provider.as_str(),
+            model_ref.provider.as_str()
+        )
+    })?;
+    let resolved_policy = resolved_model_policy_for_candidate(config, model_ref);
+    if !requested_capability.model_supports(&resolved_policy) {
+        return Err(anyhow!(
+            "model {} does not support requested route capability {:?}",
+            model_ref.as_string(),
+            requested_capability
+        ));
+    }
+    if !requested_capability.transport_supports(provider_config.transport) {
+        return Err(anyhow!(
+            "provider {} default endpoint transport {} does not support requested route capability {:?}",
+            model_ref.provider.as_str(),
+            provider_config.transport.as_str(),
+            requested_capability
+        ));
+    }
+    Ok(ResolvedModelRoute {
+        model_ref: model_ref.clone(),
+        endpoint: ResolvedProviderEndpointConfig::from_provider_runtime_config(
+            provider_config.clone(),
+        ),
+        policy: resolved_policy,
+        requested_capability,
     })
 }
 

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use anyhow::{anyhow, Result};
 
@@ -71,11 +71,11 @@ pub(crate) fn build_candidate(
     model_ref: &ModelRef,
 ) -> Result<ProviderCandidate> {
     let route = resolve_model_route_for_candidate(config, model_ref, ModelRouteCapability::Turn)?;
-    build_candidate_from_model_route(config, &route)
+    build_candidate_from_model_route(&config.home_dir, &route)
 }
 
 pub(crate) fn build_candidate_from_model_route(
-    config: &AppConfig,
+    home_dir: &Path,
     route: &ResolvedModelRoute,
 ) -> Result<ProviderCandidate> {
     let model_ref = &route.model_ref;
@@ -93,7 +93,7 @@ pub(crate) fn build_candidate_from_model_route(
                 provider_config,
                 &model_ref.model,
                 max_output_tokens,
-                &config.home_dir,
+                home_dir,
                 openai_compaction_policy,
                 resolved_policy.verbosity,
                 resolved_policy.capabilities.supports_reasoning,
@@ -104,7 +104,7 @@ pub(crate) fn build_candidate_from_model_route(
                 provider_config,
                 &model_ref.model,
                 max_output_tokens,
-                &config.home_dir,
+                home_dir,
                 openai_compaction_policy,
             )?)
         }
@@ -113,7 +113,7 @@ pub(crate) fn build_candidate_from_model_route(
                 provider_config,
                 &model_ref.model,
                 max_output_tokens,
-                &config.home_dir,
+                home_dir,
                 resolved_policy.capabilities.supports_reasoning,
             )?)
         }
@@ -122,7 +122,7 @@ pub(crate) fn build_candidate_from_model_route(
                 provider_config,
                 &model_ref.model,
                 max_output_tokens,
-                &config.home_dir,
+                home_dir,
             )?)
         }
         ProviderTransportKind::GeminiGenerateContent => {
@@ -130,7 +130,7 @@ pub(crate) fn build_candidate_from_model_route(
                 provider_config,
                 &model_ref.model,
                 max_output_tokens,
-                &config.home_dir,
+                home_dir,
             )?)
         }
     };

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -5,10 +5,9 @@ use anyhow::{anyhow, Result};
 use crate::{
     config::{
         AppConfig, ModelRef, ModelRouteCapability, ProviderTransportKind, ResolvedModelRoute,
-        ResolvedProviderEndpointConfig,
+        RuntimeModelCatalog,
     },
     context::ContextConfig,
-    model_catalog::BuiltInModelCatalog,
     provider::fallback::FallbackProvider,
 };
 
@@ -153,37 +152,23 @@ pub(crate) fn resolve_model_route_for_candidate(
             model_ref.provider.as_str()
         )
     })?;
-    let resolved_policy = resolved_model_policy_for_candidate(config, model_ref);
-    if !requested_capability.model_supports(&resolved_policy) {
-        return Err(anyhow!(
-            "model {} does not support requested route capability {:?}",
-            model_ref.as_string(),
-            requested_capability
-        ));
-    }
-    if !requested_capability.transport_supports(provider_config.transport) {
-        return Err(anyhow!(
-            "provider {} default endpoint transport {} does not support requested route capability {:?}",
-            model_ref.provider.as_str(),
-            provider_config.transport.as_str(),
-            requested_capability
-        ));
-    }
-    Ok(ResolvedModelRoute {
-        model_ref: model_ref.clone(),
-        endpoint: ResolvedProviderEndpointConfig::from_provider_runtime_config(
-            provider_config.clone(),
-        ),
-        policy: resolved_policy,
-        requested_capability,
-    })
+
+    let base_context_config = base_context_config_for_candidate(config);
+    RuntimeModelCatalog::from_config(config)
+        .resolve_model_route(&base_context_config, model_ref, requested_capability)
+        .ok_or_else(|| {
+            anyhow!(
+                "provider {} default endpoint transport {} cannot route model {} for requested route capability {:?}",
+                model_ref.provider.as_str(),
+                provider_config.transport.as_str(),
+                model_ref.as_string(),
+                requested_capability
+            )
+        })
 }
 
-fn resolved_model_policy_for_candidate(
-    config: &AppConfig,
-    model_ref: &ModelRef,
-) -> crate::model_catalog::ResolvedRuntimeModelPolicy {
-    let base_context_config = ContextConfig {
+fn base_context_config_for_candidate(config: &AppConfig) -> ContextConfig {
+    ContextConfig {
         recent_messages: config.context_window_messages,
         recent_briefs: config.context_window_briefs,
         compaction_trigger_messages: config.compaction_trigger_messages,
@@ -194,13 +179,5 @@ fn resolved_model_policy_for_candidate(
         recent_episode_candidates: config.recent_episode_candidates,
         max_relevant_episodes: config.max_relevant_episodes,
         ..ContextConfig::default()
-    };
-    BuiltInModelCatalog::default().resolve_policy(
-        model_ref,
-        &config.validated_model_overrides,
-        &config.model_discovery_cache.models(),
-        config.validated_unknown_model_fallback.as_ref(),
-        &base_context_config,
-        config.runtime_max_output_tokens,
-    )
+    }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -15,6 +15,7 @@ pub mod test_support;
 mod tool_schema;
 mod transports;
 
+pub(crate) use catalog::build_candidate_from_model_route;
 pub use catalog::{build_provider_from_config, build_provider_from_model_chain};
 pub use diagnostics::{
     provider_doctor, resolved_model_availability, resolved_model_providers,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -10,7 +10,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use tokio::sync::{Mutex, Notify, RwLock};
 
 use crate::{
-    config::{AppConfig, ModelRef, RuntimeModelCatalog},
+    config::{AppConfig, ModelRef, ModelRouteCapability, RuntimeModelCatalog},
     context::ContextConfig,
     host::RuntimeHostBridge,
     model_catalog::BuiltInModelMetadata,
@@ -20,10 +20,10 @@ use crate::{
         ModelDiscoveryCacheStatus, DEFAULT_DISCOVERY_CACHE_TTL,
     },
     provider::{
-        build_provider_from_model_chain, resolved_model_availability, AgentProvider,
-        ConversationMessage, ModelBlock, ProviderGenerateImageRequest,
-        ProviderGenerateImageResponse, ProviderJsonSchemaResponseFormat,
-        ProviderResponseFormatRequest, ProviderTurnRequest,
+        build_candidate_from_model_route, build_provider_from_model_chain,
+        resolved_model_availability, AgentProvider, ConversationMessage, ModelBlock,
+        ProviderGenerateImageRequest, ProviderGenerateImageResponse,
+        ProviderJsonSchemaResponseFormat, ProviderResponseFormatRequest, ProviderTurnRequest,
     },
     queue::RuntimeQueue,
     runtime_db::RuntimeDb,
@@ -481,23 +481,24 @@ impl RuntimeHandle {
             .vision_model
             .as_deref()
             .ok_or_else(|| anyhow!("vision selection did not include a model"))?;
-        let vision_snap = self.inner.config_snapshot.load();
-        if !vision_snap
-            .model_catalog
-            .provider_supports_view_image_observation(provider_name)
-        {
-            return Err(anyhow!(
-                "vision model {provider_name}/{model_name} is not supported by ViewImage observation generation yet"
-            ));
-        }
         let snap = self.inner.config_snapshot.load();
+        let vision_model_ref = ModelRef::parse(&format!("{provider_name}/{model_name}"))?;
+        let vision_route = snap
+            .model_catalog
+            .resolve_model_route(
+                &snap.base_context_config,
+                &vision_model_ref,
+                ModelRouteCapability::VisionObservation,
+            )
+            .ok_or_else(|| {
+                anyhow!(
+                    "vision model {provider_name}/{model_name} is not supported by ViewImage observation generation yet"
+                )
+            })?;
         let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
             anyhow!("ViewImage observation generation requires host-managed provider configuration")
         })?;
-        let provider = build_provider_from_model_chain(
-            &reconfig.config,
-            &[ModelRef::parse(&format!("{provider_name}/{model_name}"))?],
-        )?;
+        let provider = build_candidate_from_model_route(&reconfig.config, &vision_route)?.provider;
         let mut request = ProviderTurnRequest::plain(
             "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return exactly one JSON object and no markdown, prose, or implementation advice. The JSON object must match this shape: {\"type\":\"visual_observation\",\"schema\":\"visual_observation.v1\",\"summary\":\"string\",\"ocr\":[],\"elements\":[],\"relations\":[],\"issues\":[],\"uncertainties\":[],\"external_sources\":[]}. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary, uncertainties. The uncertainties field must be an array of strings; use [] when there are no caveats. The ocr, elements, relations, issues, and external_sources fields must be arrays of objects; omit them or use [] when empty. Include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
             vec![ConversationMessage::UserImage {
@@ -533,9 +534,9 @@ impl RuntimeHandle {
     ) -> Result<ProviderGenerateImageResponse> {
         let state = self.agent_state().await?;
         let snap = self.inner.config_snapshot.load();
-        let model_ref = snap
+        let route = snap
             .model_catalog
-            .select_generate_image_model(
+            .select_generate_image_route(
                 &snap.base_context_config,
                 state.model_override.as_ref(),
                 state.pending_fallback_model.as_ref(),
@@ -544,7 +545,7 @@ impl RuntimeHandle {
         let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
             anyhow!("image generation requires host-managed provider configuration")
         })?;
-        let provider = build_provider_from_model_chain(&reconfig.config, &[model_ref])?;
+        let provider = build_candidate_from_model_route(&reconfig.config, &route)?.provider;
         provider.generate_image(request).await
     }
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -498,7 +498,8 @@ impl RuntimeHandle {
         let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
             anyhow!("ViewImage observation generation requires host-managed provider configuration")
         })?;
-        let provider = build_candidate_from_model_route(&reconfig.config, &vision_route)?.provider;
+        let provider =
+            build_candidate_from_model_route(&reconfig.config.home_dir, &vision_route)?.provider;
         let mut request = ProviderTurnRequest::plain(
             "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return exactly one JSON object and no markdown, prose, or implementation advice. The JSON object must match this shape: {\"type\":\"visual_observation\",\"schema\":\"visual_observation.v1\",\"summary\":\"string\",\"ocr\":[],\"elements\":[],\"relations\":[],\"issues\":[],\"uncertainties\":[],\"external_sources\":[]}. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary, uncertainties. The uncertainties field must be an array of strings; use [] when there are no caveats. The ocr, elements, relations, issues, and external_sources fields must be arrays of objects; omit them or use [] when empty. Include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
             vec![ConversationMessage::UserImage {
@@ -545,7 +546,8 @@ impl RuntimeHandle {
         let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
             anyhow!("image generation requires host-managed provider configuration")
         })?;
-        let provider = build_candidate_from_model_route(&reconfig.config, &route)?.provider;
+        let provider =
+            build_candidate_from_model_route(&reconfig.config.home_dir, &route)?.provider;
         provider.generate_image(request).await
     }
 


### PR DESCRIPTION
## Summary
- introduce internal model route primitives for endpoint identity, route capability, and resolved provider endpoint config
- route ViewImage observation and image generation through resolved routes instead of re-deriving support from provider transport maps
- preserve legacy provider config/user-facing model selection behavior by materializing each provider as a default endpoint

## Validation
- cargo fmt --all -- --check
- cargo test runtime_model_catalog_ --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets
