### PR TITLE
fix: include sanitized tool input in audit events

### DIFF
--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, time::Instant};
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::config::ModelRef;
 use crate::prompt::EffectivePrompt;
@@ -440,6 +440,91 @@ impl RuntimeHandle {
         .run()
         .await
     }
+}
+
+pub(super) const TOOL_AUDIT_INPUT_STRING_LIMIT: usize = 4_096;
+pub(super) const TOOL_AUDIT_INPUT_PREVIEW_LIMIT: usize = 240;
+const TOOL_AUDIT_REDACTED: &str = "[REDACTED]";
+
+pub(super) fn tool_audit_input_field(call: &ToolCall) -> Option<Value> {
+    if call.name == crate::tool::names::APPLY_PATCH {
+        return Some(audit_large_input(&call.input));
+    }
+    Some(sanitize_audit_input(&call.input, None))
+}
+
+fn sanitize_audit_input(value: &Value, key: Option<&str>) -> Value {
+    if key.is_some_and(is_sensitive_audit_input_key) {
+        return Value::String(TOOL_AUDIT_REDACTED.into());
+    }
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), sanitize_audit_input(value, Some(key.as_str()))))
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| sanitize_audit_input(value, None))
+                .collect(),
+        ),
+        Value::String(value) => Value::String(truncate_audit_input_string(
+            value,
+            TOOL_AUDIT_INPUT_STRING_LIMIT,
+        )),
+        _ => value.clone(),
+    }
+}
+
+fn audit_large_input(value: &Value) -> Value {
+    let serialized = value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| value.to_string());
+    let mut audit = Map::new();
+    audit.insert(
+        "preview".into(),
+        Value::String(truncate_audit_input_string(
+            &serialized,
+            TOOL_AUDIT_INPUT_PREVIEW_LIMIT,
+        )),
+    );
+    audit.insert("bytes".into(), Value::from(serialized.len() as u64));
+    audit.insert(
+        "truncated".into(),
+        Value::Bool(serialized.chars().count() > TOOL_AUDIT_INPUT_PREVIEW_LIMIT),
+    );
+    Value::Object(audit)
+}
+
+fn is_sensitive_audit_input_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase().replace(['-', ' '], "_");
+    [
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "password",
+        "material",
+        "capability",
+    ]
+    .iter()
+    .any(|sensitive| normalized.contains(sensitive))
+}
+
+fn truncate_audit_input_string(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
 }
 
 pub(super) fn provider_lineage_failure_text(text: &str) -> String {
@@ -1448,6 +1533,7 @@ impl TurnExecution<'_> {
                             "turn_index": turn_index,
                             "run_id": run_id,
                             "work_item_id": work_item_id,
+                            "input": tool_audit_input_field(&call),
                             "exec_command_cmd": command_preview_field(&call),
                             "exec_command_display": command_display_field(&call),
                             "exec_command_batch_items": command_batch_preview_field(&call),
@@ -1602,6 +1688,7 @@ impl TurnExecution<'_> {
                                 status: record.status.clone(),
                                 duration_ms,
                                 summary: record.summary.clone(),
+                                input: tool_audit_input_field(&call),
                                 exec_command_cmd: command_preview_field(&call),
                                 exec_command_display: command_display_field(&call),
                                 exec_command_batch_items: command_batch_preview_field(&call),

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -54,6 +54,52 @@ fn truncated_mutation_recovery_hint_is_tool_specific() {
 }
 
 #[test]
+fn tool_audit_input_redacts_sensitive_values_and_truncates_long_strings() {
+    let call = ToolCall {
+        id: "call-audit".into(),
+        name: "GenerateImage".into(),
+        input: serde_json::json!({
+            "prompt": "x".repeat(5_000),
+            "api_key": "super-secret",
+            "nested": {"authorization": "Bearer secret", "size": "1024x1024"}
+        }),
+    };
+
+    let input = tool_audit_input_field(&call).expect("audit input");
+
+    assert_eq!(input["api_key"], "[REDACTED]");
+    assert_eq!(input["nested"]["authorization"], "[REDACTED]");
+    assert_eq!(input["nested"]["size"], "1024x1024");
+    assert_eq!(
+        input["prompt"].as_str().expect("prompt").chars().count(),
+        TOOL_AUDIT_INPUT_STRING_LIMIT
+    );
+}
+
+#[test]
+fn tool_audit_input_replaces_apply_patch_body_with_a_bounded_preview() {
+    let patch = format!(
+        "*** Begin Patch\n*** Add File: large.txt\n+{}\n*** End Patch\n",
+        "x".repeat(10_000)
+    );
+    let call = ToolCall {
+        id: "call-patch".into(),
+        name: crate::tool::names::APPLY_PATCH.into(),
+        input: Value::String(patch.clone()),
+    };
+
+    let input = tool_audit_input_field(&call).expect("audit input");
+
+    assert_eq!(input["bytes"], patch.len() as u64);
+    assert_eq!(input["truncated"], true);
+    assert!(
+        input["preview"].as_str().expect("preview").chars().count()
+            <= TOOL_AUDIT_INPUT_PREVIEW_LIMIT
+    );
+    assert!(input.get("output").is_none());
+}
+
+#[test]
 fn turn_local_round_recap_preserves_command_recovery_identity() {
     let command = "python - <<'PY'\nprint('turn_recap_hidden_1246')\nPY";
     let round = fixture_round_with_tool(

--- a/src/runtime/turn/tool_summary.rs
+++ b/src/runtime/turn/tool_summary.rs
@@ -1,171 +1,18 @@
 //! Tool result summarization and round recap generation.
 
-use crate::tool::names as tn;
 use serde_json::Value;
 
 use crate::tool::{
     helpers::command_digest,
+    names as tn,
     spec::{ToolResultEnvelope, ToolResultStatus},
+    summary::tool_result_summary,
     ToolCall,
 };
 
 use super::projection::estimate_text_tokens;
 use super::truncate_preview;
 use super::{TurnRoundRecord, RECAP_TEXT_PREVIEW_LIMIT};
-
-pub(super) fn artifact_paths(value: &Value) -> Vec<String> {
-    value
-        .get("artifacts")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|artifact| artifact.get("path").and_then(Value::as_str))
-        .map(ToOwned::to_owned)
-        .collect()
-}
-
-pub(super) fn summarize_exec_command_result(result: &Value) -> String {
-    let disposition = result
-        .get("disposition")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    match disposition {
-        "completed" => {
-            let exit_status = result
-                .get("exit_status")
-                .and_then(Value::as_i64)
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "unknown".into());
-            let truncated = result
-                .get("truncated")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            let artifacts = artifact_paths(result);
-            let artifact_note = if artifacts.is_empty() {
-                String::new()
-            } else {
-                format!(" artifacts={}", artifacts.join(", "))
-            };
-            format!("completed exit_status={exit_status} truncated={truncated}{artifact_note}")
-        }
-        "promoted_to_task" => {
-            let task_id = result
-                .get("task_handle")
-                .and_then(|handle| handle.get("task_id"))
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            let truncated = result
-                .get("initial_output_truncated")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            format!("promoted_to_task task_id={task_id} initial_output_truncated={truncated}")
-        }
-        "already_running" => {
-            let task_id = result
-                .get("task_handle")
-                .and_then(|handle| handle.get("task_id"))
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            let status = result
-                .get("task_handle")
-                .and_then(|handle| handle.get("status"))
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            format!("already_running task_id={task_id} status={status}")
-        }
-        _ => format!("disposition={disposition}"),
-    }
-}
-
-pub(super) fn summarize_task_output_result(result: &Value) -> String {
-    let retrieval_status = result
-        .get("retrieval_status")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    let task = result.get("task").unwrap_or(result);
-    let task_id = task.get("id").and_then(Value::as_str).unwrap_or("unknown");
-    let truncated = task
-        .get("output_truncated")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let exit_status = task
-        .get("exit_status")
-        .and_then(Value::as_i64)
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "unknown".into());
-    let artifacts = artifact_paths(task);
-    let artifact_note = if artifacts.is_empty() {
-        String::new()
-    } else {
-        format!(" artifacts={}", artifacts.join(", "))
-    };
-    format!(
-        "retrieval_status={retrieval_status} task_id={task_id} output_truncated={truncated} exit_status={exit_status}{artifact_note}"
-    )
-}
-
-pub(super) fn summarize_spawn_agent_result(result: &Value) -> Option<String> {
-    let agent_id = result.get("agent_id").and_then(Value::as_str)?;
-    let task_id = result
-        .get("task_handle")
-        .and_then(|handle| handle.get("task_id"))
-        .and_then(Value::as_str);
-    Some(match task_id {
-        Some(task_id) => format!("agent_id={agent_id} task_id={task_id}"),
-        None => format!("agent_id={agent_id}"),
-    })
-}
-
-pub(super) fn summarize_view_image_result(result: &Value) -> Option<String> {
-    let reference = result.get("visual_reference")?;
-    let observation = result.get("observation")?;
-    let reference_id = reference
-        .get("id")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    let mime = reference
-        .get("mime")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    let schema = observation
-        .get("schema")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    let prompt = observation
-        .get("prompt")
-        .and_then(Value::as_str)
-        .map(|prompt| truncate_preview(prompt, RECAP_TEXT_PREVIEW_LIMIT));
-    let summary = observation
-        .get("summary")
-        .and_then(Value::as_str)
-        .map(|summary| truncate_preview(summary, RECAP_TEXT_PREVIEW_LIMIT));
-    let ocr = observation
-        .get("ocr")
-        .and_then(Value::as_array)
-        .map(|entries| {
-            entries
-                .iter()
-                .filter_map(|entry| entry.get("text").and_then(Value::as_str))
-                .take(3)
-                .map(|text| truncate_preview(text, 80))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    let mut parts = vec![format!(
-        "visual_observation schema={schema} ref={reference_id} mime={mime}"
-    )];
-    if let Some(prompt) = prompt {
-        parts.push(format!("prompt=\"{prompt}\""));
-    }
-    if let Some(summary) = summary {
-        parts.push(format!("summary=\"{summary}\""));
-    }
-    if !ocr.is_empty() {
-        parts.push(format!("ocr=[{}]", ocr.join(" | ")));
-    }
-    Some(parts.join(" "))
-}
 
 pub(super) fn summarize_tool_result_envelope(envelope: &ToolResultEnvelope) -> String {
     match envelope.status {
@@ -174,27 +21,15 @@ pub(super) fn summarize_tool_result_envelope(envelope: &ToolResultEnvelope) -> S
             let kind = error
                 .map(|error| error.kind.as_str())
                 .unwrap_or("tool_execution_failed");
-            let message = envelope
-                .summary_text
-                .as_deref()
-                .or_else(|| error.map(|error| error.message.as_str()))
-                .unwrap_or("tool failed");
-            format!("{} error {}: {}", envelope.tool_name, kind, message)
+            format!(
+                "{} error {}: {}",
+                envelope.tool_name,
+                kind,
+                tool_result_summary(envelope)
+            )
         }
         ToolResultStatus::Success => {
-            let detail = envelope
-                .result
-                .as_ref()
-                .and_then(|result| match envelope.tool_name.as_str() {
-                    tn::EXEC_COMMAND => Some(summarize_exec_command_result(result)),
-                    tn::TASK_OUTPUT => Some(summarize_task_output_result(result)),
-                    tn::SPAWN_AGENT => summarize_spawn_agent_result(result),
-                    tn::VIEW_IMAGE => summarize_view_image_result(result),
-                    _ => None,
-                })
-                .or_else(|| envelope.summary_text.clone())
-                .unwrap_or_else(|| "completed".into());
-            format!("{} {}", envelope.tool_name, detail)
+            format!("{} {}", envelope.tool_name, tool_result_summary(envelope))
         }
     }
 }

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -187,7 +187,7 @@ impl ToolRegistry {
             },
             input: call.input.clone(),
             output: output_value,
-            summary: tool_result_summary(&result),
+            summary: super::summary::tool_result_summary(&result.envelope),
             invocation_surface: tool_invocation_surface(call),
         };
         Ok((result, record))
