### PR TITLE
fix: support xAI Responses continuation

### DIFF
--- a/docs/implementation-decisions/046-openai-incremental-continuation.md
+++ b/docs/implementation-decisions/046-openai-incremental-continuation.md
@@ -17,6 +17,14 @@ response ids, non-append conversation shape, or provider errors. Provider
 errors also clear the scoped local continuation snapshot before retry so retry
 attempts do not depend on an ambiguous server-side state.
 
+Provider-specific wire constraints are applied only after continuation
+eligibility is decided from the complete request shape. In particular, xAI
+Responses requests use `store=true` so returned response ids remain available
+for later continuation. An xAI continuation sends `previous_response_id`
+without `instructions`, while initial and full fallback requests keep
+`instructions`. Standard OpenAI Responses requests keep `store=false` and
+`instructions` for both full and incremental requests.
+
 Runtime events record secret-safe request-lowering diagnostics such as hit/miss
 status and fallback reason, but they do not expose response ids or make
 incremental continuation part of provider-neutral prompt assembly.

--- a/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
+++ b/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
@@ -2,32 +2,36 @@
 
 ## Choice
 
-Holon's first Grok integration uses the public xAI API as an OpenAI Responses
-compatible HTTP provider authenticated by `XAI_API_KEY`.
+Holon's Grok integration uses the public xAI API as an OpenAI Responses
+compatible HTTP provider authenticated by either `XAI_API_KEY` or a
+Holon-managed official xAI OAuth profile.
 
 Grok's built-in `web_search` and `x_search` are represented as xAI server-side
 tools on that Responses request. They are not exposed as a raw Holon web-search
 provider and they do not use X API search credentials.
 
-X/xAI account login reuse is left out of the HTTP provider path. If Holon later
-supports X-account-backed Grok sessions, it should integrate through an
-official Grok Build surface such as the Grok CLI / ACP process boundary, not by
-reusing browser cookies, private session files, or consumer subscription state
-as an xAI API key.
+xAI Responses requests use server-side response storage because
+`previous_response_id` continuation requires the referenced response to remain
+available. Continuation requests omit `instructions` to satisfy xAI's wire
+contract; full requests retain them.
+
+The OAuth profile is explicit provider credential material with refresh
+lifecycle managed by Holon. Browser cookies, private consumer session files,
+and implicit subscription-state reuse remain outside the HTTP provider path.
 
 ## Reason
 
-xAI's public inference API documents API-key authentication for direct
-`/v1/responses` and `/v1/chat/completions` calls. Its built-in search tools are
-server-side xAI tools on model requests.
+xAI's public inference API supports direct authenticated `/v1/responses` and
+`/v1/chat/completions` calls. Its built-in search tools are server-side xAI
+tools on model requests.
 
-Grok Build documents a separate login/session path for the official Grok CLI.
-That path can reuse an X/xAI account for the CLI product, but it is not the same
-credential contract as the public xAI API.
+Official OAuth and Grok Build login/session paths remain explicit credential or
+process boundaries; neither authorizes scraping or silently importing browser
+session state.
 
 ## Preserved boundary
 
 The `xai` provider remains a normal remote HTTP provider with explicit API-key
