### PR TITLE
refactor: model built-in provider endpoints

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -1,6 +1,3 @@
-   Compiling holon v0.23.0 (/home/jolestar/opensource/src/github.com/holon-run/holon)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.55s
-     Running `target/debug/holon-docgen models`
 ---
 title: Supported Models
 description: Complete reference of all built-in models and providers supported by Holon.
@@ -9,7 +6,8 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **40 providers** and **248 models**.
+Holon includes built-in configuration for **33 provider accounts**
+across **41 endpoints** and **247 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -20,51 +18,53 @@ under the upstream service terms, not backend automation or generic scripts.
 
 ## Provider Setup
 
-Each provider requires an API key or credential to use. Set the listed environment variable before
-running Holon.
+Each provider account endpoint requires an API key or credential to use. Set the listed
+environment variable before running Holon. `Legacy Provider Ref` is the user-visible provider id
+used in existing `provider/model` refs and config shortcuts.
 
-| Provider | Transport | Base URL | Auth Env Variable(s) |
-|----------|-----------|----------|---------------------|
-| `anthropic` | Anthropic Messages | `https://api.anthropic.com` | `ANTHROPIC_AUTH_TOKEN` |
-| `arcee` | OpenAI Chat Completions | `https://api.arcee.ai/api/v1` | `ARCEE_API_KEY` |
-| `bigmodel` | Anthropic Messages | `https://open.bigmodel.cn/api/anthropic` | `BIGMODEL_API_KEY` |
-| `byteplus` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/v3` | `BYTEPLUS_API_KEY` |
-| `byteplus-coding` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/coding/v3` | `BYTEPLUS_CODING_API_KEY or BYTEPLUS_API_KEY` |
-| `chutes` | OpenAI Chat Completions | `https://llm.chutes.ai/v1` | `CHUTES_API_KEY` |
-| `dashscope` | Anthropic Messages | `https://dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_API_KEY or QWEN_API_KEY` |
-| `dashscope-coding-plan` | Anthropic Messages | `https://coding.dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_CODING_PLAN_API_KEY` |
-| `dashscope-token-plan` | Anthropic Messages | `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic` | `DASHSCOPE_TOKEN_PLAN_API_KEY` |
-| `deepseek` | Anthropic Messages | `https://api.deepseek.com/anthropic` | `DEEPSEEK_API_KEY` |
-| `fireworks` | OpenAI Chat Completions | `https://api.fireworks.ai/inference/v1` | `FIREWORKS_API_KEY` |
-| `gemini` | Gemini Generate Content | `https://generativelanguage.googleapis.com/v1beta` | `GEMINI_API_KEY` |
-| `huggingface` | OpenAI Chat Completions | `https://router.huggingface.co/v1` | `HUGGINGFACE_API_KEY or HF_TOKEN` |
-| `kilocode` | OpenAI Chat Completions | `https://api.kilo.ai/api/gateway` | `KILOCODE_API_KEY` |
-| `litellm` | OpenAI Chat Completions | `http://localhost:4000` | `LITELLM_API_KEY` |
-| `minimax` | Anthropic Messages | `https://api.minimax.io/anthropic` | `MINIMAX_API_KEY` |
-| `mistral` | OpenAI Chat Completions | `https://api.mistral.ai/v1` | `MISTRAL_API_KEY` |
-| `moonshot` | OpenAI Chat Completions | `https://api.moonshot.ai/v1` | `MOONSHOT_API_KEY` |
-| `nearai` | OpenAI Chat Completions | `https://cloud-api.near.ai/v1` | `NEARAI_API_KEY` |
-| `nvidia` | OpenAI Chat Completions | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
-| `openai` | OpenAI Responses | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
-| `openai-codex` | OpenAI Codex | `https://chatgpt.com/backend-api/codex` | `—` |
-| `opencode-go` | OpenAI Chat Completions | `https://opencode.ai/zen/go/v1` | `OPENCODE_GO_API_KEY` |
-| `openrouter` | OpenAI Chat Completions | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
-| `qianfan` | OpenAI Chat Completions | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
-| `stepfun` | OpenAI Chat Completions | `https://api.stepfun.ai/v1` | `STEPFUN_API_KEY` |
-| `stepfun-plan` | OpenAI Chat Completions | `https://api.stepfun.ai/step_plan/v1` | `STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY` |
-| `synthetic` | Anthropic Messages | `https://api.synthetic.new/anthropic` | `SYNTHETIC_API_KEY` |
-| `tencent-tokenhub` | OpenAI Chat Completions | `https://tokenhub.tencentmaas.com/v1` | `TOKENHUB_API_KEY` |
-| `together` | OpenAI Chat Completions | `https://api.together.xyz/v1` | `TOGETHER_API_KEY` |
-| `venice` | OpenAI Chat Completions | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
-| `vercel-ai-gateway` | Anthropic Messages | `https://ai-gateway.vercel.sh` | `VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY or VERCEL_AI_GATEWAY_API_KEY` |
-| `vllm` | OpenAI Chat Completions | `http://127.0.0.1:8000/v1` | `—` |
-| `volcengine` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/compatible` | `VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `volcengine-agent` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/plan` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `volcengine-coding` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/coding` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
-| `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
-| `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
-| `zai` | Anthropic Messages | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
+| Provider Account | Endpoint | Legacy Provider Ref | Transport | Base URL | Auth Env Variable(s) |
+|------------------|----------|---------------------|-----------|----------|----------------------|
+| `anthropic` | `default` | `anthropic` | Anthropic Messages | `https://api.anthropic.com` | `ANTHROPIC_AUTH_TOKEN` |
+| `arcee` | `default` | `arcee` | OpenAI Chat Completions | `https://api.arcee.ai/api/v1` | `ARCEE_API_KEY` |
+| `bigmodel` | `default` | `bigmodel` | Anthropic Messages | `https://open.bigmodel.cn/api/anthropic` | `BIGMODEL_API_KEY` |
+| `byteplus` | `default` | `byteplus` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/v3` | `BYTEPLUS_API_KEY` |
+| `byteplus` | `coding` | `byteplus-coding` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/coding/v3` | `BYTEPLUS_CODING_API_KEY or BYTEPLUS_API_KEY` |
+| `chutes` | `default` | `chutes` | OpenAI Chat Completions | `https://llm.chutes.ai/v1` | `CHUTES_API_KEY` |
+| `dashscope` | `default` | `dashscope` | Anthropic Messages | `https://dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_API_KEY or QWEN_API_KEY` |
+| `dashscope` | `coding-plan` | `dashscope-coding-plan` | Anthropic Messages | `https://coding.dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_CODING_PLAN_API_KEY` |
+| `dashscope` | `token-plan` | `dashscope-token-plan` | Anthropic Messages | `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic` | `DASHSCOPE_TOKEN_PLAN_API_KEY` |
+| `deepseek` | `default` | `deepseek` | Anthropic Messages | `https://api.deepseek.com/anthropic` | `DEEPSEEK_API_KEY` |
+| `fireworks` | `default` | `fireworks` | OpenAI Chat Completions | `https://api.fireworks.ai/inference/v1` | `FIREWORKS_API_KEY` |
+| `gemini` | `default` | `gemini` | Gemini Generate Content | `https://generativelanguage.googleapis.com/v1beta` | `GEMINI_API_KEY` |
+| `huggingface` | `default` | `huggingface` | OpenAI Chat Completions | `https://router.huggingface.co/v1` | `HUGGINGFACE_API_KEY or HF_TOKEN` |
+| `kilocode` | `default` | `kilocode` | OpenAI Chat Completions | `https://api.kilo.ai/api/gateway` | `KILOCODE_API_KEY` |
+| `litellm` | `default` | `litellm` | OpenAI Chat Completions | `http://localhost:4000` | `LITELLM_API_KEY` |
+| `minimax` | `default` | `minimax` | Anthropic Messages | `https://api.minimax.io/anthropic` | `MINIMAX_API_KEY` |
+| `mistral` | `default` | `mistral` | OpenAI Chat Completions | `https://api.mistral.ai/v1` | `MISTRAL_API_KEY` |
+| `moonshot` | `default` | `moonshot` | OpenAI Chat Completions | `https://api.moonshot.ai/v1` | `MOONSHOT_API_KEY` |
+| `nearai` | `default` | `nearai` | OpenAI Chat Completions | `https://cloud-api.near.ai/v1` | `NEARAI_API_KEY` |
+| `nvidia` | `default` | `nvidia` | OpenAI Chat Completions | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
+| `openai` | `default` | `openai` | OpenAI Responses | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
+| `openai-codex` | `default` | `openai-codex` | OpenAI Codex | `https://chatgpt.com/backend-api/codex` | `—` |
+| `opencode-go` | `default` | `opencode-go` | OpenAI Chat Completions | `https://opencode.ai/zen/go/v1` | `OPENCODE_GO_API_KEY` |
+| `openrouter` | `default` | `openrouter` | OpenAI Chat Completions | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
+| `qianfan` | `default` | `qianfan` | OpenAI Chat Completions | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
+| `stepfun` | `default` | `stepfun` | OpenAI Chat Completions | `https://api.stepfun.ai/v1` | `STEPFUN_API_KEY` |
+| `stepfun` | `plan` | `stepfun-plan` | OpenAI Chat Completions | `https://api.stepfun.ai/step_plan/v1` | `STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY` |
+| `synthetic` | `default` | `synthetic` | Anthropic Messages | `https://api.synthetic.new/anthropic` | `SYNTHETIC_API_KEY` |
+| `tencent-tokenhub` | `default` | `tencent-tokenhub` | OpenAI Chat Completions | `https://tokenhub.tencentmaas.com/v1` | `TOKENHUB_API_KEY` |
+| `together` | `default` | `together` | OpenAI Chat Completions | `https://api.together.xyz/v1` | `TOGETHER_API_KEY` |
+| `venice` | `default` | `venice` | OpenAI Chat Completions | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
+| `vercel-ai-gateway` | `default` | `vercel-ai-gateway` | Anthropic Messages | `https://ai-gateway.vercel.sh` | `VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY or VERCEL_AI_GATEWAY_API_KEY` |
+| `vllm` | `default` | `vllm` | OpenAI Chat Completions | `http://127.0.0.1:8000/v1` | `—` |
+| `volcengine` | `default` | `volcengine` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/compatible` | `VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine` | `agent` | `volcengine-agent` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/plan` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine` | `coding` | `volcengine-coding` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/coding` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine` | `image-openai` | `volcengine-image-openai` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_IMAGE_OPENAI_API_KEY or VOLCENGINE_AGENT_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `xai` | `default` | `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
+| `xiaomi` | `default` | `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
+| `xiaomi` | `token-plan` | `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
+| `zai` | `default` | `zai` | Anthropic Messages | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
 
 ## Model Catalog
 
