### PR TITLE
fix: deduplicate promoted command task timeline events

### DIFF
--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -280,7 +280,6 @@ fn event_category(kind: &str) -> OperatorEventCategory {
         | "supervised_child_task_monitor_reattached"
         | "supervised_child_task_recovery_failed"
         | "command_task_runner_failed"
-        | "command_task_running_persisted"
         | "command_task_result_enqueue_failed" => OperatorEventCategory::Task,
         "callback_delivered"
         | "timer_create_requested"
@@ -557,8 +556,7 @@ fn is_debug_event(kind: &str, payload: &Value) -> bool {
         | "working_memory_updated"
         | "operator_delivery_submitted"
         | "operator_delivery_completed"
-        | "operator_transport_binding_upserted"
-        | "command_task_running_persisted" => true,
+        | "operator_transport_binding_upserted" => true,
         _ => false,
     }
 }
@@ -675,7 +673,6 @@ fn event_text(
             simple_event_text("Child task recovery failed", error_or_task_body(payload))
         }
         "command_task_runner_failed" => command_task_runner_failed_text(payload, fallback_summary),
-        "command_task_running_persisted" => command_task_running_persisted_text(payload),
         "command_task_result_enqueue_failed" => {
             command_task_result_enqueue_failed_text(payload, fallback_summary)
         }
@@ -1186,15 +1183,6 @@ fn command_task_runner_failed_text(
         (None, None) => "Command task runner failed".into(),
     };
     ("Command task runner failed".into(), body, summary)
-}
-
-fn command_task_running_persisted_text(payload: &Value) -> (String, Option<String>, String) {
-    let task_id = payload.get("task_id").and_then(Value::as_str);
-    let body = task_id.map(ToString::to_string);
-    let summary = task_id
-        .map(|task_id| format!("Command task running: {task_id}"))
-        .unwrap_or_else(|| "Command task running".into());
-    ("Command task running".into(), body, summary)
 }
 
 fn command_task_result_enqueue_failed_text(
@@ -2089,7 +2077,6 @@ mod tests {
         "supervised_child_task_monitor_reattached",
         "supervised_child_task_recovery_failed",
         "command_task_runner_failed",
-        "command_task_running_persisted",
         "command_task_result_enqueue_failed",
         "callback_delivered",
         "timer_create_requested",

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -665,7 +665,6 @@ impl RuntimeHandle {
                             Some(&err.to_string()),
                             true,
                         ),
-                        "command_task_result_persisted_after_runner_failure",
                     )
                     .await;
                 runtime
@@ -750,7 +749,6 @@ impl RuntimeHandle {
             &task_record,
             terminal.status.clone(),
             detail.clone(),
-            "command_task_terminal_persisted",
         )
         .await?;
         let result_text = build_command_task_result_text(
@@ -799,13 +797,8 @@ impl RuntimeHandle {
                         "error": err.to_string(),
                     }),
                 ))?;
-            self.persist_command_task_terminal_state(
-                &task_record,
-                terminal.status.clone(),
-                detail,
-                "command_task_result_persisted_after_enqueue_failure",
-            )
-            .await?;
+            self.persist_command_task_terminal_state(&task_record, terminal.status.clone(), detail)
+                .await?;
         }
 
         self.inner.task_handles.lock().await.remove(&task_record.id);
@@ -863,33 +856,6 @@ impl RuntimeHandle {
                     false,
                 )),
                 recovery: task_record.recovery.clone(),
