### PR TITLE
feat: improve web UI tool execution details

### DIFF
--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -287,6 +287,7 @@ fn is_runtime_mutable_config_key(key: &str) -> bool {
             | "model.default"
             | "model.fallbacks"
             | "vision.default"
+            | "image_generation.default"
             | "models.catalog"
             | "model.unknown_fallback"
             | "model.unknown_fallback.context_window_tokens"
@@ -988,6 +989,12 @@ fn percent_encode_path_segment(segment: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_mutable_config_keys_include_visual_model_defaults() {
+        assert!(is_runtime_mutable_config_key("vision.default"));
+        assert!(is_runtime_mutable_config_key("image_generation.default"));
+    }
 
     fn encoded(bytes: &[u8]) -> String {
         BASE64_STANDARD.encode(bytes)

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -461,6 +461,7 @@ export function AgentPage({
 
   async function handleReasoningChange(effort: string) {
     setSelectedReasoningEffort(effort);
+    setReasoningPopoverOpen(false);
     if (changingModel || !activeModelSupportsReasoning) return;
     setChangingModel("reasoning:" + effort);
     try {

--- a/web-gui/app/src/features/agent/AgentTimeline.tsx
+++ b/web-gui/app/src/features/agent/AgentTimeline.tsx
@@ -365,13 +365,23 @@ function trimActivityLine(value: string, maxLength: number): string {
 }
 
 function formatDisplayTime(value: string): string {
-  if (!value) return "—";
+  if (!value) return "-";
   const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value || "—";
-  return new Intl.DateTimeFormat(undefined, {
+  if (Number.isNaN(parsed.getTime())) return value || "-";
+  const now = new Date();
+  const sameDay =
+    parsed.getFullYear() === now.getFullYear() &&
+    parsed.getMonth() === now.getMonth() &&
+    parsed.getDate() === now.getDate();
+  const options: Intl.DateTimeFormatOptions = {
     hour: "2-digit",
     minute: "2-digit",
-  }).format(parsed);
+  };
+  if (!sameDay) {
+    options.month = "2-digit";
+    options.day = "2-digit";
+  }
+  return new Intl.DateTimeFormat(undefined, options).format(parsed);
 }
 
 function formatTimelineMeta(meta: string, displayLevel: DisplayLevel): string {

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
@@ -70,7 +70,7 @@ describe("ToolExecutionContent", () => {
     expect(html).toContain("rust runtime");
     expect(html).toContain("brave");
     expect(html).toContain("1 found");
-    expect(html).toContain("1. Tokio");
+    expect(html).toContain("tool-detail-result-index");
     expect(html).toContain("https://tokio.rs");
     expect(html).toContain("Async runtime");
   });

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
@@ -13,21 +13,33 @@ describe("ToolExecutionContent", () => {
   it("renders ViewImage details with path, dimensions, and visual observation", () => {
     const html = renderTool({
       tool_name: "ViewImage",
-      input: { path: "/tmp/screenshot.png" },
+      input: { path: "media/generated/tool-timeline-smoke.png" },
       output: {
         envelope: {
           result: {
-            dimensions: { width: 1024, height: 768 },
-            visual_observation: "A timeline screenshot.",
+            visual_reference: {
+              id: "img_test123",
+              path: "media/generated/tool-timeline-smoke.png",
+              mime: "image/png",
+              byte_count: 2048,
+              sha256: "abc123",
+              size: { width: 1024, height: 768 },
+            },
+            observation: {
+              summary: "A timeline screenshot.",
+              generated_by: { provider: "openai", model: "gpt-4o" },
+            },
           },
         },
       },
     });
 
     expect(html).toContain("Path");
-    expect(html).toContain("/tmp/screenshot.png");
+    expect(html).toContain("media/generated/tool-timeline-smoke.png");
     expect(html).toContain("1024×768");
     expect(html).toContain("A timeline screenshot.");
+    expect(html).toContain("image/png");
+    expect(html).toContain("openai/gpt-4o");
   });
 
   it("renders GenerateImage details with prompt and generated image URI", () => {

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -454,13 +454,18 @@ function MemoryGetRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const { t } = useTranslation();
   const input = isRecord(record.input) ? record.input : {};
   const output = unwrapToolOutput(record.output ?? record.result);
-  const sourceRef = nestedValue(output, ["source_ref"]) ?? nestedValue(input, ["source_ref"]);
-  const content = nestedText(output, ["content"]);
-  const truncated = nestedValue(output, ["truncated"]) === true;
+  const result = asResultRecord(output, "memory");
+  const sourceRef = nestedText(result, ["source_ref"]) ?? nestedText(input, ["source_ref"]);
+  const title = nestedText(result, ["title"]);
+  const kind = nestedText(result, ["kind"]);
+  const content = nestedText(result, ["content"]);
+  const truncated = nestedValue(result, ["truncated"]) === true;
 
   return (
     <>
       <SimpleField label={t("inspector.sourceRef")} value={sourceRef} />
+      {title ? <SimpleField label={t("inspector.title")} value={title} /> : null}
+      {kind ? <SimpleField label={t("inspector.kind")} value={kind} /> : null}
       {truncated ? <SimpleField label={t("inspector.truncated")} value={t("inspector.yes")} /> : null}
       {content ? <OutputField label={t("inspector.content")} value={truncatedText(content, 2000)} /> : null}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -315,7 +315,12 @@ function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const width = nestedValue(result, ["width"]) ?? nestedValue(dimensions, ["width"]);
   const height = nestedValue(result, ["height"]) ?? nestedValue(dimensions, ["height"]);
   const path = nestedValue(record.input, ["path", "image_path"]) ?? nestedValue(result, ["path", "image_path"]);
-  const observation = nestedText(result, ["visual_observation", "observation", "text_preview"]);
+  const observationObj = nestedValue(result, ["observation", "visual_observation"]);
+  const observation = nestedText(result, ["text_preview"])
+    || nestedText(result, ["visual_observation"])
+    || nestedText(result, ["observation"])
+    || (isRecord(observationObj) ? nestedText(observationObj, ["summary"]) : "")
+    || (isRecord(observationObj) ? textField(observationObj) : "");
   const summary = textField(result?.summary_text) || record.summary;
 
   return (
@@ -339,7 +344,9 @@ function GenerateImageRenderer({ record }: { record: RuntimeToolExecutionRecord 
   const size = nestedValue(record.input, ["size"]) ?? nestedValue(result, ["size"]);
   const background = nestedValue(record.input, ["background"]) ?? nestedValue(result, ["background"]);
   const outputFormat = nestedValue(record.input, ["output_format"]) ?? nestedValue(result, ["output_format"]);
-  const imageUri = nestedValue(result, ["image_uri", "uri", "path"]);
+  const images = arrayRecords(nestedValue(result, ["images"]));
+  const firstImageUri = images.length > 0 ? nestedText(images[0], ["uri", "path"]) : "";
+  const imageUri = nestedValue(result, ["image_uri", "uri", "path"]) ?? firstImageUri;
   const summary = textField(result?.summary_text) || record.summary;
 
   return (
@@ -361,9 +368,9 @@ function WebSearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const { t } = useTranslation();
   const input = isRecord(record.input) ? record.input : {};
   const output = unwrapToolOutput(record.output ?? record.result);
-  const results = arrayRecords(nestedValue(output, ["results"]));
+  const results = arrayRecords(nestedValue(output, ["results"]) ?? nestedValue(output, ["citations"]));
   const query = nestedValue(output, ["query"]) ?? nestedValue(input, ["query", "search_query", "q"]);
-  const provider = nestedValue(output, ["provider"]);
+  const provider = nestedValue(output, ["provider"]) ?? nestedValue(output, ["backend"]);
   const mode = nestedValue(output, ["mode"]);
   const truncated = nestedValue(output, ["truncated"]) === true;
 
@@ -433,8 +440,9 @@ function MemorySearchRenderer({ record }: { record: RuntimeToolExecutionRecord }
       {results.slice(0, 15).map((item, index) => {
         const sourceRef = nestedText(item, ["source_ref"]) || t("inspector.unknownSource");
         const score = nestedText(item, ["score"]);
-        const preview = nestedText(item, ["preview"]);
-        const text = [score ? `score: ${score}` : "", preview ? truncatedText(preview, 300) : ""].filter(Boolean).join("\n");
+        const title = nestedText(item, ["title"]);
+        const preview = nestedText(item, ["preview"]) || nestedText(item, ["snippet"]);
+        const text = [title, score ? `score: ${score}` : "", preview ? truncatedText(preview, 300) : ""].filter(Boolean).join("\n");
         return <OutputField key={index} label={`${index + 1}. ${sourceRef}`} value={text} />;
       })}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
@@ -578,15 +586,18 @@ function XSearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
 function ListModelProvidersRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const { t } = useTranslation();
   const output = unwrapToolOutput(record.output ?? record.result);
-  const providers = arrayRecords(nestedValue(output, ["providers"]) ?? nestedValue(output, ["model_providers"]));
+  const providers = arrayRecords(
+    nestedValue(output, ["providers"]) ?? nestedValue(output, ["model_providers"]) ?? nestedValue(output, ["model_discovery_cache"]),
+  );
 
   return (
     <>
       <SimpleField label={t("inspector.results")} value={t("inspector.resultsCount", { count: providers.length })} />
       {providers.map((provider, index) => {
         const id = nestedText(provider, ["id"]);
+        const providerName = nestedText(provider, ["provider"]);
         const displayName = nestedText(provider, ["display_name"]);
-        const availability = nestedText(provider, ["availability"]);
+        const availability = nestedText(provider, ["availability"]) ?? nestedText(provider, ["state"]);
         const family = nestedText(provider, ["provider_family"]);
         const providerConfigured = nestedValue(provider, ["provider_configured"]);
         const credentialConfigured = nestedValue(provider, ["credential_configured"]);
@@ -597,7 +608,7 @@ function ListModelProvidersRenderer({ record }: { record: RuntimeToolExecutionRe
         return (
           <section key={index} className="tool-detail-result-card">
             <div className="tool-detail-result-title">
-              <span>{displayName || id || "—"}</span>
+              <span>{displayName || id || providerName || "—"}</span>
               {availability ? <span className={`tool-detail-badge tool-detail-badge--${availability === "available" ? "ok" : "warn"}`}>{availability}</span> : null}
             </div>
             {id ? <p className="tool-detail-result-snippet">{id}</p> : null}

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
-import type { MouseEvent } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { formatToolExecutionDetail } from "../inspector/ActivityInspectorPanel";
+import { parseWorkspaceImageRef, WorkspaceImage } from "../../components/MarkdownContent";
 import type { RuntimeToolExecutionRecord } from "../../runtime/types";
 
 // Utility helpers (mirrors the private helpers in ActivityInspectorPanel)
@@ -99,6 +100,70 @@ export function SimpleField({ label, value }: { label: string; value: unknown })
     <div className="tool-detail-simple">
       <span className="tool-detail-simple-label">{label}</span>
       <span className="tool-detail-simple-value">{text}</span>
+    </div>
+  );
+}
+
+/** A labeled field whose value is a clickable external link. */
+export function LinkField({ label, href, text }: { label: string; href: string; text?: string }) {
+  const display = text || href;
+  return (
+    <div className="tool-detail-simple">
+      <span className="tool-detail-simple-label">{label}</span>
+      <a href={href} target="_blank" rel="noopener noreferrer" className="tool-detail-link">
+        {display}
+      </a>
+    </div>
+  );
+}
+
+/** Renders a workspace:// image URI as an actual preview when possible. */
+export function ImagePreview({ uri, alt }: { uri: string; alt?: string }) {
+  const ref = parseWorkspaceImageRef(uri);
+  if (!ref) {
+    return <SimpleField label="Image" value={uri} />;
+  }
+  return (
+    <section className="tool-detail-field">
+      <h3 className="tool-detail-field-label">Image preview</h3>
+      <div className="tool-detail-image-preview">
+        <WorkspaceImage workspaceId={ref.workspaceId} path={ref.path} alt={alt ?? ref.path} />
+      </div>
+    </section>
+  );
+}
+
+/** A card-style result item with optional clickable link, source badge, and snippet. */
+export function ResultCard({
+  index,
+  title,
+  url,
+  source,
+  snippet,
+  extra,
+}: {
+  index?: number;
+  title: string;
+  url?: string;
+  source?: string;
+  snippet?: string;
+  extra?: ReactNode;
+}) {
+  return (
+    <div className="tool-detail-result-card">
+      <div className="tool-detail-result-title">
+        {index != null ? <span className="tool-detail-result-index">{index}.</span> : null}
+        {url ? (
+          <a href={url} target="_blank" rel="noopener noreferrer" className="tool-detail-link">
+            {title}
+          </a>
+        ) : (
+          <span>{title}</span>
+        )}
+      </div>
+      {source ? <span className="tool-detail-result-source">{source}</span> : null}
+      {snippet ? <p className="tool-detail-result-snippet">{snippet}</p> : null}
+      {extra}
     </div>
   );
 }
@@ -259,6 +324,7 @@ function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
       {width != null && height != null ? <SimpleField label={t("inspector.dimensions")} value={`${width}×${height}`} /> : null}
       {observation ? <OutputField label={t("inspector.observation")} value={observation} /> : null}
       {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
+      {path ? <ImagePreview uri={String(path)} alt={observation ?? String(path)} /> : null}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
     </>
   );
@@ -285,6 +351,7 @@ function GenerateImageRenderer({ record }: { record: RuntimeToolExecutionRecord 
       <SimpleField label={t("rightPanel.output")} value={outputFormat} />
       {prompt ? <OutputField label={t("inspector.input")} value={String(prompt)} /> : null}
       {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
+      {imageUri ? <ImagePreview uri={String(imageUri)} alt={String(prompt ?? name ?? "Generated image")} /> : null}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
     </>
   );
@@ -298,6 +365,7 @@ function WebSearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const query = nestedValue(output, ["query"]) ?? nestedValue(input, ["query", "search_query", "q"]);
   const provider = nestedValue(output, ["provider"]);
   const mode = nestedValue(output, ["mode"]);
+  const truncated = nestedValue(output, ["truncated"]) === true;
 
   return (
     <>
@@ -311,8 +379,17 @@ function WebSearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
         const source = nestedText(item, ["source"]);
         const publishedAt = nestedText(item, ["published_at"]);
         const snippet = nestedText(item, ["snippet"]);
-        const text = [url, source ? `(${source})` : "", publishedAt, snippet ? truncatedText(snippet, 300) : ""].filter(Boolean).join("\n");
-        return <OutputField key={index} label={`${index + 1}. ${title}`} value={text} />;
+        const meta = [publishedAt].filter(Boolean).join(" · ");
+        return (
+          <ResultCard
+            key={index}
+            index={index + 1}
+            title={title}
+            url={url}
+            source={[source, meta].filter(Boolean).join(" · ") || undefined}
+            snippet={snippet ? truncatedText(snippet, 300) : undefined}
+          />
+        );
       })}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
     </>
@@ -323,15 +400,15 @@ function WebFetchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const { t } = useTranslation();
   const input = isRecord(record.input) ? record.input : {};
   const output = unwrapToolOutput(record.output ?? record.result);
-  const url = nestedValue(output, ["url"]) ?? nestedValue(input, ["url"]);
-  const finalUrl = nestedValue(output, ["final_url"]);
+  const url = nestedText(output, ["url"]) ?? nestedText(input, ["url"]);
+  const finalUrl = nestedText(output, ["final_url"]);
   const truncated = nestedValue(output, ["truncated"]) === true;
   const content = nestedText(output, ["text"]);
 
   return (
     <>
-      <SimpleField label={t("inspector.url")} value={url} />
-      {finalUrl && finalUrl !== url ? <SimpleField label={t("inspector.finalUrl")} value={finalUrl} /> : null}
+      {url ? <LinkField label={t("inspector.url")} href={url} /> : null}
+      {finalUrl && finalUrl !== url ? <LinkField label={t("inspector.finalUrl")} href={finalUrl} /> : null}
       <SimpleField label={t("inspector.status")} value={nestedValue(output, ["status"])} />
       <SimpleField label={t("inspector.contentType")} value={nestedValue(output, ["content_type"])} />
       <SimpleField label={t("inspector.bytesRead")} value={nestedValue(output, ["bytes_read"])} />
@@ -455,11 +532,321 @@ function UseWorkspaceRenderer({
   );
 }
 
+// XSearch renderer
+
+function XSearchRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const query = nestedText(input, ["query"]);
+  const provider = nestedValue(output, ["provider"]);
+  const model = nestedValue(output, ["model"]);
+  const backend = nestedValue(output, ["backend"]);
+  const summaryText = nestedText(output, ["summary_text"]);
+  const text = nestedText(output, ["text"]);
+  const citations = arrayRecords(nestedValue(output, ["citations"]));
+
+  return (
+    <>
+      <SimpleField label={t("inspector.query")} value={query} />
+      <SimpleField label={t("inspector.provider")} value={provider} />
+      <SimpleField label={t("inspector.model", { defaultValue: "Model" })} value={model} />
+      <SimpleField label={t("inspector.mode")} value={backend} />
+      {summaryText ? <OutputField label={t("inspector.summary")} value={summaryText} /> : null}
+      {text ? <OutputField label={t("inspector.content")} value={truncatedText(text, 2000)} /> : null}
+      {citations.length ? (
+        <section className="tool-detail-field">
+          <h3 className="tool-detail-field-label">{t("inspector.sources")}</h3>
+          {citations.map((citation, index) => {
+            const url = nestedText(citation, ["url"]);
+            const title = nestedText(citation, ["title"]) || `Citation ${index + 1}`;
+            return url ? (
+              <ResultCard key={index} index={index + 1} title={title} url={url} />
+            ) : (
+              <ResultCard key={index} index={index + 1} title={title} />
+            );
+          })}
+        </section>
+      ) : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// ListModelProviders renderer
+
+function ListModelProvidersRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const providers = arrayRecords(nestedValue(output, ["providers"]) ?? nestedValue(output, ["model_providers"]));
+
+  return (
+    <>
+      <SimpleField label={t("inspector.results")} value={t("inspector.resultsCount", { count: providers.length })} />
+      {providers.map((provider, index) => {
+        const id = nestedText(provider, ["id"]);
+        const displayName = nestedText(provider, ["display_name"]);
+        const availability = nestedText(provider, ["availability"]);
+        const family = nestedText(provider, ["provider_family"]);
+        const providerConfigured = nestedValue(provider, ["provider_configured"]);
+        const credentialConfigured = nestedValue(provider, ["credential_configured"]);
+        const modelCount = nestedValue(provider, ["model_count"]);
+        const discoveredCount = nestedValue(provider, ["discovered_model_count"]);
+        const defaultModel = nestedText(provider, ["default_model"]);
+        const endpoint = nestedText(provider, ["endpoint"]);
+        return (
+          <section key={index} className="tool-detail-result-card">
+            <div className="tool-detail-result-title">
+              <span>{displayName || id || "—"}</span>
+              {availability ? <span className={`tool-detail-badge tool-detail-badge--${availability === "available" ? "ok" : "warn"}`}>{availability}</span> : null}
+            </div>
+            {id ? <p className="tool-detail-result-snippet">{id}</p> : null}
+            <dl className="tool-detail-meta-grid">
+              {family ? <div><dt>family</dt><dd>{family}</dd></div> : null}
+              {endpoint ? <div><dt>endpoint</dt><dd>{endpoint}</dd></div> : null}
+              {providerConfigured != null ? <div><dt>configured</dt><dd>{providerConfigured ? "✓" : "✗"}</dd></div> : null}
+              {credentialConfigured != null ? <div><dt>credential</dt><dd>{credentialConfigured ? "✓" : "✗"}</dd></div> : null}
+              {modelCount != null ? <div><dt>models</dt><dd>{String(modelCount)}{discoveredCount != null ? ` (${discoveredCount} discovered)` : ""}</dd></div> : null}
+              {defaultModel ? <div><dt>default</dt><dd>{defaultModel}</dd></div> : null}
+            </dl>
+          </section>
+        );
+      })}
+      {providers.length === 0 ? (
+        <OutputField label={t("inspector.result")} value={JSON.stringify(output, null, 2)} />
+      ) : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// ListProviderModels renderer
+
+function ListProviderModelsRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const provider = nestedText(output, ["provider"]);
+  const returned = nestedValue(output, ["returned"]);
+  const limit = nestedValue(output, ["limit"]);
+  const nextCursor = nestedText(output, ["next_cursor"]);
+  const models = arrayRecords(nestedValue(output, ["models"]));
+
+  return (
+    <>
+      <SimpleField label={t("inspector.provider")} value={provider} />
+      <SimpleField label={t("inspector.returned")} value={returned != null ? String(returned) : undefined} />
+      <SimpleField label={t("inspector.limit", { defaultValue: "Limit" })} value={limit != null ? String(limit) : undefined} />
+      {nextCursor ? <SimpleField label={t("inspector.nextCursor", { defaultValue: "Next cursor" })} value={nextCursor} /> : null}
+      {models.map((model, index) => {
+        const id = nestedText(model, ["id"]);
+        const modelRef = nestedText(model, ["model_ref"]);
+        const displayName = nestedText(model, ["display_name"]);
+        const availability = nestedText(model, ["availability"]);
+        const selectable = nestedValue(model, ["selectable"]);
+        const unavailableReason = nestedText(model, ["unavailable_reason"]);
+        return (
+          <section key={index} className="tool-detail-result-card">
+            <div className="tool-detail-result-title">
+              <span>{displayName || id || "—"}</span>
+              {availability ? <span className={`tool-detail-badge tool-detail-badge--${availability === "available" ? "ok" : "warn"}`}>{availability}</span> : null}
+              {selectable != null ? <span className={`tool-detail-badge tool-detail-badge--${selectable ? "ok" : "mute"}`}>{selectable ? "selectable" : "locked"}</span> : null}
+            </div>
+            {modelRef ? <p className="tool-detail-result-snippet">{modelRef}</p> : null}
+            {unavailableReason ? <p className="tool-detail-result-snippet" style={{ color: "var(--danger)" }}>{unavailableReason}</p> : null}
+          </section>
+        );
+      })}
+      {models.length === 0 ? (
+        <OutputField label={t("inspector.result")} value={JSON.stringify(output, null, 2)} />
+      ) : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// AgentGet renderer
+
+function AgentGetRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const rawAgent = nestedValue(output, ["agent"]);
+  const agent: Record<string, unknown> = isRecord(rawAgent) ? rawAgent : (isRecord(output) ? output : {});
+  const identity = isRecord(agent.identity) ? agent.identity : {};
+  const model = isRecord(agent.model) ? agent.model : {};
+  const agentId = nestedText(identity, ["agent_id"]);
+  const visibility = nestedText(identity, ["visibility"]);
+  const ownership = nestedText(identity, ["ownership"]);
+  const profilePreset = nestedText(identity, ["profile_preset"]);
+  const effectiveModel = nestedText(model, ["effective_model", "model_ref"]);
+  const activeModel = nestedText(model, ["active_model", "model_ref"]);
+  const activeTaskCount = nestedValue(agent, ["active_task_count"]);
+  const children = arrayRecords(nestedValue(agent, ["active_children"]));
+  const waitConditions = arrayRecords(nestedValue(agent, ["active_wait_conditions"]));
+
+  return (
+    <>
+      <SimpleField label="Agent ID" value={agentId} />
+      {visibility ? <SimpleField label={t("inspector.mode")} value={visibility} /> : null}
+      {ownership ? <SimpleField label="Ownership" value={ownership} /> : null}
+      {profilePreset ? <SimpleField label="Preset" value={profilePreset} /> : null}
+      {effectiveModel ? <SimpleField label={t("inspector.model", { defaultValue: "Model" })} value={effectiveModel} /> : null}
+      {activeModel && activeModel !== effectiveModel ? <SimpleField label="Active" value={activeModel} /> : null}
+      {activeTaskCount != null ? <SimpleField label={t("inspector.tasks")} value={String(activeTaskCount)} /> : null}
+      {children.length ? (
+        <section className="tool-detail-field">
+          <h3 className="tool-detail-field-label">{t("inspector.tasks")} ({children.length})</h3>
+          {children.map((child, index) => {
+            const childId = nestedText(child, ["agent_id"]);
+            const childPreset = nestedText(child, ["profile_preset"]);
+            const childStatus = nestedText(child, ["status"]);
+            return (
+              <div key={index} className="tool-detail-result-card">
+                <div className="tool-detail-result-title"><span>{childId || "—"}</span></div>
+                <p className="tool-detail-result-snippet">{[childPreset, childStatus].filter(Boolean).join(" · ")}</p>
+              </div>
+            );
+          })}
+        </section>
+      ) : null}
+      {waitConditions.length ? (
+        <section className="tool-detail-field">
+          <h3 className="tool-detail-field-label">{t("inspector.wake", { defaultValue: "Wait" })} ({waitConditions.length})</h3>
+          {waitConditions.map((wait, index) => {
+            const wake = nestedText(wait, ["wake"]);
+            const reason = nestedText(wait, ["reason"]);
+            const resource = nestedText(wait, ["resource"]);
+            return (
+              <div key={index} className="tool-detail-result-card">
+                <div className="tool-detail-result-title"><span>{wake || "—"}</span></div>
+                <p className="tool-detail-result-snippet">{[reason, resource].filter(Boolean).join(" · ")}</p>
+              </div>
+            );
+          })}
+        </section>
+      ) : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// SpawnAgent renderer
+
+function SpawnAgentRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const agentId = nestedText(output, ["agent_id"]);
+  const childAgentId = nestedText(output, ["child_agent_id"]);
+  const supervisionTaskId = nestedText(output, ["supervision_task_id"]);
+  const taskHandle = isRecord(nestedValue(output, ["task_handle"])) ? nestedValue(output, ["task_handle"]) : undefined;
+  const taskId = nestedText(taskHandle, ["task_id"]);
+  const preset = nestedText(input, ["preset"]);
+  const template = nestedText(input, ["template"]);
+  const workspaceMode = nestedText(input, ["workspace_mode"]);
+  const initialMessage = nestedText(input, ["initial_message"]);
+
+  return (
+    <>
+      <SimpleField label="Agent ID" value={agentId} />
+      {childAgentId ? <SimpleField label="Child agent" value={childAgentId} /> : null}
+      {taskId || supervisionTaskId ? <SimpleField label="Task ID" value={taskId ?? supervisionTaskId} /> : null}
+      {preset ? <SimpleField label="Preset" value={preset} /> : null}
+      {template ? <SimpleField label="Template" value={template} /> : null}
+      {workspaceMode ? <SimpleField label="Workspace" value={workspaceMode} /> : null}
+      {initialMessage ? <OutputField label={t("inspector.input")} value={truncatedText(initialMessage, 500)} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// WaitFor renderer
+
+function WaitForRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const wake = nestedText(input, ["wake"]);
+  const reason = nestedText(input, ["reason"]);
+  const resource = nestedText(input, ["resource"]);
+  const recheckAfterMs = nestedValue(input, ["recheck_after_ms"]);
+
+  return (
+    <>
+      <SimpleField label={t("inspector.wake", { defaultValue: "Wake" })} value={wake} />
+      <SimpleField label={t("inspector.reason")} value={reason} />
+      {resource ? <SimpleField label={t("inspector.resource")} value={resource} /> : null}
+      {recheckAfterMs != null ? <SimpleField label={t("inspector.recheckAfter")} value={`${recheckAfterMs}ms`} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// Enqueue renderer
+
+function EnqueueRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const text = nestedText(input, ["text"]);
+  const priority = nestedText(input, ["priority"]);
+  const enqueued = nestedValue(output, ["enqueued"]);
+  const followUpText = nestedText(output, ["follow_up_text"]);
+  const summaryText = nestedText(output, ["summary_text"]);
+
+  return (
+    <>
+      <SimpleField label={t("inspector.mode")} value={priority} />
+      {enqueued != null ? <SimpleField label="Enqueued" value={enqueued ? "✓" : "✗"} /> : null}
+      {text ? <OutputField label={t("inspector.input")} value={truncatedText(text, 500)} /> : null}
+      {followUpText ? <OutputField label={t("inspector.content")} value={followUpText} /> : null}
+      {summaryText ? <OutputField label={t("inspector.summary")} value={summaryText} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
+// TaskOutput renderer
+
+function TaskOutputRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const taskId = nestedText(input, ["task_id"]);
+  const status = nestedText(output, ["status"]);
+  const disposition = nestedText(output, ["disposition"]);
+  const stdout = nestedText(output, ["stdout", "text"]);
+  const stderr = nestedText(output, ["stderr"]);
+  const truncated = nestedValue(output, ["truncated"]) === true;
+
+  return (
+    <>
+      <SimpleField label={t("inspector.taskId")} value={taskId} />
+      {status ? <SimpleField label={t("common.status")} value={status} /> : null}
+      {disposition ? <SimpleField label="Disposition" value={disposition} /> : null}
+      {stdout ? <OutputField label={t("inspector.stdout")} value={truncatedText(stdout, 3000)} /> : null}
+      {stderr ? <OutputField label={t("inspector.stderr")} value={truncatedText(stderr, 1000)} variant="error" /> : null}
+      {truncated ? <SimpleField label={t("inspector.truncated")} value={t("inspector.yes")} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
+}
+
 // Generic fallback renderer
 
 function GenericToolRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const { t } = useTranslation();
   const formatted = formatToolExecutionDetail(record);
-  return <OutputField label={record.tool_name ?? "Detail"} value={formatted.text} />;
+  const inputText = record.input ? JSON.stringify(record.input, null, 2) : undefined;
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const outputText = output ? JSON.stringify(output, null, 2) : undefined;
+  const summary = record.summary || formatted.text;
+  return (
+    <>
+      {summary ? <OutputField label={t("inspector.summary")} value={summary} /> : null}
+      {inputText ? <OutputField label={t("inspector.input")} value={truncatedText(inputText, 2000)} /> : null}
+      {outputText ? <OutputField label={t("inspector.result")} value={truncatedText(outputText, 2000)} /> : null}
+      {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
+    </>
+  );
 }
 
 // Public router component
@@ -492,6 +879,22 @@ export function ToolExecutionContent({
       return <MemoryGetRenderer record={record} />;
     case "UseWorkspace":
       return <UseWorkspaceRenderer record={record} onBrowseFiles={onBrowseFiles} />;
+    case "XSearch":
+      return <XSearchRenderer record={record} />;
+    case "ListModelProviders":
+      return <ListModelProvidersRenderer record={record} />;
+    case "ListProviderModels":
+      return <ListProviderModelsRenderer record={record} />;
+    case "AgentGet":
+      return <AgentGetRenderer record={record} />;
+    case "SpawnAgent":
+      return <SpawnAgentRenderer record={record} />;
+    case "WaitFor":
+      return <WaitForRenderer record={record} />;
+    case "Enqueue":
+      return <EnqueueRenderer record={record} />;
+    case "TaskOutput":
+      return <TaskOutputRenderer record={record} />;
     default:
       return <GenericToolRenderer record={record} />;
   }

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import type { MouseEvent, ReactNode } from "react";
 import { formatToolExecutionDetail } from "../inspector/ActivityInspectorPanel";
+import { useRuntimeStore } from "../../runtime/runtime-store";
 import { parseWorkspaceImageRef, WorkspaceImage } from "../../components/MarkdownContent";
 import type { RuntimeToolExecutionRecord } from "../../runtime/types";
 
@@ -309,27 +310,76 @@ function ApplyPatchRenderer({ record }: { record: RuntimeToolExecutionRecord }) 
 
 function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const { t } = useTranslation();
+  const agentId = typeof record.agent_id === "string" ? record.agent_id : undefined;
+  const workspaceId = useRuntimeStore((s) =>
+    agentId ? s.sessionsByAgentId[agentId]?.detail?.agent?.workspaceSummary?.id : undefined,
+  );
+
   const output = unwrapToolOutput(record.output ?? record.result);
   const result = asResultRecord(output, "view_image_result");
-  const dimensions = isRecord(result?.dimensions) ? result.dimensions : undefined;
-  const width = nestedValue(result, ["width"]) ?? nestedValue(dimensions, ["width"]);
-  const height = nestedValue(result, ["height"]) ?? nestedValue(dimensions, ["height"]);
-  const path = nestedValue(record.input, ["path", "image_path"]) ?? nestedValue(result, ["path", "image_path"]);
-  const observationObj = nestedValue(result, ["observation", "visual_observation"]);
-  const observation = nestedText(result, ["text_preview"])
-    || nestedText(result, ["visual_observation"])
-    || nestedText(result, ["observation"])
-    || (isRecord(observationObj) ? nestedText(observationObj, ["summary"]) : "")
-    || (isRecord(observationObj) ? textField(observationObj) : "");
+  const visualRef = isRecord(result?.visual_reference) ? result.visual_reference : undefined;
+  const sizeInfo = isRecord(visualRef?.size) ? visualRef.size : undefined;
+  const width = nestedValue(sizeInfo, ["width"]);
+  const height = nestedValue(sizeInfo, ["height"]);
+  const inputPath = nestedText(record.input, ["path", "image_path"]);
+  const resultPath = nestedText(visualRef, ["path"]);
+  const displayPath = inputPath || resultPath;
+  const mime = nestedText(visualRef, ["mime"]);
+  const byteCount = nestedValue(visualRef, ["byte_count"]);
+  const sha256 = nestedText(visualRef, ["sha256"]);
+  const refId = nestedText(visualRef, ["id"]);
+
+  const observationObj = isRecord(result?.observation) ? result.observation : undefined;
+  const observationSummary = nestedText(observationObj, ["summary"]);
+  const generatedBy = isRecord(observationObj?.generated_by) ? observationObj.generated_by : undefined;
+  const genProvider = nestedText(generatedBy, ["provider"]);
+  const genModel = nestedText(generatedBy, ["model"]);
+  const genMode = nestedText(generatedBy, ["mode"]);
+  const ocrItems = arrayRecords(nestedValue(observationObj, ["ocr"]));
+  const elementItems = arrayRecords(nestedValue(observationObj, ["elements"]));
+  const uncertaintiesRaw = nestedValue(observationObj, ["uncertainties"]);
+  const uncertainties = Array.isArray(uncertaintiesRaw)
+    ? uncertaintiesRaw
+        .map((u) =>
+          typeof u === "string" ? u : nestedText(u, ["text", "description", "summary", "message"]),
+        )
+        .filter(Boolean)
+    : [];
   const summary = textField(result?.summary_text) || record.summary;
+
+  // Construct workspace URI for relative/absolute paths that aren't already workspace://
+  const imageUri = displayPath?.startsWith("workspace://")
+    ? displayPath
+    : displayPath && workspaceId
+      ? `workspace://${workspaceId}/${displayPath.replace(/^\/+/, "")}`
+      : displayPath;
 
   return (
     <>
-      <SimpleField label={t("inspector.path")} value={path} />
+      <SimpleField label={t("inspector.path")} value={displayPath} />
+      {refId ? <SimpleField label="ID" value={refId} /> : null}
+      {mime ? <SimpleField label={t("inspector.contentType")} value={mime} /> : null}
+      {byteCount != null ? (
+        <SimpleField label={t("inspector.bytesRead")} value={String(byteCount)} />
+      ) : null}
       {width != null && height != null ? <SimpleField label={t("inspector.dimensions")} value={`${width}×${height}`} /> : null}
-      {observation ? <OutputField label={t("inspector.observation")} value={observation} /> : null}
+      {sha256 ? <SimpleField label="SHA-256" value={sha256} /> : null}
+      {genProvider || genModel ? (
+        <SimpleField label={t("inspector.model")} value={[genProvider, genModel].filter(Boolean).join("/")} />
+      ) : null}
+      {genMode ? <SimpleField label={t("inspector.mode")} value={genMode} /> : null}
+      {observationSummary ? <OutputField label={t("inspector.observation")} value={observationSummary} /> : null}
+      {ocrItems.length > 0 ? (
+        <OutputField label="OCR" value={JSON.stringify(ocrItems, null, 2)} />
+      ) : null}
+      {elementItems.length > 0 ? (
+        <OutputField label="Elements" value={JSON.stringify(elementItems, null, 2)} />
+      ) : null}
+      {uncertainties.length > 0 ? (
+        <OutputField label="Uncertainties" value={uncertainties.join("; ")} />
+      ) : null}
       {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
-      {path ? <ImagePreview uri={String(path)} alt={observation ?? String(path)} /> : null}
+      {imageUri ? <ImagePreview uri={imageUri} alt={observationSummary ?? displayPath} /> : null}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
     </>
   );

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -709,6 +709,7 @@ const en = {
     executionRoot: "Execution root",
     projectionKind: "Projection",
     cwd: "Cwd",
+    model: "Model",
   },
 
   agent: {

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -693,6 +693,7 @@ const en = {
     unknownSource: "Unknown source",
     filter: "Filter",
     workItems: "Work items",
+    title: "Title",
     workItem: "Work item",
     total: "Total",
     objective: "Objective",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -711,6 +711,7 @@ const zh: Record<string, any> = {
     executionRoot: "执行根目录",
     projectionKind: "投影类型",
     cwd: "工作目录",
+    model: "模型",
   },
 
   agent: {

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -695,6 +695,7 @@ const zh: Record<string, any> = {
     unknownSource: "未知来源",
     filter: "筛选",
     workItems: "工作项",
+    title: "标题",
     workItem: "工作项",
     total: "总计",
     objective: "目标",

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -1106,8 +1106,9 @@ function projectMemorySearchTool(payload: Record<string, unknown> | undefined): 
 
 function projectMemoryGetTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
   const output = unwrapToolResult(payload);
-  const sourceRef = stringField(output, "source_ref") ?? firstStringField(asRecord(payload?.input), ["source_ref"]);
-  const content = stringField(output, "content");
+  const memory = asRecord(output.memory) ?? output;
+  const sourceRef = stringField(memory, "source_ref") ?? firstStringField(asRecord(payload?.input), ["source_ref"]);
+  const content = stringField(memory, "content");
   const body = compactJoin([
     "Memory get",
     sourceRef ? truncateText(sourceRef, 80) : undefined,

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -992,14 +992,16 @@ function projectWorkItemMutationTool(payload: Record<string, unknown> | undefine
 function projectViewImageTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
   const input = asRecord(payload?.input);
   const result = asRecord(payload?.view_image_result) ?? asRecord(payload?.result);
-  const dimensions = asRecord(result?.dimensions);
-  const width = numberField(result, "width") ?? numberField(dimensions, "width");
-  const height = numberField(result, "height") ?? numberField(dimensions, "height");
+  const visualRef = asRecord(result?.visual_reference);
+  const sizeInfo = asRecord(visualRef?.size);
+  const width = numberField(sizeInfo, "width");
+  const height = numberField(sizeInfo, "height");
   const imagePath =
     firstStringField(input, ["path", "image_path"]) ??
     firstStringField(payload, ["path", "image_path"]) ??
-    firstStringField(result, ["path", "image_path"]);
-  const observation = firstStringField(result, ["visual_observation", "observation", "text_preview"]);
+    firstStringField(visualRef, ["path", "image_path"]);
+  const observationObj = asRecord(result?.observation);
+  const observation = firstStringField(observationObj, ["summary"]) ?? firstStringField(result, ["visual_observation", "observation", "text_preview"]);
   const body = compactJoin([
     "Viewed image",
     imagePath ? basename(imagePath) : undefined,

--- a/web-gui/app/src/runtime/useAgentDetail.ts
+++ b/web-gui/app/src/runtime/useAgentDetail.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { useRuntimeStore } from "./runtime-store";
 import type { AgentDetail, DisplayLevel } from "./types";
@@ -21,10 +21,21 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
   useEffect(() => {
     if (!agentId) return;
     registerAgentForEvents(agentId);
+  }, [agentId, registerAgentForEvents]);
+
+  const prevDisplayLevelRef = useRef<DisplayLevel | undefined>(undefined);
+  useEffect(() => {
+    if (!agentId) return;
+    const prevLevel = prevDisplayLevelRef.current;
+    const levelRank: Record<DisplayLevel, number> = { info: 0, verbose: 1, debug: 2 };
+    const levelIncreased = prevLevel != null && levelRank[displayLevel] > levelRank[prevLevel];
     if (!detail || detail.error) {
       void refreshAgentDetail(agentId, displayLevel);
+    } else if (levelIncreased) {
+      void refreshAgentDetail(agentId, displayLevel);
     }
-  }, [agentId, detail, displayLevel, refreshAgentDetail, registerAgentForEvents]);
+    prevDisplayLevelRef.current = displayLevel;
+  }, [agentId, displayLevel, refreshAgentDetail, detail]);
 
   return { detail, loading, refresh };
 }

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -5515,6 +5515,108 @@ code {
   overflow-wrap: anywhere;
 }
 
+/* Shared tool detail components: link field, image preview, result cards */
+
+.tool-detail-link {
+  color: var(--accent, var(--blue, #4f9cf9));
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.tool-detail-link:hover {
+  text-decoration: underline;
+}
+
+.tool-detail-image-preview {
+  margin-top: 8px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+}
+
+.tool-detail-image-preview img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.tool-detail-result-card {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 80%, var(--page));
+}
+
+.tool-detail-result-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  font-size: 0.88rem;
+  flex-wrap: wrap;
+}
+
+.tool-detail-result-index {
+  color: var(--muted);
+  font-weight: 400;
+  min-width: 1.5em;
+}
+
+.tool-detail-result-source {
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.tool-detail-result-snippet {
+  margin: 4px 0 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.tool-detail-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 4px 12px;
+  margin-top: 6px;
+  font-size: 0.78rem;
+}
+
+.tool-detail-meta-grid dt {
+  color: var(--muted);
+}
+
+.tool-detail-meta-grid dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.tool-detail-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
+.tool-detail-badge--ok {
+  background: color-mix(in srgb, var(--green, #2ea043) 20%, transparent);
+  color: var(--green, #2ea043);
+}
+
+.tool-detail-badge--warn {
+  background: color-mix(in srgb, var(--yellow, #d29922) 20%, transparent);
+  color: var(--yellow, #d29922);
+}
+
+.tool-detail-badge--mute {
+  background: color-mix(in srgb, var(--muted) 20%, transparent);
+  color: var(--muted);
+}
+
 /* Batch item card */
 
 .tool-detail-batch-item {


### PR DESCRIPTION
## Summary
- add structured right-panel renderers for model/provider, Agent, memory, search, image, task, work item, and coordination tool results
- improve generic tool detail fallback so input/result/error/summary stay visible instead of blank details
- fix MemoryGet result unwrapping, ViewImage metadata/image preview rendering, and image-generation model setting updates

## Verification
- cd web-gui/app && npx tsc --noEmit
- right-panel renderer unit tests: 7 passed
- browser smoke checks for ExecCommand, ApplyPatch, TaskOutput, ListTasks, CreateWorkItem detail rendering
- cargo fmt --all -- --check
- cargo test runtime_mutable_config_keys_include_visual_model_defaults
