### PR TITLE
feat: add isolated xAI XSearch tool

### DIFF
--- a/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
+++ b/docs/implementation-decisions/065-xai-grok-api-and-login-boundary.md
@@ -6,9 +6,10 @@ Holon's Grok integration uses the public xAI API as an OpenAI Responses
 compatible HTTP provider authenticated by either `XAI_API_KEY` or a
 Holon-managed official xAI OAuth profile.
 
-Grok's built-in `web_search` and `x_search` are represented as xAI server-side
-tools on that Responses request. They are not exposed as a raw Holon web-search
-provider and they do not use X API search credentials.
+Grok's hosted `x_search` is exposed through Holon's PascalCase `XSearch`
+client-side tool. `XSearch` sends a separate xAI Responses request containing
+only the hosted `x_search` tool, then returns durable final text, citations,
+and bounded diagnostics. It does not use X API search credentials.
 
 xAI Responses requests use server-side response storage because
 `previous_response_id` continuation requires the referenced response to remain
@@ -18,11 +19,18 @@ contract; full requests retain them.
 The OAuth profile is explicit provider credential material with refresh
 lifecycle managed by Holon. Browser cookies, private consumer session files,
 and implicit subscription-state reuse remain outside the HTTP provider path.
-Holon-managed web search remains the PascalCase `WebSearch` function tool.
-Names such as `x_search`, `x_semantic_search`, and `x_keyword_search` are not
-client-callable Holon tools. `x_search` is only valid as the xAI server-side
-tool type above; invented client function names remain subject to the current
-round's tool allowlist.
+Holon-managed general web search remains the PascalCase `WebSearch` function
+tool. Lowercase names such as `x_search`, `x_semantic_search`, and
+`x_keyword_search` are not client-callable Holon tools. The lowercase
+`x_search` type is valid only inside the isolated `XSearch` provider request;
+hosted/internal call items are recorded as diagnostics rather than entering
+the main agent tool execution or continuation chain.
+
+`XSearch` is available only while the `xai` provider has usable credentials.
+It is enabled automatically in that case, may be disabled with
+`x_search.enabled = false`, and may select an independent xAI model with
+`x_search.model`. Main xAI agent Responses requests do not advertise hosted
+search.
 
 X/xAI account login reuse is left out of the HTTP provider path. If Holon later
 supports X-account-backed Grok sessions, it should integrate through an
@@ -33,8 +41,9 @@ as an xAI API key.
 ## Reason
 
 xAI's public inference API supports direct authenticated `/v1/responses` and
-`/v1/chat/completions` calls. Its built-in search tools are server-side xAI
-tools on model requests.
+`/v1/chat/completions` calls. Isolating its hosted search in a client tool
+keeps provider-internal calls and response continuation state out of the main
+agent conversation while preserving searchable output for replay.
 
 Official OAuth and Grok Build login/session paths remain explicit credential or
 process boundaries; neither authorizes scraping or silently importing browser

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -337,6 +337,9 @@ TUI debug instrumentation is controlled by environment variables:
 | `web.search.providers` | string_list | `[]` | Explicit auto-mode provider attempt order |
 | `web.search.max_results` | integer | `5` | Max results returned |
 | `web.search.max_provider_attempts` | integer | `3` | Max providers attempted by fallback/aggregate routing |
+| `x_search.enabled` | boolean | `true` | Enable `XSearch` automatically when xAI credentials are available; set `false` to hide it |
+| `x_search.model` | model_ref | — | Optional xAI model route for isolated `XSearch` requests |
+| `x_search.timeout_seconds` | integer | `60` | Timeout for isolated xAI `XSearch` requests |
 | `web.providers.<name>.kind` | string | required | Provider kind: `duck_duck_go`, `searxng`, `brave`, `tencent_cloud_wsa`, `bocha`, `tavily`, `exa`, `perplexity`, `firecrawl`, `open_ai_native`, `anthropic_native`, `gemini_native`, or `command` |
 | `web.providers.<name>.base_url` | string | unset | Custom provider endpoint |
 | `web.providers.<name>.credential_profile` | string | unset | Credential profile for API-backed providers |

--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -1374,6 +1374,60 @@
         "success_result": "WebSearchResult"
       },
       "stability": "experimental"
+    },
+    {
+      "description": "Search public X posts using xAI's hosted `x_search` in an isolated provider request. Use this for X-specific content, accounts, or discussions; use `WebSearch` for the general web. Results contain durable text and citations and do not depend on the main model conversation's provider state.\n",
+      "family": "web",
+      "freeform_grammar": null,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_x_handles": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "excluded_x_handles": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "from_date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "to_date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "name": "XSearch",
+      "related_surfaces": [
+        "xAI hosted search adapter"
+      ],
+      "result_envelope": {
+        "canonical": "ToolResultEnvelope",
+        "error_result": "ToolError",
+        "model_rendering": "canonical_json_envelope",
+        "success_result": "XSearchResult"
+      },
+      "stability": "experimental"
     }
   ],
   "version": 1

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1440,11 +1440,7 @@ pub(crate) fn insert_builtin_http_provider_with_context_management(
                 None
             },
             context_management,
-            builtin_web_search: if provider == "xai" {
-                Some(xai_builtin_web_search_config())
-            } else {
-                builtin_web_search
-            },
+            builtin_web_search,
         },
     );
     Ok(())
@@ -1501,15 +1497,6 @@ pub(crate) fn deepseek_builtin_web_search_config() -> ProviderBuiltinWebSearchCo
         kind: ProviderNativeWebSearchKind::Anthropic,
         advertised_tool_type: "web_search_20250305".to_string(),
         backend_kind: "deepseek_web_search".to_string(),
