### PR TITLE
feat: persist route-aware model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ holon config providers set deepseek \
   --credential-kind api_key \
   --credential-profile deepseek
 
-holon config set model.default "deepseek/deepseek-v4-pro"
+holon config set model.default "deepseek@default/deepseek-v4-pro"
 
 # Or use a local Codex login session / Codex subscription
-holon config set model.default "openai-codex/gpt-5.5"
+holon config set model.default "openai-codex@default/gpt-5.5"
 ```
 
 Inspect the configured state with:

--- a/docs/rfcs/extensible-model-provider-configuration.md
+++ b/docs/rfcs/extensible-model-provider-configuration.md
@@ -28,6 +28,65 @@ This RFC builds on:
 - `agent-profile-model.md`
 - `agent-control-plane-model.md`
 
+## Route-Aware Model Selection Amendment
+
+Model metadata identity and executable route identity are distinct:
+
+```rust
+pub struct ModelRef {
+    pub provider: ProviderId,
+    pub model: String,
+}
+
+pub struct ModelRouteRef {
+    pub provider: ProviderId,
+    pub endpoint: ProviderEndpointId,
+    pub model: String,
+}
+```
+
+`ModelRef`, serialized as `provider/model`, remains the logical identity for
+built-in/discovered metadata, `models.catalog`, aliases, and model policy
+lookup.
+
+`ModelRouteRef`, serialized canonically as `provider@endpoint/model`, is the
+persisted executable selection. It is used by:
+
+- `model.default`
+- `model.fallbacks`
+- `vision.default`
+- explicit `image_generation.default` values
+- agent `model_override`
+- pending fallback and requested/active model state
+
+The model remainder may contain `/`, so `provider/endpoint/model` is not an
+unambiguous syntax. Canonical serialization always includes the endpoint,
+including `@default`.
+
+Readers accept legacy `provider/model` selections and upgrade them using the
+existing built-in alias/catalog endpoint rule, falling back to the provider's
+`default` endpoint. Writers always persist canonical route refs. Reading legacy
+data does not silently rewrite it.
+
+Existing data can be inspected and explicitly migrated with:
+
+```bash
+holon config migrate-model-routes
+holon config migrate-model-routes --write
+```
+
+The first form is a dry-run across `config.json` and SQLite agent state.
+`--write` persists only after complete successful preflight. Config replacement
+is atomic and creates a one-time backup; agent-state updates use one SQLite
+transaction. Because the stores cannot share one transaction, migration is
+idempotent and reports each stage separately. Invalid or ambiguous input
+prevents partial writes.
+
+All later references in this RFC to `provider/model` as a runtime selection
+format should therefore be read as legacy-compatible input. Logical catalog
+keys remain `provider/model`; executable selections and resolved runtime model
+state use `ModelRouteRef`.
+
 ## Problem
 
 Holon's current model configuration is useful but still too tightly coupled to
@@ -62,7 +121,8 @@ agent override state will become one mixed configuration surface.
 
 ## Goals
 
-- keep `provider/model` as the canonical model reference format
+- keep `provider/model` as the logical catalog/policy reference format
+- use canonical `provider@endpoint/model` for executable selections
 - allow new providers without adding a new core enum variant for every provider
 - separate provider runtime configuration from model selection
 - separate model metadata from provider endpoint/auth configuration

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -266,7 +266,7 @@ holon config credentials set --kind api_key --stdin anthropic
 ### Set the default model
 
 ```bash
-holon config set model.default "anthropic/claude-sonnet-4-6"
+holon config set model.default "anthropic@default/claude-sonnet-4-6"
 ```
 
 ### Agent-level model override
@@ -274,7 +274,7 @@ holon config set model.default "anthropic/claude-sonnet-4-6"
 An agent can override the default model:
 
 ```bash
-holon agent model set "anthropic/claude-sonnet-4-6" reviewer
+holon agent model set "anthropic@default/claude-sonnet-4-6" reviewer
 ```
 
 See [Configuration reference](/reference/configuration.md) for more details on agent model overrides.

--- a/docs/website/getting-started/onboarding.md
+++ b/docs/website/getting-started/onboarding.md
@@ -70,8 +70,9 @@ Choose your default model. The wizard lists the provider's commonly used
 models with a short description. You can also type a custom model ID if your
 preferred model is not in the list.
 
-The selected model becomes `model.default` in your config. You can override it
-per-agent later with `holon agent model set`.
+The selected executable route becomes `model.default` in canonical
+`provider@endpoint/model` form. You can override it per-agent later with
+`holon agent model set`; legacy `provider/model` input remains accepted.
 
 ### 4. Search configuration
 

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -150,10 +150,19 @@ holon agent abort reviewer
 ### Model selection
 
 ```bash
-holon config set model.default "deepseek-anthropic/deepseek-v4-pro"
-holon agent model set "anthropic/claude-sonnet-4-6" reviewer
+holon config set model.default "deepseek-anthropic@default/deepseek-v4-pro"
+holon agent model set "anthropic@default/claude-sonnet-4-6" reviewer
 holon agent model get reviewer
 holon agent model clear reviewer
+```
+
+Executable model selections use canonical
+`provider@endpoint/model` route refs. Legacy `provider/model` input remains
+accepted. Inspect or rewrite persisted legacy values with:
+
+```bash
+holon config migrate-model-routes          # dry-run
+holon config migrate-model-routes --write  # validated canonical rewrite
 ```
 
 ### Daemon management

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -31,16 +31,16 @@ and description.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `model.default` | model_ref | Default provider/model, e.g. `"anthropic/claude-sonnet-4-6"` |
-| `model.fallbacks` | model_ref_list | Ordered fallback models when the default is unavailable |
+| `model.default` | model_route_ref | Default executable route, e.g. `"anthropic@default/claude-sonnet-4-6"` |
+| `model.fallbacks` | model_route_ref_list | Ordered executable fallback routes |
 | `runtime.disable_provider_fallback` | boolean | Disable provider/model fallback; require deterministic single-provider execution |
 
 ```bash
 # Set the default model
-holon config set model.default "deepseek-anthropic/deepseek-v4-pro"
+holon config set model.default "deepseek-anthropic@default/deepseek-v4-pro"
 
 # Add fallback models (JSON array)
-holon config set model.fallbacks '["anthropic/claude-sonnet-4-6","minimax/MiniMax-M2.7"]'
+holon config set model.fallbacks '["anthropic@default/claude-sonnet-4-6","minimax@default/MiniMax-M2.7"]'
 
 # Read current default
 holon config get model.default
@@ -55,6 +55,24 @@ holon config unset model.fallbacks
 ### Per-Model Policy
 
 The `models.catalog` key lets you override runtime metadata for specific provider/model refs. Keys under `model.unknown_fallback.*` control policy for models without built-in metadata.
+
+Model metadata and executable selection use distinct identities:
+
+- `provider/model` is a logical model ref used by `models.catalog`.
+- `provider@endpoint/model` is a model route ref used by defaults, fallbacks,
+  vision/image generation selections, and agent overrides.
+
+Legacy `provider/model` selection values remain accepted, but all new writes
+include the endpoint. Inspect or explicitly rewrite existing config and agent
+state with:
+
+```bash
+holon config migrate-model-routes          # dry-run
+holon config migrate-model-routes --write  # validated canonical rewrite
+```
+
+The write creates a one-time config backup and updates all agent state in a
+SQLite transaction. Invalid or ambiguous refs prevent partial writes.
 
 ### HTTP API CORS
 
@@ -195,9 +213,9 @@ holon config set providers.volcengine.plans.image-openai.endpoint image-openai
 ```
 
 A plan maps a stable provider alias such as `volcengine-image-openai` onto a
-named endpoint while keeping the user-facing model reference shape
-`provider/model`. Existing built-in aliases and older `provider/model`
-references continue to work.
+named endpoint. Canonical selections persist that route explicitly, for example
+`volcengine@image-openai/model-id`. Existing built-in aliases and older
+`provider/model` references continue to work as compatible inputs.
 
 ### Removing a Provider
 
@@ -257,7 +275,7 @@ This shows each model's availability, credential status, provider, transport, an
 Each agent can override the default model:
 
 ```bash
