### PR TITLE
fix: preserve provider continuation lineage

### DIFF
--- a/docs/implementation-decisions/046-openai-incremental-continuation.md
+++ b/docs/implementation-decisions/046-openai-incremental-continuation.md
@@ -3,19 +3,26 @@
 OpenAI `previous_response_id` continuation is implemented as transport-local
 request lowering, not as runtime prompt semantics.
 
-The runtime still builds a complete, replayable provider turn request. The
-OpenAI transport stores only the previous request shape, full input items,
-response output items, and response id, scoped by the prompt cache agent id and
-cache key. Requests without that stable scope do not reuse a continuation
-snapshot. A later request uses `previous_response_id` only when its full input
-is a strict append-only extension of the previous request input plus the
-previous response output.
+The runtime still builds a complete provider turn request. The OpenAI transport
+stores the previous request shape, full input items, response output items,
+response id, and whether replay would omit provider-side context, scoped by the
+prompt cache agent id and cache key. Requests without that stable scope do not
+reuse a continuation snapshot. A later request uses `previous_response_id` when
+its full input is a strict append-only extension of the previous request input
+plus the locally visible previous response output.
 
-Any uncertain case falls back to a full request: prompt or cache shape changes,
-missing cache scope, tool schema changes, turn-local compaction, missing
-response ids, non-append conversation shape, or provider errors. Provider
-errors also clear the scoped local continuation snapshot before retry so retry
-attempts do not depend on an ambiguous server-side state.
+Lineage eligibility and replay eligibility are separate. A response id remains
+eligible for continuation even when the response contains provider-private
+output that cannot be reconstructed locally. If a `previous_response_id`
+request receives a 4xx response, the transport retries with its provider window
+only when that replay is lossless. Otherwise it refuses the replay instead of
+silently dropping server-side context.
+
+Other continuation misses still send a full request: prompt or cache shape
+changes, missing cache scope, tool schema changes, turn-local compaction,
+missing response ids, or non-append conversation shape. Diagnostics set
+`server_side_context_may_be_lost=true` when such a full request cannot preserve
+known provider-side context.
 
 Provider-specific wire constraints are applied only after continuation
 eligibility is decided from the complete request shape. In particular, xAI
@@ -26,5 +33,6 @@ without `instructions`, while initial and full fallback requests keep
 `instructions` for both full and incremental requests.
 
 Runtime events record secret-safe request-lowering diagnostics such as hit/miss