@@ -204,12 +204,13 @@ and capabilities.
 | `openai` | `gpt-5.6-luna` | `openai/gpt-5.6-luna` | 272000 | 128000 | ✅ | ✅ |
 | `openai` | `gpt-5.6-sol` | `openai/gpt-5.6-sol` | 272000 | 128000 | ✅ | ✅ |
 | `openai` | `gpt-5.6-terra` | `openai/gpt-5.6-terra` | 272000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-image-2` | `openai/gpt-image-2` | — | — | — | — |
 | `openai-codex` | `gpt-5.2` | `openai-codex/gpt-5.2` | 272000 | 128000 | ✅ | ✅ |
 | `openai-codex` | `gpt-5.3-codex` | `openai-codex/gpt-5.3-codex` | 272000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.3-codex-spark` | `openai-codex/gpt-5.3-codex-spark` | 128000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.4` | `openai-codex/gpt-5.4` | 272000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.4-mini` | `openai-codex/gpt-5.4-mini` | 272000 | 128000 | ✅ | ✅ |
-| `openai-codex` | `gpt-5.5` | `openai-codex/gpt-5.5` | 272000 | 128000 | ✅ | ✅ |
+| `openai-codex` | `gpt-5.5` | `openai-codex/gpt-5.5` | 272000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.6-luna` | `openai-codex/gpt-5.6-luna` | 272000 | 128000 | ✅ | ✅ |
 | `openai-codex` | `gpt-5.6-sol` | `openai-codex/gpt-5.6-sol` | 272000 | 128000 | ✅ | ✅ |
 | `openai-codex` | `gpt-5.6-terra` | `openai-codex/gpt-5.6-terra` | 272000 | 128000 | ✅ | ✅ |
@@ -266,7 +267,6 @@ and capabilities.
 | `volcengine` | `doubao-seed-2-0-code-preview-260215` | `volcengine/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | ✅ |
 | `volcengine` | `doubao-seed-2-0-lite-260215` | `volcengine/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
 | `volcengine` | `doubao-seed-2-0-pro-260215` | `volcengine/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | ✅ |