-holon agent model set "anthropic/claude-sonnet-4-6" reviewer
+holon agent model set "anthropic@default/claude-sonnet-4-6" reviewer
 ```
 
 The override is stored in the agent's own configuration, not the global `model.default`.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -664,6 +664,163 @@
         "title": "MemoryGetResult",
         "type": "object"
       },
+      "ModelConfigMigrationReport": {
+        "properties": {
+          "agent_state": {
+            "properties": {
+              "backup_path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "changed": {
+                "type": "boolean"
+              },
+              "fields": {
+                "items": {
+                  "properties": {
+                    "current": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "proposed": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "canonical",
+                        "legacy",
+                        "invalid",
+                        "ambiguous"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "location",
+                    "status",
+                    "current"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "changed",
+              "fields"
+            ],
+            "type": "object"
+          },
+          "changed": {
+            "type": "boolean"
+          },
+          "config": {
+            "properties": {
+              "backup_path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "changed": {
+                "type": "boolean"
+              },
+              "fields": {
+                "items": {
+                  "properties": {
+                    "current": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "proposed": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "canonical",
+                        "legacy",
+                        "invalid",
+                        "ambiguous"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "location",
+                    "status",
+                    "current"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "changed",
+              "fields"
+            ],
+            "type": "object"
+          },
+          "config_file_path": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "runtime_db_path": {
+            "type": "string"
+          },
+          "write": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok",
+          "write",
+          "changed",
+          "config_file_path",
+          "runtime_db_path",
+          "config",
+          "agent_state"
+        ],
+        "title": "ModelConfigMigrationReport",
+        "type": "object"
+      },
+      "ModelConfigMigrationRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "write": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "title": "ModelConfigMigrationRequest",
+        "type": "object"
+      },
       "OperatorIngressRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -8336,6 +8493,64 @@
           }
         ],
         "summary": "Update runtime config",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/config/migrate-model-routes": {
+      "post": {
+        "description": "Inspect legacy model route references or persist a complete canonical migration across config.json and agent state.",
+        "operationId": "migrateModelConfigRoutes",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelConfigMigrationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelConfigMigrationReport"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Migrate model config routes",
         "tags": [
           "runtime"
         ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -302,6 +302,14 @@ pub enum ConfigCommands {
         #[command(subcommand)]
         command: ConfigModelCommands,
     },
+    #[command(about = "Inspect or rewrite legacy model selections as canonical route refs")]
+    MigrateModelRoutes {
+        #[arg(
+            long,
+            help = "Persist the migration after a complete successful preflight"
+        )]
+        write: bool,
+    },
     List,
     Schema,
     Doctor,

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,9 +14,9 @@ use crate::{
         AttachWorkspaceRequest, BatchGetMessagesRequest, BatchGetMessagesResponse,
         BatchGetTranscriptEntriesRequest, BatchGetTranscriptEntriesResponse,
         ClearAgentModelRequest, ControlPromptRequest, CreateAgentRequest, DebugPromptRequest,
-        DetachWorkspaceRequest, ExitWorkspaceRequest, RuntimeConfigReadResponse,
-        RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse, SetAgentModelRequest,
-        TaskInputRequest, TaskStopRequest,
+        DetachWorkspaceRequest, ExitWorkspaceRequest, ModelConfigMigrationRequest,
+        RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
+        SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
     },
     model_catalog::BuiltInModelMetadata,
     system::ExecutionSnapshot,
@@ -412,6 +412,17 @@ impl LocalClient {
     ) -> Result<RuntimeConfigUpdateResponse> {
         self.patch_control_json("/control/runtime/config", request)
             .await
+    }
+
+    pub async fn migrate_model_config_routes(
+        &self,
+        write: bool,
+    ) -> Result<crate::model_config_migration::ModelConfigMigrationReport> {
+        self.post_control_json(
+            "/control/runtime/config/migrate-model-routes",
+            &ModelConfigMigrationRequest { write },
+        )
+        .await
     }
 
     #[cfg(unix)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,11 +62,11 @@ pub struct AppConfig {
     pub config_file_path: PathBuf,
     pub stored_config: HolonConfigFile,
     pub web_config: crate::web::WebConfig,
-    pub default_model: ModelRef,
-    pub fallback_models: Vec<ModelRef>,
-    pub vision_model: Option<ModelRef>,
-    pub image_generation_model: Option<ModelRef>,
-    pub vision_candidate_models: Vec<ModelRef>,
+    pub default_model: ModelRouteRef,
+    pub fallback_models: Vec<ModelRouteRef>,
+    pub vision_model: Option<ModelRouteRef>,
+    pub image_generation_model: Option<ModelRouteRef>,
+    pub vision_candidate_models: Vec<ModelRouteRef>,
     pub runtime_max_output_tokens: u32,
     pub default_tool_output_tokens: u32,
     pub max_tool_output_tokens: u32,
@@ -138,7 +138,11 @@ impl AppConfig {
     /// exist in the builtin registry regardless of whether the service is running.
     pub fn default_provider_ready(&self) -> bool {
         self.providers
-            .get(&self.default_model.provider)
+            .values()
+            .find(|provider| {
+                provider.route_provider == self.default_model.provider
+                    && provider.route_endpoint == self.default_model.endpoint
+            })
             .map(provider_has_usable_auth)
             .unwrap_or(false)
     }
@@ -276,12 +280,19 @@ impl AppConfig {
             Ok(selection) => selection,
             Err(error) if mode.allow_unresolved_model() => {
                 tracing::debug!(error = %error, "using unresolved diagnostic model for config inspection");
-                (ModelRef::new(ProviderId::openai(), "unknown"), Vec::new())
+                (
+                    ModelRouteRef::new(
+                        ProviderId::openai(),
+                        ProviderEndpointId::default_endpoint(),
+                        "unknown",
+                    ),
+                    Vec::new(),
+                )
             }
             Err(error) => return Err(error),
         };
         let vision_candidate_models =
-            authenticated_model_candidates(&providers, &validated_model_overrides);
+            authenticated_model_route_candidates(&providers, &validated_model_overrides);
         let tui_alternate_screen = env::var("HOLON_TUI_ALTERNATE_SCREEN")
             .ok()
             .map(|value| AltScreenMode::parse(&value))
@@ -361,11 +372,14 @@ impl AppConfig {
         }
     }
 
-    pub fn provider_chain(&self) -> Vec<ModelRef> {
+    pub fn provider_chain(&self) -> Vec<ModelRouteRef> {
         RuntimeModelCatalog::from_config(self).provider_chain(None)
     }
 
-    pub fn provider_chain_with_override(&self, model_override: Option<&ModelRef>) -> Vec<ModelRef> {
+    pub fn provider_chain_with_override(
+        &self,
+        model_override: Option<&ModelRouteRef>,
+    ) -> Vec<ModelRouteRef> {
         RuntimeModelCatalog::from_config(self).provider_chain(model_override)
     }
 

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -6,6 +6,16 @@ pub struct ModelRef {
     pub model: String,
 }
 
+pub(crate) fn authenticated_model_route_candidates(
+    providers: &ProviderRegistry,
+    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+) -> Vec<ModelRouteRef> {
+    authenticated_model_candidates(providers, model_overrides)
+        .iter()
+        .map(ModelRouteRef::from_legacy_model_ref)
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProviderEndpointId(String);
 
@@ -56,6 +66,103 @@ impl<'de> Deserialize<'de> for ProviderEndpointId {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModelRouteRef {
+    pub provider: ProviderId,
+    pub endpoint: ProviderEndpointId,
+    pub model: String,
+}
+
+impl ModelRouteRef {
+    pub fn new(
+        provider: ProviderId,
+        endpoint: ProviderEndpointId,
+        model: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider,
+            endpoint,
+            model: model.into(),
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("model route ref must not be empty"));
+        }
+        let (route, model) = trimmed.split_once('/').ok_or_else(|| {
+            anyhow!("invalid model route ref {trimmed}; expected provider@endpoint/model")
+        })?;
+        let (provider, endpoint) = route.split_once('@').ok_or_else(|| {
+            anyhow!("invalid model route ref {trimmed}; expected provider@endpoint/model")
+        })?;
+        let provider = ProviderId::parse(provider)?;
+        let endpoint = ProviderEndpointId::parse(endpoint)?;
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(anyhow!(
+                "invalid model route ref {trimmed}; model part must not be empty"
+            ));
+        }
+        Ok(Self::new(provider, endpoint, model))
+    }
+
+    pub fn parse_compatible(value: &str) -> Result<Self> {
+        if value
+            .trim()
+            .split_once('/')
+            .is_some_and(|(route, _)| route.contains('@'))
+        {
+            return Self::parse(value);
+        }
+        let model_ref = ModelRef::parse(value)?;
+        Ok(Self::from_legacy_model_ref(&model_ref))
+    }
+
+    pub fn from_legacy_model_ref(model_ref: &ModelRef) -> Self {
+        let catalog = BuiltInModelCatalog::default();
+        let model_ref = catalog.canonicalize_model_ref(model_ref);
+        let endpoint = catalog
+            .get(&model_ref)
+            .and_then(|metadata| metadata.endpoint.clone())
+            .unwrap_or_else(ProviderEndpointId::default_endpoint);
+        Self::new(model_ref.provider, endpoint, model_ref.model)
+    }
+
+    pub fn model_ref(&self) -> ModelRef {
+        ModelRef::new(self.provider.clone(), self.model.clone())
+    }
+
+    pub fn as_string(&self) -> String {
+        format!(
+            "{}@{}/{}",
+            self.provider.as_str(),
+            self.endpoint.as_str(),
+            self.model
+        )
+    }
+}
+
+impl Serialize for ModelRouteRef {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.as_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for ModelRouteRef {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        ModelRouteRef::parse_compatible(&raw).map_err(D::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelRouteCapability {
     Turn,
@@ -100,6 +207,7 @@ impl ResolvedProviderEndpointConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedModelRoute {
+    pub route_ref: ModelRouteRef,
     pub model_ref: ModelRef,
     pub endpoint: ResolvedProviderEndpointConfig,
     pub policy: ResolvedRuntimeModelPolicy,
@@ -118,7 +226,7 @@ impl ResolvedModelRoute {
 
 pub(crate) fn resolve_image_generation_model(
     stored_config: &HolonConfigFile,
-) -> Result<Option<ModelRef>> {
+) -> Result<Option<ModelRouteRef>> {
     if let Ok(value) = env::var("HOLON_IMAGE_GENERATION_MODEL") {
         return parse_image_generation_model_ref(&value);
     }
@@ -128,21 +236,21 @@ pub(crate) fn resolve_image_generation_model(
     Ok(None)
 }
 
-fn parse_image_generation_model_ref(value: &str) -> Result<Option<ModelRef>> {
+fn parse_image_generation_model_ref(value: &str) -> Result<Option<ModelRouteRef>> {
     if value.trim().eq_ignore_ascii_case("auto") {
         Ok(None)
     } else {
-        ModelRef::parse(value).map(Some)
+        ModelRouteRef::parse_compatible(value).map(Some)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeModelCatalog {
-    pub default_model: ModelRef,
-    pub fallback_models: Vec<ModelRef>,
-    pub vision_model: Option<ModelRef>,
-    pub image_generation_model: Option<ModelRef>,
-    pub vision_candidate_models: Vec<ModelRef>,
+    pub default_model: ModelRouteRef,
+    pub fallback_models: Vec<ModelRouteRef>,
+    pub vision_model: Option<ModelRouteRef>,
+    pub image_generation_model: Option<ModelRouteRef>,
+    pub vision_candidate_models: Vec<ModelRouteRef>,
     pub disable_provider_fallback: bool,
     pub provider_endpoints: HashMap<ProviderId, ResolvedProviderEndpointConfig>,
     pub built_in_catalog: BuiltInModelCatalog,
@@ -192,6 +300,11 @@ impl RuntimeModelCatalog {
         let model_ref = &canonical_ref;
 
         let endpoint = self.resolve_endpoint_for_model(model_ref)?;
+        let route_ref = ModelRouteRef::new(
+            endpoint.provider.clone(),
+            endpoint.endpoint.clone(),
+            model_ref.model.clone(),
+        );
 
         let policy = self.built_in_catalog.resolve_policy(
             model_ref,
@@ -207,7 +320,40 @@ impl RuntimeModelCatalog {
             return None;
         }
         Some(ResolvedModelRoute {
+            route_ref,
             model_ref: model_ref.clone(),
+            endpoint: endpoint.clone(),
+            policy,
+            requested_capability,
+        })
+    }
+
+    pub fn resolve_explicit_model_route(
+        &self,
+        base_context_config: &ContextConfig,
+        route_ref: &ModelRouteRef,
+        requested_capability: ModelRouteCapability,
+    ) -> Option<ResolvedModelRoute> {
+        let model_ref = route_ref.model_ref();
+        let endpoint = self.provider_endpoints.values().find(|endpoint| {
+            endpoint.provider == route_ref.provider && endpoint.endpoint == route_ref.endpoint
+        })?;
+        let policy = self.built_in_catalog.resolve_policy(
+            &model_ref,
+            &self.model_overrides,
+            &self.discovered_models,
+            self.unknown_model_fallback.as_ref(),
+            base_context_config,
+            self.configured_runtime_max_output_tokens,
+        );
+        if !requested_capability.model_supports(&policy)
+            || !requested_capability.transport_supports(endpoint.runtime_config.transport)
+        {
+            return None;
+        }
+        Some(ResolvedModelRoute {
+            route_ref: route_ref.clone(),
+            model_ref,
             endpoint: endpoint.clone(),
             policy,
             requested_capability,
@@ -236,7 +382,7 @@ impl RuntimeModelCatalog {
         }
     }
 
-    pub fn provider_chain(&self, model_override: Option<&ModelRef>) -> Vec<ModelRef> {
+    pub fn provider_chain(&self, model_override: Option<&ModelRouteRef>) -> Vec<ModelRouteRef> {
         if self.disable_provider_fallback {
             return vec![self.effective_model(model_override)];
         }
@@ -255,9 +401,9 @@ impl RuntimeModelCatalog {
 
     pub fn provider_chain_for_turn(
         &self,
-        model_override: Option<&ModelRef>,
-        pending_fallback_model: Option<&ModelRef>,
-    ) -> Vec<ModelRef> {
+        model_override: Option<&ModelRouteRef>,
+        pending_fallback_model: Option<&ModelRouteRef>,
+    ) -> Vec<ModelRouteRef> {
         let chain = self.provider_chain(model_override);
         let Some(pending_fallback_model) = pending_fallback_model else {
             return chain;
@@ -269,7 +415,7 @@ impl RuntimeModelCatalog {
             .unwrap_or_else(|| vec![pending_fallback_model.clone()])
     }
 
-    pub fn effective_model(&self, model_override: Option<&ModelRef>) -> ModelRef {
+    pub fn effective_model(&self, model_override: Option<&ModelRouteRef>) -> ModelRouteRef {
         model_override
             .cloned()
             .unwrap_or_else(|| self.default_model.clone())
@@ -278,9 +424,9 @@ impl RuntimeModelCatalog {
     pub fn resolved_model_policy(
         &self,
         base_context_config: &ContextConfig,
-        model_override: Option<&ModelRef>,
+        model_override: Option<&ModelRouteRef>,
     ) -> ResolvedRuntimeModelPolicy {
-        let model_ref = self.effective_model(model_override);
+        let model_ref = self.effective_model(model_override).model_ref();
         self.built_in_catalog.resolve_policy(
             &model_ref,
             &self.model_overrides,
@@ -294,11 +440,12 @@ impl RuntimeModelCatalog {
     pub fn resolved_context_config(
         &self,
         base_context_config: &ContextConfig,
-        model_override: Option<&ModelRef>,
+        model_override: Option<&ModelRouteRef>,
     ) -> ContextConfig {
+        let model_ref = self.effective_model(model_override).model_ref();
         self.built_in_catalog
             .apply_policy(
-                &self.effective_model(model_override),
+                &model_ref,
                 &self.model_overrides,
                 &self.discovered_models,
                 self.unknown_model_fallback.as_ref(),
@@ -378,8 +525,8 @@ impl RuntimeModelCatalog {
     pub fn select_view_image_vision_model(
         &self,
         base_context_config: &ContextConfig,
-        model_override: Option<&ModelRef>,
-        pending_fallback_model: Option<&ModelRef>,
+        model_override: Option<&ModelRouteRef>,
+        pending_fallback_model: Option<&ModelRouteRef>,
     ) -> ViewImageVisionSelection {
         let chain = self.provider_chain_for_turn(model_override, pending_fallback_model);
         let primary = chain
@@ -421,17 +568,18 @@ impl RuntimeModelCatalog {
     pub(crate) fn select_view_image_vision_model_from_candidates(
         &self,
         base_context_config: &ContextConfig,
-        primary: ModelRef,
-        model_refs: Vec<ModelRef>,
+        primary: ModelRouteRef,
+        model_refs: Vec<ModelRouteRef>,
         selected_adapter_reason: &str,
         unavailable_reason: &str,
     ) -> ViewImageVisionSelection {
         let mut candidates = Vec::new();
         let mut selected = None;
 
-        for model_ref in &model_refs {
+        for route_ref in &model_refs {
+            let model_ref = route_ref.model_ref();
             let policy = self.built_in_catalog.resolve_policy(
-                model_ref,
+                &model_ref,
                 &self.model_overrides,
                 &self.discovered_models,
                 self.unknown_model_fallback.as_ref(),
@@ -441,7 +589,11 @@ impl RuntimeModelCatalog {
             let image_input = policy.capabilities.image_input;
             let supported_transport = self
                 .provider_endpoints
-                .get(&model_ref.provider)
+                .values()
+                .find(|endpoint| {
+                    endpoint.provider == route_ref.provider
+                        && endpoint.endpoint == route_ref.endpoint
+                })
                 .is_some_and(|endpoint| {
                     ModelRouteCapability::VisionObservation
                         .transport_supports(endpoint.runtime_config.transport)
@@ -454,22 +606,22 @@ impl RuntimeModelCatalog {
                 "provider_transport_unsupported_for_view_image_observation"
             };
             candidates.push(ViewImageVisionCandidate {
-                provider: model_ref.provider.as_str().to_string(),
-                model: model_ref.model.clone(),
-                model_ref: model_ref.as_string(),
+                provider: route_ref.provider.as_str().to_string(),
+                model: route_ref.model.clone(),
+                model_ref: route_ref.as_string(),
                 image_input,
                 reason: reason.to_string(),
             });
             if self
-                .resolve_model_route(
+                .resolve_explicit_model_route(
                     base_context_config,
-                    model_ref,
+                    route_ref,
                     ModelRouteCapability::VisionObservation,
                 )
                 .is_some()
                 && selected.is_none()
             {
-                selected = Some(model_ref.clone());
+                selected = Some(route_ref.clone());
             }
         }
 
@@ -509,8 +661,8 @@ impl RuntimeModelCatalog {
     pub fn select_generate_image_route(
         &self,
         base_context_config: &ContextConfig,
-        model_override: Option<&ModelRef>,
-        pending_fallback_model: Option<&ModelRef>,
+        model_override: Option<&ModelRouteRef>,
+        pending_fallback_model: Option<&ModelRouteRef>,
     ) -> Option<ResolvedModelRoute> {
         let candidates = self
             .image_generation_model
@@ -520,7 +672,7 @@ impl RuntimeModelCatalog {
                 self.provider_chain_for_turn(model_override, pending_fallback_model)
             });
         candidates.into_iter().find_map(|model_ref| {
-            self.resolve_model_route(
+            self.resolve_explicit_model_route(
                 base_context_config,
                 &model_ref,
                 ModelRouteCapability::ImageGeneration,
@@ -531,22 +683,23 @@ impl RuntimeModelCatalog {
     pub fn select_generate_image_model(
         &self,
         base_context_config: &ContextConfig,
-        model_override: Option<&ModelRef>,
-        pending_fallback_model: Option<&ModelRef>,
-    ) -> Option<ModelRef> {
+        model_override: Option<&ModelRouteRef>,
+        pending_fallback_model: Option<&ModelRouteRef>,
+    ) -> Option<ModelRouteRef> {
         self.select_generate_image_route(
             base_context_config,
             model_override,
             pending_fallback_model,
         )
-        .map(|route| route.model_ref)
+        .map(|route| route.route_ref)
     }
 }
 
 impl Default for RuntimeModelCatalog {
     fn default() -> Self {
         Self {
-            default_model: ModelRef::parse("openai/gpt-5.4").expect("valid default model ref"),
+            default_model: ModelRouteRef::parse("openai@default/gpt-5.4")
+                .expect("valid default model route ref"),
             fallback_models: Vec::new(),
             vision_model: None,
             image_generation_model: None,
@@ -666,15 +819,20 @@ pub(crate) fn validate_optional_model_runtime_override(
 }
 
 pub(crate) fn resolve_model_selection_for_load_mode(
-    explicit_default: Option<ModelRef>,
-    explicit_fallbacks: Option<Vec<ModelRef>>,
+    explicit_default: Option<ModelRouteRef>,
+    explicit_fallbacks: Option<Vec<ModelRouteRef>>,
     providers: &ProviderRegistry,
     model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
     mode: ConfigLoadMode,
-) -> Result<(ModelRef, Vec<ModelRef>)> {
+) -> Result<(ModelRouteRef, Vec<ModelRouteRef>)> {
     if mode.skip_authenticated_model_resolution() {
-        let default_model =
-            explicit_default.unwrap_or_else(|| ModelRef::new(ProviderId::openai(), "unknown"));
+        let default_model = explicit_default.unwrap_or_else(|| {
+            ModelRouteRef::new(
+                ProviderId::openai(),
+                ProviderEndpointId::default_endpoint(),
+                "unknown",
+            )
+        });
         let fallback_models = explicit_fallbacks.unwrap_or_default();
         return Ok((
             default_model.clone(),
@@ -691,13 +849,13 @@ pub(crate) fn resolve_model_selection_for_load_mode(
 }
 
 pub(crate) fn resolve_model_selection_from_explicit(
-    explicit_default: Option<ModelRef>,
-    explicit_fallbacks: Option<Vec<ModelRef>>,
+    explicit_default: Option<ModelRouteRef>,
+    explicit_fallbacks: Option<Vec<ModelRouteRef>>,
     providers: &ProviderRegistry,
     model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
-) -> Result<(ModelRef, Vec<ModelRef>)> {
+) -> Result<(ModelRouteRef, Vec<ModelRouteRef>)> {
     let auth_candidates = if explicit_default.is_none() || explicit_fallbacks.is_none() {
-        authenticated_model_candidates(providers, model_overrides)
+        authenticated_model_route_candidates(providers, model_overrides)
     } else {
         Vec::new()
     };
@@ -722,19 +880,21 @@ pub(crate) fn resolve_model_selection_from_explicit(
     ))
 }
 
-pub(crate) fn resolve_default_model(stored_config: &HolonConfigFile) -> Result<Option<ModelRef>> {
+pub(crate) fn resolve_default_model(
+    stored_config: &HolonConfigFile,
+) -> Result<Option<ModelRouteRef>> {
     if let Ok(value) = env::var("HOLON_MODEL") {
-        return ModelRef::parse(&value).map(Some);
+        return ModelRouteRef::parse_compatible(&value).map(Some);
     }
     if let Some(value) = &stored_config.model.default {
-        return ModelRef::parse(value).map(Some);
+        return ModelRouteRef::parse_compatible(value).map(Some);
     }
     Ok(None)
 }
 
 pub(crate) fn resolve_fallback_models(
     stored_config: &HolonConfigFile,
-) -> Result<Option<Vec<ModelRef>>> {
+) -> Result<Option<Vec<ModelRouteRef>>> {
     if let Ok(value) = env::var("HOLON_MODEL_FALLBACKS") {
         Ok(Some(parse_model_ref_list(&value)?))
     } else if !stored_config.model.fallbacks.is_empty() {
@@ -743,7 +903,7 @@ pub(crate) fn resolve_fallback_models(
                 .model
                 .fallbacks
                 .iter()
-                .map(|value| ModelRef::parse(value))
+                .map(|value| ModelRouteRef::parse_compatible(value))
                 .collect::<Result<Vec<_>>>()?,
         ))
     } else {
@@ -751,12 +911,14 @@ pub(crate) fn resolve_fallback_models(
     }
 }
 
-pub(crate) fn resolve_vision_model(stored_config: &HolonConfigFile) -> Result<Option<ModelRef>> {
+pub(crate) fn resolve_vision_model(
+    stored_config: &HolonConfigFile,
+) -> Result<Option<ModelRouteRef>> {
     if let Ok(value) = env::var("HOLON_VISION_MODEL") {
-        return ModelRef::parse(&value).map(Some);
+        return ModelRouteRef::parse_compatible(&value).map(Some);
     }
     if let Some(value) = &stored_config.vision.default {
-        return ModelRef::parse(value).map(Some);
+        return ModelRouteRef::parse_compatible(value).map(Some);
     }
     Ok(None)
 }
@@ -843,9 +1005,9 @@ pub(crate) fn preferred_override_model_for_provider(
 }
 
 pub(crate) fn dedupe_fallback_models(
-    configured: Vec<ModelRef>,
-    default_model: &ModelRef,
-) -> Vec<ModelRef> {
+    configured: Vec<ModelRouteRef>,
+    default_model: &ModelRouteRef,
+) -> Vec<ModelRouteRef> {
     configured
         .into_iter()
         .filter(|model| model != default_model)
@@ -857,16 +1019,16 @@ pub(crate) fn dedupe_fallback_models(
         })
 }
 
-pub(crate) fn parse_model_ref_list(raw_value: &str) -> Result<Vec<ModelRef>> {
+pub(crate) fn parse_model_ref_list(raw_value: &str) -> Result<Vec<ModelRouteRef>> {
     let trimmed = raw_value.trim();
     if trimmed.starts_with('[') {
         let values: Vec<String> =
             serde_json::from_str(trimmed).context("expected a JSON string array")?;
-        let parsed: Vec<ModelRef> = values
+        let parsed: Vec<ModelRouteRef> = values
             .iter()
             .map(|s| s.trim())
             .filter(|value| !value.is_empty())
-            .map(ModelRef::parse)
+            .map(ModelRouteRef::parse_compatible)
             .collect::<Result<Vec<_>>>()?;
         if parsed.is_empty() {
             return Err(anyhow!("model ref list must not be empty"));
@@ -877,7 +1039,7 @@ pub(crate) fn parse_model_ref_list(raw_value: &str) -> Result<Vec<ModelRef>> {
         .split(',')
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(ModelRef::parse)
+        .map(ModelRouteRef::parse_compatible)
         .collect::<Result<Vec<_>>>()?;
     if values.is_empty() {
         return Err(anyhow!("model ref list must not be empty"));
@@ -888,6 +1050,48 @@ pub(crate) fn parse_model_ref_list(raw_value: &str) -> Result<Vec<ModelRef>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn model_route_ref_round_trips_model_ids_with_slashes() {
+        let route_ref =
+            ModelRouteRef::parse("openrouter@default/anthropic/claude-3.5-sonnet").unwrap();
+        assert_eq!(route_ref.provider.as_str(), "openrouter");
+        assert_eq!(route_ref.endpoint.as_str(), "default");
+        assert_eq!(route_ref.model, "anthropic/claude-3.5-sonnet");
+        assert_eq!(
+            route_ref.as_string(),
+            "openrouter@default/anthropic/claude-3.5-sonnet"
+        );
+    }
+
+    #[test]
+    fn compatible_model_route_ref_keeps_legacy_model_remainder() {
+        let route_ref =
+            ModelRouteRef::parse_compatible("openrouter/anthropic/claude-3.5-sonnet").unwrap();
+        assert_eq!(route_ref.provider.as_str(), "openrouter");
+        assert_eq!(route_ref.endpoint.as_str(), "default");
+        assert_eq!(route_ref.model, "anthropic/claude-3.5-sonnet");
+    }
+
+    #[test]
+    fn compatible_model_route_ref_upgrades_builtin_endpoint() {
+        let route_ref =
+            ModelRouteRef::parse_compatible("volcengine-image-openai/doubao-seedream-5.0-lite")
+                .unwrap();
+        assert_eq!(route_ref.provider.as_str(), "volcengine");
+        assert_eq!(route_ref.endpoint.as_str(), "plan");
+        assert_eq!(route_ref.model, "doubao-seedream-5.0-lite");
+    }
+
+    #[test]
+    fn model_route_ref_deserializes_legacy_and_serializes_canonical() {
+        let route_ref: ModelRouteRef =
+            serde_json::from_str(r#""anthropic/claude-sonnet-4""#).unwrap();
+        assert_eq!(
+            serde_json::to_string(&route_ref).unwrap(),
+            r#""anthropic@default/claude-sonnet-4""#
+        );
+    }
 
     #[test]
     fn parse_model_ref_list_json_array() {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -56,32 +56,32 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         },
         ConfigSchemaEntry {
             key: "model.default",
-            kind: "model_ref",
-            description: "Explicit default provider/model ref. When unset, the runtime derives one from authenticated providers.",
+            kind: "model_route_ref",
+            description: "Explicit default provider@endpoint/model route ref. Legacy provider/model input remains accepted. When unset, the runtime derives one from authenticated providers.",
             default: Value::Null,
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
             key: "model.fallbacks",
-            kind: "model_ref_list",
+            kind: "model_route_ref_list",
             description:
-                "Explicit fallback provider/model refs. Null or an empty persisted list means unset; when unset, the runtime derives fallbacks from authenticated providers.",
+                "Explicit fallback provider@endpoint/model route refs. Legacy provider/model input remains accepted. Null or an empty persisted list means unset; when unset, the runtime derives fallbacks from authenticated providers.",
             default: Value::Null,
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
             key: "vision.default",
-            kind: "model_ref",
+            kind: "model_route_ref",
             description:
-                "Explicit provider/model ref for ViewImage visual observation generation. When unset, ViewImage auto-discovers an authenticated image-capable provider and keeps model.fallbacks only as a compatibility candidate source.",
+                "Explicit provider@endpoint/model route ref for ViewImage visual observation generation. Legacy provider/model input remains accepted. When unset, ViewImage auto-discovers an authenticated image-capable provider and keeps model.fallbacks only as a compatibility candidate source.",
             default: Value::Null,
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
             key: "image_generation.default",
-            kind: "model_ref_or_auto",
+            kind: "model_route_ref_or_auto",
             description:
-                "Provider/model ref for GenerateImage. The default auto mode selects the first configured turn model that supports image_generation.",
+                "Provider@endpoint/model route ref for GenerateImage. Legacy provider/model input remains accepted. The default auto mode selects the first configured turn model that supports image_generation.",
             default: json!("auto"),
             allowed_values: vec!["auto"],
         },
@@ -864,7 +864,7 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
             config.api.cors.max_age_seconds = Some(parse_positive_u64_key(key, raw_value)?);
         }
         "model.default" => {
-            let parsed = ModelRef::parse(raw_value)?;
+            let parsed = ModelRouteRef::parse_compatible(raw_value)?;
             config.model.default = Some(parsed.as_string());
         }
         "model.fallbacks" => {
@@ -874,14 +874,14 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 .collect();
         }
         "vision.default" => {
-            let parsed = ModelRef::parse(raw_value)?;
+            let parsed = ModelRouteRef::parse_compatible(raw_value)?;
             config.vision.default = Some(parsed.as_string());
         }
         "image_generation.default" => {
             if raw_value.trim().eq_ignore_ascii_case("auto") {
                 config.image_generation.default = None;
             } else {
-                let parsed = ModelRef::parse(raw_value)?;
+                let parsed = ModelRouteRef::parse_compatible(raw_value)?;
                 config.image_generation.default = Some(parsed.as_string());
             }
         }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -23,11 +23,11 @@ use crate::config::{
     save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
     validate_provider_config, AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig,
     ControlAuthMode, CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile,
-    ModelConfigFile, ModelRef, ModelRouteCapability, ModelsConfigFile, ProviderAuthConfig,
-    ProviderBuiltinWebSearchConfig, ProviderConfigFile, ProviderEndpointConfigFile,
-    ProviderEndpointId, ProviderId, ProviderPlanConfigFile, ProviderRegistry,
-    ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
-    OPENAI_CODEX_CREDENTIAL_PROFILE,
+    ModelConfigFile, ModelRef, ModelRouteCapability, ModelRouteRef, ModelsConfigFile,
+    ProviderAuthConfig, ProviderBuiltinWebSearchConfig, ProviderConfigFile,
+    ProviderEndpointConfigFile, ProviderEndpointId, ProviderId, ProviderPlanConfigFile,
+    ProviderRegistry, ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog,
+    DEFAULT_LOCAL_AGENT_ID, OPENAI_CODEX_CREDENTIAL_PROFILE,
 };
 
 struct EnvVarSnapshot {
@@ -123,6 +123,10 @@ struct TestAppConfigFixture {
     config: AppConfig,
 }
 
+fn route_ref(value: &str) -> ModelRouteRef {
+    ModelRouteRef::parse_compatible(value).unwrap()
+}
+
 fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConfigFixture {
     let home_dir = tempdir().unwrap();
     let workspace_dir = tempdir().unwrap();
@@ -150,10 +154,10 @@ fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConf
         api_cors: Default::default(),
         config_file_path: home_path.join("config.json"),
         stored_config: Default::default(),
-        default_model: ModelRef::parse(default_model).unwrap(),
+        default_model: route_ref(default_model),
         fallback_models: fallback_models
             .iter()
-            .map(|value| ModelRef::parse(value).unwrap())
+            .map(|value| route_ref(value))
             .collect(),
         vision_model: None,
         image_generation_model: None,
@@ -453,7 +457,7 @@ fn set_get_and_unset_round_trip_model_default() {
     set_config_key(&mut config, "model.default", "openai-codex/gpt-5.4").unwrap();
     assert_eq!(
         get_config_key(&config, "model.default").unwrap(),
-        json!("openai-codex/gpt-5.4")
+        json!("openai-codex@default/gpt-5.4")
     );
 
     unset_config_key(&mut config, "model.default").unwrap();
@@ -1659,23 +1663,26 @@ fn model_selection_explicit_config_wins() {
     );
 
     let (default_model, fallback_models) = super::resolve_model_selection_from_explicit(
-        Some(ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()),
+        Some(route_ref("anthropic/claude-sonnet-4-6")),
         Some(vec![
-            ModelRef::parse("openai/gpt-5.4").unwrap(),
-            ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            route_ref("openai/gpt-5.4"),
+            route_ref("anthropic/claude-sonnet-4-6"),
         ]),
         &providers,
         &HashMap::new(),
     )
     .unwrap();
 
-    assert_eq!(default_model.as_string(), "anthropic/claude-sonnet-4-6");
+    assert_eq!(
+        default_model.as_string(),
+        "anthropic@default/claude-sonnet-4-6"
+    );
     assert_eq!(
         fallback_models
             .into_iter()
             .map(|model| model.as_string())
             .collect::<Vec<_>>(),
-        vec!["openai/gpt-5.4"]
+        vec!["openai@default/gpt-5.4"]
     );
 }
 
@@ -1691,13 +1698,13 @@ fn model_selection_derives_from_authenticated_providers() {
         super::resolve_model_selection_from_explicit(None, None, &providers, &HashMap::new())
             .unwrap();
 
-    assert_eq!(default_model.as_string(), "openai/gpt-5.4");
+    assert_eq!(default_model.as_string(), "openai@default/gpt-5.4");
     assert_eq!(
         fallback_models
             .into_iter()
             .map(|model| model.as_string())
             .collect::<Vec<_>>(),
-        vec!["anthropic/claude-sonnet-4-6"]
+        vec!["anthropic@default/claude-sonnet-4-6"]
     );
 }
 
@@ -1808,7 +1815,7 @@ fn config_inspection_loads_provider_state_without_resolved_model() {
     assert_eq!(view.id, "custom-openai");
     assert!(view.configured_in_config);
     assert!(!view.credential_configured);
-    assert_eq!(config.default_model.as_string(), "openai/unknown");
+    assert_eq!(config.default_model.as_string(), "openai@default/unknown");
 }
 
 #[test]
@@ -1852,7 +1859,7 @@ fn model_selection_derives_custom_provider_from_catalog_override() {
     let (default_model, fallback_models) =
         super::resolve_model_selection_from_explicit(None, None, &providers, &overrides).unwrap();
 
-    assert_eq!(default_model.as_string(), "custom-openai/model-a");
+    assert_eq!(default_model.as_string(), "custom-openai@default/model-a");
     assert!(fallback_models.is_empty());
 }
 
@@ -1911,9 +1918,9 @@ fn provider_chain_preserves_effective_order_and_deduplicates() {
     assert_eq!(
         chain,
         vec![
-            "openai/gpt-5.4",
-            "anthropic/claude-sonnet-4-6",
-            "openai-codex/gpt-5.4",
+            "openai@default/gpt-5.4",
+            "anthropic@default/claude-sonnet-4-6",
+            "openai-codex@default/gpt-5.4",
         ]
     );
 }
@@ -1921,8 +1928,11 @@ fn provider_chain_preserves_effective_order_and_deduplicates() {
 #[test]
 fn provider_chain_returns_only_effective_model_when_fallback_disabled() {
     let mut fixture = test_app_config(
-        "openai/gpt-5.4",
-        &["anthropic/claude-sonnet-4-6", "openai-codex/gpt-5.4"],
+        "openai@default/gpt-5.4",
+        &[
+            "anthropic@default/claude-sonnet-4-6",
+            "openai-codex@default/gpt-5.4",
+        ],
     );
     fixture
         .config
@@ -1938,17 +1948,20 @@ fn provider_chain_returns_only_effective_model_when_fallback_disabled() {
         .map(|model| model.as_string())
         .collect::<Vec<_>>();
 
-    assert_eq!(chain, vec!["openai/gpt-5.4"]);
+    assert_eq!(chain, vec!["openai@default/gpt-5.4"]);
 }
 
 #[test]
 fn provider_chain_with_override_inserts_override_before_runtime_default() {
     let fixture = test_app_config(
-        "anthropic/claude-sonnet-4-6",
-        &["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"],
+        "anthropic@default/claude-sonnet-4-6",
+        &[
+            "openai@default/gpt-5.4",
+            "anthropic@default/claude-sonnet-4-6",
+        ],
     );
 
-    let override_model = ModelRef::parse("openai/gpt-5.4-mini").unwrap();
+    let override_model = route_ref("openai@default/gpt-5.4-mini");
     let chain = fixture
         .config
         .provider_chain_with_override(Some(&override_model))
@@ -1959,9 +1972,9 @@ fn provider_chain_with_override_inserts_override_before_runtime_default() {
     assert_eq!(
         chain,
         vec![
-            "openai/gpt-5.4-mini",
-            "anthropic/claude-sonnet-4-6",
-            "openai/gpt-5.4",
+            "openai@default/gpt-5.4-mini",
+            "anthropic@default/claude-sonnet-4-6",
+            "openai@default/gpt-5.4",
         ]
     );
 }
@@ -1969,14 +1982,14 @@ fn provider_chain_with_override_inserts_override_before_runtime_default() {
 #[test]
 fn provider_chain_for_turn_starts_at_pending_fallback_model() {
     let fixture = test_app_config(
-        "openai/gpt-5.4",
+        "openai@default/gpt-5.4",
         &[
-            "anthropic/claude-sonnet-4-6",
-            "openai-codex/gpt-5.3-codex-spark",
+            "anthropic@default/claude-sonnet-4-6",
+            "openai-codex@default/gpt-5.3-codex-spark",
         ],
     );
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
-    let pending = ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap();
+    let pending = route_ref("anthropic/claude-sonnet-4-6");
 
     let chain = catalog
         .provider_chain_for_turn(None, Some(&pending))
@@ -1987,8 +2000,8 @@ fn provider_chain_for_turn_starts_at_pending_fallback_model() {
     assert_eq!(
         chain,
         vec![
-            "anthropic/claude-sonnet-4-6",
-            "openai-codex/gpt-5.3-codex-spark",
+            "anthropic@default/claude-sonnet-4-6",
+            "openai-codex@default/gpt-5.3-codex-spark",
         ]
     );
 }
@@ -1996,8 +2009,8 @@ fn provider_chain_for_turn_starts_at_pending_fallback_model() {
 #[test]
 fn provider_chain_with_override_returns_only_override_when_fallback_disabled() {
     let mut fixture = test_app_config(
-        "anthropic/claude-sonnet-4-6",
-        &["openai/gpt-5.4", "openai-codex/gpt-5.4"],
+        "anthropic@default/claude-sonnet-4-6",
+        &["openai@default/gpt-5.4", "openai-codex@default/gpt-5.4"],
     );
     fixture
         .config
@@ -2006,7 +2019,7 @@ fn provider_chain_with_override_returns_only_override_when_fallback_disabled() {
         .disable_provider_fallback = Some(true);
     fixture.config.disable_provider_fallback = true;
 
-    let override_model = ModelRef::parse("openai/gpt-5.4-mini").unwrap();
+    let override_model = route_ref("openai/gpt-5.4-mini");
     let chain = fixture
         .config
         .provider_chain_with_override(Some(&override_model))
@@ -2014,16 +2027,16 @@ fn provider_chain_with_override_returns_only_override_when_fallback_disabled() {
         .map(|model| model.as_string())
         .collect::<Vec<_>>();
 
-    assert_eq!(chain, vec!["openai/gpt-5.4-mini"]);
+    assert_eq!(chain, vec!["openai@default/gpt-5.4-mini"]);
 }
 
 #[test]
-fn model_ref_serializes_as_string() {
-    let model_ref = ModelRef::parse("openai/gpt-5.4").unwrap();
+fn model_route_ref_serializes_as_string() {
+    let model_ref = ModelRouteRef::parse("openai@default/gpt-5.4").unwrap();
     let encoded = serde_json::to_value(&model_ref).unwrap();
-    assert_eq!(encoded, json!("openai/gpt-5.4"));
+    assert_eq!(encoded, json!("openai@default/gpt-5.4"));
 
-    let decoded: ModelRef = serde_json::from_value(encoded).unwrap();
+    let decoded: ModelRouteRef = serde_json::from_value(encoded).unwrap();
     assert_eq!(decoded, model_ref);
 }
 
@@ -2038,7 +2051,7 @@ fn persisted_config_round_trips() {
     let loaded = load_persisted_config_at(&path).unwrap();
     assert_eq!(
         get_config_key(&loaded, "model.default").unwrap(),
-        json!("openai/gpt-5.4")
+        json!("openai@default/gpt-5.4")
     );
 }
 
@@ -2355,10 +2368,8 @@ fn runtime_model_catalog_resolves_config_override_and_unknown_fallback() {
     assert_eq!(known.prompt_budget_estimated_tokens, 24_000);
     assert_eq!(known.runtime_max_output_tokens, 4_096);
 
-    let unknown = catalog.resolved_model_policy(
-        &base_context,
-        Some(&ModelRef::parse("openai/custom-model").unwrap()),
-    );
+    let unknown =
+        catalog.resolved_model_policy(&base_context, Some(&route_ref("openai/custom-model")));
     assert_eq!(unknown.prompt_budget_estimated_tokens, 12_000);
     assert_eq!(unknown.compaction_trigger_estimated_tokens, 10_000);
     assert_eq!(
@@ -2370,7 +2381,7 @@ fn runtime_model_catalog_resolves_config_override_and_unknown_fallback() {
 #[test]
 fn view_image_vision_selection_uses_primary_when_image_capable() {
     let mut fixture = test_app_config("openai/gpt-5.4", &["anthropic/claude-sonnet-4-6"]);
-    fixture.config.vision_candidate_models = vec![ModelRef::parse("openai/gpt-5.4").unwrap()];
+    fixture.config.vision_candidate_models = vec![route_ref("openai/gpt-5.4")];
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selection = catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
@@ -2390,7 +2401,7 @@ fn view_image_vision_selection_uses_primary_when_image_capable() {
 #[test]
 fn view_image_vision_selection_uses_explicit_vision_model() {
     let mut fixture = test_app_config("arcee/trinity-mini", &["openai/gpt-5.4-mini"]);
-    fixture.config.vision_model = Some(ModelRef::parse("openai/gpt-5.4").unwrap());
+    fixture.config.vision_model = Some(route_ref("openai/gpt-5.4"));
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selection = catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
@@ -2414,7 +2425,7 @@ fn view_image_vision_selection_uses_explicit_vision_model() {
 #[test]
 fn view_image_vision_selection_auto_discovers_authenticated_adapter() {
     let mut fixture = test_app_config("arcee/trinity-mini", &[]);
-    fixture.config.vision_candidate_models = vec![ModelRef::parse("openai/gpt-5.4-mini").unwrap()];
+    fixture.config.vision_candidate_models = vec![route_ref("openai/gpt-5.4-mini")];
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selection = catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
@@ -2440,7 +2451,8 @@ fn view_image_vision_selection_auto_discovers_authenticated_adapter() {
 fn view_image_vision_selection_uses_configured_custom_auto_discovery_capabilities() {
     let mut fixture = test_app_config("arcee/trinity-mini", &[]);
     let custom_model = ModelRef::parse("custom-openai/my-vision-model").unwrap();
-    fixture.config.vision_candidate_models = vec![custom_model.clone()];
+    fixture.config.vision_candidate_models =
+        vec![ModelRouteRef::from_legacy_model_ref(&custom_model)];
     fixture.config.providers.insert(
         custom_model.provider.clone(),
         ProviderRuntimeConfig {
@@ -2513,8 +2525,7 @@ fn view_image_vision_selection_uses_configured_custom_auto_discovery_capabilitie
 #[test]
 fn view_image_vision_selection_uses_anthropic_messages_when_image_capable() {
     let mut fixture = test_app_config("anthropic/claude-sonnet-4-6", &[]);
-    fixture.config.vision_candidate_models =
-        vec![ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()];
+    fixture.config.vision_candidate_models = vec![route_ref("anthropic/claude-sonnet-4-6")];
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selection = catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
@@ -2543,7 +2554,7 @@ fn view_image_vision_selection_uses_anthropic_messages_when_image_capable() {
 #[test]
 fn view_image_vision_selection_skips_image_capable_unsupported_transports() {
     let mut fixture = test_app_config("gemini/gemini-2.5-pro", &[]);
-    fixture.config.vision_candidate_models = vec![ModelRef::parse("openai/gpt-5.4-mini").unwrap()];
+    fixture.config.vision_candidate_models = vec![route_ref("openai/gpt-5.4-mini")];
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selection = catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
@@ -2620,8 +2631,8 @@ fn view_image_vision_selection_prefers_primary_over_other_candidates() {
     // be selected first because it is tried before other candidates.
     let mut fixture = test_app_config("openai/gpt-5.4", &["anthropic/claude-sonnet-4-6"]);
     fixture.config.vision_candidate_models = vec![
-        ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-        ModelRef::parse("openai/gpt-5.4").unwrap(),
+        route_ref("anthropic/claude-sonnet-4-6"),
+        route_ref("openai/gpt-5.4"),
     ];
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
@@ -2740,11 +2751,11 @@ fn image_generation_config_accepts_explicit_model_ref() {
 
     assert_eq!(
         config.image_generation.default.as_deref(),
-        Some("openai-codex/gpt-5.5")
+        Some("openai-codex@default/gpt-5.5")
     );
     assert_eq!(
         get_config_key(&config, "image_generation.default").unwrap(),
-        json!("openai-codex/gpt-5.5")
+        json!("openai-codex@default/gpt-5.5")
     );
 
     unset_config_key(&mut config, "image_generation.default").unwrap();
@@ -2763,26 +2774,26 @@ fn generate_image_selection_auto_uses_turn_chain() {
         .select_generate_image_model(&ContextConfig::default(), None, None)
         .unwrap();
 
-    assert_eq!(selected.as_string(), "openai/gpt-image-2");
+    assert_eq!(selected.as_string(), "openai@default/gpt-image-2");
 }
 
 #[test]
 fn generate_image_selection_uses_explicit_image_generation_model() {
-    let mut fixture = test_app_config("openai/gpt-image-2", &[]);
-    fixture.config.image_generation_model = Some(ModelRef::parse("openai-codex/gpt-5.5").unwrap());
+    let mut fixture = test_app_config("openai@default/gpt-image-2", &[]);
+    fixture.config.image_generation_model = Some(route_ref("openai-codex@default/gpt-5.5"));
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selected = catalog
         .select_generate_image_model(&ContextConfig::default(), None, None)
         .unwrap();
 
-    assert_eq!(selected.as_string(), "openai-codex/gpt-5.5");
+    assert_eq!(selected.as_string(), "openai-codex@default/gpt-5.5");
 }
 
 #[test]
 fn generate_image_selection_requires_explicit_model_capability() {
-    let mut fixture = test_app_config("openai/gpt-image-2", &[]);
-    fixture.config.image_generation_model = Some(ModelRef::parse("openai/gpt-5.4").unwrap());
+    let mut fixture = test_app_config("openai@default/gpt-image-2", &[]);
+    fixture.config.image_generation_model = Some(route_ref("openai@default/gpt-5.4"));
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     assert!(catalog
@@ -2792,9 +2803,10 @@ fn generate_image_selection_requires_explicit_model_capability() {
 
 #[test]
 fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
-    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
-    fixture.config.image_generation_model =
-        Some(ModelRef::parse("volcengine-image-openai/doubao-seedream-5.0-lite").unwrap());
+    let mut fixture = test_app_config("openai@default/gpt-5.4", &[]);
+    fixture.config.image_generation_model = Some(route_ref(
+        "volcengine-image-openai/doubao-seedream-5.0-lite",
+    ));
     fixture.config.providers.insert(
         ProviderId::parse("volcengine-image-openai").unwrap(),
         ProviderRuntimeConfig {
@@ -2819,14 +2831,17 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
         .select_generate_image_model(&ContextConfig::default(), None, None)
         .unwrap();
 
-    assert_eq!(selected.as_string(), "volcengine/doubao-seedream-5.0-lite");
+    assert_eq!(
+        selected.as_string(),
+        "volcengine@plan/doubao-seedream-5.0-lite"
+    );
 }
 
 #[test]
 fn generate_image_selection_accepts_canonical_volcengine_seedream() {
-    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
+    let mut fixture = test_app_config("openai@default/gpt-5.4", &[]);
     fixture.config.image_generation_model =
-        Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
+        Some(route_ref("volcengine@plan/doubao-seedream-5.0-lite"));
     let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
@@ -2839,14 +2854,17 @@ fn generate_image_selection_accepts_canonical_volcengine_seedream() {
         .select_generate_image_model(&ContextConfig::default(), None, None)
         .unwrap();
 
-    assert_eq!(selected.as_string(), "volcengine/doubao-seedream-5.0-lite");
+    assert_eq!(
+        selected.as_string(),
+        "volcengine@plan/doubao-seedream-5.0-lite"
+    );
 }
 
 #[test]
 fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
-    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
+    let mut fixture = test_app_config("openai@default/gpt-5.4", &[]);
     fixture.config.image_generation_model =
-        Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
+        Some(route_ref("volcengine@plan/doubao-seedream-5.0-lite"));
     let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
@@ -3070,7 +3088,7 @@ fn default_provider_ready_false_for_credential_source_none() {
             builtin_web_search: None,
         },
     );
-    fixture.config.default_model = ModelRef::parse("vllm/test-model").unwrap();
+    fixture.config.default_model = route_ref("vllm/test-model");
     assert!(
         !fixture.config.default_provider_ready(),
         "CredentialSource::None providers should not be considered ready"
@@ -3080,7 +3098,7 @@ fn default_provider_ready_false_for_credential_source_none() {
 #[test]
 fn default_provider_ready_false_when_provider_missing() {
     let mut fixture = test_app_config("openai/gpt-4o", &[]);
-    fixture.config.default_model = ModelRef::parse("nonexistent/model").unwrap();
+    fixture.config.default_model = route_ref("nonexistent/model");
     assert!(
         !fixture.config.default_provider_ready(),
         "missing provider should not be ready"

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -13,7 +13,7 @@ use super::{
     runtime_activity_summary, DaemonLifecycleState, RuntimeActivityState, RuntimeConfigSurface,
     RuntimeControlAuthMode, RuntimeServiceMetadata, RuntimeStartupSurface, RuntimeStatusResponse,
 };
-use crate::config::{provider_registry_for_tests, AppConfig, ModelRef, ProviderId};
+use crate::config::{provider_registry_for_tests, AppConfig, ProviderId};
 use crate::{
     host::RuntimeHost,
     provider::StubProvider,
@@ -78,10 +78,11 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home.path().join("config.json"),
         stored_config: Default::default(),
-        default_model: ModelRef {
-            provider: ProviderId::anthropic(),
-            model: "claude-sonnet-4-6".into(),
-        },
+        default_model: crate::config::ModelRouteRef::new(
+            ProviderId::anthropic(),
+            crate::config::ProviderEndpointId::default_endpoint(),
+            "claude-sonnet-4-6",
+        ),
         fallback_models: vec![],
         vision_model: None,
         image_generation_model: None,

--- a/src/host.rs
+++ b/src/host.rs
@@ -159,7 +159,9 @@ async fn apply_spawn_model_resolution(
         return Ok(());
     }
     let provider = crate::config::ProviderId::parse(&resolution.resolved_provider)?;
-    let model_ref = crate::config::ModelRef::new(provider, resolution.resolved_model.clone());
+    let model_ref = crate::config::ModelRouteRef::from_legacy_model_ref(
+        &crate::config::ModelRef::new(provider, resolution.resolved_model.clone()),
+    );
     let reasoning_effort = resolution
         .resolved_parameters
         .as_ref()
@@ -1115,7 +1117,8 @@ impl RuntimeHost {
             .clone()
             .map(Ok)
             .unwrap_or_else(|| build_provider_from_config(&config))?;
-        let apply_patch_surface = ApplyPatchSurface::for_model_ref(&model_ref.as_string());
+        let apply_patch_surface =
+            ApplyPatchSurface::for_model_ref(&model_ref.model_ref().as_string());
         let registry = ToolRegistry::new(execution.execution_root.clone());
         let available_tools = registry
             .tool_specs_with_families_for_apply_patch_surface(apply_patch_surface)?
@@ -2192,7 +2195,7 @@ mod tests {
     use tokio::sync::Notify;
 
     use crate::{
-        config::{provider_registry_for_tests, ControlAuthMode, ModelRef},
+        config::{provider_registry_for_tests, ControlAuthMode, ModelRouteRef},
         provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
         runtime::RuntimeHandle,
         runtime_db::RuntimeDb,
@@ -2371,7 +2374,7 @@ mod tests {
             api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
-            default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            default_model: ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
             image_generation_model: None,
@@ -2657,7 +2660,10 @@ mod tests {
         let host = RuntimeHost::new(fixture.config).unwrap();
         let parent = host.default_runtime().await.unwrap();
         parent
-            .set_model_override(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap(), None)
+            .set_model_override(
+                ModelRouteRef::parse_compatible("anthropic/claude-haiku-4-5").unwrap(),
+                None,
+            )
             .await
             .unwrap();
 
@@ -2832,7 +2838,7 @@ mod tests {
         let child_summary = child.agent_summary().await.unwrap();
         assert_eq!(
             child_summary.model.override_model.unwrap().as_string(),
-            "anthropic/claude-haiku-4-5"
+            "anthropic@default/claude-haiku-4-5"
         );
         assert_eq!(
             child_summary.model.override_reasoning_effort.as_deref(),
@@ -3056,7 +3062,7 @@ mod tests {
         );
         assert_eq!(
             inherited.model.effective_model.as_string(),
-            "anthropic/claude-sonnet-4-6"
+            "anthropic@default/claude-sonnet-4-6"
         );
         assert!(inherited.model.override_model.is_none());
         assert_eq!(
@@ -3068,17 +3074,23 @@ mod tests {
         );
 
         let updated = runtime
-            .set_model_override(ModelRef::parse("openai/gpt-5.4").unwrap(), None)
+            .set_model_override(
+                ModelRouteRef::parse_compatible("openai@default/gpt-5.4").unwrap(),
+                None,
+            )
             .await
             .unwrap();
         assert_eq!(
             updated.source,
             crate::types::AgentModelSource::AgentOverride
         );
-        assert_eq!(updated.effective_model.as_string(), "openai/gpt-5.4");
+        assert_eq!(
+            updated.effective_model.as_string(),
+            "openai@default/gpt-5.4"
+        );
         assert_eq!(
             updated.runtime_default_model.as_string(),
-            "anthropic/claude-sonnet-4-6"
+            "anthropic@default/claude-sonnet-4-6"
         );
         assert_eq!(
             updated
@@ -3086,7 +3098,7 @@ mod tests {
                 .iter()
                 .map(|model| model.as_string())
                 .collect::<Vec<_>>(),
-            vec!["anthropic/claude-sonnet-4-6"]
+            vec!["anthropic@default/claude-sonnet-4-6"]
         );
         assert_eq!(
             updated.resolved_policy.prompt_budget_estimated_tokens,
@@ -3109,7 +3121,7 @@ mod tests {
         assert!(cleared.override_model.is_none());
         assert_eq!(
             cleared.effective_model.as_string(),
-            "anthropic/claude-sonnet-4-6"
+            "anthropic@default/claude-sonnet-4-6"
         );
         assert_eq!(
             cleared.resolved_policy.prompt_budget_estimated_tokens,
@@ -3131,7 +3143,8 @@ mod tests {
         )
         .unwrap();
         let mut state = AgentState::new("default");
-        state.model_override = Some(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap());
+        state.model_override =
+            Some(ModelRouteRef::parse_compatible("anthropic/claude-haiku-4-5").unwrap());
         storage.write_agent(&state).unwrap();
 
         let runtime = RuntimeHandle::new_reconfigurable_with_host_bridge(
@@ -3151,8 +3164,8 @@ mod tests {
         assert_eq!(
             runtime.current_provider().await.configured_model_refs(),
             vec![
-                "anthropic/claude-haiku-4-5".to_string(),
-                "anthropic/claude-sonnet-4-6".to_string(),
+                "anthropic@default/claude-haiku-4-5".to_string(),
+                "anthropic@default/claude-sonnet-4-6".to_string(),
             ]
         );
     }
@@ -3163,7 +3176,10 @@ mod tests {
         let host = RuntimeHost::new(fixture.config).unwrap();
         let parent = host.default_runtime().await.unwrap();
         parent
-            .set_model_override(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap(), None)
+            .set_model_override(
+                ModelRouteRef::parse_compatible("anthropic@default/claude-haiku-4-5").unwrap(),
+                None,
+            )
             .await
             .unwrap();
         let parent_state = parent.agent_state().await.unwrap();
@@ -3199,8 +3215,8 @@ mod tests {
         assert_eq!(
             child.current_provider().await.configured_model_refs(),
             vec![
-                "anthropic/claude-haiku-4-5".to_string(),
-                "anthropic/claude-sonnet-4-6".to_string(),
+                "anthropic@default/claude-haiku-4-5".to_string(),
+                "anthropic@default/claude-sonnet-4-6".to_string(),
             ]
         );
     }
@@ -4319,7 +4335,9 @@ mod tests {
         assert!(err
             .to_string()
             .contains("no available providers for configured model chain"));
-        assert!(err.to_string().contains("anthropic/claude-sonnet-4-6"));
+        assert!(err
+            .to_string()
+            .contains("anthropic@default/claude-sonnet-4-6"));
     }
 
     #[tokio::test]

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -69,6 +69,13 @@ pub struct RuntimeConfigUpdateRequest {
     pub updates: Vec<RuntimeConfigUpdateEntry>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ModelConfigMigrationRequest {
+    #[serde(default)]
+    pub write: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct RuntimeConfigUpdateEntry {
@@ -221,6 +228,29 @@ pub async fn runtime_config_update(
         results,
         runtime_surface: RuntimeConfigSurface::new(&config),
     }))
+}
+
+pub async fn runtime_config_migrate_model_routes(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<ModelConfigMigrationRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let config = state.host.config();
+    let report = crate::model_config_migration::migrate_model_config_routes(
+        &config.config_file_path,
+        state.host.runtime_db(),
+        request.write,
+    )
+    .map_err(error_response)?;
+    if request.write && report.ok && report.config.changed {
+        state
+            .host
+            .reload_all_agents_config()
+            .await
+            .map_err(error_response)?;
+    }
+    Ok(Json(report))
 }
 
 fn reject_accepted_runtime_config_results(results: &mut [RuntimeConfigUpdateResult], reason: &str) {
@@ -628,7 +658,7 @@ pub async fn set_agent_model(
     if let Some(reasoning_effort) = request.reasoning_effort.as_deref() {
         validate_reasoning_effort(reasoning_effort)?;
     }
-    let model = ModelRef::parse(&request.model).map_err(error_response)?;
+    let model = ModelRouteRef::parse_compatible(&request.model).map_err(error_response)?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -59,7 +59,8 @@ pub(crate) use crate::{
         credential_store_path, list_credential_profiles_at, load_credential_store_at,
         load_persisted_config_at, remove_credential_profile_at, save_persisted_config_at,
         set_config_key, set_credential_profile_at, unset_config_key, ApiCorsConfigFile,
-        ControlTransportKind, CredentialKind, CredentialProfileStatus, HolonConfigFile, ModelRef,
+        ControlTransportKind, CredentialKind, CredentialProfileStatus, HolonConfigFile,
+        ModelRouteRef,
     },
     daemon::{
         graceful_runtime_shutdown, runtime_activity_summary, RuntimeConfigSurface,
@@ -445,6 +446,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/control/runtime/config",
             patch(control::runtime_config_update),
+        )
+        .route(
+            "/control/runtime/config/migrate-model-routes",
+            post(control::runtime_config_migrate_model_routes),
         )
         .route("/control/runtime/shutdown", post(control::runtime_shutdown))
         .route(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod http;
 pub mod ingress;
 pub mod memory;
 pub mod model_catalog;
+pub mod model_config_migration;
 pub mod model_discovery;
 pub mod notes_catalog;
 pub mod object_query_cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1040,7 +1040,7 @@ async fn dump_prompt(
 mod tests {
     use super::*;
     use holon::{
-        config::{provider_registry_for_tests, AltScreenMode, ModelRef},
+        config::{provider_registry_for_tests, AltScreenMode, ModelRouteRef},
         runtime_db::RuntimeDb,
     };
 
@@ -1069,7 +1069,7 @@ mod tests {
             api_cors: Default::default(),
             config_file_path: home.join("config.json"),
             stored_config: Default::default(),
-            default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            default_model: ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
             image_generation_model: None,
@@ -3181,6 +3181,9 @@ async fn handle_config_command(command: ConfigCommands) -> Result<()> {
         ConfigCommands::Providers { command } => handle_config_providers_command(command).await,
         ConfigCommands::Credentials { command } => handle_config_credentials_command(command).await,
         ConfigCommands::Models { command } => handle_config_models_command(command).await,
+        ConfigCommands::MigrateModelRoutes { write } => {
+            config_migrate_model_routes_command(write).await
+        }
         ConfigCommands::List => config_list_command().await,
         ConfigCommands::Schema => config_schema_command().await,
         ConfigCommands::Doctor => {
@@ -3188,6 +3191,25 @@ async fn handle_config_command(command: ConfigCommands) -> Result<()> {
             print_json(&provider_doctor(&config))
         }
     }
+}
+
+async fn config_migrate_model_routes_command(write: bool) -> Result<()> {
+    if let Some((client, _response)) = local_runtime_config().await? {
+        let report = client.migrate_model_config_routes(write).await?;
+        return print_json(&serde_json::to_value(report)?);
+    }
+
+    let config = AppConfig::load_for_config_inspection()?;
+    let runtime_db = holon::runtime_db::RuntimeDb::open_and_migrate(
+        config.runtime_db_path(),
+        config.runtime_db_lock_path(),
+    )?;
+    let report = holon::model_config_migration::migrate_model_config_routes(
+        &config.config_file_path,
+        &runtime_db,
+        write,
+    )?;
+    print_json(&serde_json::to_value(report)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/model_config_migration.rs
+++ b/src/model_config_migration.rs
@@ -1,0 +1,559 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::params;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    config::{load_persisted_config_at, HolonConfigFile, ModelRouteRef},
+    runtime_db::RuntimeDb,
+};
+
+const AGENT_MODEL_ROUTE_FIELDS: [&str; 4] = [
+    "model_override",
+    "pending_fallback_model",
+    "last_requested_model",
+    "last_active_model",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelConfigMigrationStatus {
+    Canonical,
+    Legacy,
+    Invalid,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ModelConfigMigrationField {
+    pub location: String,
+    pub status: ModelConfigMigrationStatus,
+    pub current: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposed: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+pub struct ModelConfigMigrationStoreReport {
+    pub changed: bool,
+    pub fields: Vec<ModelConfigMigrationField>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ModelConfigMigrationReport {
+    pub ok: bool,
+    pub write: bool,
+    pub changed: bool,
+    pub config_file_path: PathBuf,
+    pub runtime_db_path: PathBuf,
+    pub config: ModelConfigMigrationStoreReport,
+    pub agent_state: ModelConfigMigrationStoreReport,
+}
+
+#[derive(Debug)]
+struct ConfigInspection {
+    config: HolonConfigFile,
+    report: ModelConfigMigrationStoreReport,
+}
+
+#[derive(Debug)]
+struct AgentStateMutation {
+    agent_id: String,
+    payload_json: String,
+}
+
+#[derive(Debug)]
+struct AgentStateInspection {
+    mutations: Vec<AgentStateMutation>,
+    report: ModelConfigMigrationStoreReport,
+}
+
+pub fn migrate_model_config_routes(
+    config_file_path: &Path,
+    runtime_db: &RuntimeDb,
+    write: bool,
+) -> Result<ModelConfigMigrationReport> {
+    let mut config = inspect_config(config_file_path)?;
+    let agent_state = inspect_agent_state(runtime_db)?;
+    let ok = all_fields_valid(&config.report) && all_fields_valid(&agent_state.report);
+
+    if write && ok {
+        if config.report.changed {
+            let backup_path = backup_config_once(config_file_path)?;
+            write_config_atomically(config_file_path, &config.config)?;
+            config.report.backup_path = backup_path;
+        }
+        if agent_state.report.changed {
+            write_agent_state_mutations(runtime_db, &agent_state.mutations)?;
+        }
+    }
+
+    let changed = config.report.changed || agent_state.report.changed;
+    Ok(ModelConfigMigrationReport {
+        ok,
+        write,
+        changed,
+        config_file_path: config_file_path.to_path_buf(),
+        runtime_db_path: runtime_db.path().to_path_buf(),
+        config: config.report,
+        agent_state: agent_state.report,
+    })
+}
+
+fn inspect_config(path: &Path) -> Result<ConfigInspection> {
+    let mut config = load_persisted_config_at(path)?;
+    let mut report = ModelConfigMigrationStoreReport::default();
+
+    inspect_optional_route(
+        "model.default",
+        &mut config.model.default,
+        false,
+        &mut report,
+    );
+    for (index, value) in config.model.fallbacks.iter_mut().enumerate() {
+        inspect_route_value(
+            format!("model.fallbacks[{index}]"),
+            value,
+            false,
+            &mut report,
+        );
+    }
+    inspect_optional_route(
+        "vision.default",
+        &mut config.vision.default,
+        false,
+        &mut report,
+    );
+    inspect_optional_route(
+        "image_generation.default",
+        &mut config.image_generation.default,
+        true,
+        &mut report,
+    );
+
+    Ok(ConfigInspection { config, report })
+}
+
+fn inspect_optional_route(
+    location: &str,
+    value: &mut Option<String>,
+    allow_auto: bool,
+    report: &mut ModelConfigMigrationStoreReport,
+) {
+    if let Some(value) = value {
+        inspect_route_value(location.to_string(), value, allow_auto, report);
+    }
+}
+
+fn inspect_route_value(
+    location: String,
+    value: &mut String,
+    allow_auto: bool,
+    report: &mut ModelConfigMigrationStoreReport,
+) {
+    let current = value.clone();
+    if allow_auto && current.trim().eq_ignore_ascii_case("auto") {
+        report.fields.push(ModelConfigMigrationField {
+            location,
+            status: ModelConfigMigrationStatus::Canonical,
+            current,
+            proposed: None,
+            error: None,
+        });
+        return;
+    }
+
+    match ModelRouteRef::parse_compatible(&current) {
+        Ok(route_ref) => {
+            let canonical = route_ref.as_string();
+            let is_canonical = current == canonical;
+            if !is_canonical {
+                *value = canonical.clone();
+                report.changed = true;
+            }
+            report.fields.push(ModelConfigMigrationField {
+                location,
+                status: if is_canonical {
+                    ModelConfigMigrationStatus::Canonical
+                } else {
+                    ModelConfigMigrationStatus::Legacy
+                },
+                current,
+                proposed: (!is_canonical).then_some(canonical),
+                error: None,
+            });
+        }
+        Err(error) => report.fields.push(ModelConfigMigrationField {
+            location,
+            status: ModelConfigMigrationStatus::Invalid,
+            current,
+            proposed: None,
+            error: Some(error.to_string()),
+        }),
+    }
+}
+
+fn inspect_agent_state(runtime_db: &RuntimeDb) -> Result<AgentStateInspection> {
+    let connection = runtime_db.connection()?;
+    let mut statement =
+        connection.prepare("SELECT agent_id, payload_json FROM agent_states ORDER BY agent_id")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut mutations = Vec::new();
+    let mut report = ModelConfigMigrationStoreReport::default();
+
+    for row in rows {
+        let (agent_id, payload_json) = row?;
+        let mut payload: Value = serde_json::from_str(&payload_json)
+            .with_context(|| format!("failed to parse agent state payload for {agent_id}"))?;
+        let object = payload
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("agent state payload for {agent_id} must be a JSON object"))?;
+        let mut row_changed = false;
+
+        for field in AGENT_MODEL_ROUTE_FIELDS {
+            let Some(value) = object.get_mut(field) else {
+                continue;
+            };
+            if value.is_null() {
+                continue;
+            }
+            let Some(raw) = value.as_str() else {
+                report.fields.push(ModelConfigMigrationField {
+                    location: format!("agent_states[{agent_id}].{field}"),
+                    status: ModelConfigMigrationStatus::Invalid,
+                    current: value.to_string(),
+                    proposed: None,
+                    error: Some("model route value must be a string or null".into()),
+                });
+                continue;
+            };
+            let current = raw.to_string();
+            match ModelRouteRef::parse_compatible(&current) {
+                Ok(route_ref) => {
+                    let canonical = route_ref.as_string();
+                    let is_canonical = current == canonical;
+                    if !is_canonical {
+                        *value = Value::String(canonical.clone());
+                        row_changed = true;
+                        report.changed = true;
+                    }
+                    report.fields.push(ModelConfigMigrationField {
+                        location: format!("agent_states[{agent_id}].{field}"),
+                        status: if is_canonical {
+                            ModelConfigMigrationStatus::Canonical
+                        } else {
+                            ModelConfigMigrationStatus::Legacy
+                        },
+                        current,
+                        proposed: (!is_canonical).then_some(canonical),
+                        error: None,
+                    });
+                }
+                Err(error) => report.fields.push(ModelConfigMigrationField {
+                    location: format!("agent_states[{agent_id}].{field}"),
+                    status: ModelConfigMigrationStatus::Invalid,
+                    current,
+                    proposed: None,
+                    error: Some(error.to_string()),
+                }),
+            }
+        }
+
+        if row_changed {
+            mutations.push(AgentStateMutation {
+                agent_id,
+                payload_json: serde_json::to_string(&payload)?,
+            });
+        }
+    }
+
+    Ok(AgentStateInspection { mutations, report })
+}
+
+fn all_fields_valid(report: &ModelConfigMigrationStoreReport) -> bool {
+    report.fields.iter().all(|field| {
+        matches!(
+            field.status,
+            ModelConfigMigrationStatus::Canonical | ModelConfigMigrationStatus::Legacy
+        )
+    })
+}
+
+fn backup_config_once(path: &Path) -> Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let backup_path = path.with_extension("json.model-route-migration.bak");
+    if !backup_path.exists() {
+        fs::copy(path, &backup_path).with_context(|| {
+            format!(
+                "failed to back up {} to {}",
+                path.display(),
+                backup_path.display()
+            )
+        })?;
+        OpenOptions::new()
+            .read(true)
+            .open(&backup_path)?
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", backup_path.display()))?;
+    }
+    Ok(Some(backup_path))
+}
+
+fn write_config_atomically(path: &Path, config: &HolonConfigFile) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let temp_path = path.with_extension(format!("json.migrate-{}", std::process::id()));
+    let content = serde_json::to_vec_pretty(config).context("failed to serialize config")?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let result = (|| {
+        let mut file = options
+            .open(&temp_path)
+            .with_context(|| format!("failed to open {}", temp_path.display()))?;
+        file.write_all(&content)
+            .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("failed to sync {}", temp_path.display()))?;
+        fs::rename(&temp_path, path).with_context(|| {
+            format!(
+                "failed to replace {} with {}",
+                path.display(),
+                temp_path.display()
+            )
+        })?;
+        OpenOptions::new()
+            .read(true)
+            .open(parent)?
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", parent.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn write_agent_state_mutations(
+    runtime_db: &RuntimeDb,
+    mutations: &[AgentStateMutation],
+) -> Result<()> {
+    runtime_db.transaction(|transaction| {
+        for mutation in mutations {
+            transaction.execute(
+                "UPDATE agent_states SET payload_json = ?1 WHERE agent_id = ?2",
+                params![mutation.payload_json, mutation.agent_id],
+            )?;
+        }
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::save_persisted_config_at, types::AgentState};
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _temp_dir: TempDir,
+        config_path: PathBuf,
+        runtime_db: RuntimeDb,
+    }
+
+    impl Fixture {
+        fn new(config: &HolonConfigFile) -> Result<Self> {
+            let temp_dir = tempfile::tempdir()?;
+            let config_path = temp_dir.path().join("config.json");
+            save_persisted_config_at(&config_path, config)?;
+            let runtime_db = RuntimeDb::open_and_migrate(
+                temp_dir.path().join("runtime.sqlite"),
+                temp_dir.path().join("runtime.lock"),
+            )?;
+            Ok(Self {
+                _temp_dir: temp_dir,
+                config_path,
+                runtime_db,
+            })
+        }
+
+        fn insert_agent_payload(&self, agent_id: &str, model: &str) -> Result<String> {
+            self.runtime_db
+                .agent_states()
+                .upsert(&AgentState::new(agent_id))?;
+            let mut payload = serde_json::to_value(AgentState::new(agent_id))?;
+            payload["model_override"] = json!(model);
+            payload["pending_fallback_model"] = json!(model);
+            payload["last_requested_model"] = json!(model);
+            payload["last_active_model"] = json!(model);
+            let payload_json = serde_json::to_string(&payload)?;
+            self.runtime_db.connection()?.execute(
+                "UPDATE agent_states SET payload_json = ?1 WHERE agent_id = ?2",
+                params![payload_json, agent_id],
+            )?;
+            Ok(payload_json)
+        }
+
+        fn agent_payload(&self, agent_id: &str) -> Result<String> {
+            Ok(self.runtime_db.connection()?.query_row(
+                "SELECT payload_json FROM agent_states WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )?)
+        }
+    }
+
+    fn legacy_config() -> HolonConfigFile {
+        let mut config = HolonConfigFile::default();
+        config.model.default = Some("openai/gpt-5.4".into());
+        config.model.fallbacks = vec![
+            "openrouter/anthropic/claude-3.5-sonnet".into(),
+            "volcengine/doubao-seedream-5.0-lite".into(),
+        ];
+        config.vision.default = Some("openai/gpt-5.4".into());
+        config.image_generation.default = Some("auto".into());
+        config
+    }
+
+    fn canonical(value: &str) -> String {
+        ModelRouteRef::parse_compatible(value).unwrap().as_string()
+    }
+
+    #[test]
+    fn dry_run_reports_changes_without_writing_either_store() -> Result<()> {
+        let fixture = Fixture::new(&legacy_config())?;
+        let original_config = fs::read(&fixture.config_path)?;
+        let original_agent = fixture.insert_agent_payload("agent-a", "openai/gpt-5.4")?;
+
+        let report = migrate_model_config_routes(&fixture.config_path, &fixture.runtime_db, false)?;
+
+        assert!(report.ok);
+        assert!(!report.write);
+        assert!(report.changed);
+        assert!(report.config.changed);
+        assert!(report.agent_state.changed);
+        assert_eq!(fs::read(&fixture.config_path)?, original_config);
+        assert_eq!(fixture.agent_payload("agent-a")?, original_agent);
+        assert!(!fixture
+            .config_path
+            .with_extension("json.model-route-migration.bak")
+            .exists());
+        Ok(())
+    }
+
+    #[test]
+    fn write_creates_one_backup_and_is_idempotent() -> Result<()> {
+        let fixture = Fixture::new(&legacy_config())?;
+        let original_config = fs::read(&fixture.config_path)?;
+        fixture.insert_agent_payload("agent-a", "volcengine/doubao-seedream-5.0-lite")?;
+
+        let first = migrate_model_config_routes(&fixture.config_path, &fixture.runtime_db, true)?;
+        assert!(first.ok);
+        assert!(first.changed);
+        let backup_path = first.config.backup_path.expect("config backup");
+        assert_eq!(fs::read(&backup_path)?, original_config);
+
+        let migrated = load_persisted_config_at(&fixture.config_path)?;
+        assert_eq!(
+            migrated.model.default.as_deref(),
+            Some(canonical("openai/gpt-5.4").as_str())
+        );
+        assert_eq!(
+            migrated.model.fallbacks,
+            vec![
+                canonical("openrouter/anthropic/claude-3.5-sonnet"),
+                canonical("volcengine/doubao-seedream-5.0-lite"),
+            ]
+        );
+        assert_eq!(migrated.image_generation.default.as_deref(), Some("auto"));
+        let agent: Value = serde_json::from_str(&fixture.agent_payload("agent-a")?)?;
+        let expected_agent = canonical("volcengine/doubao-seedream-5.0-lite");
+        for field in AGENT_MODEL_ROUTE_FIELDS {
+            assert_eq!(agent[field].as_str(), Some(expected_agent.as_str()));
+        }
+
+        let config_after_first = fs::read(&fixture.config_path)?;
+        let agent_after_first = fixture.agent_payload("agent-a")?;
+        let second = migrate_model_config_routes(&fixture.config_path, &fixture.runtime_db, true)?;
+        assert!(second.ok);
+        assert!(!second.changed);
+        assert!(!second.config.changed);
+        assert!(!second.agent_state.changed);
+        assert!(second.config.backup_path.is_none());
+        assert_eq!(fs::read(&fixture.config_path)?, config_after_first);
+        assert_eq!(fixture.agent_payload("agent-a")?, agent_after_first);
+        assert_eq!(fs::read(&backup_path)?, original_config);
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_preflight_prevents_partial_writes() -> Result<()> {
+        let fixture = Fixture::new(&legacy_config())?;
+        let original_config = fs::read(&fixture.config_path)?;
+        let original_agent = fixture.insert_agent_payload("agent-a", "not-a-model-ref")?;
+
+        let report = migrate_model_config_routes(&fixture.config_path, &fixture.runtime_db, true)?;
+
+        assert!(!report.ok);
+        assert!(report.changed);
+        assert!(report.config.changed);
+        assert!(!report.agent_state.changed);
+        assert!(report
+            .agent_state
+            .fields
+            .iter()
+            .all(|field| field.status == ModelConfigMigrationStatus::Invalid));
+        assert_eq!(fs::read(&fixture.config_path)?, original_config);
+        assert_eq!(fixture.agent_payload("agent-a")?, original_agent);
+        assert!(!fixture
+            .config_path
+            .with_extension("json.model-route-migration.bak")
+            .exists());
+        Ok(())
+    }
+
+    #[test]
+    fn agent_state_batch_rolls_back_when_any_update_fails() -> Result<()> {
+        let mut config = HolonConfigFile::default();
+        config.model.default = Some(canonical("openai/gpt-5.4"));
+        let fixture = Fixture::new(&config)?;
+        let original_a = fixture.insert_agent_payload("agent-a", "openai/gpt-5.4")?;
+        let original_b = fixture.insert_agent_payload("agent-b", "openai/gpt-5.4")?;
+        fixture.runtime_db.connection()?.execute_batch(
+            "CREATE TRIGGER reject_agent_b_model_route_migration
+             BEFORE UPDATE OF payload_json ON agent_states
+             WHEN OLD.agent_id = 'agent-b'
+             BEGIN
+               SELECT RAISE(ABORT, 'reject agent-b migration');
+             END;",
+        )?;
+
+        let error = migrate_model_config_routes(&fixture.config_path, &fixture.runtime_db, true)
+            .expect_err("second update should abort the transaction");
+
+        assert!(error.to_string().contains("reject agent-b migration"));
+        assert_eq!(fixture.agent_payload("agent-a")?, original_a);
+        assert_eq!(fixture.agent_payload("agent-b")?, original_b);
+        Ok(())
+    }
+}

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -9,8 +9,8 @@ use crate::{
     config::{
         built_in_provider_default_config, credential_store_path, load_persisted_config_at,
         save_persisted_config_at, set_credential_profile_at, validate_provider_config, AppConfig,
-        CredentialKind, CredentialSource, ModelRef, ProviderAuthConfig, ProviderConfigFile,
-        ProviderId, ProviderRuntimeConfig,
+        CredentialKind, CredentialSource, ModelRef, ModelRouteRef, ProviderAuthConfig,
+        ProviderConfigFile, ProviderId, ProviderRuntimeConfig,
     },
     model_catalog::BuiltInModelCatalog,
     web::{WebProviderAuthClass, WebProviderSupportStatus},
@@ -114,7 +114,7 @@ pub struct OnboardingWizardDraft {
     pub provider: ProviderId,
     pub credential_profile: String,
     pub credential_kind: CredentialKind,
-    pub default_model: ModelRef,
+    pub default_model: ModelRouteRef,
     pub search: OnboardingSearchSelection,
 }
 
@@ -149,7 +149,7 @@ pub struct OnboardingProviderChoice {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OnboardingModelChoice {
-    pub model: ModelRef,
+    pub model: ModelRouteRef,
     pub title: String,
     pub detail: String,
     pub custom: bool,
@@ -272,14 +272,17 @@ pub fn onboarding_model_choices(
     }
     if models.is_empty() {
         models.push(OnboardingModelChoice {
-            model: ModelRef::new(provider.clone(), "unknown"),
-            title: format!("{}/unknown", provider.as_str()),
+            model: ModelRouteRef::from_legacy_model_ref(&ModelRef::new(
+                provider.clone(),
+                "unknown",
+            )),
+            title: format!("{}@default/unknown", provider.as_str()),
             detail: "custom provider model placeholder".into(),
             custom: false,
         });
     }
     models.push(OnboardingModelChoice {
-        model: ModelRef::new(provider.clone(), "__custom__"),
+        model: ModelRouteRef::from_legacy_model_ref(&ModelRef::new(provider.clone(), "__custom__")),
         title: "Custom model…".into(),
         detail: format!("enter any {} model id", provider.as_str()),
         custom: true,
@@ -309,14 +312,19 @@ fn configured_model_choices(
         .collect::<Vec<_>>();
     override_models.sort_by_key(ModelRef::as_string);
     for model in override_models {
-        push_configured_model_choice(&mut models, &model, provider, "configured model override");
+        push_configured_model_choice(
+            &mut models,
+            &ModelRouteRef::from_legacy_model_ref(&model),
+            provider,
+            "configured model override",
+        );
     }
     models
 }
 
 fn push_configured_model_choice(
     models: &mut Vec<OnboardingModelChoice>,
-    model: &ModelRef,
+    model: &ModelRouteRef,
     provider: &ProviderId,
     detail: &str,
 ) {
@@ -359,8 +367,8 @@ impl RuntimeModelCatalogShim {
                 };
                 OnboardingModelChoice {
                     title: format!("{}{}", entry.display_name, preferred_suffix),
-                    detail: entry.model_ref.as_string(),
-                    model: entry.model_ref,
+                    detail: ModelRouteRef::from_legacy_model_ref(&entry.model_ref).as_string(),
+                    model: ModelRouteRef::from_legacy_model_ref(&entry.model_ref),
                     custom: false,
                 }
             })
@@ -984,8 +992,8 @@ mod tests {
         config::{
             credential_store_path, load_credential_store_at, load_persisted_config_at,
             provider_registry_for_tests, AppConfig, ControlAuthMode, CredentialKind,
-            CredentialSource, ModelRef, ProviderAuthConfig, ProviderConfigFile, ProviderEndpointId,
-            ProviderId, ProviderRuntimeConfig, ProviderTransportKind,
+            CredentialSource, ModelRef, ModelRouteRef, ProviderAuthConfig, ProviderConfigFile,
+            ProviderEndpointId, ProviderId, ProviderRuntimeConfig, ProviderTransportKind,
         },
         model_catalog::ModelRuntimeOverride,
         onboarding::{
@@ -1021,7 +1029,7 @@ mod tests {
             api_cors: Default::default(),
             config_file_path: home_dir.join("config.json"),
             stored_config: Default::default(),
-            default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
+            default_model: ModelRouteRef::parse_compatible("openai/gpt-5.4").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
             image_generation_model: None,
@@ -1115,7 +1123,7 @@ mod tests {
     #[test]
     fn credential_repair_plan_preserves_provider_auth_contract() {
         let mut config = test_config(None);
-        config.default_model = ModelRef::parse("openai-codex/gpt-5.4").unwrap();
+        config.default_model = ModelRouteRef::parse_compatible("openai-codex/gpt-5.4").unwrap();
 
         let plan = credential_repair_plan(&config).expect("repair plan");
 
@@ -1129,7 +1137,7 @@ mod tests {
     #[test]
     fn credential_repair_plan_marks_unknown_default_provider_unconfigured() {
         let mut config = test_config(None);
-        config.default_model = ModelRef::parse("custom/gpt-5.4").unwrap();
+        config.default_model = ModelRouteRef::parse_compatible("custom/gpt-5.4").unwrap();
 
         let plan = credential_repair_plan(&config).expect("repair plan");
 
@@ -1212,8 +1220,9 @@ mod tests {
         config
             .providers
             .insert(deepseek.clone(), deepseek_config.clone());
-        config.default_model = ModelRef::parse("openai/custom-default").unwrap();
-        config.fallback_models = vec![ModelRef::parse("openai/custom-fallback").unwrap()];
+        config.default_model = ModelRouteRef::parse_compatible("openai/custom-default").unwrap();
+        config.fallback_models =
+            vec![ModelRouteRef::parse_compatible("openai/custom-fallback").unwrap()];
         config.validated_model_overrides.insert(
             ModelRef::parse("openai/custom-override").unwrap(),
             ModelRuntimeOverride::default(),
@@ -1243,12 +1252,18 @@ mod tests {
         assert!(providers.iter().any(|provider| provider.id == deepseek));
 
         let models = onboarding_model_choices(&config, &ProviderId::openai());
-        assert_eq!(models[0].model.as_string(), "openai/custom-default");
-        assert_eq!(models[1].model.as_string(), "openai/custom-fallback");
-        assert_eq!(models[2].model.as_string(), "openai/custom-override");
+        assert_eq!(models[0].model.as_string(), "openai@default/custom-default");
+        assert_eq!(
+            models[1].model.as_string(),
+            "openai@default/custom-fallback"
+        );
+        assert_eq!(
+            models[2].model.as_string(),
+            "openai@default/custom-override"
+        );
         assert!(models
             .iter()
-            .any(|choice| choice.model.as_string() == "openai/gpt-5.4"));
+            .any(|choice| choice.model.as_string() == "openai@default/gpt-5.4"));
         assert!(models
             .iter()
             .any(|choice| choice.custom && choice.title == "Custom model…"));
@@ -1261,7 +1276,7 @@ mod tests {
             provider: ProviderId::openai(),
             credential_profile: "openai".into(),
             credential_kind: CredentialKind::ApiKey,
-            default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
+            default_model: ModelRouteRef::parse("openai@default/gpt-5.4").unwrap(),
             search: OnboardingSearchSelection::ManagedDuckDuckGo,
         };
 
@@ -1272,12 +1287,15 @@ mod tests {
 
         assert_eq!(summary.provider, "openai");
         assert_eq!(summary.applied_via, "offline_store");
-        assert_eq!(summary.default_model, "openai/gpt-5.4");
+        assert_eq!(summary.default_model, "openai@default/gpt-5.4");
         assert_eq!(summary.search, "Managed WebSearch: DuckDuckGo");
         assert!(summary.credential_written);
         assert!(!format!("{summary:?}").contains("test-secret"));
 
-        assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-5.4"));
+        assert_eq!(
+            persisted.model.default.as_deref(),
+            Some("openai@default/gpt-5.4")
+        );
         assert_eq!(persisted.web.search.enabled, Some(true));
         assert_eq!(persisted.web.search.builtin_provider.enabled, Some(false));
         assert_eq!(persisted.web.search.provider.as_deref(), Some("duckduckgo"));
@@ -1309,7 +1327,7 @@ mod tests {
             provider: ProviderId::openai(),
             credential_profile: "openai".into(),
             credential_kind: CredentialKind::ApiKey,
-            default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
+            default_model: ModelRouteRef::parse("openai@default/gpt-5.4").unwrap(),
             search: OnboardingSearchSelection::Auto,
         };
 

--- a/src/onboarding_tui.rs
+++ b/src/onboarding_tui.rs
@@ -24,7 +24,7 @@ use crate::{
         oauth_provider_config, run_codex_oauth_login_profile_material,
         run_oauth_device_login_profile_material,
     },
-    config::{AppConfig, CredentialKind, ModelRef, ProviderId},
+    config::{AppConfig, CredentialKind, ModelRef, ModelRouteRef, ProviderId},
     onboarding::{
         onboarding_model_choices, onboarding_provider_choices, onboarding_search_choices,
         OnboardingModelChoice, OnboardingProviderChoice, OnboardingSearchChoice,
@@ -270,7 +270,7 @@ impl OnboardingTuiApp {
                     self.selected_model = None;
                     self.custom_model_input.clear();
                     self.status =
-                        "Enter a model id. Use `provider/model` or a model name for this provider."
+                        "Enter a model id. Use `provider@endpoint/model`, legacy `provider/model`, or a model name for this provider."
                             .into();
                     self.step = Step::CustomModel;
                 } else {
@@ -387,15 +387,18 @@ impl OnboardingTuiApp {
     }
 }
 
-fn parse_custom_model_ref(provider: &OnboardingProviderChoice, input: &str) -> Result<ModelRef> {
+fn parse_custom_model_ref(
+    provider: &OnboardingProviderChoice,
+    input: &str,
+) -> Result<ModelRouteRef> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         anyhow::bail!("enter a model id before continuing");
     }
     let model_ref = if trimmed.contains('/') {
-        ModelRef::parse(trimmed)?
+        ModelRouteRef::parse_compatible(trimmed)?
     } else {
-        ModelRef::new(provider.id.clone(), trimmed)
+        ModelRouteRef::from_legacy_model_ref(&ModelRef::new(provider.id.clone(), trimmed))
     };
     if model_ref.provider != provider.id {
         anyhow::bail!(
@@ -663,7 +666,7 @@ fn draw_custom_model(frame: &mut Frame<'_>, area: Rect, app: &OnboardingTuiApp) 
                 .map(|provider| provider.id.as_str().to_string())
                 .unwrap_or_else(|| "-".into())
         )),
-        Line::from("accepted forms: provider/model or model-name"),
+        Line::from("accepted forms: provider@endpoint/model, legacy provider/model, or model-name"),
         Line::from(""),
         Line::from(format!("model: {}", app.custom_model_input)),
     ]);

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -9,11 +9,12 @@ use crate::{
     diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
         BatchGetMessagesRequest, CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest,
-        MemoryGetRequest, PickWorkItemRequest, PickWorkItemResponse, RuntimeConfigReadResponse,
-        RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse, SearchRequest, SearchResponse,
-        UpdateWorkItemRequest,
+        MemoryGetRequest, ModelConfigMigrationRequest, PickWorkItemRequest, PickWorkItemResponse,
+        RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
+        SearchRequest, SearchResponse, UpdateWorkItemRequest,
     },
     memory::MemoryGetResult,
+    model_config_migration::ModelConfigMigrationReport,
     types::{
         AddSkillRequest, BriefRecord, TaskInputResult, TaskOutputResult, TaskStatusSnapshot,
         TaskStopResult, TimerRecord, ToolExecutionRecord, WorkItemRecord,
@@ -138,6 +139,7 @@ const ROUTES: &[RouteSpec] = &[
     route_with_response("get", "/control/runtime/performance", "runtimePerformance", "runtime", "Runtime performance diagnostics", "Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.", None, "PerformanceDiagnosticsSnapshot", AuthKind::Control),
     route_with_response("get", "/control/runtime/config", "runtimeConfig", "runtime", "Runtime config", "Return the daemon effective runtime configuration surface.", None, "RuntimeConfigReadResponse", AuthKind::Control),
     route_with_response("patch", "/control/runtime/config", "runtimeConfigUpdate", "runtime", "Update runtime config", "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.", Some("RuntimeConfigUpdateRequest"), "RuntimeConfigUpdateResponse", AuthKind::Control),
+    route_with_response("post", "/control/runtime/config/migrate-model-routes", "migrateModelConfigRoutes", "runtime", "Migrate model config routes", "Inspect legacy model route references or persist a complete canonical migration across config.json and agent state.", Some("ModelConfigMigrationRequest"), "ModelConfigMigrationReport", AuthKind::Control),
     route("get", "/control/runtime/credentials", "runtimeCredentials", "runtime", "Runtime credential profiles", "List credential profiles stored in the runtime credential store.", None, AuthKind::Control),
     route("put", "/control/runtime/credentials/{profile}", "setRuntimeCredential", "runtime", "Set runtime credential", "Set an API key credential profile in the runtime credential store.", Some("SetCredentialRequest"), AuthKind::Control),
     route("delete", "/control/runtime/credentials/{profile}", "deleteRuntimeCredential", "runtime", "Delete runtime credential", "Remove a credential profile from the runtime credential store.", None, AuthKind::Control),
@@ -604,6 +606,14 @@ fn component_schemas() -> Value {
     schemas.insert(
         "RuntimeConfigUpdateResponse".into(),
         component_schema::<RuntimeConfigUpdateResponse>(),
+    );
+    schemas.insert(
+        "ModelConfigMigrationRequest".into(),
+        component_schema::<ModelConfigMigrationRequest>(),
+    );
+    schemas.insert(
+        "ModelConfigMigrationReport".into(),
+        component_schema::<ModelConfigMigrationReport>(),
     );
     schemas.insert(
         "PickWorkItemRequest".into(),

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 
 use crate::{
     config::{
-        AppConfig, ModelRef, ModelRouteCapability, ProviderTransportKind, ResolvedModelRoute,
+        AppConfig, ModelRouteCapability, ModelRouteRef, ProviderTransportKind, ResolvedModelRoute,
         RuntimeModelCatalog,
     },
     context::ContextConfig,
@@ -32,7 +32,7 @@ pub fn build_provider_from_config(config: &AppConfig) -> Result<Arc<dyn AgentPro
 
 pub fn build_provider_from_model_chain(
     config: &AppConfig,
-    provider_chain: &[ModelRef],
+    provider_chain: &[ModelRouteRef],
 ) -> Result<Arc<dyn AgentProvider>> {
     let mut candidates = Vec::new();
     let mut errors = Vec::new();
@@ -67,9 +67,10 @@ pub fn build_provider_from_model_chain(
 
 pub(crate) fn build_candidate(
     config: &AppConfig,
-    model_ref: &ModelRef,
+    route_ref: &ModelRouteRef,
 ) -> Result<ProviderCandidate> {
-    let route = resolve_model_route_for_candidate(config, model_ref, ModelRouteCapability::Turn)?;
+    let route =
+        resolve_explicit_model_route_for_candidate(config, route_ref, ModelRouteCapability::Turn)?;
     build_candidate_from_model_route(&config.home_dir, &route)
 }
 
@@ -134,34 +135,26 @@ pub(crate) fn build_candidate_from_model_route(
         }
     };
     Ok(ProviderCandidate {
-        model_ref: model_ref.as_string(),
+        model_ref: route.route_ref.as_string(),
         provider_name: route.provider_name().to_string(),
         provider,
     })
 }
 
-pub(crate) fn resolve_model_route_for_candidate(
+pub(crate) fn resolve_explicit_model_route_for_candidate(
     config: &AppConfig,
-    model_ref: &ModelRef,
+    route_ref: &ModelRouteRef,
     requested_capability: ModelRouteCapability,
 ) -> Result<ResolvedModelRoute> {
-    let provider_config = config.providers.get(&model_ref.provider).ok_or_else(|| {
-        anyhow!(
-            "unknown provider {}; configure providers.{}",
-            model_ref.provider.as_str(),
-            model_ref.provider.as_str()
-        )
-    })?;
-
     let base_context_config = base_context_config_for_candidate(config);
     RuntimeModelCatalog::from_config(config)
-        .resolve_model_route(&base_context_config, model_ref, requested_capability)
+        .resolve_explicit_model_route(&base_context_config, route_ref, requested_capability)
         .ok_or_else(|| {
             anyhow!(
-                "provider {} default endpoint transport {} cannot route model {} for requested route capability {:?}",
-                model_ref.provider.as_str(),
-                provider_config.transport.as_str(),
-                model_ref.as_string(),
+                "provider endpoint {}@{} cannot route model {} for requested route capability {:?}",
+                route_ref.provider.as_str(),
+                route_ref.endpoint.as_str(),
+                route_ref.as_string(),
                 requested_capability
             )
         })

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -22,7 +22,8 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
     let catalog = RuntimeModelCatalog::from_config(config);
     let mut providers = Vec::new();
     let mut model_availability = Vec::new();
-    for model_ref in config.provider_chain() {
+    for route_ref in config.provider_chain() {
+        let model_ref = route_ref.model_ref();
         let availability = provider_availability(config, &model_ref);
         let provider_cfg = config
             .providers
@@ -43,8 +44,9 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
             })
             .unwrap_or_else(|| json!({"error": "provider_not_configured"}));
         providers.push(json!({
-            "model": model_ref.as_string(),
-            "provider": model_ref.provider.as_str(),
+            "model": route_ref.as_string(),
+            "provider": route_ref.provider.as_str(),
+            "endpoint": route_ref.endpoint.as_str(),
             "settings": provider_cfg,
             "availability": availability,
         }));
@@ -73,7 +75,7 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
 
     json!({
         "default_model": config.default_model.as_string(),
-        "fallback_models": config.fallback_models.iter().map(ModelRef::as_string).collect::<Vec<_>>(),
+        "fallback_models": config.fallback_models.iter().map(|model| model.as_string()).collect::<Vec<_>>(),
         "disable_provider_fallback": config.provider_fallback_disabled(),
         "runtime_max_output_tokens": config.runtime_max_output_tokens,
         "retry_policy": provider_retry_policy_json(),
@@ -93,11 +95,12 @@ pub fn resolved_model_availability(config: &AppConfig) -> Vec<ResolvedModelAvail
         models.insert(entry.model_ref.as_string(), entry.model_ref);
     }
     models.insert(
-        config.default_model.as_string(),
-        config.default_model.clone(),
+        config.default_model.model_ref().as_string(),
+        config.default_model.model_ref(),
     );
     for model_ref in &config.fallback_models {
-        models.insert(model_ref.as_string(), model_ref.clone());
+        let model_ref = model_ref.model_ref();
+        models.insert(model_ref.as_string(), model_ref);
     }
     for model_ref in config.validated_model_overrides.keys() {
         models.insert(model_ref.as_string(), model_ref.clone());
@@ -316,7 +319,8 @@ fn resolved_model_availability_entry(
     availability: &Value,
 ) -> ResolvedModelAvailability {
     let base_context = base_context_config(config);
-    let policy = catalog.resolved_model_policy(&base_context, Some(model_ref));
+    let route_ref = crate::config::ModelRouteRef::from_legacy_model_ref(model_ref);
+    let policy = catalog.resolved_model_policy(&base_context, Some(&route_ref));
     let route = catalog.resolve_model_route(&base_context, model_ref, ModelRouteCapability::Turn);
     let metadata_source = if config.validated_model_overrides.contains_key(model_ref) {
         "config_override".to_string()
@@ -434,7 +438,8 @@ fn base_context_config(config: &AppConfig) -> ContextConfig {
 }
 
 fn provider_availability(config: &AppConfig, model_ref: &ModelRef) -> Value {
-    let mut availability = match build_candidate(config, model_ref) {
+    let route_ref = crate::config::ModelRouteRef::from_legacy_model_ref(model_ref);
+    let mut availability = match build_candidate(config, &route_ref) {
         Ok(candidate) => json!({
             "available": true,
             "prompt_capabilities": candidate.provider.prompt_capabilities(),
@@ -542,8 +547,12 @@ mod tests {
             api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
-            default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
-            fallback_models: vec![ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()],
+            default_model: crate::config::ModelRouteRef::parse_compatible("openai/gpt-5.4")
+                .unwrap(),
+            fallback_models: vec![crate::config::ModelRouteRef::parse_compatible(
+                "anthropic/claude-sonnet-4-6",
+            )
+            .unwrap()],
             vision_model: None,
             image_generation_model: None,
             vision_candidate_models: Vec::new(),
@@ -735,8 +744,10 @@ mod tests {
             route_provider.clone(),
             built_ins.get(&route_provider).unwrap().clone(),
         );
-        fixture.config.image_generation_model =
-            Some(ModelRef::parse("volcengine/doubao-seedream-5.0-lite").unwrap());
+        fixture.config.image_generation_model = Some(
+            crate::config::ModelRouteRef::parse_compatible("volcengine/doubao-seedream-5.0-lite")
+                .unwrap(),
+        );
 
         let availability = resolved_model_availability(&fixture.config);
         let seedream = availability

--- a/src/provider/tests/openai_chat_completions.rs
+++ b/src/provider/tests/openai_chat_completions.rs
@@ -2,7 +2,7 @@
 
 use super::support::*;
 use super::*;
-use crate::config::{ModelRef, ProviderId, ProviderTransportKind};
+use crate::config::{ModelRouteRef, ProviderId, ProviderTransportKind};
 use crate::provider::provider_transport_diagnostics;
 use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
 use crate::provider::transports::build_chat_completion_messages;
@@ -19,10 +19,13 @@ fn build_candidate_creates_chat_completions_provider() {
         .unwrap()
         .transport = ProviderTransportKind::OpenAiChatCompletions;
 
-    let candidate = build_candidate(&fixture.config, &ModelRef::parse("openai/gpt-5.4").unwrap())
-        .expect("chat completions provider should build");
+    let candidate = build_candidate(
+        &fixture.config,
+        &ModelRouteRef::parse_compatible("openai/gpt-5.4").unwrap(),
+    )
+    .expect("chat completions provider should build");
 
-    assert_eq!(candidate.model_ref, "openai/gpt-5.4");
+    assert_eq!(candidate.model_ref, "openai@default/gpt-5.4");
     assert_eq!(candidate.provider_name, "openai");
 }
 

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -8,8 +8,8 @@ use std::sync::{
 use super::support::*;
 use super::*;
 use crate::config::{
-    CredentialKind, CredentialSource, ModelRef, ProviderAuthConfig, ProviderEndpointId, ProviderId,
-    ProviderRuntimeConfig, ProviderTransportKind,
+    CredentialKind, CredentialSource, ModelRouteRef, ProviderAuthConfig, ProviderEndpointId,
+    ProviderId, ProviderRuntimeConfig, ProviderTransportKind,
 };
 use crate::provider::retry::{
     classify_provider_error, ProviderFailureKind, RetryDisposition, PROVIDER_MAX_RETRIES,
@@ -18,13 +18,17 @@ use axum::{extract::State, http::header, response::IntoResponse, routing::post, 
 use chrono::Utc;
 use serde_json::{json, Value};
 
+fn route_ref(value: &str) -> ModelRouteRef {
+    ModelRouteRef::parse_compatible(value).unwrap()
+}
+
 #[test]
 fn build_candidate_routes_openai_model_refs() {
     let fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
     let config = &fixture.config;
-    let model_ref = ModelRef::parse("openai/gpt-5.4").unwrap();
+    let model_ref = route_ref("openai/gpt-5.4");
     let candidate = build_candidate(config, &model_ref).unwrap();
-    assert_eq!(candidate.model_ref, "openai/gpt-5.4");
+    assert_eq!(candidate.model_ref, "openai@default/gpt-5.4");
 
     let provider = OpenAiProvider::from_config(config, "gpt-5.4").unwrap();
     let _typed: Arc<dyn super::super::AgentProvider> = Arc::new(provider);
@@ -33,16 +37,16 @@ fn build_candidate_routes_openai_model_refs() {
 #[test]
 fn build_candidate_routes_anthropic_model_refs() {
     let fixture = test_config(
-        "anthropic/claude-sonnet-4-6",
+        "anthropic@default/claude-sonnet-4-6",
         &[],
         None,
         Some("anthropic-token"),
         false,
     );
     let config = &fixture.config;
-    let model_ref = ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap();
+    let model_ref = route_ref("anthropic@default/claude-sonnet-4-6");
     let candidate = build_candidate(config, &model_ref).unwrap();
-    assert_eq!(candidate.model_ref, "anthropic/claude-sonnet-4-6");
+    assert_eq!(candidate.model_ref, "anthropic@default/claude-sonnet-4-6");
 
     let provider = AnthropicProvider::from_config_with_model(config, "claude-sonnet-4-6").unwrap();
     let _typed: Arc<dyn super::super::AgentProvider> = Arc::new(provider);
@@ -50,11 +54,11 @@ fn build_candidate_routes_anthropic_model_refs() {
 
 #[test]
 fn build_candidate_routes_codex_model_refs() {
-    let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    let fixture = test_config("openai-codex@default/gpt-5.4", &[], None, None, true);
     let config = &fixture.config;
-    let model_ref = ModelRef::parse("openai-codex/gpt-5.4").unwrap();
+    let model_ref = route_ref("openai-codex@default/gpt-5.4");
     let candidate = build_candidate(config, &model_ref).unwrap();
-    assert_eq!(candidate.model_ref, "openai-codex/gpt-5.4");
+    assert_eq!(candidate.model_ref, "openai-codex@default/gpt-5.4");
 
     let provider = OpenAiCodexProvider::from_config(config, "gpt-5.4").unwrap();
     let _typed: Arc<dyn super::super::AgentProvider> = Arc::new(provider);
@@ -62,7 +66,7 @@ fn build_candidate_routes_codex_model_refs() {
 
 #[test]
 fn build_candidate_routes_gemini_model_refs() {
-    let mut fixture = test_config("gemini/gemini-3-pro", &[], None, None, false);
+    let mut fixture = test_config("gemini@default/gemini-3-pro", &[], None, None, false);
     let gemini = fixture
         .config
         .providers
@@ -71,9 +75,9 @@ fn build_candidate_routes_gemini_model_refs() {
     gemini.credential = Some("gemini-key".into());
 
     let config = &fixture.config;
-    let model_ref = ModelRef::parse("gemini/gemini-3-pro").unwrap();
+    let model_ref = route_ref("gemini/gemini-3-pro");
     let candidate = build_candidate(config, &model_ref).unwrap();
-    assert_eq!(candidate.model_ref, "gemini/gemini-3-pro");
+    assert_eq!(candidate.model_ref, "gemini@default/gemini-3-pro");
 
     let provider_config = config.providers.get(&ProviderId::gemini()).unwrap();
     let provider = GeminiProvider::from_runtime_config(
@@ -88,41 +92,33 @@ fn build_candidate_routes_gemini_model_refs() {
 
 #[test]
 fn build_candidate_reports_missing_auth_for_each_provider() {
-    let openai = test_config("openai/gpt-5.4", &[], None, None, false);
-    let openai_err = build_candidate(&openai.config, &ModelRef::parse("openai/gpt-5.4").unwrap())
+    let openai = test_config("openai@default/gpt-5.4", &[], None, None, false);
+    let openai_err = build_candidate(&openai.config, &route_ref("openai@default/gpt-5.4"))
         .err()
         .expect("missing OPENAI_API_KEY should fail openai candidate");
     assert!(openai_err.to_string().contains("missing OPENAI_API_KEY"));
 
     let anthropic = test_config("anthropic/claude-sonnet-4-6", &[], None, None, false);
-    let anthropic_err = build_candidate(
-        &anthropic.config,
-        &ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-    )
-    .err()
-    .expect("missing ANTHROPIC_AUTH_TOKEN should fail anthropic candidate");
+    let anthropic_err =
+        build_candidate(&anthropic.config, &route_ref("anthropic/claude-sonnet-4-6"))
+            .err()
+            .expect("missing ANTHROPIC_AUTH_TOKEN should fail anthropic candidate");
     assert!(anthropic_err
         .to_string()
         .contains("missing ANTHROPIC_AUTH_TOKEN"));
 
     let codex = test_config("openai-codex/gpt-5.4", &[], None, None, false);
-    let codex_err = build_candidate(
-        &codex.config,
-        &ModelRef::parse("openai-codex/gpt-5.4").unwrap(),
-    )
-    .err()
-    .expect("missing Codex auth should fail codex candidate");
+    let codex_err = build_candidate(&codex.config, &route_ref("openai-codex/gpt-5.4"))
+        .err()
+        .expect("missing Codex auth should fail codex candidate");
     assert!(codex_err
         .to_string()
         .contains("no Holon openai-codex credential profile or usable Codex CLI credentials"));
 
     let gemini = test_config("gemini/gemini-3-pro", &[], None, None, false);
-    let gemini_err = build_candidate(
-        &gemini.config,
-        &ModelRef::parse("gemini/gemini-3-pro").unwrap(),
-    )
-    .err()
-    .expect("missing GEMINI_API_KEY should fail gemini candidate");
+    let gemini_err = build_candidate(&gemini.config, &route_ref("gemini/gemini-3-pro"))
+        .err()
+        .expect("missing GEMINI_API_KEY should fail gemini candidate");
     assert!(gemini_err.to_string().contains("missing GEMINI_API_KEY"));
 }
 
@@ -212,20 +208,20 @@ fn build_provider_from_config_uses_effective_fallback_order() {
 
     let doctor = provider_doctor(config);
     let providers = doctor["providers"].as_array().unwrap();
-    assert_eq!(providers[0]["model"], "openai-codex/gpt-5.4");
+    assert_eq!(providers[0]["model"], "openai-codex@default/gpt-5.4");
     assert_eq!(providers[0]["availability"]["available"], Value::Bool(true));
-    assert_eq!(providers[1]["model"], "openai/gpt-5.4");
+    assert_eq!(providers[1]["model"], "openai@default/gpt-5.4");
     assert_eq!(
         providers[1]["availability"]["available"],
         Value::Bool(false)
     );
-    assert_eq!(providers[2]["model"], "anthropic/claude-sonnet-4-6");
+    assert_eq!(providers[2]["model"], "anthropic@default/claude-sonnet-4-6");
     assert_eq!(providers[2]["availability"]["available"], Value::Bool(true));
 }
 
 #[tokio::test]
 async fn openai_codex_expired_cli_token_fails_fast_with_login_hint() {
-    let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    let fixture = test_config("openai-codex@default/gpt-5.4", &[], None, None, true);
     let codex_home = fixture
         .config
         .providers
@@ -331,16 +327,18 @@ fn build_provider_from_config_fails_when_no_provider_is_available() {
     assert!(err
         .to_string()
         .contains("no available providers for configured model chain"));
-    assert!(err.to_string().contains("openai-codex/gpt-5.4"));
-    assert!(err.to_string().contains("openai/gpt-5.4"));
-    assert!(err.to_string().contains("anthropic/claude-sonnet-4-6"));
+    assert!(err.to_string().contains("openai-codex@default/gpt-5.4"));
+    assert!(err.to_string().contains("openai@default/gpt-5.4"));
+    assert!(err
+        .to_string()
+        .contains("anthropic@default/claude-sonnet-4-6"));
 }
 
 #[test]
 fn fallback_provider_reports_conservative_prompt_capability_intersection() {
     let fixture = test_config(
-        "openai/gpt-5.4",
-        &["anthropic/claude-sonnet-4-6"],
+        "openai@default/gpt-5.4",
+        &["anthropic@default/claude-sonnet-4-6"],
         Some("sk-test-key"),
         Some("sk-ant-test-token"),
         false,
@@ -403,12 +401,12 @@ fn provider_doctor_reports_when_provider_fallback_is_disabled() {
     assert_eq!(doctor["disable_provider_fallback"], Value::Bool(true));
     let providers = doctor["providers"].as_array().unwrap();
     assert_eq!(providers.len(), 1);
-    assert_eq!(providers[0]["model"], "anthropic/claude-sonnet-4-6");
+    assert_eq!(providers[0]["model"], "anthropic@default/claude-sonnet-4-6");
 }
 
 #[test]
 fn provider_doctor_reports_codex_as_available_when_credentials_exist() {
-    let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    let fixture = test_config("openai-codex@default/gpt-5.4", &[], None, None, true);
     let doctor = provider_doctor(&fixture.config);
     assert_eq!(
         doctor["retry_policy"]["max_retries_per_provider"],
@@ -993,7 +991,7 @@ async fn openai_provider_retries_transient_server_errors() {
     let timeline = diagnostics.expect("missing attempt timeline");
     assert_eq!(
         timeline.winning_model_ref.as_deref(),
-        Some("openai/gpt-5.4")
+        Some("openai@default/gpt-5.4")
     );
     assert_eq!(
         timeline
@@ -1199,7 +1197,7 @@ async fn provider_fallback_defers_after_retry_exhaustion() {
     assert_eq!(timeline.winning_model_ref.as_deref(), None);
     assert_eq!(
         timeline.pending_fallback_model_ref.as_deref(),
-        Some("anthropic/claude-sonnet-4-6")
+        Some("anthropic@default/claude-sonnet-4-6")
     );
     assert_eq!(
         timeline
@@ -1289,12 +1287,12 @@ async fn provider_fallback_defers_after_fail_fast_error() {
     assert_eq!(anthropic_attempts.load(Ordering::SeqCst), 0);
     let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
     assert_eq!(timeline.attempts.len(), 1);
-    assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
+    assert_eq!(timeline.requested_model_ref, "openai@default/gpt-5.4");
     assert_eq!(timeline.active_model_ref.as_deref(), None);
     assert_eq!(timeline.winning_model_ref.as_deref(), None);
     assert_eq!(
         timeline.pending_fallback_model_ref.as_deref(),
-        Some("anthropic/claude-sonnet-4-6")
+        Some("anthropic@default/claude-sonnet-4-6")
     );
     assert_eq!(
         timeline.attempts[0].outcome,
@@ -1483,9 +1481,9 @@ fn build_provider_from_config_preserves_order_of_unique_models() {
     assert_eq!(
         refs.as_slice(),
         &[
-            "anthropic/claude-sonnet-4-6",
-            "openai/gpt-5.4",
-            "openai-codex/gpt-5.4"
+            "anthropic@default/claude-sonnet-4-6",
+            "openai@default/gpt-5.4",
+            "openai-codex@default/gpt-5.4"
         ]
     );
 }
@@ -1493,8 +1491,11 @@ fn build_provider_from_config_preserves_order_of_unique_models() {
 #[test]
 fn build_provider_from_config_skips_unavailable_models_and_continues() {
     let fixture = test_config(
-        "anthropic/claude-sonnet-4-6",
-        &["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"],
+        "anthropic@default/claude-sonnet-4-6",
+        &[
+            "openai@default/gpt-5.4",
+            "anthropic@default/claude-sonnet-4-6",
+        ],
         None,
         Some("anthropic-token"),
         false,
@@ -1502,14 +1503,14 @@ fn build_provider_from_config_skips_unavailable_models_and_continues() {
     let provider = build_provider_from_config(&fixture.config).unwrap();
     let refs = provider.configured_model_refs();
     assert_eq!(refs.len(), 1);
-    assert_eq!(refs[0], "anthropic/claude-sonnet-4-6");
+    assert_eq!(refs[0], "anthropic@default/claude-sonnet-4-6");
 }
 
 #[test]
 fn build_provider_from_config_fails_on_unavailable_primary_when_fallback_disabled() {
     let mut fixture = test_config(
-        "openai/gpt-5.4",
-        &["anthropic/claude-sonnet-4-6"],
+        "openai@default/gpt-5.4",
+        &["anthropic@default/claude-sonnet-4-6"],
         None,
         Some("anthropic-token"),
         false,
@@ -1527,15 +1528,20 @@ fn build_provider_from_config_fails_on_unavailable_primary_when_fallback_disable
     assert!(err
         .to_string()
         .contains("no available providers for configured model chain"));
-    assert!(err.to_string().contains("openai/gpt-5.4"));
-    assert!(!err.to_string().contains("anthropic/claude-sonnet-4-6"));
+    assert!(err.to_string().contains("openai@default/gpt-5.4"));
+    assert!(!err
+        .to_string()
+        .contains("anthropic@default/claude-sonnet-4-6"));
 }
 
 #[test]
 fn build_provider_from_config_fails_when_all_models_unavailable() {
     let fixture = test_config(
-        "openai/gpt-5.4",
-        &["anthropic/claude-sonnet-4-6", "openai-codex/gpt-5.4"],
+        "openai@default/gpt-5.4",
+        &[
+            "anthropic@default/claude-sonnet-4-6",
+            "openai-codex@default/gpt-5.4",
+        ],
         None,
         None,
         false,
@@ -1544,14 +1550,16 @@ fn build_provider_from_config_fails_when_all_models_unavailable() {
         .err()
         .expect("should fail when all providers unavailable");
     assert!(err.to_string().contains("no available providers"));
-    assert!(err.to_string().contains("openai/gpt-5.4"));
-    assert!(err.to_string().contains("anthropic/claude-sonnet-4-6"));
-    assert!(err.to_string().contains("openai-codex/gpt-5.4"));
+    assert!(err.to_string().contains("openai@default/gpt-5.4"));
+    assert!(err
+        .to_string()
+        .contains("anthropic@default/claude-sonnet-4-6"));
+    assert!(err.to_string().contains("openai-codex@default/gpt-5.4"));
 }
 
 #[test]
 fn build_provider_from_config_uses_custom_openai_responses_provider() {
-    let mut fixture = test_config("openrouter/custom-model", &[], None, None, false);
+    let mut fixture = test_config("openrouter@default/custom-model", &[], None, None, false);
     let provider_id = ProviderId::parse("openrouter").unwrap();
     fixture.config.providers.insert(
         provider_id.clone(),
@@ -1581,7 +1589,7 @@ fn build_provider_from_config_uses_custom_openai_responses_provider() {
     let provider = build_provider_from_config(&fixture.config).unwrap();
     assert_eq!(
         provider.configured_model_refs(),
-        vec!["openrouter/custom-model"]
+        vec!["openrouter@default/custom-model"]
     );
 
     let doctor = provider_doctor(&fixture.config);
@@ -1625,26 +1633,29 @@ fn build_candidate_accepts_openai_responses_without_auth() {
         },
     );
 
-    let candidate = build_candidate(
-        &fixture.config,
-        &ModelRef::parse("local-openai/custom-model").unwrap(),
-    )
-    .unwrap();
+    let candidate =
+        build_candidate(&fixture.config, &route_ref("local-openai/custom-model")).unwrap();
 
-    assert_eq!(candidate.model_ref, "local-openai/custom-model");
+    assert_eq!(candidate.model_ref, "local-openai@default/custom-model");
     assert_eq!(candidate.provider_name, "local-openai");
 }
 
 #[test]
 fn build_candidate_handles_multiple_openai_models() {
-    let fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    let fixture = test_config(
+        "openai@default/gpt-5.4",
+        &[],
+        Some("openai-key"),
+        None,
+        false,
+    );
     let config = &fixture.config;
 
-    let gpt54 = build_candidate(config, &ModelRef::parse("openai/gpt-5.4").unwrap()).unwrap();
-    let gpt53 = build_candidate(config, &ModelRef::parse("openai/gpt-5.3").unwrap()).unwrap();
+    let gpt54 = build_candidate(config, &route_ref("openai@default/gpt-5.4")).unwrap();
+    let gpt53 = build_candidate(config, &route_ref("openai@default/gpt-5.3")).unwrap();
 
-    assert_eq!(gpt54.model_ref, "openai/gpt-5.4");
-    assert_eq!(gpt53.model_ref, "openai/gpt-5.3");
+    assert_eq!(gpt54.model_ref, "openai@default/gpt-5.4");
+    assert_eq!(gpt53.model_ref, "openai@default/gpt-5.3");
     assert_eq!(gpt54.provider_name, "openai");
     assert_eq!(gpt53.provider_name, "openai");
 }
@@ -1652,7 +1663,7 @@ fn build_candidate_handles_multiple_openai_models() {
 #[test]
 fn build_candidate_handles_multiple_anthropic_models() {
     let fixture = test_config(
-        "anthropic/claude-sonnet-4-6",
+        "anthropic@default/claude-sonnet-4-6",
         &[],
         None,
         Some("anthropic-token"),
@@ -1660,19 +1671,11 @@ fn build_candidate_handles_multiple_anthropic_models() {
     );
     let config = &fixture.config;
 
-    let sonnet = build_candidate(
-        config,
-        &ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-    )
-    .unwrap();
-    let haiku = build_candidate(
-        config,
-        &ModelRef::parse("anthropic/claude-haiku-4-5").unwrap(),
-    )
-    .unwrap();
+    let sonnet = build_candidate(config, &route_ref("anthropic/claude-sonnet-4-6")).unwrap();
+    let haiku = build_candidate(config, &route_ref("anthropic/claude-haiku-4-5")).unwrap();
 
-    assert_eq!(sonnet.model_ref, "anthropic/claude-sonnet-4-6");
-    assert_eq!(haiku.model_ref, "anthropic/claude-haiku-4-5");
+    assert_eq!(sonnet.model_ref, "anthropic@default/claude-sonnet-4-6");
+    assert_eq!(haiku.model_ref, "anthropic@default/claude-haiku-4-5");
     assert_eq!(sonnet.provider_name, "anthropic");
     assert_eq!(haiku.provider_name, "anthropic");
 }
@@ -1680,8 +1683,8 @@ fn build_candidate_handles_multiple_anthropic_models() {
 #[test]
 fn provider_doctor_includes_partial_availability_in_chain() {
     let fixture = test_config(
-        "anthropic/claude-sonnet-4-6",
-        &["openai/gpt-5.4", "openai-codex/gpt-5.4"],
+        "anthropic@default/claude-sonnet-4-6",
+        &["openai@default/gpt-5.4", "openai-codex@default/gpt-5.4"],
         None,
         Some("anthropic-token"),
         false,
@@ -1691,17 +1694,17 @@ fn provider_doctor_includes_partial_availability_in_chain() {
     assert_eq!(providers.len(), 3);
 
     // Default model should be available
-    assert_eq!(providers[0]["model"], "anthropic/claude-sonnet-4-6");
+    assert_eq!(providers[0]["model"], "anthropic@default/claude-sonnet-4-6");
     assert_eq!(providers[0]["availability"]["available"], Value::Bool(true));
 
     // Fallbacks should be unavailable
-    assert_eq!(providers[1]["model"], "openai/gpt-5.4");
+    assert_eq!(providers[1]["model"], "openai@default/gpt-5.4");
     assert_eq!(
         providers[1]["availability"]["available"],
         Value::Bool(false)
     );
 
-    assert_eq!(providers[2]["model"], "openai-codex/gpt-5.4");
+    assert_eq!(providers[2]["model"], "openai-codex@default/gpt-5.4");
     assert_eq!(
         providers[2]["availability"]["available"],
         Value::Bool(false)
@@ -1717,7 +1720,7 @@ fn build_candidate_reports_empty_api_key_as_missing() {
         .get_mut(&ProviderId::openai())
         .unwrap()
         .credential = Some("".to_string());
-    let err = build_candidate(&fixture.config, &ModelRef::parse("openai/gpt-5.4").unwrap())
+    let err = build_candidate(&fixture.config, &route_ref("openai/gpt-5.4"))
         .err()
         .expect("empty API key should fail");
     assert!(err.to_string().contains("missing OPENAI_API_KEY"));
@@ -1732,7 +1735,7 @@ fn build_candidate_reports_whitespace_api_key_as_missing() {
         .get_mut(&ProviderId::openai())
         .unwrap()
         .credential = Some("   ".to_string());
-    let err = build_candidate(&fixture.config, &ModelRef::parse("openai/gpt-5.4").unwrap())
+    let err = build_candidate(&fixture.config, &route_ref("openai/gpt-5.4"))
         .err()
         .expect("whitespace API key should fail");
     assert!(err.to_string().contains("missing OPENAI_API_KEY"));
@@ -1756,18 +1759,14 @@ fn build_candidate_requires_at_least_one_available_provider_in_chain() {
 #[test]
 fn build_candidate_succeeds_with_valid_codex_auth() {
     let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
-    let candidate = build_candidate(
-        &fixture.config,
-        &ModelRef::parse("openai-codex/gpt-5.4").unwrap(),
-    )
-    .unwrap();
-    assert_eq!(candidate.model_ref, "openai-codex/gpt-5.4");
+    let candidate = build_candidate(&fixture.config, &route_ref("openai-codex/gpt-5.4")).unwrap();
+    assert_eq!(candidate.model_ref, "openai-codex@default/gpt-5.4");
     assert_eq!(candidate.provider_name, "openai-codex");
 }
 
 #[test]
 fn provider_doctor_distinguishes_auth_from_other_errors() {
-    let fixture = test_config("openai/gpt-5.4", &[], None, None, false);
+    let fixture = test_config("openai@default/gpt-5.4", &[], None, None, false);
     let doctor = provider_doctor(&fixture.config);
     let providers = doctor["providers"].as_array().unwrap();
     let provider = &providers[0];
@@ -1793,7 +1792,7 @@ fn provider_doctor_distinguishes_auth_from_other_errors() {
 #[test]
 fn build_candidate_fails_when_openai_env_auth_missing() {
     let fixture = test_config("openai/gpt-5.4", &[], None, None, false);
-    let err = build_candidate(&fixture.config, &ModelRef::parse("openai/gpt-5.4").unwrap())
+    let err = build_candidate(&fixture.config, &route_ref("openai/gpt-5.4"))
         .err()
         .expect("missing env auth should fail");
     assert!(err.to_string().contains("missing OPENAI_API_KEY"));
@@ -1802,24 +1801,18 @@ fn build_candidate_fails_when_openai_env_auth_missing() {
 #[test]
 fn build_candidate_fails_when_anthropic_env_auth_missing() {
     let fixture = test_config("anthropic/claude-sonnet-4-6", &[], None, None, false);
-    let err = build_candidate(
-        &fixture.config,
-        &ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-    )
-    .err()
-    .expect("missing env auth should fail");
+    let err = build_candidate(&fixture.config, &route_ref("anthropic/claude-sonnet-4-6"))
+        .err()
+        .expect("missing env auth should fail");
     assert!(err.to_string().contains("missing ANTHROPIC_AUTH_TOKEN"));
 }
 
 #[test]
 fn build_candidate_fails_when_codex_external_cli_auth_missing() {
     let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, false);
-    let err = build_candidate(
-        &fixture.config,
-        &ModelRef::parse("openai-codex/gpt-5.4").unwrap(),
-    )
-    .err()
-    .expect("missing external CLI auth should fail");
+    let err = build_candidate(&fixture.config, &route_ref("openai-codex/gpt-5.4"))
+        .err()
+        .expect("missing external CLI auth should fail");
     assert!(err
         .to_string()
         .contains("no Holon openai-codex credential profile or usable Codex CLI credentials"));
@@ -1828,16 +1821,16 @@ fn build_candidate_fails_when_codex_external_cli_auth_missing() {
 #[test]
 fn build_candidate_succeeds_with_openai_env_auth() {
     let fixture = test_config("openai/gpt-5.4", &[], Some("sk-test-key"), None, false);
-    let candidate = build_candidate(&fixture.config, &ModelRef::parse("openai/gpt-5.4").unwrap())
+    let candidate = build_candidate(&fixture.config, &route_ref("openai/gpt-5.4"))
         .expect("valid env auth should succeed");
-    assert_eq!(candidate.model_ref, "openai/gpt-5.4");
+    assert_eq!(candidate.model_ref, "openai@default/gpt-5.4");
     assert_eq!(candidate.provider_name, "openai");
 }
 
 #[test]
 fn build_candidate_succeeds_with_anthropic_env_auth() {
     let fixture = test_config(
-        "anthropic/claude-sonnet-4-6",
+        "anthropic@default/claude-sonnet-4-6",
         &[],
         None,
         Some("sk-ant-test-token"),
@@ -1845,16 +1838,16 @@ fn build_candidate_succeeds_with_anthropic_env_auth() {
     );
     let candidate = build_candidate(
         &fixture.config,
-        &ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        &route_ref("anthropic@default/claude-sonnet-4-6"),
     )
     .expect("valid env auth should succeed");
-    assert_eq!(candidate.model_ref, "anthropic/claude-sonnet-4-6");
+    assert_eq!(candidate.model_ref, "anthropic@default/claude-sonnet-4-6");
     assert_eq!(candidate.provider_name, "anthropic");
 }
 
 #[test]
 fn provider_doctor_reports_missing_openai_env_auth() {
-    let fixture = test_config("openai/gpt-5.4", &[], None, None, false);
+    let fixture = test_config("openai@default/gpt-5.4", &[], None, None, false);
     let doctor = provider_doctor(&fixture.config);
     let providers = doctor["providers"].as_array().unwrap();
     let openai_provider = providers

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::{
-    config::{provider_registry_for_tests, AppConfig, ControlAuthMode, ModelRef},
+    config::{provider_registry_for_tests, AppConfig, ControlAuthMode},
     prompt::PromptStability,
     tool::{ToolRegistry, ToolSpec},
 };
@@ -291,10 +291,10 @@ pub fn test_config(
         api_cors: Default::default(),
         config_file_path: home_path.join("config.json"),
         stored_config: Default::default(),
-        default_model: ModelRef::parse(default_model).unwrap(),
+        default_model: crate::config::ModelRouteRef::parse_compatible(default_model).unwrap(),
         fallback_models: fallback_models
             .iter()
-            .map(|value| ModelRef::parse(value).unwrap())
+            .map(|value| crate::config::ModelRouteRef::parse_compatible(value).unwrap())
             .collect(),
         vision_model: None,
         image_generation_model: None,

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tokio::task::JoinHandle;
 
 use crate::{
-    config::{AppConfig, ModelRef},
+    config::{AppConfig, ModelRouteRef},
     host::RuntimeHost,
     ingress::InboundRequest,
     provider::ProviderCacheUsage,
@@ -100,9 +100,9 @@ pub struct RunOnceResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_cache_usage: Option<RunProviderCacheUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requested_model: Option<ModelRef>,
+    pub requested_model: Option<ModelRouteRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_model: Option<ModelRef>,
+    pub active_model: Option<ModelRouteRef>,
     pub fallback_active: bool,
     pub model_rounds: u64,
     pub tool_calls: usize,
@@ -1084,9 +1084,9 @@ fn batched_exec_command_items(tools: &[ToolExecutionRecord]) -> usize {
 
 fn latest_run_model_state(
     events: &[AuditEvent],
-    fallback_requested_model: Option<ModelRef>,
-    fallback_active_model: Option<ModelRef>,
-) -> (Option<ModelRef>, Option<ModelRef>, bool) {
+    fallback_requested_model: Option<ModelRouteRef>,
+    fallback_active_model: Option<ModelRouteRef>,
+) -> (Option<ModelRouteRef>, Option<ModelRouteRef>, bool) {
     let mut requested_model = fallback_requested_model;
     let mut active_model = fallback_active_model;
     let mut fallback_active = requested_model
@@ -1102,13 +1102,13 @@ fn latest_run_model_state(
             .data
             .get("requested_model")
             .and_then(|value| value.as_str())
-            .and_then(|value| ModelRef::parse(value).ok())
+            .and_then(|value| ModelRouteRef::parse_compatible(value).ok())
             .or(requested_model);
         active_model = event
             .data
             .get("active_model")
             .and_then(|value| value.as_str())
-            .and_then(|value| ModelRef::parse(value).ok())
+            .and_then(|value| ModelRouteRef::parse_compatible(value).ok())
             .or(active_model);
         fallback_active = event
             .data

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -10,7 +10,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use tokio::sync::{Mutex, Notify, RwLock};
 
 use crate::{
-    config::{AppConfig, ModelRef, ModelRouteCapability, RuntimeModelCatalog},
+    config::{AppConfig, ModelRef, ModelRouteCapability, ModelRouteRef, RuntimeModelCatalog},
     context::ContextConfig,
     host::RuntimeHostBridge,
     model_catalog::BuiltInModelMetadata,
@@ -336,13 +336,13 @@ impl RuntimeHandle {
     }
 
     pub(crate) fn apply_patch_surface_for_state(&self, state: &AgentState) -> ApplyPatchSurface {
-        let model_ref = self
+        let route_ref = self
             .selected_model_ref_for_state(state)
             .unwrap_or_else(|| self.model_state_for(state).effective_model);
-        ApplyPatchSurface::for_model_ref(&model_ref.as_string())
+        ApplyPatchSurface::for_model_ref(&route_ref.model_ref().as_string())
     }
 
-    fn selected_model_ref_for_state(&self, state: &AgentState) -> Option<ModelRef> {
+    fn selected_model_ref_for_state(&self, state: &AgentState) -> Option<ModelRouteRef> {
         let snap = self.inner.config_snapshot.load();
         snap.model_catalog
             .provider_chain_for_turn(

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -753,7 +753,7 @@ impl RuntimeHandle {
 
     pub async fn set_model_override(
         &self,
-        model_override: crate::config::ModelRef,
+        model_override: crate::config::ModelRouteRef,
         reasoning_effort: Option<String>,
     ) -> Result<crate::types::AgentModelState> {
         let mut next_state = self.agent_state().await?;

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -57,8 +57,9 @@ async fn attached_workspace_inheritance_preserves_execution_boundary() {
             access_mode: WorkspaceAccessMode::SharedRead,
         });
         guard.state.execution_profile.process_execution_exposed = false;
-        guard.state.model_override =
-            Some(crate::config::ModelRef::parse("anthropic/claude-haiku-4-5").unwrap());
+        guard.state.model_override = Some(
+            crate::config::ModelRouteRef::parse_compatible("anthropic/claude-haiku-4-5").unwrap(),
+        );
         parent.inner.storage.write_agent(&guard.state).unwrap();
     }
     let parent_state = parent.agent_state().await.unwrap();
@@ -295,8 +296,10 @@ async fn preview_prompt_uses_codex_apply_patch_surface_even_when_prompt_tools_ar
     .unwrap();
     {
         let mut guard = runtime.inner.agent.lock().await;
-        guard.state.model_override =
-            Some(crate::config::ModelRef::parse("openai-codex/gpt-5.3-codex-spark").unwrap());
+        guard.state.model_override = Some(
+            crate::config::ModelRouteRef::parse_compatible("openai-codex/gpt-5.3-codex-spark")
+                .unwrap(),
+        );
         runtime.inner.storage.write_agent(&guard.state).unwrap();
     }
 

--- a/src/runtime/tests/tui_pipeline_e2e.rs
+++ b/src/runtime/tests/tui_pipeline_e2e.rs
@@ -3,7 +3,7 @@ use super::support::*;
 
 use crate::{
     client::{AgentStateSnapshot, AgentStreamEvent, StateSessionSnapshot, StreamEventEnvelope},
-    config::ModelRef,
+    config::ModelRouteRef,
     model_catalog::ResolvedRuntimeModelPolicy,
     provider::test_support::{ScriptedAgentProvider, ScriptedProviderStep},
     system::{ExecutionProfile, ExecutionSnapshot},
@@ -42,11 +42,13 @@ fn minimal_agent_summary(agent_id: &str) -> AgentSummary {
         lifecycle: AgentLifecycleHint::default(),
         scheduling_posture: Default::default(),
         model: AgentModelState {
-            effective_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            effective_model: ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6")
+                .unwrap(),
             requested_model: None,
             active_model: None,
             fallback_active: false,
-            runtime_default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            runtime_default_model: ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6")
+                .unwrap(),
             override_model: None,
             override_reasoning_effort: None,
             source: AgentModelSource::RuntimeDefault,

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -970,11 +970,11 @@ async fn runtime_persists_provider_attempt_timeline_on_successful_round() {
     );
     assert_eq!(
         assistant_round.data["requested_model"].as_str(),
-        Some("openai/gpt-5.4")
+        Some("openai@default/gpt-5.4")
     );
     assert_eq!(
         assistant_round.data["active_model"].as_str(),
-        Some("anthropic/claude-sonnet-4-6")
+        Some("anthropic@default/claude-sonnet-4-6")
     );
     assert_eq!(
         assistant_round.data["fallback_active"].as_bool(),
@@ -1026,11 +1026,11 @@ async fn runtime_persists_provider_attempt_timeline_on_successful_round() {
         .is_some());
     assert_eq!(
         provider_event.data["requested_model"].as_str(),
-        Some("openai/gpt-5.4")
+        Some("openai@default/gpt-5.4")
     );
     assert_eq!(
         provider_event.data["active_model"].as_str(),
-        Some("anthropic/claude-sonnet-4-6")
+        Some("anthropic@default/claude-sonnet-4-6")
     );
     assert_eq!(provider_event.data["fallback_active"].as_bool(), Some(true));
 }
@@ -1070,7 +1070,7 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
             .as_ref()
             .map(|model| model.as_string())
             .as_deref(),
-        Some("anthropic/claude-sonnet-4-6")
+        Some("anthropic@default/claude-sonnet-4-6")
     );
     assert_eq!(
         state.last_turn_terminal.as_ref().map(|record| record.kind),

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
 
-use crate::config::ModelRef;
+use crate::config::ModelRouteRef;
 use crate::prompt::EffectivePrompt;
 use crate::provider::{
     provider_attempt_timeline, provider_error_is_context_length_exceeded, AgentProvider,
@@ -160,7 +160,7 @@ impl RuntimeHandle {
         let Some(fallback_ref) = timeline.pending_fallback_model_ref.as_deref() else {
             return Ok(None);
         };
-        let Ok(fallback_model) = ModelRef::parse(fallback_ref) else {
+        let Ok(fallback_model) = ModelRouteRef::parse_compatible(fallback_ref) else {
             return Ok(None);
         };
         let terminal_kind = if side_effect_boundary_crossed {

--- a/src/runtime/turn/projection.rs
+++ b/src/runtime/turn/projection.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
-use crate::config::ModelRef;
+use crate::config::ModelRouteRef;
 use crate::provider::{
     ConversationMessage, ModelBlock, PromptContentBlock, ProviderAttemptTimeline,
     ProviderPromptFrame, ToolResultBlock,
@@ -148,8 +148,8 @@ pub(super) fn estimate_prompt_frame_tokens(prompt_frame: &ProviderPromptFrame) -
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct ProviderAttemptModelState {
-    pub(super) requested_model: Option<ModelRef>,
-    pub(super) active_model: Option<ModelRef>,
+    pub(super) requested_model: Option<ModelRouteRef>,
+    pub(super) active_model: Option<ModelRouteRef>,
     pub(super) fallback_active: bool,
 }
 
@@ -185,13 +185,13 @@ pub(super) fn provider_attempt_model_state(
         return ProviderAttemptModelState::default();
     };
     let requested_model = (!timeline.requested_model_ref.is_empty())
-        .then(|| ModelRef::parse(&timeline.requested_model_ref).ok())
+        .then(|| ModelRouteRef::parse_compatible(&timeline.requested_model_ref).ok())
         .flatten();
     let active_model = timeline
         .active_model_ref
         .as_deref()
         .or(timeline.winning_model_ref.as_deref())
-        .and_then(|model| ModelRef::parse(model).ok());
+        .and_then(|model| ModelRouteRef::parse_compatible(model).ok());
     let fallback_active = requested_model
         .as_ref()
         .zip(active_model.as_ref())

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -1212,8 +1212,8 @@ mod tests {
         }
     }
 
-    fn model_ref() -> crate::config::ModelRef {
-        crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()
+    fn model_ref() -> crate::config::ModelRouteRef {
+        crate::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap()
     }
 
     fn agent_summary(status: AgentStatus, posture: AgentSchedulingPosture) -> AgentSummary {

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -227,7 +227,7 @@ mod tests {
     use super::{clamp_model_picker_selection, model_picker_rows, selected_model_picker_row};
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
     use crate::{
-        config::{ModelRef, ProviderId},
+        config::{ModelRef, ModelRouteRef},
         model_catalog::{ModelCapabilityFlags, ModelMetadataSource, ResolvedRuntimeModelPolicy},
         types::{
             AgentIdentityView, AgentKind, AgentLifecycleHint, AgentModelSource, AgentModelState,
@@ -258,6 +258,10 @@ mod tests {
             },
             source: ModelMetadataSource::BuiltInCatalog,
         }
+    }
+
+    fn route_ref(model: &str) -> ModelRouteRef {
+        ModelRouteRef::parse_compatible(model).unwrap()
     }
 
     fn availability(
@@ -320,10 +324,10 @@ mod tests {
             scheduling_posture: Default::default(),
             model: AgentModelState {
                 source: AgentModelSource::RuntimeDefault,
-                runtime_default_model: ModelRef::new(ProviderId::openai(), "gpt-5.4"),
-                effective_model: ModelRef::new(ProviderId::openai(), "gpt-5.4"),
-                requested_model: Some(ModelRef::new(ProviderId::openai(), "gpt-5.4")),
-                active_model: Some(ModelRef::new(ProviderId::openai(), "gpt-5.4")),
+                runtime_default_model: route_ref("openai/gpt-5.4"),
+                effective_model: route_ref("openai/gpt-5.4"),
+                requested_model: Some(route_ref("openai/gpt-5.4")),
+                active_model: Some(route_ref("openai/gpt-5.4")),
                 fallback_active: false,
                 effective_fallback_models: Vec::new(),
                 override_model: None,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1303,10 +1303,10 @@ impl TuiProjection {
         let has_requested_model = payload.get("requested_model").is_some();
         let has_active_model = payload.get("active_model").is_some();
         let requested_model = payload.get("requested_model").and_then(|value| {
-            decode_value::<Option<crate::config::ModelRef>>(value.clone()).unwrap_or(None)
+            decode_value::<Option<crate::config::ModelRouteRef>>(value.clone()).unwrap_or(None)
         });
         let active_model = payload.get("active_model").and_then(|value| {
-            decode_value::<Option<crate::config::ModelRef>>(value.clone()).unwrap_or(None)
+            decode_value::<Option<crate::config::ModelRouteRef>>(value.clone()).unwrap_or(None)
         });
         let fallback_active = payload.get("fallback_active").and_then(Value::as_bool);
 
@@ -1817,6 +1817,10 @@ mod tests {
 
     fn test_log_writer() -> crate::tui::logging::TuiLogWriter {
         crate::tui::logging::TuiLogWriter::new_temp().unwrap()
+    }
+
+    fn route_ref(value: &str) -> crate::config::ModelRouteRef {
+        crate::config::ModelRouteRef::parse_compatible(value).unwrap()
     }
 
     #[test]
@@ -2852,7 +2856,7 @@ mod tests {
     fn projection_updates_model_from_override_lifecycle_events() {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
         let mut model = projection.agent.model.clone();
-        let override_model = crate::config::ModelRef::parse("openai/gpt-5.4").unwrap();
+        let override_model = route_ref("openai/gpt-5.4");
         model.source = AgentModelSource::AgentOverride;
         model.effective_model = override_model.clone();
         model.requested_model = Some(override_model.clone());
@@ -2879,7 +2883,7 @@ mod tests {
                 .override_model
                 .as_ref()
                 .map(|model| model.as_string()),
-            Some("openai/gpt-5.4".into())
+            Some("openai@default/gpt-5.4".into())
         );
         assert_eq!(
             projection.agent.model.override_reasoning_effort.as_deref(),
@@ -2910,7 +2914,7 @@ mod tests {
                 .requested_model
                 .as_ref()
                 .map(|model| model.as_string()),
-            Some("openai/gpt-5.4".into())
+            Some("openai@default/gpt-5.4".into())
         );
         assert_eq!(
             projection
@@ -2919,7 +2923,7 @@ mod tests {
                 .active_model
                 .as_ref()
                 .map(|model| model.as_string()),
-            Some("anthropic/claude-sonnet-4-6".into())
+            Some("anthropic@default/claude-sonnet-4-6".into())
         );
         assert!(projection.agent.model.fallback_active);
         assert!(!projection.stale_slices.contains(&ProjectionSlice::Agent));
@@ -3489,19 +3493,11 @@ mod tests {
             lifecycle: AgentLifecycleHint::default(),
             scheduling_posture: Default::default(),
             model: AgentModelState {
-                effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
-                    .unwrap(),
-                requested_model: Some(
-                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-                ),
-                active_model: Some(
-                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-                ),
+                effective_model: route_ref("anthropic/claude-sonnet-4-6"),
+                requested_model: Some(route_ref("anthropic/claude-sonnet-4-6")),
+                active_model: Some(route_ref("anthropic/claude-sonnet-4-6")),
                 fallback_active: false,
-                runtime_default_model: crate::config::ModelRef::parse(
-                    "anthropic/claude-sonnet-4-6",
-                )
-                .unwrap(),
+                runtime_default_model: route_ref("anthropic/claude-sonnet-4-6"),
                 override_model: None,
                 override_reasoning_effort: None,
                 source: AgentModelSource::RuntimeDefault,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1063,6 +1063,10 @@ mod tests {
     use serde_json::{json, Value};
     use std::path::PathBuf;
 
+    fn route_ref(value: &str) -> crate::config::ModelRouteRef {
+        crate::config::ModelRouteRef::parse_compatible(value).unwrap()
+    }
+
     fn sample_agent_summary() -> AgentSummary {
         let mut state = AgentState::new("default");
         state.status = crate::types::AgentStatus::AwakeIdle;
@@ -1084,19 +1088,11 @@ mod tests {
             lifecycle: AgentLifecycleHint::default(),
             scheduling_posture: Default::default(),
             model: AgentModelState {
-                effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
-                    .unwrap(),
-                requested_model: Some(
-                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-                ),
-                active_model: Some(
-                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-                ),
+                effective_model: route_ref("anthropic/claude-sonnet-4-6"),
+                requested_model: Some(route_ref("anthropic/claude-sonnet-4-6")),
+                active_model: Some(route_ref("anthropic/claude-sonnet-4-6")),
                 fallback_active: false,
-                runtime_default_model: crate::config::ModelRef::parse(
-                    "anthropic/claude-sonnet-4-6",
-                )
-                .unwrap(),
+                runtime_default_model: route_ref("anthropic/claude-sonnet-4-6"),
                 override_model: None,
                 override_reasoning_effort: None,
                 source: AgentModelSource::RuntimeDefault,
@@ -1263,30 +1259,25 @@ mod tests {
         let inherited = sample_agent_summary();
         assert_eq!(
             render_model_status(&inherited),
-            "model: anthropic/claude-sonnet-4-6"
+            "model: anthropic@default/claude-sonnet-4-6"
         );
 
         let mut overridden = sample_agent_summary();
-        overridden.model.override_model =
-            Some(crate::config::ModelRef::parse("openai/gpt-5.4").unwrap());
-        overridden.model.effective_model =
-            crate::config::ModelRef::parse("openai/gpt-5.4").unwrap();
-        overridden.model.active_model =
-            Some(crate::config::ModelRef::parse("openai/gpt-5.4").unwrap());
+        overridden.model.override_model = Some(route_ref("openai/gpt-5.4"));
+        overridden.model.effective_model = route_ref("openai/gpt-5.4");
+        overridden.model.active_model = Some(route_ref("openai/gpt-5.4"));
         assert_eq!(
             render_model_status(&overridden),
-            "model: openai/gpt-5.4 (agent override)"
+            "model: openai@default/gpt-5.4 (agent override)"
         );
 
         let mut fallback = overridden;
-        fallback.model.requested_model =
-            Some(crate::config::ModelRef::parse("openai/gpt-5.4").unwrap());
-        fallback.model.active_model =
-            Some(crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap());
+        fallback.model.requested_model = Some(route_ref("openai/gpt-5.4"));
+        fallback.model.active_model = Some(route_ref("anthropic/claude-sonnet-4-6"));
         fallback.model.fallback_active = true;
         assert_eq!(
             render_model_status(&fallback),
-            "model: anthropic/claude-sonnet-4-6 (fallback from openai/gpt-5.4)"
+            "model: anthropic@default/claude-sonnet-4-6 (fallback from openai@default/gpt-5.4)"
         );
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -67,7 +67,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: temp.join("config.json"),
         stored_config: Default::default(),
-        default_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: crate::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,
@@ -201,16 +204,23 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
         lifecycle: AgentLifecycleHint::default(),
         scheduling_posture: Default::default(),
         model: AgentModelState {
-            effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            effective_model: crate::config::ModelRouteRef::parse_compatible(
+                "anthropic/claude-sonnet-4-6",
+            )
+            .unwrap(),
             requested_model: Some(
-                crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                crate::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6")
+                    .unwrap(),
             ),
             active_model: Some(
-                crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                crate::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6")
+                    .unwrap(),
             ),
             fallback_active: false,
-            runtime_default_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
-                .unwrap(),
+            runtime_default_model: crate::config::ModelRouteRef::parse_compatible(
+                "anthropic/claude-sonnet-4-6",
+            )
+            .unwrap(),
             override_model: None,
             override_reasoning_effort: None,
             source: AgentModelSource::RuntimeDefault,
@@ -711,7 +721,7 @@ fn statusbar_view_model_shows_workspace_label_execution_root_and_model() {
         .contains("opensource/src/github.com/holon-run/holon)"));
     assert!(view_model
         .context_line
-        .contains("anthropic/claude-sonnet-4-6"));
+        .contains("anthropic@default/claude-sonnet-4-6"));
     assert!(!view_model.context_line.contains("model:"));
 }
 
@@ -786,7 +796,7 @@ fn statusbar_view_model_converges_from_provider_round_model_event() {
 
     assert!(view_model
         .context_line
-        .contains("anthropic/claude-sonnet-4-6 (fallback from openai/gpt-5.4)"));
+        .contains("anthropic@default/claude-sonnet-4-6 (fallback from openai@default/gpt-5.4)"));
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use crate::config::ModelRef;
+use crate::config::ModelRouteRef;
 use crate::ids;
 use crate::model_catalog::ResolvedRuntimeModelPolicy;
 use crate::system::{
@@ -1872,15 +1872,15 @@ pub struct AgentState {
     #[serde(default)]
     pub last_continuation: Option<ContinuationResolution>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_override: Option<ModelRef>,
+    pub model_override: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_override_reasoning_effort: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pending_fallback_model: Option<ModelRef>,
+    pub pending_fallback_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_requested_model: Option<ModelRef>,
+    pub last_requested_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_active_model: Option<ModelRef>,
+    pub last_active_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_turn_terminal: Option<TurnTerminalRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4402,13 +4402,13 @@ pub struct AgentModelOverrideAuditEvent {
     #[serde(alias = "session_id")]
     pub agent_id: String,
     pub source: AgentModelSource,
-    pub effective_model: ModelRef,
+    pub effective_model: ModelRouteRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_model: Option<ModelRef>,
+    pub requested_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_model: Option<ModelRef>,
+    pub active_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub override_model: Option<ModelRef>,
+    pub override_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub override_reasoning_effort: Option<String>,
     #[serde(default)]
@@ -4736,18 +4736,18 @@ pub enum AgentModelSource {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentModelState {
     pub source: AgentModelSource,
-    pub runtime_default_model: ModelRef,
-    pub effective_model: ModelRef,
+    pub runtime_default_model: ModelRouteRef,
+    pub effective_model: ModelRouteRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_model: Option<ModelRef>,
+    pub requested_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_model: Option<ModelRef>,
+    pub active_model: Option<ModelRouteRef>,
     #[serde(default)]
     pub fallback_active: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub effective_fallback_models: Vec<ModelRef>,
+    pub effective_fallback_models: Vec<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub override_model: Option<ModelRef>,
+    pub override_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub override_reasoning_effort: Option<String>,
     #[serde(default)]
@@ -4906,18 +4906,18 @@ pub struct AgentSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentListModelSummary {
     pub source: AgentModelSource,
-    pub runtime_default_model: ModelRef,
-    pub effective_model: ModelRef,
+    pub runtime_default_model: ModelRouteRef,
+    pub effective_model: ModelRouteRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_model: Option<ModelRef>,
+    pub requested_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_model: Option<ModelRef>,
+    pub active_model: Option<ModelRouteRef>,
     #[serde(default)]
     pub fallback_active: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub effective_fallback_models: Vec<ModelRef>,
+    pub effective_fallback_models: Vec<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub override_model: Option<ModelRef>,
+    pub override_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub override_reasoning_effort: Option<String>,
 }
@@ -5368,7 +5368,7 @@ mod tests {
 
         assert_eq!(
             model.effective_model,
-            ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()
+            ModelRouteRef::parse("anthropic@default/claude-sonnet-4-6").unwrap()
         );
         assert_eq!(
             model.resolved_policy.source,

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -382,11 +382,11 @@ fn config_set_unset_reports_offline_application_path_on_stderr() {
 
     let (set, set_stderr) =
         run_json_with_stderr(&home, &["config", "set", "model.default", "openai/gpt-4.1"]);
-    assert_eq!(set, json!("openai/gpt-4.1"));
+    assert_eq!(set, json!("openai@default/gpt-4.1"));
     assert_eq!(set_stderr, "applied_via=offline_store\n");
 
     let get = run_json(&home, &["config", "get", "model.default"]);
-    assert_eq!(get, json!("openai/gpt-4.1"));
+    assert_eq!(get, json!("openai@default/gpt-4.1"));
 
     let (unset, unset_stderr) = run_json_with_stderr(&home, &["config", "unset", "model.default"]);
     assert_eq!(
@@ -423,7 +423,7 @@ fn config_set_prefers_running_daemon_runtime_config_api() {
             stderr,
         )
     };
-    assert_eq!(set, json!("openai/gpt-4.1"));
+    assert_eq!(set, json!("openai@default/gpt-4.1"));
     assert!(
         set_stderr.contains("applied_via=daemon_api\n"),
         "stderr should report daemon application path: {set_stderr}"
@@ -434,7 +434,7 @@ fn config_set_prefers_running_daemon_runtime_config_api() {
         &["config", "get", "model.default"],
         &[("HOLON_HTTP_ADDR", &addr)],
     );
-    assert_eq!(get, json!("openai/gpt-4.1"));
+    assert_eq!(get, json!("openai@default/gpt-4.1"));
 
     let (unset, unset_stderr) = {
         let mut command = isolated_holon_command(&home);

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -86,7 +86,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 94, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 95, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/live_llm_baseline.rs
+++ b/tests/live_llm_baseline.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use holon::{
-    config::{AppConfig, ModelRef, ProviderId, ProviderTransportKind},
+    config::{AppConfig, ModelRouteRef, ProviderId, ProviderTransportKind},
     prompt::PromptStability,
     provider::{
         build_provider_from_model_chain, AgentProvider, AnthropicProvider, ConversationMessage,
@@ -21,7 +21,7 @@ fn live_baseline_model_limit() -> usize {
         .unwrap_or(1)
 }
 
-fn live_baseline_models(config: &AppConfig) -> Vec<ModelRef> {
+fn live_baseline_models(config: &AppConfig) -> Vec<ModelRouteRef> {
     config
         .provider_chain()
         .into_iter()

--- a/tests/live_prompt_continuity.rs
+++ b/tests/live_prompt_continuity.rs
@@ -30,7 +30,7 @@ fn live_runtime_config() -> Result<(AppConfig, tempfile::TempDir, tempfile::Temp
 
     let model = live_prompt_continuity_model()?;
     config.default_agent_id = "live-prompt-continuity".into();
-    config.default_model = model.clone();
+    config.default_model = holon::config::ModelRouteRef::from_legacy_model_ref(&model);
     config.fallback_models.clear();
     config.disable_provider_fallback = true;
     config.home_dir = data_dir.path().to_path_buf();

--- a/tests/live_provider_smoke.rs
+++ b/tests/live_provider_smoke.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 use holon::{
-    config::{AppConfig, ModelRef, ProviderId, ProviderTransportKind},
+    config::{AppConfig, ModelRef, ModelRouteRef, ProviderId, ProviderTransportKind},
     context::ContextConfig,
     model_catalog::{BuiltInModelCatalog, ResolvedRuntimeModelPolicy},
     provider::{
@@ -44,7 +44,7 @@ struct SmokeResult {
 /// Only providers that appear in the chain (i.e. have a valid credential) are
 /// included.
 fn provider_model_map(config: &AppConfig) -> BTreeMap<ProviderId, String> {
-    let chain: Vec<ModelRef> = config.provider_chain();
+    let chain: Vec<ModelRouteRef> = config.provider_chain();
     let mut map = BTreeMap::new();
     for model_ref in chain {
         map.entry(model_ref.provider.clone())

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use holon::{
-    config::{AppConfig, ControlAuthMode, ModelRef},
+    config::{AppConfig, ControlAuthMode},
     host::RuntimeHost,
     provider::{
         test_support::{ScriptedAgentProvider, ScriptedProviderStep},
@@ -38,7 +38,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
-        default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: holon::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -244,6 +244,23 @@
     "aliases": []
   },
   {
+    "path": "config.migrate-model-routes",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "write",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "config.models",
     "positionals": [],
     "flags": [],

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -1612,6 +1612,22 @@
   },
   {
     "method": "post",
+    "path": "/api/control/runtime/config/migrate-model-routes",
+    "handler": "runtime_config_migrate_model_routes",
+    "operation_id": "migrateModelConfigRoutes",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": "ModelConfigMigrationRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/api/control/runtime/shutdown",
     "handler": "runtime_shutdown",
     "operation_id": "runtimeShutdown",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1138,7 +1138,8 @@ pub async fn skill_library_reconcile_and_check_lock_file() -> Result<()> {
 
 pub async fn control_agent_model_override_set_and_clear_updates_status() -> Result<()> {
     let mut config = test_config();
-    config.default_model = holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap();
+    config.default_model =
+        holon::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap();
     config
         .providers
         .get_mut(&holon::config::ProviderId::anthropic())
@@ -1157,7 +1158,7 @@ pub async fn control_agent_model_override_set_and_clear_updates_status() -> Resu
     assert_eq!(set_payload["model"]["source"], "agent_override");
     assert_eq!(
         set_payload["model"]["effective_model"],
-        "anthropic/claude-haiku-4-5"
+        "anthropic@default/claude-haiku-4-5"
     );
 
     let status_payload: serde_json::Value = client
@@ -1169,7 +1170,7 @@ pub async fn control_agent_model_override_set_and_clear_updates_status() -> Resu
     assert_eq!(status_payload["model"]["source"], "agent_override");
     assert_eq!(
         status_payload["agent"]["model_override"],
-        "anthropic/claude-haiku-4-5"
+        "anthropic@default/claude-haiku-4-5"
     );
 
     let clear_response = client
@@ -2038,12 +2039,18 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     );
     assert_eq!(
         valid_model_payload["runtime_surface"]["model_default"],
-        "openai/gpt-4.1"
+        "openai@default/gpt-4.1"
     );
-    assert_eq!(host.config().default_model.as_string(), "openai/gpt-4.1");
+    assert_eq!(
+        host.config().default_model.as_string(),
+        "openai@default/gpt-4.1"
+    );
 
     let persisted = load_persisted_config_at(&config.config_file_path)?;
-    assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
+    assert_eq!(
+        persisted.model.default.as_deref(),
+        Some("openai@default/gpt-4.1")
+    );
 
     let provider_config_response = client
         .patch(format!("http://{addr}/api/control/runtime/config"))
@@ -2204,7 +2211,10 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     );
 
     let persisted = load_persisted_config_at(&config.config_file_path)?;
-    assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
+    assert_eq!(
+        persisted.model.default.as_deref(),
+        Some("openai@default/gpt-4.1")
+    );
     assert_eq!(
         persisted
             .web

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -160,7 +160,10 @@ impl TestConfigBuilder {
             api_cors: Default::default(),
             config_file_path: data_dir.join("config.json"),
             stored_config: Default::default(),
-            default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            default_model: holon::config::ModelRouteRef::parse_compatible(
+                "anthropic/claude-sonnet-4-6",
+            )
+            .unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
             image_generation_model: None,

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -40,7 +40,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
-        default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: holon::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -39,7 +39,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
-        default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: holon::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -38,7 +38,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
-        default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: holon::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -39,7 +39,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
-        default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: holon::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -39,7 +39,10 @@ fn test_config() -> AppConfig {
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
-        default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+        default_model: holon::config::ModelRouteRef::parse_compatible(
+            "anthropic/claude-sonnet-4-6",
+        )
+        .unwrap(),
         fallback_models: Vec::new(),
         vision_model: None,
         image_generation_model: None,

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -187,7 +187,7 @@ export function AgentPage({
   const timelineVersion = `${timeline.length}:${newestTimelineItem?.id ?? ""}:${timeline[0]?.id ?? ""}:${detail?.events?.length ?? 0}:${hasOlderEvents}`;
   const hasHiddenTimelineItems = timeline.length >= visibleTimelineItemLimit && sourceTimeline.length > visibleTimelineItemLimit;
   const groupedModelOptions = useMemo(() => groupModelOptionsByProvider(modelCatalog.options), [modelCatalog.options]);
-  const activeModelOption = useMemo(() => modelCatalog.options.find((option) => option.model === activeAgent.model), [activeAgent.model, modelCatalog.options]);
+  const activeModelOption = useMemo(() => modelCatalog.options.find((option) => option.routeRef === activeAgent.model), [activeAgent.model, modelCatalog.options]);
   const activeModelSupportsReasoning = activeModelOption?.supportsReasoningEffort ?? Boolean(activeAgent.modelReasoningEffort);
   const activeReasoningBadge = activeModelSupportsReasoning ? (activeAgent.modelReasoningEffort ?? "auto") : undefined;
   const activeModelTitle = modelButtonTitle(activeAgent.model, activeReasoningBadge, activeAgent.modelSource === "agent_override");
@@ -435,9 +435,9 @@ export function AgentPage({
       reasoningEffort = "auto";
     }
 
-    setChangingModel(option.model);
+    setChangingModel(option.routeRef);
     try {
-      await onSetModel(option.model, option.supportsReasoningEffort && reasoningEffort !== "auto" ? reasoningEffort : undefined);
+      await onSetModel(option.routeRef, option.supportsReasoningEffort && reasoningEffort !== "auto" ? reasoningEffort : undefined);
       setModelPickerOpen(false);
     } catch {
       // Store exposes the user-facing error.
@@ -727,8 +727,8 @@ export function AgentPage({
                           <div className="model-options" role="listbox" aria-label={t("agent.providerModelsAria", { provider: currentProvider })}>
                             {currentProviderModels.map((option) => (
                               <button
-                                className={`model-option ${option.model === activeAgent.model ? "is-active" : ""}`}
-                                key={option.model}
+                                className={`model-option ${option.routeRef === activeAgent.model ? "is-active" : ""}`}
+                                key={option.routeRef}
                                 type="button"
                                 disabled={!option.available || changingModel !== null}
                                 title={option.unavailableReason ?? option.model}
@@ -741,7 +741,7 @@ export function AgentPage({
                                 <span className="model-option-meta">
                                   {option.supportsReasoningEffort ? <small>{t("agent.reasoningMeta")}</small> : null}
                                   {!option.available ? <small>{t("agent.unavailableMeta")}</small> : null}
-                                  {changingModel === option.model ? <em>{t("common.saving")}</em> : null}
+                                  {changingModel === option.routeRef ? <em>{t("common.saving")}</em> : null}
                                 </span>
                               </button>
                             ))}
@@ -786,9 +786,12 @@ function modelButtonTitle(model: string, reasoningEffort: string | undefined, is
 function groupModelOptionsByProvider(options: RuntimeModelOption[]): Array<{ provider: string; availableCount: number; models: RuntimeModelOption[] }> {
   const groups = new Map<string, RuntimeModelOption[]>();
   for (const option of options) {
-    const models = groups.get(option.provider) ?? [];
+    const provider = option.endpoint === "default"
+      ? option.providerFamily
+      : `${option.providerFamily} / ${option.endpoint}`;
+    const models = groups.get(provider) ?? [];
     models.push(option);
-    groups.set(option.provider, models);
+    groups.set(provider, models);
   }
   return Array.from(groups.entries())
     .map(([provider, models]) => ({

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -363,12 +363,12 @@ export function SettingsPage({
   const configuredProviderCount = surface?.providers.filter((provider) => provider.credentialConfigured).length ?? 0;
   const searchProviderCount = surface?.webSearchProviders.length ?? 0;
   const configuredSearchProviderCount = surface?.webSearchProviders.filter((provider) => provider.credentialConfigured).length ?? 0;
-  const visionRouteProvider = modelCatalog.options.find((model) => model.model === visionDefault)?.routeProvider
+  const visionRouteProvider = modelCatalog.options.find((model) => model.routeRef === visionDefault)?.routeProvider
     ?? visionDefault.split("/")[0];
   const visionProviderReady = visionDefault
     ? surface?.providers.find((provider) => provider.id === visionRouteProvider)?.credentialConfigured
     : undefined;
-  const imageGenRouteProvider = modelCatalog.options.find((model) => model.model === imageGenDefault)?.routeProvider
+  const imageGenRouteProvider = modelCatalog.options.find((model) => model.routeRef === imageGenDefault)?.routeProvider
     ?? imageGenDefault.split("/")[0];
   const imageGenProviderReady = imageGenDefault
     ? surface?.providers.find((provider) => provider.id === imageGenRouteProvider)?.credentialConfigured
@@ -779,7 +779,7 @@ export function SettingsPage({
                   <input list="available-models" value={modelDefault} onChange={(event) => setModelDefault(event.target.value)} />
                   <datalist id="available-models">
                     {availableModels.map((model) => (
-                      <option key={model.model} value={model.model}>
+                      <option key={model.routeRef} value={model.routeRef}>
                         {model.displayName}
                       </option>
                     ))}
@@ -833,25 +833,25 @@ export function SettingsPage({
                            setModelFallbacks(modelFallbacks.slice(0, -1));
                          }
                        }}
-                       placeholder={modelFallbacks.length === 0 ? "provider/model" : ""}
+                         placeholder={modelFallbacks.length === 0 ? "provider@endpoint/model" : ""}
                      />
                      {fallbackInput && (
                        availableModels
-                         .filter((m) => m.model.toLowerCase().includes(fallbackInput.toLowerCase()) && !modelFallbacks.includes(m.model))
+                         .filter((m) => m.model.toLowerCase().includes(fallbackInput.toLowerCase()) && !modelFallbacks.includes(m.routeRef))
                          .slice(0, 10)
                          .length > 0 && (
                          <div className="settings-chip-suggestions">
                            {availableModels
-                             .filter((m) => m.model.toLowerCase().includes(fallbackInput.toLowerCase()) && !modelFallbacks.includes(m.model))
+                             .filter((m) => m.model.toLowerCase().includes(fallbackInput.toLowerCase()) && !modelFallbacks.includes(m.routeRef))
                              .slice(0, 10)
                              .map((model) => (
                                <button
-                                 key={model.model}
+                                 key={model.routeRef}
                                  type="button"
                                  className="settings-chip-suggestion"
                                  onClick={() => {
-                                   if (!modelFallbacks.includes(model.model)) {
-                                     setModelFallbacks([...modelFallbacks, model.model]);
+                                   if (!modelFallbacks.includes(model.routeRef)) {
+                                     setModelFallbacks([...modelFallbacks, model.routeRef]);
                                    }
                                    setFallbackInput("");
                                  }}
@@ -940,10 +940,10 @@ export function SettingsPage({
               >
                 <label>
                   <span>{t("settings.visionDefaultModel")}</span>
-                  <input list="vision-models" value={visionDefault} onChange={(event) => setVisionDefault(event.target.value)} placeholder="provider/model or empty for auto" />
+                  <input list="vision-models" value={visionDefault} onChange={(event) => setVisionDefault(event.target.value)} placeholder="provider@endpoint/model or empty for auto" />
                   <datalist id="vision-models">
                     {visionModels.map((model) => (
-                      <option key={model.model} value={model.model}>
+                      <option key={model.routeRef} value={model.routeRef}>
                         {model.displayName}
                       </option>
                     ))}
@@ -990,10 +990,10 @@ export function SettingsPage({
               >
                 <label>
                   <span>{t("settings.imageGenDefaultModel")}</span>
-                  <input list="image-gen-models" value={imageGenDefault} onChange={(event) => setImageGenDefault(event.target.value)} placeholder="provider/model or empty for auto" />
+                  <input list="image-gen-models" value={imageGenDefault} onChange={(event) => setImageGenDefault(event.target.value)} placeholder="provider@endpoint/model or empty for auto" />
                   <datalist id="image-gen-models">
                     {imageGenModels.map((model) => (
-                      <option key={model.model} value={model.model}>
+                      <option key={model.routeRef} value={model.routeRef}>
                         {model.displayName}
                       </option>
                     ))}
@@ -1639,7 +1639,7 @@ export function SettingsPage({
                   </header>
                   <div className="model-table" role="table" aria-label={`${provider} models`}>
                     {models.map((model) => (
-                      <div className="model-table-row" role="row" key={model.model}>
+                      <div className="model-table-row" role="row" key={model.routeRef}>
                         <div role="cell">
                           <strong>{model.displayName}</strong>
                           <span>{model.model}</span>

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -19,6 +19,7 @@ describe("projectModelOptions", () => {
     expect(options).toEqual([
       expect.objectContaining({
         model: "openai-codex/gpt-5.5",
+        routeRef: "openai-codex@default/gpt-5.5",
         provider: "openai-codex",
         supportsReasoningEffort: true,
       }),
@@ -47,6 +48,7 @@ describe("projectModelOptions", () => {
 
     expect(options).toEqual([
       expect.objectContaining({
+        routeRef: "volcengine@plan/doubao-seedream-5.0-lite",
         provider: "volcengine",
         providerFamily: "volcengine",
         endpoint: "plan",
@@ -76,6 +78,7 @@ describe("projectModelOptions", () => {
 
     expect(options[0]).toEqual(
       expect.objectContaining({
+        routeRef: "volcengine@plan/doubao-seed-2.0-pro",
         providerFamily: "volcengine",
         endpoint: "plan",
         routeProvider: "volcengine-agent",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1971,19 +1971,25 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
   if (response.model_availability?.length) {
     return response.model_availability
       .filter((entry): entry is ModelAvailabilityDto & { model: string } => Boolean(entry.model))
-      .map((entry) => ({
-        model: entry.model,
-        provider: entry.provider ?? entry.model.split("/")[0] ?? "unknown",
-        providerFamily: entry.provider_family ?? entry.provider ?? entry.model.split("/")[0] ?? "unknown",
-        endpoint: entry.endpoint ?? "default",
-        routeProvider: entry.route_provider ?? entry.provider ?? entry.model.split("/")[0] ?? "unknown",
-        displayName: entry.display_name ?? entry.model,
-        available: entry.available ?? false,
-        unavailableReason: entry.unavailable_reason,
-        supportsImageInput: entry.policy?.capabilities?.image_input ?? false,
-        supportsImageGeneration: entry.policy?.capabilities?.image_generation ?? false,
-        supportsReasoningEffort: supportsReasoningEffort(entry),
-      }))
+      .map((entry) => {
+        const provider = entry.provider ?? entry.model.split("/")[0] ?? "unknown";
+        const providerFamily = entry.provider_family ?? provider;
+        const endpoint = entry.endpoint ?? "default";
+        return {
+          model: entry.model,
+          routeRef: modelRouteRef(entry.model, providerFamily, endpoint),
+          provider,
+          providerFamily,
+          endpoint,
+          routeProvider: entry.route_provider ?? provider,
+          displayName: entry.display_name ?? entry.model,
+          available: entry.available ?? false,
+          unavailableReason: entry.unavailable_reason,
+          supportsImageInput: entry.policy?.capabilities?.image_input ?? false,
+          supportsImageGeneration: entry.policy?.capabilities?.image_generation ?? false,
+          supportsReasoningEffort: supportsReasoningEffort(entry),
+        };
+      })
       .sort(compareModelOptions);
   }
 
@@ -1991,12 +1997,16 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
     .map((entry) => {
       const model = typeof entry === "string" ? entry : entry.model;
       if (!model) return undefined;
+      const provider = typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.provider ?? model.split("/")[0] ?? "unknown");
+      const providerFamily = typeof entry === "string" ? provider : (entry.provider_family ?? provider);
+      const endpoint = typeof entry === "string" ? "default" : (entry.endpoint ?? "default");
       return {
         model,
-        provider: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.provider ?? model.split("/")[0] ?? "unknown"),
-        providerFamily: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.provider_family ?? entry.provider ?? model.split("/")[0] ?? "unknown"),
-        endpoint: typeof entry === "string" ? "default" : (entry.endpoint ?? "default"),
-        routeProvider: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.route_provider ?? entry.provider ?? model.split("/")[0] ?? "unknown"),
+        routeRef: modelRouteRef(model, providerFamily, endpoint),
+        provider,
+        providerFamily,
+        endpoint,
+        routeProvider: typeof entry === "string" ? provider : (entry.route_provider ?? provider),
         displayName: typeof entry === "string" ? model : (entry.display_name ?? model),
         available: true,
         supportsImageInput: typeof entry === "string" ? false : (entry.capabilities?.image_input ?? false),
@@ -2006,6 +2016,13 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
     })
     .filter((entry): entry is RuntimeModelOption => Boolean(entry))
     .sort(compareModelOptions);
+}
+
+function modelRouteRef(model: string, providerFamily: string, endpoint: string): string {
+  const separator = model.indexOf("/");
+  if (separator > 0 && model.slice(0, separator).includes("@")) return model;
+  const modelName = separator >= 0 ? model.slice(separator + 1) : model;
+  return `${providerFamily}@${endpoint}/${modelName}`;
 }
 
 function supportsReasoningEffort(entry: ModelAvailabilityDto | RuntimeAvailableModelDto): boolean {

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -238,6 +238,7 @@ export interface AgentSummary {
 
 export interface RuntimeModelOption {
   model: string;
+  routeRef: string;
   provider: string;
   providerFamily: string;
   endpoint: string;


### PR DESCRIPTION
## Summary

- separate logical `ModelRef` (`provider/model`) from executable `ModelRouteRef` (`provider@endpoint/model`)
- preserve endpoint identity across runtime defaults/fallbacks, vision and image generation settings, agent overrides, fallback state, runtime projections, CLI/API, TUI, onboarding, and Web GUI mutations
- accept legacy model selections on read while making all new writes canonical
- add `config migrate-model-routes` dry-run/write flows with complete preflight, atomic config replacement and one-time backup, plus transactional SQLite agent-state migration
- expose canonical route refs through model catalog/control DTOs and update OpenAPI, snapshots, RFC, and user documentation

## Runtime contract

`models.catalog` and model policy remain keyed by logical `provider/model`. Executable selections now persist `provider@endpoint/model`, including explicit `@default`, so configured transport/auth routing is not lost during persistence or restart recovery.

Migration rejects invalid or ambiguous refs before writing. Config and SQLite are independently durable and idempotent because they cannot share a cross-store transaction.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- Web GUI tests and production build
- route-ref parsing, capability validation, legacy upgrade, config mutation, agent-state persistence, migration dry-run/backup/idempotency/rollback tests
- CLI, HTTP route, and OpenAPI snapshot regressions
- `cargo test`
