### PR TITLE
fix(skills): harden update job feedback

### DIFF
--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -310,7 +310,7 @@ pub(super) async fn create_skill_update_job(
                             job.summary = if total == 0 {
                                 "No matching skills to update".into()
                             } else {
-                                format!("Updating 0 of {total} skills")
+                                format!("Starting update of {total} skills")
                             };
                         });
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3193,7 +3193,9 @@ async fn post_control_json_value<T: serde::Serialize>(
 }
 
 async fn wait_for_job(config: &AppConfig, job_id: &str) -> Result<serde_json::Value> {
-    loop {
+    const JOB_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
+    let deadline = tokio::time::Instant::now() + JOB_WAIT_TIMEOUT;
+    while tokio::time::Instant::now() < deadline {
         let response = get_json(config, &format!("/jobs/{job_id}")).await?;
         let job = response
             .get("job")
@@ -3203,6 +3205,10 @@ async fn wait_for_job(config: &AppConfig, job_id: &str) -> Result<serde_json::Va
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
+    Err(anyhow!(
+        "timed out after {} seconds waiting for job {job_id}",
+        JOB_WAIT_TIMEOUT.as_secs()
+    ))
 }
 
 async fn get_json(config: &AppConfig, path: &str) -> Result<serde_json::Value> {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -350,11 +350,27 @@ export interface SkillInstallJob {
 }
 
 const SKILL_INSTALL_JOBS_STORAGE_KEY = "holon.webGui.skillInstallJobs.v1";
+const SKILL_JOB_TERMINAL_RETENTION = 20;
+
+function retainSkillJobs(jobs: SkillInstallJob[]): SkillInstallJob[] {
+  let terminalToDrop = Math.max(
+    0,
+    jobs.filter((job) => job.status === "completed" || job.status === "failed").length
+      - SKILL_JOB_TERMINAL_RETENTION,
+  );
+  return jobs.filter((job) => {
+    if (job.status === "queued" || job.status === "running" || terminalToDrop === 0) {
+      return true;
+    }
+    terminalToDrop -= 1;
+    return false;
+  });
+}
 
 function loadSkillInstallJobs(): SkillInstallJob[] {
   try {
     const raw = localStorage.getItem(SKILL_INSTALL_JOBS_STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as SkillInstallJob[]) : [];
+    return raw ? retainSkillJobs(JSON.parse(raw) as SkillInstallJob[]) : [];
   } catch {
     return [];
   }
@@ -362,8 +378,9 @@ function loadSkillInstallJobs(): SkillInstallJob[] {
 
 function saveSkillInstallJobs(jobs: SkillInstallJob[]): void {
   try {
-    if (jobs.length) {
-      localStorage.setItem(SKILL_INSTALL_JOBS_STORAGE_KEY, JSON.stringify(jobs));
+    const retainedJobs = retainSkillJobs(jobs);
+    if (retainedJobs.length) {
+      localStorage.setItem(SKILL_INSTALL_JOBS_STORAGE_KEY, JSON.stringify(retainedJobs));
     } else {
       localStorage.removeItem(SKILL_INSTALL_JOBS_STORAGE_KEY);
     }
@@ -1383,7 +1400,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       const source = "package" in input ? input.package : "path" in input ? input.path : "name" in input ? input.name : "unknown";
       const job: SkillInstallJob = { jobId, source, status: "queued" };
       set((state) => {
-        const jobs = [...state.skillInstallJobs, job];
+        const jobs = retainSkillJobs([...state.skillInstallJobs, job]);
         saveSkillInstallJobs(jobs);
         return { skillInstallJobs: jobs };
       });
@@ -1425,7 +1442,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         status: "queued",
       };
       set((state) => {
-        const jobs = [...state.skillInstallJobs, job];
+        const jobs = retainSkillJobs([...state.skillInstallJobs, job]);
         saveSkillInstallJobs(jobs);
         return { skillInstallJobs: jobs };
       });
@@ -2779,8 +2796,10 @@ function updateSkillInstallJob(
   summary?: string,
 ): void {
   set((state) => {
-    const jobs = state.skillInstallJobs.map((j) =>
-      j.jobId === jobId ? { ...j, status, error, summary } : j
+    const jobs = retainSkillJobs(
+      state.skillInstallJobs.map((j) =>
+        j.jobId === jobId ? { ...j, status, error, summary } : j
+      ),
     );
     saveSkillInstallJobs(jobs);
     return { skillInstallJobs: jobs };


### PR DESCRIPTION
## Summary

Follow up on the non-blocking review suggestions from #2181:

- add a 180-second timeout to CLI job polling
- improve the initial skill update progress summary
- retain at most 20 terminal skill jobs in Web GUI localStorage while preserving queued/running jobs

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test`
- targeted CLI contract tests
- Web GUI typecheck and 155 tests
