### PR TITLE
fix: project model catalog routes and image capabilities

### DIFF
--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -4,7 +4,10 @@ use serde_json::{json, Value};
 
 use crate::{
     auth::{load_codex_cli_credential, load_codex_oauth_profile_credential},
-    config::{AppConfig, CredentialSource, ModelRef, ProviderId, RuntimeModelCatalog},
+    config::{
+        AppConfig, CredentialSource, ModelRef, ModelRouteCapability, ProviderId,
+        RuntimeModelCatalog,
+    },
     context::ContextConfig,
     onboarding::{onboarding_report, search_diagnostics},
     types::{
@@ -128,14 +131,20 @@ pub(crate) fn resolved_model_providers_from_availability_for_runtime(
     let mut providers = BTreeMap::<String, Vec<&ResolvedModelAvailability>>::new();
     for model in models {
         providers
-            .entry(model.provider.clone())
+            .entry(provider_endpoint_group_id(
+                &model.provider_family,
+                &model.endpoint,
+            ))
             .or_default()
             .push(model);
     }
     if let Some(config) = config {
-        for provider_id in config.providers.keys() {
+        for provider in config.providers.values() {
             providers
-                .entry(provider_id.as_str().to_string())
+                .entry(provider_endpoint_group_id(
+                    provider.route_provider.as_str(),
+                    provider.route_endpoint.as_str(),
+                ))
                 .or_default();
         }
     }
@@ -143,15 +152,20 @@ pub(crate) fn resolved_model_providers_from_availability_for_runtime(
     providers
         .into_iter()
         .map(|(provider_id, models)| {
-            let parsed_provider_id = ProviderId::parse(&provider_id).ok();
-            let provider = config
-                .and_then(|config| {
-                    parsed_provider_id
-                        .as_ref()
-                        .map(|provider_id| (config, provider_id))
-                })
-                .and_then(|(config, provider_id)| config.providers.get(provider_id));
             let first_model = models.first().copied();
+            let configured_provider = config.and_then(|config| {
+                config.providers.values().find(|provider| {
+                    provider_endpoint_group_id(
+                        provider.route_provider.as_str(),
+                        provider.route_endpoint.as_str(),
+                    ) == provider_id
+                })
+            });
+            let route_provider_id = first_model
+                .map(|model| model.route_provider.as_str())
+                .or_else(|| configured_provider.map(|provider| provider.id.as_str()))
+                .unwrap_or(provider_id.as_str());
+            let provider = configured_provider;
             let available_count = models.iter().filter(|model| model.available).count();
             let model_count = models.len();
             let availability = if model_count == 0 || available_count == 0 {
@@ -170,9 +184,8 @@ pub(crate) fn resolved_model_providers_from_availability_for_runtime(
                 .or_else(|| {
                     if provider.is_some() {
                         config.and_then(|config| {
-                            parsed_provider_id
-                                .as_ref()
-                                .map(|provider_id| provider_source_for_config(config, provider_id))
+                            provider
+                                .map(|provider| provider_source_for_config(config, &provider.id))
                         })
                     } else {
                         None
@@ -185,7 +198,20 @@ pub(crate) fn resolved_model_providers_from_availability_for_runtime(
 
             ModelProviderEntry {
                 id: provider_id.clone(),
-                display_name: Some(provider_id.clone()),
+                provider_family: first_model
+                    .map(|model| model.provider_family.clone())
+                    .or_else(|| {
+                        provider.map(|provider| provider.route_provider.as_str().to_string())
+                    })
+                    .unwrap_or_else(|| provider_id.clone()),
+                endpoint: first_model
+                    .map(|model| model.endpoint.clone())
+                    .or_else(|| {
+                        provider.map(|provider| provider.route_endpoint.as_str().to_string())
+                    })
+                    .unwrap_or_else(|| "default".to_string()),
+                route_provider: route_provider_id.to_string(),
+                display_name: first_model.map(|model| model.provider_family.clone()),
                 availability,
                 provider_configured,
                 provider_source,
@@ -199,8 +225,10 @@ pub(crate) fn resolved_model_providers_from_availability_for_runtime(
                     .and_then(|model| model.credential_kind.clone())
                     .or_else(|| provider.map(|provider| provider.auth.kind.as_str().to_string())),
                 credential_configured,
-                default_model: config
-                    .and_then(|config| default_model_for_provider(config, &provider_id)),
+                default_model: config.and_then(|config| {
+                    first_model
+                        .and_then(|model| default_model_for_provider(config, &model.provider))
+                }),
                 model_count,
                 discovered_model_count: models
                     .iter()
@@ -210,6 +238,14 @@ pub(crate) fn resolved_model_providers_from_availability_for_runtime(
             }
         })
         .collect()
+}
+
+fn provider_endpoint_group_id(provider_family: &str, endpoint: &str) -> String {
+    if endpoint == "default" {
+        provider_family.to_string()
+    } else {
+        format!("{provider_family}:{endpoint}")
+    }
 }
 
 pub fn resolved_provider_models(config: &AppConfig, provider: &str) -> Vec<ProviderModelEntry> {
@@ -223,7 +259,12 @@ pub(crate) fn provider_models_from_availability_for_runtime(
 ) -> Vec<ProviderModelEntry> {
     models
         .iter()
-        .filter(|model| model.provider == provider)
+        .filter(|model| {
+            model.provider == provider
+                || model.provider_family == provider
+                || model.route_provider == provider
+                || provider_endpoint_group_id(&model.provider_family, &model.endpoint) == provider
+        })
         .cloned()
         .into_iter()
         .map(|model| {
@@ -231,6 +272,9 @@ pub(crate) fn provider_models_from_availability_for_runtime(
             let supported_parameters = supported_model_parameters(&model);
             ProviderModelEntry {
                 provider: model.provider,
+                provider_family: model.provider_family,
+                endpoint: model.endpoint,
+                route_provider: model.route_provider,
                 id: model_id,
                 model_ref: model.model,
                 display_name: model.display_name,
@@ -268,6 +312,7 @@ fn resolved_model_availability_entry(
 ) -> ResolvedModelAvailability {
     let base_context = base_context_config(config);
     let policy = catalog.resolved_model_policy(&base_context, Some(model_ref));
+    let route = catalog.resolve_model_route(&base_context, model_ref, ModelRouteCapability::Turn);
     let metadata_source = if config.validated_model_overrides.contains_key(model_ref) {
         "config_override".to_string()
     } else {
@@ -276,9 +321,13 @@ fn resolved_model_availability_entry(
             .and_then(|value| value.as_str().map(ToString::to_string))
             .unwrap_or_else(|| "unknown_fallback".to_string())
     };
-    let provider = config.providers.get(&model_ref.provider);
+    let route_provider = route
+        .as_ref()
+        .map(|route| route.endpoint.runtime_config.id.clone())
+        .unwrap_or_else(|| model_ref.provider.clone());
+    let provider = config.providers.get(&route_provider);
     let provider_configured = provider.is_some();
-    let provider_source = provider.map(|_| provider_source_for_config(config, &model_ref.provider));
+    let provider_source = provider.map(|_| provider_source_for_config(config, &route_provider));
     let credential_configured = provider
         .map(provider_static_credential_configured)
         .unwrap_or(false);
@@ -304,6 +353,17 @@ fn resolved_model_availability_entry(
     ResolvedModelAvailability {
         model: model_ref.as_string(),
         provider: model_ref.provider.as_str().to_string(),
+        provider_family: route
+            .as_ref()
+            .map(|route| route.endpoint.provider.as_str())
+            .unwrap_or_else(|| model_ref.provider.as_str())
+            .to_string(),
+        endpoint: route
+            .as_ref()
+            .map(|route| route.endpoint.endpoint.as_str())
+            .unwrap_or("default")
+            .to_string(),
+        route_provider: route_provider.as_str().to_string(),
         display_name: policy.display_name.clone(),
         metadata_source,
         provider_configured,
@@ -639,6 +699,52 @@ mod tests {
             .supported_parameters
             .iter()
             .any(|parameter| parameter == "max_output_tokens"));
+    }
+
+    #[test]
+    fn resolved_model_projection_preserves_canonical_provider_endpoint_and_route_provider() {
+        let mut fixture = test_config(Some("openai-key"));
+        let route_provider = ProviderId::parse("volcengine-agent").unwrap();
+        let built_ins = crate::config::built_in_provider_registry_with_settings(
+            &std::collections::HashMap::from([(
+                "VOLCENGINE_AGENT_API_KEY".to_string(),
+                "volcengine-key".to_string(),
+            )]),
+        )
+        .unwrap();
+        fixture.config.providers.insert(
+            route_provider.clone(),
+            built_ins.get(&route_provider).unwrap().clone(),
+        );
+        fixture.config.image_generation_model =
+            Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
+
+        let availability = resolved_model_availability(&fixture.config);
+        let seedream = availability
+            .iter()
+            .find(|entry| entry.model == "volcengine/doubao-seedream-5.0-lite")
+            .expect("canonical Volcengine model");
+        assert_eq!(seedream.provider, "volcengine");
+        assert_eq!(seedream.provider_family, "volcengine");
+        assert_eq!(seedream.endpoint, "plan");
+        assert_eq!(seedream.route_provider, "volcengine-agent");
+        assert!(seedream.policy.capabilities.image_generation);
+
+        let providers = resolved_model_providers(&fixture.config);
+        let volcengine = providers
+            .iter()
+            .find(|entry| entry.provider_family == "volcengine" && entry.endpoint == "plan")
+            .expect("Volcengine plan provider");
+        assert_eq!(volcengine.id, "volcengine:plan");
+        assert_eq!(volcengine.route_provider, "volcengine-agent");
+
+        let models = resolved_provider_models(&fixture.config, "volcengine:plan");
+        assert!(models.iter().any(|entry| {
+            entry.model_ref == "volcengine/doubao-seedream-5.0-lite"
+                && entry.provider_family == "volcengine"
+                && entry.endpoint == "plan"
+                && entry.route_provider == "volcengine-agent"
+        }));
     }
 
     #[test]

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -140,6 +140,9 @@ mod tests {
         };
         ProviderModelEntry {
             provider: "test".to_string(),
+            provider_family: "test".to_string(),
+            endpoint: "default".to_string(),
+            route_provider: "test".to_string(),
             id: model_ref.trim_start_matches("test/").to_string(),
             model_ref: model_ref.to_string(),
             display_name: model_ref.to_string(),

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -270,6 +270,9 @@ mod tests {
         ResolvedModelAvailability {
             model: model.into(),
             provider: model_ref.provider.as_str().into(),
+            provider_family: model_ref.provider.as_str().into(),
+            endpoint: "default".into(),
+            route_provider: model_ref.provider.as_str().into(),
             display_name: display_name.into(),
             metadata_source: "built_in_catalog".into(),
             provider_configured: true,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -282,6 +282,9 @@ fn sample_model_availability(
     crate::types::ResolvedModelAvailability {
         model: model.into(),
         provider: model_ref.provider.as_str().into(),
+        provider_family: model_ref.provider.as_str().into(),
+        endpoint: "default".into(),
+        route_provider: model_ref.provider.as_str().into(),
         display_name: display_name.into(),
         metadata_source: "remote_discovered".into(),
         provider_configured: true,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4758,6 +4758,9 @@ pub struct AgentModelState {
 pub struct ResolvedModelAvailability {
     pub model: String,
     pub provider: String,
+    pub provider_family: String,
+    pub endpoint: String,
+    pub route_provider: String,
     pub display_name: String,
     pub metadata_source: String,
     pub provider_configured: bool,
@@ -4794,6 +4797,9 @@ pub enum ModelAvailability {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModelProviderEntry {
     pub id: String,
+    pub provider_family: String,
+    pub endpoint: String,
+    pub route_provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     pub availability: ModelProviderAvailability,
@@ -4818,6 +4824,9 @@ pub struct ModelProviderEntry {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderModelEntry {
     pub provider: String,
+    pub provider_family: String,
+    pub endpoint: String,
+    pub route_provider: String,
     pub id: String,
     pub model_ref: String,
     pub display_name: String,

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -257,7 +257,7 @@ export function SettingsPage({
   const visionModels = useMemo(() => modelCatalog.options.filter((model) => model.available && model.supportsImageInput), [modelCatalog.options]);
   const imageGenModels = useMemo(() => modelCatalog.options.filter((model) => model.available && model.supportsImageGeneration), [modelCatalog.options]);
   const providersWithModels = useMemo(
-    () => new Set(modelCatalog.options.map((m) => m.provider)),
+    () => new Set(modelCatalog.options.map((model) => model.routeProvider)),
     [modelCatalog.options],
   );
   const sortedProviders = useMemo(
@@ -363,8 +363,16 @@ export function SettingsPage({
   const configuredProviderCount = surface?.providers.filter((provider) => provider.credentialConfigured).length ?? 0;
   const searchProviderCount = surface?.webSearchProviders.length ?? 0;
   const configuredSearchProviderCount = surface?.webSearchProviders.filter((provider) => provider.credentialConfigured).length ?? 0;
-  const visionProviderReady = visionDefault ? surface?.providers.find((provider) => provider.id === visionDefault.split("/")[0])?.credentialConfigured : undefined;
-  const imageGenProviderReady = imageGenDefault ? surface?.providers.find((provider) => provider.id === imageGenDefault.split("/")[0])?.credentialConfigured : undefined;
+  const visionRouteProvider = modelCatalog.options.find((model) => model.model === visionDefault)?.routeProvider
+    ?? visionDefault.split("/")[0];
+  const visionProviderReady = visionDefault
+    ? surface?.providers.find((provider) => provider.id === visionRouteProvider)?.credentialConfigured
+    : undefined;
+  const imageGenRouteProvider = modelCatalog.options.find((model) => model.model === imageGenDefault)?.routeProvider
+    ?? imageGenDefault.split("/")[0];
+  const imageGenProviderReady = imageGenDefault
+    ? surface?.providers.find((provider) => provider.id === imageGenRouteProvider)?.credentialConfigured
+    : undefined;
 
   async function saveRuntimeConfig() {
     setSaveMessage(undefined);
@@ -1571,6 +1579,9 @@ export function SettingsPage({
                           <StatusChip className={`settings-status ${model.available ? "available" : "unavailable"}`} tone={model.available ? "success" : "error"} iconOnly title={model.available ? t("settings.availableLabel") : t("settings.unavailableLabel")} />
                         </div>
                         <div role="cell">
+                          {model.endpoint !== "default" ? <span className="settings-pill">{model.endpoint}</span> : null}
+                          {model.supportsImageInput ? <span className="settings-pill">image input</span> : null}
+                          {model.supportsImageGeneration ? <span className="settings-pill">image generation</span> : null}
                           {model.supportsReasoningEffort ? <span className="settings-pill">reasoning</span> : null}
                           {model.unavailableReason ? <small>{model.unavailableReason}</small> : null}
                         </div>
@@ -1590,9 +1601,12 @@ export function SettingsPage({
 function groupModelsByProvider(options: RuntimeModelOption[]): Array<[string, RuntimeModelOption[]]> {
   const grouped = new Map<string, RuntimeModelOption[]>();
   for (const option of options) {
-    const models = grouped.get(option.provider) ?? [];
+    const provider = option.endpoint === "default"
+      ? option.providerFamily
+      : `${option.providerFamily} / ${option.endpoint}`;
+    const models = grouped.get(provider) ?? [];
     models.push(option);
-    grouped.set(option.provider, models);
+    grouped.set(provider, models);
   }
   return Array.from(grouped.entries()).sort(([left], [right]) => left.localeCompare(right));
 }

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -24,6 +24,66 @@ describe("projectModelOptions", () => {
       }),
     ]);
   });
+
+  it("preserves route identity and independent image capabilities from availability", () => {
+    const options = projectModelOptions({
+      model_availability: [
+        {
+          model: "volcengine/doubao-seedream-5.0-lite",
+          provider: "volcengine",
+          provider_family: "volcengine",
+          endpoint: "plan",
+          route_provider: "volcengine-agent",
+          available: true,
+          policy: {
+            capabilities: {
+              image_input: false,
+              image_generation: true,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(options).toEqual([
+      expect.objectContaining({
+        provider: "volcengine",
+        providerFamily: "volcengine",
+        endpoint: "plan",
+        routeProvider: "volcengine-agent",
+        supportsImageInput: false,
+        supportsImageGeneration: true,
+      }),
+    ]);
+  });
+
+  it("preserves route identity and image capabilities from available models", () => {
+    const options = projectModelOptions({
+      available_models: [
+        {
+          model: "volcengine/doubao-seed-2.0-pro",
+          provider: "volcengine",
+          provider_family: "volcengine",
+          endpoint: "plan",
+          route_provider: "volcengine-agent",
+          capabilities: {
+            image_input: true,
+            image_generation: false,
+          },
+        },
+      ],
+    });
+
+    expect(options[0]).toEqual(
+      expect.objectContaining({
+        providerFamily: "volcengine",
+        endpoint: "plan",
+        routeProvider: "volcengine-agent",
+        supportsImageInput: true,
+        supportsImageGeneration: false,
+      }),
+    );
+  });
 });
 
 describe("createRuntimeClient", () => {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -372,6 +372,9 @@ interface RuntimeModelsDto {
 interface RuntimeAvailableModelDto {
   model?: string;
   provider?: string;
+  provider_family?: string;
+  endpoint?: string;
+  route_provider?: string;
   display_name?: string;
   capabilities?: {
     image_input?: boolean;
@@ -394,6 +397,9 @@ interface RuntimeAvailableModelDto {
 interface ModelAvailabilityDto {
   model?: string;
   provider?: string;
+  provider_family?: string;
+  endpoint?: string;
+  route_provider?: string;
   display_name?: string;
   available?: boolean;
   unavailable_reason?: string;
@@ -1969,6 +1975,9 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
       .map((entry) => ({
         model: entry.model,
         provider: entry.provider ?? entry.model.split("/")[0] ?? "unknown",
+        providerFamily: entry.provider_family ?? entry.provider ?? entry.model.split("/")[0] ?? "unknown",
+        endpoint: entry.endpoint ?? "default",
+        routeProvider: entry.route_provider ?? entry.provider ?? entry.model.split("/")[0] ?? "unknown",
         displayName: entry.display_name ?? entry.model,
         available: entry.available ?? false,
         unavailableReason: entry.unavailable_reason,
@@ -1986,6 +1995,9 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
       return {
         model,
         provider: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.provider ?? model.split("/")[0] ?? "unknown"),
+        providerFamily: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.provider_family ?? entry.provider ?? model.split("/")[0] ?? "unknown"),
+        endpoint: typeof entry === "string" ? "default" : (entry.endpoint ?? "default"),
+        routeProvider: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.route_provider ?? entry.provider ?? model.split("/")[0] ?? "unknown"),
         displayName: typeof entry === "string" ? model : (entry.display_name ?? model),
         available: true,
         supportsImageInput: typeof entry === "string" ? false : (entry.capabilities?.image_input ?? false),

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -239,6 +239,9 @@ export interface AgentSummary {
 export interface RuntimeModelOption {
   model: string;
   provider: string;
+  providerFamily: string;
+  endpoint: string;
+  routeProvider: string;
   displayName: string;
   available: boolean;
   unavailableReason?: string;


### PR DESCRIPTION
## Summary
- project model catalog entries through their resolved runtime provider route so canonical providers such as `volcengine` retain endpoint-specific models without exposing legacy provider ids as separate product providers
- expose route metadata and distinct `image_input` / `image_generation` capabilities across the models API, provider-list tool, TUI, and Web GUI
- add separate Settings selectors for the default image-understanding and image-generation models, with capability-aware candidate filtering

## Runtime concept
This keeps model identity, logical provider, resolved endpoint/account, and model capabilities separate. Catalog consumers now use the resolved route projection while preserving endpoint identity where model names overlap.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test`
- `npm test` in `web-gui/app` (157 tests)
- `npm run typecheck` in `web-gui/app`
