### PR TITLE
feat: add xAI Grok provider search support

### DIFF
--- a/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
+++ b/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
@@ -1,0 +1,33 @@
+# xAI Grok API and X Login Boundary
+
+## Choice
+
+Holon's first Grok integration uses the public xAI API as an OpenAI Responses
+compatible HTTP provider authenticated by `XAI_API_KEY`.
+
+Grok's built-in `web_search` and `x_search` are represented as xAI server-side
+tools on that Responses request. They are not exposed as a raw Holon web-search
+provider and they do not use X API search credentials.
+
+X/xAI account login reuse is left out of the HTTP provider path. If Holon later
+supports X-account-backed Grok sessions, it should integrate through an
+official Grok Build surface such as the Grok CLI / ACP process boundary, not by
+reusing browser cookies, private session files, or consumer subscription state
+as an xAI API key.
+
+## Reason
+
+xAI's public inference API documents API-key authentication for direct
+`/v1/responses` and `/v1/chat/completions` calls. Its built-in search tools are
+server-side xAI tools on model requests.
+
+Grok Build documents a separate login/session path for the official Grok CLI.
+That path can reuse an X/xAI account for the CLI product, but it is not the same
+credential contract as the public xAI API.
+
+## Preserved boundary
+
+The `xai` provider remains a normal remote HTTP provider with explicit API-key
+credentials. Future X-account reuse must be a separate process/agent transport
+with its own lifecycle and trust boundary, rather than hidden auth behavior in
+the OpenAI-compatible transport.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -76,3 +76,4 @@ Current decision notes:
 - [056 Prompt Cache Workspace Guidance Boundary](./056-prompt-cache-workspace-guidance-boundary.md)
 - [057 OpenAI Codex OAuth Refresh Boundary](./057-openai-codex-oauth-refresh-boundary.md)
 - [059 Bounded Performance Diagnostics](./059-bounded-performance-diagnostics.md)
