### PR TITLE
feat: canonicalize volcengine image endpoint model ref with legacy alias

### DIFF
--- a/docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md
+++ b/docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md
@@ -1,0 +1,28 @@
+# Canonical Model Ref with Legacy Alias
+
+## Choice
+
+Built-in image generation models that belong to a multi-endpoint provider
+(e.g. Volcengine Seedream under the `image-openai` endpoint) are now cataloged
+under their **canonical provider id** (`volcengine`) with an explicit `endpoint`
+field, instead of under the legacy flattened provider id
+(`volcengine-image-openai`).
+
+A legacy alias map (`BuiltInModelCatalog::legacy_aliases`) transparently
+resolves old model refs like `volcengine-image-openai/doubao-seedream-5.0-lite`
+to the canonical form `volcengine/doubao-seedream-5.0-lite` inside
+`resolve_model_route`, so existing user configs continue to work without
+manual migration.
+
+## Reason
+
+The catalog, docgen, and settings UI should all present one canonical
+provider identity. Keeping the legacy id as a separate catalog entry created
+provider sprawl and made the three-column (provider / endpoint / legacy)
+identity visible only in docs, not in the runtime model ref itself.
+
+## Preserved boundary
+
+Legacy provider ids remain valid as configuration keys and as model ref input;
+they are normalized to canonical form at route resolution time. No user-facing
+breaking change; old configs work unchanged.

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -267,6 +267,7 @@ and capabilities.
 | `volcengine` | `doubao-seed-2-0-code-preview-260215` | `volcengine/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | ✅ |
 | `volcengine` | `doubao-seed-2-0-lite-260215` | `volcengine/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
 | `volcengine` | `doubao-seed-2-0-pro-260215` | `volcengine/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | ✅ |
+| `volcengine` | `doubao-seedream-5.0-lite` | `volcengine/doubao-seedream-5.0-lite` | — | — | — | — |
 | `volcengine-agent` | `ark-code-latest` | `volcengine-agent/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `volcengine-agent` | `deepseek-v3-2-251201` | `volcengine-agent/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
 | `volcengine-agent` | `deepseek-v4-flash` | `volcengine-agent/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