-credentials. Future X-account reuse must be a separate process/agent transport
-with its own lifecycle and trust boundary, rather than hidden auth behavior in
-the OpenAI-compatible transport.
+or OAuth credentials. Any future consumer-session reuse must use an official
+process/agent transport with its own lifecycle and trust boundary, rather than
+hidden auth behavior in the OpenAI-compatible transport.

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -315,8 +315,145 @@ async fn openai_responses_uses_incremental_continuation_for_strict_append() {
     let bodies = captured_bodies.lock().unwrap();
     assert_eq!(bodies.len(), 2);
     assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+    assert_eq!(bodies[1]["instructions"], json!("rendered system"));
     assert_eq!(bodies[1]["input"].as_array().unwrap().len(), 1);
     assert_eq!(bodies[1]["input"][0]["type"], json!("function_call_output"));
+}
+
+#[tokio::test]
+async fn xai_responses_omits_instructions_only_for_incremental_continuation() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Json(openai_tool_call_response("resp_1"))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let fixture = test_config("openai/gpt-5.4", &[], Some("xai-key"), None, false);
+    let mut provider_config = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    provider_config.id = ProviderId::parse("xai").unwrap();
+    provider_config.route_provider = ProviderId::parse("xai").unwrap();
+    provider_config.base_url = base_url;
+    let provider = OpenAiProvider::from_runtime_config(
+        &provider_config,
+        "grok-4.5",
+        fixture.config.runtime_max_output_tokens,
+        &fixture.config.home_dir,
+    )
+    .unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let response = provider
+        .complete_turn(provider_continuation_request_with_prompt_frame())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response
+            .request_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
+        Some("incremental_continuation_omit_instructions")
+    );
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    assert_eq!(bodies[0]["instructions"], json!("rendered system"));
+    assert_eq!(bodies[0]["store"], json!(true));
+    assert!(bodies[0].get("tools").is_none());
+    assert!(bodies[0].get("tool_choice").is_none());
+    assert!(bodies[0].get("parallel_tool_calls").is_none());
+    assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+    assert_eq!(bodies[1]["store"], json!(true));
+    assert!(bodies[1].get("instructions").is_none());
+    assert_eq!(bodies[1]["input"].as_array().unwrap().len(), 1);
+    assert_eq!(bodies[1]["input"][0]["type"], json!("function_call_output"));
+}
+
+#[tokio::test]
+async fn xai_responses_prompt_change_keeps_instructions_and_uses_full_request() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Json(openai_tool_call_response("resp_1"))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let fixture = test_config("openai/gpt-5.4", &[], Some("xai-key"), None, false);
+    let mut provider_config = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    provider_config.id = ProviderId::parse("xai").unwrap();
+    provider_config.route_provider = ProviderId::parse("xai").unwrap();
+    provider_config.base_url = base_url;
+    let provider = OpenAiProvider::from_runtime_config(
+        &provider_config,
+        "grok-4.5",
+        fixture.config.runtime_max_output_tokens,
+        &fixture.config.home_dir,
+    )
+    .unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let mut changed = provider_continuation_request_with_prompt_frame();
+    changed.prompt_frame.system_prompt = "changed rendered system".into();
+    let response = provider.complete_turn(changed).await.unwrap();
+
+    assert_eq!(
+        response
+            .request_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+            .and_then(|diagnostics| diagnostics.fallback_reason.as_deref()),
+        Some("request_shape_changed")
+    );
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    assert!(bodies[1].get("previous_response_id").is_none());
+    assert_eq!(bodies[1]["instructions"], json!("changed rendered system"));
+    assert_eq!(bodies[1]["store"], json!(true));
+    assert!(bodies[1]["input"].as_array().unwrap().len() > 1);
 }
 
 #[tokio::test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -61,6 +61,7 @@ pub struct OpenAiProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    continuation_contract: OpenAiResponsesContinuationContract,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
@@ -105,6 +106,12 @@ pub struct OpenAiChatCompletionsProvider {
 pub(crate) enum OpenAiResponsesTransportContract {
     StandardJson,
     CodexStreaming,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OpenAiResponsesContinuationContract {
+    Standard,
+    StoreResponsesAndOmitInstructionsWithPreviousResponseId,
 }
 
 const OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND: &str = "responses_compact";
@@ -325,6 +332,11 @@ impl OpenAiProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            continuation_contract: if provider_config.id.as_str() == "xai" {
+                OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
+            } else {
+                OpenAiResponsesContinuationContract::Standard
+            },
             builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
@@ -930,7 +942,13 @@ impl AgentProvider for OpenAiProvider {
             self.reasoning_effort.as_deref(),
             None,
         )?;
-        let mut plan = plan_openai_responses_request(body, &request, &self.continuation, true)?;
+        let mut plan = plan_openai_responses_request(
+            body,
+            &request,
+            &self.continuation,
+            true,
+            self.continuation_contract,
+        )?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
@@ -1181,7 +1199,13 @@ impl AgentProvider for OpenAiCodexProvider {
             },
             self.verbosity,
         )?;
-        let mut plan = plan_openai_responses_request(body, &request, &self.continuation, false)?;
+        let mut plan = plan_openai_responses_request(
+            body,
+            &request,
+            &self.continuation,
+            false,
+            OpenAiResponsesContinuationContract::Standard,
+        )?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
@@ -2039,11 +2063,13 @@ pub(crate) fn build_openai_responses_request(
         "model": model,
         "instructions": request.prompt_frame.system_prompt,
         "input": build_openai_input(&request.conversation)?,
-        "tools": tools,
-        "tool_choice": "auto",
-        "parallel_tool_calls": false,
         "store": false,
     });
+    if !tools.is_empty() {
+        body["tools"] = Value::Array(tools);
+        body["tool_choice"] = Value::String("auto".to_string());
+        body["parallel_tool_calls"] = Value::Bool(false);
+    }
     if let Some(cache) = request.prompt_frame.cache.as_ref() {
         body["prompt_cache_key"] = Value::String(cache.prompt_cache_key.clone());
     }