@@ -239,35 +239,6 @@ fn is_model_facing_tool(name: &str) -> bool {
     !super::names::HIDDEN_FROM_MODEL_TOOLS.contains(&name)
 }
 
-fn tool_result_summary(result: &ToolResult) -> String {
-    if let Some(error) = result.tool_error() {
-        return super::helpers::truncate_text(&error.message, 200);
-    }
-    let summary = result
-        .summary_text()
-        .map(ToString::to_string)
-        .or_else(|| summary_from_result_payload(result.envelope.result.as_ref()))
-        .unwrap_or_else(|| result.envelope.tool_name.clone());
-    super::helpers::truncate_text(&summary, 200)
-}
-
-fn summary_from_result_payload(value: Option<&Value>) -> Option<String> {
-    let object = value?.as_object()?;
-    for field in [
-        "disposition",
-        "retrieval_status",
-        "status",
-        "task_id",
-        "agent_id",
-        "id",
-    ] {
-        if let Some(summary) = object.get(field).and_then(Value::as_str) {
-            return Some(summary.to_string());
-        }
-    }
-    None
-}
-
 fn build_tool_spec_catalog() -> Result<ToolSpecCatalog> {
     Ok(ToolSpecCatalog {
         entries: tools::builtin_tool_definitions()?
@@ -283,16 +254,13 @@ fn catalog_entry(family: ToolCapabilityFamily, spec: ToolSpec) -> ToolCatalogEnt
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        build_tool_spec_catalog, summary_from_result_payload, tool_result_summary, ToolRegistry,
-    };
+    use super::{build_tool_spec_catalog, ToolRegistry};
     use crate::{
         provider::{emitted_tool_json_schema, validate_emitted_tool_schema, ToolSchemaContract},
         tool::schema::validate_source_tool_schema,
-        tool::{ToolError, ToolResult},
         types::ToolCapabilityFamily,
     };
-    use serde_json::{json, Value};
+    use serde_json::Value;
     use std::path::PathBuf;
 
     fn assert_final_schema_shape(schema: &Value) {
@@ -563,44 +531,6 @@ mod tests {
                     .is_some_and(|modes| modes.iter().any(|mode| mode.as_str() == Some("inherit")))
         });
         assert!(constrains_workspace_mode_for_public_named);
-    }
-
-    #[test]
-    fn summary_from_result_payload_prefers_small_status_fields() {
-        assert_eq!(
-            summary_from_result_payload(Some(&json!({
-                "disposition": "completed",
-                "stdout_preview": "ignored"
-            }))),
-            Some("completed".to_string())
-        );
-        assert_eq!(
-            summary_from_result_payload(Some(&json!({
-                "retrieval_status": "success",
-                "task": {"status": "completed"}
-            }))),
-            Some("success".to_string())
-        );
-        assert_eq!(
-            summary_from_result_payload(Some(&json!({"stdout_preview": "only"}))),
-            None
-        );
-    }
-
-    #[test]
-    fn tool_result_summary_falls_back_to_tool_name_when_payload_has_no_small_fields() {
-        let result = ToolResult::success(
-            "AgentGet",
-            json!({
-                "profile": {"name": "default"},
-                "active_tasks": [{"id": "task-1"}]
-            }),
-            None,
-        );
-        assert_eq!(tool_result_summary(&result), "AgentGet");
-
-        let error = ToolResult::error("ExecCommand", ToolError::new("failure", "command exploded"));
-        assert_eq!(tool_result_summary(&error), "command exploded");
     }
 
     #[test]

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod helpers;
 pub mod names;
 pub(crate) mod schema_support;
 pub mod spec;
+pub(crate) mod summary;
 pub(crate) mod tools;
 
 pub(crate) use schema_support as schema;

--- a/src/tool/summary.rs
+++ b/src/tool/summary.rs
@@ -155,11 +155,11 @@ fn summarize_view_image_result(result: &Value) -> Option<String> {
     let prompt = observation
         .get("prompt")
         .and_then(Value::as_str)
-        .map(|prompt| truncate_text(prompt, 160));
+        .map(|prompt| truncate_text(prompt.trim(), 160));
     let summary = observation
         .get("summary")
         .and_then(Value::as_str)
-        .map(|summary| truncate_text(summary, 160));
+        .map(|summary| truncate_text(summary.trim(), 160));
     let ocr = observation
         .get("ocr")
         .and_then(Value::as_array)
@@ -168,7 +168,7 @@ fn summarize_view_image_result(result: &Value) -> Option<String> {
                 .iter()
                 .filter_map(|entry| entry.get("text").and_then(Value::as_str))
                 .take(3)
-                .map(|text| truncate_text(text, 80))
+                .map(|text| truncate_text(text.trim(), 80))
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
@@ -242,6 +242,35 @@ mod tests {
         assert_eq!(
             tool_result_summary(&result.envelope),
             "completed exit_status=2 truncated=false"
+        );
+    }
+
+    #[test]
+    fn view_image_result_summary_trims_observation_text() {
+        let result = ToolResult::success(
+            "ViewImage",
+            json!({
+                "visual_reference": {
+                    "id": "image-1",
+                    "mime": "image/png"
+                },
+                "observation": {
+                    "schema": "visual_observation.v1",
+                    "prompt": "  inspect this  ",
+                    "summary": "  a diagram  ",
+                    "ocr": [{"text": "  label  "}]
+                }
+            }),
+            None,
+        );
+
+        assert_eq!(
+            tool_result_summary(&result.envelope),
+            concat!(
+                "visual_observation schema=visual_observation.v1 ",
+                "ref=image-1 mime=image/png prompt=\"inspect this\" ",
+                "summary=\"a diagram\" ocr=[label]"
+            )
         );
     }
 }

--- a/src/tool/summary.rs
+++ b/src/tool/summary.rs
@@ -1,0 +1,247 @@
+//! Canonical human-readable summaries of tool execution results.
+
+use serde_json::Value;
+
+use super::{
+    helpers::truncate_text,
+    names as tn,
+    spec::{ToolResultEnvelope, ToolResultStatus},
+};
+
+const TOOL_RESULT_SUMMARY_LIMIT: usize = 200;
+
+pub(crate) fn tool_result_summary(envelope: &ToolResultEnvelope) -> String {
+    let summary = match envelope.status {
+        ToolResultStatus::Error => envelope
+            .summary_text
+            .clone()
+            .or_else(|| envelope.error.as_ref().map(|error| error.message.clone()))
+            .unwrap_or_else(|| "tool failed".into()),
+        ToolResultStatus::Success => envelope
+            .result
+            .as_ref()
+            .and_then(|result| match envelope.tool_name.as_str() {
+                tn::EXEC_COMMAND => Some(summarize_exec_command_result(result)),
+                tn::TASK_OUTPUT => Some(summarize_task_output_result(result)),
+                tn::SPAWN_AGENT => summarize_spawn_agent_result(result),
+                tn::VIEW_IMAGE => summarize_view_image_result(result),
+                _ => None,
+            })
+            .or_else(|| envelope.summary_text.clone())
+            .or_else(|| summary_from_result_payload(envelope.result.as_ref()))
+            .unwrap_or_else(|| "completed".into()),
+    };
+    truncate_text(&summary, TOOL_RESULT_SUMMARY_LIMIT)
+}
+
+fn artifact_paths(value: &Value) -> Vec<String> {
+    value
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|artifact| artifact.get("path").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn summarize_exec_command_result(result: &Value) -> String {
+    let disposition = result
+        .get("disposition")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    match disposition {
+        "completed" => {
+            let exit_status = result
+                .get("exit_status")
+                .and_then(Value::as_i64)
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".into());
+            let truncated = result
+                .get("truncated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let artifacts = artifact_paths(result);
+            let artifact_note = if artifacts.is_empty() {
+                String::new()
+            } else {
+                format!(" artifacts={}", artifacts.join(", "))
+            };
+            format!("completed exit_status={exit_status} truncated={truncated}{artifact_note}")
+        }
+        "promoted_to_task" => {
+            let task_id = result
+                .get("task_handle")
+                .and_then(|handle| handle.get("task_id"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let truncated = result
+                .get("initial_output_truncated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            format!("promoted_to_task task_id={task_id} initial_output_truncated={truncated}")
+        }
+        "already_running" => {
+            let task_id = result
+                .get("task_handle")
+                .and_then(|handle| handle.get("task_id"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let status = result
+                .get("task_handle")
+                .and_then(|handle| handle.get("status"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            format!("already_running task_id={task_id} status={status}")
+        }
+        _ => format!("disposition={disposition}"),
+    }
+}
+
+fn summarize_task_output_result(result: &Value) -> String {
+    let retrieval_status = result
+        .get("retrieval_status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let task = result.get("task").unwrap_or(result);
+    let task_id = task.get("id").and_then(Value::as_str).unwrap_or("unknown");
+    let truncated = task
+        .get("output_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let exit_status = task
+        .get("exit_status")
+        .and_then(Value::as_i64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".into());
+    let artifacts = artifact_paths(task);
+    let artifact_note = if artifacts.is_empty() {
+        String::new()
+    } else {
+        format!(" artifacts={}", artifacts.join(", "))
+    };
+    format!(
+        "retrieval_status={retrieval_status} task_id={task_id} output_truncated={truncated} exit_status={exit_status}{artifact_note}"
+    )
+}
+
+fn summarize_spawn_agent_result(result: &Value) -> Option<String> {
+    let agent_id = result.get("agent_id").and_then(Value::as_str)?;
+    let task_id = result
+        .get("task_handle")
+        .and_then(|handle| handle.get("task_id"))
+        .and_then(Value::as_str);
+    Some(match task_id {
+        Some(task_id) => format!("agent_id={agent_id} task_id={task_id}"),
+        None => format!("agent_id={agent_id}"),
+    })
+}
+
+fn summarize_view_image_result(result: &Value) -> Option<String> {
+    let reference = result.get("visual_reference")?;
+    let observation = result.get("observation")?;
+    let reference_id = reference
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let mime = reference
+        .get("mime")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let schema = observation
+        .get("schema")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let prompt = observation
+        .get("prompt")
+        .and_then(Value::as_str)
+        .map(|prompt| truncate_text(prompt, 160));
+    let summary = observation
+        .get("summary")
+        .and_then(Value::as_str)
+        .map(|summary| truncate_text(summary, 160));
+    let ocr = observation
+        .get("ocr")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry.get("text").and_then(Value::as_str))
+                .take(3)
+                .map(|text| truncate_text(text, 80))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut parts = vec![format!(
+        "visual_observation schema={schema} ref={reference_id} mime={mime}"
+    )];
+    if let Some(prompt) = prompt {
+        parts.push(format!("prompt=\"{prompt}\""));
+    }
+    if let Some(summary) = summary {
+        parts.push(format!("summary=\"{summary}\""));
+    }
+    if !ocr.is_empty() {
+        parts.push(format!("ocr=[{}]", ocr.join(" | ")));
+    }
+    Some(parts.join(" "))
+}
+
+fn summary_from_result_payload(value: Option<&Value>) -> Option<String> {
+    let object = value?.as_object()?;
+    for field in [
+        "disposition",
+        "retrieval_status",
+        "status",
+        "task_id",
+        "agent_id",
+        "id",
+    ] {
+        if let Some(summary) = object.get(field).and_then(Value::as_str) {
+            return Some(summary.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::tool_result_summary;
+    use crate::tool::{ToolError, ToolResult};
+
+    #[test]
+    fn result_summary_falls_back_to_completed_instead_of_the_tool_name() {
+        let result = ToolResult::success(
+            "AgentGet",
+            json!({
+                "profile": {"name": "default"},
+                "active_tasks": [{"id": "task-1"}]
+            }),
+            None,
+        );
+        assert_eq!(tool_result_summary(&result.envelope), "completed");
+
+        let error = ToolResult::error("ExecCommand", ToolError::new("failure", "command exploded"));
+        assert_eq!(tool_result_summary(&error.envelope), "command exploded");
+    }
+
+    #[test]
+    fn result_summary_uses_tool_specific_result_fields() {
+        let result = ToolResult::success(
+            "ExecCommand",
+            json!({
+                "disposition": "completed",
+                "exit_status": 2,
+                "truncated": false
+            }),
+            None,
+        );
+        assert_eq!(
+            tool_result_summary(&result.envelope),
+            "completed exit_status=2 truncated=false"
+        );
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -4374,6 +4374,8 @@ pub struct ToolExecutionAuditEvent {
     pub duration_ms: u64,
     pub summary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec_command_cmd: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec_command_display: Option<String>,
@@ -5953,6 +5955,7 @@ mod tests {
             status: ToolExecutionStatus::Success,
             duration_ms: 42,
             summary: "command completed".into(),
+            input: Some(serde_json::json!({"cmd": "cargo test"})),
             exec_command_cmd: Some("cargo test".into()),
             exec_command_display: Some("cargo test".into()),
             exec_command_batch_items: None,
@@ -5966,6 +5969,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(payload["tool_execution_id"], "tool-1");
+        assert_eq!(payload["input"]["cmd"], "cargo test");
         assert!(payload.get("output").is_none());
         assert!(payload.get("tool_result").is_none());
         assert!(payload.get("exec_command_result").is_none());

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -987,11 +987,15 @@ function projectWorkItemMutationTool(payload: Record<string, unknown> | undefine
 }
 
 function projectViewImageTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const input = asRecord(payload?.input);
   const result = asRecord(payload?.view_image_result) ?? asRecord(payload?.result);
   const dimensions = asRecord(result?.dimensions);
   const width = numberField(result, "width") ?? numberField(dimensions, "width");
   const height = numberField(result, "height") ?? numberField(dimensions, "height");
-  const imagePath = firstStringField(payload, ["path", "image_path"]) ?? firstStringField(result, ["path", "image_path"]);
+  const imagePath =
+    firstStringField(input, ["path", "image_path"]) ??
+    firstStringField(payload, ["path", "image_path"]) ??
+    firstStringField(result, ["path", "image_path"]);
   const observation = firstStringField(result, ["visual_observation", "observation", "text_preview"]);
   const body = compactJoin([
     "Viewed image",
@@ -1121,11 +1125,13 @@ function formatBytesRead(bytes: number): string {
 }
 
 function projectSpawnAgentTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const input = asRecord(payload?.input);
   const result = asRecord(payload?.spawn_agent_result) ?? unwrapToolResult(payload);
-  const agentId = stringField(result, "agent_id") ?? stringField(payload, "agent_id");
-  const preset = stringField(payload, "preset") ?? stringField(result, "preset");
-  const template = stringField(payload, "template") ?? stringField(result, "template");
-  const initialMessage = stringField(payload, "initial_message") ?? stringField(result, "initial_message");
+  const agentId = stringField(result, "agent_id") ?? stringField(input, "agent_id") ?? stringField(payload, "agent_id");
+  const preset = stringField(input, "preset") ?? stringField(payload, "preset") ?? stringField(result, "preset");
+  const template = stringField(input, "template") ?? stringField(payload, "template") ?? stringField(result, "template");
+  const initialMessage =
+    stringField(input, "initial_message") ?? stringField(payload, "initial_message") ?? stringField(result, "initial_message");
   const body = compactJoin([
     "Spawned agent",
     agentId ?? "agent",
@@ -1137,9 +1143,10 @@ function projectSpawnAgentTool(payload: Record<string, unknown> | undefined): Pi
 }
 
 function projectUseWorkspaceTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
-  const path = stringField(payload, "path");
-  const workspaceId = stringField(payload, "workspace_id");
-  const mode = stringField(payload, "mode");
+  const input = asRecord(payload?.input);
+  const path = stringField(input, "path") ?? stringField(payload, "path");
+  const workspaceId = stringField(input, "workspace_id") ?? stringField(payload, "workspace_id");
+  const mode = stringField(input, "mode") ?? stringField(payload, "mode");
   const body = compactJoin([
     "Switched workspace",
     path ?? workspaceId,
@@ -1149,8 +1156,9 @@ function projectUseWorkspaceTool(payload: Record<string, unknown> | undefined): 
 }
 
 function projectEnqueueTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
-  const text = stringField(payload, "text");
-  const priority = stringField(payload, "priority");
+  const input = asRecord(payload?.input);
+  const text = stringField(input, "text") ?? stringField(payload, "text");
+  const priority = stringField(input, "priority") ?? stringField(payload, "priority");
   const body = compactJoin([
     "Enqueued follow-up",
     priority && priority !== "normal" ? priority : undefined,
@@ -1160,10 +1168,11 @@ function projectEnqueueTool(payload: Record<string, unknown> | undefined): Pick<
 }
 
 function projectGenerateImageTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const input = asRecord(payload?.input);
   const result = asRecord(payload?.generate_image_result) ?? unwrapToolResult(payload);
-  const prompt = stringField(payload, "prompt") ?? stringField(result, "prompt");
-  const name = stringField(payload, "name") ?? stringField(result, "name");
-  const size = stringField(payload, "size") ?? stringField(result, "size");
+  const prompt = stringField(input, "prompt") ?? stringField(payload, "prompt") ?? stringField(result, "prompt");
+  const name = stringField(input, "name") ?? stringField(payload, "name") ?? stringField(result, "name");
+  const size = stringField(input, "size") ?? stringField(payload, "size") ?? stringField(result, "size");
   const imageUri = firstStringField(result, ["image_uri", "uri", "path"]);
   const body = compactJoin([
     "Generated image",
@@ -1175,7 +1184,8 @@ function projectGenerateImageTool(payload: Record<string, unknown> | undefined):
 }
 
 function projectAgentGetTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
-  const agentId = stringField(payload, "agent_id");
+  const input = asRecord(payload?.input);
+  const agentId = stringField(input, "agent_id") ?? stringField(payload, "agent_id");
   const result = unwrapToolResult(payload);
   const visibility = stringField(result, "visibility");
   const ownership = stringField(result, "ownership");

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -179,7 +179,7 @@ describe("reduceAgentSessionTimeline", () => {
         events: [
           toolEvent("view-image", "ViewImage", {
             duration_ms: 9700,
-            path: "/Users/jolestar/Desktop/Screenshot.png",
+            input: { path: "/Users/jolestar/Desktop/Screenshot.png" },
             view_image_result: {
               dimensions: { width: 1200, height: 800 },
               visual_observation: "A browser screenshot showing the conversation timeline.",
@@ -196,6 +196,48 @@ describe("reduceAgentSessionTimeline", () => {
         body: "Viewed image · Screenshot.png · 1200×800 · A browser screenshot showing the conversation timeline. · 9.7s",
       }),
     );
+  });
+
+  it("projects tool call parameters from sanitized audit input", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("spawn-agent-1", "SpawnAgent", {
+            input: {
+              agent_id: "reviewer",
+              preset: "public_named",
+              template: "holon-reviewer",
+              initial_message: "Review issue #2150",
+            },
+            summary: "agent_id=reviewer",
+          }),
+          toolEvent("use-workspace-2", "UseWorkspace", {
+            input: { workspace_id: "ws_issue_2150", mode: "isolated" },
+            summary: "completed",
+          }),
+          toolEvent("enqueue-3", "Enqueue", {
+            input: { priority: "next", text: "Continue issue #2150 implementation" },
+            summary: "completed",
+          }),
+          toolEvent("generate-image-4", "GenerateImage", {
+            input: { name: "timeline", size: "1536x1024", prompt: "A tool execution timeline" },
+            summary: "completed",
+          }),
+          toolEvent("agent-get-5", "AgentGet", {
+            input: { agent_id: "holon-dev" },
+            summary: "completed",
+          }),
+        ],
+      },
+    });
+
+    expect(timeline.map((item) => item.body)).toEqual([
+      expect.stringContaining("Spawned agent · reviewer · public_named · holon-reviewer · Review issue #2150"),
+      expect.stringContaining("Switched workspace · ws_issue_2150 · isolated"),
+      expect.stringContaining("Enqueued follow-up · next · Continue issue #2150 implementation"),
+      expect.stringContaining("Generated image · timeline · 1536x1024 · A tool execution timeline"),
+      expect.stringContaining("Inspected agent · holon-dev"),
+    ]);
   });
 
   it("projects ListTasks tools as readable active task summaries", () => {


### PR DESCRIPTION
## Summary

- add a sanitized `input` snapshot to `ToolExecutionAuditEvent` for both successful and failed tool executions
- redact sensitive keys, bound long strings, and replace large `ApplyPatch` bodies with a compact preview/size record
- centralize canonical tool result summaries and reuse them for persisted records and round recaps
- update the Web GUI timeline projector to read known tool parameters from `payload.input`

Closes #2150.

## Verification

- `cargo fmt --all -- --check`
- `cargo test tool_audit_input --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm --prefix web-gui/app test -- session-reducer.test.ts` (47 tests passed)
- `npm --prefix web-gui/app run build`
