### PR TITLE
feat(web-gui): Task detail layered renderers + lifecycle activity merging

### DIFF
--- a/web-gui/app/src/features/agent/AgentTimeline.tsx
+++ b/web-gui/app/src/features/agent/AgentTimeline.tsx
@@ -245,6 +245,9 @@ function ActivityTrail({
               {activityIcon(activity)}
             </span>
             <span className="activity-body">{activity.body}</span>
+            {activity.stateEvolution ? (
+              <span className="activity-state-evolution">{activity.stateEvolution.map((s) => s.replace(/^Task\s+/, "")).join(" → ")}</span>
+            ) : null}
           </button>
         );
 

--- a/web-gui/app/src/features/agent/timeline-utils.ts
+++ b/web-gui/app/src/features/agent/timeline-utils.ts
@@ -70,6 +70,7 @@ export function timelineItemToWorkingActivity(item: AgentTimelineItem): AgentTim
     stateObjectRef: item.stateObjectRef,
     relatedStateObjectRef: item.relatedStateObjectRef,
     detail: item.detail,
+    stateEvolution: item.stateEvolution,
     rawEvent: item.rawEvent,
     debug: item.debug,
   };

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusBadge } from "../../components/ui/StatusChip";
 import { ToolExecutionContent } from "./ToolExecutionRenderers";
+import { TaskDetailContent, normalizeTaskDetailContent } from "./TaskDetailRenderers";
 import type { AgentSummary, SkillCatalogEntry, SkillCatalogState, TaskDetailState, TaskSummary, ToolExecutionDetailState, WorkItemDetailState, WorkItemSummary } from "../../runtime/types";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
