### PR TITLE
feat(skills): run catalog updates as jobs

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -367,7 +367,8 @@
         "properties": {
           "kind": {
             "enum": [
-              "skill.install"
+              "skill.install",
+              "skill.update"
             ],
             "type": "string"
           },
@@ -9770,7 +9771,7 @@
     },
     "/api/skills/catalog/update": {
       "post": {
-        "description": "Fetch supported remote Skill Library entries described by .skill-lock.json and update changed skills. Returns per-skill status.",
+        "description": "Queue an asynchronous update of supported remote Skill Library entries described by .skill-lock.json. Progress and per-skill results are available through the returned job.",
         "operationId": "updateSkillCatalog",
         "parameters": [],
         "requestBody": {
@@ -9788,11 +9789,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/JobResponse"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -145,7 +145,7 @@ async fn create_skill_install_job(
     state.jobs.insert(job.clone());
 
     let jobs = state.jobs.clone();
-    let skill_install_jobs = state.skill_install_jobs.clone();
+    let skill_library_write_jobs = state.skill_library_write_jobs.clone();
     let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
     let job_id = id.clone();
     tokio::spawn(async move {
@@ -161,7 +161,7 @@ async fn create_skill_install_job(
                 error: None,
             }];
         });
-        let permit = match skill_install_jobs.acquire_owned().await {
+        let permit = match skill_library_write_jobs.acquire_owned().await {
             Ok(permit) => permit,
             Err(error) => {
                 let message = format!("skill install queue closed: {error}");
@@ -247,6 +247,165 @@ async fn create_skill_install_job(
         })),
     ))
         .into_response())
