### PR TITLE
feat: switch Volcengine plan tier to OpenAI Responses transport

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **41 endpoints** and **247 models**.
+across **40 endpoints** and **247 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -57,10 +57,9 @@ used in existing `provider/model` refs and config shortcuts.
 | `venice` | `default` | `venice` | OpenAI Chat Completions | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
 | `vercel-ai-gateway` | `default` | `vercel-ai-gateway` | Anthropic Messages | `https://ai-gateway.vercel.sh` | `VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY or VERCEL_AI_GATEWAY_API_KEY` |
 | `vllm` | `default` | `vllm` | OpenAI Chat Completions | `http://127.0.0.1:8000/v1` | `—` |
-| `volcengine` | `default` | `volcengine` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/compatible` | `VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `volcengine` | `agent` | `volcengine-agent` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/plan` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `volcengine` | `coding` | `volcengine-coding` | Anthropic Messages | `https://ark.cn-beijing.volces.com/api/coding` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
-| `volcengine` | `image-openai` | `volcengine-image-openai` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_IMAGE_OPENAI_API_KEY or VOLCENGINE_AGENT_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
+| `volcengine` | `default` | `volcengine` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/v3` | `VOLCENGINE_API_KEY` |
+| `volcengine` | `plan` | `volcengine-agent` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_IMAGE_OPENAI_API_KEY` |
+| `volcengine` | `coding` | `volcengine-coding` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY` |
 | `xai` | `default` | `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `xiaomi` | `default` | `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
 | `xiaomi` | `token-plan` | `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -845,7 +845,7 @@ fn built_in_provider_endpoint_identity(
         "stepfun-plan" => ("stepfun", "plan"),
         "volcengine-coding" => ("volcengine", "coding"),
         "volcengine-agent" => ("volcengine", "plan"),
-        "volcengine-image-openai" => ("volcengine", "plan-openai"),
+        "volcengine-image-openai" => ("volcengine", "plan"),
         "xiaomi-token-plan" => ("xiaomi", "token-plan"),
         _ => {
             return Ok((
@@ -1188,23 +1188,15 @@ pub(crate) fn populate_built_in_provider_catalog(
         &["VOLCENGINE_CODING_API_KEY"],
         settings_env,
     )?;
-    // Agent Plan tier — Anthropic compatible at /api/plan (isolated key, no cross-tier fallback).
-    insert_anthropic_compatible_provider(
-        catalog,
-        "volcengine-agent",
-        "https://ark.cn-beijing.volces.com/api/plan",
-        &["VOLCENGINE_AGENT_API_KEY"],
-        settings_env,
-    )?;
-    // Agent Plan OpenAI tier — OpenAI Responses at /api/plan/v3 (text + image generation, same key as agent plan).
+    // Agent Plan tier — OpenAI Responses at /api/plan/v3 (text + image generation, isolated key, no cross-tier fallback).
     insert_builtin_http_provider(
         catalog,
-        "volcengine-image-openai",
+        "volcengine-agent",
         ProviderTransportKind::OpenAiResponses,
         "https://ark.cn-beijing.volces.com/api/plan/v3",
         &[
-            "VOLCENGINE_IMAGE_OPENAI_API_KEY",
             "VOLCENGINE_AGENT_API_KEY",
+            "VOLCENGINE_IMAGE_OPENAI_API_KEY",
         ],
         settings_env,
     )?;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1290,11 +1290,11 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         "https://gemini.example/v1beta".to_string(),
     );
     settings_env.insert(
-        "VOLCENGINE_IMAGE_OPENAI_API_KEY".to_string(),
-        "volcengine-image-key".to_string(),
+        "VOLCENGINE_AGENT_API_KEY".to_string(),
+        "volcengine-agent-key".to_string(),
     );
     settings_env.insert(
-        "HOLON_VOLCENGINE_IMAGE_OPENAI_BASE_URL".to_string(),
+        "HOLON_VOLCENGINE_AGENT_BASE_URL".to_string(),
         "https://ark.example/api/v3".to_string(),
     );
 
@@ -1380,42 +1380,40 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         Some("dashscope-coding-plan-key")
     );
 
-    let volcengine_image_openai = providers
-        .get(&ProviderId::parse("volcengine-image-openai").unwrap())
+    let volcengine_agent = providers
+        .get(&ProviderId::parse("volcengine-agent").unwrap())
         .unwrap();
     assert_eq!(
-        volcengine_image_openai.transport,
+        volcengine_agent.transport,
         ProviderTransportKind::OpenAiResponses
     );
+    assert_eq!(volcengine_agent.base_url, "https://ark.example/api/v3");
     assert_eq!(
-        volcengine_image_openai.base_url,
-        "https://ark.example/api/v3"
-    );
-    assert_eq!(
-        volcengine_image_openai.auth.env.as_deref(),
-        Some("VOLCENGINE_IMAGE_OPENAI_API_KEY")
-    );
-    assert_eq!(
-        volcengine_image_openai.credential.as_deref(),
-        Some("volcengine-image-key")
-    );
-    let mut volcengine_agent_only_env = HashMap::new();
-    volcengine_agent_only_env.insert(
-        "VOLCENGINE_AGENT_API_KEY".to_string(),
-        "volcengine-agent-key".to_string(),
-    );
-    let volcengine_agent_only_providers =
-        super::built_in_provider_registry_with_settings(&volcengine_agent_only_env).unwrap();
-    let volcengine_image_openai = volcengine_agent_only_providers
-        .get(&ProviderId::parse("volcengine-image-openai").unwrap())
-        .unwrap();
-    assert_eq!(
-        volcengine_image_openai.auth.env.as_deref(),
+        volcengine_agent.auth.env.as_deref(),
         Some("VOLCENGINE_AGENT_API_KEY")
     );
     assert_eq!(
-        volcengine_image_openai.credential.as_deref(),
+        volcengine_agent.credential.as_deref(),
         Some("volcengine-agent-key")
+    );
+    // Backward compat: VOLCENGINE_IMAGE_OPENAI_API_KEY still works as fallback.
+    let mut volcengine_image_openai_only_env = HashMap::new();
+    volcengine_image_openai_only_env.insert(
+        "VOLCENGINE_IMAGE_OPENAI_API_KEY".to_string(),
+        "volcengine-image-key".to_string(),
+    );
+    let volcengine_image_openai_only_providers =
+        super::built_in_provider_registry_with_settings(&volcengine_image_openai_only_env).unwrap();
+    let volcengine_agent = volcengine_image_openai_only_providers
+        .get(&ProviderId::parse("volcengine-agent").unwrap())
+        .unwrap();
+    assert_eq!(
+        volcengine_agent.auth.env.as_deref(),
+        Some("VOLCENGINE_IMAGE_OPENAI_API_KEY")
+    );
+    assert_eq!(
+        volcengine_agent.credential.as_deref(),
+        Some("volcengine-image-key")
     );
 
     let nearai = providers
@@ -2678,11 +2676,8 @@ fn runtime_model_catalog_resolves_image_generation_route() {
 
 #[test]
 fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
-    let mut fixture = test_app_config(
-        "openai/gpt-5.4",
-        &["volcengine-image-openai/doubao-seedream-5.0-lite"],
-    );
-    let legacy_provider = ProviderId::parse("volcengine-image-openai").unwrap();
+    let mut fixture = test_app_config("openai/gpt-5.4", &["volcengine/doubao-seedream-5.0-lite"]);
+    let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
         legacy_provider.clone(),
@@ -2703,10 +2698,10 @@ fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
         ModelRouteCapability::ImageGeneration
     );
     assert_eq!(route.endpoint.provider.as_str(), "volcengine");
-    assert_eq!(route.endpoint.endpoint.as_str(), "plan-openai");
+    assert_eq!(route.endpoint.endpoint.as_str(), "plan");
     assert_eq!(
         route.endpoint.runtime_config.id.as_str(),
-        "volcengine-image-openai"
+        "volcengine-agent"
     );
 }
 
@@ -2797,7 +2792,7 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
         ProviderRuntimeConfig {
             id: ProviderId::parse("volcengine-image-openai").unwrap(),
             route_provider: ProviderId::parse("volcengine").unwrap(),
-            route_endpoint: ProviderEndpointId::parse("plan-openai").unwrap(),
+            route_endpoint: ProviderEndpointId::parse("plan").unwrap(),
             transport: ProviderTransportKind::OpenAiResponses,
             base_url: "https://ark.cn-beijing.volces.com/api/plan/v3".into(),
             auth: ProviderAuthConfig::default(),
@@ -2824,7 +2819,7 @@ fn generate_image_selection_accepts_canonical_volcengine_seedream() {
     let mut fixture = test_app_config("openai/gpt-5.4", &[]);
     fixture.config.image_generation_model =
         Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
-    let legacy_provider = ProviderId::parse("volcengine-image-openai").unwrap();
+    let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
         legacy_provider.clone(),
@@ -2844,7 +2839,7 @@ fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
     let mut fixture = test_app_config("openai/gpt-5.4", &[]);
     fixture.config.image_generation_model =
         Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
-    let legacy_provider = ProviderId::parse("volcengine-image-openai").unwrap();
+    let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
         legacy_provider.clone(),
@@ -2861,10 +2856,10 @@ fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
         "volcengine/doubao-seedream-5.0-lite"
     );
     assert_eq!(route.endpoint.provider.as_str(), "volcengine");
-    assert_eq!(route.endpoint.endpoint.as_str(), "plan-openai");
+    assert_eq!(route.endpoint.endpoint.as_str(), "plan");
     assert_eq!(
         route.endpoint.runtime_config.id.as_str(),
-        "volcengine-image-openai"
+        "volcengine-agent"
     );
 }
 
@@ -3021,12 +3016,12 @@ fn provider_doc_entries_are_sorted_and_populated() {
     assert_eq!(dashscope_token_plan.provider.as_str(), "dashscope");
     assert_eq!(dashscope_token_plan.endpoint.as_str(), "token-plan");
 
-    let volcengine_image = entries
+    let volcengine_agent = entries
         .iter()
-        .find(|entry| entry.legacy_provider.as_str() == "volcengine-image-openai")
-        .expect("volcengine-image-openai doc entry");
-    assert_eq!(volcengine_image.provider.as_str(), "volcengine");
-    assert_eq!(volcengine_image.endpoint.as_str(), "plan-openai");
+        .find(|entry| entry.legacy_provider.as_str() == "volcengine-agent")
+        .expect("volcengine-agent doc entry");
+    assert_eq!(volcengine_agent.provider.as_str(), "volcengine");
+    assert_eq!(volcengine_agent.endpoint.as_str(), "plan");
 }
 
 #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2396,7 +2396,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
-            endpoint: Some(ProviderEndpointId::parse("plan-openai").expect("valid built-in endpoint id")),
+            endpoint: Some(ProviderEndpointId::parse("plan").expect("valid built-in endpoint id")),
         },
         catalog_model(
             "xiaomi",
@@ -3209,9 +3209,9 @@ mod tests {
 
     #[test]
     fn volcengine_catalog_respects_anthropic_compatible_output_limits() {
-        // Regression test for #2095: Volcengine's Anthropic-compatible API
-        // (Agent Plan tier only) rejects max_tokens above 128000. Standard and
-        // Coding tiers now use OpenAI Responses, so the limit does not apply.
+        // Regression test for #2095: All Volcengine tiers now use OpenAI
+        // Responses. The 128000 limit on volcengine-agent models is a
+        // conservative model definition choice, not an API constraint.
         let catalog = BuiltInModelCatalog::new();
 
         for removed_model_ref in [

--- a/tests/live_volcengine_image.rs
+++ b/tests/live_volcengine_image.rs
@@ -13,11 +13,11 @@ fn live_volcengine_image_model() -> String {
 #[ignore = "requires a Volcengine Ark image generation credential profile and network access"]
 async fn live_volcengine_ark_seedream_generates_image_with_openai_images_api() -> Result<()> {
     let config = AppConfig::load()?;
-    let provider_id = ProviderId::parse("volcengine-image-openai")?;
+    let provider_id = ProviderId::parse("volcengine-agent")?;
     let provider_config = config
         .providers
         .get(&provider_id)
-        .ok_or_else(|| anyhow::anyhow!("missing volcengine-image-openai provider config"))?;
+        .ok_or_else(|| anyhow::anyhow!("missing volcengine-agent provider config"))?;
     let model = live_volcengine_image_model();
     let provider = OpenAiChatCompletionsProvider::from_runtime_config(
         provider_config,
@@ -34,7 +34,7 @@ async fn live_volcengine_ark_seedream_generates_image_with_openai_images_api() -
         })
         .await?;
 
-    assert_eq!(output.provider.as_str(), "volcengine-image-openai");
+    assert_eq!(output.provider.as_str(), "volcengine-agent");
     assert_eq!(output.model, model);
     assert_eq!(output.images.len(), 1);
     assert!(


### PR DESCRIPTION
## Summary

Merge `volcengine-image-openai` endpoint into `volcengine-agent` (plan tier), unifying text and image generation under a single OpenAI Responses endpoint.

## Changes

- **Transport switch**: `volcengine-agent` plan tier changed from Anthropic Messages (`/api/plan`) to OpenAI Responses (`/api/plan/v3`). All Volcengine tiers now consistently use OpenAI Responses.
- **Endpoint merge**: Removed `volcengine-image-openai` as a separate endpoint definition. Image generation now goes through the same `plan` endpoint as text.
- **Backward compatibility**: `VOLCENGINE_IMAGE_OPENAI_API_KEY` remains as a fallback env var for `volcengine-agent`. `volcengine-image-openai` legacy provider ID still resolves to `(volcengine, plan)` via `built_in_provider_endpoint_identity`.
- **Model metadata**: `doubao-seedream-5.0-lite` endpoint changed from `plan-openai` to `plan`.
- **Tests**: Updated all tests referencing `volcengine-image-openai` / `plan-openai`.
- **Docs**: Regenerated `docs/website/reference/models.md`.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- All affected unit tests pass ✅
- Livetest (with `volcengine-agent:default` credential profile):
  - OpenAI Responses text endpoint (`/api/plan/v3/responses`, model `glm-5.2`): HTTP 200 ✅
  - OpenAI Images endpoint (`/api/plan/v3/images/generations`, model `doubao-seedream-5.0-lite`): HTTP 200, generated 1 image ✅