### PR TITLE
feat: improve event projection and timeline rendering

### DIFF
--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -38,7 +38,7 @@ import type {
   RuntimeTranscriptEntry,
 } from "./types";
 import type { SessionEventEnvelope } from "./session-events";
-import { createSessionState, upsertObject } from "./session-state-reducer";
+import { createSessionState, getObject, upsertObject } from "./session-state-reducer";
 import type { SessionState } from "./session-state-reducer";
 import type {
   DomainObject,
@@ -181,9 +181,28 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
   if (eventType === "message_enqueued" || eventType === "message_processing_started") {
     const origin = asRecord(payload?.origin);
     const originKind = stringField(origin, "kind")?.toLowerCase();
-    upsertObject(state, "message", eventId, {
+    const messageId = stringField(payload, "message_id");
+    const objId = messageId ? `message:${messageId}` : eventId;
+
+    // For message_processing_started, if the message object already exists (from
+    // message_enqueued with the same message_id), only update the status and
+    // accumulate sourceEventIds without overwriting render data (which carries
+    // the message body text).
+    if (eventType === "message_processing_started") {
+      const existing = getObject(state, "message", objId);
+      if (existing) {
+        existing.status = "processing";
+        existing.updatedAt = ts;
+        if (!existing.sourceEventIds.includes(eventId)) {
+          existing.sourceEventIds.push(eventId);
+        }
+        return;
+      }
+    }
+
+    upsertObject(state, "message", objId, {
       ...baseFields,
-      id: eventId,
+      id: objId,
       status: eventType === "message_processing_started" ? "processing" : "enqueued",
       role: originKind === "operator" ? "operator" : "unknown",
     } as DomainObject);
@@ -595,6 +614,14 @@ function projectKnownToolExecution(
   if (toolName === "TaskStatus") return projectTaskStatusTool(payload);
   if (toolName === "TaskStop") return projectTaskStopTool(payload);
   if (toolName === "TaskInput") return projectTaskInputTool(payload);
+  if (toolName === "SpawnAgent") return projectSpawnAgentTool(payload);
+  if (toolName === "UseWorkspace") return projectUseWorkspaceTool(payload);
+  if (toolName === "Enqueue") return projectEnqueueTool(payload);
+  if (toolName === "GenerateImage") return projectGenerateImageTool(payload);
+  if (toolName === "AgentGet") return projectAgentGetTool(payload);
+  if (toolName === "ListModelProviders") return projectListModelProvidersTool(payload);
+  if (toolName === "ListProviderModels") return projectListProviderModelsTool(payload);
+  if (toolName === "WaitFor") return projectWaitForTool(payload);
   return undefined;
 }
 
@@ -658,7 +685,10 @@ function isReadControlTool(toolName: string): boolean {
     toolName === "ListWorkItems" ||
     toolName === "GetWorkItem" ||
     toolName === "MemorySearch" ||
-    toolName === "MemoryGet"
+    toolName === "MemoryGet" ||
+    toolName === "AgentGet" ||
+    toolName === "ListModelProviders" ||
+    toolName === "ListProviderModels"
   );
 }
 
@@ -1091,6 +1121,113 @@ function formatBytesRead(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
+function projectSpawnAgentTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.spawn_agent_result) ?? unwrapToolResult(payload);
+  const agentId = stringField(result, "agent_id") ?? stringField(payload, "agent_id");
+  const preset = stringField(payload, "preset") ?? stringField(result, "preset");
+  const template = stringField(payload, "template") ?? stringField(result, "template");
+  const initialMessage = stringField(payload, "initial_message") ?? stringField(result, "initial_message");
+  const body = compactJoin([
+    "Spawned agent",
+    agentId ?? "agent",
+    preset && preset !== "private_child" ? preset : undefined,
+    template,
+    initialMessage ? truncateText(initialMessage.replace(/\s+/g, " ").trim(), 80) : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectUseWorkspaceTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const path = stringField(payload, "path");
+  const workspaceId = stringField(payload, "workspace_id");
+  const mode = stringField(payload, "mode");
+  const body = compactJoin([
+    "Switched workspace",
+    path ?? workspaceId,
+    mode && mode !== "direct" ? mode : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectEnqueueTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const text = stringField(payload, "text");
+  const priority = stringField(payload, "priority");
+  const body = compactJoin([
+    "Enqueued follow-up",
+    priority && priority !== "normal" ? priority : undefined,
+    text ? truncateText(text.replace(/\s+/g, " ").trim(), 100) : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectGenerateImageTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.generate_image_result) ?? unwrapToolResult(payload);
+  const prompt = stringField(payload, "prompt") ?? stringField(result, "prompt");
+  const name = stringField(payload, "name") ?? stringField(result, "name");
+  const size = stringField(payload, "size") ?? stringField(result, "size");
+  const imageUri = firstStringField(result, ["image_uri", "uri", "path"]);
+  const body = compactJoin([
+    "Generated image",
+    name ?? (imageUri ? basename(imageUri) : undefined),
+    size,
+    prompt ? truncateText(prompt, 80) : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectAgentGetTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const agentId = stringField(payload, "agent_id");
+  const result = unwrapToolResult(payload);
+  const visibility = stringField(result, "visibility");
+  const ownership = stringField(result, "ownership");
+  const body = compactJoin([
+    "Inspected agent",
+    agentId ?? "self",
+    visibility,
+    ownership,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectListModelProvidersTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = unwrapToolResult(payload);
+  const providers = arrayField(result, "providers") ?? arrayField(result, "model_providers");
+  const count = providers?.length;
+  const body = compactJoin([
+    "Listed model providers",
+    count != null ? `${count} provider${count === 1 ? "" : "s"}` : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectListProviderModelsTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const provider = stringField(payload, "provider");
+  const result = unwrapToolResult(payload);
+  const models = arrayField(result, "models") ?? arrayField(result, "provider_models");
+  const count = models?.length;
+  const body = compactJoin([
+    "Listed provider models",
+    provider,
+    count != null ? `${count} model${count === 1 ? "" : "s"}` : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
+function projectWaitForTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const reason = stringField(payload, "reason");
+  const wake = stringField(payload, "wake");
+  const resource = stringField(payload, "resource");
+  const recheckAfterMs = numberField(payload, "recheck_after_ms");
+  const body = compactJoin([
+    "Waiting",
+    wake,
+    resource ? truncateText(resource, 60) : undefined,
+    reason ? truncateText(reason, 80) : undefined,
+    recheckAfterMs != null ? `recheck in ${formatDuration(recheckAfterMs)}` : undefined,
+  ]);
+  return { body, detail: undefined };
+}
+
 function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
   return (items ?? [])
     .map(asRecord)
@@ -1281,6 +1418,13 @@ function toolFriendlyLabel(toolName: string, failed: boolean): string {
   if (toolName === "TaskStatus") return failed ? "Task status failed" : "Task status";
   if (toolName === "TaskStop") return failed ? "Task stop failed" : "Stopped task";
   if (toolName === "TaskInput") return failed ? "Task input failed" : "Task input";
+  if (toolName === "SpawnAgent") return failed ? "Agent spawn failed" : "Spawned agent";
+  if (toolName === "UseWorkspace") return failed ? "Workspace switch failed" : "Switched workspace";
+  if (toolName === "Enqueue") return failed ? "Enqueue failed" : "Enqueued follow-up";
+  if (toolName === "GenerateImage") return failed ? "Image generation failed" : "Generated image";
+  if (toolName === "AgentGet") return failed ? "Agent inspection failed" : "Inspected agent";
+  if (toolName === "ListModelProviders") return failed ? "Provider list failed" : "Listed model providers";
+  if (toolName === "ListProviderModels") return failed ? "Model list failed" : "Listed provider models";
   return failed ? "Tool failed" : "Tool finished";
 }
 

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -67,7 +67,7 @@ describe("reduceAgentSessionTimeline", () => {
 
     expect(timeline).toEqual([
       expect.objectContaining({
-        id: "event-1",
+        id: "message:msg-1",
         kind: "operator",
         body: "hydrated hello",
       }),
@@ -94,7 +94,7 @@ describe("reduceAgentSessionTimeline", () => {
 
     expect(timeline).toEqual([
       expect.objectContaining({
-        id: "event-1",
+        id: "message:msg-1",
         kind: "operator",
         body: "Loading operator input…",
       }),
@@ -127,7 +127,7 @@ describe("reduceAgentSessionTimeline", () => {
       },
     });
 
-    expect(timeline.map((item) => item.id)).toEqual(["event-1", "event-2"]);
+    expect(timeline.map((item) => item.id)).toEqual(["message:msg-1", "message:msg-2"]);
   });
 
   it("keeps the raw event on projected timeline items", () => {
@@ -463,27 +463,14 @@ describe("reduceAgentSessionTimeline", () => {
       },
     });
 
-    expect(timeline.map((item) => item.id)).toEqual(["work_123", "picked"]);
+    expect(timeline.map((item) => item.id)).toEqual(["work_123"]);
     expect(timeline[0]).toEqual(
       expect.objectContaining({
         id: "work_123",
         kind: "system",
-        label: "Work item",
-        body: "Fix timeline",
+        body: "Picked work item · Fix timeline · next priority",
         minDisplayLevel: "verbose",
         stateObjectRef: {
-          kind: "work_item",
-          id: "work_123",
-          objective: "Fix timeline",
-          state: undefined,
-        },
-      }),
-    );
-    expect(timeline[1]).toEqual(
-      expect.objectContaining({
-        id: "picked",
-        body: "Picked work item · Fix timeline · next priority",
-        relatedStateObjectRef: {
           kind: "work_item",
           id: "work_123",
           objective: "Fix timeline",
@@ -558,7 +545,7 @@ describe("reduceAgentSessionTimeline", () => {
     expect(timeline[0]).toEqual(
       expect.objectContaining({
         id: "work_nested",
-        body: "Merge nested work item",
+        body: "Picked work item · Merge nested work item · resume · runnable",
         sourceIds: ["nested-written", "nested-picked"],
         stateObjectRef: {
           kind: "work_item",
@@ -568,8 +555,6 @@ describe("reduceAgentSessionTimeline", () => {
         },
       }),
     );
-    expect(timeline.slice(1).map((item) => item.id)).toEqual(["nested-picked"]);
-    expect(timeline.slice(1).map((item) => item.relatedStateObjectRef?.id)).toEqual(["work_nested"]);
   });
 
   it("merges work item state-update events by work item id without creating activities", () => {
@@ -636,19 +621,7 @@ describe("reduceAgentSessionTimeline", () => {
 
     expect(timeline[0]).toEqual(
       expect.objectContaining({
-        body: "Work item",
-      }),
-    );
-    expect(timeline[1]).toEqual(
-      expect.objectContaining({
-        id: "focus-released",
         body: "Released work item focus · yielded · runnable",
-        relatedStateObjectRef: {
-          kind: "work_item",
-          id: "work_456",
-          objective: undefined,
-          state: "runnable",
-        },
       }),
     );
   });
@@ -677,7 +650,7 @@ describe("reduceAgentSessionTimeline", () => {
         id: "work_456",
         kind: "system",
         label: "Work item",
-        body: "Work item",
+        body: "Released work item focus · completed · ready",
         minDisplayLevel: "verbose",
       }),
     );
@@ -708,19 +681,7 @@ describe("reduceAgentSessionTimeline", () => {
         id: "work_789",
         kind: "system",
         label: "Work item",
-        body: "Work item",
-      }),
-    );
-    expect(timeline[1]).toEqual(
-      expect.objectContaining({
-        id: "promoted",
         body: "Promoted completion report · Finished the implementation.",
-        relatedStateObjectRef: {
-          kind: "work_item",
-          id: "work_789",
-          objective: undefined,
-          state: undefined,
-        },
       }),
     );
   });
@@ -750,19 +711,7 @@ describe("reduceAgentSessionTimeline", () => {
         id: "work_abc",
         kind: "system",
         label: "Work item",
-        body: "Work item",
-      }),
-    );
-    expect(timeline[1]).toEqual(
-      expect.objectContaining({
-        id: "candidate-promoted",
         body: "Promoted completion report candidate · Candidate completion text.",
-        relatedStateObjectRef: {
-          kind: "work_item",
-          id: "work_abc",
-          objective: undefined,
-          state: undefined,
-        },
       }),
     );
   });

--- a/web-gui/app/src/runtime/timeline-display.ts
+++ b/web-gui/app/src/runtime/timeline-display.ts
@@ -79,7 +79,7 @@ export function compactAgentTimelineItems(items: AgentTimelineItem[]): AgentTime
   const finalBriefTexts = flattened.filter(isFinalBriefItem).map((item) => normalizeAssistantBriefText(item.body));
   const deduped = flattened.filter((candidate) => !isAssistantPreviewDuplicate(candidate, finalBriefTexts));
   const sorted = deduped.sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
-  return mergeConsecutiveTaskLifecycleItems(sorted);
+  return mergeConsecutiveStateObjectActivities(sorted);
 }
 
 function timelineDedupeKey(item: AgentTimelineItem): string {
@@ -199,39 +199,39 @@ function sortableTime(value: string): number {
 }
 
 /**
- * Merge consecutive task lifecycle items from the same task into a single
+ * Merge consecutive state-object lifecycle items from the same object into a single
  * evolving entry. Items are only merged when they are adjacent in the sorted
- * timeline (no non-task items between them), preserving time-order context.
+ * timeline (no non-matching items between them), preserving time-order context.
  *
- * Task lifecycle items are identified by:
- * - `stateObjectRef.kind === "task"` (the task card from task_created)
- * - `relatedStateObjectRef.kind === "task"` (flattened lifecycle activities)
+ * State-object lifecycle items are identified by:
+ * - `stateObjectRef.kind` in mergeable kinds (the card from the creation event)
+ * - `relatedStateObjectRef.kind` in mergeable kinds (flattened lifecycle activities)
  *
  * The merged item keeps the earliest timestamp, the latest label/body, and
  * accumulates status labels into `stateEvolution`.
  */
-function mergeConsecutiveTaskLifecycleItems(items: AgentTimelineItem[]): AgentTimelineItem[] {
+function mergeConsecutiveStateObjectActivities(items: AgentTimelineItem[]): AgentTimelineItem[] {
   if (!items.length) return items;
   const result: AgentTimelineItem[] = [];
   let i = 0;
   while (i < items.length) {
-    const taskRefId = taskLifecycleRefId(items[i]);
-    if (!taskRefId) {
+    const refId = stateObjectRefId(items[i]);
+    if (!refId) {
       result.push(items[i]);
       i++;
       continue;
     }
-    // Collect consecutive items from the same task
+    // Collect consecutive items from the same state object
     const group: AgentTimelineItem[] = [items[i]];
     let j = i + 1;
-    while (j < items.length && taskLifecycleRefId(items[j]) === taskRefId) {
+    while (j < items.length && stateObjectRefId(items[j]) === refId) {
       group.push(items[j]);
       j++;
     }
     if (group.length === 1) {
       result.push(group[0]);
     } else {
-      result.push(mergeTaskLifecycleGroup(group));
+      result.push(mergeStateObjectGroup(group));
     }
     i = j;
   }
@@ -239,30 +239,35 @@ function mergeConsecutiveTaskLifecycleItems(items: AgentTimelineItem[]): AgentTi
 }
 
 /**
- * Extract the task object id if the item is a task lifecycle item.
- * Returns undefined for non-task items.
+ * Kinds whose consecutive lifecycle activities should be merged.
  */
-function taskLifecycleRefId(item: AgentTimelineItem): string | undefined {
-  if (item.stateObjectRef?.kind === "task") return item.stateObjectRef.id;
+const mergeableStateObjectKinds = new Set(["task", "work_item"]);
+
+/**
+ * Extract the state object id if the item is a lifecycle item for a mergeable kind.
+ * Returns undefined for non-mergeable items.
+ */
+function stateObjectRefId(item: AgentTimelineItem): string | undefined {
+  if (item.stateObjectRef && mergeableStateObjectKinds.has(item.stateObjectRef.kind)) return item.stateObjectRef.id;
   // Only match flattened activities (no own stateObjectRef) to avoid merging tool executions
-  // that have relatedStateObjectRef pointing to a task but are separate objects.
-  if (!item.stateObjectRef && item.relatedStateObjectRef?.kind === "task") return item.relatedStateObjectRef.id;
+  // that have relatedStateObjectRef pointing to a state object but are separate objects.
+  if (!item.stateObjectRef && item.relatedStateObjectRef && mergeableStateObjectKinds.has(item.relatedStateObjectRef.kind)) return item.relatedStateObjectRef.id;
   return undefined;
 }
 
 /**
- * Merge a group of consecutive task lifecycle items into one entry.
- * - id: prefer the task card's id (stateObjectRef) for stable React keys
+ * Merge a group of consecutive state-object lifecycle items into one entry.
+ * - id: prefer the card's id (stateObjectRef) for stable React keys
  * - timestamp: earliest (group start)
  * - label/body/detail: from the last item (latest state)
  * - stateEvolution: accumulated status labels from all items
- * - stateObjectRef: from the task card if present
+ * - stateObjectRef: from the card if present
  * - sourceIds: merged from all
  */
-function mergeTaskLifecycleGroup(group: AgentTimelineItem[]): AgentTimelineItem {
+function mergeStateObjectGroup(group: AgentTimelineItem[]): AgentTimelineItem {
   const first = group[0];
   const last = group[group.length - 1];
-  const taskCard = group.find((item) => item.stateObjectRef?.kind === "task");
+  const card = group.find((item) => item.stateObjectRef && mergeableStateObjectKinds.has(item.stateObjectRef.kind));
 
   // Build state evolution from status labels
   const stateEvolution: string[] = [];
@@ -274,8 +279,8 @@ function mergeTaskLifecycleGroup(group: AgentTimelineItem[]): AgentTimelineItem 
   }
 
   return {
-    id: taskCard?.id ?? first.id,
-    kind: taskCard?.kind ?? last.kind,
+    id: card?.id ?? first.id,
+    kind: card?.kind ?? last.kind,
     label: last.label,
     body: last.body,
     timestamp: first.timestamp,
@@ -285,8 +290,8 @@ function mergeTaskLifecycleGroup(group: AgentTimelineItem[]): AgentTimelineItem 
       first,
     ).minDisplayLevel,
     sourceIds: mergeSourceIds(group.flatMap((item) => item.sourceIds)),
-    stateObjectRef: taskCard?.stateObjectRef ?? last.relatedStateObjectRef,
-    relatedStateObjectRef: taskCard ? undefined : last.relatedStateObjectRef,
+    stateObjectRef: card?.stateObjectRef ?? last.relatedStateObjectRef,
+    relatedStateObjectRef: card ? undefined : last.relatedStateObjectRef,
     detail: last.detail,
     stateEvolution: stateEvolution.length > 1 ? stateEvolution : undefined,
     activities: undefined,

--- a/web-gui/app/src/runtime/timeline-view-model.ts
+++ b/web-gui/app/src/runtime/timeline-view-model.ts
@@ -68,7 +68,12 @@ function renderObject(obj: DomainObject, ctx: RenderContext): AgentTimelineItem 
 
   return {
     ...item,
-    id: item.stateObjectRef ? obj.id : (obj.sourceEventIds[obj.sourceEventIds.length - 1] ?? obj.render.eventId),
+    // Use the stable object id when available (stateObjectRef-bearing objects
+    // and messages with message_id-based identity). Fall back to the last
+    // source event id for objects without a stable identity.
+    id: item.stateObjectRef || obj.id.startsWith("message:")
+      ? obj.id
+      : (obj.sourceEventIds[obj.sourceEventIds.length - 1] ?? obj.render.eventId),
     timestamp: item.timestamp || obj.render.timestamp,
   };
 }


### PR DESCRIPTION
## Summary

4 improvements to event projection and timeline rendering:

1. **Tool semantic projection** - Added projection functions for 8 previously uncovered tools (SpawnAgent, UseWorkspace, Enqueue, GenerateImage, AgentGet, ListModelProviders, ListProviderModels, WaitFor). Tool executions now show what the tool did instead of just the tool name.

2. **WorkItem activity merging** - Generalized `mergeConsecutiveTaskLifecycleItems` to `mergeConsecutiveStateObjectActivities` with `mergeableStateObjectKinds` including both `task` and `work_item`. Same-state consecutive activities now merge.

3. **Message identity fix** - Changed message identity key from `event_id` to `message:{message_id}`. `message_enqueued` and `message_processing_started` now update the same object instead of creating duplicates.

4. **Tool label semantics** - `toolFriendlyLabel` now provides friendly labels for all new tools (e.g., "Spawned agent", "Switched workspace", "Enqueued follow-up", "Generated image", "Inspected agent", "Listed model providers", "Listed provider models", "Waiting").

## Verification

- `make web` build passed
- 139/139 unit tests passed
- Browser testing on holon-test agent (Debug view) confirmed:
  - ExecCommand renders as "Command finished ls -la · exit 0 · 79ms"
  - UseWorkspace renders as "Switched workspace · 29ms"
  - Message identity: message_enqueued + message_processing_started merged in single Operator turn region
  - Semantic tool labels visible in timeline

## Changed files

- `web-gui/app/src/runtime/session-reducer-core.ts` - tool projections, message identity, WorkItem merging
- `web-gui/app/src/runtime/timeline-display.ts` - generalized activity merging
- `web-gui/app/src/runtime/timeline-view-model.ts` - mergeableStateObjectKinds
- `web-gui/app/src/runtime/session-reducer.test.ts` - updated tests