+}
+
+pub(super) async fn create_skill_update_job(
+    state: Arc<AppState>,
+    request: crate::types::UpdateSkillRequest,
+) -> Result<axum::response::Response, (StatusCode, Json<Value>)> {
+    let id = format!("job_{}", Uuid::new_v4().simple());
+    let now = Utc::now();
+    let target = request.name.clone().unwrap_or_else(|| "all skills".into());
+    let job = JobSnapshot {
+        id: id.clone(),
+        kind: "skill.update".into(),
+        status: JobStatus::Queued,
+        phase: "queued".into(),
+        progress: JobProgress::default(),
+        summary: format!("Queued update for {target}"),
+        items: Vec::new(),
+        result: None,
+        error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    state.jobs.insert(job.clone());
+
+    let jobs = state.jobs.clone();
+    let skill_library_write_jobs = state.skill_library_write_jobs.clone();
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
+    let job_id = id.clone();
+    tokio::spawn(async move {
+        let permit = match skill_library_write_jobs.acquire_owned().await {
+            Ok(permit) => permit,
+            Err(error) => {
+                let message = format!("skill library write queue closed: {error}");
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.summary = "Skill update queue closed".into();
+                    job.error = Some(message);
+                });
+                return;
+            }
+        };
+        jobs.update(&job_id, |job| {
+            job.status = JobStatus::Running;
+            job.phase = "updating".into();
+            job.summary = format!("Updating {target}");
+        });
+
+        let progress_jobs = jobs.clone();
+        let progress_job_id = job_id.clone();
+        let name = request.name.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            crate::skills::update_library_skills_with_progress(
+                &user_home,
+                name.as_deref(),
+                |progress| match progress {
+                    crate::skills::SkillLibraryUpdateProgress::Started { total } => {
+                        progress_jobs.update(&progress_job_id, |job| {
+                            job.progress.total = total;
+                            job.summary = if total == 0 {
+                                "No matching skills to update".into()
+                            } else {
+                                format!("Updating 0 of {total} skills")
+                            };
+                        });
+                    }
+                    crate::skills::SkillLibraryUpdateProgress::Item(status) => {
+                        progress_jobs.update(&progress_job_id, |job| {
+                            job.progress.current += 1;
+                            job.items.push(skill_update_job_item(&status));
+                            job.summary = format!(
+                                "Checked {} of {} skills",
+                                job.progress.current, job.progress.total
+                            );
+                        });
+                    }
+                },
+            )
+        })
+        .await;
+
+        match result {
+            Ok(Ok(update_result)) => jobs.update(&job_id, |job| {
+                let (updated, unchanged, skipped, failed) =
+                    skill_update_counts(&update_result.statuses);
+                job.status = JobStatus::Completed;
+                job.phase = "completed".into();
+                job.summary = format!(
+                    "Skill update completed: {updated} updated, {unchanged} unchanged, {skipped} skipped, {failed} failed"
+                );
+                job.result = serde_json::to_value(update_result).ok();
+            }),
+            Ok(Err(error)) => {
+                let message = error.to_string();
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.summary = "Skill update failed".into();
+                    job.error = Some(message);
+                });
+            }
+            Err(error) => {
+                let message = format!("skill update worker failed: {error}");
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.summary = "Skill update worker failed".into();
+                    job.error = Some(message);
+                });
+            }
+        }
+    });
+
+    Ok(((
+        StatusCode::ACCEPTED,
+        Json(json!({
+            "ok": true,
+            "job": job,
+        })),
+    ))
+        .into_response())
+}
+
+fn skill_update_job_item(status: &crate::skills::SkillLibraryUpdateStatus) -> JobItem {
+    let (job_status, outcome) = match status.status {
+        crate::skills::SkillLibraryUpdateState::Updated => (JobStatus::Completed, "updated"),
+        crate::skills::SkillLibraryUpdateState::Unchanged => (JobStatus::Completed, "unchanged"),
+        crate::skills::SkillLibraryUpdateState::Skipped => (JobStatus::Completed, "skipped"),
+        crate::skills::SkillLibraryUpdateState::Failed => (JobStatus::Failed, "failed"),
+    };
+    JobItem {
+        id: status.name.clone(),
+        status: job_status,
+        summary: format!("{}: {outcome}", status.name),
+        error: status.reason.clone(),
+    }
+}
+
+fn skill_update_counts(
+    statuses: &[crate::skills::SkillLibraryUpdateStatus],
+) -> (usize, usize, usize, usize) {
+    statuses.iter().fold(
+        (0, 0, 0, 0),
+        |(updated, unchanged, skipped, failed), status| match status.status {
+            crate::skills::SkillLibraryUpdateState::Updated => {
+                (updated + 1, unchanged, skipped, failed)
+            }
+            crate::skills::SkillLibraryUpdateState::Unchanged => {
+                (updated, unchanged + 1, skipped, failed)
+            }
+            crate::skills::SkillLibraryUpdateState::Skipped => {
+                (updated, unchanged, skipped + 1, failed)
+            }
+            crate::skills::SkillLibraryUpdateState::Failed => {
+                (updated, unchanged, skipped, failed + 1)
+            }
+        },
+    )
 }
 
 pub(super) async fn create_template_remote_source_sync_job(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -175,7 +175,7 @@ pub struct AppState {
     pub web_dist: Option<Arc<PathBuf>>,
     pub skills_registry: Arc<tokio::sync::RwLock<SkillsRegistry>>,
     pub jobs: JobRegistry,
-    pub skill_install_jobs: Arc<tokio::sync::Semaphore>,
+    pub skill_library_write_jobs: Arc<tokio::sync::Semaphore>,
     pub template_remote_source_sync_jobs: Arc<tokio::sync::Semaphore>,
 }
 
@@ -238,7 +238,7 @@ impl AppState {
             .control_token_required(ControlTransportKind::Tcp);
         let skills_registry = host.skills_registry();
         let jobs = JobRegistry::default();
-        let skill_install_jobs = Arc::new(tokio::sync::Semaphore::new(1));
+        let skill_library_write_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         let template_remote_source_sync_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         Self {
             host,
@@ -248,7 +248,7 @@ impl AppState {
             web_dist: None,
             skills_registry,
             jobs,
-            skill_install_jobs,
+            skill_library_write_jobs,
             template_remote_source_sync_jobs,
         }
     }
@@ -264,7 +264,7 @@ impl AppState {
         // Unix control is local IPC; filesystem permissions are the access boundary.
         let skills_registry = host.skills_registry();
         let jobs = JobRegistry::default();
-        let skill_install_jobs = Arc::new(tokio::sync::Semaphore::new(1));
+        let skill_library_write_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         let template_remote_source_sync_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         Self {
             host,
@@ -274,7 +274,7 @@ impl AppState {
             web_dist: None,
             skills_registry,
             jobs,
-            skill_install_jobs,
+            skill_library_write_jobs,
             template_remote_source_sync_jobs,
         }
     }

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -156,16 +156,9 @@ pub async fn update_skill_catalog(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(request): Json<crate::types::UpdateSkillRequest>,
-) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+) -> Result<axum::response::Response, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
-    let result = crate::skills::update_library_skills(&user_home, request.name.as_deref())
-        .map_err(error_response)?;
-    Ok(Json(json!({
-        "ok": true,
-        "library": USER_GLOBAL_LIBRARY_LABEL,
-        "result": result,
-    })))
+    jobs::create_skill_update_job(state, request).await
 }
 
 pub async fn check_skill_catalog(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::{
     io::{IsTerminal, Write},
     net::SocketAddr,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -3015,12 +3016,26 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
             .await
         }
         SkillsCommands::Update { name } => {
-            post_control_json(
+            let response = post_control_json_value(
                 config,
                 "/skills/catalog/update",
                 &holon::types::UpdateSkillRequest { name },
             )
-            .await
+            .await?;
+            let job_id = response["job"]["id"]
+                .as_str()
+                .ok_or_else(|| anyhow!("skill update response did not include a job id"))?;
+            let job = wait_for_job(config, job_id).await?;
+            if job["status"] == "failed" {
+                return Err(anyhow!(
+                    "{}",
+                    job["error"]
+                        .as_str()
+                        .or_else(|| job["summary"].as_str())
+                        .unwrap_or("skill update failed")
+                ));
+            }
+            print_json(job.get("result").unwrap_or(&job))
         }
         SkillsCommands::Check { name } => {
             post_control_json(
@@ -3166,6 +3181,28 @@ async fn post_control_json<T: serde::Serialize>(
     let client = LocalClient::new(config.clone())?;
     let value: serde_json::Value = client.post_control_json(path, payload).await?;
     print_json(&value)
+}
+
+async fn post_control_json_value<T: serde::Serialize>(
+    config: &AppConfig,
+    path: &str,
+    payload: &T,
+) -> Result<serde_json::Value> {
+    let client = LocalClient::new(config.clone())?;
+    client.post_control_json(path, payload).await
+}
+
+async fn wait_for_job(config: &AppConfig, job_id: &str) -> Result<serde_json::Value> {
+    loop {
+        let response = get_json(config, &format!("/jobs/{job_id}")).await?;
+        let job = response
+            .get("job")
+            .ok_or_else(|| anyhow!("job response did not include a job"))?;
+        if matches!(job["status"].as_str(), Some("completed") | Some("failed")) {
+            return Ok(job.clone());
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }
 
 async fn get_json(config: &AppConfig, path: &str) -> Result<serde_json::Value> {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -102,7 +102,7 @@ const ROUTES: &[RouteSpec] = &[
     route("post", "/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
     route("post", "/skills/catalog/reconcile", "reconcileSkillCatalog", "skills", "Reconcile skill library lock", "Reconcile local Skill Library contents with .skill-lock.json, then check consistency. This does not fetch remote updates.", Some("ReconcileSkillRequest"), AuthKind::Control),
     route("post", "/skills/catalog/refresh", "refreshSkillCatalog", "skills", "Refresh runtime catalog", "Refresh runtime Skill Library catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates.", Some("RefreshCatalogRequest"), AuthKind::Control),
-    route("post", "/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Fetch supported remote Skill Library entries described by .skill-lock.json and update changed skills. Returns per-skill status.", Some("UpdateSkillRequest"), AuthKind::Control),
+    route_with_response("post", "/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Queue an asynchronous update of supported remote Skill Library entries described by .skill-lock.json. Progress and per-skill results are available through the returned job.", Some("UpdateSkillRequest"), "JobResponse", AuthKind::Control),
     route("post", "/skills/catalog/check", "checkSkillCatalog", "skills", "Check skill library", "Check Skill Library and lock-file consistency.", Some("CheckSkillRequest"), AuthKind::Control),
     route("get", "/templates/catalog", "templatesCatalog", "templates", "Template catalog", "Return the global AgentTemplate catalog (user global library + synced remote sources).", None, AuthKind::RemoteAccess),
     route("get", "/templates/catalog/{catalog_id}", "templateDetail", "templates", "Template detail", "Return template detail with full AGENTS.md content, manifest, and skill dependencies.", None, AuthKind::RemoteAccess),
@@ -525,7 +525,7 @@ fn component_schemas() -> Value {
         json!({
             "type": "object",
             "properties": {
-                "kind": { "type": "string", "enum": ["skill.install"] },
+                "kind": { "type": "string", "enum": ["skill.install", "skill.update"] },
                 "params": { "$ref": "#/components/schemas/AddSkillRequest" }
             },
             "required": ["kind", "params"],

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -1741,6 +1741,12 @@ pub enum SkillLibraryUpdateState {
     Failed,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillLibraryUpdateProgress {
+    Started { total: usize },
+    Item(SkillLibraryUpdateStatus),
+}
+
 pub fn check_library_skills(
     user_home: &Path,
     name_filter: Option<&str>,
@@ -1818,7 +1824,20 @@ pub fn update_library_skills(
     user_home: &Path,
     name_filter: Option<&str>,
 ) -> Result<SkillLibraryUpdateResult> {
-    update_library_skills_with_remote_updater(user_home, name_filter, &GithubSkillRemoteUpdater)
+    update_library_skills_with_progress(user_home, name_filter, |_| {})
+}
+
+pub fn update_library_skills_with_progress(
+    user_home: &Path,
+    name_filter: Option<&str>,
+    on_progress: impl FnMut(SkillLibraryUpdateProgress),
+) -> Result<SkillLibraryUpdateResult> {
+    update_library_skills_with_remote_updater(
+        user_home,
+        name_filter,
+        &GithubSkillRemoteUpdater,
+        on_progress,
+    )
 }
 
 trait SkillRemoteUpdater {
@@ -1879,6 +1898,7 @@ fn update_library_skills_with_remote_updater(
     user_home: &Path,
     name_filter: Option<&str>,
     updater: &dyn SkillRemoteUpdater,
+    mut on_progress: impl FnMut(SkillLibraryUpdateProgress),
 ) -> Result<SkillLibraryUpdateResult> {
     if let Some(name) = name_filter {
         validate_skill_name(name)?;
@@ -1898,42 +1918,51 @@ fn update_library_skills_with_remote_updater(
         .filter(|(name, _)| name_filter.is_none_or(|filter| name.as_str() == filter))
         .map(|(name, entry)| (name.clone(), entry.clone()))
         .collect::<Vec<_>>();
+    on_progress(SkillLibraryUpdateProgress::Started {
+        total: entries.len(),
+    });
 
     let mut statuses = Vec::new();
     let mut lock_changed = false;
     for (name, entry) in entries {
         let Some(source) = LockedRemoteSkillSource::from_lock_entry(&name, &entry) else {
-            statuses.push(SkillLibraryUpdateStatus {
+            let status = SkillLibraryUpdateStatus {
                 name,
                 status: SkillLibraryUpdateState::Skipped,
                 previous_hash: None,
                 latest_hash: None,
                 reason: Some("lock entry is not a supported remote GitHub v3 skill source".into()),
-            });
+            };
+            on_progress(SkillLibraryUpdateProgress::Item(status.clone()));
+            statuses.push(status);
             continue;
         };
         let previous_hash = source.skill_folder_hash.clone();
         let latest_hash = match updater.latest_hash(&source) {
             Ok(hash) => hash,
             Err(error) => {
-                statuses.push(SkillLibraryUpdateStatus {
+                let status = SkillLibraryUpdateStatus {
                     name,
                     status: SkillLibraryUpdateState::Failed,
                     previous_hash: Some(previous_hash),
                     latest_hash: None,
                     reason: Some(error.to_string()),
-                });
+                };
+                on_progress(SkillLibraryUpdateProgress::Item(status.clone()));
+                statuses.push(status);
                 continue;
             }
         };
         if latest_hash == previous_hash {
-            statuses.push(SkillLibraryUpdateStatus {
+            let status = SkillLibraryUpdateStatus {
                 name,
                 status: SkillLibraryUpdateState::Unchanged,
                 previous_hash: Some(previous_hash),
                 latest_hash: Some(latest_hash),
                 reason: None,
-            });
+            };
+            on_progress(SkillLibraryUpdateProgress::Item(status.clone()));
+            statuses.push(status);
             continue;
         }
         let destination = skills_root.join(&source.skill_name);
@@ -1942,22 +1971,26 @@ fn update_library_skills_with_remote_updater(
             Ok(()) => {
                 refresh_updated_lock_entry(&mut lock, &source.skill_name, &latest_hash)?;
                 lock_changed = true;
-                statuses.push(SkillLibraryUpdateStatus {
+                let status = SkillLibraryUpdateStatus {
                     name,
                     status: SkillLibraryUpdateState::Updated,
                     previous_hash: Some(previous_hash),
                     latest_hash: Some(latest_hash),
                     reason: None,
-                });
+                };
+                on_progress(SkillLibraryUpdateProgress::Item(status.clone()));
+                statuses.push(status);
             }
             Err(error) => {
-                statuses.push(SkillLibraryUpdateStatus {
+                let status = SkillLibraryUpdateStatus {
                     name,
                     status: SkillLibraryUpdateState::Failed,
                     previous_hash: Some(previous_hash),
                     latest_hash: Some(latest_hash),
                     reason: Some(error.to_string()),
-                });
+                };
+                on_progress(SkillLibraryUpdateProgress::Item(status.clone()));
+                statuses.push(status);
             }
         }
     }
@@ -3418,7 +3451,8 @@ mod tests {
             contents: HashMap::new(),
         };
 
-        let result = update_library_skills_with_remote_updater(&user_home, None, &updater).unwrap();
+        let result =
+            update_library_skills_with_remote_updater(&user_home, None, &updater, |_| {}).unwrap();
 
         assert_eq!(result.statuses.len(), 1);
         assert_eq!(result.statuses[0].name, "demo");
@@ -3481,7 +3515,8 @@ mod tests {
         };
 
         let result =
-            update_library_skills_with_remote_updater(&user_home, Some("demo"), &updater).unwrap();
+            update_library_skills_with_remote_updater(&user_home, Some("demo"), &updater, |_| {})
+                .unwrap();
 
         assert_eq!(result.statuses.len(), 1);
         assert_eq!(result.statuses[0].status, SkillLibraryUpdateState::Updated);
@@ -3543,7 +3578,8 @@ mod tests {
             contents: HashMap::new(),
         };
 
-        let result = update_library_skills_with_remote_updater(&user_home, None, &updater).unwrap();
+        let result =
+            update_library_skills_with_remote_updater(&user_home, None, &updater, |_| {}).unwrap();
 
         assert_eq!(result.statuses.len(), 2);
         assert!(result
@@ -3584,7 +3620,8 @@ mod tests {
             latest_hashes: HashMap::from([("demo".into(), "new-hash".into())]),
             contents: HashMap::from([("demo".into(), "# updated".into())]),
         };
-        update_library_skills_with_remote_updater(&user_home, Some("demo"), &updater).unwrap();
+        update_library_skills_with_remote_updater(&user_home, Some("demo"), &updater, |_| {})
+            .unwrap();
         let lock = read_skill_lock(&user_home).unwrap();
         let entry = lock
             .get("skills")

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -20,6 +20,54 @@ fn holon_bin() -> PathBuf {
         .expect("CARGO_BIN_EXE_holon should be set for integration tests")
 }
 
+fn write_json_response(stream: &mut TcpStream, body: &str) {
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .expect("write mock response");
+}
+
+#[test]
+fn skills_update_waits_for_job_and_prints_result() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock control plane");
+    let addr = listener.local_addr().expect("mock control plane address");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept update request");
+        let request = read_http_request(&mut stream);
+        assert!(request.starts_with("POST /api/skills/catalog/update "));
+        let body = r#"{"ok":true,"job":{"id":"job_test","status":"queued"}}"#;
+        write_json_response(&mut stream, body);
+
+        let (mut stream, _) = listener.accept().expect("accept job request");
+        let request = read_http_request(&mut stream);
+        assert!(request.starts_with("GET /api/jobs/job_test "));
+        let body = r#"{"ok":true,"job":{"id":"job_test","status":"completed","result":{"statuses":[{"name":"demo","status":"updated"}]}}}"#;
+        write_json_response(&mut stream, body);
+    });
+
+    let (mut command, _home) = isolated_holon_command();
+    let output = command
+        .env("HOLON_HTTP_ADDR", addr.to_string())
+        .args(["skills", "update"])
+        .output()
+        .expect("run holon");
+    handle.join().expect("mock control plane thread");
+
+    let expected = serde_json::json!({
+        "statuses": [{"name": "demo", "status": "updated"}]
+    });
+    let (stdout, stderr) = output_text(&output);
+    assert_eq!(output.status.code(), Some(0), "stderr:\n{stderr}");
+    assert!(stderr.is_empty(), "stderr should stay empty: {stderr}");
+    assert_eq!(
+        stdout,
+        format!("{}\n", serde_json::to_string_pretty(&expected).unwrap())
+    );
+}
+
 #[test]
 fn control_plane_post_commands_pretty_print_json_stdout() {
     let cases: &[(&[&str], &str)] = &[
@@ -62,7 +110,6 @@ fn control_plane_post_commands_pretty_print_json_stdout() {
         (&["skills", "remove", "ghx"], "/api/skills/catalog/remove"),
         (&["skills", "refresh"], "/api/skills/catalog/refresh"),
         (&["skills", "reconcile"], "/api/skills/catalog/reconcile"),
-        (&["skills", "update"], "/api/skills/catalog/update"),
         (&["skills", "check"], "/api/skills/catalog/check"),
         (
             &["skills", "enable", "ghx"],

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -134,6 +134,7 @@ export function App() {
   const removeSkillFromCatalog = useRuntimeStore((state) => state.removeSkillFromCatalog);
   const updateSkillCatalog = useRuntimeStore((state) => state.updateSkillCatalog);
   const skillInstallJobs = useRuntimeStore((state) => state.skillInstallJobs);
+  const dismissSkillJob = useRuntimeStore((state) => state.dismissSkillJob);
   const agentSkillCatalog = useRuntimeStore((state) =>
     sidePanelAgentId ? state.agentSkillCatalogByAgentId[sidePanelAgentId] : undefined,
   );
@@ -627,6 +628,7 @@ export function App() {
             installJobs={skillInstallJobs}
             onRefresh={refreshSkillCatalog}
             onUpdateSkill={updateSkillCatalog}
+            onDismissJob={dismissSkillJob}
             onAddSkill={addSkillToCatalog}
             onRemoveSkill={removeSkillFromCatalog}
             onOpenSkill={navigateSkill}

--- a/web-gui/app/src/features/skills/SkillsPage.tsx
+++ b/web-gui/app/src/features/skills/SkillsPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
-import { ArrowLeft, PackageOpen, RefreshCw } from "lucide-react";
+import { useMemo, useState, type FormEvent } from "react";
+import { ArrowLeft, PackageOpen, RefreshCw, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 
@@ -19,6 +19,7 @@ interface SkillsPageProps {
   installJobs: SkillInstallJob[];
   onRefresh: () => void;
   onUpdateSkill: (name?: string) => Promise<boolean>;
+  onDismissJob: (jobId: string) => void;
   onAddSkill: (input: AddSkillInput) => Promise<boolean>;
   onRemoveSkill: (name: string) => Promise<boolean>;
   onOpenSkill: (skillId: string) => void;
@@ -33,6 +34,7 @@ export function SkillsPage({
   installJobs,
   onRefresh,
   onUpdateSkill,
+  onDismissJob,
   onAddSkill,
   onRemoveSkill,
   onOpenSkill,
@@ -46,7 +48,6 @@ export function SkillsPage({
   const [addSkillName, setAddSkillName] = useState("");
   const [addMode, setAddMode] = useState<SkillInstallMode>("linked");
   const stats = useMemo(() => skillStats(skills), [skills]);
-  const [updateFeedback, setUpdateFeedback] = useState<{ ok: boolean; message: string } | null>(null);
   const visibleSkills = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return skills.filter((skill) => {
@@ -71,26 +72,12 @@ export function SkillsPage({
     }
   }
 
-  useEffect(() => {
-    if (!updateFeedback) return;
-    const timer = setTimeout(() => setUpdateFeedback(null), 4000);
-    return () => clearTimeout(timer);
-  }, [updateFeedback]);
-
   async function removeSkill(name: string) {
     await onRemoveSkill(name);
   }
 
   async function updateSkill(name?: string) {
-    const ok = await onUpdateSkill(name);
-    if (ok) {
-      setUpdateFeedback({
-        ok: true,
-        message: name ? t("skillsPage.updateSingleSuccess", { name }) : t("skillsPage.updateAllSuccess"),
-      });
-    } else {
-      setUpdateFeedback({ ok: false, message: t("skillsPage.updateFailed") });
-    }
+    await onUpdateSkill(name);
   }
 
   return (
@@ -112,11 +99,6 @@ export function SkillsPage({
       </section>
 
       <section className="skills-summary" aria-label={t("skillsPage.librarySummary")}>
-        {updateFeedback ? (
-          <div className={`skills-update-feedback ${updateFeedback.ok ? "success" : "error"}`} role="status">
-            {updateFeedback.message}
-          </div>
-        ) : null}
         {stats.map((stat) => (
           <Card className="skills-stat" key={stat.label}>
             <strong>{stat.value}</strong>
@@ -140,8 +122,13 @@ export function SkillsPage({
               ) : null}
               <span className="skills-install-job-source">{job.source}</span>
               <span className={`skills-install-job-status status-${job.status}`}>
-                {job.status === "failed" ? t("skillsPage.installFailed", { error: job.error ?? t("skillsPage.unknownError") }) : job.status}
+                {job.error ?? job.summary ?? job.status}
               </span>
+              {(job.status === "completed" || job.status === "failed") ? (
+                <button type="button" onClick={() => onDismissJob(job.jobId)} aria-label={t("common.dismiss")}>
+                  <X size={14} />
+                </button>
+              ) : null}
             </div>
           ))}
         </div>

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -951,11 +951,22 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
       await postJson<unknown>(fetchImpl, baseUrl, "/skills/catalog/remove", { name }, requestHeaders);
     },
-    async updateSkillCatalog(name?: string): Promise<void> {
+    async updateSkillCatalog(name?: string): Promise<string> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
-      await postJson<unknown>(fetchImpl, baseUrl, "/skills/catalog/update", { name }, requestHeaders);
+      const response = await postJson<JobResponseDto>(
+        fetchImpl,
+        baseUrl,
+        "/skills/catalog/update",
+        { name },
+        requestHeaders,
+      );
+      const jobId = response.job?.id;
+      if (!jobId) {
+        throw new Error("Skill update job response did not include a job id.");
+      }
+      return jobId;
     },
     async checkSkillCatalog(name?: string): Promise<void> {
       if (!baseUrl) {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -302,6 +302,7 @@ export interface RuntimeStoreState {
   addSkillToCatalog: (input: AddSkillInput) => Promise<boolean>;
   removeSkillFromCatalog: (name: string) => Promise<boolean>;
   updateSkillCatalog: (name?: string) => Promise<boolean>;
+  dismissSkillJob: (jobId: string) => void;
   checkSkillCatalog: (name?: string) => Promise<boolean>;
   refreshAgentSkillCatalog: (agentId: string | undefined) => Promise<void>;
   enableAgentSkill: (agentId: string | undefined, name: string) => Promise<boolean>;
@@ -342,7 +343,9 @@ const activeEventStreams = new Map<string, AgentEventStreamSubscription>();
 export interface SkillInstallJob {
   jobId: string;
   source: string;
+  kind?: "install" | "update";
   status: "queued" | "running" | "completed" | "failed";
+  summary?: string;
   error?: string;
 }
 
@@ -359,9 +362,8 @@ function loadSkillInstallJobs(): SkillInstallJob[] {
 
 function saveSkillInstallJobs(jobs: SkillInstallJob[]): void {
   try {
-    const active = jobs.filter((j) => j.status === "queued" || j.status === "running");
-    if (active.length) {
-      localStorage.setItem(SKILL_INSTALL_JOBS_STORAGE_KEY, JSON.stringify(active));
+    if (jobs.length) {
+      localStorage.setItem(SKILL_INSTALL_JOBS_STORAGE_KEY, JSON.stringify(jobs));
     } else {
       localStorage.removeItem(SKILL_INSTALL_JOBS_STORAGE_KEY);
     }
@@ -1413,22 +1415,33 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   updateSkillCatalog: async (name) => {
-    set({ skillCatalogLoading: true, skillCatalogError: undefined });
+    set({ skillCatalogError: undefined });
     try {
-      await runtimeClient.updateSkillCatalog(name);
-      const skillCatalog = await runtimeClient.getSkillCatalog();
-      set({ skillCatalog, skillCatalogLoading: false, skillCatalogError: skillCatalog.error });
+      const jobId = await runtimeClient.updateSkillCatalog(name);
+      const job: SkillInstallJob = {
+        jobId,
+        source: name ?? "all skills",
+        kind: "update",
+        status: "queued",
+      };
+      set((state) => {
+        const jobs = [...state.skillInstallJobs, job];
+        saveSkillInstallJobs(jobs);
+        return { skillInstallJobs: jobs };
+      });
+      void pollSkillInstallJob(set, get, jobId);
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         skillCatalog: { ...state.skillCatalog, error: message },
-        skillCatalogLoading: false,
         skillCatalogError: message,
       }));
       return false;
     }
   },
+
+  dismissSkillJob: (jobId) => removeSkillInstallJob(set, get, jobId),
 
   checkSkillCatalog: async (name) => {
     set({ skillCatalogLoading: true, skillCatalogError: undefined });
@@ -2708,22 +2721,26 @@ async function pollSkillInstallJob(
       await new Promise((resolve) => globalThis.setTimeout(resolve, SKILL_JOB_POLL_INTERVAL_MS));
       const job = await runtimeClient.getJob(jobId);
       if (job.status === "completed") {
-        removeSkillInstallJob(set, get, jobId);
+        updateSkillInstallJob(set, jobId, "completed", undefined, job.summary);
         await get().refreshSkillCatalog();
         return;
       }
       if (job.status === "failed") {
-        updateSkillInstallJob(set, jobId, "failed", job.error || job.summary);
-        removeSkillInstallJobAfterDelay(set, get, jobId, 10_000);
+        updateSkillInstallJob(set, jobId, "failed", job.error || job.summary, job.summary);
         return;
       }
-      updateSkillInstallJob(set, jobId, job.status === "running" ? "running" : "queued");
+      updateSkillInstallJob(
+        set,
+        jobId,
+        job.status === "running" ? "running" : "queued",
+        undefined,
+        job.summary,
+      );
     } catch {
       // Network error — keep retrying until deadline
     }
   }
-  updateSkillInstallJob(set, jobId, "failed", "Timed out waiting for skill install.");
-  removeSkillInstallJobAfterDelay(set, get, jobId, 10_000);
+  updateSkillInstallJob(set, jobId, "failed", "Timed out waiting for skill job.");
 }
 
 const TEMPLATE_SYNC_POLL_INTERVAL_MS = 1_000;
@@ -2754,9 +2771,17 @@ async function pollTemplateSyncJob(
   throw new Error("Timed out waiting for template remote source sync.");
 }
 
-function updateSkillInstallJob(set: StoreSet, jobId: string, status: SkillInstallJob["status"], error?: string): void {
+function updateSkillInstallJob(
+  set: StoreSet,
+  jobId: string,
+  status: SkillInstallJob["status"],
+  error?: string,
+  summary?: string,
+): void {
   set((state) => {
-    const jobs = state.skillInstallJobs.map((j) => j.jobId === jobId ? { ...j, status, error } : j);
+    const jobs = state.skillInstallJobs.map((j) =>
+      j.jobId === jobId ? { ...j, status, error, summary } : j
+    );
     saveSkillInstallJobs(jobs);
     return { skillInstallJobs: jobs };
   });
@@ -2768,10 +2793,6 @@ function removeSkillInstallJob(set: StoreSet, get: () => RuntimeStoreState, jobI
     saveSkillInstallJobs(jobs);
     return { skillInstallJobs: jobs };
   });
-}
-
-function removeSkillInstallJobAfterDelay(set: StoreSet, get: () => RuntimeStoreState, jobId: string, delayMs: number): void {
-  window.setTimeout(() => removeSkillInstallJob(set, get, jobId), delayMs);
 }
 
 function mergeAgentIntoBootstrap(bootstrap: RuntimeBootstrap, updatedAgent: AgentSummary): RuntimeBootstrap {


### PR DESCRIPTION
## 概要

- 将 `POST /skills/catalog/update` 改为返回 `202` 的 `skill.update` 后台 job，并与 skill install 共用 Global Skill Library 单并发写门
- 为 catalog update 增加逐 skill 进度与最终结果，覆盖 `updated`、`unchanged`、`skipped`、`failed` 以及 job 级失败
- 保持 `holon skills update` 的同步用户语义：CLI 等待 job 完成并打印最终结果
- Web GUI 支持 update job 的排队、运行、恢复轮询、逐项结果、部分失败与完成消息
- 更新 OpenAPI 快照和 CLI 契约测试

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test`
- `npm run typecheck`（`web-gui/app`）
- `npm test -- --run`（`web-gui/app`）

Closes #2179
