### PR TITLE
fix: classify runtime checkpoint rounds

### DIFF
--- a/docs/rfcs/operator-display-levels-and-event-presentation.md
+++ b/docs/rfcs/operator-display-levels-and-event-presentation.md
@@ -258,6 +258,7 @@ shown, hidden, merged, attached, or left to trace inspection.
 | Message aborts and failures | `message_processing_aborted` when it explains an abort or failure | `info` |
 | Message queue and admission plumbing | `message_enqueued`, `message_admitted`, `message_processing_started`, `turn_started` | `trace_only` |
 | Assistant text progress | `assistant_round_recorded`, `text_only_round_observed` with assistant text | `verbose` |
+| Runtime-private checkpoint rounds | `assistant_round_recorded`, `text_only_round_observed`, and `provider_round_completed` with `round_purpose = runtime_checkpoint` | `trace_only`; raw evidence remains available and explicitly labeled |
 | Tool-only assistant rounds | `assistant_round_recorded` with only tool calls | `verbose`, but normally merged into the related tool item |
 | Provider telemetry | `provider_round_completed` | `debug` |
 | Command and tool lifecycle | `process_execution_requested`, `tool_executed`, `tool_execution_failed`, `truncated_mutation_tool_call_rejected` | `verbose`; failures may promote to `info` when operator-relevant |
@@ -412,6 +413,12 @@ Intermediate assistant text is progress. It is not part of the result-oriented
 
 Tool-only assistant rounds are better expressed as the actual tool or command
 activity.
+
+Runtime-private checkpoint rounds are not assistant progress. Curated
+`info`/`verbose` projections must omit their text regardless of language or
+format. Debug/raw inspectors may expose the original event and transcript
+blocks, but must preserve the `runtime_checkpoint` purpose label so the content
+cannot be mistaken for operator-facing assistant prose.
 
 ### Provider Rounds
 

--- a/docs/rfcs/runtime-object-and-reference-model.md
+++ b/docs/rfcs/runtime-object-and-reference-model.md
@@ -374,6 +374,7 @@ returned and Holon accepted as the assistant side of the conversation.
 It may include:
 
 - block list;
+- round purpose (`agent_response` or `runtime_checkpoint`);
 - round number;
 - stop reason;
 - token usage;
@@ -384,6 +385,12 @@ It may include:
 
 Briefs may reference an assistant round when their text is derived from that
 assistant output.
+
+`runtime_checkpoint` rounds are runtime-private continuity evidence. They are
+not eligible as the source of terminal text or a brief. This does not imply a
+one-to-one relationship between ordinary assistant rounds, turn terminals, and
+briefs: a turn may still produce multiple independently identified briefs, and
+WorkItem completion promotion may occur before the turn terminates.
 
 ### Tool Results
 

--- a/docs/rfcs/turn-local-context-compaction.md
+++ b/docs/rfcs/turn-local-context-compaction.md
@@ -167,6 +167,39 @@ logical cycle:
 
 Compacting raw blocks independently would break that meaning.
 
