### PR TITLE
fix: normalize xAI Responses tool arguments

### DIFF
--- a/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
+++ b/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
@@ -18,6 +18,17 @@ contract; full requests retain them.
 The OAuth profile is explicit provider credential material with refresh
 lifecycle managed by Holon. Browser cookies, private consumer session files,
 and implicit subscription-state reuse remain outside the HTTP provider path.
+Holon-managed web search remains the PascalCase `WebSearch` function tool.
+Names such as `x_search`, `x_semantic_search`, and `x_keyword_search` are not
+client-callable Holon tools. `x_search` is only valid as the xAI server-side
+tool type above; invented client function names remain subject to the current
+round's tool allowlist.
+
+X/xAI account login reuse is left out of the HTTP provider path. If Holon later
+supports X-account-backed Grok sessions, it should integrate through an
+official Grok Build surface such as the Grok CLI / ACP process boundary, not by
+reusing browser cookies, private session files, or consumer subscription state
+as an xAI API key.
 
 ## Reason
 

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -30,6 +30,22 @@ fn openai_tool_call_response(response_id: &str) -> Value {
     })
 }
 
+fn openai_non_object_tool_call_response(response_id: &str) -> Value {
+    json!({
+        "id": response_id,
+        "status": "completed",
+        "usage": { "input_tokens": 256, "output_tokens": 2 },
+        "output": [{
+            "type": "function_call",
+            "id": "fc_non_persisted",
+            "status": "completed",
+            "call_id": "invented-1",
+            "name": "x_semantic_search",
+            "arguments": "[\"holon\"]"
+        }]
+    })
+}
+
 fn openai_text_response(response_id: &str, text: &str) -> Value {
     openai_text_response_with_input_tokens(response_id, text, 2)
 }
@@ -318,6 +334,80 @@ async fn openai_responses_uses_incremental_continuation_for_strict_append() {
     assert_eq!(bodies[1]["instructions"], json!("rendered system"));
     assert_eq!(bodies[1]["input"].as_array().unwrap().len(), 1);
     assert_eq!(bodies[1]["input"][0]["type"], json!("function_call_output"));
+}
+
+#[tokio::test]
+async fn openai_responses_normalizes_non_object_tool_arguments_before_continuation() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Json(openai_non_object_tool_call_response("resp_1"))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let first = provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    assert_eq!(first.blocks.len(), 1);
+    match &first.blocks[0] {
+        ModelBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "invented-1");
+            assert_eq!(name, "x_semantic_search");
+            assert_eq!(input, &json!({ "_raw": ["holon"] }));
+        }
+        block => panic!("expected tool use, got {block:?}"),
+    }
+
+    let mut continuation = provider_turn_request_with_prompt_frame();
+    continuation.conversation.extend([
+        ConversationMessage::AssistantBlocks(first.blocks),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "invented-1".into(),
+            content: "Failed: x_semantic_search not exposed for round".into(),
+            is_error: true,
+            error: None,
+        }]),
+    ]);
+    let response = provider.complete_turn(continuation).await.unwrap();
+
+    assert_eq!(
+        response
+            .request_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
+        Some("provider_window_replay")
+    );
+    let bodies = captured_bodies.lock().unwrap();
+    assert!(bodies[1].get("previous_response_id").is_none());
+    let replay = bodies[1]["input"].as_array().unwrap();
+    assert_eq!(replay.len(), 3);
+    assert_eq!(replay[1]["type"], json!("function_call"));
+    assert_eq!(replay[1]["arguments"], json!("{\"_raw\":[\"holon\"]}"));
+    assert_eq!(replay[2]["type"], json!("function_call_output"));
 }
 
 #[tokio::test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -249,6 +249,7 @@ pub(crate) struct ParsedOpenAiResponse {
     pub(crate) response: ProviderTurnResponse,
     pub(crate) response_id: Option<String>,
     pub(crate) output_items: Vec<Value>,