-    }
-}
-
-pub(crate) fn xai_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
-    ProviderBuiltinWebSearchConfig {
-        enabled: true,
-        kind: ProviderNativeWebSearchKind::Xai,
-        advertised_tool_type: "web_search".to_string(),
-        backend_kind: "xai_web_search_x_search".to_string(),
     }
 }
 
@@ -1633,14 +1620,10 @@ pub(crate) fn validate_provider_builtin_web_search(
             }
         }
         (ProviderTransportKind::OpenAiResponses, ProviderNativeWebSearchKind::Xai) => {
-            if search.advertised_tool_type == "web_search" {
-                Ok(())
-            } else {
-                Err(anyhow!(
-                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search for xAI Responses native search",
-                    provider_id.as_str()
-                ))
-            }
+            Err(anyhow!(
+                "providers.{}.builtin_web_search cannot enable xAI hosted search; use the isolated XSearch tool",
+                provider_id.as_str()
+            ))
         }
         (ProviderTransportKind::OpenAiCodexResponses, ProviderNativeWebSearchKind::OpenAi) => {
             if search.advertised_tool_type == "web_search" {

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -20,8 +20,26 @@ pub struct HolonConfigFile {
     pub tui: TuiConfigFile,
     #[serde(default, skip_serializing_if = "WebConfigFile::is_empty")]
     pub web: WebConfigFile,
+    #[serde(default, skip_serializing_if = "XSearchConfigFile::is_empty")]
+    pub x_search: XSearchConfigFile,
     #[serde(default, skip_serializing_if = "AgentTemplatesConfigFile::is_empty")]
     pub agent_templates: AgentTemplatesConfigFile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct XSearchConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+}
+
+impl XSearchConfigFile {
+    pub fn is_empty(&self) -> bool {
+        self.enabled.is_none() && self.model.is_none() && self.timeout_seconds.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,6 +29,7 @@ mod models;
 mod providers;
 mod schema;
 mod web;
+mod x_search;
 
 pub use builtin_providers::*;
 pub use credentials::*;
@@ -37,6 +38,7 @@ pub use models::*;
 pub use providers::*;
 pub use schema::*;
 pub use web::*;
+pub use x_search::*;
 
 #[derive(Debug, Clone)]
 pub struct AppConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -453,6 +453,27 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
+            key: "x_search.enabled",
+            kind: "boolean",
+            description: "Enable XSearch when the xAI provider has a configured credential.",
+            default: json!(true),
+            allowed_values: vec!["true", "false"],
+        },
+        ConfigSchemaEntry {
+            key: "x_search.model",
+            kind: "model_ref",
+            description: "Optional xAI model route used by isolated XSearch requests.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "x_search.timeout_seconds",
+            kind: "positive_integer",
+            description: "Timeout in seconds for isolated xAI XSearch requests.",
+            default: json!(crate::config::DEFAULT_X_SEARCH_TIMEOUT_SECONDS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
             key: "web.providers.<name>.kind",
             kind: "string",
             description: "Web search provider kind: duck_duck_go, searxng, brave, tencent_cloud_wsa, bocha, tavily, exa, perplexity, firecrawl, open_ai_native, anthropic_native, gemini_native, command.",
@@ -711,6 +732,22 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .enabled
             .map(Value::Bool)
             .unwrap_or(Value::Null)),
+        "x_search.enabled" => Ok(config
+            .x_search
+            .enabled
+            .map(Value::Bool)
+            .unwrap_or(Value::Null)),
+        "x_search.model" => Ok(config
+            .x_search
+            .model
+            .as_ref()
+            .map(|value| Value::String(value.clone()))
+            .unwrap_or(Value::Null)),
+        "x_search.timeout_seconds" => Ok(config
+            .x_search
+            .timeout_seconds
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
         "web.search.builtin_provider.enabled" => Ok(config
             .web
             .search
@@ -968,6 +1005,21 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
             );
         }
+        "x_search.enabled" => {
+            config.x_search.enabled = Some(
+                parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
+            );
+        }
+        "x_search.model" => {
+            let parsed = ModelRouteRef::parse_compatible(raw_value)?;
+            if parsed.provider.as_str() != ProviderId::XAI {
+                return Err(anyhow!("{key} must reference the xai provider"));
+            }
+            config.x_search.model = Some(parsed.as_string());
+        }
+        "x_search.timeout_seconds" => {
+            config.x_search.timeout_seconds = Some(parse_positive_u64_key(key, raw_value)?);
+        }
         "web.search.builtin_provider.enabled" => {
             config.web.search.builtin_provider.enabled = Some(
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
@@ -1200,6 +1252,9 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "web.search.providers" => config.web.search.providers.clear(),
         "web.search.max_results" => config.web.search.max_results = None,
         "web.search.max_provider_attempts" => config.web.search.max_provider_attempts = None,
+        "x_search.enabled" => config.x_search.enabled = None,
+        "x_search.model" => config.x_search.model = None,
+        "x_search.timeout_seconds" => config.x_search.timeout_seconds = None,
         key if key.starts_with("web.providers.") && key.ends_with(".kind") => {
             let rest = key.strip_prefix("web.providers.").unwrap();
             let name = rest.strip_suffix(".kind").unwrap();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -27,7 +27,8 @@ use crate::config::{
     ProviderAuthConfig, ProviderBuiltinWebSearchConfig, ProviderConfigFile,
     ProviderEndpointConfigFile, ProviderEndpointId, ProviderId, ProviderPlanConfigFile,
     ProviderRegistry, ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog,
-    DEFAULT_LOCAL_AGENT_ID, OPENAI_CODEX_CREDENTIAL_PROFILE,
+    XSearchRuntimeConfig, DEFAULT_LOCAL_AGENT_ID, DEFAULT_X_SEARCH_MODEL,
+    OPENAI_CODEX_CREDENTIAL_PROFILE,
 };
 
 struct EnvVarSnapshot {
@@ -182,6 +183,44 @@ fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConf
         _workspace_dir: workspace_dir,
         config,
     }
+}
+
+#[test]
+fn disabled_x_search_config_is_unavailable() {
+    let mut fixture = test_app_config("openai/gpt-4o-mini", &[]);
+    fixture.config.stored_config.x_search.enabled = Some(false);
+    assert!(XSearchRuntimeConfig::from_app_config(&fixture.config)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn x_search_auto_enables_with_xai_credential_and_supports_model_override() {
+    let mut fixture = test_app_config("openai/gpt-4o-mini", &[]);
+    let mut xai = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    let xai_id = ProviderId::parse("xai").unwrap();
+    xai.id = xai_id.clone();
+    xai.route_provider = xai_id.clone();
+    xai.base_url = "https://api.x.ai/v1".into();
+    xai.credential = Some("xai-key".into());
+    xai.builtin_web_search = None;
+    fixture.config.providers.insert(xai_id, xai);
+
+    let automatic = XSearchRuntimeConfig::from_app_config(&fixture.config)
+        .unwrap()
+        .unwrap();
+    assert_eq!(automatic.model, DEFAULT_X_SEARCH_MODEL);
+
+    fixture.config.stored_config.x_search.model = Some("xai/grok-4.5".into());
+    let overridden = XSearchRuntimeConfig::from_app_config(&fixture.config)
+        .unwrap()
+        .unwrap();
+    assert_eq!(overridden.model, "grok-4.5");
 }
 
 #[test]
@@ -848,10 +887,7 @@ fn built_in_provider_registry_declares_provider_specific_builtin_search() {
     let xai = registry.get(&ProviderId::parse("xai").unwrap()).unwrap();
     assert_eq!(xai.transport, ProviderTransportKind::OpenAiResponses);
     assert_eq!(xai.reasoning_effort.as_deref(), Some("medium"));
-    let xai_search = xai.builtin_web_search.as_ref().unwrap();
-    assert_eq!(xai_search.kind, ProviderNativeWebSearchKind::Xai);
-    assert_eq!(xai_search.advertised_tool_type, "web_search");
-    assert_eq!(xai_search.backend_kind, "xai_web_search_x_search");
+    assert!(xai.builtin_web_search.is_none());
 }
 
 #[test]

--- a/src/config/x_search.rs
+++ b/src/config/x_search.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+
+use super::{AppConfig, ModelRouteRef, ProviderId, ProviderRuntimeConfig, ProviderTransportKind};
+
+pub const DEFAULT_X_SEARCH_MODEL: &str = "grok-4-1-fast";
+pub const DEFAULT_X_SEARCH_TIMEOUT_SECONDS: u64 = 60;
+
+#[derive(Debug, Clone)]
+pub struct XSearchRuntimeConfig {
+    pub provider: ProviderRuntimeConfig,
+    pub model: String,
+    pub timeout: Duration,
+}
+
+impl XSearchRuntimeConfig {
+    pub fn from_app_config(config: &AppConfig) -> Result<Option<Self>> {
+        if config.stored_config.x_search.enabled == Some(false) {
+            return Ok(None);
+        }
+        let xai_id = ProviderId::parse(ProviderId::XAI)?;
+        let Some(provider) = config.providers.get(&xai_id) else {
+            return Ok(None);
+        };
+        if !provider.has_configured_credential() {
+            return Ok(None);
+        }
+        if provider.transport != ProviderTransportKind::OpenAiResponses {
+            return Err(anyhow!(
+                "x_search requires the xai provider to use openai_responses transport"
+            ));
+        }
+
+        let model = match config.stored_config.x_search.model.as_deref() {
+            Some(model) => {
+                let route = ModelRouteRef::parse_compatible(model)?;
+                if route.provider != xai_id {
+                    return Err(anyhow!("x_search.model must reference the xai provider"));
+                }
+                if route.endpoint != provider.route_endpoint {
+                    return Err(anyhow!(
+                        "x_search.model endpoint does not match the active xai provider endpoint"
+                    ));
+                }
+                route.model
+            }
+            None => DEFAULT_X_SEARCH_MODEL.to_string(),
+        };
+        let timeout_seconds = config
+            .stored_config
+            .x_search
+            .timeout_seconds
+            .unwrap_or(DEFAULT_X_SEARCH_TIMEOUT_SECONDS);
+        if timeout_seconds == 0 {
+            return Err(anyhow!("x_search.timeout_seconds must be positive"));
+        }
+
+        Ok(Some(Self {
+            provider: provider.clone(),
+            model,
+            timeout: Duration::from_secs(timeout_seconds),
+        }))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod types;
 pub mod web;
 pub mod work_item_plan;
 pub mod work_item_refs;
+pub mod x_search;
 
 #[cfg(test)]
 mod test_env;

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -2088,7 +2088,6 @@ pub(crate) fn build_openai_responses_request(
         .collect::<Result<Vec<_>>>()?;
     if let Some(tool) = openai_native_web_search_tool(request) {
         tools.push(tool);
-        tools.extend(openai_native_web_search_extra_tools(request));
     }
 
     let mut body = json!({
@@ -2148,18 +2147,6 @@ fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value>
         ProviderNativeWebSearchKind::OpenAi => Some(json!({ "type": native.advertised_tool_type })),
         ProviderNativeWebSearchKind::Xai => Some(json!({ "type": native.advertised_tool_type })),
         _ => None,
-    }
-}
-
-fn openai_native_web_search_extra_tools(request: &ProviderTurnRequest) -> Vec<Value> {
-    if request
-        .native_web_search
-        .as_ref()
-        .is_some_and(|native| native.kind == ProviderNativeWebSearchKind::Xai)
-    {
-        vec![json!({ "type": "x_search" })]
-    } else {
-        Vec::new()
     }
 }
 
@@ -6264,7 +6251,7 @@ mod tests {
     }
 
     #[test]
-    fn openai_responses_request_lowers_xai_native_search_tools_and_reasoning() {
+    fn openai_responses_request_does_not_add_xai_x_search_tool() {
         let mut request = ProviderTurnRequest::plain(
             "system",
             vec![ConversationMessage::UserText("search X and the web".into())],
@@ -6294,7 +6281,7 @@ mod tests {
         assert!(tools
             .iter()
             .any(|tool| tool == &json!({ "type": "web_search" })));
-        assert!(tools
+        assert!(!tools
             .iter()
             .any(|tool| tool == &json!({ "type": "x_search" })));
         assert_eq!(body["reasoning"]["effort"], json!("medium"));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -833,6 +833,10 @@ impl RuntimeHandle {
         self.inner.config_snapshot.load().web_config.clone()
     }
 
+    pub(crate) fn x_search_config(&self) -> Option<crate::config::XSearchRuntimeConfig> {
+        self.inner.config_snapshot.load().x_search_config.clone()
+    }
+
     fn user_home(&self) -> Option<PathBuf> {
         if let Some(provider_reconfig) =
             self.inner.config_snapshot.load().provider_reconfig.as_ref()

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -57,7 +57,7 @@ pub(super) struct ConfigSnapshot {
 
 impl ConfigSnapshot {
     /// Build a fresh snapshot from a config, preserving the agent's current model override.
-    pub fn from_config(config: &AppConfig) -> Self {
+    pub fn from_config(config: &AppConfig) -> Result<Self> {
         let model_catalog = RuntimeModelCatalog::from_config(config);
         let model_availability = resolved_model_availability(config);
         let provider_reconfig = Some(ProviderReconfigurator {
@@ -75,7 +75,7 @@ impl ConfigSnapshot {
             max_relevant_episodes: config.max_relevant_episodes,
             ..ContextConfig::default()
         };
-        Self {
+        Ok(Self {
             model_catalog,
             model_availability,
             base_context_config,
@@ -83,12 +83,8 @@ impl ConfigSnapshot {
             default_tool_output_tokens: config.default_tool_output_tokens as u64,
             max_tool_output_tokens: config.max_tool_output_tokens as u64,
             web_config: config.web_config.clone(),
-            x_search_config: crate::config::XSearchRuntimeConfig::from_app_config(config)
-                .unwrap_or_else(|error| {
-                    tracing::warn!(error = %error, "invalid x_search configuration");
-                    None
-                }),
-        }
+            x_search_config: crate::config::XSearchRuntimeConfig::from_app_config(config)?,
+        })
     }
 }
 
@@ -237,6 +233,11 @@ impl RuntimeHandle {
         host_bridge: Option<RuntimeHostBridge>,
         event_bus: Option<EventBus>,
     ) -> Result<Self> {
+        let x_search_config = provider_reconfig
+            .as_ref()
+            .map(|reconfig| crate::config::XSearchRuntimeConfig::from_app_config(&reconfig.config))
+            .transpose()?
+            .flatten();
         let config_snapshot = Arc::new(ConfigSnapshot {
             model_catalog: model_catalog.clone(),
             model_availability: model_availability.clone(),
@@ -245,7 +246,7 @@ impl RuntimeHandle {
             default_tool_output_tokens,
             max_tool_output_tokens,
             web_config: web_config.clone(),
-            x_search_config: None,
+            x_search_config,
         });
         let mut provider = provider;
         let PreparedRuntimeStorage {
@@ -413,7 +414,7 @@ impl RuntimeHandle {
     /// the old snapshot continues unaffected; the next turn picks up the
     /// new snapshot automatically.
     pub(crate) async fn reload_config(&self, config: &AppConfig) -> Result<()> {
-        let new_snapshot = Arc::new(ConfigSnapshot::from_config(config));
+        let new_snapshot = Arc::new(ConfigSnapshot::from_config(config)?);
         // Atomically swap the snapshot.
         self.inner.config_snapshot.store(new_snapshot);
         // Rebuild provider + context_config for current state.
@@ -658,7 +659,7 @@ impl RuntimeHandle {
         config.model_discovery_cache = cache;
         self.inner
             .config_snapshot
-            .store(Arc::new(ConfigSnapshot::from_config(&config)));
+            .store(Arc::new(ConfigSnapshot::from_config(&config)?));
         Ok(())
     }
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -52,6 +52,7 @@ pub(super) struct ConfigSnapshot {
     pub default_tool_output_tokens: u64,
     pub max_tool_output_tokens: u64,
     pub web_config: crate::web::WebConfig,
+    pub x_search_config: Option<crate::config::XSearchRuntimeConfig>,
 }
 
 impl ConfigSnapshot {
@@ -82,6 +83,11 @@ impl ConfigSnapshot {
             default_tool_output_tokens: config.default_tool_output_tokens as u64,
             max_tool_output_tokens: config.max_tool_output_tokens as u64,
             web_config: config.web_config.clone(),
+            x_search_config: crate::config::XSearchRuntimeConfig::from_app_config(config)
+                .unwrap_or_else(|error| {
+                    tracing::warn!(error = %error, "invalid x_search configuration");
+                    None
+                }),
         }
     }
 }
@@ -239,6 +245,7 @@ impl RuntimeHandle {
             default_tool_output_tokens,
             max_tool_output_tokens,
             web_config: web_config.clone(),
+            x_search_config: None,
         });
         let mut provider = provider;
         let PreparedRuntimeStorage {

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -167,6 +167,9 @@ impl RuntimeHandle {
                     .profile_preset
                     .allows_tool_capability_family(*family)
             })
+            .filter(|(_, tool)| {
+                tool.name != crate::tool::names::X_SEARCH || self.x_search_config().is_some()
+            })
             .map(|(_, tool)| tool)
             .collect())
     }
@@ -440,7 +443,6 @@ async fn probe_builtin_web_search_capability(
     ) {
         (ProviderNativeWebSearchKind::OpenAi, "openai_responses", "web_search_preview")
         | (ProviderNativeWebSearchKind::OpenAi, "openai_codex_responses", "web_search")
-        | (ProviderNativeWebSearchKind::Xai, "openai_responses", "web_search")
         | (ProviderNativeWebSearchKind::Anthropic, "anthropic_messages", "web_search_20250305") => {
             true
         }
@@ -1082,7 +1084,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn builtin_web_search_probe_accepts_xai_responses_contract() {
+    async fn builtin_web_search_probe_rejects_xai_responses_contract() {
         let capability = crate::provider::ProviderBuiltinWebSearchCapability {
             kind: ProviderNativeWebSearchKind::Xai,
             provider_id: "xai".into(),
@@ -1100,8 +1102,11 @@ mod tests {
         )
         .await;
 
-        assert_eq!(result.status, BuiltinWebSearchProbeStatus::Supported);
-        assert_eq!(result.reason, None);
+        assert_eq!(result.status, BuiltinWebSearchProbeStatus::Unsupported);
+        assert!(result
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("incompatible")));
     }
 
     #[test]

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -361,6 +361,11 @@ async fn filtered_tool_specs_expose_x_search_only_after_xai_activation() {
         .any(|tool| tool.name == crate::tool::names::X_SEARCH));
 
     let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    config
+        .providers
+        .get_mut(&crate::config::ProviderId::openai())
+        .unwrap()
+        .credential = Some("openai-key".into());
     let mut xai = config
         .providers
         .get(&crate::config::ProviderId::openai())

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -351,6 +351,38 @@ async fn filtered_tool_specs_keep_exec_command_visible_when_process_execution_di
 }
 
 #[tokio::test]
+async fn filtered_tool_specs_expose_x_search_only_after_xai_activation() {
+    let (home, _host, runtime) = host_backed_test_runtime().await;
+    let identity = runtime.agent_identity_view().await.unwrap();
+    assert!(!runtime
+        .filtered_tool_specs(&identity)
+        .unwrap()
+        .iter()
+        .any(|tool| tool.name == crate::tool::names::X_SEARCH));
+
+    let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    let mut xai = config
+        .providers
+        .get(&crate::config::ProviderId::openai())
+        .unwrap()
+        .clone();
+    let xai_id = crate::config::ProviderId::parse("xai").unwrap();
+    xai.id = xai_id.clone();
+    xai.route_provider = xai_id.clone();
+    xai.base_url = "https://api.x.ai/v1".into();
+    xai.credential = Some("xai-key".into());
+    xai.builtin_web_search = None;
+    config.providers.insert(xai_id, xai);
+    runtime.reload_config(&config).await.unwrap();
+
+    assert!(runtime
+        .filtered_tool_specs(&identity)
+        .unwrap()
+        .iter()
+        .any(|tool| tool.name == crate::tool::names::X_SEARCH));
+}
+
+#[tokio::test]
 async fn filtered_tool_specs_do_not_expose_worktree_discard() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -45,6 +45,7 @@ pub(crate) fn context_config() -> ContextConfig {
             .filter(|(family, _)| {
                 AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
             })
+            .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
             .map(|(_, tool)| tool)
             .collect::<Vec<_>>();
     let prompt_budget_estimated_tokens =
@@ -71,6 +72,7 @@ pub(crate) fn continuation_ready_context_config(
         .filter(|(family, _)| {
             AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
         })
+        .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
         .map(|(_, tool)| tool)
         .collect::<Vec<_>>();
     let prompt_budget_estimated_tokens =

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -514,6 +514,7 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
         .filter(|(family, _)| {
             AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
         })
+        .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
         .map(|(_, tool)| tool)
         .collect::<Vec<_>>();
     let continuation_effective_budget = 1_000;
@@ -780,6 +781,7 @@ async fn turn_local_compaction_fails_fast_when_baseline_exceeds_budget() {
         .filter(|(family, _)| {
             AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
         })
+        .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
         .map(|(_, tool)| tool)
         .collect::<Vec<_>>();
     let continuation_effective_budget = 320;

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -116,6 +116,7 @@ fn tool_success_result_contract(name: &str) -> &'static str {
         tn::USE_WORKSPACE => "UseWorkspaceResult",
         tn::WEB_FETCH => "WebFetchResult",
         tn::WEB_SEARCH => "WebSearchResult",
+        tn::X_SEARCH => "XSearchResult",
         _ => "tool-specific JSON payload",
     }
 }
@@ -152,6 +153,7 @@ fn related_surfaces_for_tool(name: &str) -> Vec<&'static str> {
         }
         tn::APPLY_PATCH | tn::USE_WORKSPACE => vec!["workspace/runtime file APIs"],
         tn::WEB_FETCH | tn::WEB_SEARCH => vec!["web adapter APIs"],
+        tn::X_SEARCH => vec!["xAI hosted search adapter"],
         tn::MEMORY_SEARCH | tn::MEMORY_GET => vec!["memory/runtime APIs"],
         _ => Vec::new(),
     }

--- a/src/tool/names.rs
+++ b/src/tool/names.rs
@@ -40,6 +40,7 @@ pub mod tool_names {
     pub const WAIT_FOR: &str = "WaitFor";
     pub const WEB_FETCH: &str = "WebFetch";
     pub const WEB_SEARCH: &str = "WebSearch";
+    pub const X_SEARCH: &str = "XSearch";
 }
 
 pub use tool_names::*;
@@ -130,4 +131,5 @@ pub const ALL_TOOL_NAMES: &[&str] = &[
     WAIT_FOR,
     WEB_FETCH,
     WEB_SEARCH,
+    X_SEARCH,
 ];

--- a/src/tool/tool_descriptions/x_search.md
+++ b/src/tool/tool_descriptions/x_search.md
@@ -1,0 +1,1 @@
+Search public X posts using xAI's hosted `x_search` in an isolated provider request. Use this for X-specific content, accounts, or discussions; use `WebSearch` for the general web. Results contain durable text and citations and do not depend on the main model conversation's provider state.

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod web_fetch;
 pub(crate) mod web_search;
 pub(crate) mod work_item_action;
 pub(crate) mod work_item_query;
+pub(crate) mod x_search;
 
 pub(crate) struct BuiltinToolDefinition {
     pub(crate) family: ToolCapabilityFamily,
@@ -77,6 +78,7 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         view_image::definition()?,
         web_fetch::definition()?,
         web_search::definition()?,
+        x_search::definition()?,
     ])
 }
 
@@ -189,6 +191,7 @@ pub(crate) async fn execute_builtin_tool(
         web_search::NAME => {
             web_search::execute(runtime, agent_id, authority_class, &call.input).await
         }
+        x_search::NAME => x_search::execute(runtime, agent_id, authority_class, &call.input).await,
         _ => Err(anyhow!("unknown builtin tool {}", call.name)),
     }
 }
@@ -272,6 +275,7 @@ mod tests {
             "WaitFor" => "src/tool/tool_descriptions/wait_for.md",
             "WebFetch" => "src/tool/tool_descriptions/web_fetch.md",
             "WebSearch" => "src/tool/tool_descriptions/web_search.md",
+            "XSearch" => "src/tool/tool_descriptions/x_search.md",
             _ => return None,
         })
     }

--- a/src/tool/tools/x_search.rs
+++ b/src/tool/tools/x_search.rs
@@ -1,0 +1,120 @@
+use anyhow::{anyhow, Result};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime::RuntimeHandle,
+    tool::{helpers::parse_tool_args, spec::typed_spec},
+    types::{AuthorityClass, ToolCapabilityFamily},
+    x_search::{search, XSearchRequest},
+};
+
+use super::{serialize_success, BuiltinToolDefinition};
+
+pub(crate) const NAME: &str = crate::tool::names::X_SEARCH;
+const MAX_HANDLES: usize = 10;
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct XSearchArgs {
+    query: String,
+    #[serde(default)]
+    allowed_x_handles: Vec<String>,
+    #[serde(default)]
+    excluded_x_handles: Vec<String>,
+    from_date: Option<String>,
+    to_date: Option<String>,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::Web,
+        spec: typed_spec::<XSearchArgs>(NAME, include_str!("../tool_descriptions/x_search.md"))?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _authority_class: &AuthorityClass,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: XSearchArgs = parse_tool_args(NAME, input)?;
+    let query = required_string(args.query, "query")?;
+    let allowed_x_handles = normalize_handles(args.allowed_x_handles, "allowed_x_handles")?;
+    let excluded_x_handles = normalize_handles(args.excluded_x_handles, "excluded_x_handles")?;
+    let from_date = normalize_date(args.from_date, "from_date")?;
+    let to_date = normalize_date(args.to_date, "to_date")?;
+    if from_date
+        .as_deref()
+        .zip(to_date.as_deref())
+        .is_some_and(|(from_date, to_date)| from_date > to_date)
+    {
+        return Err(anyhow!("from_date must not be later than to_date"));
+    }
+    let config = runtime.x_search_config().ok_or_else(|| {
+        anyhow!("x_search_unavailable: xAI is not configured or XSearch is disabled")
+    })?;
+    serialize_success(
+        NAME,
+        &search(
+            XSearchRequest {
+                query,
+                allowed_x_handles,
+                excluded_x_handles,
+                from_date,
+                to_date,
+            },
+            &config,
+        )
+        .await?,
+    )
+}
+
+fn required_string(value: String, field: &str) -> Result<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(anyhow!("{field} must not be empty"))
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+fn normalize_handles(values: Vec<String>, field: &str) -> Result<Vec<String>> {
+    if values.len() > MAX_HANDLES {
+        return Err(anyhow!("{field} supports at most {MAX_HANDLES} handles"));
+    }
+    values
+        .into_iter()
+        .map(|value| {
+            let value = value.trim().trim_start_matches('@');
+            if value.is_empty()
+                || !value
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || character == '_')
+            {
+                Err(anyhow!("{field} contains an invalid X handle"))
+            } else {
+                Ok(value.to_string())
+            }
+        })
+        .collect()
+}
+
+fn normalize_date(value: Option<String>, field: &str) -> Result<Option<String>> {
+    value
+        .map(|value| {
+            let value = required_string(value, field)?;
+            let valid = value.len() == 10
+                && value.as_bytes()[4] == b'-'
+                && value.as_bytes()[7] == b'-'
+                && chrono::NaiveDate::parse_from_str(&value, "%Y-%m-%d").is_ok();
+            if valid {
+                Ok(value)
+            } else {
+                Err(anyhow!("{field} must use YYYY-MM-DD format"))
+            }
+        })
+        .transpose()
+}

--- a/src/x_search.rs
+++ b/src/x_search.rs
@@ -1,0 +1,284 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::config::XSearchRuntimeConfig;
+
+#[derive(Debug, Clone)]
+pub struct XSearchRequest {
+    pub query: String,
+    pub allowed_x_handles: Vec<String>,
+    pub excluded_x_handles: Vec<String>,
+    pub from_date: Option<String>,
+    pub to_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct XSearchResponse {
+    pub text: String,
+    pub citations: Vec<XSearchCitation>,
+    pub provider: String,
+    pub backend: String,
+    pub model: String,
+    pub diagnostics: XSearchDiagnostics,
+    pub summary_text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct XSearchCitation {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_index: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_index: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct XSearchDiagnostics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_request_id: Option<String>,
+    pub latency_ms: u64,
+    pub hosted_item_types: BTreeMap<String, usize>,
+}
+
+pub async fn search(
+    request: XSearchRequest,
+    config: &XSearchRuntimeConfig,
+) -> Result<XSearchResponse> {
+    let credential = config
+        .provider
+        .credential
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("x_search_unavailable: xAI credential is not available"))?;
+    let body = build_request_body(&request, &config.model);
+    let client = Client::builder()
+        .timeout(config.timeout)
+        .build()
+        .context("failed to build x_search HTTP client")?;
+    let started = Instant::now();
+    let response = client
+        .post(format!(
+            "{}/responses",
+            config.provider.base_url.trim_end_matches('/')
+        ))
+        .bearer_auth(credential)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("x_search request failed")?;
+    let provider_request_id = response
+        .headers()
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(ToString::to_string);
+    let status = response.status();
+    let response_body: Value = response
+        .json()
+        .await
+        .context("x_search response was not valid JSON")?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "x_search provider returned HTTP {}: {}",
+            status.as_u16(),
+            provider_error_message(&response_body)
+        ));
+    }
+
+    let (text, citations, hosted_item_types) = parse_response(&response_body)?;
+    Ok(XSearchResponse {
+        summary_text: format!(
+            "xAI X search returned {} citation{}",
+            citations.len(),
+            if citations.len() == 1 { "" } else { "s" }
+        ),
+        text,
+        citations,
+        provider: "xai".into(),
+        backend: "x_search".into(),
+        model: config.model.clone(),
+        diagnostics: XSearchDiagnostics {
+            provider_request_id,
+            latency_ms: duration_millis(started.elapsed()),
+            hosted_item_types,
+        },
+    })
+}
+
+pub(crate) fn build_request_body(request: &XSearchRequest, model: &str) -> Value {
+    let mut tool = json!({ "type": "x_search" });
+    if !request.allowed_x_handles.is_empty() {
+        tool["allowed_x_handles"] = json!(request.allowed_x_handles);
+    }
+    if !request.excluded_x_handles.is_empty() {
+        tool["excluded_x_handles"] = json!(request.excluded_x_handles);
+    }
+    if let Some(from_date) = request.from_date.as_deref() {
+        tool["from_date"] = json!(from_date);
+    }
+    if let Some(to_date) = request.to_date.as_deref() {
+        tool["to_date"] = json!(to_date);
+    }
+    json!({
+        "model": model,
+        "input": request.query,
+        "tools": [tool],
+        "tool_choice": "auto",
+        "store": false,
+    })
+}
+
+pub(crate) fn parse_response(
+    response: &Value,
+) -> Result<(String, Vec<XSearchCitation>, BTreeMap<String, usize>)> {
+    let mut text = String::new();
+    let mut citations = Vec::new();
+    let mut seen_urls = HashSet::new();
+    let mut hosted_item_types = BTreeMap::new();
+    for item in response
+        .get("output")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let item_type = item
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        if item_type != "message" {
+            *hosted_item_types.entry(item_type.to_string()).or_default() += 1;
+            continue;
+        }
+        for content in item
+            .get("content")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if content.get("type").and_then(Value::as_str) != Some("output_text") {
+                continue;
+            }
+            if let Some(value) = content.get("text").and_then(Value::as_str) {
+                text.push_str(value);
+            }
+            for annotation in content
+                .get("annotations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if annotation.get("type").and_then(Value::as_str) != Some("url_citation") {
+                    continue;
+                }
+                let Some(url) = annotation.get("url").and_then(Value::as_str) else {
+                    continue;
+                };
+                if seen_urls.insert(url.to_string()) {
+                    citations.push(XSearchCitation {
+                        url: url.to_string(),
+                        title: annotation
+                            .get("title")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string),
+                        start_index: annotation.get("start_index").and_then(Value::as_u64),
+                        end_index: annotation.get("end_index").and_then(Value::as_u64),
+                    });
+                }
+            }
+        }
+    }
+    if text.trim().is_empty() {
+        return Err(anyhow!(
+            "x_search response did not contain final output text"
+        ));
+    }
+    Ok((text, citations, hosted_item_types))
+}
+
+fn provider_error_message(body: &Value) -> String {
+    body.pointer("/error/message")
+        .and_then(Value::as_str)
+        .or_else(|| body.get("message").and_then(Value::as_str))
+        .unwrap_or("unknown provider error")
+        .to_string()
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_uses_only_x_search_and_disables_storage() {
+        let body = build_request_body(
+            &XSearchRequest {
+                query: "Holon updates".into(),
+                allowed_x_handles: vec!["holon_run".into()],
+                excluded_x_handles: vec![],
+                from_date: Some("2026-07-01".into()),
+                to_date: None,
+            },
+            "grok-4-1-fast",
+        );
+
+        assert_eq!(body["model"], "grok-4-1-fast");
+        assert_eq!(body["input"], "Holon updates");
+        assert_eq!(body["store"], false);
+        assert_eq!(body["tools"][0]["type"], "x_search");
+        assert_eq!(body["tools"][0]["allowed_x_handles"][0], "holon_run");
+        assert_eq!(body["tools"][0]["from_date"], "2026-07-01");
+        assert_eq!(body["tools"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn response_extracts_text_and_deduplicates_citations() {
+        let response = json!({
+            "output": [
+                {"type": "x_search_call", "id": "search_1", "status": "completed"},
+                {"type": "x_keyword_search", "arguments": {"query": "internal"}},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "Result",
+                        "annotations": [
+                            {"type": "url_citation", "url": "https://x.com/a/status/1", "title": "A", "start_index": 0, "end_index": 6},
+                            {"type": "url_citation", "url": "https://x.com/a/status/1", "title": "A duplicate"}
+                        ]
+                    }]
+                }
+            ]
+        });
+
+        let (text, citations, diagnostics) = parse_response(&response).unwrap();
+        assert_eq!(text, "Result");
+        assert_eq!(citations.len(), 1);
+        assert_eq!(citations[0].url, "https://x.com/a/status/1");
+        assert_eq!(diagnostics.get("x_search_call"), Some(&1));
+        assert_eq!(diagnostics.get("x_keyword_search"), Some(&1));
+    }
+
+    #[test]
+    fn response_requires_final_text() {
+        let error = parse_response(&json!({
+            "output": [{"type": "x_search_call", "status": "completed"}]
+        }))
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("did not contain final output text"));
+    }
+}

--- a/tests/live_xai.rs
+++ b/tests/live_xai.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 use holon::{
-    config::{AppConfig, ProviderId},
+    config::{AppConfig, ProviderId, XSearchRuntimeConfig},
     provider::{
-        AgentProvider, ConversationMessage, ModelBlock, OpenAiProvider,
-        ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
-        ProviderTurnRequest,
+        AgentProvider, ConversationMessage, ModelBlock, OpenAiProvider, ProviderPromptCache,
+        ProviderPromptFrame, ProviderTurnRequest,
     },
+    x_search::{search, XSearchRequest},
 };
 
 fn live_xai_model() -> String {
@@ -105,48 +105,25 @@ async fn live_xai_responses_uses_incremental_continuation_without_instructions()
 
 #[tokio::test]
 #[ignore = "requires configured xAI credentials, network access, and x_search support"]
-async fn live_xai_builtin_x_search_reports_native_lowering() -> Result<()> {
+async fn live_xai_x_search_returns_durable_text_and_citations() -> Result<()> {
     let config = AppConfig::load()?;
-    let provider = live_xai_provider(&config)?;
-    let capability = provider
-        .builtin_web_search()
-        .context("xai provider should declare builtin web search")?;
-    assert_eq!(capability.advertised_tool_type, "web_search");
-    assert_eq!(capability.backend_kind, "xai_web_search_x_search");
-    let native_web_search = ProviderNativeWebSearchRequest {
-        kind: capability.kind,
-        provider_id: "xai".into(),
-        provider_model_ref: capability.provider_model_ref,
-        advertised_tool_type: capability.advertised_tool_type,
-        backend_kind: capability.backend_kind,
-        max_results: Some(3),
-    };
+    let x_search_config = XSearchRuntimeConfig::from_app_config(&config)?
+        .context("xAI must be configured and XSearch enabled")?;
+    let output = search(
+        XSearchRequest {
+            query: "Recent public posts from xAI about Grok".into(),
+            allowed_x_handles: vec!["xai".into()],
+            excluded_x_handles: Vec::new(),
+            from_date: None,
+            to_date: None,
+        },
+        &x_search_config,
+    )
+    .await?;
 
-    provider
-        .probe_builtin_web_search(native_web_search.clone())
-        .await?;
-    let output = provider
-        .complete_turn(ProviderTurnRequest {
-            prompt_frame: ProviderPromptFrame::plain(
-                "Use native web search and reply with one concise sentence.",
-            ),
-            conversation: vec![ConversationMessage::UserText(
-                "Search the web for the official xAI homepage and state its site name.".into(),
-            )],
-            tools: Vec::new(),
-            native_web_search: Some(native_web_search),
-            response_format: None,
-        })
-        .await?;
-
-    let diagnostics = output
-        .request_diagnostics
-        .as_ref()
-        .and_then(|diagnostics| diagnostics.native_web_search.as_ref())
-        .context("native web search diagnostics should be recorded")?;
-    assert!(diagnostics.lowered);
-    assert_eq!(diagnostics.advertised_tool_type, "web_search");
-    assert_eq!(diagnostics.backend_kind, "xai_web_search_x_search");
-    assert!(!response_text(&output.blocks).trim().is_empty());
+    assert!(!output.text.trim().is_empty());
+    assert_eq!(output.provider, "xai");
+    assert_eq!(output.backend, "x_search");
+    assert!(!output.citations.is_empty());
     Ok(())
 }


### PR DESCRIPTION
## 概要

- 新增独立的 Holon `XSearch` 客户端工具，通过隔离的 xAI Responses 请求搜索 X 内容
- 在 xAI provider 激活时默认暴露 `XSearch`，支持通过 `x_search.enabled = false` 显式禁用及独立 model/timeout 配置
- 从主 agent Responses 会话移除隐式 hosted `x_search`，避免 xAI 内部搜索调用进入本地工具执行与 continuation 链
- 将最终文本、citations 与诊断信息作为普通工具结果持久化，支持 replay
- 补充配置文档、实现决策、schema snapshot 及隔离/错误/timeout/泄漏回归测试

## 验证

- `cargo fmt --all -- --check`
- `cargo test`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

当前环境未配置 `XAI_API_KEY`，因此未执行真实 xAI livetest；mock integration 与完整本地测试均已通过。

Closes #2180