### PR TITLE
feat(web-gui): generalize OAuth device login for multiple providers

### DIFF
--- a/web-gui/app/src/features/settings/SettingsPage.test.ts
+++ b/web-gui/app/src/features/settings/SettingsPage.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { buildSearchProviderConfigUpdates, buildVisionConfigUpdates, sortProvidersForSettings, sortSearchProvidersForSettings } from "./SettingsPage";
+import {
+  buildSearchProviderConfigUpdates,
+  buildVisionConfigUpdates,
+  sortProvidersForSettings,
+  sortSearchProvidersForSettings,
+  supportsOAuthDeviceLogin,
+} from "./SettingsPage";
 import type { RuntimeProviderSummary, RuntimeWebSearchProviderSummary } from "../../runtime/types";
 
 function provider(id: string, credentialConfigured: boolean): RuntimeProviderSummary {
@@ -90,5 +96,16 @@ describe("buildSearchProviderConfigUpdates", () => {
       { key: "web.providers.searxng.base_url", value: "https://search.example.test" },
       { key: "web.providers.searxng.credential_profile", value: "" },
     ]);
+  });
+});
+
+describe("supportsOAuthDeviceLogin", () => {
+  it("accepts openai-codex and xai", () => {
+    expect(supportsOAuthDeviceLogin("openai-codex")).toBe(true);
+    expect(supportsOAuthDeviceLogin("xai")).toBe(true);
+  });
+
+  it("rejects other providers", () => {
+    expect(supportsOAuthDeviceLogin("openai")).toBe(false);
   });
 });

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -37,7 +37,7 @@ interface SettingsPageProps {
   onSetCredential: (profile: string, kind: string, material: string) => Promise<unknown>;
   onDeleteCredential: (profile: string) => Promise<void>;
   codexDeviceLogin: CodexDeviceLoginState;
-  onStartCodexDeviceLogin: () => Promise<void>;
+  onStartCodexDeviceLogin: (providerId?: string) => Promise<void>;
   onClearCodexDeviceLogin: () => void;
 }
 
@@ -64,6 +64,10 @@ type ProviderDraft = Pick<
 >;
 
 type SearchProviderDraft = Pick<RuntimeWebSearchProviderSummary, "kind" | "baseUrl" | "credentialProfile">;
+
+export function supportsOAuthDeviceLogin(providerId: string): boolean {
+  return providerId === "openai-codex" || providerId === "xai";
+}
 
 type StandardSearchProviderDefinition = {
   id: string;
@@ -1280,7 +1284,7 @@ export function SettingsPage({
                           <>
                           <div className="settings-actions">
                             <Button type="button" variant="secondary" disabled={credentialStoreLoading}
-                              onClick={() => void onStartCodexDeviceLogin()}>
+                              onClick={() => void onStartCodexDeviceLogin(provider.id)}>
                               {provider.credentialConfigured ? "Re-login" : "Login with Device Flow"}
                             </Button>
                           </div>

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1016,14 +1016,14 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
       await deleteJson<unknown>(fetchImpl, baseUrl, `/control/runtime/credentials/${encodeURIComponent(profile)}`, requestHeaders);
     },
-    async startCodexDeviceLogin(): Promise<CodexDeviceLoginResponse> {
+    async startCodexDeviceLogin(providerId = "openai-codex"): Promise<CodexDeviceLoginResponse> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
       const response = await postJson<CodexDeviceStartDto>(
         fetchImpl,
         baseUrl,
-        "/auth/codex/device/start",
+        `/auth/${encodeURIComponent(providerId)}/device/start`,
         {},
         requestHeaders,
       );

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -309,7 +309,7 @@ export interface RuntimeStoreState {
   refreshCredentialStore: () => Promise<void>;
   setCredential: (profile: string, kind: string, material: string) => Promise<CredentialProfileStatus | undefined>;
   deleteCredential: (profile: string) => Promise<void>;
-  startCodexDeviceLogin: () => Promise<void>;
+  startCodexDeviceLogin: (providerId?: string) => Promise<void>;
   clearCodexDeviceLogin: () => void;
   runSearch: (query: string, options?: RuntimeSearchOptions) => Promise<void>;
   loadSearchResultContent: (sourceRef: string) => Promise<void>;
@@ -1628,10 +1628,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set({ credentialStoreError: message });
     }
   },
-  startCodexDeviceLogin: async () => {
+  startCodexDeviceLogin: async (providerId = "openai-codex") => {
     set({ codexDeviceLogin: { status: "starting" } });
     try {
-      const resp = await runtimeClient.startCodexDeviceLogin();
+      const resp = await runtimeClient.startCodexDeviceLogin(providerId);
       set({
         codexDeviceLogin: {
           status: "waiting",


### PR DESCRIPTION
## Summary

Frontend OAuth device login is no longer hardcoded to Codex. The settings page now passes the current `provider.id` to the generic `/auth/{provider}/device/start` endpoint (added in #2154), so xAI and other OAuth-supporting providers can reuse the existing device login flow.

## Changes

- **`client.ts`**: `startCodexDeviceLogin(providerId)` calls `/auth/{provider}/device/start` instead of hardcoded `/auth/codex/device/start`
- **`runtime-store.ts`**: `startCodexDeviceLogin` passes `providerId` through to the client
- **`SettingsPage.tsx`**: OAuth login button passes `provider.id`; adds `supportsOAuthDeviceLogin()` helper (returns true for `openai-codex` and `xai`)
- **`SettingsPage.test.ts`**: tests for `supportsOAuthDeviceLogin`

## Verification

- `pnpm exec vitest run` — 56 tests passed (2 test files)
- `pnpm exec tsc --noEmit` — no new errors (1 pre-existing `unist` module resolution error unrelated to this change)

## Notes

This is the frontend counterpart to #2154 (backend OAuth generalization). The `supportsOAuthDeviceLogin` helper is exported for future use in auth-mode switching UI (API Key ↔ OAuth toggle), which will be a follow-up.

Part of #2153