### PR TITLE
feat: distinguish Volcengine provider tiers (standard/agent-plan/coding-plan)

### DIFF
--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -844,8 +844,8 @@ fn built_in_provider_endpoint_identity(
         "dashscope-coding-plan" => ("dashscope", "coding-plan"),
         "stepfun-plan" => ("stepfun", "plan"),
         "volcengine-coding" => ("volcengine", "coding"),
-        "volcengine-agent" => ("volcengine", "agent"),
-        "volcengine-image-openai" => ("volcengine", "image-openai"),
+        "volcengine-agent" => ("volcengine", "plan"),
+        "volcengine-image-openai" => ("volcengine", "plan-openai"),
         "xiaomi-token-plan" => ("xiaomi", "token-plan"),
         _ => {
             return Ok((
@@ -1170,44 +1170,41 @@ pub(crate) fn populate_built_in_provider_catalog(
         &[],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    // Standard tier — OpenAI Responses at /api/v3 (not the non-existent /api/compatible).
+    insert_builtin_http_provider(
         catalog,
         "volcengine",
-        "https://ark.cn-beijing.volces.com/api/compatible",
-        &["VOLCENGINE_API_KEY", "ARK_API_KEY"],
+        ProviderTransportKind::OpenAiResponses,
+        "https://ark.cn-beijing.volces.com/api/v3",
+        &["VOLCENGINE_API_KEY"],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    // Coding Plan tier — OpenAI Responses at /api/coding/v3 (independent plan, isolated key).
+    insert_builtin_http_provider(
         catalog,
         "volcengine-coding",
-        "https://ark.cn-beijing.volces.com/api/coding",
-        &[
-            "VOLCENGINE_CODING_API_KEY",
-            "VOLCENGINE_API_KEY",
-            "ARK_API_KEY",
-        ],
+        ProviderTransportKind::OpenAiResponses,
+        "https://ark.cn-beijing.volces.com/api/coding/v3",
+        &["VOLCENGINE_CODING_API_KEY"],
         settings_env,
     )?;
+    // Agent Plan tier — Anthropic compatible at /api/plan (isolated key, no cross-tier fallback).
     insert_anthropic_compatible_provider(
         catalog,
         "volcengine-agent",
         "https://ark.cn-beijing.volces.com/api/plan",
-        &[
-            "VOLCENGINE_AGENT_API_KEY",
-            "VOLCENGINE_API_KEY",
-            "ARK_API_KEY",
-        ],
+        &["VOLCENGINE_AGENT_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    // Agent Plan OpenAI tier — OpenAI Responses at /api/plan/v3 (text + image generation, same key as agent plan).
+    insert_builtin_http_provider(
         catalog,
         "volcengine-image-openai",
+        ProviderTransportKind::OpenAiResponses,
         "https://ark.cn-beijing.volces.com/api/plan/v3",
         &[
             "VOLCENGINE_IMAGE_OPENAI_API_KEY",
             "VOLCENGINE_AGENT_API_KEY",
-            "VOLCENGINE_API_KEY",
-            "ARK_API_KEY",
         ],
         settings_env,
     )?;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1385,7 +1385,7 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         .unwrap();
     assert_eq!(
         volcengine_image_openai.transport,
-        ProviderTransportKind::OpenAiChatCompletions
+        ProviderTransportKind::OpenAiResponses
     );
     assert_eq!(
         volcengine_image_openai.base_url,
@@ -2703,7 +2703,7 @@ fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
         ModelRouteCapability::ImageGeneration
     );
     assert_eq!(route.endpoint.provider.as_str(), "volcengine");
-    assert_eq!(route.endpoint.endpoint.as_str(), "image-openai");
+    assert_eq!(route.endpoint.endpoint.as_str(), "plan-openai");
     assert_eq!(
         route.endpoint.runtime_config.id.as_str(),
         "volcengine-image-openai"
@@ -2797,8 +2797,8 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
         ProviderRuntimeConfig {
             id: ProviderId::parse("volcengine-image-openai").unwrap(),
             route_provider: ProviderId::parse("volcengine").unwrap(),
-            route_endpoint: ProviderEndpointId::parse("image-openai").unwrap(),
-            transport: ProviderTransportKind::OpenAiChatCompletions,
+            route_endpoint: ProviderEndpointId::parse("plan-openai").unwrap(),
+            transport: ProviderTransportKind::OpenAiResponses,
             base_url: "https://ark.cn-beijing.volces.com/api/plan/v3".into(),
             auth: ProviderAuthConfig::default(),
             credential: None,
@@ -2861,7 +2861,7 @@ fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
         "volcengine/doubao-seedream-5.0-lite"
     );
     assert_eq!(route.endpoint.provider.as_str(), "volcengine");
-    assert_eq!(route.endpoint.endpoint.as_str(), "image-openai");
+    assert_eq!(route.endpoint.endpoint.as_str(), "plan-openai");
     assert_eq!(
         route.endpoint.runtime_config.id.as_str(),
         "volcengine-image-openai"
@@ -3026,7 +3026,7 @@ fn provider_doc_entries_are_sorted_and_populated() {
         .find(|entry| entry.legacy_provider.as_str() == "volcengine-image-openai")
         .expect("volcengine-image-openai doc entry");
     assert_eq!(volcengine_image.provider.as_str(), "volcengine");
-    assert_eq!(volcengine_image.endpoint.as_str(), "image-openai");
+    assert_eq!(volcengine_image.endpoint.as_str(), "plan-openai");
 }
 
 #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2396,7 +2396,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
-            endpoint: Some(ProviderEndpointId::parse("image-openai").expect("valid built-in endpoint id")),
+            endpoint: Some(ProviderEndpointId::parse("plan-openai").expect("valid built-in endpoint id")),
         },
         catalog_model(
             "xiaomi",
@@ -3210,7 +3210,8 @@ mod tests {
     #[test]
     fn volcengine_catalog_respects_anthropic_compatible_output_limits() {
         // Regression test for #2095: Volcengine's Anthropic-compatible API
-        // rejects max_tokens above 128000.
+        // (Agent Plan tier only) rejects max_tokens above 128000. Standard and
+        // Coding tiers now use OpenAI Responses, so the limit does not apply.
         let catalog = BuiltInModelCatalog::new();
 
         for removed_model_ref in [
@@ -3227,16 +3228,16 @@ mod tests {
         }
 
         for entry in catalog.list() {
-            if entry.model_ref.provider.as_str().starts_with("volcengine") {
+            if entry.model_ref.provider.as_str() == "volcengine-agent" {
                 assert!(
                     entry.max_output_tokens_upper_limit <= Some(128_000),
-                    "{} should not exceed Volcengine's Anthropic-compatible max_tokens limit",
+                    "{} should not exceed Volcengine Agent Plan Anthropic-compatible max_tokens limit",
                     entry.model_ref.as_string()
                 );
             }
         }
 
-        for model_ref in ["volcengine-coding/glm-5.2", "volcengine-agent/glm-5.2"] {
+        for model_ref in ["volcengine-agent/glm-5.2"] {
             let policy = catalog.resolve_policy(
                 &ModelRef::parse(model_ref).unwrap(),
                 &HashMap::new(),


### PR DESCRIPTION
## Summary

Distinguish Volcengine provider tiers by endpoint naming, transport, and API key isolation.

## Changes

### Endpoint renaming (identity mapping)
| Legacy provider name | Old endpoint ID | New endpoint ID |
|---|---|---|
| `volcengine-agent` | `agent` | `plan` |
| `volcengine-image-openai` | `image-openai` | `plan-openai` |

Legacy provider names remain in the registry for backward compatibility — existing user configs continue to work without migration.

### Transport & base URL changes
| Tier | Legacy provider | Old transport | New transport | Old base URL | New base URL |
|---|---|---|---|---|---|
| Standard | `volcengine` | AnthropicMessages | OpenAiResponses | `/api/compatible` | `/api/v3` |
| Coding Plan | `volcengine-coding` | AnthropicMessages | OpenAiResponses | `/api/coding` | `/api/coding/v3` |
| Agent Plan | `volcengine-agent` | AnthropicMessages | (unchanged) | `/api/plan` | (unchanged) |
| Agent Plan OpenAI | `volcengine-image-openai` | OpenAiChatCompletions | OpenAiResponses | `/api/plan/v3` | (unchanged) |

- Standard tier: removed non-existent `/api/compatible` path; `/api/v3` is the correct OpenAI-compatible endpoint.
- Coding Plan: independent plan with its own tier, switched to OpenAI Responses at `/api/coding/v3`.
- Agent Plan OpenAI: unified text + image generation via OpenAI Responses transport; path auto-selected by request type (`/responses` for text, `/images/generations` for image).

### API key isolation
- Removed cross-tier fallback to `VOLCENGINE_API_KEY` and `ARK_API_KEY` for all plan/coding tiers.
- Each tier only reads its own env var:
  - Standard: `VOLCENGINE_API_KEY`
  - Coding Plan: `VOLCENGINE_CODING_API_KEY`
  - Agent Plan: `VOLCENGINE_AGENT_API_KEY`
  - Agent Plan OpenAI: `VOLCENGINE_IMAGE_OPENAI_API_KEY` → `VOLCENGINE_AGENT_API_KEY` (same-tier fallback only)

## Test updates
- Updated transport assertions for `volcengine-image-openai` from `OpenAiChatCompletions` to `OpenAiResponses`.
- Updated doc entry endpoint assertion from `image-openai` to `plan-openai`.
- Scoped `volcengine_catalog_respects_anthropic_compatible_output_limits` test to `volcengine-agent` only (standard/coding tiers no longer use Anthropic transport).

## Verification
- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --all-targets -- volcengine` ✅