-| `volcengine` | `glm-4-7-251222` | `volcengine/glm-4-7-251222` | 204800 | 131072 | ✅ | — |
 | `volcengine-agent` | `ark-code-latest` | `volcengine-agent/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `volcengine-agent` | `deepseek-v3-2-251201` | `volcengine-agent/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
 | `volcengine-agent` | `deepseek-v4-flash` | `volcengine-agent/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
@@ -274,8 +274,7 @@ and capabilities.
 | `volcengine-agent` | `doubao-seed-2-0-code-preview-260215` | `volcengine-agent/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | — |
 | `volcengine-agent` | `doubao-seed-2-0-lite-260215` | `volcengine-agent/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
 | `volcengine-agent` | `doubao-seed-2-0-pro-260215` | `volcengine-agent/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | — |
-| `volcengine-agent` | `glm-4-7-251222` | `volcengine-agent/glm-4-7-251222` | 204800 | 131072 | ✅ | — |
-| `volcengine-agent` | `glm-5.2` | `volcengine-agent/glm-5.2` | 204800 | 131072 | ✅ | — |
+| `volcengine-agent` | `glm-5.2` | `volcengine-agent/glm-5.2` | 204800 | 128000 | ✅ | — |
 | `volcengine-agent` | `kimi-k2.6` | `volcengine-agent/kimi-k2.6` | 262144 | 32768 | ✅ | — |
 | `volcengine-agent` | `kimi-k2.7-code` | `volcengine-agent/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
 | `volcengine-coding` | `ark-code-latest` | `volcengine-coding/ark-code-latest` | 256000 | 65536 | ✅ | — |
@@ -285,10 +284,10 @@ and capabilities.
 | `volcengine-coding` | `doubao-seed-2-0-code-preview-260215` | `volcengine-coding/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | — |
 | `volcengine-coding` | `doubao-seed-2-0-lite-260215` | `volcengine-coding/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
 | `volcengine-coding` | `doubao-seed-2-0-pro-260215` | `volcengine-coding/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | — |
