### PR TITLE
fix: repair agent home workspace invariant

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -2924,6 +2924,11 @@ mod tests {
         let parent_state = parent.agent_state().await.unwrap();
         assert!(parent_state.active_workspace_entry.is_some());
         assert!(parent_state.worktree_session.is_some());
+        let parent_home_id = crate::types::agent_home_workspace_id(&parent_state.id);
+        assert!(
+            parent_state.attached_workspaces.contains(&parent_home_id),
+            "parent state should contain its own agent home"
+        );
 
         host.spawn_public_named_agent(
             parent.clone(),
@@ -2938,9 +2943,14 @@ mod tests {
 
         let named = host.get_public_agent("release-bot").await.unwrap();
         let named_state = named.agent_state().await.unwrap();
+        let named_home_id = crate::types::agent_home_workspace_id("release-bot");
         assert_eq!(
             named_state.attached_workspaces,
-            parent_state.attached_workspaces
+            vec![named_home_id, workspace.workspace_id.clone()]
+        );
+        assert!(
+            !named_state.attached_workspaces.contains(&parent_home_id),
+            "public named agent should not inherit the caller's agent home"
         );
         assert!(
             named_state.active_workspace_entry.is_none(),

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -11,7 +11,9 @@ use crate::{
     runtime_db::RuntimeDb,
     storage::AppStorage,
     system::WorkspaceAccessMode,
-    types::{AgentIdentityRecord, WorkspaceEntry, WorkspaceOccupancyRecord},
+    types::{
+        agent_home_workspace_id, AgentIdentityRecord, WorkspaceEntry, WorkspaceOccupancyRecord,
+    },
 };
 
 #[derive(Clone)]
@@ -206,7 +208,11 @@ impl RuntimeRegistry {
         workspace_anchor: PathBuf,
     ) -> Result<WorkspaceEntry> {
         let workspace_anchor = crate::system::workspace::normalize_path(&workspace_anchor)?;
-        let det_id = ids::deterministic_workspace_id(&workspace_anchor);
+        let agent_home = self.agent_home_workspace_entry_for_anchor(&workspace_anchor)?;
+        let det_id = agent_home
+            .as_ref()
+            .map(|entry| entry.workspace_id.clone())
+            .unwrap_or_else(|| ids::deterministic_workspace_id(&workspace_anchor));
         if let Some(existing) = self
             .inner
             .host_storage
@@ -226,13 +232,30 @@ impl RuntimeRegistry {
                 self.inner
                     .host_storage
                     .migrate_workspace_id(&existing.workspace_id, &det_id)?;
+                if let Some(entry) = agent_home {
+                    self.inner.host_storage.append_workspace_entry(&entry)?;
+                    return Ok(entry);
+                }
                 let mut migrated = existing;
                 migrated.workspace_id = det_id;
                 return Ok(migrated);
             }
+            if let Some(entry) = agent_home {
+                if existing.workspace_alias != entry.workspace_alias
+                    || existing.workspace_kind != entry.workspace_kind
+                    || existing.owner_agent_id != entry.owner_agent_id
+                {
+                    self.inner.host_storage.append_workspace_entry(&entry)?;
+                    return Ok(entry);
+                }
+            }
             return Ok(existing);
         }
 
+        if let Some(entry) = agent_home {
+            self.inner.host_storage.append_workspace_entry(&entry)?;
+            return Ok(entry);
+        }
         let repo_name = workspace_anchor
             .file_name()
             .and_then(|name| name.to_str())
@@ -240,6 +263,37 @@ impl RuntimeRegistry {
         let entry = WorkspaceEntry::new(det_id, workspace_anchor, repo_name);
         self.inner.host_storage.append_workspace_entry(&entry)?;
         Ok(entry)
+    }
+
+    fn agent_home_workspace_entry_for_anchor(
+        &self,
+        workspace_anchor: &std::path::Path,
+    ) -> Result<Option<WorkspaceEntry>> {
+        let agents_root =
+            crate::system::workspace::normalize_path(&self.config().data_dir.join("agents"))?;
+        let Ok(agent_id_path) = workspace_anchor.strip_prefix(&agents_root) else {
+            return Ok(None);
+        };
+        if agent_id_path.components().count() != 1 {
+            return Ok(None);
+        }
+        let Some(agent_id) = agent_id_path.file_name().and_then(|name| name.to_str()) else {
+            return Ok(None);
+        };
+        if self.agent_identity_record(agent_id)?.is_none()
+            && agent_id != self.config().default_agent_id
+        {
+            return Ok(None);
+        }
+        let mut entry = WorkspaceEntry::new(
+            agent_home_workspace_id(agent_id),
+            workspace_anchor.to_path_buf(),
+            Some("AgentHome".into()),
+        );
+        entry.workspace_alias = Some(crate::types::AGENT_HOME_WORKSPACE_ID.into());
+        entry.workspace_kind = Some("agent_home".into());
+        entry.owner_agent_id = Some(agent_id.to_string());
+        Ok(Some(entry))
     }
 
     pub(crate) fn ensure_default_agent_identity(&self) -> Result<AgentIdentityRecord> {
@@ -598,5 +652,28 @@ mod tests {
 
         let entry = registry.ensure_workspace_entry(repo_path).unwrap();
         assert_eq!(entry.repo_name.as_deref(), Some("my-repo-name"));
+    }
+
+    #[test]
+    fn ensure_workspace_entry_recognizes_agent_home_path() {
+        let (_home, registry) = test_registry();
+        registry.ensure_default_agent_identity().unwrap();
+        let agent_id = registry.config().default_agent_id.clone();
+        let agent_home = registry.config().agent_root_dir().join(&agent_id);
+        std::fs::create_dir_all(&agent_home).unwrap();
+
+        let entry = registry.ensure_workspace_entry(agent_home.clone()).unwrap();
+
+        assert_eq!(entry.workspace_id, agent_home_workspace_id(&agent_id));
+        assert_eq!(entry.workspace_alias.as_deref(), Some("agent_home"));
+        assert_eq!(entry.workspace_kind.as_deref(), Some("agent_home"));
+        assert_eq!(entry.owner_agent_id.as_deref(), Some(agent_id.as_str()));
+        assert_eq!(
+            entry.workspace_id,
+            registry
+                .ensure_workspace_entry(agent_home)
+                .unwrap()
+                .workspace_id
+        );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -887,9 +887,36 @@ impl RuntimeHandle {
         let next_state = {
             let guard = self.inner.agent.lock().await;
             let mut next_state = guard.state.clone();
-            next_state.attached_workspaces = parent_state.attached_workspaces.clone();
+            next_state.attached_workspaces =
+                workspace::inherited_attached_workspaces_for_agent(parent_state, &next_state.id);
             next_state.active_workspace_entry = parent_state.active_workspace_entry.clone();
             next_state.worktree_session = parent_state.worktree_session.clone();
+            workspace::canonicalize_agent_home_bindings(
+                &mut next_state,
+                self.inner.storage.data_dir(),
+                &guard.state.id,
+            )?;
+            if next_state
+                .active_workspace_entry
+                .as_ref()
+                .is_some_and(|entry| {
+                    entry.workspace_id == AGENT_HOME_WORKSPACE_ID
+                        || entry.workspace_id.starts_with("agent_home:")
+                })
+            {
+                let access_mode = next_state
+                    .active_workspace_entry
+                    .as_ref()
+                    .map(|entry| entry.access_mode)
+                    .unwrap_or(WorkspaceAccessMode::ExclusiveWrite);
+                next_state.active_workspace_entry =
+                    Some(workspace::canonical_agent_home_active_entry(
+                        self.inner.storage.data_dir(),
+                        &guard.state.id,
+                        access_mode,
+                    )?);
+                next_state.worktree_session = None;
+            }
             next_state.execution_profile = parent_state.execution_profile.clone();
             next_state.model_override = parent_state.model_override.clone();
             next_state
@@ -918,9 +945,15 @@ impl RuntimeHandle {
         let next_state = {
             let guard = self.inner.agent.lock().await;
             let mut next_state = guard.state.clone();
-            next_state.attached_workspaces = parent_state.attached_workspaces.clone();
+            next_state.attached_workspaces =
+                workspace::inherited_attached_workspaces_for_agent(parent_state, &next_state.id);
             next_state.active_workspace_entry = None;
             next_state.worktree_session = None;
+            workspace::canonicalize_agent_home_bindings(
+                &mut next_state,
+                self.inner.storage.data_dir(),
+                &guard.state.id,
+            )?;
             next_state.execution_profile = parent_state.execution_profile.clone();
             next_state.model_override = parent_state.model_override.clone();
             next_state

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1062,14 +1062,21 @@ impl RuntimeHandle {
         {
             return Ok(existing);
         }
-        let workspace = WorkspaceEntry::new(
-            crate::ids::deterministic_workspace_id(&normalized_anchor),
-            normalized_anchor.clone(),
-            normalized_anchor
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(ToString::to_string),
-        );
+        let workspace = if normalized_anchor == self.inner.storage.data_dir() {
+            crate::runtime::workspace::agent_home_workspace_entry(
+                self.inner.storage.data_dir(),
+                &self.agent_id().await?,
+            )
+        } else {
+            WorkspaceEntry::new(
+                crate::ids::deterministic_workspace_id(&normalized_anchor),
+                normalized_anchor.clone(),
+                normalized_anchor
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(ToString::to_string),
+            )
+        };
         Ok(workspace)
     }
 

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -41,7 +41,10 @@ async fn attached_workspace_inheritance_preserves_execution_boundary() {
     .unwrap();
     {
         let mut guard = parent.inner.agent.lock().await;
-        guard.state.attached_workspaces = vec!["repo-a".into()];
+        guard.state.attached_workspaces = vec![
+            crate::types::agent_home_workspace_id("default"),
+            "repo-a".into(),
+        ];
         guard.state.active_workspace_entry = Some(ActiveWorkspaceEntry {
             workspace_id: "repo-a".into(),
             workspace_anchor: parent_workspace.path().to_path_buf(),
@@ -79,7 +82,13 @@ async fn attached_workspace_inheritance_preserves_execution_boundary() {
         .unwrap();
     let child_state = child.agent_state().await.unwrap();
 
-    assert_eq!(child_state.attached_workspaces, vec!["repo-a".to_string()]);
+    assert_eq!(
+        child_state.attached_workspaces,
+        vec![
+            crate::types::agent_home_workspace_id("release-bot"),
+            "repo-a".to_string()
+        ]
+    );
     assert!(child_state.active_workspace_entry.is_none());
     assert!(child_state.worktree_session.is_none());
     assert_eq!(

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -45,14 +45,6 @@ pub(crate) fn agent_home_workspace_entry(data_dir: &Path, agent_id: &str) -> Wor
     entry
 }
 
-/// Canonicalize legacy `AGENT_HOME_WORKSPACE_ID` references in agent state to
-/// the deterministic, agent-specific canonical ID.
-///
-/// # Migration path (deprecated)
-///
-/// This function exists solely to migrate agents that still reference the
-/// old constant `AGENT_HOME_WORKSPACE_ID`. It is planned for removal once
-/// migration logs confirm no agents require canonicalization.
 pub(crate) fn canonicalize_agent_home_bindings(
     state: &mut AgentState,
     data_dir: &Path,
@@ -87,6 +79,9 @@ pub(crate) fn canonicalize_agent_home_bindings(
         let next_id = if workspace_id == AGENT_HOME_WORKSPACE_ID {
             changed = true;
             canonical_id.as_str()
+        } else if workspace_id.starts_with("agent_home:") && workspace_id != &canonical_id {
+            changed = true;
+            continue;
         } else {
             workspace_id.as_str()
         };
@@ -97,13 +92,12 @@ pub(crate) fn canonicalize_agent_home_bindings(
         }
     }
 
-    if state
-        .active_workspace_entry
-        .as_ref()
-        .is_some_and(|entry| entry.workspace_id == canonical_id)
-        && !next.iter().any(|id| id == &canonical_id)
-    {
-        next.push(canonical_id);
+    if !next.iter().any(|id| id == &canonical_id) {
+        next.insert(0, canonical_id);
+        changed = true;
+    } else if next.first() != Some(&canonical_id) {
+        next.retain(|id| id != &canonical_id);
+        next.insert(0, canonical_id);
         changed = true;
     }
 
@@ -116,6 +110,24 @@ pub(crate) fn canonicalize_agent_home_bindings(
     }
 
     Ok(changed)
+}
+
+pub(crate) fn inherited_attached_workspaces_for_agent(
+    parent_state: &AgentState,
+    agent_id: &str,
+) -> Vec<String> {
+    let canonical_id = agent_home_workspace_id(agent_id);
+    let mut inherited = Vec::with_capacity(parent_state.attached_workspaces.len().max(1));
+    inherited.push(canonical_id);
+    for workspace_id in &parent_state.attached_workspaces {
+        if workspace_id == AGENT_HOME_WORKSPACE_ID || workspace_id.starts_with("agent_home:") {
+            continue;
+        }
+        if !inherited.iter().any(|id| id == workspace_id) {
+            inherited.push(workspace_id.clone());
+        }
+    }
+    inherited
 }
 
 pub(crate) fn canonical_agent_home_active_entry(
@@ -481,14 +493,36 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_handles_no_active_workspace_entry() {
+    fn canonicalize_repairs_missing_own_agent_home() {
         let data_dir = PathBuf::from("/tmp/agent-home");
         let mut state = AgentState::new("my-agent");
-        // No active_workspace_entry and no legacy references.
         state.attached_workspaces = vec!["ws_other".to_string()];
 
         let changed = canonicalize_agent_home_bindings(&mut state, &data_dir, "my-agent").unwrap();
 
-        assert!(!changed, "should be no-op with no legacy references");
+        assert!(changed, "should repair missing own agent home");
+        assert_eq!(
+            state.attached_workspaces,
+            vec![agent_home_workspace_id("my-agent"), "ws_other".to_string()]
+        );
+    }
+
+    #[test]
+    fn canonicalize_filters_foreign_agent_home_bindings() {
+        let data_dir = PathBuf::from("/tmp/agent-home");
+        let mut state = AgentState::new("my-agent");
+        state.attached_workspaces = vec![
+            "agent_home:other-agent".to_string(),
+            "ws_other".to_string(),
+            agent_home_workspace_id("my-agent"),
+        ];
+
+        let changed = canonicalize_agent_home_bindings(&mut state, &data_dir, "my-agent").unwrap();
+
+        assert!(changed, "should filter foreign agent home");
+        assert_eq!(
+            state.attached_workspaces,
+            vec![agent_home_workspace_id("my-agent"), "ws_other".to_string()]
+        );
     }
 }


### PR DESCRIPTION
Fixes #2140.

## Summary
- repair agent state so each agent keeps its own `agent_home:<agent_id>` binding and filters inherited foreign `agent_home:*` bindings
- make public named/private child workspace inheritance keep non-home project workspaces while replacing parent home with child home
- recognize direct attaches to an agent's own home path as `agent_home:<agent_id>` with agent-home metadata instead of a generic deterministic workspace id

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib --no-run`
- `cargo test --lib attached_workspace_inheritance_preserves_execution_boundary`
- `cargo test --lib canonicalize_repairs_missing_own_agent_home`
- `cargo test --lib ensure_workspace_entry_recognizes_agent_home_path`
- `cargo test --lib public_named_initial_message_is_optional_and_inherits_only_attached_workspaces`
- `cargo test --lib workspace`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