+    supports_id_continuation: bool,
 }
 
 impl OpenAiProvider {
@@ -2697,6 +2698,7 @@ fn update_openai_continuation(
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
         (Some(response_id), false) => {
             state.next_generation = state.next_generation.saturating_add(1);
+            let response_id = parsed.supports_id_continuation.then(|| response_id.clone());
             let mut items = provider_input
                 .into_iter()
                 .map(|item| canonicalize_openai_provider_item(&item))
@@ -2710,7 +2712,7 @@ fn update_openai_continuation(
             let mut append_match_items = append_match_input;
             append_match_items.extend(openai_append_match_output_items(&parsed.output_items));
             Some(OpenAiProviderWindow {
-                response_id: Some(response_id.clone()),
+                response_id,
                 request_shape,
                 latest_compaction_index: latest_openai_compaction_index(&items),
                 items,
@@ -2726,6 +2728,23 @@ fn update_openai_continuation(
     } else {
         state.windows.remove(&scope);
     }
+}
+
+fn openai_output_supports_id_continuation(output_items: &[Value]) -> bool {
+    output_items.iter().all(|item| {
+        if item.get("type").and_then(Value::as_str) != Some("function_call") {
+            return true;
+        }
+        match item.get("arguments") {
+            Some(Value::Object(_)) => true,
+            Some(Value::String(arguments)) => {
+                arguments.trim().is_empty()
+                    || serde_json::from_str::<Value>(arguments)
+                        .is_ok_and(|arguments| arguments.is_object())
+            }
+            _ => false,
+        }
+    })
 }
 
 fn openai_append_match_output_items(output_items: &[Value]) -> Vec<Value> {
@@ -3552,14 +3571,11 @@ fn canonicalize_openai_provider_item(item: &Value) -> Value {
         object.remove("status");
     }
     if object.get("type").and_then(Value::as_str) == Some("function_call") {
-        if let Some(arguments) = object.get("arguments").and_then(Value::as_str) {
-            if let Ok(parsed_arguments) = serde_json::from_str::<Value>(arguments) {
-                object.insert(
-                    "arguments".into(),
-                    Value::String(canonical_json(&parsed_arguments)),
-                );
-            }
-        }
+        let arguments = normalize_openai_function_arguments(object.get("arguments"));
+        object.insert(
+            "arguments".into(),
+            Value::String(canonical_json(&arguments)),
+        );
     }
     item
 }
@@ -3655,12 +3671,9 @@ fn canonicalize_openai_append_match_content_item(role: &str, item: &Value) -> Va
 fn canonicalize_openai_append_match_function_call(
     object: &serde_json::Map<String, Value>,
 ) -> Value {
-    let arguments = object
-        .get("arguments")
-        .and_then(Value::as_str)
-        .map(canonicalize_openai_arguments_string)
-        .map(Value::String)
-        .unwrap_or_else(|| object.get("arguments").cloned().unwrap_or(Value::Null));
+    let arguments = Value::String(canonical_json(&normalize_openai_function_arguments(
+        object.get("arguments"),
+    )));
     json!({
         "type": "function_call",
         "call_id": object.get("call_id").cloned().unwrap_or(Value::Null),
@@ -3680,10 +3693,19 @@ fn canonicalize_openai_append_match_custom_tool_call(
     })
 }
 
-fn canonicalize_openai_arguments_string(arguments: &str) -> String {
-    serde_json::from_str::<Value>(arguments)
-        .map(|parsed| canonical_json(&parsed))
-        .unwrap_or_else(|_| arguments.to_string())
+fn normalize_openai_function_arguments(arguments: Option<&Value>) -> Value {
+    let parsed = match arguments {
+        Some(Value::String(arguments)) if arguments.trim().is_empty() => return json!({}),
+        Some(Value::String(arguments)) => {
+            serde_json::from_str(arguments).unwrap_or_else(|_| Value::String(arguments.clone()))
+        }
+        Some(arguments) => arguments.clone(),
+        None => return json!({}),
+    };
+    match parsed {
+        Value::Object(_) => parsed,
+        raw => json!({ "_raw": raw }),
+    }
 }
 
 fn openai_without_provider_item_id(item: &Value) -> Value {
@@ -3800,7 +3822,9 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
                                     "type": "function_call",
                                     "call_id": id,
                                     "name": name,
-                                    "arguments": canonical_json(input),
+                                    "arguments": canonical_json(
+                                        &normalize_openai_function_arguments(Some(input))
+                                    ),
                                 }));
                             }
                         }
@@ -4231,6 +4255,7 @@ pub(crate) fn parse_chat_completion_response(response: Value) -> Result<ParsedOp
         },
         response_id,
         output_items,
+        supports_id_continuation: true,
     })
 }
 
@@ -5423,6 +5448,7 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                 "missing output array",
             )
         })?;
+    let supports_id_continuation = openai_output_supports_id_continuation(output);
     let output_items = output
         .iter()
         .map(canonicalize_openai_provider_item)
@@ -5465,15 +5491,7 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                         "missing name",
                     )
                 })?;
-                let input = match item.get("arguments") {
-                    Some(Value::String(arguments)) if !arguments.trim().is_empty() => {
-                        serde_json::from_str(arguments).map_err(|error| {
-                            invalid_response_error("invalid function_call arguments", error)
-                        })?
-                    }
-                    Some(Value::Object(arguments)) => Value::Object(arguments.clone()),
-                    _ => json!({}),
-                };
+                let input = normalize_openai_function_arguments(item.get("arguments"));
                 blocks.push(ModelBlock::ToolUse {
                     id: id.to_string(),
                     name: name.to_string(),
@@ -5572,6 +5590,7 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
         },
         response_id,
         output_items,
+        supports_id_continuation,
     })
 }
 


### PR DESCRIPTION
## Summary
- normalize Responses `function_call.arguments` to a JSON object before transcript replay
- disable `previous_response_id` continuation when the provider returned malformed or non-object function arguments, so the normalized provider window is replayed instead
- preserve the existing `tool_not_exposed_for_round` allowlist rejection and clarify `WebSearch` versus xAI native `x_search`

## Verification
- `cargo fmt --all -- --check`
- `cargo test disallowed_tool_call_is_rejected_and_recovery_continues --lib`
- `cargo test openai_responses_ --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2163
