### PR TITLE
fix: lower xAI OAuth credentials for XSearch

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use diagnostics::{
 };
 pub use http_trace::ProviderHttpTraceDiagnostics;
 pub(crate) use retry::sanitize_transport_url;
+pub(crate) use transports::OpenAiBearerAuth;
 pub use transports::{
     AnthropicProvider, GeminiProvider, OpenAiChatCompletionsProvider, OpenAiCodexProvider,
     OpenAiProvider,

--- a/src/provider/transports/mod.rs
+++ b/src/provider/transports/mod.rs
@@ -10,6 +10,7 @@ use std::{env, time::Duration};
 
 pub use anthropic::AnthropicProvider;
 pub use gemini::GeminiProvider;
+pub(crate) use openai::OpenAiBearerAuth;
 pub(crate) use openai::OpenAiCompactionPolicy;
 #[cfg(test)]
 pub(crate) use openai::OpenAiResponsesTransportContract;

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -54,10 +54,7 @@ pub struct OpenAiProvider {
     client: Client,
     provider_id: String,
     base_url: String,
-    api_key: Option<String>,
-    credential_profile: Option<String>,
-    credential_material: Option<String>,
-    credential_store_path: Option<PathBuf>,
+    auth: OpenAiBearerAuth,
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
@@ -66,6 +63,16 @@ pub struct OpenAiProvider {
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct OpenAiBearerAuth {
+    client: Client,
+    provider_id: String,
+    api_key: Option<String>,
+    credential_profile: Option<String>,
+    credential_material: Option<String>,
+    credential_store_path: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -292,6 +299,47 @@ impl OpenAiProvider {
         compaction_policy: OpenAiCompactionPolicy,
     ) -> Result<Self> {
         let client = build_http_client()?;
+        let auth = OpenAiBearerAuth::from_runtime_config(provider_config, client.clone())?;
+        Ok(Self {
+            client,
+            provider_id: provider_config.id.as_str().to_string(),
+            base_url: provider_config.base_url.trim_end_matches('/').to_string(),
+            auth,
+            model: model.to_string(),
+            max_output_tokens,
+            reasoning_effort: provider_config.reasoning_effort.clone(),
+            continuation_contract: if provider_config.id.as_str() == "xai" {
+                OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
+            } else {
+                OpenAiResponsesContinuationContract::Standard
+            },
+            builtin_web_search: provider_config.builtin_web_search.clone(),
+            compaction_policy,
+            trace_home_dir: trace_home_dir.to_path_buf(),
+            continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
+        })
+    }
+
+    async fn resolve_auth_headers(&self) -> Result<Vec<(&'static str, String)>> {
+        self.auth.resolve_auth_headers().await
+    }
+
+    async fn refresh_auth_headers_after_failure(
+        &self,
+        error: &anyhow::Error,
+    ) -> Result<Option<Vec<(&'static str, String)>>> {
+        if !is_openai_codex_auth_status_error(error) {
+            return Ok(None);
+        }
+        self.auth.refresh_auth_headers().await
+    }
+}
+
+impl OpenAiBearerAuth {
+    pub(crate) fn from_runtime_config(
+        provider_config: &ProviderRuntimeConfig,
+        client: Client,
+    ) -> Result<Self> {
         let oauth_profile = matches!(
             (provider_config.auth.source, provider_config.auth.kind),
             (CredentialSource::AuthProfile, CredentialKind::OAuth)
@@ -319,7 +367,6 @@ impl OpenAiProvider {
         Ok(Self {
             client,
             provider_id: provider_config.id.as_str().to_string(),
-            base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             api_key,
             credential_profile: oauth_profile.then(|| {
                 provider_config
@@ -332,18 +379,6 @@ impl OpenAiProvider {
                 .then(|| provider_config.credential.clone())
                 .flatten(),
             credential_store_path: provider_config.credential_store_path.clone(),
-            model: model.to_string(),
-            max_output_tokens,
-            reasoning_effort: provider_config.reasoning_effort.clone(),
-            continuation_contract: if provider_config.id.as_str() == "xai" {
-                OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
-            } else {
-                OpenAiResponsesContinuationContract::Standard
-            },
-            builtin_web_search: provider_config.builtin_web_search.clone(),
-            compaction_policy,
-            trace_home_dir: trace_home_dir.to_path_buf(),
-            continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
     }
 
@@ -359,12 +394,12 @@ impl OpenAiProvider {
         load_oauth_profile_credential(material, profile).map(Some)
     }
 
-    async fn resolve_auth_headers(&self) -> Result<Vec<(&'static str, String)>> {
+    pub(crate) async fn resolve_authorization_header(&self) -> Result<Option<String>> {
         if let Some(api_key) = self.api_key.as_ref() {
-            return Ok(vec![("authorization", format!("Bearer {api_key}"))]);
+            return Ok(Some(format!("Bearer {api_key}")));
         }
         let Some(credential) = self.resolve_oauth_credential()? else {
-            return Ok(Vec::new());
+            return Ok(None);
         };
         let credential = if credential
             .expires_at
@@ -374,10 +409,16 @@ impl OpenAiProvider {
         } else {
             credential
         };
-        Ok(vec![(
-            "authorization",
-            format!("Bearer {}", credential.access_token),
-        )])
+        Ok(Some(format!("Bearer {}", credential.access_token)))
+    }
+
+    async fn resolve_auth_headers(&self) -> Result<Vec<(&'static str, String)>> {
+        Ok(self
+            .resolve_authorization_header()
+            .await?
+            .into_iter()
+            .map(|value| ("authorization", value))
+            .collect())
     }
 
     async fn refresh_oauth_profile(&self, force: bool) -> Result<OAuthCredential> {
@@ -428,18 +469,19 @@ impl OpenAiProvider {
         Ok(refreshed.credential)
     }
 
-    async fn refresh_auth_headers_after_failure(
-        &self,
-        error: &anyhow::Error,
-    ) -> Result<Option<Vec<(&'static str, String)>>> {
-        if self.credential_profile.is_none() || !is_openai_codex_auth_status_error(error) {
+    pub(crate) async fn refresh_authorization_header(&self) -> Result<Option<String>> {
+        if self.credential_profile.is_none() {
             return Ok(None);
         }
         let credential = self.refresh_oauth_profile(true).await?;
-        Ok(Some(vec![(
-            "authorization",
-            format!("Bearer {}", credential.access_token),
-        )]))
+        Ok(Some(format!("Bearer {}", credential.access_token)))
+    }
+
+    async fn refresh_auth_headers(&self) -> Result<Option<Vec<(&'static str, String)>>> {
+        Ok(self
+            .refresh_authorization_header()
+            .await?
+            .map(|value| vec![("authorization", value)]))
     }
 }
 

--- a/src/x_search.rs
+++ b/src/x_search.rs
@@ -8,7 +8,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::config::XSearchRuntimeConfig;
+use crate::{config::XSearchRuntimeConfig, provider::OpenAiBearerAuth};
 
 #[derive(Debug, Clone)]
 pub struct XSearchRequest {
@@ -53,29 +53,28 @@ pub async fn search(
     request: XSearchRequest,
     config: &XSearchRuntimeConfig,
 ) -> Result<XSearchResponse> {
-    let credential = config
-        .provider
-        .credential
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| anyhow!("x_search_unavailable: xAI credential is not available"))?;
     let body = build_request_body(&request, &config.model);
     let client = Client::builder()
         .timeout(config.timeout)
         .build()
         .context("failed to build x_search HTTP client")?;
+    let auth = OpenAiBearerAuth::from_runtime_config(&config.provider, client.clone())?;
+    let mut authorization = auth
+        .resolve_authorization_header()
+        .await?
+        .ok_or_else(|| anyhow!("x_search_unavailable: xAI credential is not available"))?;
     let started = Instant::now();
-    let response = client
-        .post(format!(
-            "{}/responses",
-            config.provider.base_url.trim_end_matches('/')
-        ))
-        .bearer_auth(credential)
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .context("x_search request failed")?;
+    let endpoint = format!(
+        "{}/responses",
+        config.provider.base_url.trim_end_matches('/')
+    );
+    let mut response = send_request(&client, &endpoint, &authorization, &body).await?;
+    if matches!(response.status().as_u16(), 401 | 403) {
+        if let Some(refreshed) = auth.refresh_authorization_header().await? {
+            authorization = refreshed;
+            response = send_request(&client, &endpoint, &authorization, &body).await?;
+        }
+    }
     let provider_request_id = response
         .headers()
         .get("x-request-id")
@@ -112,6 +111,22 @@ pub async fn search(
             hosted_item_types,
         },
     })
+}
+
+async fn send_request(
+    client: &Client,
+    endpoint: &str,
+    authorization: &str,
+    body: &Value,
+) -> Result<reqwest::Response> {
+    client
+        .post(endpoint)
+        .header("authorization", authorization)
+        .header("content-type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .context("x_search request failed")
 }
 
 pub(crate) fn build_request_body(request: &XSearchRequest, model: &str) -> Value {
@@ -219,6 +234,40 @@ fn duration_millis(duration: Duration) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{
+        AnthropicContextManagementConfig, CredentialKind, CredentialSource, ProviderAuthConfig,
+        ProviderEndpointId, ProviderId, ProviderRuntimeConfig, ProviderTransportKind,
+    };
+    use tokio::{io::AsyncReadExt, io::AsyncWriteExt, net::TcpListener};
+
+    fn xai_oauth_config(base_url: String, credential: String) -> XSearchRuntimeConfig {
+        let xai = ProviderId::parse("xai").unwrap();
+        XSearchRuntimeConfig {
+            provider: ProviderRuntimeConfig {
+                id: xai.clone(),
+                route_provider: xai,
+                route_endpoint: ProviderEndpointId::default_endpoint(),
+                transport: ProviderTransportKind::OpenAiResponses,
+                base_url,
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::AuthProfile,
+                    kind: CredentialKind::OAuth,
+                    env: None,
+                    profile: Some("xai".into()),
+                    external: None,
+                },
+                credential: Some(credential),
+                credential_store_path: None,
+                codex_home: None,
+                originator: None,
+                reasoning_effort: Some("medium".into()),
+                context_management: AnthropicContextManagementConfig::default(),
+                builtin_web_search: None,
+            },
+            model: "grok-test".into(),
+            timeout: Duration::from_secs(5),
+        }
+    }
 
     #[test]
     fn request_uses_only_x_search_and_disables_storage() {
@@ -280,5 +329,65 @@ mod tests {
         assert!(error
             .to_string()
             .contains("did not contain final output text"));
+    }
+
+    #[tokio::test]
+    async fn search_lowers_xai_oauth_profile_to_access_token() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 8192];
+            let size = stream.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
+            assert!(
+                request
+                    .to_ascii_lowercase()
+                    .contains("authorization: bearer oauth-access-token\r\n"),
+                "request did not contain the OAuth access token: {request}"
+            );
+            assert!(!request.contains("\"access_token\""));
+
+            let body = json!({
+                "output": [{
+                    "type": "message",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "OAuth search result",
+                        "annotations": []
+                    }]
+                }]
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        let credential = json!({
+            "tokens": {
+                "access_token": "oauth-access-token",
+                "refresh_token": "refresh-token"
+            }
+        })
+        .to_string();
+        let config = xai_oauth_config(format!("http://{address}"), credential);
+
+        let response = search(
+            XSearchRequest {
+                query: "Holon OAuth".into(),
+                allowed_x_handles: Vec::new(),
+                excluded_x_handles: Vec::new(),
+                from_date: None,
+                to_date: None,
+            },
+            &config,
+        )
+        .await
+        .unwrap();
+
+        server.await.unwrap();
+        assert_eq!(response.text, "OAuth search result");
     }
 }


### PR DESCRIPTION
## 概要

- 将 provider bearer credential lowering 收敛到共享认证路径
- 让独立 `XSearch` 对 OAuth credential profile 提取并按现有语义刷新 `access_token`，不再把 profile JSON 当作 bearer token
- 保留 API key 与直接 bearer token 行为，并增加经过真实 `x_search::search` HTTP 边界的回归测试

## 验证

- `cargo fmt --all -- --check`
- `cargo test x_search::tests::search_lowers_xai_oauth_profile_to_access_token --lib -- --exact`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test live_xai live_xai_x_search_returns_durable_text_and_citations -- --ignored --nocapture`（使用设备上已有 xAI OAuth profile，真实网络测试通过）
