### PR TITLE
fix: prevent checkpoint operator delivery gaps

### DIFF
--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -633,6 +633,16 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                 provider_request_id: None,
                 request_diagnostics: None,
             },
+            5 => ProviderTurnResponse {
+                blocks: Vec::new(),
+                stop_reason: Some("end_turn".into()),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
+                request_diagnostics: None,
+            },
             _ => ProviderTurnResponse {
                 blocks: vec![ModelBlock::Text {
                     text: "Finished after compacted continuation.".into(),

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -734,6 +734,9 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
         assert!(events
             .iter()
             .any(|event| event.kind == "turn_local_checkpoint_resume_requested"));
+        assert!(events
+            .iter()
+            .any(|event| event.kind == "checkpoint_operator_delivery_retry"));
         assert!(
             format!("{:?}", checkpoint_resume_request.conversation)
                 .contains("Continue from the checkpoint's next goal-aligned action now"),

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -581,11 +581,12 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
     assert_eq!(outcome.terminal_kind, TurnTerminalKind::Completed);
     assert_eq!(outcome.final_text, "Finished after compacted continuation.");
     assert!(outcome.final_text_source_assistant_round_id.is_some());
-    assert_eq!(*provider.calls.lock().await, 5);
+    assert_eq!(*provider.calls.lock().await, 6);
 
     let requests = provider.requests.lock().await;
     let continuation_request = requests.get(3).expect("missing round 4 request");
     let checkpoint_resume_request = requests.get(4).expect("missing round 5 request");
+    let pending_delivery_retry_request = requests.get(5).expect("missing round 6 request");
     let cache = continuation_request
         .prompt_frame
         .cache
@@ -737,6 +738,16 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
             format!("{:?}", checkpoint_resume_request.conversation)
                 .contains("Continue from the checkpoint's next goal-aligned action now"),
             "checkpoint-only compaction response should continue inside the same turn"
+        );
+        assert!(
+            format!("{:?}", checkpoint_resume_request.conversation)
+                .contains("has not been delivered to the operator"),
+            "checkpoint continuation must state that private checkpoint content is undelivered"
+        );
+        assert!(
+            format!("{:?}", pending_delivery_retry_request.conversation)
+                .contains("has not been delivered to the operator"),
+            "an empty visible response must not complete pending checkpoint delivery"
         );
     } else {
         assert!(serialized_conversation.contains("first-round-output-should-not-stay-exact"));

--- a/src/runtime/turn/checkpoint.rs
+++ b/src/runtime/turn/checkpoint.rs
@@ -37,6 +37,21 @@ pub(super) struct TurnLocalCheckpointState {
     pub(super) latest: Option<TurnLocalCheckpointRecord>,
     pub(super) pending: Option<PendingCheckpointRequest>,
     pub(super) anchor_generation: u64,
+    operator_delivery_pending: bool,
+}
+
+impl TurnLocalCheckpointState {
+    pub(super) fn mark_operator_delivery_pending(&mut self) {
+        self.operator_delivery_pending = true;
+    }
+
+    pub(super) fn clear_operator_delivery_pending(&mut self) {
+        self.operator_delivery_pending = false;
+    }
+
+    pub(super) fn operator_delivery_pending(&self) -> bool {
+        self.operator_delivery_pending
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -85,6 +100,7 @@ pub(super) fn checkpoint_state_from_last_terminal(
         }),
         pending: None,
         anchor_generation: checkpoint.current_anchor_generation,
+        operator_delivery_pending: false,
     }
 }
 

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1511,6 +1511,13 @@ impl TurnExecution<'_> {
                                 "reason": "checkpoint_operator_delivery_pending",
                             }),
                         ))?;
+                        runtime.inner.storage.append_event(&AuditEvent::new(
+                            "checkpoint_operator_delivery_retry",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "round": round,
+                            }),
+                        ))?;
                         continue;
                     }
                     checkpoint_state.clear_operator_delivery_pending();

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1263,6 +1263,7 @@ impl TurnExecution<'_> {
                         text: checkpoint_text.clone(),
                         anchor_generation: pending_checkpoint.anchor_generation,
                     });