-status and fallback reason, but they do not expose response ids or make
-incremental continuation part of provider-neutral prompt assembly.
+status, fallback reason, and possible server-side context loss, but they do not
+expose response ids or make incremental continuation part of provider-neutral
+prompt assembly.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -891,7 +891,8 @@ mod tests {
 
     #[test]
     fn parse_model_ref_list_json_array() {
-        let refs = parse_model_ref_list(r#"["openai-codex/gpt-5","anthropic/claude-sonnet-4"]"#).unwrap();
+        let refs =
+            parse_model_ref_list(r#"["openai-codex/gpt-5","anthropic/claude-sonnet-4"]"#).unwrap();
         assert_eq!(refs.len(), 2);
         assert_eq!(refs[0].provider.as_str(), "openai-codex");
         assert_eq!(refs[1].provider.as_str(), "anthropic");

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -280,6 +280,8 @@ pub struct ProviderIncrementalContinuationDiagnostics {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_side_context_may_be_lost: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub incremental_input_items: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_input_items: Option<usize>,

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -10,7 +10,7 @@ use super::*;
 use crate::config::{ModelRef, ProviderId};
 use crate::model_catalog::ModelRuntimeOverride;
 use crate::provider::transports::set_stream_idle_timeout_override_for_tests;
-use crate::provider::ProviderNativeWebSearchKind;
+use crate::provider::{ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest};
 use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use serde_json::{json, Value};
 
@@ -36,6 +36,26 @@ fn openai_non_object_tool_call_response(response_id: &str) -> Value {
         "status": "completed",
         "usage": { "input_tokens": 256, "output_tokens": 2 },
         "output": [{
+            "type": "function_call",
+            "id": "fc_non_persisted",
+            "status": "completed",
+            "call_id": "invented-1",
+            "name": "x_semantic_search",
+            "arguments": "[\"holon\"]"
+        }]
+    })
+}
+
+fn xai_search_and_non_object_tool_call_response(response_id: &str) -> Value {
+    json!({
+        "id": response_id,
+        "status": "completed",
+        "usage": { "input_tokens": 256, "output_tokens": 2 },
+        "output": [{
+            "type": "x_search_call",
+            "id": "search_1",
+            "status": "completed"
+        }, {
             "type": "function_call",
             "id": "fc_non_persisted",
             "status": "completed",
@@ -399,15 +419,292 @@ async fn openai_responses_normalizes_non_object_tool_arguments_before_continuati
             .request_diagnostics
             .as_ref()
             .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
-        Some("provider_window_replay")
+        Some("incremental_continuation")
     );
     let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+    let incremental = bodies[1]["input"].as_array().unwrap();
+    assert_eq!(incremental.len(), 1);
+    assert_eq!(incremental[0]["type"], json!("function_call_output"));
+}
+
+#[tokio::test]
+async fn openai_responses_replays_lossless_window_after_continuation_rejection() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                match attempts.fetch_add(1, Ordering::SeqCst) {
+                    0 => Json(openai_tool_call_response("resp_1")).into_response(),
+                    1 => (StatusCode::BAD_REQUEST, "continuation rejected").into_response(),
+                    _ => Json(openai_text_response("resp_2", "done")).into_response(),
+                }
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let response = provider
+        .complete_turn(provider_continuation_request_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let diagnostics = response.request_diagnostics.as_ref().unwrap();
+    assert_eq!(diagnostics.request_lowering_mode, "provider_window_replay");
+    let continuation = diagnostics.incremental_continuation.as_ref().unwrap();
+    assert_eq!(continuation.status, "fallback_provider_window_replay");
+    assert_eq!(
+        continuation.fallback_reason.as_deref(),
+        Some("previous_response_id_rejected")
+    );
+    assert_eq!(continuation.server_side_context_may_be_lost, None);
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 3);
+    assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+    assert!(bodies[2].get("previous_response_id").is_none());
+    assert_eq!(bodies[2]["input"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn xai_native_search_preserves_continuation_after_rejected_internal_tool_call() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Json(xai_search_and_non_object_tool_call_response("resp_1"))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let fixture = test_config("openai/gpt-5.4", &[], Some("xai-key"), None, false);
+    let mut provider_config = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    provider_config.id = ProviderId::parse("xai").unwrap();
+    provider_config.route_provider = ProviderId::parse("xai").unwrap();
+    provider_config.base_url = base_url;
+    let provider = OpenAiProvider::from_runtime_config(
+        &provider_config,
+        "grok-4.5",
+        fixture.config.runtime_max_output_tokens,
+        &fixture.config.home_dir,
+    )
+    .unwrap();
+
+    let mut first_request = provider_turn_request_with_prompt_frame();
+    first_request.native_web_search = Some(ProviderNativeWebSearchRequest {
+        kind: ProviderNativeWebSearchKind::Xai,
+        provider_id: "xai".into(),
+        provider_model_ref: "xai/grok-4.5".into(),
+        advertised_tool_type: "web_search".into(),
+        backend_kind: "xai_web_search_x_search".into(),
+        max_results: Some(5),
+    });
+    let first = provider.complete_turn(first_request.clone()).await.unwrap();
+    assert_eq!(first.blocks.len(), 1);
+
+    let mut continuation = first_request;
+    continuation.conversation.extend([
+        ConversationMessage::AssistantBlocks(first.blocks),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "invented-1".into(),
+            content: "Failed: x_semantic_search not exposed for round".into(),
+            is_error: true,
+            error: None,
+        }]),
+    ]);
+    let response = provider.complete_turn(continuation).await.unwrap();
+
+    let diagnostics = response
+        .request_diagnostics
+        .as_ref()
+        .expect("request diagnostics");
+    assert_eq!(
+        diagnostics.request_lowering_mode,
+        "incremental_continuation_omit_instructions"
+    );
+    assert_eq!(
+        diagnostics
+            .incremental_continuation
+            .as_ref()
+            .and_then(|continuation| continuation.server_side_context_may_be_lost),
+        None
+    );
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+    let incremental = bodies[1]["input"].as_array().unwrap();
+    assert_eq!(incremental.len(), 1);
+    assert_eq!(incremental[0]["type"], json!("function_call_output"));
+}
+
+#[tokio::test]
+async fn xai_native_search_refuses_lossy_replay_after_continuation_rejection() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Json(xai_search_and_non_object_tool_call_response("resp_1")).into_response()
+                } else {
+                    (StatusCode::BAD_REQUEST, "continuation rejected").into_response()
+                }
+            }
+        }),
+    ))
+    .await;
+    let fixture = test_config("openai/gpt-5.4", &[], Some("xai-key"), None, false);
+    let mut provider_config = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    provider_config.id = ProviderId::parse("xai").unwrap();
+    provider_config.route_provider = ProviderId::parse("xai").unwrap();
+    provider_config.base_url = base_url;
+    let provider = OpenAiProvider::from_runtime_config(
+        &provider_config,
+        "grok-4.5",
+        fixture.config.runtime_max_output_tokens,
+        &fixture.config.home_dir,
+    )
+    .unwrap();
+
+    let mut first_request = provider_turn_request_with_prompt_frame();
+    first_request.native_web_search = Some(ProviderNativeWebSearchRequest {
+        kind: ProviderNativeWebSearchKind::Xai,
+        provider_id: "xai".into(),
+        provider_model_ref: "xai/grok-4.5".into(),
+        advertised_tool_type: "web_search".into(),
+        backend_kind: "xai_web_search_x_search".into(),
+        max_results: Some(5),
+    });
+    let first = provider.complete_turn(first_request.clone()).await.unwrap();
+    let mut continuation = first_request;
+    continuation.conversation.extend([
+        ConversationMessage::AssistantBlocks(first.blocks),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "invented-1".into(),
+            content: "Failed: x_semantic_search not exposed for round".into(),
+            is_error: true,
+            error: None,
+        }]),
+    ]);
+
+    let error = provider.complete_turn(continuation).await.unwrap_err();
+    let message = format!("{error:#}");
+    assert!(message.contains("refused provider-window replay"));
+    assert!(message.contains("server_side_search_context"));
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+}
+
+#[tokio::test]
+async fn xai_native_search_fallback_warns_when_server_context_may_be_lost() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Json(xai_search_and_non_object_tool_call_response("resp_1"))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let fixture = test_config("openai/gpt-5.4", &[], Some("xai-key"), None, false);
+    let mut provider_config = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    provider_config.id = ProviderId::parse("xai").unwrap();
+    provider_config.route_provider = ProviderId::parse("xai").unwrap();
+    provider_config.base_url = base_url;
+    let provider = OpenAiProvider::from_runtime_config(
+        &provider_config,
+        "grok-4.5",
+        fixture.config.runtime_max_output_tokens,
+        &fixture.config.home_dir,
+    )
+    .unwrap();
+
+    let mut request = provider_turn_request_with_prompt_frame();
+    request.native_web_search = Some(ProviderNativeWebSearchRequest {
+        kind: ProviderNativeWebSearchKind::Xai,
+        provider_id: "xai".into(),
+        provider_model_ref: "xai/grok-4.5".into(),
+        advertised_tool_type: "web_search".into(),
+        backend_kind: "xai_web_search_x_search".into(),
+        max_results: Some(5),
+    });
+    provider.complete_turn(request.clone()).await.unwrap();
+    request.native_web_search.as_mut().unwrap().max_results = Some(10);
+    let response = provider.complete_turn(request).await.unwrap();
+
+    let continuation = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+        .expect("incremental continuation diagnostics");
+    assert_eq!(
+        continuation.fallback_reason.as_deref(),
+        Some("request_shape_changed")
+    );
+    assert_eq!(continuation.server_side_context_may_be_lost, Some(true));
+    let bodies = captured_bodies.lock().unwrap();
     assert!(bodies[1].get("previous_response_id").is_none());