+### 6.1 Checkpoint Round Purpose
+
+A provider round requested by the runtime solely to create a compaction
+checkpoint is still stored as `TranscriptEntry::AssistantRound`, but it must be
+marked with:
+
+```json
+{
+  "round_purpose": "runtime_checkpoint",
+  "visibility": "runtime_private",
+  "checkpoint_request_id": "..."
+}
+```
+
+Ordinary rounds use `round_purpose = "agent_response"`.
+
+This distinction is semantic, not a text heuristic. A runtime checkpoint:
+
+- remains durable transcript and audit evidence;
+- may be replayed to the provider as continuity state;
+- must not become `TurnTerminalRecord.final_text`;
+- must not become `final_text_source_assistant_round_id`;
+- must not be promoted to a brief merely because it contains text;
+- must not contribute text to max-output recovery history.
+
+Briefs and assistant rounds remain non-bijective. One turn may produce multiple
+briefs, including WorkItem completion reports, and no rule here introduces a
+single terminal-brief assumption.
+
+Checkpoint generation should best-effort follow the current response language
+contract from the trusted prompt and context. Language mismatch does not block
+checkpoint recording, compaction, or continuation.
+
 ## 7. Bounded Provider Projection
 
 Before every continuation request after round 1, Holon should build a fresh

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -364,6 +364,13 @@ fn event_visibility(
     category: OperatorEventCategory,
     context: &OperatorPresentationContext,
 ) -> OperatorVisibility {
+    if matches!(
+        kind,
+        "assistant_round_recorded" | "provider_round_completed" | "text_only_round_observed"
+    ) && is_runtime_checkpoint_round(payload)
+    {
+        return OperatorVisibility::Trace;
+    }
     match (kind, category) {
         ("operator_notification_requested", _) => OperatorVisibility::ActionRequired,
         ("brief_created", _) => brief_visibility(payload, context),
@@ -450,6 +457,9 @@ fn turn_terminal_provider_lineage(payload: &Value) -> bool {
 }
 
 fn is_verbose_event(kind: &str, payload: &Value) -> bool {
+    if is_runtime_checkpoint_round(payload) {
+        return false;
+    }
     match kind {
         "assistant_round_recorded" => payload_text_present(payload, "text_preview"),
         "text_only_round_observed" => {
@@ -570,6 +580,10 @@ fn payload_text_present(payload: &Value, field: &str) -> bool {
         .get(field)
         .and_then(Value::as_str)
         .is_some_and(|text| !text.trim().is_empty())
+}
+
+fn is_runtime_checkpoint_round(payload: &Value) -> bool {
+    payload.get("round_purpose").and_then(Value::as_str) == Some("runtime_checkpoint")
 }
 
 fn provider_round_has_useful_telemetry(payload: &Value) -> bool {
@@ -1587,6 +1601,18 @@ fn legacy_command_summary(summary: &str) -> Option<(&str, &str)> {
 }
 
 fn assistant_round_recorded_text(payload: &Value) -> (String, Option<String>, String) {
+    if is_runtime_checkpoint_round(payload) {
+        let mode = payload
+            .get("checkpoint_mode")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let body = format!("Internal continuity evidence (mode={mode})");
+        return (
+            "Runtime checkpoint".into(),
+            Some(body.clone()),
+            format!("Runtime checkpoint: {body}"),
+        );
+    }
     let text = payload
         .get("text_preview")
         .and_then(Value::as_str)
@@ -2478,6 +2504,39 @@ mod tests {
             empty.summary,
             "Assistant round completed without text (stop=end_turn)"
         );
+    }
+
+    #[test]
+    fn runtime_checkpoint_round_is_debug_only_and_explicitly_labeled() {
+        let context = OperatorPresentationContext::default();
+        let payload = json!({
+            "round_purpose": "runtime_checkpoint",
+            "checkpoint_mode": "full",
+            "text_preview": "internal checkpoint text"
+        });
+        let checkpoint =
+            present_operator_event("assistant_round_recorded", &payload, "fallback", &context);
+
+        assert_eq!(checkpoint.visibility, OperatorVisibility::Trace);
+        assert_eq!(checkpoint.title, "Runtime checkpoint");
+        assert_eq!(
+            checkpoint.body.as_deref(),
+            Some("Internal continuity evidence (mode=full)")
+        );
+        assert!(!super::is_operator_event_in_display_mode(
+            "assistant_round_recorded",
+            &payload,
+            "fallback",
+            &context,
+            OperatorDisplayMode::Verbose
+        ));
+        assert!(super::is_operator_event_in_display_mode(
+            "assistant_round_recorded",
+            &payload,
+            "fallback",
+            &context,
+            OperatorDisplayMode::Debug
+        ));
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -893,21 +893,27 @@ impl PresentationReducer {
                 }
 
                 "assistant_round_recorded" | "text_only_round_observed" => {
-                    if let Some(text) = round_text_preview(event) {
-                        let text_key = normalized_event_text_key(event, &text);
-                        if !text.trim().is_empty()
-                            && !matches_final_brief_text(event, &text, &final_brief_texts)
-                            && self.observed_assistant_text_keys.insert(text_key)
-                        {
-                            self.observed_assistant_texts
-                                .insert(strip_preview_ellipsis(normalized_text(&text).as_str()));
-                            items.push(TimedItem::from_event(
-                                PresentationItem::AssistantProgress {
-                                    text,
-                                    state: ItemState::Stable,
-                                },
-                                event,
-                            ));
+                    let runtime_checkpoint =
+                        event.payload.get("round_purpose").and_then(Value::as_str)
+                            == Some("runtime_checkpoint");
+                    if !runtime_checkpoint {
+                        if let Some(text) = round_text_preview(event) {
+                            let text_key = normalized_event_text_key(event, &text);
+                            if !text.trim().is_empty()
+                                && !matches_final_brief_text(event, &text, &final_brief_texts)
+                                && self.observed_assistant_text_keys.insert(text_key)
+                            {
+                                self.observed_assistant_texts.insert(strip_preview_ellipsis(
+                                    normalized_text(&text).as_str(),
+                                ));
+                                items.push(TimedItem::from_event(
+                                    PresentationItem::AssistantProgress {
+                                        text,
+                                        state: ItemState::Stable,
+                                    },
+                                    event,
+                                ));
+                            }
                         }
                     }
                 }
@@ -3729,6 +3735,27 @@ mod tests {
             }
             other => panic!("expected AssistantProgress, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn reducer_hides_runtime_checkpoint_assistant_rounds() {
+        let assistant = make_event(
+            "assistant_round_recorded",
+            "assistant round",
+            json!({
+                "agent_id": "default",
+                "round_purpose": "runtime_checkpoint",
+                "text_preview": "internal checkpoint text"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(
+            &[assistant],
+            &BriefTextLookup(&std::collections::BTreeMap::new()),
+        );
+
+        assert!(items.is_empty());
     }
 
     #[test]

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -578,6 +578,8 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
         .unwrap();
 
     assert_eq!(outcome.terminal_kind, TurnTerminalKind::Completed);
+    assert_eq!(outcome.final_text, "Finished after compacted continuation.");
+    assert!(outcome.final_text_source_assistant_round_id.is_some());
     assert_eq!(*provider.calls.lock().await, 5);
 
     let requests = provider.requests.lock().await;
@@ -684,6 +686,36 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
                     && event.data["checkpoint_request_id"].as_str() == Some(checkpoint_request_id)
             })
             .expect("missing structured checkpoint recorded event");
+        let checkpoint_assistant_event = events
+            .iter()
+            .find(|event| {
+                event.kind == "assistant_round_recorded"
+                    && event.data["checkpoint_request_id"].as_str() == Some(checkpoint_request_id)
+            })
+            .expect("missing checkpoint assistant round event");
+        assert_eq!(
+            checkpoint_assistant_event.data["round_purpose"].as_str(),
+            Some("runtime_checkpoint")
+        );
+        assert_eq!(
+            checkpoint_assistant_event.data["visibility"].as_str(),
+            Some("runtime_private")
+        );
+        let checkpoint_assistant_round_id = checkpoint_assistant_event.data["assistant_round_id"]
+            .as_str()
+            .expect("checkpoint assistant round id");
+        assert_ne!(
+            outcome.final_text_source_assistant_round_id.as_deref(),
+            Some(checkpoint_assistant_round_id)
+        );
+        let checkpoint_transcript = transcript
+            .iter()
+            .find(|entry| entry.id == checkpoint_assistant_round_id)
+            .expect("missing checkpoint assistant transcript");
+        assert_eq!(
+            checkpoint_transcript.data["round_purpose"].as_str(),
+            Some("runtime_checkpoint")
+        );
         assert_eq!(
             Some(checkpoint_request_id),
             checkpoint_requested.data["checkpoint_request_id"].as_str()

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -20,10 +20,10 @@ use crate::runtime::provider_turn::{
 use crate::storage::to_json_value;
 use crate::tool::{ToolCall, ToolError};
 use crate::types::{
-    AdmissionContext, AuditEvent, AuthorityClass, MessageBody, MessageDeliverySurface,
-    MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
-    TokenUsage, ToolExecutionAuditEvent, TranscriptEntry, TranscriptEntryKind, TurnTerminalKind,
-    TurnTerminalRecord,
+    AdmissionContext, AssistantRoundPurpose, AuditEvent, AuthorityClass, MessageBody,
+    MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+    QueueEntryRecord, QueueEntryStatus, TokenUsage, ToolExecutionAuditEvent, TranscriptEntry,
+    TranscriptEntryKind, TurnTerminalKind, TurnTerminalRecord,
 };
 
 use super::checkpoint::{
@@ -492,7 +492,7 @@ impl TurnExecution<'_> {
         let mut round = 0usize;
         let mut truncated_text_history = Vec::new();
         let mut last_assistant_message: Option<String> = None;
-        let mut last_assistant_round_id: Option<String>;
+        let mut last_assistant_round_id: Option<String> = None;
         let mut max_output_recovery_count = 0usize;
         let mut rounds_since_work_item_update = 0usize;
         let mut rounds_since_work_item_reminder = work_item_stale_reminder_cooldown_rounds();
@@ -1002,6 +1002,18 @@ impl TurnExecution<'_> {
             };
 
             let assistant_blocks = response.blocks.clone();
+            let pending_checkpoint_metadata = checkpoint_state.pending.as_ref().map(|pending| {
+                (
+                    pending.request_id.clone(),
+                    pending.mode,
+                    pending.requested_at_round,
+                )
+            });
+            let round_purpose = if pending_checkpoint_metadata.is_some() {
+                AssistantRoundPurpose::RuntimeCheckpoint
+            } else {
+                AssistantRoundPurpose::AgentResponse
+            };
             let mut tool_calls = Vec::new();
             let mut text_blocks = Vec::new();
             let mut thinking_block_count = 0usize;
@@ -1048,28 +1060,38 @@ impl TurnExecution<'_> {
                 .filter(|text| !text.is_empty())
                 .collect::<Vec<_>>()
                 .join("\n\n");
-            let aggregated_text = combine_text_history(&truncated_text_history, &text_blocks)
-                .into_iter()
-                .map(|text| text.trim().to_string())
-                .filter(|text| !text.is_empty())
-                .collect::<Vec<_>>()
-                .join("\n\n");
-            if !aggregated_text.is_empty() {
-                last_assistant_message = Some(aggregated_text.clone());
-            } else if !truncated_text_history.is_empty() {
-                // If current round has no text, preserve text history from previous rounds
-                // This ensures that summaries before tool calls are not lost
-                let history_text = truncated_text_history
-                    .iter()
-                    .map(|text| text.trim())
+            if round_purpose == AssistantRoundPurpose::AgentResponse {
+                let aggregated_text = combine_text_history(&truncated_text_history, &text_blocks)
+                    .into_iter()
+                    .map(|text| text.trim().to_string())
                     .filter(|text| !text.is_empty())
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if !history_text.is_empty() {
-                    last_assistant_message = Some(history_text);
+                if !aggregated_text.is_empty() {
+                    last_assistant_message = Some(aggregated_text);
+                } else if !truncated_text_history.is_empty() {
+                    // If current round has no text, preserve text history from previous rounds.
+                    let history_text = truncated_text_history
+                        .iter()
+                        .map(|text| text.trim())
+                        .filter(|text| !text.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n\n");
+                    if !history_text.is_empty() {
+                        last_assistant_message = Some(history_text);
+                    }
                 }
             }
             let token_usage = TokenUsage::new(response.input_tokens, response.output_tokens);
+            let checkpoint_request_id = pending_checkpoint_metadata
+                .as_ref()
+                .map(|(request_id, _, _)| request_id.clone());
+            let checkpoint_mode = pending_checkpoint_metadata
+                .as_ref()
+                .map(|(_, mode, _)| mode.as_str());
+            let checkpoint_requested_at_round = pending_checkpoint_metadata
+                .as_ref()
+                .map(|(_, _, requested_at_round)| *requested_at_round);
 
             runtime.inner.storage.append_event(&AuditEvent::new(
                 "provider_round_completed",
@@ -1078,6 +1100,15 @@ impl TurnExecution<'_> {
                     "turn_index": turn_index,
                     "run_id": run_id,
                     "round": round,
+                    "round_purpose": round_purpose.as_str(),
+                    "visibility": if round_purpose == AssistantRoundPurpose::RuntimeCheckpoint {
+                        "runtime_private"
+                    } else {
+                        "operator_visible"
+                    },
+                    "checkpoint_request_id": checkpoint_request_id.clone(),
+                    "checkpoint_mode": checkpoint_mode,
+                    "checkpoint_requested_at_round": checkpoint_requested_at_round,
                     "work_item_id": round_work_item_id.clone(),
                     "stop_reason": stop_reason,
                     "context_build_ms": context_build_ms,
@@ -1180,6 +1211,15 @@ impl TurnExecution<'_> {
                     None,
                     serde_json::json!({
                         "blocks": &completed_round_assistant_blocks,
+                        "round_purpose": round_purpose.as_str(),
+                        "visibility": if round_purpose == AssistantRoundPurpose::RuntimeCheckpoint {
+                            "runtime_private"
+                        } else {
+                            "operator_visible"
+                        },
+                        "checkpoint_request_id": checkpoint_request_id.clone(),
+                        "checkpoint_mode": checkpoint_mode,
+                        "checkpoint_requested_at_round": checkpoint_requested_at_round,
                         "work_item_id": round_work_item_id.clone(),
                         "token_usage": token_usage,
                         "provider_cache_usage": cache_usage,
@@ -1197,7 +1237,9 @@ impl TurnExecution<'_> {
             };
             let assistant_round_id = assistant_round_transcript_entry.id.clone();
             runtime.persist_transcript_evidence(&assistant_round_transcript_entry)?;
-            last_assistant_round_id = Some(assistant_round_id.clone());
+            if round_purpose == AssistantRoundPurpose::AgentResponse {
+                last_assistant_round_id = Some(assistant_round_id.clone());
+            }
             runtime.inner.storage.append_event(&AuditEvent::new(
                 "assistant_round_recorded",
                 serde_json::json!({
@@ -1206,6 +1248,15 @@ impl TurnExecution<'_> {
                     "turn_index": turn_index,
                     "run_id": run_id,
                     "round": round,
+                    "round_purpose": round_purpose.as_str(),
+                    "visibility": if round_purpose == AssistantRoundPurpose::RuntimeCheckpoint {
+                        "runtime_private"
+                    } else {
+                        "operator_visible"
+                    },
+                    "checkpoint_request_id": checkpoint_request_id.clone(),
+                    "checkpoint_mode": checkpoint_mode,
+                    "checkpoint_requested_at_round": checkpoint_requested_at_round,
                     "work_item_id": round_work_item_id.clone(),
                     "stop_reason": stop_reason,
                     "text_block_count": text_blocks.len(),
@@ -1227,6 +1278,15 @@ impl TurnExecution<'_> {
                         "turn_index": turn_index,
                         "run_id": run_id,
                         "round": round,
+                        "round_purpose": round_purpose.as_str(),
+                        "visibility": if round_purpose == AssistantRoundPurpose::RuntimeCheckpoint {
+                            "runtime_private"
+                        } else {
+                            "operator_visible"
+                        },
+                        "checkpoint_request_id": checkpoint_request_id,
+                        "checkpoint_mode": checkpoint_mode,
+                        "checkpoint_requested_at_round": checkpoint_requested_at_round,
                         "stop_reason": stop_reason,
                         "has_text": !combined_text.is_empty(),
                         "text_preview": if combined_text.is_empty() {
@@ -1278,7 +1338,9 @@ impl TurnExecution<'_> {
 
             if tool_calls.is_empty() && is_max_output_stop_reason(stop_reason.as_deref()) {
                 if max_output_recovery_count < MAX_OUTPUT_RECOVERY_ATTEMPTS {
-                    if !combined_text.is_empty() {
+                    if round_purpose == AssistantRoundPurpose::AgentResponse
+                        && !combined_text.is_empty()
+                    {
                         truncated_text_history.push(combined_text.clone());
                     }
                     max_output_recovery_count += 1;

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -79,7 +79,9 @@ const OPERATOR_INTERJECTION_HEADER: &str =
     "[Operator message received while this turn was in progress]";
 const COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT: &str = "\
 [Runtime-generated full progress checkpoint request]
-You are crossing a context compaction boundary. Before continuing, include a concise progress checkpoint for continuation in your next assistant message.
+You are crossing a context compaction boundary. Produce a concise runtime-private progress checkpoint for continuation in your next assistant message.
+This checkpoint is internal continuity state, not operator-facing prose. Do not treat it as a status update or later repeat its headings or metadata to the operator unless explicitly asked.
+Best effort: write the checkpoint in the current target response language inferred from the trusted prompt and context. Language mismatch must not prevent checkpoint creation or continuation.
 
 Include:
 - current user goal
@@ -97,7 +99,7 @@ Do not assume the task requires code changes unless the user goal does.";
 const DELTA_CHECKPOINT_PREVIEW_LIMIT: usize = 1_200;
 const CHECKPOINT_RESUME_PROMPT: &str = "\
 [Runtime-generated checkpoint continuation]
-Continue from the checkpoint's next goal-aligned action now. Do not restate the checkpoint. If the checkpoint says enough evidence exists to act, call the concrete mutation, verification, or delivery tool next; otherwise run only the named bounded command/query.";
+Continue from the checkpoint's next goal-aligned action now. The preceding checkpoint is runtime-private continuity state, not operator-facing prose. Do not restate its headings, metadata, or content unless the operator explicitly asks about it. If the checkpoint says enough evidence exists to act, call the concrete mutation, verification, or delivery tool next; otherwise run only the named bounded command/query.";
 
 fn truncate_preview(text: &str, limit: usize) -> String {
     let trimmed = text.trim();

--- a/src/runtime/turn/reminders.rs
+++ b/src/runtime/turn/reminders.rs
@@ -237,6 +237,8 @@ pub(super) fn build_delta_checkpoint_prompt(
         "\
 [Runtime-generated delta progress checkpoint request]
 You are crossing another context compaction boundary. A previous checkpoint is still the active base.
+This delta is runtime-private continuity state, not operator-facing prose. Do not later repeat its headings or metadata to the operator unless explicitly asked.
+Best effort: write the delta in the current target response language inferred from the trusted prompt and context. Language mismatch must not prevent checkpoint creation or continuation.
 
 {base_source}
 Base checkpoint preview:

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -1455,14 +1455,21 @@ fn build_turn_local_projection_strict_fallback_preserves_one_exact_round() {
         fixture_round(2, &"beta ".repeat(170)),
         fixture_round(3, &"gamma ".repeat(170)),
     ];
+    let prompt_frame = fixture_prompt_frame();
+    let mut minimum_viable_conversation = vec![ConversationMessage::UserBlocks(
+        prompt_frame.context_blocks.clone(),
+    )];
+    minimum_viable_conversation.extend(exact_round_messages(&rounds[2]));
+    let prompt_budget = estimate_projection_tokens(&prompt_frame, &minimum_viable_conversation)
+        + CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS;
 
     let projection = build_turn_local_projection(
-        &fixture_prompt_frame(),
+        &prompt_frame,
         &rounds,
         &[],
         &TurnLocalCheckpointState::default(),
         Some("req-1".into()),
-        700 + estimate_text_tokens(COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT),
+        prompt_budget,
         120,
     );
 
@@ -1491,14 +1498,27 @@ fn build_turn_local_projection_adds_checkpoint_prompt_when_compaction_applies() 
         fixture_round(2, &"beta ".repeat(170)),
         fixture_round(3, &"gamma ".repeat(170)),
     ];
+    let prompt_frame = fixture_prompt_frame();
+    let checkpoint_state = TurnLocalCheckpointState::default();
+    let checkpoint_request =
+        build_turn_local_checkpoint_request(&checkpoint_state, Some("req-1".into()));
+    let mut checkpointed_minimum_conversation = vec![ConversationMessage::UserBlocks(
+        prompt_frame.context_blocks.clone(),
+    )];
+    checkpointed_minimum_conversation.extend(exact_round_messages(&rounds[2]));
+    checkpointed_minimum_conversation
+        .push(ConversationMessage::UserText(checkpoint_request.prompt));
+    let prompt_budget =
+        estimate_projection_tokens(&prompt_frame, &checkpointed_minimum_conversation)
+            + CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS;
 
     let projection = build_turn_local_projection(
-        &fixture_prompt_frame(),
+        &prompt_frame,
         &rounds,
         &[],
-        &TurnLocalCheckpointState::default(),
+        &checkpoint_state,
         Some("req-1".into()),
-        700 + estimate_text_tokens(COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT),
+        prompt_budget,
         120,
     );
 
@@ -1550,14 +1570,26 @@ fn build_turn_local_projection_uses_structured_checkpoint_state_for_delta_prompt
         ),
     ];
     let checkpoint_state = checkpoint_state_with_latest("结构化记录：继续处理 #495。", 2, 0);
+    let prompt_frame = fixture_prompt_frame();
+    let checkpoint_request =
+        build_turn_local_checkpoint_request(&checkpoint_state, Some("req-delta".into()));
+    let mut checkpointed_minimum_conversation = vec![ConversationMessage::UserBlocks(
+        prompt_frame.context_blocks.clone(),
+    )];
+    checkpointed_minimum_conversation.extend(exact_round_messages(&rounds[2]));
+    checkpointed_minimum_conversation
+        .push(ConversationMessage::UserText(checkpoint_request.prompt));
+    let prompt_budget =
+        estimate_projection_tokens(&prompt_frame, &checkpointed_minimum_conversation)
+            + CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS;
 
     let projection = build_turn_local_projection(
-        &fixture_prompt_frame(),
+        &prompt_frame,
         &rounds,
         &[],
         &checkpoint_state,
         Some("req-delta".into()),
-        700 + estimate_text_tokens(COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT),
+        prompt_budget,
         120,
     );
 
@@ -1845,14 +1877,21 @@ fn build_turn_local_projection_keeps_follow_up_prompt_final_during_compaction() 
         fixture_round(2, &"beta ".repeat(170)),
         fixture_round_with_follow_up(3, &"gamma ".repeat(170), follow_up),
     ];
+    let prompt_frame = fixture_prompt_frame();
+    let mut minimum_viable_conversation = vec![ConversationMessage::UserBlocks(
+        prompt_frame.context_blocks.clone(),
+    )];
+    minimum_viable_conversation.extend(exact_round_messages(&rounds[2]));
+    let prompt_budget = estimate_projection_tokens(&prompt_frame, &minimum_viable_conversation)
+        + CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS;
 
     let projection = build_turn_local_projection(
-        &fixture_prompt_frame(),
+        &prompt_frame,
         &rounds,
         &[],
         &TurnLocalCheckpointState::default(),
         Some("req-1".into()),
-        700 + estimate_text_tokens(COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT),
+        prompt_budget,
         120,
     );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4551,6 +4551,22 @@ pub enum TranscriptEntryKind {
     SubagentAssistantRound,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantRoundPurpose {
+    AgentResponse,
+    RuntimeCheckpoint,
+}
+
+impl AssistantRoundPurpose {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentResponse => "agent_response",
+            Self::RuntimeCheckpoint => "runtime_checkpoint",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TranscriptEntry {
     pub id: String,

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -515,6 +515,9 @@ function projectAssistantRoundRecorded(
   payload: Record<string, unknown> | undefined,
   transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>,
 ): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> | undefined {
+  if (stringField(payload, "round_purpose") === "runtime_checkpoint") {
+    return undefined;
+  }
   const transcriptText = transcriptTextForPayload(payload, transcriptEntriesById);
   if (transcriptText) {
     return {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1179,6 +1179,40 @@ describe("reduceAgentSessionTimeline", () => {
       }),
     );
   });
+
+  it("keeps runtime checkpoint assistant rounds out of the curated timeline", () => {
+    const checkpoint = event({
+      id: "checkpoint-round",
+      event_seq: 25,
+      type: "assistant_round_recorded",
+      payload: {
+        assistant_round_id: "round_checkpoint",
+        round_purpose: "runtime_checkpoint",
+        checkpoint_mode: "full",
+        text_preview: "Internal checkpoint text.",
+      },
+    });
+    const timeline = reduceAgentSessionTimeline({
+      events: { events: [checkpoint] },
+      transcriptEntriesById: {
+        round_checkpoint: {
+          id: "round_checkpoint",
+          data: {
+            round_purpose: "runtime_checkpoint",
+            blocks: [{ type: "text", text: "Internal checkpoint text." }],
+          },
+        },
+      },
+    });
+
+    expect(timeline).toEqual([]);
+    expect(debugAgentSessionEvents([checkpoint])).toEqual([
+      expect.objectContaining({
+        id: "debug:checkpoint-round",
+        rawEvent: checkpoint,
+      }),
+    ]);
+  });
 });
 
 describe("filterTimelineByDisplayLevel", () => {


### PR DESCRIPTION
## Summary
- classify provider assistant rounds as `agent_response` or `runtime_checkpoint` and persist checkpoint request metadata in transcript/audit evidence
- prevent runtime checkpoint text from becoming terminal result text, brief source text, max-output recovery history, or curated info/verbose assistant progress
- retain checkpoint evidence on debug/raw surfaces, preserve multi-brief and WorkItem completion behavior, and document the semantic boundary
- reinforce the best-effort response-language instruction for all operator-visible assistant prose without adding language detection, retries, or extra model calls

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test`
- `npm test` (`web-gui/app`)
- `npm run typecheck` (`web-gui/app`)