+- [065 xAI Grok API and X Login Boundary](./065-xai-grok-api-and-login-boundary.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **247 models**.
+across **40 endpoints** and **248 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -60,7 +60,7 @@ used in existing `provider/model` refs and config shortcuts.
 | `volcengine` | `default` | `volcengine` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/v3` | `VOLCENGINE_API_KEY` |
 | `volcengine` | `plan` | `volcengine-agent` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_IMAGE_OPENAI_API_KEY` |
 | `volcengine` | `coding` | `volcengine-coding` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY` |
-| `xai` | `default` | `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
+| `xai` | `default` | `xai` | OpenAI Responses | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `xiaomi` | `default` | `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
 | `xiaomi` | `token-plan` | `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
 | `zai` | `default` | `zai` | Anthropic Messages | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
@@ -295,6 +295,7 @@ and capabilities.
 | `xai` | `grok-4-1-fast` | `xai/grok-4-1-fast` | 2000000 | 30000 | ✅ | ✅ |
 | `xai` | `grok-4-fast` | `xai/grok-4-fast` | 2000000 | 30000 | ✅ | ✅ |
 | `xai` | `grok-4-fast-non-reasoning` | `xai/grok-4-fast-non-reasoning` | 2000000 | 30000 | — | ✅ |
+| `xai` | `grok-4.5` | `xai/grok-4.5` | 500000 | 64000 | ✅ | ✅ |
 | `xai` | `grok-code-fast-1` | `xai/grok-code-fast-1` | 256000 | 10000 | ✅ | — |
 | `xiaomi` | `mimo-v2-flash` | `xiaomi/mimo-v2-flash` | 262144 | 8192 | — | — |
 | `xiaomi` | `mimo-v2-omni` | `xiaomi/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1214,9 +1214,10 @@ pub(crate) fn populate_built_in_provider_catalog(
         &["XIAOMI_TOKEN_PLAN_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_builtin_http_provider(
         catalog,
         "xai",
+        ProviderTransportKind::OpenAiResponses,
         "https://api.x.ai/v1",
         &["XAI_API_KEY"],
         settings_env,
@@ -1433,9 +1434,17 @@ pub(crate) fn insert_builtin_http_provider_with_context_management(
             credential_store_path: None,
             codex_home: None,
             originator: None,
-            reasoning_effort: None,
+            reasoning_effort: if provider == "xai" {
+                Some("medium".into())
+            } else {
+                None
+            },
             context_management,
-            builtin_web_search,
+            builtin_web_search: if provider == "xai" {
+                Some(xai_builtin_web_search_config())
+            } else {
+                builtin_web_search
+            },
         },
     );
     Ok(())
@@ -1492,6 +1501,15 @@ pub(crate) fn deepseek_builtin_web_search_config() -> ProviderBuiltinWebSearchCo
         kind: ProviderNativeWebSearchKind::Anthropic,
         advertised_tool_type: "web_search_20250305".to_string(),
         backend_kind: "deepseek_web_search".to_string(),
+    }
+}
+
+pub(crate) fn xai_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::Xai,
+        advertised_tool_type: "web_search".to_string(),
+        backend_kind: "xai_web_search_x_search".to_string(),
     }
 }
 
@@ -1610,6 +1628,16 @@ pub(crate) fn validate_provider_builtin_web_search(
             } else {
                 Err(anyhow!(
                     "providers.{}.builtin_web_search.advertised_tool_type must be web_search_preview for OpenAI Responses native search",
+                    provider_id.as_str()
+                ))
+            }
+        }
+        (ProviderTransportKind::OpenAiResponses, ProviderNativeWebSearchKind::Xai) => {
+            if search.advertised_tool_type == "web_search" {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search for xAI Responses native search",
                     provider_id.as_str()
                 ))
             }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -840,6 +840,14 @@ fn built_in_provider_registry_declares_provider_specific_builtin_search() {
     assert_eq!(deepseek_search.kind, ProviderNativeWebSearchKind::Anthropic);
     assert_eq!(deepseek_search.advertised_tool_type, "web_search_20250305");
     assert_eq!(deepseek_search.backend_kind, "deepseek_web_search");
+
+    let xai = registry.get(&ProviderId::parse("xai").unwrap()).unwrap();
+    assert_eq!(xai.transport, ProviderTransportKind::OpenAiResponses);
+    assert_eq!(xai.reasoning_effort.as_deref(), Some("medium"));
+    let xai_search = xai.builtin_web_search.as_ref().unwrap();
+    assert_eq!(xai_search.kind, ProviderNativeWebSearchKind::Xai);
+    assert_eq!(xai_search.advertised_tool_type, "web_search");
+    assert_eq!(xai_search.backend_kind, "xai_web_search_x_search");
 }
 
 #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2510,6 +2510,15 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         catalog_model("xai", "grok-4", "Grok 4", 256_000, 64_000, true, false),
         catalog_model(
             "xai",
+            "grok-4.5",
+            "Grok 4.5",
+            500_000,
+            64_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "xai",
             "grok-4-fast",
             "Grok 4 Fast",
             2_000_000,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -176,6 +176,7 @@ pub enum ProviderNativeWebSearchKind {
     OpenAi,
     Anthropic,
     Gemini,
+    Xai,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -55,6 +55,7 @@ pub struct OpenAiProvider {
     api_key: Option<String>,
     model: String,
     max_output_tokens: u32,
+    reasoning_effort: Option<String>,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
@@ -302,6 +303,7 @@ impl OpenAiProvider {
             api_key,
             model: model.to_string(),
             max_output_tokens,
+            reasoning_effort: provider_config.reasoning_effort.clone(),
             builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
@@ -809,7 +811,7 @@ impl AgentProvider for OpenAiProvider {
             &request,
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Relaxed,
-            None,
+            self.reasoning_effort.as_deref(),
             None,
         )?;
         let mut plan = plan_openai_responses_request(body, &request, &self.continuation, true)?;
@@ -946,7 +948,7 @@ impl AgentProvider for OpenAiProvider {
             &probe_request,
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Relaxed,
-            None,
+            self.reasoning_effort.as_deref(),
             None,
         )?;
         let headers = self
@@ -1865,6 +1867,7 @@ pub(crate) fn build_openai_responses_request(
         .collect::<Result<Vec<_>>>()?;
     if let Some(tool) = openai_native_web_search_tool(request) {
         tools.push(tool);
+        tools.extend(openai_native_web_search_extra_tools(request));
     }
 
     let mut body = json!({
@@ -1882,6 +1885,9 @@ pub(crate) fn build_openai_responses_request(
     if let Some(response_format) = openai_response_format(request) {
         body["text"]["format"] = response_format;
     }
+    if let Some(reasoning_effort) = reasoning_effort {
+        body["reasoning"] = json!({ "effort": reasoning_effort });
+    }
     match contract {
         OpenAiResponsesTransportContract::StandardJson => {
             body["max_output_tokens"] = Value::from(max_output_tokens);
@@ -1891,8 +1897,7 @@ pub(crate) fn build_openai_responses_request(
             if let Some(verbosity) = verbosity {
                 body["text"] = json!({ "verbosity": verbosity.as_str() });
             }
-            if let Some(reasoning_effort) = reasoning_effort {
-                body["reasoning"] = json!({ "effort": reasoning_effort });
+            if reasoning_effort.is_some() {
                 body["include"] = json!(["reasoning.encrypted_content"]);
             } else {
                 body["reasoning"] = Value::Null;
@@ -1916,10 +1921,23 @@ fn openai_response_format(request: &ProviderTurnRequest) -> Option<Value> {
 
 fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value> {
     let native = request.native_web_search.as_ref()?;
-    if native.kind != ProviderNativeWebSearchKind::OpenAi {
-        return None;
+    match native.kind {
+        ProviderNativeWebSearchKind::OpenAi => Some(json!({ "type": native.advertised_tool_type })),
+        ProviderNativeWebSearchKind::Xai => Some(json!({ "type": "web_search" })),
+        _ => None,
     }
-    Some(json!({ "type": native.advertised_tool_type }))
+}
+
+fn openai_native_web_search_extra_tools(request: &ProviderTurnRequest) -> Vec<Value> {
+    if request
+        .native_web_search
+        .as_ref()
+        .is_some_and(|native| native.kind == ProviderNativeWebSearchKind::Xai)
+    {
+        vec![json!({ "type": "x_search" })]
+    } else {
+        Vec::new()
+    }
 }
 
 fn openai_request_controls_diagnostics(body: &Value) -> ProviderOpenAiRequestControlsDiagnostics {
@@ -2431,7 +2449,10 @@ fn native_web_search_diagnostics(
     request: &ProviderTurnRequest,
 ) -> Option<ProviderNativeWebSearchDiagnostics> {
     let native = request.native_web_search.as_ref()?;
-    let lowered = native.kind == ProviderNativeWebSearchKind::OpenAi;
+    let lowered = matches!(
+        native.kind,
+        ProviderNativeWebSearchKind::OpenAi | ProviderNativeWebSearchKind::Xai
+    );
     Some(ProviderNativeWebSearchDiagnostics {
         kind: native.kind,
         provider_id: native.provider_id.clone(),
@@ -2439,8 +2460,9 @@ fn native_web_search_diagnostics(
         advertised_tool_type: native.advertised_tool_type.clone(),
         backend_kind: native.backend_kind.clone(),
         lowered,
-        fallback_reason: (!lowered)
-            .then(|| "openai responses transport only supports OpenAI-native web search".into()),
+        fallback_reason: (!lowered).then(|| {
+            "openai responses transport only supports OpenAI/xAI-native web search".into()
+        }),
     })
 }
 
@@ -5356,7 +5378,7 @@ mod tests {
     use super::{
         build_openai_codex_image_generation_request, build_openai_responses_request,
         chat_completions_url, choose_openai_codex_credential, consume_openai_sse_event,
-        incremental_diagnostics, latest_openai_compaction_index,
+        incremental_diagnostics, latest_openai_compaction_index, native_web_search_diagnostics,
         openai_compaction_trigger_for_request_plan, openai_compaction_trigger_for_window,
         openai_provider_window_compaction_candidate,
         parse_openai_codex_image_generation_response_items, plan_openai_responses_request,
@@ -5845,6 +5867,49 @@ mod tests {
             .expect("tools should be an array")
             .iter()
             .any(|tool| tool == &json!({ "type": "web_search_preview" })));
+    }
+
+    #[test]
+    fn openai_responses_request_lowers_xai_native_search_tools_and_reasoning() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("search X and the web".into())],
+            vec![],
+        );
+        request.native_web_search = Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::Xai,
+            provider_id: "xai".into(),
+            provider_model_ref: "xai/grok-4-fast".into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: "xai_web_search_x_search".into(),
+            max_results: Some(5),
+        });
+
+        let body = build_openai_responses_request(
+            "grok-4-fast",
+            1024,
+            &request,
+            OpenAiResponsesTransportContract::StandardJson,
+            ToolSchemaContract::Strict,
+            Some("medium"),
+            None,
+        )
+        .expect("xAI responses request should build");
+
+        let tools = body["tools"].as_array().expect("tools should be an array");
+        assert!(tools
+            .iter()
+            .any(|tool| tool == &json!({ "type": "web_search" })));
+        assert!(tools
+            .iter()
+            .any(|tool| tool == &json!({ "type": "x_search" })));
+        assert_eq!(body["reasoning"]["effort"], json!("medium"));
+
+        let diagnostics = native_web_search_diagnostics(&request)
+            .expect("native web search diagnostics should be recorded");
+        assert!(diagnostics.lowered);
+        assert_eq!(diagnostics.kind, ProviderNativeWebSearchKind::Xai);
+        assert_eq!(diagnostics.fallback_reason, None);
     }
 
     #[test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1923,7 +1923,7 @@ fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value>
     let native = request.native_web_search.as_ref()?;
     match native.kind {
         ProviderNativeWebSearchKind::OpenAi => Some(json!({ "type": native.advertised_tool_type })),
-        ProviderNativeWebSearchKind::Xai => Some(json!({ "type": "web_search" })),
+        ProviderNativeWebSearchKind::Xai => Some(json!({ "type": native.advertised_tool_type })),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- add built-in xAI provider on OpenAI Responses with default medium reasoning effort
- lower xAI native web_search + x_search tools through the Responses transport
- add Grok 4.5 catalog/docs plus an implementation decision for X login/API boundaries

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test built_in_provider_registry_declares_provider_specific_builtin_search
- cargo test openai_responses_request_lowers_xai_native_search_tools_and_reasoning
- cargo test xai_native_search
- cargo run --bin holon-docgen -- models > /tmp/holon-models.md && diff -u docs/website/reference/models.md /tmp/holon-models.md

## Live test
- skipped: no XAI_API_KEY or xAI/Grok credential profile is available on this node