### PR TITLE
feat: add UseWorkspace detail renderer with file explorer link

### DIFF
--- a/src/tool/tools/use_workspace.rs
+++ b/src/tool/tools/use_workspace.rs
@@ -186,6 +186,7 @@ pub(crate) async fn execute(
                             .workspace_id
                             .unwrap_or_else(|| AGENT_HOME_WORKSPACE_ID.to_string()),
                         workspace_anchor: snapshot.workspace_anchor,
+                        execution_root_id: snapshot.execution_root_id,
                         execution_root: snapshot.execution_root,
                         cwd: snapshot.cwd,
                         mode: mode_arg_label(mode).to_string(),
@@ -217,6 +218,7 @@ pub(crate) async fn execute(
                 .workspace_id
                 .unwrap_or_else(|| AGENT_HOME_WORKSPACE_ID.to_string()),
             workspace_anchor: snapshot.workspace_anchor,
+            execution_root_id: snapshot.execution_root_id,
             execution_root: snapshot.execution_root,
             cwd: snapshot.cwd,
             mode: mode_label.to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3414,6 +3414,8 @@ pub struct ViewImageVisionSelection {
 pub struct UseWorkspaceResult {
     pub workspace_id: String,
     pub workspace_anchor: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_root_id: Option<String>,
     pub execution_root: PathBuf,
     pub cwd: PathBuf,
     pub mode: String,

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -650,6 +650,7 @@ export function ToolExecutionDetailPanel({
   relatedStateObjectRef,
   onOpenWorkItem,
   onOpenTask,
+  onBrowseFiles,
 }: {
   toolExecutionId: string;
   toolName?: string;
@@ -657,6 +658,7 @@ export function ToolExecutionDetailPanel({
   relatedStateObjectRef?: import("../../runtime/types").TimelineStateObjectRef;
   onOpenWorkItem?: (workItem: WorkItemSummary) => void;
   onOpenTask?: (task: TaskSummary) => void;
+  onBrowseFiles?: (workspaceId: string, executionRootId?: string) => void;
 }) {
   const { t } = useTranslation();
   const loading = detailState?.loading && !detailState?.toolExecution;
@@ -707,7 +709,7 @@ export function ToolExecutionDetailPanel({
           </div>
         ) : null}
       </dl>
-      {record ? <ToolExecutionContent record={record} /> : null}
+      {record ? <ToolExecutionContent record={record} onBrowseFiles={onBrowseFiles} /> : null}
     </article>
   );
 }

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -194,7 +194,7 @@ export function RightSidePanel({
           </div>
         ) : activeView.kind === "tool_execution_detail" ? (
           <div className="inspector-stack">
-            <ToolExecutionDetailPanel toolExecutionId={activeView.toolExecutionId} toolName={activeView.toolName} detailState={toolExecutionDetailState} relatedStateObjectRef={activeView.relatedStateObjectRef} onOpenWorkItem={onOpenWorkItemDetail} onOpenTask={onOpenTask} />
+            <ToolExecutionDetailPanel toolExecutionId={activeView.toolExecutionId} toolName={activeView.toolName} detailState={toolExecutionDetailState} relatedStateObjectRef={activeView.relatedStateObjectRef} onOpenWorkItem={onOpenWorkItemDetail} onOpenTask={onOpenTask} onBrowseFiles={onBrowseFiles} />
           </div>
         ) : activeView.kind === "file_browser" ? (
           <FileBrowserPanel key={`${activeView.workspaceId}:${activeView.initialFilePath ?? ""}`} workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} onClose={onNavigateBack} />

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
@@ -142,4 +142,29 @@ describe("ToolExecutionContent", () => {
     expect(html).toContain("turn:abc");
     expect(html).toContain("Full memory content");
   });
+
+  it("renders UseWorkspace details with workspace path and file browser link", () => {
+    const html = renderTool({
+      tool_name: "UseWorkspace",
+      input: { path: "/home/user/project", mode: "direct" },
+      output: {
+        envelope: {
+          result: {
+            workspace_id: "ws_abc123",
+            workspace_anchor: "/home/user/project",
+            execution_root_id: "root-xyz",
+            execution_root: "/home/user/project",
+            cwd: "/home/user/project",
+            mode: "direct",
+            projection_kind: "canonical_root",
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("ws_abc123");
+    expect(html).toContain("/home/user/project");
+    expect(html).toContain("direct");
+    expect(html).toContain("canonical_root");
+  });
 });

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import type { MouseEvent } from "react";
 import { formatToolExecutionDetail } from "../inspector/ActivityInspectorPanel";
 import type { RuntimeToolExecutionRecord } from "../../runtime/types";
 
@@ -382,6 +383,78 @@ function MemoryGetRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   );
 }
 
+// UseWorkspace renderer
+
+function UseWorkspaceRenderer({
+  record,
+  onBrowseFiles,
+}: {
+  record: RuntimeToolExecutionRecord;
+  onBrowseFiles?: (workspaceId: string, executionRootId?: string) => void;
+}) {
+  const { t } = useTranslation();
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = isRecord(output) ? output : undefined;
+  const input = isRecord(record.input) ? record.input : {};
+
+  const workspaceId = nestedText(result, ["workspace_id"]) || nestedText(input, ["workspace_id"]);
+  const workspaceAnchor = nestedText(result, ["workspace_anchor"]) || nestedText(input, ["path"]);
+  const executionRoot = nestedText(result, ["execution_root"]);
+  const executionRootId = nestedText(result, ["execution_root_id"]);
+  const cwd = nestedText(result, ["cwd"]);
+  const mode = nestedText(result, ["mode"]) || nestedText(input, ["mode"]);
+  const projectionKind = nestedText(result, ["projection_kind"]);
+  const summary = textField(result?.summary_text) || record.summary;
+
+  const canBrowse = !!workspaceId && !!onBrowseFiles;
+  const browse = canBrowse
+    ? (e: MouseEvent) => {
+        e.preventDefault();
+        onBrowseFiles!(workspaceId, executionRootId || undefined);
+      }
+    : undefined;
+
+  return (
+    <>
+      {workspaceId ? <SimpleField label={t("inspector.workspaceId")} value={workspaceId} /> : null}
+      {workspaceAnchor ? (
+        <div className="tool-detail-simple">
+          <span className="tool-detail-simple-label">{t("inspector.workspacePath")}</span>
+          {browse ? (
+            <a href="#" className="workspace-path-link" onClick={browse}>
+              {workspaceAnchor}
+            </a>
+          ) : (
+            <span className="tool-detail-simple-value">{workspaceAnchor}</span>
+          )}
+        </div>
+      ) : null}
+      {executionRoot ? (
+        <div className="tool-detail-simple">
+          <span className="tool-detail-simple-label">{t("inspector.executionRoot")}</span>
+          {browse ? (
+            <a href="#" className="workspace-path-link" onClick={browse}>
+              {executionRoot}
+            </a>
+          ) : (
+            <span className="tool-detail-simple-value">{executionRoot}</span>
+          )}
+        </div>
+      ) : null}
+      {cwd ? <SimpleField label={t("inspector.cwd")} value={cwd} /> : null}
+      {mode ? <SimpleField label={t("inspector.mode")} value={mode} /> : null}
+      {projectionKind ? <SimpleField label={t("inspector.projectionKind")} value={projectionKind} /> : null}
+      {canBrowse ? (
+        <a href="#" className="workspace-path-link tool-detail-browse-link" onClick={browse}>
+          {t("fileBrowser.openInFileBrowser")}
+        </a>
+      ) : null}
+      {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
 // Generic fallback renderer
 
 function GenericToolRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
@@ -391,7 +464,13 @@ function GenericToolRenderer({ record }: { record: RuntimeToolExecutionRecord })
 
 // Public router component
 
-export function ToolExecutionContent({ record }: { record: RuntimeToolExecutionRecord }) {
+export function ToolExecutionContent({
+  record,
+  onBrowseFiles,
+}: {
+  record: RuntimeToolExecutionRecord;
+  onBrowseFiles?: (workspaceId: string, executionRootId?: string) => void;
+}) {
   switch (record.tool_name) {
     case "ExecCommand":
       return <ExecCommandRenderer record={record} />;
@@ -411,6 +490,8 @@ export function ToolExecutionContent({ record }: { record: RuntimeToolExecutionR
       return <MemorySearchRenderer record={record} />;
     case "MemoryGet":
       return <MemoryGetRenderer record={record} />;
+    case "UseWorkspace":
+      return <UseWorkspaceRenderer record={record} onBrowseFiles={onBrowseFiles} />;
     default:
       return <GenericToolRenderer record={record} />;
   }

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -693,6 +693,11 @@ const en = {
     batchItem: "Batch item",
     current: "current",
     yes: "yes",
+    workspaceId: "Workspace ID",
+    workspacePath: "Workspace path",
+    executionRoot: "Execution root",
+    projectionKind: "Projection",
+    cwd: "Cwd",
   },
 
   agent: {

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -695,6 +695,11 @@ const zh: Record<string, any> = {
     batchItem: "批量项",
     current: "当前",
     yes: "是",
+    workspaceId: "工作区 ID",
+    workspacePath: "工作区路径",
+    executionRoot: "执行根目录",
+    projectionKind: "投影类型",
+    cwd: "工作目录",
   },
 
   agent: {


### PR DESCRIPTION
## Summary

Add a custom tool execution detail renderer for the UseWorkspace tool in the right-side panel.

Previously, UseWorkspace tool executions fell through to the generic renderer, showing only raw text. Now the detail view shows structured fields:

- **Workspace ID** — the workspace identifier
- **Workspace path** — , clickable to open the file browser
- **Execution root** — , clickable to open the file browser
- **Cwd** — the current working directory
- **Mode** — direct / isolated
- **Projection** — canonical_root / git_worktree_root

The path links call `onBrowseFiles(workspaceId, executionRootId)`, opening the FileBrowserPanel at the correct workspace and execution root — same pattern as the agent overview workspace list.

### Rust changes
- Added `execution_root_id: Option<String>` to `UseWorkspaceResult` so the frontend can pass the correct execution root ID to the file browser (important for isolated/worktree workspaces).

### Frontend changes
- New `UseWorkspaceRenderer` in `ToolExecutionRenderers.tsx`
- `onBrowseFiles` prop threaded through `ToolExecutionContent` → `ToolExecutionDetailPanel` → `RightSidePanel`
- i18n keys added to `en.ts` and `zh-CN.ts`
- Test case covering UseWorkspace rendering

## Test plan
- [x] `cargo check` passes
- [x] `vitest run ToolExecutionRenderers.test.tsx` — 7/7 pass
- [ ] CI