### PR TITLE
feat: resolve model capabilities by route

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -54,6 +54,7 @@ implementation and tests.
 - [Execution Policy and Virtual Execution Boundary](./execution-policy-and-virtual-execution-boundary.md)
 - [Runtime Configuration Surface](./runtime-configuration-surface.md)
 - [Extensible Model And Provider Configuration](./extensible-model-provider-configuration.md)
+- [Model Capability Resolution](./model-capability-resolution.md)
 
 ## Workspace And Instruction Surface
 

--- a/docs/rfcs/model-capability-resolution.md
+++ b/docs/rfcs/model-capability-resolution.md
@@ -1,0 +1,104 @@
+# Model Capability Resolution
+
+## Status
+
+Accepted for incremental implementation.
+
+## Problem
+
+Holon historically stored model capability booleans next to model metadata and
+used them directly for routing and UI projection. That shape conflates three
+different facts:
+
+1. what the model can intrinsically consume or produce;
+2. what a provider endpoint accepts for that model;
+3. what the selected Holon transport can encode and send.
+
+The conflation is most visible for image generation and reasoning controls. A
+text model may expose image generation through a hosted tool without producing
+images intrinsically, and a reasoning model may not accept a user-selected
+effort level on every endpoint.
+
+## Contract
+
+Capability resolution has three inputs:
+
+### Intrinsic model capabilities
+
+`ModelIntrinsicCapabilities` describes stable model properties:
+
+- input and output modalities;
+- reasoning behavior;
+- model-owned execution and tool-call properties.
+
+The canonical catalog owns this layer. Endpoint or transport facts must not be
+stored here.
+
+### Endpoint model policy
+
+`EndpointModelPolicy` describes the contract for one model on one endpoint:
+
+- accepted request parameters and their allowed values;
+- endpoint-specific limits;
+- availability and endpoint-specific restrictions.
+
+This layer is keyed by `ModelRouteRef`, not only by `ModelRef`.
+
+### Transport capabilities
+
+`TransportCapabilities` describes what a Holon transport implementation can
+encode. A model or endpoint declaration cannot enable behavior absent from the
+transport.
+
+### Resolved capabilities
+
+`ResolvedModelCapabilities` is the intersection used for routing and client
+projection. Routing must consume this resolved object instead of independently
+checking catalog booleans and transport kinds.
+
+`supported_parameters` remains a compatibility list of parameter names.
+`parameter_contracts` is the authoritative resolved contract and carries
+allowed values. Clients should migrate to the latter.
+
+## Reasoning
+
+Reasoning behavior and reasoning control are separate:
+
+- `none`: the model is not declared as a reasoning model;
+- `fixed`: reasoning behavior exists but has no user control;
+- `effort`: the endpoint accepts named effort levels;
+- `budget`: the endpoint accepts a token budget.
+
+During migration, the legacy `supports_reasoning` flag continues to project
+intrinsic `fixed` reasoning, while endpoint `reasoning_effort` options project
+an accepted parameter contract. Catalog calibration will move entries to the
+explicit representation without changing route identity.
+
+## Modalities
+
+Input and output modalities replace new uses of `image_input` and
+`image_generation`. The legacy booleans remain accepted during migration and
+project to `text` plus optional `image` modalities.
+
+Hosted image generation remains an endpoint/transport behavior. It must not be
+interpreted as proof that the text model intrinsically emits image bytes.
+
+## Migration boundary
+
+This RFC deliberately does not merge duplicate package-provider catalog
+entries. Canonical model identity and route-level metadata migration are a
+separate change:
+
+1. introduce and consume the resolved contract;
+2. migrate endpoint overrides and aliases;
+3. remove legacy booleans only after config and discovery compatibility no
+   longer depend on them.
+
+## Acceptance criteria
+
+- route selection uses one resolved capability object;
+- diagnostics expose intrinsic, endpoint, transport, and resolved facts;
+- parameter allowed values are available without client-side inference;
+- existing config and serialized compatibility fields continue to work;
+- tests cover a model capability rejected by transport and route-specific
+  reasoning effort values.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -204,6 +204,59 @@ impl ModelRouteCapability {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedModelCapabilities {
+    pub intrinsic: crate::model_catalog::ModelIntrinsicCapabilities,
+    pub endpoint: crate::model_catalog::EndpointModelPolicy,
+    pub transport: TransportCapabilities,
+    pub image_input: bool,
+    pub image_output: bool,
+}
+
+impl ResolvedModelCapabilities {
+    fn resolve(policy: &ResolvedRuntimeModelPolicy, transport: ProviderTransportKind) -> Self {
+        let intrinsic = policy.capabilities.intrinsic();
+        let endpoint = crate::model_catalog::EndpointModelPolicy {
+            accepted_parameters: resolved_parameter_contracts(policy),
+        };
+        let transport = transport.capabilities();
+        Self {
+            image_input: policy.capabilities.image_input && transport.image_input,
+            image_output: policy.capabilities.image_generation && transport.image_output,
+            intrinsic,
+            endpoint,
+            transport,
+        }
+    }
+
+    pub fn supports(&self, capability: ModelRouteCapability) -> bool {
+        match capability {
+            ModelRouteCapability::Turn => true,
+            ModelRouteCapability::VisionObservation => self.image_input,
+            ModelRouteCapability::ImageGeneration => self.image_output,
+        }
+    }
+}
+
+fn resolved_parameter_contracts(
+    policy: &ResolvedRuntimeModelPolicy,
+) -> Vec<crate::model_catalog::ModelParameterSupport> {
+    let mut parameters = Vec::new();
+    if !policy.reasoning_effort_options.is_empty() {
+        parameters.push(crate::model_catalog::ModelParameterSupport {
+            name: "reasoning_effort".to_string(),
+            allowed_values: policy.reasoning_effort_options.clone(),
+        });
+    }
+    if policy.max_output_tokens_upper_limit.is_some() || policy.runtime_max_output_tokens > 0 {
+        parameters.push(crate::model_catalog::ModelParameterSupport {
+            name: "max_output_tokens".to_string(),
+            allowed_values: Vec::new(),
+        });
+    }
+    parameters
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedProviderEndpointConfig {
     pub provider: ProviderId,
@@ -227,6 +280,7 @@ pub struct ResolvedModelRoute {
     pub model_ref: ModelRef,
     pub endpoint: ResolvedProviderEndpointConfig,
     pub policy: ResolvedRuntimeModelPolicy,
+    pub capabilities: ResolvedModelCapabilities,
     pub requested_capability: ModelRouteCapability,
 }
 
@@ -330,9 +384,9 @@ impl RuntimeModelCatalog {
             base_context_config,
             self.configured_runtime_max_output_tokens,
         );
-        if !requested_capability.model_supports(&policy)
-            || !requested_capability.transport_supports(endpoint.runtime_config.transport)
-        {
+        let capabilities =
+            ResolvedModelCapabilities::resolve(&policy, endpoint.runtime_config.transport);
+        if !capabilities.supports(requested_capability) {
             return None;
         }
         Some(ResolvedModelRoute {
@@ -340,6 +394,7 @@ impl RuntimeModelCatalog {
             model_ref: model_ref.clone(),
             endpoint: endpoint.clone(),
             policy,
+            capabilities,
             requested_capability,
         })
     }
@@ -362,9 +417,9 @@ impl RuntimeModelCatalog {
             base_context_config,
             self.configured_runtime_max_output_tokens,
         );
-        if !requested_capability.model_supports(&policy)
-            || !requested_capability.transport_supports(endpoint.runtime_config.transport)
-        {
+        let capabilities =
+            ResolvedModelCapabilities::resolve(&policy, endpoint.runtime_config.transport);
+        if !capabilities.supports(requested_capability) {
             return None;
         }
         Some(ResolvedModelRoute {
@@ -372,6 +427,7 @@ impl RuntimeModelCatalog {
             model_ref,
             endpoint: endpoint.clone(),
             policy,
+            capabilities,
             requested_capability,
         })
     }
@@ -1066,6 +1122,53 @@ pub(crate) fn parse_model_ref_list(raw_value: &str) -> Result<Vec<ModelRouteRef>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolved_capabilities_intersect_model_and_transport_image_output() {
+        let policy = ResolvedRuntimeModelPolicy {
+            capabilities: crate::model_catalog::ModelCapabilityFlags {
+                image_generation: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let capabilities =
+            ResolvedModelCapabilities::resolve(&policy, ProviderTransportKind::AnthropicMessages);
+
+        assert!(capabilities
+            .intrinsic
+            .output_modalities
+            .contains(&crate::model_catalog::ModelModality::Image));
+        assert!(!capabilities.transport.image_output);
+        assert!(!capabilities.image_output);
+        assert!(!capabilities.supports(ModelRouteCapability::ImageGeneration));
+    }
+
+    #[test]
+    fn resolved_capabilities_preserve_reasoning_effort_allowed_values() {
+        let policy = ResolvedRuntimeModelPolicy {
+            reasoning_effort_options: vec!["low".into(), "high".into()],
+            ..Default::default()
+        };
+
+        let capabilities =
+            ResolvedModelCapabilities::resolve(&policy, ProviderTransportKind::OpenAiResponses);
+
+        assert_eq!(
+            capabilities.endpoint.accepted_parameters,
+            vec![
+                crate::model_catalog::ModelParameterSupport {
+                    name: "reasoning_effort".into(),
+                    allowed_values: vec!["low".into(), "high".into()],
+                },
+                crate::model_catalog::ModelParameterSupport {
+                    name: "max_output_tokens".into(),
+                    allowed_values: Vec::new(),
+                },
+            ]
+        );
+    }
 
     #[test]
     fn model_route_ref_round_trips_model_ids_with_slashes() {

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -49,6 +49,12 @@ pub enum ProviderTransportKind {
     GeminiGenerateContent,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransportCapabilities {
+    pub image_input: bool,
+    pub image_output: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProviderId(String);
 
@@ -286,6 +292,13 @@ impl ProviderTransportKind {
             self,
             Self::OpenAiCodexResponses | Self::OpenAiResponses | Self::OpenAiChatCompletions
         )
+    }
+
+    pub fn capabilities(self) -> TransportCapabilities {
+        TransportCapabilities {
+            image_input: self.supports_view_image_observation_generation(),
+            image_output: self.supports_image_generation(),
+        }
     }
 }
 

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -41,6 +41,68 @@ pub struct ModelCapabilityFlags {
     pub interactive_exec: bool,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelModality {
+    Text,
+    Image,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelReasoningCapability {
+    None,
+    Fixed,
+    Effort,
+    Budget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelIntrinsicCapabilities {
+    pub input_modalities: Vec<ModelModality>,
+    pub output_modalities: Vec<ModelModality>,
+    pub reasoning: ModelReasoningCapability,
+    pub parallel_tool_calls: bool,
+    pub interactive_exec: bool,
+}
+
+impl ModelCapabilityFlags {
+    pub fn intrinsic(&self) -> ModelIntrinsicCapabilities {
+        let mut input_modalities = vec![ModelModality::Text];
+        if self.image_input {
+            input_modalities.push(ModelModality::Image);
+        }
+        let mut output_modalities = vec![ModelModality::Text];
+        if self.image_generation {
+            output_modalities.push(ModelModality::Image);
+        }
+        ModelIntrinsicCapabilities {
+            input_modalities,
+            output_modalities,
+            reasoning: if self.supports_reasoning {
+                ModelReasoningCapability::Fixed
+            } else {
+                ModelReasoningCapability::None
+            },
+            parallel_tool_calls: self.parallel_tool_calls,
+            interactive_exec: self.interactive_exec,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelParameterSupport {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct EndpointModelPolicy {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_parameters: Vec<ModelParameterSupport>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ModelCapabilityOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -294,6 +294,11 @@ pub(crate) fn provider_models_from_availability_for_runtime(
                 selectable: model.available,
                 unavailable_reason: model.unavailable_reason,
                 metadata_source: model.metadata_source,
+                parameter_contracts: model
+                    .resolved_capabilities
+                    .as_ref()
+                    .map(|capabilities| capabilities.endpoint.accepted_parameters.clone())
+                    .unwrap_or_default(),
                 supported_parameters,
                 policy: model.policy,
                 policy_notes: Vec::new(),
@@ -362,6 +367,7 @@ fn resolved_model_availability_entry(
         availability_failure_reason
     };
 
+    let resolved_capabilities = route.as_ref().map(|route| route.capabilities.clone());
     ResolvedModelAvailability {
         model: model_ref.as_string(),
         provider: model_ref.provider.as_str().to_string(),
@@ -387,6 +393,7 @@ fn resolved_model_availability_entry(
         available,
         unavailable_reason,
         policy,
+        resolved_capabilities,
     }
 }
 
@@ -730,6 +737,15 @@ mod tests {
             .supported_parameters
             .iter()
             .any(|parameter| parameter == "max_output_tokens"));
+        let reasoning_effort = openai
+            .parameter_contracts
+            .iter()
+            .find(|parameter| parameter.name == "reasoning_effort")
+            .expect("resolved reasoning effort contract");
+        assert_eq!(
+            reasoning_effort.allowed_values,
+            vec!["low", "medium", "high", "xhigh"]
+        );
     }
 
     #[test]

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -151,6 +151,7 @@ mod tests {
             unavailable_reason: None,
             metadata_source: "test".to_string(),
             policy,
+            parameter_contracts: Vec::new(),
             supported_parameters: Vec::new(),
             policy_notes: Vec::new(),
         }

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -290,6 +290,7 @@ mod tests {
             available,
             unavailable_reason: (!available).then_some("credential_missing".into()),
             policy: policy(model, display_name, reasoning),
+            resolved_capabilities: None,
         }
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -332,6 +332,7 @@ fn sample_model_availability(
                 .unwrap_or_default(),
             source: crate::model_catalog::ModelMetadataSource::RemoteDiscovered,
         },
+        resolved_capabilities: None,
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4777,6 +4777,8 @@ pub struct ResolvedModelAvailability {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unavailable_reason: Option<String>,
     pub policy: ResolvedRuntimeModelPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_capabilities: Option<crate::config::ResolvedModelCapabilities>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -4836,6 +4838,8 @@ pub struct ProviderModelEntry {
     pub unavailable_reason: Option<String>,
     pub metadata_source: String,
     pub policy: ResolvedRuntimeModelPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameter_contracts: Vec<crate::model_catalog::ModelParameterSupport>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub supported_parameters: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary
- define intrinsic model, endpoint policy, and transport support as separate capability layers
- resolve route capabilities and supported parameters from the intersection of all three layers
- add provider-neutral reasoning control and input/output modality contracts while preserving compatibility projections
- expose the resolved contract through diagnostics, model listing, and the TUI model picker
- document the contract and migration boundary in a focused RFC

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