-            };
-            self.apply_task_transition(task_state_reducer::TaskTransition::new(
-                &running_task,
-                "task_status_updated",
-            ))
-            .await?;
-            self.inner
-                .storage
-                .append_event(&crate::types::AuditEvent::new(
-                    "command_task_running_persisted",
-                    serde_json::json!({
-                        "task_id": task_record.id,
-                    }),
-                ))?;
-
-            let running_task = TaskRecord {
-                status: TaskStatus::Running,
-                updated_at: chrono::Utc::now(),
-                detail: Some(command_task_detail(
-                    resolved,
-                    promoted_from_exec_command,
-                    captured,
-                    None,
-                    None,
-                    false,
-                )),
-                ..task_record.clone()
             };
             self.apply_task_transition(task_state_reducer::TaskTransition::new(
                 &running_task,
@@ -965,7 +931,6 @@ impl RuntimeHandle {
         task_record: &TaskRecord,
         status: TaskStatus,
         detail: serde_json::Value,
-        event_kind: &'static str,
     ) -> Result<()> {
         let fallback = TaskRecord {
             id: task_record.id.clone(),
@@ -980,8 +945,9 @@ impl RuntimeHandle {
             detail: Some(detail),
             recovery: task_record.recovery.clone(),
         };
-        self.apply_task_transition(task_state_reducer::TaskTransition::new(
-            &fallback, event_kind,
+        self.apply_task_transition_silent(task_state_reducer::TaskTransition::new(
+            &fallback,
+            "command_task_terminal_persisted",
         ))
         .await?;
         Ok(())
@@ -1779,10 +1745,23 @@ mod tests {
             .contains("failed to query command status"));
 
         let events = runtime.inner.storage.read_recent_events(20).unwrap();
-        assert!(events.iter().any(|event| {
-            event.kind == "command_task_terminal_persisted"
-                && event.data["task_id"].as_str() == Some(task.id.as_str())
-        }));
+        assert!(!events
+            .iter()
+            .any(|event| event.kind == "command_task_terminal_persisted"));
+        assert!(!events
+            .iter()
+            .any(|event| event.kind == "command_task_running_persisted"));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.kind == "task_status_updated"
+                        && event.data["task_id"].as_str() == Some(task.id.as_str())
+                        && event.data["status"].as_str() == Some("running")
+                })
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -44,6 +44,21 @@ impl<'a> TaskTransition<'a> {
 
 impl RuntimeHandle {
     pub(super) async fn apply_task_transition(&self, transition: TaskTransition<'_>) -> Result<()> {
+        self.apply_task_transition_inner(transition, true).await
+    }
+
+    pub(super) async fn apply_task_transition_silent(
+        &self,
+        transition: TaskTransition<'_>,
+    ) -> Result<()> {
+        self.apply_task_transition_inner(transition, false).await
+    }
+
+    async fn apply_task_transition_inner(
+        &self,
+        transition: TaskTransition<'_>,
+        emit_event: bool,
+    ) -> Result<()> {
         let task = transition.task;
         if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, task) {
             return Ok(());
@@ -60,10 +75,12 @@ impl RuntimeHandle {
             }
             guard.persist_state(&self.inner.storage)?;
         }
-        self.inner.storage.append_event(&AuditEvent::new(
-            transition.event_kind,
-            to_json_value(&TaskLifecycleAuditEvent::from_task(task)),
-        ))?;
+        if emit_event {
+            self.inner.storage.append_event(&AuditEvent::new(
+                transition.event_kind,
+                to_json_value(&TaskLifecycleAuditEvent::from_task(task)),
+            ))?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
# Fix duplicate promoted command task timeline events

Closes #2145.

## Requirements

- Emit only one running lifecycle event when an `ExecCommand` is promoted to a command task.
- Preserve terminal task state before result delivery without exposing a redundant persisted event in the operator timeline.
- Remove the obsolete `command_task_running_persisted` operator-event rendering path.

## Changes

- Removed the duplicate running transition and its dedicated persisted audit event.
- Added a silent task-state reducer entry point for terminal pre-persistence.
- Kept the final `task_result_received` delivery event as the visible terminal lifecycle signal.
- Updated command-task coverage to assert the persisted-only events are absent and the running update is emitted once.

## Verification

- `cargo test --lib runtime::command_task`
- `cargo test --lib runtime::task_state_reducer`
- `cargo test --lib operator_event`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test`

All checks passed.