@@ -610,18 +611,8 @@ export function TaskDetailPanel({ task, detailState }: { task: TaskSummary; deta
   const output = detailState?.output;
   const taskRecord = output?.task;
   const status = taskRecord?.status ?? output?.status ?? task.status;
-  const summary = taskRecord?.summary ?? output?.summary ?? task.summary;
-  const exitStatus = taskRecord?.exit_status;
-  const outputText =
-    taskRecord?.output_preview ??
-    output?.output ??
-    output?.stdout ??
-    "";
-  const stderrText = output?.stderr ?? "";
-  const truncated = taskRecord?.output_truncated ?? output?.truncated;
-  const command = task.command;
-  const taskIdShort = task.id.replace(/^task:/, "").slice(0, 12);
-  const resultSummary = taskRecord?.result_summary;
+  const detail = normalizeTaskDetailContent(task, output);
+  const summary = detail.summary || task.summary;
 
   return (
     <article className="task-detail inspector-list-item featured">
@@ -633,15 +624,9 @@ export function TaskDetailPanel({ task, detailState }: { task: TaskSummary; deta
       {detailState?.error ? <p className="inspector-error">{detailState.error}</p> : null}
       <dl className="inspector-facts">
         <div>
-          <dt>{t("rightPanel.kind")}</dt>
+          <dt>{t("inspector.kind")}</dt>
           <dd>{task.kind}</dd>
         </div>
-        {exitStatus != null ? (
-          <div>
-            <dt>{t("inspector.exit")}</dt>
-            <dd>{exitStatus}</dd>
-          </div>
-        ) : null}
         {task.workdir ? (
           <div>
             <dt>{t("rightPanel.workdir")}</dt>
@@ -649,30 +634,7 @@ export function TaskDetailPanel({ task, detailState }: { task: TaskSummary; deta
           </div>
         ) : null}
       </dl>
-      {command ? (
-        <section className="work-item-detail-section">
-          <h3>{t("rightPanel.command")}</h3>
-          <pre className="task-command-pre">{command}</pre>
-        </section>
-      ) : null}
-      {resultSummary ? (
-        <section className="work-item-detail-section">
-          <h3>{t("rightPanel.output")}</h3>
-          <pre>{resultSummary}</pre>
-        </section>
-      ) : null}
-      {outputText ? (
-        <section className="work-item-detail-section">
-          <h3>{truncated ? t("rightPanel.outputTruncated") : t("rightPanel.output")}</h3>
-          <pre>{outputText}</pre>
-        </section>
-      ) : null}
-      {stderrText ? (
-        <section className="work-item-detail-section">
-          <h3>{t("rightPanel.stderr")}</h3>
-          <pre>{stderrText}</pre>
-        </section>
-      ) : null}
+      <TaskDetailContent task={task} output={output} />
     </article>
   );
 }

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -624,6 +624,10 @@ export function TaskDetailPanel({ task, detailState }: { task: TaskSummary; deta
       {detailState?.error ? <p className="inspector-error">{detailState.error}</p> : null}
       <dl className="inspector-facts">
         <div>
+          <dt>{t("inspector.taskId")}</dt>
+          <dd><code>{task.id}</code></dd>
+        </div>
+        <div>
           <dt>{t("inspector.kind")}</dt>
           <dd>{task.kind}</dd>
         </div>

--- a/web-gui/app/src/features/right-panel/TaskDetailRenderers.test.ts
+++ b/web-gui/app/src/features/right-panel/TaskDetailRenderers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTaskDetailContent } from "./TaskDetailRenderers";
+
+describe("normalizeTaskDetailContent", () => {
+  it("prefers split stdout/stderr over duplicate raw output for command tasks", () => {
+    expect(
+      normalizeTaskDetailContent(
+        {
+          id: "task_1",
+          kind: "command_task",
+          status: "completed",
+          summary: "cargo test",
+          command: "cargo test",
+        },
+        {
+          summary: "cargo test",
+          task: {
+            summary: "cargo test",
+            result_summary: "command exited with status 0",
+            output_preview: "tests passed",
+            exit_status: 0,
+          },
+          stdout: "tests passed",
+          output: "tests passed",
+        },
+      ),
+    ).toMatchObject({
+      summary: "cargo test",
+      command: "cargo test",
+      result: "command exited with status 0",
+      stdout: "tests passed",
+      rawOutput: "",
+      exitStatus: 0,
+    });
+  });
+
+  it("falls back to preview output when no full output or split streams exist", () => {
+    expect(
+      normalizeTaskDetailContent(
+        {
+          id: "task_2",
+          kind: "command_task",
+          status: "running",
+          summary: "npm run dev",
+        },
+        {
+          task: {
+            summary: "npm run dev",
+            output_preview: "server booting",
+            output_truncated: true,
+          },
+        },
+      ),
+    ).toMatchObject({
+      summary: "npm run dev",
+      rawOutput: "server booting",
+      rawOutputTruncated: true,
+    });
+  });
+
+  it("does not repeat the header summary as a result block", () => {
+    expect(
+      normalizeTaskDetailContent(
+        {
+          id: "task_3",
+          kind: "command_task",
+          status: "completed",
+          summary: "npm run build",
+        },
+        {
+          summary: "npm run build",
+          task: {
+            summary: "npm run build",
+          },
+        },
+      ).result,
+    ).toBe("");
+  });
+});

--- a/web-gui/app/src/features/right-panel/TaskDetailRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/TaskDetailRenderers.tsx
@@ -1,0 +1,113 @@
+import { useTranslation } from "react-i18next";
+
+import type { RuntimeTaskOutputResult, TaskSummary } from "../../runtime/types";
+import { OutputField, SimpleField } from "./ToolExecutionRenderers";
+
+function textField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function scalarText(value: unknown): string {
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+function sameText(left: string, right: string): boolean {
+  return left.trim() !== "" && left === right;
+}
+
+function firstText(...values: unknown[]): string {
+  for (const value of values) {
+    const text = textField(value) || scalarText(value);
+    if (text.trim() !== "") return text;
+  }
+  return "";
+}
+
+export interface NormalizedTaskDetailContent {
+  summary: string;
+  command: string;
+  result: string;
+  stdout: string;
+  stderr: string;
+  rawOutput: string;
+  rawOutputTruncated: boolean;
+  exitStatus?: unknown;
+}
+
+export function normalizeTaskDetailContent(task: TaskSummary, output?: RuntimeTaskOutputResult): NormalizedTaskDetailContent {
+  const taskRecord = output?.task;
+  const summary = firstText(taskRecord?.summary, output?.summary, task.summary);
+  const command = textField(task.command);
+  const stdout = textField(output?.stdout);
+  const stderr = textField(output?.stderr);
+  const hasSplitStreams = stdout !== "" || stderr !== "";
+  const resultCandidate = firstText(taskRecord?.result_summary, output?.summary);
+  const result = sameText(resultCandidate, summary) ? "" : resultCandidate;
+  const rawOutputCandidate = hasSplitStreams ? "" : firstText(output?.output, taskRecord?.output_preview);
+  const rawOutput =
+    sameText(rawOutputCandidate, result) || sameText(rawOutputCandidate, summary)
+      ? ""
+      : rawOutputCandidate;
+
+  return {
+    summary,
+    command,
+    result,
+    stdout,
+    stderr,
+    rawOutput,
+    rawOutputTruncated: taskRecord?.output_truncated === true || output?.truncated === true,
+    exitStatus: taskRecord?.exit_status,
+  };
+}
+
+function CommandTaskRenderer({ task, output }: { task: TaskSummary; output?: RuntimeTaskOutputResult }) {
+  const { t } = useTranslation();
+  const detail = normalizeTaskDetailContent(task, output);
+
+  return (
+    <>
+      {detail.command ? <OutputField label={t("inspector.command")} value={detail.command} /> : null}
+      {detail.result ? <OutputField label={t("inspector.result")} value={detail.result} /> : null}
+      {detail.stdout ? <OutputField label={t("inspector.stdout")} value={detail.stdout} /> : null}
+      {detail.stderr ? <OutputField label={t("inspector.stderr")} value={detail.stderr} variant="error" /> : null}
+      {detail.rawOutput ? (
+        <OutputField
+          label={detail.rawOutputTruncated ? t("inspector.outputTruncated") : t("inspector.rawOutput")}
+          value={detail.rawOutput}
+        />
+      ) : null}
+      {detail.exitStatus != null ? <SimpleField label={t("inspector.exit")} value={detail.exitStatus} /> : null}
+    </>
+  );
+}
+
+function DefaultTaskRenderer({ task, output }: { task: TaskSummary; output?: RuntimeTaskOutputResult }) {
+  const { t } = useTranslation();
+  const detail = normalizeTaskDetailContent(task, output);
+
+  return (
+    <>
+      {detail.command ? <OutputField label={t("inspector.command")} value={detail.command} /> : null}
+      {detail.result ? <OutputField label={t("inspector.result")} value={detail.result} /> : null}
+      {detail.stdout ? <OutputField label={t("inspector.stdout")} value={detail.stdout} /> : null}
+      {detail.stderr ? <OutputField label={t("inspector.stderr")} value={detail.stderr} variant="error" /> : null}
+      {detail.rawOutput ? (
+        <OutputField
+          label={detail.rawOutputTruncated ? t("inspector.outputTruncated") : t("inspector.output")}
+          value={detail.rawOutput}
+        />
+      ) : null}
+      {detail.exitStatus != null ? <SimpleField label={t("inspector.exit")} value={detail.exitStatus} /> : null}
+    </>
+  );
+}
+
+export function TaskDetailContent({ task, output }: { task: TaskSummary; output?: RuntimeTaskOutputResult }) {
+  if (task.kind === "command_task") {
+    return <CommandTaskRenderer task={task} output={output} />;
+  }
+
+  return <DefaultTaskRenderer task={task} output={output} />;
+}

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -63,8 +63,8 @@ function patchInputText(input: unknown): string {
 
 // Shared rendering primitives
 
-/** A labeled code/output block rendered as a standalone section. */
-function OutputField({
+/** A labeled code/output block rendered as a standalone section. Exported for reuse by other detail panels. */
+export function OutputField({
   label,
   value,
   variant,
@@ -83,7 +83,7 @@ function OutputField({
 }
 
 /** A simple inline key-value row for scalar fields like exit status. */
-function SimpleField({ label, value }: { label: string; value: unknown }) {
+export function SimpleField({ label, value }: { label: string; value: unknown }) {
   const text = textField(value) || scalarText(value);
   if (!text) return null;
   return (

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -636,6 +636,7 @@ const en = {
     patch: "Patch",
     patchDiff: "Patch diff",
     output: "Output",
+    rawOutput: "Raw output",
     activity: "Activity",
     summary: "Summary",
     stdout: "Stdout",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -638,6 +638,7 @@ const zh: Record<string, any> = {
     patch: "补丁",
     patchDiff: "补丁差异",
     output: "输出",
+    rawOutput: "原始输出",
     activity: "活动",
     summary: "摘要",
     stdout: "标准输出",

--- a/web-gui/app/src/runtime/object-renderers.ts
+++ b/web-gui/app/src/runtime/object-renderers.ts
@@ -120,7 +120,7 @@ function renderTaskObject(obj: TaskObject, ctx: RenderContext): AgentTimelineIte
   return {
     id: obj.id,
     kind: "tool" as const,
-    label: taskStatusLabel(obj.status),
+    label: taskStatusLabel(obj.initialStatus ?? obj.status),
     body: summary,
     timestamp: obj.render.timestamp,
     meta: obj.render.meta,

--- a/web-gui/app/src/runtime/session-object-types.ts
+++ b/web-gui/app/src/runtime/session-object-types.ts
@@ -73,6 +73,7 @@ export interface TaskObject extends BaseObject {
   status: TaskStatus;
   summary?: string;
   activityIds?: string[];
+  initialStatus?: TaskStatus;
 }
 
 export type WorkItemStatus =

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -206,6 +206,7 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
   } else if (eventType === "task_created" || eventType === "task_status_updated" || eventType === "task_result_received") {
     const taskId = stringField(payload, "task_id");
     const taskObjId = taskId ? `task:${taskId}` : eventId;
+    const existingTask = state.tasks.get(taskObjId);
     const taskStatus = firstStringField(payload, ["task_status", "status"]) as TaskObject["status"];
     const summary = stringField(payload, "summary") ?? state.tasks.get(taskObjId)?.summary;
     const isActivity = eventType !== "task_created";
@@ -214,6 +215,7 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
       ...baseFields,
       id: taskObjId,
       status: taskStatus ?? (eventType === "task_created" ? "created" : "running"),
+      initialStatus: existingTask?.initialStatus ?? (taskStatus ?? "created"),
       summary,
       activityIds,
     } as DomainObject);

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -800,23 +800,18 @@ describe("reduceAgentSessionTimeline", () => {
 
     // Task StateObject renders as a stable card; task_result_received is an
     // ActivityView that gets flattened back into the timeline by compactAgentTimelineItems.
-    expect(timeline).toHaveLength(2);
-    const taskCard = timeline.find((item) => item.kind === "tool");
-    expect(taskCard).toEqual(
+    // Consecutive task lifecycle items from the same task are merged into one entry
+    // with stateEvolution tracking the status progression.
+    expect(timeline).toHaveLength(1);
+    const merged = timeline.find((item) => item.id === "task:task_123");
+    expect(merged).toEqual(
       expect.objectContaining({
         id: "task:task_123",
         kind: "tool",
         label: "Task completed",
-        body: "Run command: npm test",
-        stateObjectRef: { kind: "task", id: "task:task_123", status: "completed", summary: "Run command: npm test" },
-      }),
-    );
-    const activity = timeline.find((item) => item.id === "task-result");
-    expect(activity).toEqual(
-      expect.objectContaining({
-        kind: "event",
-        label: "Task completed",
         body: "Run command: npm test · exit 0 · 42 tests passed",
+        stateObjectRef: { kind: "task", id: "task:task_123", status: "completed", summary: "Run command: npm test" },
+        stateEvolution: ["Task queued", "Task completed"],
         detail: {
           label: "Task details",
           text: "task: task_123 · output: /tmp/task.log · 42 tests passed",
@@ -846,18 +841,14 @@ describe("reduceAgentSessionTimeline", () => {
       },
     });
 
-    expect(timeline).toHaveLength(2);
-    const card = timeline.find((item) => item.kind === "tool");
-    expect(card).toEqual(
+    // Single task_result_received creates task card + activity which are merged.
+    // Both have same label "Task failed" so stateEvolution is not set (length <= 1).
+    expect(timeline).toHaveLength(1);
+    const merged = timeline[0]!;
+    expect(merged).toEqual(
       expect.objectContaining({
-        label: "Task failed",
-        body: "Run command: cargo test",
-        minDisplayLevel: "info",
-      }),
-    );
-    const activity = timeline.find((item) => item.id === "task-failed");
-    expect(activity).toEqual(
-      expect.objectContaining({
+        id: "task:task_failed",
+        kind: "tool",
         label: "Task failed",
         body: "Run command: cargo test · exit 101 · tests failed",
         minDisplayLevel: "info",
@@ -904,25 +895,19 @@ describe("reduceAgentSessionTimeline", () => {
       },
     });
 
-    // Task card + 2 flattened activities (running, completed) = 3 items
-    expect(timeline).toHaveLength(3);
-    const card = timeline.find((item) => item.kind === "tool");
-    expect(card).toEqual(
+    // All 3 consecutive task lifecycle items from the same task are merged into one entry.
+    // The merged item shows the final status label and accumulates stateEvolution.
+    expect(timeline).toHaveLength(1);
+    const merged = timeline[0]!;
+    expect(merged).toEqual(
       expect.objectContaining({
         id: "task:task_abc",
         kind: "tool",
         label: "Task completed",
-        body: "npm run build",
+        body: "npm run build · exit 0",
         stateObjectRef: { kind: "task", id: "task:task_abc", status: "completed", summary: "npm run build" },
+        stateEvolution: ["Task queued", "Task running", "Task completed"],
       }),
-    );
-    const runningActivity = timeline.find((item) => item.id === "t-running");
-    expect(runningActivity).toEqual(
-      expect.objectContaining({ label: "Task running", body: "npm run build" }),
-    );
-    const doneActivity = timeline.find((item) => item.id === "t-done");
-    expect(doneActivity).toEqual(
-      expect.objectContaining({ label: "Task completed", body: "npm run build · exit 0" }),
     );
   });
 

--- a/web-gui/app/src/runtime/timeline-display.ts
+++ b/web-gui/app/src/runtime/timeline-display.ts
@@ -78,7 +78,8 @@ export function compactAgentTimelineItems(items: AgentTimelineItem[]): AgentTime
   const flattened = flattenTimelineActivities(items);
   const finalBriefTexts = flattened.filter(isFinalBriefItem).map((item) => normalizeAssistantBriefText(item.body));
   const deduped = flattened.filter((candidate) => !isAssistantPreviewDuplicate(candidate, finalBriefTexts));
-  return deduped.sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
+  const sorted = deduped.sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
+  return mergeConsecutiveTaskLifecycleItems(sorted);
 }
 
 function timelineDedupeKey(item: AgentTimelineItem): string {
@@ -195,4 +196,101 @@ function normalizeTextKey(text: string): string {
 function sortableTime(value: string): number {
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+/**
+ * Merge consecutive task lifecycle items from the same task into a single
+ * evolving entry. Items are only merged when they are adjacent in the sorted
+ * timeline (no non-task items between them), preserving time-order context.
+ *
+ * Task lifecycle items are identified by:
+ * - `stateObjectRef.kind === "task"` (the task card from task_created)
+ * - `relatedStateObjectRef.kind === "task"` (flattened lifecycle activities)
+ *
+ * The merged item keeps the earliest timestamp, the latest label/body, and
+ * accumulates status labels into `stateEvolution`.
+ */
+function mergeConsecutiveTaskLifecycleItems(items: AgentTimelineItem[]): AgentTimelineItem[] {
+  if (!items.length) return items;
+  const result: AgentTimelineItem[] = [];
+  let i = 0;
+  while (i < items.length) {
+    const taskRefId = taskLifecycleRefId(items[i]);
+    if (!taskRefId) {
+      result.push(items[i]);
+      i++;
+      continue;
+    }
+    // Collect consecutive items from the same task
+    const group: AgentTimelineItem[] = [items[i]];
+    let j = i + 1;
+    while (j < items.length && taskLifecycleRefId(items[j]) === taskRefId) {
+      group.push(items[j]);
+      j++;
+    }
+    if (group.length === 1) {
+      result.push(group[0]);
+    } else {
+      result.push(mergeTaskLifecycleGroup(group));
+    }
+    i = j;
+  }
+  return result;
+}
+
+/**
+ * Extract the task object id if the item is a task lifecycle item.
+ * Returns undefined for non-task items.
+ */
+function taskLifecycleRefId(item: AgentTimelineItem): string | undefined {
+  if (item.stateObjectRef?.kind === "task") return item.stateObjectRef.id;
+  // Only match flattened activities (no own stateObjectRef) to avoid merging tool executions
+  // that have relatedStateObjectRef pointing to a task but are separate objects.
+  if (!item.stateObjectRef && item.relatedStateObjectRef?.kind === "task") return item.relatedStateObjectRef.id;
+  return undefined;
+}
+
+/**
+ * Merge a group of consecutive task lifecycle items into one entry.
+ * - id: prefer the task card's id (stateObjectRef) for stable React keys
+ * - timestamp: earliest (group start)
+ * - label/body/detail: from the last item (latest state)
+ * - stateEvolution: accumulated status labels from all items
+ * - stateObjectRef: from the task card if present
+ * - sourceIds: merged from all
+ */
+function mergeTaskLifecycleGroup(group: AgentTimelineItem[]): AgentTimelineItem {
+  const first = group[0];
+  const last = group[group.length - 1];
+  const taskCard = group.find((item) => item.stateObjectRef?.kind === "task");
+
+  // Build state evolution from status labels
+  const stateEvolution: string[] = [];
+  for (const item of group) {
+    const label = item.label;
+    if (label && !stateEvolution.includes(label)) {
+      stateEvolution.push(label);
+    }
+  }
+
+  return {
+    id: taskCard?.id ?? first.id,
+    kind: taskCard?.kind ?? last.kind,
+    label: last.label,
+    body: last.body,
+    timestamp: first.timestamp,
+    meta: last.meta,
+    minDisplayLevel: group.reduce(
+      (min, item) => (displayLevelRank[item.minDisplayLevel] < displayLevelRank[min.minDisplayLevel] ? item : min),
+      first,
+    ).minDisplayLevel,
+    sourceIds: mergeSourceIds(group.flatMap((item) => item.sourceIds)),
+    stateObjectRef: taskCard?.stateObjectRef ?? last.relatedStateObjectRef,
+    relatedStateObjectRef: taskCard ? undefined : last.relatedStateObjectRef,
+    detail: last.detail,
+    stateEvolution: stateEvolution.length > 1 ? stateEvolution : undefined,
+    activities: undefined,
+    rawEvent: last.rawEvent,
+    debug: last.debug,
+  };
 }

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -454,6 +454,7 @@ export interface AgentTimelineActivity {
   stateObjectRef?: TimelineStateObjectRef;
   relatedStateObjectRef?: TimelineStateObjectRef;
   detail?: AgentTimelineItemDetail;
+  stateEvolution?: string[];
   rawEvent?: unknown;
   debug?: string;
 }
@@ -598,6 +599,7 @@ export interface AgentTimelineItem {
   stateObjectRef?: TimelineStateObjectRef;
   relatedStateObjectRef?: TimelineStateObjectRef;
   detail?: AgentTimelineItemDetail;
+  stateEvolution?: string[];
   activities?: AgentTimelineActivity[];
   rawEvent?: unknown;
   debug?: string;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2006,6 +2006,14 @@ code {
   font-size: 11px;
 }
 
+.activity-state-evolution {
+  flex: 0 0 auto;
+  margin-left: 4px;
+  color: var(--faint);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 .activity-meta {
   grid-template-columns: minmax(0, 1fr) auto;
   color: var(--faint);


### PR DESCRIPTION
## Summary

Three related improvements to the Web GUI runtime timeline and task detail rendering:

### 1. Refactor Task Detail to layered renderer pattern (`f5bc2370`)
- Introduces `TaskDetailRenderers.tsx` with `CommandTaskRenderer`, structuring task detail into ordered blocks: Command → Result → Stdout → Stderr → Output → Exit
- Aligns structure with the existing `ToolExecutionRenderers` pattern
- Refactors `AgentTimeline.tsx` to use the new renderer

### 2. Show task ID in TaskDetailPanel (`837b35fa`)
- Adds `<code>{task.id}</code>` to the facts section of `TaskDetailPanel`, placed before Kind
- Makes task identification easier during debugging

### 3. Merge consecutive task lifecycle activities (`95a192a2`)
- Same-task consecutive lifecycle activities (e.g. `task_created → task_status_updated → task_result_received`) with no intervening timeline entries are merged into a single evolving entry
- State chain displayed as `queued → running → completed` via `stateEvolution` field
- Uses `task_id` as React key for stable identity (prevents flicker during streaming)
- Post-processing merge pass in `compactAgentTimelineItems` after sort, so it works correctly with streaming events
- When messages or other timeline entries intervene, lifecycle items remain as separate entries

### Test plan
- [x] `make web` build passes
- [x] `session-reducer.test.ts` — 44 tests pass
- [ ] Operator visual verification in Web GUI

### Changed files
- `web-gui/app/src/runtime/session-object-types.ts` — TaskObject `initialStatus` field
- `web-gui/app/src/runtime/session-reducer-core.ts` — set/preserve `initialStatus`
- `web-gui/app/src/runtime/object-renderers.ts` — `renderTaskObject` uses `initialStatus`
- `web-gui/app/src/runtime/types.ts` — `AgentTimelineItem.stateEvolution`
- `web-gui/app/src/runtime/timeline-display.ts` — `mergeConsecutiveTaskLifecycleItems` pass
- `web-gui/app/src/features/agent/AgentTimeline.tsx` — render `stateEvolution` chain
- `web-gui/app/src/styles/globals.css` — `.activity-state-evolution` styles
- `web-gui/app/src/runtime/session-reducer.test.ts` — updated 3 tests