@@ -287,7 +288,6 @@ and capabilities.
 | `volcengine-coding` | `glm-5.2` | `volcengine-coding/glm-5.2` | 204800 | 128000 | ✅ | — |
 | `volcengine-coding` | `kimi-k2.6` | `volcengine-coding/kimi-k2.6` | 262144 | 32768 | ✅ | — |
 | `volcengine-coding` | `kimi-k2.7-code` | `volcengine-coding/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
-| `volcengine-image-openai` | `doubao-seedream-5.0-lite` | `volcengine-image-openai/doubao-seedream-5.0-lite` | — | — | — | — |
 | `xai` | `grok-3` | `xai/grok-3` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-fast` | `xai/grok-3-fast` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-mini` | `xai/grok-3-mini` | 131072 | 8192 | ✅ | — |

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -188,7 +188,11 @@ impl RuntimeModelCatalog {
         model_ref: &ModelRef,
         requested_capability: ModelRouteCapability,
     ) -> Option<ResolvedModelRoute> {
-        let endpoint = self.provider_endpoints.get(&model_ref.provider)?;
+        let canonical_ref = self.built_in_catalog.canonicalize_model_ref(model_ref);
+        let model_ref = &canonical_ref;
+
+        let endpoint = self.resolve_endpoint_for_model(model_ref)?;
+
         let policy = self.built_in_catalog.resolve_policy(
             model_ref,
             &self.model_overrides,
@@ -208,6 +212,28 @@ impl RuntimeModelCatalog {
             policy,
             requested_capability,
         })
+    }
+
+    /// Resolve the provider endpoint config for a (possibly canonical) model ref.
+    /// Uses the model metadata's endpoint field when available to find the
+    /// correct endpoint among multiple endpoints under the same canonical provider.
+    fn resolve_endpoint_for_model(
+        &self,
+        model_ref: &ModelRef,
+    ) -> Option<&ResolvedProviderEndpointConfig> {
+        let model_endpoint = self
+            .built_in_catalog
+            .get(model_ref)
+            .and_then(|metadata| metadata.endpoint.as_ref());
+        match model_endpoint {
+            // Model declares a specific non-default endpoint: find by (provider, endpoint)
+            Some(endpoint) => self
+                .provider_endpoints
+                .values()
+                .find(|e| e.provider == model_ref.provider && &e.endpoint == endpoint),
+            // Default endpoint or no catalog metadata: direct key lookup
+            None => self.provider_endpoints.get(&model_ref.provider),
+        }
     }
 
     pub fn provider_chain(&self, model_override: Option<&ModelRef>) -> Vec<ModelRef> {
@@ -338,6 +364,7 @@ impl RuntimeModelCatalog {
                     override_config.capabilities.as_ref(),
                 ),
                 source: crate::model_catalog::ModelMetadataSource::ConfigOverride,
+                endpoint: None,
             });
         }
         models.sort_by(|left, right| {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2696,7 +2696,7 @@ fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
 
     assert_eq!(
         route.model_ref.as_string(),
-        "volcengine-image-openai/doubao-seedream-5.0-lite"
+        "volcengine/doubao-seedream-5.0-lite"
     );
     assert_eq!(
         route.requested_capability,
@@ -2796,8 +2796,8 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
         ProviderId::parse("volcengine-image-openai").unwrap(),
         ProviderRuntimeConfig {
             id: ProviderId::parse("volcengine-image-openai").unwrap(),
-            route_provider: ProviderId::parse("volcengine-image-openai").unwrap(),
-            route_endpoint: ProviderEndpointId::default_endpoint(),
+            route_provider: ProviderId::parse("volcengine").unwrap(),
+            route_endpoint: ProviderEndpointId::parse("image-openai").unwrap(),
             transport: ProviderTransportKind::OpenAiChatCompletions,
             base_url: "https://ark.cn-beijing.volces.com/api/plan/v3".into(),
             auth: ProviderAuthConfig::default(),
@@ -2816,9 +2816,55 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
         .select_generate_image_model(&ContextConfig::default(), None, None)
         .unwrap();
 
+    assert_eq!(selected.as_string(), "volcengine/doubao-seedream-5.0-lite");
+}
+
+#[test]
+fn generate_image_selection_accepts_canonical_volcengine_seedream() {
+    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
+    fixture.config.image_generation_model =
+        Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
+    let legacy_provider = ProviderId::parse("volcengine-image-openai").unwrap();
+    let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+    fixture.config.providers.insert(
+        legacy_provider.clone(),
+        built_ins.get(&legacy_provider).unwrap().clone(),
+    );
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let selected = catalog
+        .select_generate_image_model(&ContextConfig::default(), None, None)
+        .unwrap();
+
+    assert_eq!(selected.as_string(), "volcengine/doubao-seedream-5.0-lite");
+}
+
+#[test]
+fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
+    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
+    fixture.config.image_generation_model =
+        Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
+    let legacy_provider = ProviderId::parse("volcengine-image-openai").unwrap();
+    let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+    fixture.config.providers.insert(
+        legacy_provider.clone(),
+        built_ins.get(&legacy_provider).unwrap().clone(),
+    );
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let route = catalog
+        .select_generate_image_route(&ContextConfig::default(), None, None)
+        .unwrap();
+
     assert_eq!(
-        selected.as_string(),
-        "volcengine-image-openai/doubao-seedream-5.0-lite"
+        route.model_ref.as_string(),
+        "volcengine/doubao-seedream-5.0-lite"
+    );
+    assert_eq!(route.endpoint.provider.as_str(), "volcengine");
+    assert_eq!(route.endpoint.endpoint.as_str(), "image-openai");
+    assert_eq!(
+        route.endpoint.runtime_config.id.as_str(),
+        "volcengine-image-openai"
     );
 }
 
@@ -2846,6 +2892,7 @@ fn runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins() {
                 tool_output_truncation_estimated_tokens: None,
                 capabilities: Default::default(),
                 source: ModelMetadataSource::RemoteDiscovered,
+                endpoint: None,
             }],
         },
     );

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{ModelRef, ProviderId};
+use crate::config::{ModelRef, ProviderEndpointId, ProviderId};
 use crate::context::ContextConfig;
 
 const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 95;
@@ -105,6 +105,10 @@ pub struct BuiltInModelMetadata {
     #[serde(default)]
     pub capabilities: ModelCapabilityFlags,
     pub source: ModelMetadataSource,
+    /// Non-default endpoint this model belongs to under its canonical provider.
+    /// When `None`, the model uses the provider's default endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<ProviderEndpointId>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -231,12 +235,14 @@ impl Default for ResolvedRuntimeModelPolicy {
 pub struct BuiltInModelCatalog {
     entries: HashMap<ModelRef, BuiltInModelMetadata>,
     preferred_models: HashMap<ProviderId, ModelRef>,
+    aliases: HashMap<ModelRef, ModelRef>,
 }
 
 impl BuiltInModelCatalog {
     pub fn new() -> Self {
         let mut entries = HashMap::new();
         let mut preferred_models = HashMap::new();
+        let aliases = Self::legacy_aliases();
         for entry in built_in_entries() {
             if is_turn_default_candidate(&entry) {
                 preferred_models
@@ -248,11 +254,34 @@ impl BuiltInModelCatalog {
         Self {
             entries,
             preferred_models,
+            aliases,
         }
     }
 
     pub fn get(&self, model_ref: &ModelRef) -> Option<&BuiltInModelMetadata> {
         self.entries.get(model_ref)
+    }
+
+    /// Resolve a legacy model ref to its canonical form.
+    /// Returns the input unchanged if no alias exists.
+    pub fn canonicalize_model_ref(&self, model_ref: &ModelRef) -> ModelRef {
+        self.aliases
+            .get(model_ref)
+            .cloned()
+            .unwrap_or_else(|| model_ref.clone())
+    }
+
+    /// Legacy model ref → canonical model ref aliases for backward compatibility.
+    fn legacy_aliases() -> HashMap<ModelRef, ModelRef> {
+        let mut aliases = HashMap::new();
+        aliases.insert(
+            ModelRef::new(
+                provider_id("volcengine-image-openai"),
+                "doubao-seedream-5.0-lite",
+            ),
+            ModelRef::new(provider_id("volcengine"), "doubao-seedream-5.0-lite"),
+        );
+        aliases
     }
 
     pub fn list(&self) -> Vec<BuiltInModelMetadata> {
@@ -510,6 +539,7 @@ fn catalog_model(
             ..ModelCapabilityFlags::default()
         },
         source: ModelMetadataSource::BuiltInCatalog,
+        endpoint: None,
     }
 }
 
@@ -561,6 +591,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::anthropic(), "claude-haiku-4-5"),
@@ -579,6 +610,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.5"),
@@ -599,6 +631,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
@@ -619,6 +652,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.3-codex"),
@@ -639,6 +673,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.3-codex-spark"),
@@ -659,6 +694,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai(), "gpt-image-2"),
@@ -676,6 +712,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai(), "gpt-5.4"),
@@ -694,6 +731,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::ConservativeBuiltin,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai(), "gpt-5.3"),
@@ -712,6 +750,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::ConservativeBuiltin,
+            endpoint: None,
         },
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai(), "gpt-5.4-mini"),
@@ -730,6 +769,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::ConservativeBuiltin,
+            endpoint: None,
         },
     ];
     entries.extend(compatible_provider_model_entries());
@@ -2337,7 +2377,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         BuiltInModelMetadata {
             model_ref: ModelRef::new(
-                provider_id("volcengine-image-openai"),
+                provider_id("volcengine"),
                 "doubao-seedream-5.0-lite",
             ),
             display_name: "Doubao Seedream 5.0 Lite".into(),
@@ -2356,6 +2396,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: Some(ProviderEndpointId::parse("image-openai").expect("valid built-in endpoint id")),
         },
         catalog_model(
             "xiaomi",

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -318,6 +318,7 @@ impl OpenRouterModel {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
         })
     }
 }


### PR DESCRIPTION
## Summary

Migrate the Volcengine Seedream image generation model from the legacy flattened provider id `volcengine-image-openai/doubao-seedream-5.0-lite` to the canonical form `volcengine/doubao-seedream-5.0-lite` with an explicit `endpoint` field set to `image-openai`.

This completes the model catalog refactoring (Phase 1-5 → final convergence) by upgrading the last remaining legacy model ref to the canonical provider + endpoint identity.

## Changes

- **`src/model_catalog.rs`**: Add `endpoint: Option<ProviderEndpointId>` to `BuiltInModelMetadata`; add `aliases` map + `canonicalize_model_ref()` + `legacy_aliases()` to `BuiltInModelCatalog`; change Seedream entry from `volcengine-image-openai` → `volcengine` + `endpoint: Some("image-openai")`
- **`src/config/models.rs`**: Update `resolve_model_route()` to canonicalize model ref and use new `resolve_endpoint_for_model()` for endpoint-aware lookup (finds by canonical provider + endpoint instead of direct provider key)
- **`src/model_discovery.rs`**: Add `endpoint: None` to discovered model metadata
- **`docs/website/reference/models.md`**: Regenerated via `holon-docgen` — Seedream now shows under `volcengine` provider
- **`docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md`**: Decision note
- **Tests**: Updated legacy test assertions to expect canonical ref; added canonical ref tests for both model selection and route endpoint resolution

## Backward compatibility

Old user configs using `volcengine-image-openai/doubao-seedream-5.0-lite` continue to work without manual migration. The legacy alias is transparently resolved to the canonical form at route resolution time.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib` ✅ 2106 passed, 0 failed