-    let replay = bodies[1]["input"].as_array().unwrap();
-    assert_eq!(replay.len(), 3);
-    assert_eq!(replay[1]["type"], json!("function_call"));
-    assert_eq!(replay[1]["arguments"], json!("{\"_raw\":[\"holon\"]}"));
-    assert_eq!(replay[2]["type"], json!("function_call_output"));
 }
 
 #[tokio::test]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -681,6 +681,8 @@ async fn xai_native_search_fallback_warns_when_server_context_may_be_lost() {
     .unwrap();
 
     let mut request = provider_turn_request_with_prompt_frame();
+    request.prompt_frame.cache.as_mut().unwrap().agent_id =
+        "xai-native-search-fallback-warning".into();
     request.native_web_search = Some(ProviderNativeWebSearchRequest {
         kind: ProviderNativeWebSearchKind::Xai,
         provider_id: "xai".into(),
@@ -689,8 +691,21 @@ async fn xai_native_search_fallback_warns_when_server_context_may_be_lost() {
         backend_kind: "xai_web_search_x_search".into(),
         max_results: Some(5),
     });
-    provider.complete_turn(request.clone()).await.unwrap();
-    request.native_web_search.as_mut().unwrap().max_results = Some(10);
+    let first = provider.complete_turn(request.clone()).await.unwrap();
+    request.conversation.extend([
+        ConversationMessage::AssistantBlocks(first.blocks),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "invented-1".into(),
+            content: "Failed: x_semantic_search not exposed for round".into(),
+            is_error: true,
+            error: None,
+        }]),
+    ]);
+    request
+        .native_web_search
+        .as_mut()
+        .unwrap()
+        .advertised_tool_type = "web_search_preview".into();
     let response = provider.complete_turn(request).await.unwrap();
 
     let continuation = response

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -201,6 +201,7 @@ struct OpenAiProviderWindow {
     request_shape: OpenAiRequestShape,
     items: Vec<Value>,
     append_match_items: Vec<Value>,
+    replay_loss_reason: Option<String>,
     latest_compaction_index: Option<usize>,
     latest_input_tokens: u64,
     generation: u64,
@@ -222,9 +223,12 @@ struct OpenAiRequestShape {
 #[derive(Debug)]
 struct OpenAiRequestPlan {
     body: Value,
+    fallback_body: Option<Value>,
     scope: Option<OpenAiContinuationScope>,
     append_match_input: Vec<Value>,
     provider_input: Vec<Value>,
+    fallback_provider_input: Option<Vec<Value>>,
+    replay_loss_reason: Option<String>,
     request_shape: OpenAiRequestShape,
     diagnostics: ProviderRequestDiagnostics,
 }
@@ -249,7 +253,6 @@ pub(crate) struct ParsedOpenAiResponse {
     pub(crate) response: ProviderTurnResponse,
     pub(crate) response_id: Option<String>,
     pub(crate) output_items: Vec<Value>,
-    supports_id_continuation: bool,
 }
 
 impl OpenAiProvider {
@@ -970,6 +973,8 @@ impl AgentProvider for OpenAiProvider {
             sent_diagnostics.openai_remote_compaction = Some(remote_compaction);
             sent_diagnostics.request_lowering_mode = plan.diagnostics.request_lowering_mode.clone();
         }
+        let mut final_provider_input = plan.provider_input.clone();
+        let mut final_replay_loss_reason = plan.replay_loss_reason.clone();
         let parsed = match send_openai_responses_request(
             &self.client,
             openai_responses_url(&self.base_url),
@@ -982,28 +987,44 @@ impl AgentProvider for OpenAiProvider {
         {
             Ok(parsed) => parsed,
             Err(error) => {
-                let Some(refreshed_headers) =
+                let retried = if let Some(refreshed_headers) =
                     self.refresh_auth_headers_after_failure(&error).await?
-                else {
-                    invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
-                    return Err(error);
-                };
-                headers = refreshed_headers;
-                match send_openai_responses_request(
-                    &self.client,
-                    openai_responses_url(&self.base_url),
-                    plan.body,
-                    headers.clone(),
-                    trace.as_ref(),
-                    request_agent_id(&request),
-                )
-                .await
                 {
+                    headers = refreshed_headers;
+                    send_openai_responses_request(
+                        &self.client,
+                        openai_responses_url(&self.base_url),
+                        plan.body.clone(),
+                        headers.clone(),
+                        trace.as_ref(),
+                        request_agent_id(&request),
+                    )
+                    .await
+                } else {
+                    Err(error)
+                };
+                match retried {
                     Ok(parsed) => parsed,
-                    Err(error) => {
-                        invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
-                        return Err(error);
-                    }
+                    Err(error) => match retry_openai_responses_with_lossless_replay(
+                        &self.client,
+                        openai_responses_url(&self.base_url),
+                        &plan,
+                        headers.clone(),
+                        trace.as_ref(),
+                        request_agent_id(&request),
+                        error,
+                        &mut sent_diagnostics,
+                        &mut final_provider_input,
+                        &mut final_replay_loss_reason,
+                    )
+                    .await
+                    {
+                        Ok(parsed) => parsed,
+                        Err(error) => {
+                            invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
+                            return Err(error);
+                        }
+                    },
                 }
             }
         };
@@ -1012,7 +1033,8 @@ impl AgentProvider for OpenAiProvider {
             plan_scope.clone(),
             plan_request_shape.clone(),
             plan.append_match_input,
-            plan.provider_input,
+            final_provider_input,
+            final_replay_loss_reason,
             &parsed,
         );
         if sent_diagnostics.openai_remote_compaction.is_none() {
@@ -1293,6 +1315,7 @@ impl AgentProvider for OpenAiCodexProvider {
             plan_request_shape.clone(),
             plan.append_match_input,
             plan.provider_input,
+            plan.replay_loss_reason,
             &parsed,
         );
         if sent_diagnostics.openai_remote_compaction.is_none() {
@@ -1510,6 +1533,7 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
             plan.request_shape,
             plan.append_match_input,
             plan.provider_input,
+            plan.replay_loss_reason,
             &parsed,
         );
 
@@ -1784,9 +1808,12 @@ fn plan_chat_completion_request(
             full_body.clone(),
             OpenAiRequestPlan {
                 body: full_body,
+                fallback_body: None,
                 scope,
                 append_match_input: full_messages.clone(),
                 provider_input: full_messages,
+                fallback_provider_input: None,
+                replay_loss_reason: None,
                 request_shape,
                 diagnostics: incremental_diagnostics(
                     "full_request",
@@ -1813,9 +1840,12 @@ fn plan_chat_completion_request(
             full_body.clone(),
             OpenAiRequestPlan {
                 body: full_body,
+                fallback_body: None,
                 scope,
                 append_match_input: full_messages.clone(),
                 provider_input: full_messages,
+                fallback_provider_input: None,
+                replay_loss_reason: None,
                 request_shape,
                 diagnostics: incremental_diagnostics(
                     "full_request",
@@ -1839,9 +1869,12 @@ fn plan_chat_completion_request(
             full_body.clone(),
             OpenAiRequestPlan {
                 body: full_body,
+                fallback_body: None,
                 scope,
                 append_match_input: full_messages.clone(),
                 provider_input: full_messages,
+                fallback_provider_input: None,
+                replay_loss_reason: previous.replay_loss_reason,
                 request_shape,
                 diagnostics: incremental_diagnostics(
                     "full_request",
@@ -1870,9 +1903,12 @@ fn plan_chat_completion_request(
         full_body.clone(),
         OpenAiRequestPlan {
             body: full_body,
+            fallback_body: None,
             scope,
             append_match_input: full_messages.clone(),
             provider_input: full_messages,
+            fallback_provider_input: None,
+            replay_loss_reason: previous.replay_loss_reason,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -2193,9 +2229,12 @@ fn plan_openai_responses_request(
     let Some(scope_ref) = scope.as_ref() else {
         return Ok(OpenAiRequestPlan {
             body,
+            fallback_body: None,
             scope,
             append_match_input,
             provider_input: full_input,
+            fallback_provider_input: None,
+            replay_loss_reason: None,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -2216,9 +2255,12 @@ fn plan_openai_responses_request(
     let Some(previous) = previous else {
         return Ok(OpenAiRequestPlan {
             body,
+            fallback_body: None,
             scope,
             append_match_input,
             provider_input: full_input,
+            fallback_provider_input: None,
+            replay_loss_reason: None,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -2235,25 +2277,29 @@ fn plan_openai_responses_request(
 
     if previous.request_shape != request_shape {
         let request_shape_hash = request_shape_hash(&request_shape);
+        let diagnostics = incremental_diagnostics(
+            "full_request",
+            "request_shape_changed",
+            None,
+            full_input_items,
+            Some(OpenAiContinuationMismatchDiagnostics {
+                request_shape_hash: Some(request_shape_hash),
+                ..OpenAiContinuationMismatchDiagnostics::default()
+            }),
+            request_controls,
+            native_web_search_diagnostics(request),
+            response_format_diagnostics(true, request),
+        );
         return Ok(OpenAiRequestPlan {
             body,
+            fallback_body: None,
             scope,
             append_match_input,
             provider_input: full_input,
+            fallback_provider_input: None,
+            replay_loss_reason: previous.replay_loss_reason,
             request_shape,
-            diagnostics: incremental_diagnostics(
-                "full_request",
-                "request_shape_changed",
-                None,
-                full_input_items,
-                Some(OpenAiContinuationMismatchDiagnostics {
-                    request_shape_hash: Some(request_shape_hash),
-                    ..OpenAiContinuationMismatchDiagnostics::default()
-                }),
-                request_controls,
-                native_web_search_diagnostics(request),
-                response_format_diagnostics(true, request),
-            ),
+            diagnostics,
         });
     }
 
@@ -2267,22 +2313,26 @@ fn plan_openai_responses_request(
         || append_match_input.len() <= expected_prefix.len()
         || !append_match_input.starts_with(&expected_prefix)
     {
+        let diagnostics = incremental_diagnostics(
+            "full_request",
+            "conversation_not_strict_append_only",
+            None,
+            full_input_items,
+            Some(mismatch),
+            request_controls,
+            native_web_search_diagnostics(request),
+            response_format_diagnostics(true, request),
+        );
         return Ok(OpenAiRequestPlan {
             body,
+            fallback_body: None,
             scope,
             append_match_input,
             provider_input: full_input,
+            fallback_provider_input: None,
+            replay_loss_reason: previous.replay_loss_reason,
             request_shape,
-            diagnostics: incremental_diagnostics(
-                "full_request",
-                "conversation_not_strict_append_only",
-                None,
-                full_input_items,
-                Some(mismatch),
-                request_controls,
-                native_web_search_diagnostics(request),
-                response_format_diagnostics(true, request),
-            ),
+            diagnostics,
         });
     }
 
@@ -2292,7 +2342,21 @@ fn plan_openai_responses_request(
         .flatten();
     let has_response_id = response_id.is_some();
     let replay_is_compacted = previous.latest_compaction_index.is_some();
+    let mut fallback_body = None;
+    let mut fallback_provider_input = None;
     let provider_input = if let Some(response_id) = response_id {
+        let mut replay_input = previous.items.clone();
+        replay_input.extend(incremental_input.clone());
+        if previous.replay_loss_reason.is_none() {
+            let mut replay_body = body.clone();
+            replay_body["input"] = Value::Array(replay_input.clone());
+            replay_body
+                .as_object_mut()
+                .expect("OpenAI Responses request body should be an object")
+                .remove("previous_response_id");
+            fallback_body = Some(replay_body);
+            fallback_provider_input = Some(replay_input);
+        }
         body["input"] = Value::Array(incremental_input.clone());
         body["previous_response_id"] = Value::String(response_id);
         if continuation_contract
@@ -2312,9 +2376,12 @@ fn plan_openai_responses_request(
     let request_shape_hash = request_shape_hash(&request_shape);
     Ok(OpenAiRequestPlan {
         body,
+        fallback_body,
         scope,
         append_match_input,
         provider_input,
+        fallback_provider_input,
+        replay_loss_reason: previous.replay_loss_reason.clone(),
         request_shape,
         diagnostics: ProviderRequestDiagnostics {
             request_lowering_mode: openai_append_match_lowering_mode(
@@ -2329,6 +2396,9 @@ fn plan_openai_responses_request(
             incremental_continuation: Some(ProviderIncrementalContinuationDiagnostics {
                 status: "hit".into(),
                 fallback_reason: None,
+                server_side_context_may_be_lost: (!has_response_id
+                    && previous.replay_loss_reason.is_some())
+                .then_some(true),
                 incremental_input_items: Some(incremental_input.len()),
                 full_input_items: Some(full_input_items),
                 expected_prefix_items: Some(expected_prefix.len()),
@@ -2624,6 +2694,7 @@ fn incremental_diagnostics(
         incremental_continuation: Some(ProviderIncrementalContinuationDiagnostics {
             status: "fallback_full_request".into(),
             fallback_reason: Some(fallback_reason.into()),
+            server_side_context_may_be_lost: None,
             incremental_input_items,
             full_input_items: Some(full_input_items),
             expected_prefix_items: Some(mismatch.expected_prefix_items),
@@ -2688,6 +2759,7 @@ fn update_openai_continuation(
     request_shape: OpenAiRequestShape,
     append_match_input: Vec<Value>,
     provider_input: Vec<Value>,
+    prior_replay_loss_reason: Option<String>,
     parsed: &ParsedOpenAiResponse,
 ) {
     let Some(scope) = scope else {
@@ -2698,7 +2770,7 @@ fn update_openai_continuation(
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
         (Some(response_id), false) => {
             state.next_generation = state.next_generation.saturating_add(1);
-            let response_id = parsed.supports_id_continuation.then(|| response_id.clone());
+            let response_id = Some(response_id.clone());
             let mut items = provider_input
                 .into_iter()
                 .map(|item| canonicalize_openai_provider_item(&item))
@@ -2717,6 +2789,13 @@ fn update_openai_continuation(
                 latest_compaction_index: latest_openai_compaction_index(&items),
                 items,
                 append_match_items,
+                replay_loss_reason: prior_replay_loss_reason.or_else(|| {
+                    parsed
+                        .output_items
+                        .iter()
+                        .any(openai_is_server_side_search_item)
+                        .then(|| "server_side_search_context".into())
+                }),
                 generation: state.next_generation,
                 latest_input_tokens,
             })
@@ -2730,28 +2809,19 @@ fn update_openai_continuation(
     }
 }
 
-fn openai_output_supports_id_continuation(output_items: &[Value]) -> bool {
-    output_items.iter().all(|item| {
-        if item.get("type").and_then(Value::as_str) != Some("function_call") {
-            return true;
-        }
-        match item.get("arguments") {
-            Some(Value::Object(_)) => true,
-            Some(Value::String(arguments)) => {
-                arguments.trim().is_empty()
-                    || serde_json::from_str::<Value>(arguments)
-                        .is_ok_and(|arguments| arguments.is_object())
-            }
-            _ => false,
-        }
-    })
-}
-
 fn openai_append_match_output_items(output_items: &[Value]) -> Vec<Value> {
     output_items
         .iter()
+        .filter(|item| !openai_is_server_side_search_item(item))
         .filter_map(openai_append_match_output_item)
         .collect()
+}
+
+fn openai_is_server_side_search_item(item: &Value) -> bool {
+    matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("web_search_call" | "x_search_call")
+    )
 }
 
 fn openai_append_match_output_item(item: &Value) -> Option<Value> {
@@ -2972,6 +3042,7 @@ async fn maybe_compact_openai_provider_window(
                 request_shape: request_shape.clone(),
                 items,
                 append_match_items: window.append_match_items,
+                replay_loss_reason: None,
                 latest_compaction_index,
                 latest_input_tokens: 0,
                 generation,
@@ -3027,6 +3098,7 @@ async fn maybe_compact_openai_request_plan(
         latest_compaction_index: latest_openai_compaction_index(&compactable_items),
         items: compactable_items,
         append_match_items: plan.append_match_input.clone(),
+        replay_loss_reason: previous.replay_loss_reason.clone(),
         latest_input_tokens: previous.latest_input_tokens,
         generation: previous.generation,
     };
@@ -4255,7 +4327,6 @@ pub(crate) fn parse_chat_completion_response(response: Value) -> Result<ParsedOp
         },
         response_id,
         output_items,
-        supports_id_continuation: true,
     })
 }
 
@@ -4690,6 +4761,47 @@ async fn send_openai_responses_request(
         .map_err(|error| invalid_response_error("invalid OpenAI-style JSON", error))?;
     parse_openai_response_with_transport_state(parsed)
         .map(|parsed| parsed.with_provider_request_id(provider_request_id))
+}
+
+async fn retry_openai_responses_with_lossless_replay(
+    client: &Client,
+    url: String,
+    plan: &OpenAiRequestPlan,
+    headers: Vec<(&str, String)>,
+    trace: Option<&ProviderHttpTrace>,
+    agent_id: Option<&str>,
+    error: anyhow::Error,
+    diagnostics: &mut ProviderRequestDiagnostics,
+    final_provider_input: &mut Vec<Value>,
+    final_replay_loss_reason: &mut Option<String>,
+) -> Result<ParsedOpenAiResponse> {
+    if !matches!(error_status(&error), Some(400..=499))
+        || plan.body.get("previous_response_id").is_none()
+    {
+        return Err(error);
+    }
+    let Some(fallback_body) = plan.fallback_body.clone() else {
+        return Err(error).with_context(|| {
+            format!(
+                "OpenAI Responses continuation failed and Holon refused provider-window replay because it would lose {}",
+                plan.replay_loss_reason
+                    .as_deref()
+                    .unwrap_or("server-side response context")
+            )
+        });
+    };
+    *final_provider_input = plan
+        .fallback_provider_input
+        .clone()
+        .expect("lossless replay body should have matching provider input");
+    *final_replay_loss_reason = None;
+    diagnostics.request_lowering_mode = "provider_window_replay".into();
+    if let Some(continuation) = diagnostics.incremental_continuation.as_mut() {
+        continuation.status = "fallback_provider_window_replay".into();
+        continuation.fallback_reason = Some("previous_response_id_rejected".into());
+        continuation.server_side_context_may_be_lost = None;
+    }
+    send_openai_responses_request(client, url, fallback_body, headers, trace, agent_id).await
 }
 
 async fn send_openai_images_request(
@@ -5448,7 +5560,6 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                 "missing output array",
             )
         })?;
-    let supports_id_continuation = openai_output_supports_id_continuation(output);
     let output_items = output
         .iter()
         .map(canonicalize_openai_provider_item)
@@ -5590,7 +5701,6 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
         },
         response_id,
         output_items,
-        supports_id_continuation,
     })
 }
 
@@ -6450,6 +6560,7 @@ mod tests {
             append_match_items: Vec::new(),
             latest_compaction_index: None,
             latest_input_tokens: 0,
+            replay_loss_reason: None,
             generation: 1,
         };
 
@@ -6476,6 +6587,7 @@ mod tests {
             append_match_items: Vec::new(),
             latest_compaction_index: None,
             latest_input_tokens: 0,
+            replay_loss_reason: None,
             generation: 1,
         };
 
@@ -6504,6 +6616,7 @@ mod tests {
             append_match_items: Vec::new(),
             latest_compaction_index: None,
             latest_input_tokens: 512,
+            replay_loss_reason: None,
             generation: 1,
         };
 
@@ -6532,13 +6645,17 @@ mod tests {
             append_match_items: Vec::new(),
             latest_compaction_index: Some(0),
             latest_input_tokens: 0,
+            replay_loss_reason: None,
             generation: 1,
         };
         let plan = OpenAiRequestPlan {
             body: json!({ "model": "gpt-test", "input": [] }),
+            fallback_body: None,
             scope: None,
             append_match_input: Vec::new(),
             provider_input: vec![json!({ "type": "message", "content": "continue" })],
+            fallback_provider_input: None,
+            replay_loss_reason: None,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "provider_window_compacted",

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -223,11 +223,10 @@ struct OpenAiRequestShape {
 #[derive(Debug)]
 struct OpenAiRequestPlan {
     body: Value,
-    fallback_body: Option<Value>,
+    fallback_replay: Option<(Value, Vec<Value>)>,
     scope: Option<OpenAiContinuationScope>,
     append_match_input: Vec<Value>,
     provider_input: Vec<Value>,
-    fallback_provider_input: Option<Vec<Value>>,
     replay_loss_reason: Option<String>,
     request_shape: OpenAiRequestShape,
     diagnostics: ProviderRequestDiagnostics,
@@ -1808,11 +1807,10 @@ fn plan_chat_completion_request(
             full_body.clone(),
             OpenAiRequestPlan {
                 body: full_body,
-                fallback_body: None,
+                fallback_replay: None,
                 scope,
                 append_match_input: full_messages.clone(),
                 provider_input: full_messages,
-                fallback_provider_input: None,
                 replay_loss_reason: None,
                 request_shape,
                 diagnostics: incremental_diagnostics(
@@ -1840,11 +1838,10 @@ fn plan_chat_completion_request(
             full_body.clone(),
             OpenAiRequestPlan {
                 body: full_body,
-                fallback_body: None,
+                fallback_replay: None,
                 scope,
                 append_match_input: full_messages.clone(),
                 provider_input: full_messages,
-                fallback_provider_input: None,
                 replay_loss_reason: None,
                 request_shape,
                 diagnostics: incremental_diagnostics(
@@ -1869,11 +1866,10 @@ fn plan_chat_completion_request(
             full_body.clone(),
             OpenAiRequestPlan {
                 body: full_body,
-                fallback_body: None,
+                fallback_replay: None,
                 scope,
                 append_match_input: full_messages.clone(),
                 provider_input: full_messages,
-                fallback_provider_input: None,
                 replay_loss_reason: previous.replay_loss_reason,
                 request_shape,
                 diagnostics: incremental_diagnostics(
@@ -1903,11 +1899,10 @@ fn plan_chat_completion_request(
         full_body.clone(),
         OpenAiRequestPlan {
             body: full_body,
-            fallback_body: None,
+            fallback_replay: None,
             scope,
             append_match_input: full_messages.clone(),
             provider_input: full_messages,
-            fallback_provider_input: None,
             replay_loss_reason: previous.replay_loss_reason,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -2229,11 +2224,10 @@ fn plan_openai_responses_request(
     let Some(scope_ref) = scope.as_ref() else {
         return Ok(OpenAiRequestPlan {
             body,
-            fallback_body: None,
+            fallback_replay: None,
             scope,
             append_match_input,
             provider_input: full_input,
-            fallback_provider_input: None,
             replay_loss_reason: None,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -2255,11 +2249,10 @@ fn plan_openai_responses_request(
     let Some(previous) = previous else {
         return Ok(OpenAiRequestPlan {
             body,
-            fallback_body: None,
+            fallback_replay: None,
             scope,
             append_match_input,
             provider_input: full_input,
-            fallback_provider_input: None,
             replay_loss_reason: None,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -2277,7 +2270,7 @@ fn plan_openai_responses_request(
 
     if previous.request_shape != request_shape {
         let request_shape_hash = request_shape_hash(&request_shape);
-        let diagnostics = incremental_diagnostics(
+        let mut diagnostics = incremental_diagnostics(
             "full_request",
             "request_shape_changed",
             None,
@@ -2290,13 +2283,19 @@ fn plan_openai_responses_request(
             native_web_search_diagnostics(request),
             response_format_diagnostics(true, request),
         );
+        if previous.replay_loss_reason.is_some() {
+            diagnostics
+                .incremental_continuation
+                .as_mut()
+                .expect("incremental diagnostics should include continuation details")
+                .server_side_context_may_be_lost = Some(true);
+        }
         return Ok(OpenAiRequestPlan {
             body,
-            fallback_body: None,
+            fallback_replay: None,
             scope,
             append_match_input,
             provider_input: full_input,
-            fallback_provider_input: None,
             replay_loss_reason: previous.replay_loss_reason,
             request_shape,
             diagnostics,
@@ -2313,7 +2312,7 @@ fn plan_openai_responses_request(
         || append_match_input.len() <= expected_prefix.len()
         || !append_match_input.starts_with(&expected_prefix)
     {
-        let diagnostics = incremental_diagnostics(
+        let mut diagnostics = incremental_diagnostics(
             "full_request",
             "conversation_not_strict_append_only",
             None,
@@ -2323,13 +2322,19 @@ fn plan_openai_responses_request(
             native_web_search_diagnostics(request),
             response_format_diagnostics(true, request),
         );
+        if previous.replay_loss_reason.is_some() {
+            diagnostics
+                .incremental_continuation
+                .as_mut()
+                .expect("incremental diagnostics should include continuation details")
+                .server_side_context_may_be_lost = Some(true);
+        }
         return Ok(OpenAiRequestPlan {
             body,
-            fallback_body: None,
+            fallback_replay: None,
             scope,
             append_match_input,
             provider_input: full_input,
-            fallback_provider_input: None,
             replay_loss_reason: previous.replay_loss_reason,
             request_shape,
             diagnostics,
@@ -2342,8 +2347,7 @@ fn plan_openai_responses_request(
         .flatten();
     let has_response_id = response_id.is_some();
     let replay_is_compacted = previous.latest_compaction_index.is_some();
-    let mut fallback_body = None;
-    let mut fallback_provider_input = None;
+    let mut fallback_replay = None;
     let provider_input = if let Some(response_id) = response_id {
         let mut replay_input = previous.items.clone();
         replay_input.extend(incremental_input.clone());
@@ -2354,8 +2358,7 @@ fn plan_openai_responses_request(
                 .as_object_mut()
                 .expect("OpenAI Responses request body should be an object")
                 .remove("previous_response_id");
-            fallback_body = Some(replay_body);
-            fallback_provider_input = Some(replay_input);
+            fallback_replay = Some((replay_body, replay_input));
         }
         body["input"] = Value::Array(incremental_input.clone());
         body["previous_response_id"] = Value::String(response_id);
@@ -2376,11 +2379,10 @@ fn plan_openai_responses_request(
     let request_shape_hash = request_shape_hash(&request_shape);
     Ok(OpenAiRequestPlan {
         body,
-        fallback_body,
+        fallback_replay,
         scope,
         append_match_input,
         provider_input,
-        fallback_provider_input,
         replay_loss_reason: previous.replay_loss_reason.clone(),
         request_shape,
         diagnostics: ProviderRequestDiagnostics {
@@ -4780,7 +4782,7 @@ async fn retry_openai_responses_with_lossless_replay(
     {
         return Err(error);
     }
-    let Some(fallback_body) = plan.fallback_body.clone() else {
+    let Some((fallback_body, fallback_provider_input)) = plan.fallback_replay.clone() else {
         return Err(error).with_context(|| {
             format!(
                 "OpenAI Responses continuation failed and Holon refused provider-window replay because it would lose {}",
@@ -4790,10 +4792,7 @@ async fn retry_openai_responses_with_lossless_replay(
             )
         });
     };
-    *final_provider_input = plan
-        .fallback_provider_input
-        .clone()
-        .expect("lossless replay body should have matching provider input");
+    *final_provider_input = fallback_provider_input;
     *final_replay_loss_reason = None;
     diagnostics.request_lowering_mode = "provider_window_replay".into();
     if let Some(continuation) = diagnostics.incremental_continuation.as_mut() {
@@ -6650,11 +6649,10 @@ mod tests {
         };
         let plan = OpenAiRequestPlan {
             body: json!({ "model": "gpt-test", "input": [] }),
-            fallback_body: None,
+            fallback_replay: None,
             scope: None,
             append_match_input: Vec::new(),
             provider_input: vec![json!({ "type": "message", "content": "continue" })],
-            fallback_provider_input: None,
             replay_loss_reason: None,
             request_shape,
             diagnostics: incremental_diagnostics(


### PR DESCRIPTION
## Summary

- 分离 Responses 服务端 lineage eligibility 与本地 provider-window replay eligibility
- 保留 leaked non-exposed tool call 的策略拒绝语义，同时允许 xAI native search 后继续使用 `previous_response_id`
- continuation 4xx 时仅对无损窗口自动 replay；存在服务端搜索上下文依赖时拒绝有损 replay
- 增加 `server_side_context_may_be_lost` fallback diagnostics，并更新 continuation 决策文档

## Tests

- `cargo test openai_responses_replays_lossless_window_after_continuation_rejection --lib`
- `cargo test xai_native_search_refuses_lossy_replay_after_continuation_rejection --lib`
- `cargo test xai_native_search_preserves_continuation_after_rejected_internal_tool_call --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2167
