### PR TITLE
fix: preserve model tool call kinds

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -398,6 +398,8 @@ pub enum ModelBlock {
         id: String,
         name: String,
         input: Value,
+        #[serde(default)]
+        kind: ModelToolCallKind,
     },
     Thinking {
         text: String,
@@ -410,6 +412,14 @@ pub enum ModelBlock {
         /// Must be passed back verbatim in subsequent requests.
         data: String,
     },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelToolCallKind {
+    #[default]
+    Function,
+    Custom,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/provider/test_support.rs
+++ b/src/provider/test_support.rs
@@ -15,7 +15,9 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde_json::Value;
 
-use super::{AgentProvider, ModelBlock, ProviderTurnRequest, ProviderTurnResponse};
+use super::{
+    AgentProvider, ModelBlock, ModelToolCallKind, ProviderTurnRequest, ProviderTurnResponse,
+};
 
 #[derive(Debug, Clone)]
 pub enum ScriptedProviderStep {
@@ -50,6 +52,7 @@ impl ScriptedProviderStep {
             id: id.into(),
             name: name.into(),
             input,
+            kind: ModelToolCallKind::Function,
         }])
     }
 

--- a/src/provider/tests/anthropic_messages.rs
+++ b/src/provider/tests/anthropic_messages.rs
@@ -508,6 +508,7 @@ async fn anthropic_response_preserves_thinking_blocks_for_round_trip() {
                 id: "tool-1".into(),
                 name: "ProbeTool".into(),
                 input: json!({ "reason": "round-trip" }),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
@@ -645,6 +646,7 @@ async fn anthropic_response_preserves_redacted_thinking_blocks_for_round_trip() 
                 id: "tool-1".into(),
                 name: "ProbeTool".into(),
                 input: json!({ "reason": "round-trip" }),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
@@ -824,6 +826,7 @@ async fn anthropic_claude_code_prompt_cache_strategy_does_not_cache_mark_tool_re
                 id: "exec-1".into(),
                 name: "ExecCommand".into(),
                 input: json!({ "cmd": "gh issue view 565" }),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {

--- a/src/provider/tests/openai_chat_completions.rs
+++ b/src/provider/tests/openai_chat_completions.rs
@@ -153,6 +153,7 @@ fn chat_completion_message_conversion_handles_tool_calls_in_assistant_message() 
                 id: "call_123".to_string(),
                 name: "get_current_time".to_string(),
                 input: json!({}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
     ];
@@ -185,11 +186,13 @@ fn chat_completion_message_conversion_handles_multiple_tool_calls() {
                 id: "call_1".to_string(),
                 name: "search_news".to_string(),
                 input: json!({"query": "recent"}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
             ModelBlock::ToolUse {
                 id: "call_2".to_string(),
                 name: "get_weather".to_string(),
                 input: json!({"location": "Paris"}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
     ];
@@ -225,6 +228,7 @@ fn chat_completion_message_conversion_handles_assistant_text_with_tool_calls() {
                 id: "call_calc".to_string(),
                 name: "calculator".to_string(),
                 input: json!({"expression": "2+2"}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
     ];
@@ -292,7 +296,9 @@ fn parse_chat_completion_response_extracts_text_and_tool_calls() {
 
     // Second block should be tool call
     match &parsed.response.blocks[1] {
-        ModelBlock::ToolUse { id, name, input } => {
+        ModelBlock::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "call_1");
             assert_eq!(name, "search");
             assert_eq!(input.to_string(), r#"{"query":"test"}"#);
@@ -338,7 +344,9 @@ fn parse_chat_completion_response_handles_empty_arguments() {
         .expect("should parse response with empty arguments");
 
     match &parsed.response.blocks[0] {
-        ModelBlock::ToolUse { id, name, input } => {
+        ModelBlock::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "call_noargs");
             assert_eq!(name, "get_status");
             assert_eq!(input.to_string(), "{}"); // Empty arguments should become empty object
@@ -356,6 +364,7 @@ fn chat_completion_message_conversion_handles_tool_results() {
             id: "call_time".to_string(),
             name: "get_current_time".to_string(),
             input: json!({}),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "call_time".to_string(),
@@ -388,11 +397,13 @@ fn chat_completion_message_conversion_handles_multiple_tool_results() {
                 id: "call_1".to_string(),
                 name: "search_news".to_string(),
                 input: json!({"query": "test"}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
             ModelBlock::ToolUse {
                 id: "call_2".to_string(),
                 name: "get_weather".to_string(),
                 input: json!({"location": "Paris"}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
         ConversationMessage::UserToolResults(vec![
@@ -440,6 +451,7 @@ fn chat_completion_handles_multi_turn_conversation_with_tools() {
             id: "call_calc".to_string(),
             name: "calculator".to_string(),
             input: json!({"expression": "2+2"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         // Turn 2: Tool returns result
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
@@ -896,6 +908,7 @@ fn chat_completion_handles_mixed_tool_and_text_messages() {
                 id: "call_123".to_string(),
                 name: "test_tool".to_string(),
                 input: json!({"param": "value"}),
+                kind: crate::provider::ModelToolCallKind::Function,
             },
         ]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
@@ -974,6 +987,7 @@ fn chat_completion_handles_tool_call_with_complex_arguments() {
             id: "call_complex".to_string(),
             name: "complex_tool".to_string(),
             input: complex_input.clone(),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ])];
 

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -230,6 +230,7 @@ fn provider_nearly_large_window_continuation_with_prompt_frame() -> ProviderTurn
             id: "exec-1".into(),
             name: "ExecCommand".into(),
             input: json!({ "cmd": "printf ok" }),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "exec-1".into(),
@@ -248,6 +249,7 @@ fn provider_large_window_continuation_with_prompt_frame() -> ProviderTurnRequest
             id: "exec-1".into(),
             name: "ExecCommand".into(),
             input: json!({ "cmd": "printf ok" }),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "exec-1".into(),
@@ -394,7 +396,9 @@ async fn openai_responses_normalizes_non_object_tool_arguments_before_continuati
         .unwrap();
     assert_eq!(first.blocks.len(), 1);
     match &first.blocks[0] {
-        ModelBlock::ToolUse { id, name, input } => {
+        ModelBlock::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "invented-1");
             assert_eq!(name, "x_semantic_search");
             assert_eq!(input, &json!({ "_raw": ["holon"] }));
@@ -1969,6 +1973,7 @@ async fn openai_responses_does_not_reuse_without_prompt_cache_scope() {
             id: "exec-1".into(),
             name: "ExecCommand".into(),
             input: json!({ "cmd": "printf ok" }),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "exec-1".into(),

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -493,7 +493,7 @@ async fn openai_codex_provider_sends_streaming_requests_and_parses_terminal_resp
     ));
     assert!(matches!(
         &response.blocks[1],
-        ModelBlock::ToolUse { id, name, input }
+        ModelBlock::ToolUse { id, name, input, .. }
         if id == "call_1" && name == "ExecCommand" && input["cmd"] == "sed -n '1,40p' src/main.rs"
     ));
 }

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -185,6 +185,7 @@ pub fn provider_continuation_request_with_prompt_frame() -> ProviderTurnRequest 
             id: "exec-1".into(),
             name: "ExecCommand".into(),
             input: json!({ "cmd": "printf ok" }),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "exec-1".into(),

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -59,10 +59,33 @@ fn openai_input_preserves_tool_results() {
             id: "call_1".into(),
             name: "ExecCommand".into(),
             input: json!({"cmd": "sed -n '1,40p' src/main.rs", "workdir": "."}),
+            kind: crate::provider::ModelToolCallKind::Function,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "call_1".into(),
             content: "file contents".into(),
+            is_error: false,
+            error: None,
+        }]),
+    ])
+    .unwrap();
+    assert_eq!(input[1]["type"], "function_call");
+    assert_eq!(input[2]["type"], "function_call_output");
+}
+
+#[test]
+fn openai_input_preserves_apply_patch_function_tool_results() {
+    let input = build_openai_input(&[
+        ConversationMessage::UserText("inspect".into()),
+        ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
+            id: "call_1".into(),
+            name: "ApplyPatch".into(),
+            input: json!("--- /dev/null\n+++ b/note.txt\n@@ -0,0 +1,1 @@\n+hi\n"),
+            kind: crate::provider::ModelToolCallKind::Function,
+        }]),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "call_1".into(),
+            content: "Success. Updated the following files:\nA note.txt".into(),
             is_error: false,
             error: None,
         }]),
@@ -80,6 +103,7 @@ fn openai_input_preserves_apply_patch_custom_tool_results() {
             id: "call_1".into(),
             name: "ApplyPatch".into(),
             input: json!("--- /dev/null\n+++ b/note.txt\n@@ -0,0 +1,1 @@\n+hi\n"),
+            kind: crate::provider::ModelToolCallKind::Custom,
         }]),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
             tool_use_id: "call_1".into(),
@@ -130,6 +154,55 @@ fn parse_openai_response_handles_text_and_function_calls() {
             .map(|usage| usage.read_input_tokens),
         Some(5)
     );
+    assert!(matches!(
+        &parsed.blocks[1],
+        ModelBlock::ToolUse {
+            kind: crate::provider::ModelToolCallKind::Function,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn model_tool_call_kind_defaults_to_function_for_legacy_blocks() {
+    let block: ModelBlock = serde_json::from_value(json!({
+        "type": "tool_use",
+        "id": "call_legacy",
+        "name": "ApplyPatch",
+        "input": {
+            "patch": "legacy function probe"
+        }
+    }))
+    .unwrap();
+    assert!(matches!(
+        block,
+        ModelBlock::ToolUse {
+            kind: crate::provider::ModelToolCallKind::Function,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn model_tool_call_kind_preserves_custom_across_serialization() {
+    let block = ModelBlock::ToolUse {
+        id: "call_custom".into(),
+        name: "ApplyPatch".into(),
+        input: json!("custom patch probe"),
+        kind: crate::provider::ModelToolCallKind::Custom,
+    };
+    let serialized = serde_json::to_value(&block).unwrap();
+    assert_eq!(serialized["kind"], json!("custom"));
+    let restored: ModelBlock = serde_json::from_value(serialized).unwrap();
+    assert!(matches!(
+        restored,
+        ModelBlock::ToolUse {
+            id,
+            name,
+            input,
+            kind: crate::provider::ModelToolCallKind::Custom,
+        } if id == "call_custom" && name == "ApplyPatch" && input == json!("custom patch probe")
+    ));
 }
 
 #[test]
@@ -148,9 +221,15 @@ fn parse_openai_response_handles_custom_tool_calls() {
     let parsed = parse_openai_response(response).unwrap();
     assert_eq!(parsed.blocks.len(), 1);
     match &parsed.blocks[0] {
-        ModelBlock::ToolUse { id, name, input } => {
+        ModelBlock::ToolUse {
+            id,
+            name,
+            input,
+            kind,
+        } => {
             assert_eq!(id, "call_patch");
             assert_eq!(name, "ApplyPatch");
+            assert_eq!(*kind, crate::provider::ModelToolCallKind::Custom);
             assert_eq!(
                 input.as_str(),
                 Some("--- /dev/null\n+++ b/note.txt\n@@ -0,0 +1,1 @@\n+hi\n")

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -20,8 +20,8 @@ use crate::{
         builtin_web_search_probe_turn_request,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
         AgentProvider, AnthropicPromptCacheDiagnostics, CacheBreakpointInfo, ConversationMessage,
-        ModelBlock, PromptContentBlock, ProviderBuiltinWebSearchCapability, ProviderCacheUsage,
-        ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
+        ModelBlock, ModelToolCallKind, PromptContentBlock, ProviderBuiltinWebSearchCapability,
+        ProviderCacheUsage, ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest, ProviderPromptCapability,
         ProviderResponseFormatDiagnostics, ProviderResponseFormatRequest, ProviderTurnRequest,
         ProviderTurnResponse,
@@ -1409,7 +1409,9 @@ fn conversation_message_to_api(
                                     "type": "text",
                                     "text": text,
                                 }),
-                                ModelBlock::ToolUse { id, name, input } => json!({
+                                ModelBlock::ToolUse {
+                                    id, name, input, ..
+                                } => json!({
                                     "type": "tool_use",
                                     "id": id,
                                     "name": name,
@@ -1603,6 +1605,7 @@ fn api_response_block_to_model(
                 id: block.id?,
                 name,
                 input,
+                kind: ModelToolCallKind::Function,
             })
         }
         "thinking" => Some(ModelBlock::Thinking {
@@ -2115,7 +2118,9 @@ fn hash_model_block(block: &ModelBlock) -> String {
             let value = json!({ "type": "redacted_thinking", "data": data });
             sha256_hex(canonical_json(&value).as_bytes())
         }
-        ModelBlock::ToolUse { id, name, input } => {
+        ModelBlock::ToolUse {
+            id, name, input, ..
+        } => {
             let value = json!({
                 "type": "tool_use",
                 "id": id,
@@ -2241,6 +2246,7 @@ mod tests {
                 id: "toolu_1".to_string(),
                 name: "ExecCommand".to_string(),
                 input: json!({ "cmd": "printf ok" }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }]),
             ConversationMessage::UserToolResults(vec![ToolResultBlock {
                 tool_use_id: "toolu_1".to_string(),
@@ -2487,6 +2493,7 @@ mod tests {
                 id: "toolu_1".to_string(),
                 name: "ExecCommand".to_string(),
                 input: json!({ "cmd": "printf ok" }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }]),
             ConversationMessage::UserToolResults(vec![ToolResultBlock {
                 tool_use_id: "toolu_1".to_string(),

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -10,8 +10,8 @@ use crate::{
     config::ProviderRuntimeConfig,
     provider::{
         http_trace::ProviderHttpTrace, AgentProvider, ConversationMessage, ModelBlock,
-        ProviderCacheUsage, ProviderPromptCapability, ProviderRequestDiagnostics,
-        ProviderTurnRequest, ProviderTurnResponse,
+        ModelToolCallKind, ProviderCacheUsage, ProviderPromptCapability,
+        ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
     },
 };
 
@@ -459,6 +459,7 @@ fn gemini_parts_to_model_blocks(parts: Vec<GeminiPart>) -> Vec<ModelBlock> {
                 id: gemini_tool_use_id(&call.name, index),
                 name: call.name,
                 input: call.args,
+                kind: ModelToolCallKind::Function,
             })
         })
         .collect()

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -29,15 +29,15 @@ use crate::{
     provider::{
         builtin_web_search_probe_turn_request, emitted_tool_json_schema,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
-        AgentProvider, ConversationMessage, ModelBlock, ProviderBuiltinWebSearchCapability,
-        ProviderCacheUsage, ProviderGenerateImageRequest, ProviderGenerateImageResponse,
-        ProviderGeneratedImage, ProviderIncrementalContinuationDiagnostics,
-        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
-        ProviderNativeWebSearchRequest, ProviderOpenAiRemoteCompactionDiagnostics,
-        ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
-        ProviderResponseFormatDiagnostics, ProviderResponseFormatRequest,
-        ProviderTransportDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
-        ToolSchemaContract,
+        AgentProvider, ConversationMessage, ModelBlock, ModelToolCallKind,
+        ProviderBuiltinWebSearchCapability, ProviderCacheUsage, ProviderGenerateImageRequest,
+        ProviderGenerateImageResponse, ProviderGeneratedImage,
+        ProviderIncrementalContinuationDiagnostics, ProviderNativeWebSearchDiagnostics,
+        ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
+        ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
+        ProviderPromptFrame, ProviderRequestDiagnostics, ProviderResponseFormatDiagnostics,
+        ProviderResponseFormatRequest, ProviderTransportDiagnostics, ProviderTurnRequest,
+        ProviderTurnResponse, ToolSchemaContract,
     },
     token_estimate::estimate_json_tokens,
 };
@@ -2042,7 +2042,9 @@ pub(crate) fn build_chat_completion_messages(
                         ModelBlock::Text { text } => {
                             text_parts.push(text.clone());
                         }
-                        ModelBlock::ToolUse { id, name, input } => {
+                        ModelBlock::ToolUse {
+                            id, name, input, ..
+                        } => {
                             tool_calls.push(json!({
                                 "id": id,
                                 "type": "function",
@@ -3873,7 +3875,7 @@ fn lock_openai_continuation(
 
 pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result<Vec<Value>> {
     let mut items = Vec::new();
-    let mut custom_tool_calls = HashMap::<String, bool>::new();
+    let mut tool_call_kinds = HashMap::<String, ModelToolCallKind>::new();
     for message in conversation {
         match message {
             ConversationMessage::UserText(text) => items.push(json!({
@@ -3909,26 +3911,29 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
                 for block in blocks {
                     match block {
                         ModelBlock::Text { text } => pending_text.push(text.clone()),
-                        ModelBlock::ToolUse { id, name, input } => {
+                        ModelBlock::ToolUse {
+                            id,
+                            name,
+                            input,
+                            kind,
+                        } => {
                             flush_assistant_text(&mut items, &mut pending_text);
-                            if let Some(raw_input) = openai_custom_tool_input(name, input) {
-                                custom_tool_calls.insert(id.clone(), true);
-                                items.push(json!({
-                                    "type": "custom_tool_call",
-                                    "call_id": id,
-                                    "name": name,
-                                    "input": raw_input,
-                                }));
-                            } else {
-                                custom_tool_calls.insert(id.clone(), false);
-                                items.push(json!({
+                            tool_call_kinds.insert(id.clone(), *kind);
+                            match kind {
+                                ModelToolCallKind::Function => items.push(json!({
                                     "type": "function_call",
                                     "call_id": id,
                                     "name": name,
                                     "arguments": canonical_json(
                                         &normalize_openai_function_arguments(Some(input))
                                     ),
-                                }));
+                                })),
+                                ModelToolCallKind::Custom => items.push(json!({
+                                    "type": "custom_tool_call",
+                                    "call_id": id,
+                                    "name": name,
+                                    "input": openai_custom_tool_input(input)?,
+                                })),
                             }
                         }
                         ModelBlock::Thinking { .. } | ModelBlock::RedactedThinking { .. } => {}
@@ -3938,14 +3943,9 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
             }
             ConversationMessage::UserToolResults(results) => {
                 for result in results {
-                    let item_type = if custom_tool_calls
-                        .get(&result.tool_use_id)
-                        .copied()
-                        .unwrap_or(false)
-                    {
-                        "custom_tool_call_output"
-                    } else {
-                        "function_call_output"
+                    let item_type = match tool_call_kinds.get(&result.tool_use_id) {
+                        Some(ModelToolCallKind::Custom) => "custom_tool_call_output",
+                        Some(ModelToolCallKind::Function) | None => "function_call_output",
                     };
                     items.push(json!({
                         "type": item_type,
@@ -3959,17 +3959,19 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
     Ok(items)
 }
 
-fn openai_custom_tool_input(name: &str, input: &Value) -> Option<String> {
-    if name != crate::tool::tools::apply_patch_tool::NAME {
-        return None;
-    }
+fn openai_custom_tool_input(input: &Value) -> Result<String> {
     match input {
-        Value::String(value) => Some(value.clone()),
+        Value::String(value) => Ok(value.clone()),
         Value::Object(map) => map
             .get("patch")
             .and_then(Value::as_str)
-            .map(ToString::to_string),
-        _ => None,
+            .map(ToString::to_string)
+            .ok_or_else(|| {
+                anyhow::anyhow!("custom tool call input must contain string field `patch`")
+            }),
+        _ => anyhow::bail!(
+            "custom tool call input must be a string or an object containing string field `patch`"
+        ),
     }
 }
 
@@ -4293,6 +4295,7 @@ pub(crate) fn parse_chat_completion_response(response: Value) -> Result<ParsedOp
                 id: id.to_string(),
                 name: name.to_string(),
                 input: arguments,
+                kind: ModelToolCallKind::Function,
             });
         }
     }
@@ -5635,6 +5638,7 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                     id: id.to_string(),
                     name: name.to_string(),
                     input,
+                    kind: ModelToolCallKind::Function,
                 });
             }
             Some("custom_tool_call") => {
@@ -5664,6 +5668,7 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                     id: id.to_string(),
                     name: name.to_string(),
                     input: Value::String(input.to_string()),
+                    kind: ModelToolCallKind::Custom,
                 });
             }
             _ => {}

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -198,6 +198,7 @@ impl AgentProvider for OperatorInterjectionProbeProvider {
                         "reason": "wait for operator interjection",
                         "duration_ms": 1,
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 10,

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -316,6 +316,7 @@ impl AgentProvider for OneToolThenTextProvider {
                     "cmd": "printf 'ok'",
                     "shell": "sh"
                 }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }]
         } else {
             vec![ModelBlock::Text {
@@ -579,6 +580,7 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                             "cmd": "printf 'first-round-output-should-not-stay-exact'",
                             "yield_time_ms": 30000
                         }),
+                        kind: crate::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -601,6 +603,7 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                             "cmd": "printf 'second-round-output-should-remain-exact'",
                             "yield_time_ms": 30000
                         }),
+                        kind: crate::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -623,6 +626,7 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                             "cmd": "printf 'third-round-output-should-remain-exact'",
                             "yield_time_ms": 30000
                         }),
+                        kind: crate::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -673,6 +677,7 @@ impl AgentProvider for BaselineOverBudgetProbeProvider {
                     input: serde_json::json!({
                         "cmd": "printf 'baseline-over-budget'"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: Some("tool_use".into()),
                 input_tokens: 0,
@@ -708,6 +713,7 @@ impl AgentProvider for SleepOnlyToolProvider {
                     "reason": "waiting for review",
                     "duration_ms": 250
                 }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }],
             stop_reason: None,
             input_tokens: 10,
@@ -743,6 +749,7 @@ impl AgentProvider for WaitForOnlyToolProvider {
                     "resource": "github:holon-run/holon#1939",
                     "recheck_after_ms": 1800000
                 }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }],
             stop_reason: None,
             input_tokens: 10,
@@ -768,6 +775,7 @@ impl AgentProvider for DisallowedToolThenTextProvider {
                     input: serde_json::json!({
                         "prompt": "removed public task surface"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 10,
@@ -824,6 +832,7 @@ impl AgentProvider for MaxOutputMutationToolProvider {
                     input: serde_json::json!({
                         "patch": "--- /dev/null\n+++ b/app.txt\n@@ -0,0 +1 @@\n+should-not-be-written\n"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: Some("max_tokens".into()),
                 input_tokens: 20,
@@ -1121,6 +1130,7 @@ impl AgentProvider for StagnatingAfterVerificationProvider {
                     input: serde_json::json!({
                         "patch": "--- a/app.txt\n+++ b/app.txt\n@@ -1,1 +1,1 @@\n-before\n+after\n"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 },
                 ModelBlock::ToolUse {
                     id: "verify".into(),
@@ -1129,6 +1139,7 @@ impl AgentProvider for StagnatingAfterVerificationProvider {
                         "cmd": "printf 'tests passed'",
                         "shell": "sh"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 },
             ],
             2 => vec![ModelBlock::ToolUse {
@@ -1138,11 +1149,13 @@ impl AgentProvider for StagnatingAfterVerificationProvider {
                     "cmd": "cat app.txt",
                     "workdir": "."
                 }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }],
             _ => vec![ModelBlock::ToolUse {
                 id: "agent".into(),
                 name: "AgentGet".into(),
                 input: serde_json::json!({}),
+                kind: crate::provider::ModelToolCallKind::Function,
             }],
         };
 
@@ -1173,6 +1186,7 @@ impl AgentProvider for SkillReadProvider {
                     "cmd": "cat .agents/skills/demo/SKILL.md",
                     "workdir": "."
                 }),
+                kind: crate::provider::ModelToolCallKind::Function,
             }],
             _ => vec![ModelBlock::Text {
                 text: "Skill loaded and applied.".into(),
@@ -1203,6 +1217,7 @@ impl AgentProvider for SkillActivationCommandProvider {
                 id: "activate-skill".into(),
                 name: self.tool_name.into(),
                 input: self.input.clone(),
+                kind: crate::provider::ModelToolCallKind::Function,
             }],
             _ => vec![ModelBlock::Text {
                 text: "Skill activation observed.".into(),

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -61,6 +61,7 @@ impl AgentProvider for CompleteWorkItemReportProvider {
                 input: serde_json::json!({
                     "work_item_id": self.work_item_id.clone()
                 }),
+                kind: crate::provider::ModelToolCallKind::Function,
             });
             blocks
         } else {
@@ -102,6 +103,7 @@ impl AgentProvider for CompleteThenExecProvider {
                     input: serde_json::json!({
                         "work_item_id": self.work_item_id.clone()
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 },
                 ModelBlock::ToolUse {
                     id: "verify".into(),
@@ -110,6 +112,7 @@ impl AgentProvider for CompleteThenExecProvider {
                         "cmd": "printf 'verified'",
                         "shell": "sh"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 },
             ]
         } else {
@@ -152,6 +155,7 @@ impl AgentProvider for StaleTextThenCompleteProvider {
                         "cmd": "printf 'inspected'",
                         "shell": "sh"
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 },
                 ModelBlock::ToolUse {
                     id: "complete-work".into(),
@@ -159,6 +163,7 @@ impl AgentProvider for StaleTextThenCompleteProvider {
                     input: serde_json::json!({
                         "work_item_id": self.work_item_id.clone()
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 },
             ]
         } else {
@@ -204,6 +209,7 @@ impl AgentProvider for MultiCompleteWorkItemReportProvider {
                     input: serde_json::json!({
                         "work_item_id": work_item_id
                     }),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 });
             }
             blocks

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1110,7 +1110,9 @@ impl TurnExecution<'_> {
                             text_blocks.push(text.clone());
                         }
                     }
-                    ModelBlock::ToolUse { id, name, input } => {
+                    ModelBlock::ToolUse {
+                        id, name, input, ..
+                    } => {
                         tool_calls.push(ToolCall {
                             id: id.clone(),
                             name: name.clone(),

--- a/src/runtime/turn/projection.rs
+++ b/src/runtime/turn/projection.rs
@@ -72,9 +72,9 @@ pub(super) fn estimate_json_tokens(value: &Value) -> usize {
 pub(super) fn estimate_model_block_tokens(block: &ModelBlock) -> usize {
     match block {
         ModelBlock::Text { text } => estimate_text_tokens(text),
-        ModelBlock::ToolUse { id, name, input } => {
-            estimate_text_tokens(id) + estimate_text_tokens(name) + estimate_json_tokens(input)
-        }
+        ModelBlock::ToolUse {
+            id, name, input, ..
+        } => estimate_text_tokens(id) + estimate_text_tokens(name) + estimate_json_tokens(input),
         ModelBlock::Thinking { text, .. } => estimate_text_tokens(text),
         ModelBlock::RedactedThinking { data } => estimate_text_tokens(data),
     }

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -245,6 +245,7 @@ fn fixture_round_with_tool(
             id: call.id.clone(),
             name: call.name.clone(),
             input,
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ];
     let text_blocks = vec![text.to_string()];
@@ -271,6 +272,7 @@ fn fixture_tool_only_round_with_result(round: usize, follow_up: &str) -> TurnRou
         id: call.id.clone(),
         name: call.name.clone(),
         input: call.input.clone(),
+        kind: crate::provider::ModelToolCallKind::Function,
     }];
     let tool_results = vec![ToolResultBlock {
         tool_use_id: call.id.clone(),
@@ -1238,6 +1240,7 @@ fn context_management_eligibility_keeps_recent_and_excludes_risky_results() {
                     id: format!("call_{index}"),
                     name: (*name).to_string(),
                     input: serde_json::json!({}),
+                    kind: crate::provider::ModelToolCallKind::Function,
                 })
                 .collect(),
         ),
@@ -1347,6 +1350,7 @@ fn fixture_round_with_large_tool_result(
             id: call.id.clone(),
             name: call.name.clone(),
             input: call.input.clone(),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ];
     let tool_results = vec![ToolResultBlock {
@@ -2020,6 +2024,7 @@ fn degraded_round_messages_no_trimmable_returns_exact() {
             id: call.id.clone(),
             name: call.name.clone(),
             input: call.input.clone(),
+            kind: crate::provider::ModelToolCallKind::Function,
         }],
         text_blocks: Vec::new(),
         tool_calls: vec![call],
@@ -2180,6 +2185,7 @@ fn completion_report_texts_captures_text_before_complete_work_item() {
             id: "call_cw1".to_string(),
             name: "CompleteWorkItem".to_string(),
             input: serde_json::json!({"work_item_id": "work_123"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ];
 
@@ -2203,6 +2209,7 @@ fn completion_report_texts_skips_thinking_blocks() {
             id: "call_cw2".to_string(),
             name: "CompleteWorkItem".to_string(),
             input: serde_json::json!({"work_item_id": "work_456"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ];
 
@@ -2222,6 +2229,7 @@ fn completion_report_texts_clears_pending_on_non_complete_tool() {
             id: "call_exec".to_string(),
             name: "ExecCommand".to_string(),
             input: serde_json::json!({"cmd": "echo hi"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
         ModelBlock::Text {
             text: "Completion report.".to_string(),
@@ -2230,6 +2238,7 @@ fn completion_report_texts_clears_pending_on_non_complete_tool() {
             id: "call_cw3".to_string(),
             name: "CompleteWorkItem".to_string(),
             input: serde_json::json!({"work_item_id": "work_789"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ];
 
@@ -2249,6 +2258,7 @@ fn completion_report_texts_multiple_complete_work_items() {
             id: "call_cw_a".to_string(),
             name: "CompleteWorkItem".to_string(),
             input: serde_json::json!({"work_item_id": "work_a"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
         ModelBlock::Text {
             text: "Second report.".to_string(),
@@ -2257,6 +2267,7 @@ fn completion_report_texts_multiple_complete_work_items() {
             id: "call_cw_b".to_string(),
             name: "CompleteWorkItem".to_string(),
             input: serde_json::json!({"work_item_id": "work_b"}),
+            kind: crate::provider::ModelToolCallKind::Function,
         },
     ];
 
@@ -2274,6 +2285,7 @@ fn completion_report_texts_empty_when_no_text_precedes() {
         id: "call_cw_empty".to_string(),
         name: "CompleteWorkItem".to_string(),
         input: serde_json::json!({"work_item_id": "work_x"}),
+        kind: crate::provider::ModelToolCallKind::Function,
     }];
 
     let reports = completion_report_texts_by_tool_id(&blocks);

--- a/tests/live_anthropic.rs
+++ b/tests/live_anthropic.rs
@@ -153,6 +153,7 @@ async fn live_provider_accepts_tool_result_continuation_with_runtime_tools() -> 
                         input: serde_json::json!({
                             "cmd": "gh issue view 565 --json title,body,labels,state,url"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ]),
                 ConversationMessage::UserToolResults(vec![ToolResultBlock {

--- a/tests/live_openai.rs
+++ b/tests/live_openai.rs
@@ -1,8 +1,13 @@
 use anyhow::Result;
 use holon::{
     config::AppConfig,
-    provider::{AgentProvider, ConversationMessage, OpenAiProvider, ProviderTurnRequest},
+    provider::{
+        AgentProvider, ConversationMessage, ModelBlock, ModelToolCallKind, OpenAiCodexProvider,
+        OpenAiProvider, ProviderTurnRequest, ToolResultBlock,
+    },
+    tool::ToolSpec,
 };
+use serde_json::json;
 
 fn live_config() -> Result<AppConfig> {
     AppConfig::load()
@@ -10,6 +15,24 @@ fn live_config() -> Result<AppConfig> {
 
 fn live_openai_model() -> String {
     std::env::var("HOLON_LIVE_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".into())
+}
+
+fn live_openai_codex_model() -> String {
+    std::env::var("HOLON_LIVE_OPENAI_CODEX_MODEL").unwrap_or_else(|_| "gpt-5.3-codex-spark".into())
+}
+
+fn live_openai_responses_provider(config: &AppConfig) -> Result<Box<dyn AgentProvider>> {
+    match OpenAiProvider::from_config(config, &live_openai_model()) {
+        Ok(provider) => Ok(Box::new(provider)),
+        Err(openai_error) => OpenAiCodexProvider::from_config(config, &live_openai_codex_model())
+            .map(|provider| Box::new(provider) as Box<dyn AgentProvider>)
+            .map_err(|codex_error| {
+                anyhow::anyhow!(
+                    "standard OpenAI Responses unavailable ({openai_error}); \
+                     OpenAI Codex Responses unavailable ({codex_error})"
+                )
+            }),
+    }
 }
 
 #[tokio::test]
@@ -27,5 +50,73 @@ async fn live_openai_provider_returns_real_response() -> Result<()> {
         ))
         .await?;
     assert!(!output.blocks.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires real provider credentials and network access"]
+async fn live_openai_apply_patch_function_call_kind_survives_continuation() -> Result<()> {
+    let config = live_config()?;
+    let provider = live_openai_responses_provider(&config)?;
+    let tools = vec![ToolSpec {
+        name: "ApplyPatch".into(),
+        description: "Record a patch string for this transport probe. Do not apply it.".into(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "patch": { "type": "string" }
+            },
+            "required": ["patch"],
+            "additionalProperties": false
+        }),
+        freeform_grammar: None,
+    }];
+    let user = ConversationMessage::UserText(
+        "Call the ApplyPatch tool exactly once with {\"patch\":\"live function probe\"}. Do not answer with plain text."
+            .into(),
+    );
+    let first = provider
+        .complete_turn(ProviderTurnRequest::plain(
+            "Follow tool requirements exactly.",
+            vec![user.clone()],
+            tools.clone(),
+        ))
+        .await?;
+    let (call_id, input) = first
+        .blocks
+        .iter()
+        .find_map(|block| match block {
+            ModelBlock::ToolUse {
+                id,
+                name,
+                input,
+                kind,
+            } if name == "ApplyPatch" => Some((id.clone(), input.clone(), *kind)),
+            _ => None,
+        })
+        .map(|(id, input, kind)| {
+            assert_eq!(kind, ModelToolCallKind::Function);
+            (id, input)
+        })
+        .expect("expected ApplyPatch function call from real OpenAI response");
+    assert_eq!(input["patch"], json!("live function probe"));
+
+    let second = provider
+        .complete_turn(ProviderTurnRequest::plain(
+            "Follow tool requirements exactly.",
+            vec![
+                user,
+                ConversationMessage::AssistantBlocks(first.blocks),
+                ConversationMessage::UserToolResults(vec![ToolResultBlock {
+                    tool_use_id: call_id,
+                    content: "Recorded live function probe.".into(),
+                    is_error: false,
+                    error: None,
+                }]),
+            ],
+            tools,
+        ))
+        .await?;
+    assert!(!second.blocks.is_empty());
     Ok(())
 }

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -205,6 +205,7 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
                         input: json!({
                             "work_item_id": work_item_id.clone()
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -230,6 +231,7 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
                         "work_item_id": work_item_id.clone(),
                         "blocked_by": "Main implementation is in place; annotations still need cleanup."
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 },
             ],
             _ => vec![ModelBlock::Text {
@@ -388,6 +390,7 @@ impl AgentProvider for FileEditingProvider {
                         input: json!({
                             "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "read-1".into(),
@@ -396,6 +399,7 @@ impl AgentProvider for FileEditingProvider {
                             "cmd": "cat notes/result.txt",
                             "workdir": "."
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -468,6 +472,7 @@ impl AgentProvider for MultiMutatingToolsProvider {
                         input: json!({
                             "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+alpha\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "patch-2".into(),
@@ -475,6 +480,7 @@ impl AgentProvider for MultiMutatingToolsProvider {
                         input: json!({
                             "patch": "--- a/notes/result.txt\n+++ b/notes/result.txt\n@@ -1,1 +1,1 @@\n-alpha\n+beta\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "patch-3".into(),
@@ -482,6 +488,7 @@ impl AgentProvider for MultiMutatingToolsProvider {
                         input: json!({
                             "patch": "--- /dev/null\n+++ b/notes/extra.txt\n@@ -0,0 +1,1 @@\n+gamma\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -576,6 +583,7 @@ impl AgentProvider for TerminalDeliveryProvider {
                         input: json!({
                             "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "verify-1".into(),
@@ -584,6 +592,7 @@ impl AgentProvider for TerminalDeliveryProvider {
                             "cmd": "printf tests_passed",
                             "login": false
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -605,6 +614,7 @@ impl AgentProvider for TerminalDeliveryProvider {
                         input: json!({
                             "reason": "sleep requested"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -658,6 +668,7 @@ impl AgentProvider for SleepOnlyTerminalProvider {
                     input: json!({
                         "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -674,6 +685,7 @@ impl AgentProvider for SleepOnlyTerminalProvider {
                     input: json!({
                         "reason": "sleep requested"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -703,6 +715,7 @@ impl AgentProvider for EmptyTerminalDeliveryProvider {
                         input: json!({
                             "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "verify-1".into(),
@@ -711,6 +724,7 @@ impl AgentProvider for EmptyTerminalDeliveryProvider {
                             "cmd": "printf tests_passed",
                             "login": false
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -732,6 +746,7 @@ impl AgentProvider for EmptyTerminalDeliveryProvider {
                         input: json!({
                             "reason": "sleep requested"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -831,6 +846,7 @@ impl AgentProvider for SleepTaskProvider {
                         "reason": "background nap",
                         "duration_ms": self.duration_ms
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -908,6 +924,7 @@ impl AgentProvider for CommandTaskProvider {
                         "tty": false,
                         "max_output_tokens": 256
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -1136,6 +1153,7 @@ impl AgentProvider for DelegatedRunOnceProvider {
                         "initial_message": "delegated-child",
                         "workspace_mode": "inherit"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -1181,6 +1199,7 @@ impl AgentProvider for TwoRoundProvider {
                     id: "tool-1".into(),
                     name: "AgentGet".into(),
                     input: json!({}),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -1389,6 +1408,7 @@ impl AgentProvider for BudgetWarningCheckProvider {
                         "cmd": "true",
                         "yield_time_ms": 0,
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 50,
@@ -1463,6 +1483,7 @@ impl AgentProvider for WorktreeTaskProvider {
                         "initial_message": "inspect this worktree",
                         "workspace_mode": "worktree"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,

--- a/tests/support/runtime_compaction_providers.rs
+++ b/tests/support/runtime_compaction_providers.rs
@@ -91,6 +91,7 @@ impl AgentProvider for MaxOutputRecoveryProvider {
                     input: json!({
                         "reason": "Generated comprehensive technical report covering architecture patterns, data flow strategies, security considerations, performance optimization, and monitoring approaches. All requested sections have been completed."
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -148,6 +149,7 @@ impl AgentProvider for RepeatedCompactionProvider {
                             "cmd": "printf 'round-1-output'",
                             "max_output_tokens": 12
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -170,6 +172,7 @@ impl AgentProvider for RepeatedCompactionProvider {
                             "cmd": "printf 'round-2-output'",
                             "max_output_tokens": 12
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -192,6 +195,7 @@ impl AgentProvider for RepeatedCompactionProvider {
                             "cmd": "printf 'round-3-output'",
                             "max_output_tokens": 12
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -288,6 +292,7 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                             "cmd": "printf 'recovery-round-2-output'",
                             "max_output_tokens": 16
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -311,6 +316,7 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                             "cmd": "printf 'recovery-round-3-output'",
                             "max_output_tokens": 16
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -426,7 +432,8 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                         input: serde_json::json!({
                             "cmd": "awk 'BEGIN { for (i=0; i<900; i++) printf \"exec_round_2_marker \" }'",
                             "max_output_tokens": 24
-                        })
+                        }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),
@@ -458,7 +465,8 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                             input: serde_json::json!({
                                 "task_id": task_id,
                                 "block": false
-                            })
+                            }),
+                            kind: holon::provider::ModelToolCallKind::Function,
                         },
                     ],
                     stop_reason: Some("tool_use".into()),
@@ -484,7 +492,8 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                         input: serde_json::json!({
                             "cmd": "awk 'BEGIN { for (i=0; i<840; i++) printf \"exec_round_4_marker \" }'",
                             "max_output_tokens": 24
-                        })
+                        }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: Some("tool_use".into()),

--- a/tests/support/runtime_providers.rs
+++ b/tests/support/runtime_providers.rs
@@ -53,6 +53,7 @@ impl AgentProvider for ToolUsingProvider {
                     id: "tool-1".into(),
                     name: "AgentGet".into(),
                     input: json!({}),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -109,6 +110,7 @@ impl AgentProvider for FileEditingProvider {
                         input: json!({
                             "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "read-1".into(),
@@ -117,6 +119,7 @@ impl AgentProvider for FileEditingProvider {
                             "cmd": "cat notes/result.txt",
                             "workdir": "."
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -179,6 +182,7 @@ impl AgentProvider for TerminalResultBriefProvider {
                             input: json!({
                                 "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                             }),
+                            kind: holon::provider::ModelToolCallKind::Function,
                         },
                         ModelBlock::ToolUse {
                             id: "verify-1".into(),
@@ -187,6 +191,7 @@ impl AgentProvider for TerminalResultBriefProvider {
                                 "cmd": "printf tests_passed",
                                 "login": false
                             }),
+                            kind: holon::provider::ModelToolCallKind::Function,
                         },
                     ],
                     stop_reason: None,
@@ -209,6 +214,7 @@ impl AgentProvider for TerminalResultBriefProvider {
                         input: json!({
                             "reason": "sleep requested"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -275,6 +281,7 @@ impl AgentProvider for SleepOnlyCompletionAfterTextProvider {
                             input: json!({
                                 "patch": "--- /dev/null\n+++ b/notes/result.txt\n@@ -0,0 +1,1 @@\n+hello from holon\n"
                             }),
+                            kind: holon::provider::ModelToolCallKind::Function,
                         },
                     ],
                     stop_reason: None,
@@ -293,6 +300,7 @@ impl AgentProvider for SleepOnlyCompletionAfterTextProvider {
                     input: json!({
                         "reason": "delivery complete"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -334,6 +342,7 @@ impl AgentProvider for ShellProvider {
                     input: json!({
                         "cmd": "printf shell_ok"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -406,6 +415,7 @@ impl AgentProvider for TruncatedShellReinjectionProvider {
                         "login": false,
                         "max_output_tokens": 32
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -477,6 +487,7 @@ impl AgentProvider for LongShellProvider {
                         "cmd": "printf start && sleep 1 && printf done",
                         "yield_time_ms": 50
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -704,11 +715,13 @@ impl AgentProvider for ToolErrorProvider {
                         input: json!({
                             "yield_time_ms": 10
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "bad-tool".into(),
                         name: "DefinitelyNotATool".into(),
                         input: json!({}),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                     ModelBlock::ToolUse {
                         id: "retired-read".into(),
@@ -716,6 +729,7 @@ impl AgentProvider for ToolErrorProvider {
                         input: json!({
                             "file_path": "notes/result.txt"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     },
                 ],
                 stop_reason: None,
@@ -829,6 +843,7 @@ impl AgentProvider for UseWorkspaceProvider {
                         "mode": "isolated",
                         "isolation_label": self.branch_name
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 100,
@@ -913,6 +928,7 @@ impl AgentProvider for WorktreeLifecycleProvider {
                             "mode": "isolated",
                             "isolation_label": self.branch_name
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     }],
                     stop_reason: None,
                     input_tokens: 100,
@@ -944,6 +960,7 @@ impl AgentProvider for WorktreeLifecycleProvider {
                         input: json!({
                             "workspace_id": "agent_home"
                         }),
+                        kind: holon::provider::ModelToolCallKind::Function,
                     }],
                     stop_reason: None,
                     input_tokens: 100,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -94,6 +94,7 @@ impl AgentProvider for SleepThenRecordTaskResultProvider {
                     input: json!({
                         "reason": "wait for background command result"
                     }),
+                    kind: holon::provider::ModelToolCallKind::Function,
                 }],
                 stop_reason: None,
                 input_tokens: 10,


### PR DESCRIPTION
## 概要

- 在 provider-neutral 的 `ModelBlock::ToolUse` 中持久化 `function` / `custom` 调用种类
- OpenAI Responses continuation 按保存的 kind 构造 call 与 output，不再根据工具名称或 payload 猜测
- 历史 transcript 缺少 kind 时兼容默认为 `function`，其他 provider transport 显式产生 `function`
- 增加真实 OpenAI Responses livetest，覆盖名为 `ApplyPatch` 的普通 function call 在 continuation 中不得变为 custom call

Closes #2191

## 验证

- `cargo test provider::tests::tool_schema --lib -- --nocapture`（22 passed）
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --test live_openai live_openai_apply_patch_function_call_kind_survives_continuation -- --ignored --exact --nocapture`（真实 OpenAI Responses，1 passed）
