### PR TITLE
fix: resolve per-model reasoning options

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -197,6 +197,8 @@ pub struct ResolvedRuntimeModelPolicy {
     pub max_output_tokens_upper_limit: Option<u32>,
     #[serde(default)]
     pub capabilities: ModelCapabilityFlags,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasoning_effort_options: Vec<String>,
     pub source: ModelMetadataSource,
 }
 
@@ -226,6 +228,7 @@ impl Default for ResolvedRuntimeModelPolicy {
                 DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
             max_output_tokens_upper_limit: None,
             capabilities: ModelCapabilityFlags::default(),
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::UnknownFallback,
         }
     }
@@ -435,6 +438,7 @@ impl BuiltInModelCatalog {
         {
             override_capabilities.apply_to(&mut capabilities);
         }
+        let reasoning_effort_options = reasoning_effort_options(model_ref, &capabilities);
 
         ResolvedRuntimeModelPolicy {
             model_ref: model_ref.clone(),
@@ -450,6 +454,7 @@ impl BuiltInModelCatalog {
             tool_output_truncation_estimated_tokens,
             max_output_tokens_upper_limit,
             capabilities,
+            reasoning_effort_options,
             source,
         }
     }
@@ -510,6 +515,26 @@ fn percent_of(total: usize, percent: usize) -> usize {
 
 fn provider_id(provider: &str) -> ProviderId {
     ProviderId::parse(provider).expect("valid built-in provider id")
+}
+
+fn reasoning_effort_options(
+    model_ref: &ModelRef,
+    capabilities: &ModelCapabilityFlags,
+) -> Vec<String> {
+    if !capabilities.supports_reasoning {
+        return Vec::new();
+    }
+
+    let options = match model_ref.provider.as_str() {
+        "openai" | "openai-codex" => &["low", "medium", "high", "xhigh"][..],
+        "volcengine" | "volcengine-agent" | "volcengine-coding"
+            if !matches!(model_ref.model.as_str(), "kimi-k2.6" | "kimi-k2.7-code") =>
+        {
+            &["low", "medium", "high"][..]
+        }
+        _ => &[][..],
+    };
+    options.iter().map(|option| (*option).to_string()).collect()
 }
 
 fn catalog_model(
@@ -2168,7 +2193,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             4_096,
             false,
-            true,
+            false,
         ),
         catalog_model(
             "volcengine",
@@ -2176,7 +2201,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "Doubao Seed 2.0 Pro",
             256_000,
             4_096,
-            false,
+            true,
             true,
         ),
         catalog_model(
@@ -3261,6 +3286,68 @@ mod tests {
             );
             assert_eq!(policy.runtime_max_output_tokens, 128_000);
             assert_eq!(policy.max_output_tokens_upper_limit, Some(128_000));
+        }
+    }
+
+    #[test]
+    fn volcengine_reasoning_effort_options_follow_route_contract() {
+        let catalog = BuiltInModelCatalog::new();
+
+        for model_ref in [
+            "volcengine/doubao-seed-2-0-pro-260215",
+            "volcengine-coding/glm-5.2",
+            "volcengine-agent/glm-5.2",
+        ] {
+            let policy = catalog.resolve_policy(
+                &ModelRef::parse(model_ref).unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert_eq!(
+                policy.reasoning_effort_options,
+                ["low", "medium", "high"],
+                "{model_ref}"
+            );
+        }
+
+        for model_ref in [
+            "volcengine-coding/kimi-k2.6",
+            "volcengine-agent/kimi-k2.7-code",
+        ] {
+            let policy = catalog.resolve_policy(
+                &ModelRef::parse(model_ref).unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert!(policy.capabilities.supports_reasoning, "{model_ref}");
+            assert!(policy.reasoning_effort_options.is_empty(), "{model_ref}");
+        }
+    }
+
+    #[test]
+    fn volcengine_deepseek_v3_2_is_not_a_vision_model() {
+        let catalog = BuiltInModelCatalog::new();
+
+        for model_ref in [
+            "volcengine/deepseek-v3-2-251201",
+            "volcengine-coding/deepseek-v3-2-251201",
+            "volcengine-agent/deepseek-v3-2-251201",
+        ] {
+            let policy = catalog.resolve_policy(
+                &ModelRef::parse(model_ref).unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert!(!policy.capabilities.image_input, "{model_ref}");
         }
     }
 }

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -303,7 +303,10 @@ pub(crate) fn provider_models_from_availability_for_runtime(
 }
 
 fn supported_model_parameters(model: &ResolvedModelAvailability) -> Vec<String> {
-    let mut parameters = vec!["reasoning_effort".to_string()];
+    let mut parameters = Vec::new();
+    if !model.policy.reasoning_effort_options.is_empty() {
+        parameters.push("reasoning_effort".to_string());
+    }
     if model.policy.max_output_tokens_upper_limit.is_some()
         || model.policy.runtime_max_output_tokens > 0
     {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1467,6 +1467,7 @@ impl TuiApp {
             }
             OverlayState::ModelEffortPicker {
                 model,
+                options,
                 mut selected,
                 return_filter,
                 return_selected,
@@ -1483,23 +1484,25 @@ impl TuiApp {
                         };
                     }
                     TuiKeyAction::OverlayAccept => {
-                        self.apply_model_effort_picker_selection(&model, selected)
+                        self.apply_model_effort_picker_selection(&model, &options, selected)
                             .await?;
                     }
                     TuiKeyAction::OverlayMoveUp => {
                         selected = selected.saturating_sub(1);
                         self.overlay = OverlayState::ModelEffortPicker {
                             model,
+                            options,
                             selected,
                             return_filter,
                             return_selected,
                         };
                     }
                     TuiKeyAction::OverlayMoveDown => {
-                        let max = crate::tui::overlay::MODEL_REASONING_EFFORT_OPTIONS.len() - 1;
+                        let max = options.len();
                         selected = (selected + 1).min(max);
                         self.overlay = OverlayState::ModelEffortPicker {
                             model,
+                            options,
                             selected,
                             return_filter,
                             return_selected,
@@ -1508,6 +1511,7 @@ impl TuiApp {
                     _ => {
                         self.overlay = OverlayState::ModelEffortPicker {
                             model,
+                            options,
                             selected,
                             return_filter,
                             return_selected,
@@ -2219,15 +2223,16 @@ impl TuiApp {
             }
             crate::tui::model_picker::ModelPickerChoice::Model {
                 model,
-                supports_reasoning_effort,
+                reasoning_effort_options,
             } => {
                 if self.onboarding_model_picker {
                     self.apply_onboarding_default_model(&model).await?;
                     return Ok(());
                 }
-                if supports_reasoning_effort {
+                if !reasoning_effort_options.is_empty() {
                     self.overlay = OverlayState::ModelEffortPicker {
                         model,
+                        options: reasoning_effort_options,
                         selected: 0,
                         return_filter: filter.to_string(),
                         return_selected: selected,
@@ -2260,20 +2265,17 @@ impl TuiApp {
     async fn apply_model_effort_picker_selection(
         &mut self,
         model: &str,
+        options: &[String],
         selected: usize,
     ) -> Result<()> {
         let agent_id = self
             .selected_agent_id()
             .ok_or_else(|| anyhow!("no agent selected"))?
             .to_string();
-        let reasoning_effort = crate::tui::overlay::MODEL_REASONING_EFFORT_OPTIONS
-            .get(selected)
-            .copied()
-            .unwrap_or("xhigh");
-        let reasoning_effort = if reasoning_effort == "inherit" {
+        let reasoning_effort = if selected == 0 {
             None
         } else {
-            Some(reasoning_effort.to_string())
+            options.get(selected - 1).cloned()
         };
         self.set_model_override(&agent_id, model, reasoning_effort)
             .await?;

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -8,7 +8,7 @@ pub(super) enum ModelPickerChoice {
     },
     Model {
         model: String,
-        supports_reasoning_effort: bool,
+        reasoning_effort_options: Vec<String>,
     },
 }
 
@@ -196,7 +196,7 @@ fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
     ModelPickerRow {
         choice: ModelPickerChoice::Model {
             model: entry.model.clone(),
-            supports_reasoning_effort: supports_reasoning_effort(entry),
+            reasoning_effort_options: entry.policy.reasoning_effort_options.clone(),
         },
         title: format!("{}  {}", entry.model, entry.display_name),
         detail: format!(
@@ -218,8 +218,7 @@ fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
 }
 
 fn supports_reasoning_effort(entry: &ResolvedModelAvailability) -> bool {
-    entry.policy.capabilities.supports_reasoning
-        && entry.transport.as_deref() == Some("openai_codex_responses")
+    !entry.policy.reasoning_effort_options.is_empty()
 }
 
 #[cfg(test)]
@@ -256,6 +255,9 @@ mod tests {
                 supports_reasoning: reasoning,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: reasoning
+                .then(|| vec!["low".into(), "medium".into(), "high".into()])
+                .unwrap_or_default(),
             source: ModelMetadataSource::BuiltInCatalog,
         }
     }

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -2,9 +2,6 @@ use super::*;
 use crate::tui::composer::ComposerState;
 use unicode_width::UnicodeWidthStr;
 
-pub(super) const MODEL_REASONING_EFFORT_OPTIONS: [&str; 5] =
-    ["inherit", "low", "medium", "high", "xhigh"];
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum OverlayState {
     None,
@@ -49,6 +46,7 @@ pub(super) enum OverlayState {
     },
     ModelEffortPicker {
         model: String,
+        options: Vec<String>,
         selected: usize,
         return_filter: String,
         return_selected: usize,
@@ -145,8 +143,11 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
             selected,
         } => draw_model_picker_overlay(frame, app, provider.as_deref(), filter, *selected),
         OverlayState::ModelEffortPicker {
-            model, selected, ..
-        } => draw_model_effort_picker_overlay(frame, app, model, *selected),
+            model,
+            options,
+            selected,
+            ..
+        } => draw_model_effort_picker_overlay(frame, app, model, options, *selected),
         OverlayState::DebugPromptInput { composer } => draw_input_modal(
             frame,
             "Debug Prompt",
@@ -675,6 +676,7 @@ fn draw_model_effort_picker_overlay(
     frame: &mut Frame<'_>,
     app: &TuiApp,
     model: &str,
+    options: &[String],
     selected: usize,
 ) {
     let popup = centered_rect(70, 42, frame.area());
@@ -695,10 +697,10 @@ fn draw_model_effort_picker_overlay(
     );
     frame.render_widget(header, layout[0]);
 
-    let items = MODEL_REASONING_EFFORT_OPTIONS
-        .iter()
+    let items = std::iter::once("inherit")
+        .chain(options.iter().map(String::as_str))
         .map(|option| {
-            let detail = if *option == "inherit" {
+            let detail = if option == "inherit" {
                 "use provider/runtime default"
             } else {
                 "force reasoning effort"
@@ -707,9 +709,7 @@ fn draw_model_effort_picker_overlay(
         })
         .collect::<Vec<_>>();
     let mut state = ListState::default();
-    state.select(Some(
-        selected.min(MODEL_REASONING_EFFORT_OPTIONS.len().saturating_sub(1)),
-    ));
+    state.select(Some(selected.min(options.len())));
     let list = List::new(items)
         .block(Block::default().title("Effort").borders(Borders::ALL))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -3520,6 +3520,7 @@ mod tests {
                         image_input: true,
                         ..crate::model_catalog::ModelCapabilityFlags::default()
                     },
+                    reasoning_effort_options: Vec::new(),
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
                 },
             },

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1115,6 +1115,7 @@ mod tests {
                         image_input: true,
                         ..crate::model_catalog::ModelCapabilityFlags::default()
                     },
+                    reasoning_effort_options: Vec::new(),
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
                 },
             },

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -242,6 +242,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
                     image_input: true,
                     ..crate::model_catalog::ModelCapabilityFlags::default()
                 },
+                reasoning_effort_options: Vec::new(),
                 source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
             },
         },
@@ -326,6 +327,9 @@ fn sample_model_availability(
                 supports_reasoning: reasoning,
                 ..crate::model_catalog::ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: reasoning
+                .then(|| vec!["low".into(), "medium".into(), "high".into()])
+                .unwrap_or_default(),
             source: crate::model_catalog::ModelMetadataSource::RemoteDiscovered,
         },
     }
@@ -1862,6 +1866,7 @@ async fn model_picker_opens_effort_for_models_with_reasoning_support() {
         app.overlay,
         OverlayState::ModelEffortPicker {
             model: "openai_codex/gpt-5.4".into(),
+            options: vec!["low".into(), "medium".into(), "high".into()],
             selected: 0,
             return_filter: String::new(),
             return_selected: 1
@@ -1894,6 +1899,7 @@ async fn model_effort_picker_esc_returns_to_provider_model_page() {
     );
     app.overlay = OverlayState::ModelEffortPicker {
         model: "openai_codex/gpt-5.4".into(),
+        options: vec!["low".into(), "medium".into(), "high".into()],
         selected: 0,
         return_filter: "gpt".into(),
         return_selected: 1,

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -653,7 +653,7 @@ export function AgentPage({
                       {reasoningPopoverOpen ? (
                         <div className="thinking-popover" role="dialog" aria-label={t("agent.thinkingLevel")}>
                           <div className="reasoning-options">
-                            {["auto", "low", "medium", "high", "xhigh"].map((effort) => (
+                            {["auto", ...(activeModelOption?.reasoningEffortOptions ?? [])].map((effort) => (
                               <button
                                 className={`${(activeReasoningBadge ?? "auto") === effort ? "is-active" : ""} ${changingModel === "reasoning:" + effort ? "is-saving" : ""}`}
                                 key={effort}

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -22,6 +22,7 @@ describe("projectModelOptions", () => {
         routeRef: "openai-codex@default/gpt-5.5",
         provider: "openai-codex",
         supportsReasoningEffort: true,
+        reasoningEffortOptions: ["low", "medium", "high"],
       }),
     ]);
   });

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -59,6 +59,34 @@ describe("projectModelOptions", () => {
     ]);
   });
 
+  it("uses the resolved reasoning effort options for a plan route", () => {
+    const options = projectModelOptions({
+      model_availability: [
+        {
+          model: "volcengine/glm-5.2",
+          provider: "volcengine",
+          provider_family: "volcengine",
+          endpoint: "plan",
+          route_provider: "volcengine-agent",
+          available: true,
+          policy: {
+            reasoning_effort_options: ["low", "medium", "high"],
+            capabilities: {
+              supports_reasoning: true,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(options[0]).toEqual(
+      expect.objectContaining({
+        supportsReasoningEffort: true,
+        reasoningEffortOptions: ["low", "medium", "high"],
+      }),
+    );
+  });
+
   it("preserves route identity and image capabilities from available models", () => {
     const options = projectModelOptions({
       available_models: [

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -2059,7 +2059,7 @@ function reasoningEffortOptions(entry: ModelAvailabilityDto | RuntimeAvailableMo
   if (entry.policy?.reasoning_effort_options) {
     return entry.policy.reasoning_effort_options;
   }
-  return supportsReasoningEffort(entry) ? ["low", "medium", "high", "xhigh"] : [];
+  return supportsReasoningEffort(entry) ? ["low", "medium", "high"] : [];
 }
 
 function compareModelOptions(left: RuntimeModelOption, right: RuntimeModelOption): number {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -384,6 +384,7 @@ interface RuntimeAvailableModelDto {
   };
   policy?: {
     supported_parameters?: string[];
+    reasoning_effort_options?: string[];
     capabilities?: {
       image_input?: boolean;
       image_generation?: boolean;
@@ -405,6 +406,7 @@ interface ModelAvailabilityDto {
   unavailable_reason?: string;
   policy?: {
     supported_parameters?: string[];
+    reasoning_effort_options?: string[];
     capabilities?: {
       image_input?: boolean;
       image_generation?: boolean;
@@ -1999,6 +2001,7 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
           supportsImageInput: entry.policy?.capabilities?.image_input ?? false,
           supportsImageGeneration: entry.policy?.capabilities?.image_generation ?? false,
           supportsReasoningEffort: supportsReasoningEffort(entry),
+          reasoningEffortOptions: reasoningEffortOptions(entry),
         };
       })
       .sort(compareModelOptions);
@@ -2023,6 +2026,7 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
         supportsImageInput: typeof entry === "string" ? false : (entry.capabilities?.image_input ?? false),
         supportsImageGeneration: typeof entry === "string" ? false : (entry.capabilities?.image_generation ?? false),
         supportsReasoningEffort: typeof entry === "string" ? false : supportsReasoningEffort(entry),
+        reasoningEffortOptions: typeof entry === "string" ? [] : reasoningEffortOptions(entry),
       };
     })
     .filter((entry): entry is RuntimeModelOption => Boolean(entry))
@@ -2037,6 +2041,9 @@ function modelRouteRef(model: string, providerFamily: string, endpoint: string):
 }
 
 function supportsReasoningEffort(entry: ModelAvailabilityDto | RuntimeAvailableModelDto): boolean {
+  if (entry.policy?.reasoning_effort_options) {
+    return entry.policy.reasoning_effort_options.length > 0;
+  }
   return (
     entry.policy?.supported_parameters?.includes("reasoning_effort") ||
     ("supported_parameters" in entry && entry.supported_parameters?.includes("reasoning_effort")) ||
@@ -2046,6 +2053,13 @@ function supportsReasoningEffort(entry: ModelAvailabilityDto | RuntimeAvailableM
     ("capabilities" in entry && entry.capabilities?.reasoning_summaries) ||
     false
   );
+}
+
+function reasoningEffortOptions(entry: ModelAvailabilityDto | RuntimeAvailableModelDto): string[] {
+  if (entry.policy?.reasoning_effort_options) {
+    return entry.policy.reasoning_effort_options;
+  }
+  return supportsReasoningEffort(entry) ? ["low", "medium", "high", "xhigh"] : [];
 }
 
 function compareModelOptions(left: RuntimeModelOption, right: RuntimeModelOption): number {

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -249,6 +249,7 @@ export interface RuntimeModelOption {
   supportsImageInput: boolean;
   supportsImageGeneration: boolean;
   supportsReasoningEffort: boolean;
+  reasoningEffortOptions: string[];
 }
 
 export interface RuntimeModelCatalog {


### PR DESCRIPTION
## Summary
- add resolved per-model reasoning effort options to model diagnostics
- expose only supported reasoning levels in TUI and Web GUI
- correct Volcengine model capability metadata and add regression coverage

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`
- `cargo test model_catalog::tests::volcengine_ --lib`
- `npm test -- --run src/runtime/client.test.ts` (web-gui/app)
- `npm run typecheck` (web-gui/app)

## Livetest
- `cargo test --test live_provider_smoke -- --ignored --nocapture` reached the configured Volcengine provider, but the request failed with `AccountOverdue`; credentials/routes were discovered correctly, while account billing prevented a successful live response.