@@ -2141,7 +2167,13 @@ fn plan_openai_responses_request(
     request: &ProviderTurnRequest,
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
     allow_previous_response_id: bool,
+    continuation_contract: OpenAiResponsesContinuationContract,
 ) -> Result<OpenAiRequestPlan> {
+    if continuation_contract
+        == OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
+    {
+        body["store"] = Value::Bool(true);
+    }
     let full_input = body
         .get("input")
         .and_then(Value::as_array)
@@ -2262,6 +2294,13 @@ fn plan_openai_responses_request(
     let provider_input = if let Some(response_id) = response_id {
         body["input"] = Value::Array(incremental_input.clone());
         body["previous_response_id"] = Value::String(response_id);
+        if continuation_contract
+            == OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
+        {
+            body.as_object_mut()
+                .expect("OpenAI Responses request body should be an object")
+                .remove("instructions");
+        }
         incremental_input.clone()
     } else {
         let mut provider_input = previous.items.clone();
@@ -2280,6 +2319,7 @@ fn plan_openai_responses_request(
             request_lowering_mode: openai_append_match_lowering_mode(
                 has_response_id,
                 replay_is_compacted,
+                continuation_contract,
             ),
             anthropic_cache: None,
             anthropic_context_management: None,
@@ -2308,9 +2348,19 @@ fn plan_openai_responses_request(
     })
 }
 
-fn openai_append_match_lowering_mode(has_response_id: bool, replay_is_compacted: bool) -> String {
+fn openai_append_match_lowering_mode(
+    has_response_id: bool,
+    replay_is_compacted: bool,
+    continuation_contract: OpenAiResponsesContinuationContract,
+) -> String {
     if has_response_id {
-        "incremental_continuation".into()
+        if continuation_contract
+            == OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
+        {
+            "incremental_continuation_omit_instructions".into()
+        } else {
+            "incremental_continuation".into()
+        }
     } else if replay_is_compacted {
         "provider_window_compacted".into()
     } else {
@@ -5549,8 +5599,8 @@ mod tests {
         parse_openai_codex_image_generation_response_items, plan_openai_responses_request,
         resolve_openai_codex_credential, CredentialStoreRefreshLock, OpenAiCodexProvider,
         OpenAiCompactionPolicy, OpenAiContinuationState, OpenAiProvider, OpenAiProviderWindow,
-        OpenAiRequestPlan, OpenAiRequestShape, OpenAiResponsesTransportContract,
-        ToolSchemaContract,
+        OpenAiRequestPlan, OpenAiRequestShape, OpenAiResponsesContinuationContract,
+        OpenAiResponsesTransportContract, ToolSchemaContract,
     };
     use crate::auth::CodexCliCredential;
     use crate::config::{
@@ -6305,6 +6355,7 @@ mod tests {
             &request,
             &Arc::new(Mutex::new(OpenAiContinuationState::default())),
             false,
+            OpenAiResponsesContinuationContract::Standard,
         )
         .expect("openai codex responses request should plan");
 

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -440,6 +440,7 @@ async fn probe_builtin_web_search_capability(
     ) {
         (ProviderNativeWebSearchKind::OpenAi, "openai_responses", "web_search_preview")
         | (ProviderNativeWebSearchKind::OpenAi, "openai_codex_responses", "web_search")
+        | (ProviderNativeWebSearchKind::Xai, "openai_responses", "web_search")
         | (ProviderNativeWebSearchKind::Anthropic, "anthropic_messages", "web_search_20250305") => {
             true
         }
@@ -1078,6 +1079,29 @@ mod tests {
             transient.status,
             BuiltinWebSearchProbeStatus::TransientFailure
         );
+    }
+
+    #[tokio::test]
+    async fn builtin_web_search_probe_accepts_xai_responses_contract() {
+        let capability = crate::provider::ProviderBuiltinWebSearchCapability {
+            kind: ProviderNativeWebSearchKind::Xai,
+            provider_id: "xai".into(),
+            provider_model_ref: "xai/grok-test".into(),
+            provider_transport: "openai_responses".into(),
+            provider_base_url: "https://api.x.ai/v1".into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: "xai_web_search_x_search".into(),
+        };
+
+        let result = probe_builtin_web_search_capability(
+            &ProbeProvider { result: Ok(()) },
+            &capability,
+            search_config().max_results,
+        )
+        .await;
+
+        assert_eq!(result.status, BuiltinWebSearchProbeStatus::Supported);
+        assert_eq!(result.reason, None);
     }
 
     #[test]

--- a/tests/live_xai.rs
+++ b/tests/live_xai.rs
@@ -1,0 +1,152 @@
+use anyhow::{Context, Result};
+use holon::{
+    config::{AppConfig, ProviderId},
+    provider::{
+        AgentProvider, ConversationMessage, ModelBlock, OpenAiProvider,
+        ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
+        ProviderTurnRequest,
+    },
+};
+
+fn live_xai_model() -> String {
+    std::env::var("HOLON_LIVE_XAI_MODEL").unwrap_or_else(|_| "grok-4-1-fast".into())
+}
+
+fn live_xai_provider(config: &AppConfig) -> Result<OpenAiProvider> {
+    let provider_id = ProviderId::parse("xai")?;
+    let provider_config = config
+        .providers
+        .get(&provider_id)
+        .context("xai provider is missing from config")?;
+    OpenAiProvider::from_runtime_config(
+        provider_config,
+        &live_xai_model(),
+        config.runtime_max_output_tokens,
+        &config.home_dir,
+    )
+}
+
+fn continuation_prompt_frame() -> ProviderPromptFrame {
+    ProviderPromptFrame {
+        system_prompt: "Follow the user's exact reply format.".into(),
+        system_blocks: Vec::new(),
+        context_blocks: Vec::new(),
+        cache: Some(ProviderPromptCache {
+            agent_id: "live-xai-continuation".into(),
+            prompt_cache_key: "live-xai-continuation".into(),
+            context_fingerprint: "live-xai-continuation".into(),
+            compression_epoch: 0,
+        }),
+    }
+}
+
+fn response_text(blocks: &[ModelBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ModelBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn response_token(blocks: &[ModelBlock]) -> String {
+    response_text(blocks)
+        .trim()
+        .trim_matches(|character: char| character.is_ascii_punctuation())
+        .to_owned()
+}
+
+#[tokio::test]
+#[ignore = "requires configured xAI credentials and network access"]
+async fn live_xai_responses_uses_incremental_continuation_without_instructions() -> Result<()> {
+    let config = AppConfig::load()?;
+    let provider = live_xai_provider(&config)?;
+    let prompt_frame = continuation_prompt_frame();
+    let first_user = ConversationMessage::UserText("Reply with exactly ALPHA-2158.".into());
+    let first = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: prompt_frame.clone(),
+            conversation: vec![first_user.clone()],
+            tools: Vec::new(),
+            native_web_search: None,
+            response_format: None,
+        })
+        .await?;
+    assert_eq!(response_token(&first.blocks), "ALPHA-2158");
+
+    let second = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame,
+            conversation: vec![
+                first_user,
+                ConversationMessage::AssistantBlocks(first.blocks),
+                ConversationMessage::UserText(
+                    "Reply with exactly the token from your preceding answer.".into(),
+                ),
+            ],
+            tools: Vec::new(),
+            native_web_search: None,
+            response_format: None,
+        })
+        .await?;
+
+    assert_eq!(response_token(&second.blocks), "ALPHA-2158");
+    assert_eq!(
+        second
+            .request_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
+        Some("incremental_continuation_omit_instructions")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires configured xAI credentials, network access, and x_search support"]
+async fn live_xai_builtin_x_search_reports_native_lowering() -> Result<()> {
+    let config = AppConfig::load()?;
+    let provider = live_xai_provider(&config)?;
+    let capability = provider
+        .builtin_web_search()
+        .context("xai provider should declare builtin web search")?;
+    assert_eq!(capability.advertised_tool_type, "web_search");
+    assert_eq!(capability.backend_kind, "xai_web_search_x_search");
+    let native_web_search = ProviderNativeWebSearchRequest {
+        kind: capability.kind,
+        provider_id: "xai".into(),
+        provider_model_ref: capability.provider_model_ref,
+        advertised_tool_type: capability.advertised_tool_type,
+        backend_kind: capability.backend_kind,
+        max_results: Some(3),
+    };
+
+    provider
+        .probe_builtin_web_search(native_web_search.clone())
+        .await?;
+    let output = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: ProviderPromptFrame::plain(
+                "Use native web search and reply with one concise sentence.",
+            ),
+            conversation: vec![ConversationMessage::UserText(
+                "Search the web for the official xAI homepage and state its site name.".into(),
+            )],
+            tools: Vec::new(),
+            native_web_search: Some(native_web_search),
+            response_format: None,
+        })
+        .await?;
+
+    let diagnostics = output
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.native_web_search.as_ref())
+        .context("native web search diagnostics should be recorded")?;
+    assert!(diagnostics.lowered);
+    assert_eq!(diagnostics.advertised_tool_type, "web_search");
+    assert_eq!(diagnostics.backend_kind, "xai_web_search_x_search");
+    assert!(!response_text(&output.blocks).trim().is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add an explicit xAI Responses continuation contract that reuses `previous_response_id` while omitting `instructions` on the continuation wire request
- preserve full request-shape comparison before applying provider-specific lowering, and expose the applied `request_lowering_mode`
- accept xAI's native `x_search` contract and avoid sending empty tool-related fields
- add provider regressions, focused xAI OAuth livetests, and update the implementation decisions

## Verification

- `cargo test xai_responses_ --lib`
- `HOLON_LIVE_XAI_MODEL=grok-4-1-fast cargo test --test live_xai -- --ignored --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

The two ignored livetests passed using the local Holon-managed xAI OAuth profile, covering both incremental continuation and native `x_search`.

Closes #2158
