### PR TITLE
feat: render additional tool details in side panel

### DIFF
--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import "../../i18n/config";
+
+import { ToolExecutionContent } from "./ToolExecutionRenderers";
+import type { RuntimeToolExecutionRecord } from "../../runtime/types";
+
+function renderTool(record: RuntimeToolExecutionRecord): string {
+  return renderToStaticMarkup(<ToolExecutionContent record={record} />);
+}
+
+describe("ToolExecutionContent", () => {
+  it("renders ViewImage details with path, dimensions, and visual observation", () => {
+    const html = renderTool({
+      tool_name: "ViewImage",
+      input: { path: "/tmp/screenshot.png" },
+      output: {
+        envelope: {
+          result: {
+            dimensions: { width: 1024, height: 768 },
+            visual_observation: "A timeline screenshot.",
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("Path");
+    expect(html).toContain("/tmp/screenshot.png");
+    expect(html).toContain("1024×768");
+    expect(html).toContain("A timeline screenshot.");
+  });
+
+  it("renders GenerateImage details with prompt and generated image URI", () => {
+    const html = renderTool({
+      tool_name: "GenerateImage",
+      input: { name: "hero", size: "1536x1024", prompt: "A Holon agent dashboard" },
+      output: {
+        envelope: {
+          result: {
+            image_uri: "workspace://agent_home/holon-dev/media/generated/hero.png",
+            output_format: "png",
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("hero");
+    expect(html).toContain("1536x1024");
+    expect(html).toContain("workspace://agent_home/holon-dev/media/generated/hero.png");
+    expect(html).toContain("A Holon agent dashboard");
+  });
+
+  it("renders WebSearch details as a structured result list", () => {
+    const html = renderTool({
+      tool_name: "WebSearch",
+      input: { query: "rust runtime" },
+      output: {
+        envelope: {
+          result: {
+            query: "rust runtime",
+            provider: "brave",
+            mode: "single",
+            results: [{ title: "Tokio", url: "https://tokio.rs", source: "tokio.rs", snippet: "Async runtime" }],
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("Query");
+    expect(html).toContain("rust runtime");
+    expect(html).toContain("brave");
+    expect(html).toContain("1 found");
+    expect(html).toContain("1. Tokio");
+    expect(html).toContain("https://tokio.rs");
+    expect(html).toContain("Async runtime");
+  });
+
+  it("renders WebFetch details with URL metadata and content", () => {
+    const html = renderTool({
+      tool_name: "WebFetch",
+      input: { url: "https://example.com" },
+      output: {
+        envelope: {
+          result: {
+            url: "https://example.com",
+            final_url: "https://www.example.com",
+            status: 200,
+            content_type: "text/html",
+            bytes_read: 2048,
+            truncated: true,
+            text: "# Example\n\nFetched content.",
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("https://example.com");
+    expect(html).toContain("https://www.example.com");
+    expect(html).toContain("200");
+    expect(html).toContain("text/html");
+    expect(html).toContain("2048");
+    expect(html).toContain("# Example");
+    expect(html).toContain("Fetched content.");
+  });
+
+  it("renders MemorySearch details with source refs and previews", () => {
+    const html = renderTool({
+      tool_name: "MemorySearch",
+      input: { query: "device oauth" },
+      output: {
+        envelope: {
+          result: {
+            query: "device oauth",
+            results: [{ source_ref: "turn:abc", score: 0.95, preview: "Device OAuth implementation notes" }],
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("device oauth");
+    expect(html).toContain("1 found");
+    expect(html).toContain("1. turn:abc");
+    expect(html).toContain("score: 0.95");
+    expect(html).toContain("Device OAuth implementation notes");
+  });
+
+  it("renders MemoryGet details with source ref and fetched content", () => {
+    const html = renderTool({
+      tool_name: "MemoryGet",
+      input: { source_ref: "turn:abc" },
+      output: {
+        envelope: {
+          result: {
+            source_ref: "turn:abc",
+            truncated: false,
+            content: "Full memory content",
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("turn:abc");
+    expect(html).toContain("Full memory content");
+  });
+});

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -55,6 +55,14 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
+function truncatedText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  const truncated = value.slice(0, maxChars - 1);
+  const lastNewline = truncated.lastIndexOf("\n");
+  const cutPoint = lastNewline > maxChars * 0.6 ? lastNewline : truncated.length;
+  return `${truncated.slice(0, cutPoint)}…`;
+}
+
 function patchInputText(input: unknown): string {
   if (typeof input === "string") return input;
   if (!isRecord(input)) return "";
@@ -233,6 +241,147 @@ function ApplyPatchRenderer({ record }: { record: RuntimeToolExecutionRecord }) 
   );
 }
 
+function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "view_image_result");
+  const dimensions = isRecord(result?.dimensions) ? result.dimensions : undefined;
+  const width = nestedValue(result, ["width"]) ?? nestedValue(dimensions, ["width"]);
+  const height = nestedValue(result, ["height"]) ?? nestedValue(dimensions, ["height"]);
+  const path = nestedValue(record.input, ["path", "image_path"]) ?? nestedValue(result, ["path", "image_path"]);
+  const observation = nestedText(result, ["visual_observation", "observation", "text_preview"]);
+  const summary = textField(result?.summary_text) || record.summary;
+
+  return (
+    <>
+      <SimpleField label={t("inspector.path")} value={path} />
+      {width != null && height != null ? <SimpleField label={t("inspector.dimensions")} value={`${width}×${height}`} /> : null}
+      {observation ? <OutputField label={t("inspector.observation")} value={observation} /> : null}
+      {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+function GenerateImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "generate_image_result");
+  const prompt = nestedValue(record.input, ["prompt"]) ?? nestedValue(result, ["prompt"]);
+  const name = nestedValue(record.input, ["name"]) ?? nestedValue(result, ["name"]);
+  const size = nestedValue(record.input, ["size"]) ?? nestedValue(result, ["size"]);
+  const background = nestedValue(record.input, ["background"]) ?? nestedValue(result, ["background"]);
+  const outputFormat = nestedValue(record.input, ["output_format"]) ?? nestedValue(result, ["output_format"]);
+  const imageUri = nestedValue(result, ["image_uri", "uri", "path"]);
+  const summary = textField(result?.summary_text) || record.summary;
+
+  return (
+    <>
+      <SimpleField label={t("rightPanel.name")} value={name} />
+      <SimpleField label={t("inspector.dimensions")} value={size} />
+      <SimpleField label={t("inspector.path")} value={imageUri} />
+      <SimpleField label={t("inspector.mode")} value={background} />
+      <SimpleField label={t("rightPanel.output")} value={outputFormat} />
+      {prompt ? <OutputField label={t("inspector.input")} value={String(prompt)} /> : null}
+      {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+function WebSearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const results = arrayRecords(nestedValue(output, ["results"]));
+  const query = nestedValue(output, ["query"]) ?? nestedValue(input, ["query", "search_query", "q"]);
+  const provider = nestedValue(output, ["provider"]);
+  const mode = nestedValue(output, ["mode"]);
+
+  return (
+    <>
+      <SimpleField label={t("inspector.query")} value={query} />
+      <SimpleField label={t("inspector.provider")} value={provider} />
+      <SimpleField label={t("inspector.mode")} value={mode} />
+      <SimpleField label={t("inspector.results")} value={t("inspector.resultsCount", { count: results.length })} />
+      {results.slice(0, 15).map((item, index) => {
+        const title = nestedText(item, ["title"]) || t("inspector.untitled");
+        const url = nestedText(item, ["url"]);
+        const source = nestedText(item, ["source"]);
+        const publishedAt = nestedText(item, ["published_at"]);
+        const snippet = nestedText(item, ["snippet"]);
+        const text = [url, source ? `(${source})` : "", publishedAt, snippet ? truncatedText(snippet, 300) : ""].filter(Boolean).join("\n");
+        return <OutputField key={index} label={`${index + 1}. ${title}`} value={text} />;
+      })}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+function WebFetchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const url = nestedValue(output, ["url"]) ?? nestedValue(input, ["url"]);
+  const finalUrl = nestedValue(output, ["final_url"]);
+  const truncated = nestedValue(output, ["truncated"]) === true;
+  const content = nestedText(output, ["text"]);
+
+  return (
+    <>
+      <SimpleField label={t("inspector.url")} value={url} />
+      {finalUrl && finalUrl !== url ? <SimpleField label={t("inspector.finalUrl")} value={finalUrl} /> : null}
+      <SimpleField label={t("inspector.status")} value={nestedValue(output, ["status"])} />
+      <SimpleField label={t("inspector.contentType")} value={nestedValue(output, ["content_type"])} />
+      <SimpleField label={t("inspector.bytesRead")} value={nestedValue(output, ["bytes_read"])} />
+      {truncated ? <SimpleField label={t("inspector.truncated")} value={t("inspector.yes")} /> : null}
+      {content ? <OutputField label={t("inspector.content")} value={truncatedText(content, 2000)} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+function MemorySearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const results = arrayRecords(nestedValue(output, ["results"]));
+  const query = nestedValue(output, ["query"]) ?? nestedValue(input, ["query"]);
+
+  return (
+    <>
+      <SimpleField label={t("inspector.query")} value={query} />
+      <SimpleField label={t("inspector.results")} value={t("inspector.resultsCount", { count: results.length })} />
+      {results.slice(0, 15).map((item, index) => {
+        const sourceRef = nestedText(item, ["source_ref"]) || t("inspector.unknownSource");
+        const score = nestedText(item, ["score"]);
+        const preview = nestedText(item, ["preview"]);
+        const text = [score ? `score: ${score}` : "", preview ? truncatedText(preview, 300) : ""].filter(Boolean).join("\n");
+        return <OutputField key={index} label={`${index + 1}. ${sourceRef}`} value={text} />;
+      })}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+function MemoryGetRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const sourceRef = nestedValue(output, ["source_ref"]) ?? nestedValue(input, ["source_ref"]);
+  const content = nestedText(output, ["content"]);
+  const truncated = nestedValue(output, ["truncated"]) === true;
+
+  return (
+    <>
+      <SimpleField label={t("inspector.sourceRef")} value={sourceRef} />
+      {truncated ? <SimpleField label={t("inspector.truncated")} value={t("inspector.yes")} /> : null}
+      {content ? <OutputField label={t("inspector.content")} value={truncatedText(content, 2000)} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
 // Generic fallback renderer
 
 function GenericToolRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
@@ -250,6 +399,18 @@ export function ToolExecutionContent({ record }: { record: RuntimeToolExecutionR
       return <ExecCommandBatchRenderer record={record} />;
     case "ApplyPatch":
       return <ApplyPatchRenderer record={record} />;
+    case "ViewImage":
+      return <ViewImageRenderer record={record} />;
+    case "GenerateImage":
+      return <GenerateImageRenderer record={record} />;
+    case "WebSearch":
+      return <WebSearchRenderer record={record} />;
+    case "WebFetch":
+      return <WebFetchRenderer record={record} />;
+    case "MemorySearch":
+      return <MemorySearchRenderer record={record} />;
+    case "MemoryGet":
+      return <MemoryGetRenderer record={record} />;
     default:
       return <GenericToolRenderer record={record} />;
   }


### PR DESCRIPTION
## Summary
- add structured right-panel detail renderers for ViewImage, GenerateImage, WebSearch, WebFetch, MemorySearch, and MemoryGet
- show key input/output metadata plus bounded textual content/results instead of falling back to generic text
- add component coverage for the new tool renderers

## Verification
- npm test -- ToolExecutionRenderers
- npm run typecheck
- npm test
- git diff --check
- npm run build