-| `volcengine-coding` | `glm-4-7-251222` | `volcengine-coding/glm-4-7-251222` | 204800 | 131072 | ✅ | — |
-| `volcengine-coding` | `glm-5.2` | `volcengine-coding/glm-5.2` | 204800 | 131072 | ✅ | — |
+| `volcengine-coding` | `glm-5.2` | `volcengine-coding/glm-5.2` | 204800 | 128000 | ✅ | — |
 | `volcengine-coding` | `kimi-k2.6` | `volcengine-coding/kimi-k2.6` | 262144 | 32768 | ✅ | — |
 | `volcengine-coding` | `kimi-k2.7-code` | `volcengine-coding/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
+| `volcengine-image-openai` | `doubao-seedream-5.0-lite` | `volcengine-image-openai/doubao-seedream-5.0-lite` | — | — | — | — |
 | `xai` | `grok-3` | `xai/grok-3` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-fast` | `xai/grok-3-fast` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-mini` | `xai/grok-3-mini` | 131072 | 8192 | ✅ | — |
@@ -321,4 +320,3 @@ and capabilities.
 | `zai` | `glm-5.1` | `zai/glm-5.1` | 202800 | 131072 | ✅ | — |
 | `zai` | `glm-5.2` | `zai/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-5v-turbo` | `zai/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |
-Generated model reference: 40 providers, 248 models.

--- a/src/bin/holon-docgen.rs
+++ b/src/bin/holon-docgen.rs
@@ -6,6 +6,8 @@
 //! Run in a clean environment (no HOLON_* or provider-specific env overrides) for
 //! deterministic output that reflects the true built-in defaults.
 
+use std::collections::BTreeSet;
+
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
@@ -44,6 +46,10 @@ fn generate_models_doc() -> anyhow::Result<()> {
     let catalog = holon::model_catalog::BuiltInModelCatalog::new();
     let models = catalog.list();
     let providers = holon::config::built_in_provider_doc_entries()?;
+    let provider_accounts = providers
+        .iter()
+        .map(|entry| entry.provider.as_str())
+        .collect::<BTreeSet<_>>();
 
     // Print header — use print! to avoid an extra blank line after the header
     // separator row, which would break Markdown table rendering.
@@ -56,7 +62,8 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **{provider_count} providers** and **{model_count} models**.
+Holon includes built-in configuration for **{provider_account_count} provider accounts**
+across **{endpoint_count} endpoints** and **{model_count} models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -67,13 +74,15 @@ under the upstream service terms, not backend automation or generic scripts.
 
 ## Provider Setup
 
-Each provider requires an API key or credential to use. Set the listed environment variable before
-running Holon.
+Each provider account endpoint requires an API key or credential to use. Set the listed
+environment variable before running Holon. `Legacy Provider Ref` is the user-visible provider id
+used in existing `provider/model` refs and config shortcuts.
 
-| Provider | Transport | Base URL | Auth Env Variable(s) |
-|----------|-----------|----------|---------------------|
+| Provider Account | Endpoint | Legacy Provider Ref | Transport | Base URL | Auth Env Variable(s) |
+|------------------|----------|---------------------|-----------|----------|----------------------|
 "#,
-        provider_count = providers.len(),
+        provider_account_count = provider_accounts.len(),
+        endpoint_count = providers.len(),
         model_count = models.len(),
     );
 
@@ -82,8 +91,10 @@ running Holon.
         let env_display = entry.auth_env.as_deref().unwrap_or("—");
 
         println!(
-            "| `{name}` | {transport} | `{url}` | `{env}` |",
-            name = entry.id.as_str(),
+            "| `{provider}` | `{endpoint}` | `{legacy_provider}` | {transport} | `{url}` | `{env}` |",
+            provider = entry.provider.as_str(),
+            endpoint = entry.endpoint.as_str(),
+            legacy_provider = entry.legacy_provider.as_str(),
             transport = transport_str,
             url = entry.base_url,
             env = env_display,
@@ -124,8 +135,11 @@ and capabilities.
         );
     }
 
