### PR TITLE
fix: harden model route parsing and endpoint readiness

### DIFF
--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -835,7 +835,7 @@ impl BuiltInProviderCatalog {
     }
 }
 
-fn built_in_provider_endpoint_identity(
+pub(crate) fn built_in_provider_endpoint_identity(
     legacy_provider: &ProviderId,
 ) -> Result<(ProviderId, ProviderEndpointId)> {
     let (provider, endpoint) = match legacy_provider.as_str() {

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -124,13 +124,26 @@ impl ModelRouteRef {
     }
 
     pub fn from_legacy_model_ref(model_ref: &ModelRef) -> Self {
+        let (route_provider, route_endpoint) =
+            built_in_provider_endpoint_identity(&model_ref.provider).unwrap_or_else(|_| {
+                (
+                    model_ref.provider.clone(),
+                    ProviderEndpointId::default_endpoint(),
+                )
+            });
         let catalog = BuiltInModelCatalog::default();
         let model_ref = catalog.canonicalize_model_ref(model_ref);
-        let endpoint = catalog
-            .get(&model_ref)
-            .and_then(|metadata| metadata.endpoint.clone())
-            .unwrap_or_else(ProviderEndpointId::default_endpoint);
-        Self::new(model_ref.provider, endpoint, model_ref.model)
+        let endpoint = if route_provider != model_ref.provider
+            || route_endpoint != ProviderEndpointId::default_endpoint()
+        {
+            route_endpoint
+        } else {
+            catalog
+                .get(&model_ref)
+                .and_then(|metadata| metadata.endpoint.clone())
+                .unwrap_or(route_endpoint)
+        };
+        Self::new(route_provider, endpoint, model_ref.model)
     }
 
     pub fn model_ref(&self) -> ModelRef {
@@ -1084,6 +1097,23 @@ mod tests {
         assert_eq!(route_ref.provider.as_str(), "volcengine");
         assert_eq!(route_ref.endpoint.as_str(), "plan");
         assert_eq!(route_ref.model, "doubao-seedream-5.0-lite");
+    }
+
+    #[test]
+    fn compatible_model_route_ref_upgrades_legacy_plan_provider() {
+        let route_ref =
+            ModelRouteRef::parse_compatible("dashscope-token-plan/qwen3.7-max").unwrap();
+        assert_eq!(route_ref.provider.as_str(), "dashscope");
+        assert_eq!(route_ref.endpoint.as_str(), "token-plan");
+        assert_eq!(route_ref.model, "qwen3.7-max");
+    }
+
+    #[test]
+    fn compatible_model_route_ref_preserves_endpoint_across_model_alias() {
+        let route_ref = ModelRouteRef::parse_compatible("dashscope-token-plan/qwen-3.7").unwrap();
+        assert_eq!(route_ref.provider.as_str(), "dashscope");
+        assert_eq!(route_ref.endpoint.as_str(), "token-plan");
+        assert_eq!(route_ref.model, "qwen3.7-max");
     }
 
     #[test]

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -109,14 +109,17 @@ impl ModelRouteRef {
     }
 
     pub fn parse_compatible(value: &str) -> Result<Self> {
-        if value
-            .trim()
+        let trimmed = value.trim();
+        let accepted_formats = || {
+            format!("invalid model reference {trimmed}; expected provider@endpoint/model or legacy provider/model")
+        };
+        if trimmed
             .split_once('/')
             .is_some_and(|(route, _)| route.contains('@'))
         {
-            return Self::parse(value);
+            return Self::parse(trimmed).with_context(accepted_formats);
         }
-        let model_ref = ModelRef::parse(value)?;
+        let model_ref = ModelRef::parse(trimmed).with_context(accepted_formats)?;
         Ok(Self::from_legacy_model_ref(&model_ref))
     }
 
@@ -1081,6 +1084,31 @@ mod tests {
         assert_eq!(route_ref.provider.as_str(), "volcengine");
         assert_eq!(route_ref.endpoint.as_str(), "plan");
         assert_eq!(route_ref.model, "doubao-seedream-5.0-lite");
+    }
+
+    #[test]
+    fn compatible_model_route_ref_rejects_malformed_route_segments() {
+        for value in [
+            "openai@/gpt-5.4",
+            "openai@@default/gpt-5.4",
+            "openai@default/",
+        ] {
+            let error = ModelRouteRef::parse_compatible(value)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains("expected provider@endpoint/model or legacy provider/model"),
+                "unexpected error for {value}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn compatible_model_route_ref_reports_both_accepted_formats() {
+        let error = ModelRouteRef::parse_compatible("not-a-model-ref")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("expected provider@endpoint/model or legacy provider/model"));
     }
 
     #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3060,6 +3060,45 @@ fn default_provider_ready_with_configured_credential() {
 }
 
 #[test]
+fn default_provider_ready_matches_the_selected_endpoint() {
+    let mut fixture = test_app_config("openai@coding/gpt-4o", &[]);
+    let openai = ProviderId::openai();
+    let default_provider = fixture.config.providers.get_mut(&openai).unwrap();
+    default_provider.credential = None;
+
+    let coding_alias = ProviderId::parse("openai-coding").unwrap();
+    fixture.config.providers.insert(
+        coding_alias.clone(),
+        ProviderRuntimeConfig {
+            id: coding_alias,
+            route_provider: openai,
+            route_endpoint: ProviderEndpointId::parse("coding").unwrap(),
+            transport: ProviderTransportKind::OpenAiResponses,
+            base_url: "https://coding.example/v1".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::Env,
+                kind: CredentialKind::ApiKey,
+                env: Some("OPENAI_CODING_API_KEY".into()),
+                profile: None,
+                external: None,
+            },
+            credential: Some("coding-key".into()),
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        },
+    );
+
+    assert!(
+        fixture.config.default_provider_ready(),
+        "the selected coding endpoint credential should determine readiness"
+    );
+}
+
+#[test]
 fn default_provider_ready_false_for_credential_source_none() {
     let mut fixture = test_app_config("openai/gpt-4o", &[]);
     // Simulate a local provider (e.g. vllm) with CredentialSource::None.

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -281,6 +281,10 @@ impl BuiltInModelCatalog {
             ),
             ModelRef::new(provider_id("volcengine"), "doubao-seedream-5.0-lite"),
         );
+        aliases.insert(
+            ModelRef::new(provider_id("dashscope-token-plan"), "qwen-3.7"),
+            ModelRef::new(provider_id("dashscope"), "qwen3.7-max"),
+        );
         aliases
     }
 


### PR DESCRIPTION
## Summary

Follow up on the non-blocking review feedback from #2177:

- reject malformed route-aware references such as empty or duplicated endpoint segments
- report that both `provider@endpoint/model` and legacy `provider/model` formats were attempted
- verify provider readiness against the endpoint selected by the default route rather than another configured endpoint for the same canonical provider

The agent-state migration scope was also audited in #2177: the four migrated columns are the complete persisted model-selection fields; work items, briefs, and turn records do not embed mutable model-route selections requiring migration.

## Verification

- `cargo fmt --all`
- `cargo test config::models::tests::compatible_model_route_ref`
- `cargo test config::tests::default_provider_ready_matches_the_selected_endpoint`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