+                    checkpoint_state.mark_operator_delivery_pending();
                 }
                 runtime.inner.storage.append_event(&AuditEvent::new(
                     "turn_local_checkpoint_recorded",
@@ -1493,6 +1494,27 @@ impl TurnExecution<'_> {
             }
 
             if tool_calls.is_empty() {
+                if checkpoint_state.operator_delivery_pending() {
+                    if combined_text.is_empty() {
+                        completed_rounds.push(build_checkpoint_resume_round(
+                            round,
+                            completed_round_assistant_blocks,
+                            text_blocks,
+                        ));
+                        runtime.persist_transcript_evidence(&TranscriptEntry::new(
+                            agent_id.to_string(),
+                            TranscriptEntryKind::ContinuationPrompt,
+                            Some(round),
+                            None,
+                            serde_json::json!({
+                                "text": CHECKPOINT_RESUME_PROMPT,
+                                "reason": "checkpoint_operator_delivery_pending",
+                            }),
+                        ))?;
+                        continue;
+                    }
+                    checkpoint_state.clear_operator_delivery_pending();
+                }
                 let final_text = last_assistant_message.clone().unwrap_or_default();
                 let terminal = runtime
                     .persist_turn_terminal_record(
@@ -1950,7 +1972,10 @@ impl TurnExecution<'_> {
             }
             completed_rounds.push(round_record);
 
-            if all_tool_results_should_sleep && !has_operator_interjections {
+            if all_tool_results_should_sleep
+                && !has_operator_interjections
+                && !checkpoint_state.operator_delivery_pending()
+            {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
                 let terminal = runtime
                     .persist_turn_terminal_record(

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -80,7 +80,7 @@ const OPERATOR_INTERJECTION_HEADER: &str =
 const COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT: &str = "\
 [Runtime-generated full progress checkpoint request]
 You are crossing a context compaction boundary. Produce a concise runtime-private progress checkpoint for continuation in your next assistant message.
-This checkpoint is internal continuity state, not operator-facing prose. Do not treat it as a status update or later repeat its headings or metadata to the operator unless explicitly asked.
+This checkpoint is internal continuity state and has not been delivered to the operator. Do not treat it as a status update or later repeat its headings or metadata to the operator unless explicitly asked.
 Best effort: write the checkpoint in the current target response language inferred from the trusted prompt and context. Language mismatch must not prevent checkpoint creation or continuation.
 
 Include:
@@ -99,7 +99,7 @@ Do not assume the task requires code changes unless the user goal does.";
 const DELTA_CHECKPOINT_PREVIEW_LIMIT: usize = 1_200;
 const CHECKPOINT_RESUME_PROMPT: &str = "\
 [Runtime-generated checkpoint continuation]
-Continue from the checkpoint's next goal-aligned action now. The preceding checkpoint is runtime-private continuity state, not operator-facing prose. Do not restate its headings, metadata, or content unless the operator explicitly asks about it. If the checkpoint says enough evidence exists to act, call the concrete mutation, verification, or delivery tool next; otherwise run only the named bounded command/query.";
+Continue from the checkpoint's next goal-aligned action now. The preceding checkpoint is runtime-private continuity state and has not been delivered to the operator. Do not restate its headings, metadata, or internal process unless the operator explicitly asks about it. If it contains conclusions that answer the operator's request and those conclusions have not appeared in an operator-visible response in this turn, synthesize them into the next formal operator-facing answer. Do not claim that checkpoint content was already delivered. If the checkpoint says enough evidence exists to act, call the concrete mutation, verification, or delivery tool next; otherwise run only the named bounded command/query.";
 
 fn truncate_preview(text: &str, limit: usize) -> String {
     let trimmed = text.trim();

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -484,19 +484,18 @@ fn checkpoint_state_with_latest(
     response_round: usize,
     anchor_generation: u64,
 ) -> TurnLocalCheckpointState {
-    TurnLocalCheckpointState {
-        latest: Some(TurnLocalCheckpointRecord {
-            request_id: format!("req-{response_round}"),
-            requested_at_round: response_round,
-            response_round: Some(response_round),
-            source_turn_index: None,
-            mode: TurnLocalCheckpointMode::Full,
-            text: text.to_string(),
-            anchor_generation,
-        }),
-        pending: None,
+    let mut state = TurnLocalCheckpointState::default();
+    state.latest = Some(TurnLocalCheckpointRecord {
+        request_id: format!("req-{response_round}"),
+        requested_at_round: response_round,
+        response_round: Some(response_round),
+        source_turn_index: None,
+        mode: TurnLocalCheckpointMode::Full,
+        text: text.to_string(),
         anchor_generation,
-    }
+    });
+    state.anchor_generation = anchor_generation;
+    state
 }
 
 fn fixture_prompt_frame() -> ProviderPromptFrame {
@@ -1753,6 +1752,7 @@ fn checkpoint_state_can_resume_from_structured_terminal_checkpoint() {
 
     let state = checkpoint_state_from_last_terminal(Some(&terminal));
 
+    assert!(!state.operator_delivery_pending());
     let latest = state.latest.expect("checkpoint should seed latest state");
     assert_eq!(latest.request_id, "checkpoint-7");
     assert_eq!(latest.requested_at_round, 3);
@@ -1761,6 +1761,17 @@ fn checkpoint_state_can_resume_from_structured_terminal_checkpoint() {
     assert_eq!(latest.anchor_generation, 2);
     assert_eq!(state.anchor_generation, 5);
     assert!(latest.text.contains("结构化 checkpoint"));
+}
+
+#[test]
+fn checkpoint_operator_delivery_pending_is_turn_local() {
+    let mut state = TurnLocalCheckpointState::default();
+
+    assert!(!state.operator_delivery_pending());
+    state.mark_operator_delivery_pending();
+    assert!(state.operator_delivery_pending());
+    state.clear_operator_delivery_pending();
+    assert!(!state.operator_delivery_pending());
 }
 
 #[test]
@@ -1828,6 +1839,9 @@ fn checkpoint_resume_round_carries_runtime_follow_up_prompt() {
     assert_eq!(round.follow_up_user_texts.len(), 1);
     assert!(round.follow_up_user_texts[0]
         .contains("Continue from the checkpoint's next goal-aligned action now"));
+    assert!(round.follow_up_user_texts[0].contains("has not been delivered to the operator"));
+    assert!(round.follow_up_user_texts[0].contains("synthesize them"));
+    assert!(round.follow_up_user_texts[0].contains("Do not claim"));
     assert!(round.estimated_tokens > 0);
 }
 


### PR DESCRIPTION
## Summary

- mark a turn-local checkpoint as pending operator delivery until a non-empty operator-visible response is produced
- clarify that runtime-private checkpoint content has not yet been delivered and must be synthesized into the resumed answer
- preserve the boundary that final briefs come only from operator-visible responses
- add unit and end-to-end regressions for checkpoint resume and empty-response handling

Closes #2187

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