-    let provider_count = providers.len();
+    let provider_account_count = provider_accounts.len();
+    let endpoint_count = providers.len();
     let model_count = models.len();
-    eprintln!("Generated model reference: {provider_count} providers, {model_count} models.");
+    eprintln!(
+        "Generated model reference: {provider_account_count} provider accounts, {endpoint_count} endpoints, {model_count} models."
+    );
     Ok(())
 }

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -197,9 +197,9 @@ pub(crate) fn built_in_provider_default_config_with_settings(
     provider_id: &ProviderId,
     settings_env: &HashMap<String, String>,
 ) -> Result<Option<ProviderConfigFile>> {
-    let registry = built_in_provider_registry_with_settings(&settings_env)?;
-    Ok(registry
-        .get(provider_id)
+    let catalog = BuiltInProviderCatalog::with_settings(settings_env)?;
+    Ok(catalog
+        .legacy_runtime(provider_id)
         .map(|provider| ProviderConfigFile {
             transport: provider.transport,
             base_url: provider.base_url.clone(),
@@ -212,6 +212,9 @@ pub(crate) fn built_in_provider_default_config_with_settings(
 /// Provider metadata for documentation generation.
 #[derive(Debug, Clone)]
 pub struct ProviderDocEntry {
+    pub provider: ProviderId,
+    pub endpoint: ProviderEndpointId,
+    pub legacy_provider: ProviderId,
     pub id: ProviderId,
     pub transport: ProviderTransportKind,
     pub base_url: String,
@@ -221,18 +224,7 @@ pub struct ProviderDocEntry {
 /// Returns built-in provider metadata for documentation generation.
 pub fn built_in_provider_doc_entries() -> Result<Vec<ProviderDocEntry>> {
     let settings_env = HashMap::new();
-    let registry = built_in_provider_registry_with_settings(&settings_env)?;
-    let mut entries: Vec<ProviderDocEntry> = registry
-        .values()
-        .map(|provider| ProviderDocEntry {
-            id: provider.id.clone(),
-            transport: provider.transport,
-            base_url: provider.base_url.clone(),
-            auth_env: provider.auth.env.clone(),
-        })
-        .collect();
-    entries.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
-    Ok(entries)
+    Ok(BuiltInProviderCatalog::with_settings(&settings_env)?.doc_entries())
 }
 
 pub fn provider_config_views(config: &AppConfig) -> Vec<ProviderConfigView> {
@@ -296,7 +288,109 @@ pub(crate) fn resolve_provider_registry(
 pub(crate) fn built_in_provider_registry_with_settings(
     settings_env: &HashMap<String, String>,
 ) -> Result<ProviderRegistry> {
-    let mut registry = ProviderRegistry::new();
+    Ok(BuiltInProviderCatalog::with_settings(settings_env)?.into_legacy_registry())
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BuiltInProviderEndpointDefinition {
+    pub provider: ProviderId,
+    pub endpoint: ProviderEndpointId,
+    pub legacy_provider: ProviderId,
+    pub runtime_config: ProviderRuntimeConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct BuiltInProviderCatalog {
+    endpoints: Vec<BuiltInProviderEndpointDefinition>,
+}
+
+impl BuiltInProviderCatalog {
+    pub(crate) fn with_settings(settings_env: &HashMap<String, String>) -> Result<Self> {
+        let mut catalog = Self::default();
+        populate_built_in_provider_catalog(&mut catalog, settings_env)?;
+        Ok(catalog)
+    }
+
+    pub(crate) fn insert_endpoint(
+        &mut self,
+        provider: ProviderId,
+        endpoint: ProviderEndpointId,
+        legacy_provider: ProviderId,
+        runtime_config: ProviderRuntimeConfig,
+    ) {
+        self.endpoints.push(BuiltInProviderEndpointDefinition {
+            provider,
+            endpoint,
+            legacy_provider,
+            runtime_config,
+        });
+    }
+
+    pub(crate) fn legacy_runtime(
+        &self,
+        provider_id: &ProviderId,
+    ) -> Option<&ProviderRuntimeConfig> {
+        self.endpoints
+            .iter()
+            .find(|endpoint| &endpoint.legacy_provider == provider_id)
+            .map(|endpoint| &endpoint.runtime_config)
+    }
+
+    pub(crate) fn into_legacy_registry(self) -> ProviderRegistry {
+        self.endpoints
+            .into_iter()
+            .map(|endpoint| (endpoint.legacy_provider, endpoint.runtime_config))
+            .collect()
+    }
+
+    pub(crate) fn doc_entries(&self) -> Vec<ProviderDocEntry> {
+        let mut entries = self
+            .endpoints
+            .iter()
+            .map(|endpoint| ProviderDocEntry {
+                provider: endpoint.provider.clone(),
+                endpoint: endpoint.endpoint.clone(),
+                legacy_provider: endpoint.legacy_provider.clone(),
+                id: endpoint.legacy_provider.clone(),
+                transport: endpoint.runtime_config.transport,
+                base_url: endpoint.runtime_config.base_url.clone(),
+                auth_env: endpoint.runtime_config.auth.env.clone(),
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
+        entries
+    }
+}
+
+fn built_in_provider_endpoint_identity(
+    legacy_provider: &ProviderId,
+) -> Result<(ProviderId, ProviderEndpointId)> {
+    let (provider, endpoint) = match legacy_provider.as_str() {
+        "byteplus-coding" => ("byteplus", "coding"),
+        "dashscope-token-plan" => ("dashscope", "token-plan"),
+        "dashscope-coding-plan" => ("dashscope", "coding-plan"),
+        "stepfun-plan" => ("stepfun", "plan"),
+        "volcengine-coding" => ("volcengine", "coding"),
+        "volcengine-agent" => ("volcengine", "agent"),
+        "volcengine-image-openai" => ("volcengine", "image-openai"),
+        "xiaomi-token-plan" => ("xiaomi", "token-plan"),
+        _ => {
+            return Ok((
+                legacy_provider.clone(),
+                ProviderEndpointId::default_endpoint(),
+            ));
+        }
+    };
+    Ok((
+        ProviderId::parse(provider)?,
+        ProviderEndpointId::parse(endpoint)?,
+    ))
+}
+
+pub(crate) fn populate_built_in_provider_catalog(
+    catalog: &mut BuiltInProviderCatalog,
+    settings_env: &HashMap<String, String>,
+) -> Result<()> {
     let openai_codex = ProviderId::openai_codex();
     let openai_codex_reasoning_effort = env::var("HOLON_OPENAI_CODEX_REASONING_EFFORT")
         .ok()
@@ -304,7 +398,9 @@ pub(crate) fn built_in_provider_registry_with_settings(
         .or_else(|| Some("low".to_string()))
         .map(|value| validate_openai_reasoning_effort(&value).map(|_| value))
         .transpose()?;
-    registry.insert(
+    catalog.insert_endpoint(
+        openai_codex.clone(),
+        ProviderEndpointId::default_endpoint(),
         openai_codex.clone(),
         ProviderRuntimeConfig {
             id: openai_codex,
@@ -332,7 +428,9 @@ pub(crate) fn built_in_provider_registry_with_settings(
         },
     );
     let openai = ProviderId::openai();
-    registry.insert(
+    catalog.insert_endpoint(
+        openai.clone(),
+        ProviderEndpointId::default_endpoint(),
         openai.clone(),
         ProviderRuntimeConfig {
             id: openai,
@@ -358,7 +456,9 @@ pub(crate) fn built_in_provider_registry_with_settings(
         },
     );
     let anthropic = ProviderId::anthropic();
-    registry.insert(
+    catalog.insert_endpoint(
+        anthropic.clone(),
+        ProviderEndpointId::default_endpoint(),
         anthropic.clone(),
         ProviderRuntimeConfig {
             id: anthropic,
@@ -382,7 +482,9 @@ pub(crate) fn built_in_provider_registry_with_settings(
         },
     );
     let gemini = ProviderId::gemini();
-    registry.insert(
+    catalog.insert_endpoint(
+        gemini.clone(),
+        ProviderEndpointId::default_endpoint(),
         gemini.clone(),
         ProviderRuntimeConfig {
             id: gemini,
@@ -406,196 +508,196 @@ pub(crate) fn built_in_provider_registry_with_settings(
         },
     );
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "arcee",
         "https://api.arcee.ai/api/v1",
         &["ARCEE_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "byteplus",
         "https://ark.ap-southeast.bytepluses.com/api/v3",
         &["BYTEPLUS_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "byteplus-coding",
         "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
         &["BYTEPLUS_CODING_API_KEY", "BYTEPLUS_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "chutes",
         "https://llm.chutes.ai/v1",
         &["CHUTES_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "dashscope",
         "https://dashscope.aliyuncs.com/apps/anthropic",
         &["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "dashscope-token-plan",
         "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
         &["DASHSCOPE_TOKEN_PLAN_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "dashscope-coding-plan",
         "https://coding.dashscope.aliyuncs.com/apps/anthropic",
         &["DASHSCOPE_CODING_PLAN_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "deepseek",
         "https://api.deepseek.com/anthropic",
         &["DEEPSEEK_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "fireworks",
         "https://api.fireworks.ai/inference/v1",
         &["FIREWORKS_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "huggingface",
         "https://router.huggingface.co/v1",
         &["HUGGINGFACE_API_KEY", "HF_TOKEN"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "kilocode",
         "https://api.kilo.ai/api/gateway",
         &["KILOCODE_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "litellm",
         "http://localhost:4000",
         &["LITELLM_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "mistral",
         "https://api.mistral.ai/v1",
         &["MISTRAL_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "moonshot",
         "https://api.moonshot.ai/v1",
         &["MOONSHOT_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "nearai",
         "https://cloud-api.near.ai/v1",
         &["NEARAI_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "nvidia",
         "https://integrate.api.nvidia.com/v1",
         &["NVIDIA_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "opencode-go",
         "https://opencode.ai/zen/go/v1",
         &["OPENCODE_GO_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "openrouter",
         "https://openrouter.ai/api/v1",
         &["OPENROUTER_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "qianfan",
         "https://qianfan.baidubce.com/v2",
         &["QIANFAN_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "stepfun",
         "https://api.stepfun.ai/v1",
         &["STEPFUN_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "stepfun-plan",
         "https://api.stepfun.ai/step_plan/v1",
         &["STEPFUN_PLAN_API_KEY", "STEPFUN_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "synthetic",
         "https://api.synthetic.new/anthropic",
         &["SYNTHETIC_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "tencent-tokenhub",
         "https://tokenhub.tencentmaas.com/v1",
         &["TOKENHUB_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "together",
         "https://api.together.xyz/v1",
         &["TOGETHER_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "venice",
         "https://api.venice.ai/api/v1",
         &["VENICE_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "vllm",
         "http://127.0.0.1:8000/v1",
         &[],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "volcengine",
         "https://ark.cn-beijing.volces.com/api/compatible",
         &["VOLCENGINE_API_KEY", "ARK_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "volcengine-coding",
         "https://ark.cn-beijing.volces.com/api/coding",
         &[
@@ -606,7 +708,7 @@ pub(crate) fn built_in_provider_registry_with_settings(
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "volcengine-agent",
         "https://ark.cn-beijing.volces.com/api/plan",
         &[
@@ -617,7 +719,7 @@ pub(crate) fn built_in_provider_registry_with_settings(
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "volcengine-image-openai",
         "https://ark.cn-beijing.volces.com/api/plan/v3",
         &[
@@ -629,49 +731,49 @@ pub(crate) fn built_in_provider_registry_with_settings(
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "xiaomi",
         "https://api.xiaomimimo.com/v1",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "xiaomi-token-plan",
         "https://token-plan-cn.xiaomimimo.com/v1",
         &["XIAOMI_TOKEN_PLAN_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
-        &mut registry,
+        catalog,
         "xai",
         "https://api.x.ai/v1",
         &["XAI_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "zai",
         "https://api.z.ai/api/anthropic",
         &["ZAI_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "bigmodel",
         "https://open.bigmodel.cn/api/anthropic",
         &["BIGMODEL_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
-        &mut registry,
+        catalog,
         "minimax",
         "https://api.minimax.io/anthropic",
         &["MINIMAX_API_KEY"],
         settings_env,
     )?;
-    insert_vercel_ai_gateway_provider(&mut registry, settings_env)?;
-    Ok(registry)
+    insert_vercel_ai_gateway_provider(catalog, settings_env)?;
+    Ok(())
 }
 
 /// Public entry point for tools that need the built-in provider registry (e.g. docgen).
@@ -681,14 +783,14 @@ pub fn built_in_provider_registry() -> Result<ProviderRegistry> {
 }
 
 pub(crate) fn insert_openai_compatible_provider(
-    registry: &mut ProviderRegistry,
+    catalog: &mut BuiltInProviderCatalog,
     provider: &str,
     default_base_url: &str,
     env_names: &[&str],
     settings_env: &HashMap<String, String>,
 ) -> Result<()> {
     insert_builtin_http_provider(
-        registry,
+        catalog,
         provider,
         ProviderTransportKind::OpenAiChatCompletions,
         default_base_url,
@@ -701,7 +803,7 @@ pub(crate) fn insert_openai_compatible_provider(
 /// lowering while avoiding implicit Claude-specific beta injection. Operators can
 /// still override cache strategy and betas explicitly with env config.
 pub(crate) fn insert_anthropic_compatible_provider(
-    registry: &mut ProviderRegistry,
+    catalog: &mut BuiltInProviderCatalog,
     provider: &str,
     default_base_url: &str,
     env_names: &[&str],
@@ -714,7 +816,7 @@ pub(crate) fn insert_anthropic_compatible_provider(
         _ => None,
     };
     insert_builtin_http_provider_with_context_management(
-        registry,
+        catalog,
         provider,
         ProviderTransportKind::AnthropicMessages,
         default_base_url,
@@ -726,7 +828,7 @@ pub(crate) fn insert_anthropic_compatible_provider(
 }
 
 pub(crate) fn insert_vercel_ai_gateway_provider(
-    registry: &mut ProviderRegistry,
+    catalog: &mut BuiltInProviderCatalog,
     settings_env: &HashMap<String, String>,
 ) -> Result<()> {
     let context_management = resolve_anthropic_compatible_context_management_config()?;
@@ -761,7 +863,9 @@ pub(crate) fn insert_vercel_ai_gateway_provider(
         )
     };
     let id = ProviderId::parse("vercel-ai-gateway")?;
-    registry.insert(
+    catalog.insert_endpoint(
+        id.clone(),
+        ProviderEndpointId::default_endpoint(),
         id.clone(),
         ProviderRuntimeConfig {
             id,
@@ -788,7 +892,7 @@ pub(crate) fn insert_vercel_ai_gateway_provider(
 }
 
 pub(crate) fn insert_builtin_http_provider(
-    registry: &mut ProviderRegistry,
+    catalog: &mut BuiltInProviderCatalog,
     provider: &str,
     transport: ProviderTransportKind,
     default_base_url: &str,
@@ -796,7 +900,7 @@ pub(crate) fn insert_builtin_http_provider(
     settings_env: &HashMap<String, String>,
 ) -> Result<()> {
     insert_builtin_http_provider_with_context_management(
-        registry,
+        catalog,
         provider,
         transport,
         default_base_url,
@@ -808,7 +912,7 @@ pub(crate) fn insert_builtin_http_provider(
 }
 
 pub(crate) fn insert_builtin_http_provider_with_context_management(
-    registry: &mut ProviderRegistry,
+    catalog: &mut BuiltInProviderCatalog,
     provider: &str,
     transport: ProviderTransportKind,
     default_base_url: &str,
@@ -818,6 +922,7 @@ pub(crate) fn insert_builtin_http_provider_with_context_management(
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
 ) -> Result<()> {
     let id = ProviderId::parse(provider)?;
+    let (provider_id, endpoint_id) = built_in_provider_endpoint_identity(&id)?;
     let base_url_env = format!("HOLON_{}_BASE_URL", env_key_fragment(provider));
     let base_url = get_config_value(&base_url_env, None, settings_env)
         .unwrap_or_else(|| default_base_url.to_string());
@@ -832,7 +937,9 @@ pub(crate) fn insert_builtin_http_provider_with_context_management(
                 Some(env_names.join(" or "))
             }
         });
-    registry.insert(
+    catalog.insert_endpoint(
+        provider_id,
+        endpoint_id,
         id.clone(),
         ProviderRuntimeConfig {
             id,

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -16,6 +16,22 @@ impl ProviderEndpointId {
         Self(Self::DEFAULT.to_string())
     }
 
+    pub(crate) fn parse(value: &str) -> Result<Self> {
+        let normalized = value.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            return Err(anyhow!("provider endpoint id must not be empty"));
+        }
+        if !normalized
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
+        {
+            return Err(anyhow!(
+                "invalid provider endpoint id {normalized}; expected lowercase ascii, digits, '-' or '_'"
+            ));
+        }
+        Ok(Self(normalized))
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2716,13 +2716,28 @@ fn provider_doc_entries_are_sorted_and_populated() {
     let entries =
         built_in_provider_doc_entries().expect("built_in_provider_doc_entries should succeed");
     assert!(!entries.is_empty(), "should have at least one provider");
-    // Verify entries are sorted by id
+    // Legacy provider refs remain sorted for stable generated docs.
     for i in 1..entries.len() {
         assert!(
             entries[i - 1].id.as_str() <= entries[i].id.as_str(),
             "entries must be sorted by id"
         );
     }
+
+    let dashscope_token_plan = entries
+        .iter()
+        .find(|entry| entry.legacy_provider.as_str() == "dashscope-token-plan")
+        .expect("dashscope-token-plan doc entry");
+    assert_eq!(dashscope_token_plan.id.as_str(), "dashscope-token-plan");
+    assert_eq!(dashscope_token_plan.provider.as_str(), "dashscope");
+    assert_eq!(dashscope_token_plan.endpoint.as_str(), "token-plan");
+
+    let volcengine_image = entries
+        .iter()
+        .find(|entry| entry.legacy_provider.as_str() == "volcengine-image-openai")
+        .expect("volcengine-image-openai doc entry");
+    assert_eq!(volcengine_image.provider.as_str(), "volcengine");
+    assert_eq!(volcengine_image.endpoint.as_str(), "image-openai");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- model built-in providers internally as provider accounts with endpoints while preserving legacy provider ids
- expose provider account, endpoint, and legacy provider ref in generated model docs
- add coverage for provider doc entry endpoint mappings and preserve existing legacy registry behavior

## Verification
- cargo fmt --all -- --check
- cargo test built_in_provider_ --lib
- cargo test provider_doc_entries_are_sorted_and_populated --lib
- cargo test runtime_model_catalog_ --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets
