### PR TITLE
fix: unify visual model auto defaults

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1802,7 +1802,10 @@
                 "type": "boolean"
               },
               "image_generation_default": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "max_tool_output_tokens": {
                 "format": "uint32",
@@ -1982,7 +1985,6 @@
             "required": [
               "model_default",
               "model_fallbacks",
-              "image_generation_default",
               "model_catalog",
               "unknown_model_fallback_configured",
               "runtime_max_output_tokens",
@@ -2083,7 +2085,10 @@
                 "type": "boolean"
               },
               "image_generation_default": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "max_tool_output_tokens": {
                 "format": "uint32",
@@ -2263,7 +2268,6 @@
             "required": [
               "model_default",
               "model_fallbacks",
-              "image_generation_default",
               "model_catalog",
               "unknown_model_fallback_configured",
               "runtime_max_output_tokens",

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -71,18 +71,18 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         },
         ConfigSchemaEntry {
             key: "vision.default",
-            kind: "model_route_ref",
+            kind: "model_route_ref_or_auto",
             description:
-                "Explicit provider@endpoint/model route ref for ViewImage visual observation generation. Legacy provider/model input remains accepted. When unset, ViewImage auto-discovers an authenticated image-capable provider and keeps model.fallbacks only as a compatibility candidate source.",
+                "Explicit provider@endpoint/model route ref for ViewImage visual observation generation. Legacy provider/model input remains accepted. Null, unset, or the legacy auto alias lets ViewImage auto-discover an authenticated image-capable provider and keeps model.fallbacks only as a compatibility candidate source.",
             default: Value::Null,
-            allowed_values: vec![],
+            allowed_values: vec!["auto"],
         },
         ConfigSchemaEntry {
             key: "image_generation.default",
             kind: "model_route_ref_or_auto",
             description:
-                "Provider@endpoint/model route ref for GenerateImage. Legacy provider/model input remains accepted. The default auto mode selects the first configured turn model that supports image_generation.",
-            default: json!("auto"),
+                "Provider@endpoint/model route ref for GenerateImage. Legacy provider/model input and the legacy auto alias remain accepted. Null or unset selects the first configured turn model that supports image_generation.",
+            default: Value::Null,
             allowed_values: vec!["auto"],
         },
         ConfigSchemaEntry {
@@ -616,7 +616,7 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .default
             .as_ref()
             .map(|value| Value::String(value.clone()))
-            .unwrap_or_else(|| json!("auto"))),
+            .unwrap_or(Value::Null)),
         "models.catalog" => Ok(serde_json::to_value(&config.models.catalog)?),
         "model.unknown_fallback" => Ok(config
             .model
@@ -911,8 +911,12 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 .collect();
         }
         "vision.default" => {
-            let parsed = ModelRouteRef::parse_compatible(raw_value)?;
-            config.vision.default = Some(parsed.as_string());
+            if raw_value.trim().eq_ignore_ascii_case("auto") {
+                config.vision.default = None;
+            } else {
+                let parsed = ModelRouteRef::parse_compatible(raw_value)?;
+                config.vision.default = Some(parsed.as_string());
+            }
         }
         "image_generation.default" => {
             if raw_value.trim().eq_ignore_ascii_case("auto") {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2761,13 +2761,21 @@ fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
 }
 
 #[test]
-fn image_generation_config_defaults_to_auto() {
+fn visual_model_defaults_use_null_for_auto() {
     let mut config = HolonConfigFile::default();
 
     assert_eq!(
-        get_config_key(&config, "image_generation.default").unwrap(),
-        json!("auto")
+        get_config_key(&config, "vision.default").unwrap(),
+        Value::Null
     );
+    assert_eq!(
+        get_config_key(&config, "image_generation.default").unwrap(),
+        Value::Null
+    );
+
+    set_config_key(&mut config, "vision.default", "auto").unwrap();
+    assert!(config.vision.default.is_none());
+    assert!(config.vision.is_empty());
 
     set_config_key(&mut config, "image_generation.default", "auto").unwrap();
     assert!(config.image_generation.default.is_none());
@@ -2797,7 +2805,7 @@ fn image_generation_config_accepts_explicit_model_ref() {
     unset_config_key(&mut config, "image_generation.default").unwrap();
     assert_eq!(
         get_config_key(&config, "image_generation.default").unwrap(),
-        json!("auto")
+        Value::Null
     );
 }
 

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -83,7 +83,7 @@ pub struct RuntimeConfigSurface {
     pub model_default: String,
     pub model_fallbacks: Vec<String>,
     pub vision_default: Option<String>,
-    pub image_generation_default: String,
+    pub image_generation_default: Option<String>,
     pub model_catalog: Vec<String>,
     pub unknown_model_fallback_configured: bool,
     pub runtime_max_output_tokens: u32,
@@ -150,8 +150,7 @@ impl RuntimeConfigSurface {
             image_generation_default: config
                 .image_generation_model
                 .as_ref()
-                .map(|value| value.as_string())
-                .unwrap_or_else(|| "auto".to_string()),
+                .map(|value| value.as_string()),
             model_catalog,
             unknown_model_fallback_configured: config.validated_unknown_model_fallback.is_some(),
             runtime_max_output_tokens: config.runtime_max_output_tokens,

--- a/src/model_config_migration.rs
+++ b/src/model_config_migration.rs
@@ -151,6 +151,23 @@ fn inspect_optional_route(
     allow_auto: bool,
     report: &mut ModelConfigMigrationStoreReport,
 ) {
+    if allow_auto
+        && value
+            .as_deref()
+            .is_some_and(|current| current.trim().eq_ignore_ascii_case("auto"))
+    {
+        let current = value.take().unwrap_or_default();
+        report.changed = true;
+        report.fields.push(ModelConfigMigrationField {
+            location: location.to_string(),
+            status: ModelConfigMigrationStatus::Legacy,
+            current,
+            proposed: Some("<unset>".into()),
+            error: None,
+        });
+        return;
+    }
+
     if let Some(value) = value {
         inspect_route_value(location.to_string(), value, allow_auto, report);
     }
@@ -485,7 +502,7 @@ mod tests {
                 canonical("volcengine/doubao-seedream-5.0-lite"),
             ]
         );
-        assert_eq!(migrated.image_generation.default.as_deref(), Some("auto"));
+        assert!(migrated.image_generation.default.is_none());
         let agent: Value = serde_json::from_str(&fixture.agent_payload("agent-a")?)?;
         let expected_agent = canonical("volcengine/doubao-seedream-5.0-lite");
         for field in AGENT_MODEL_ROUTE_FIELDS {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -3064,7 +3064,7 @@ mod tests {
             model_default: "anthropic/claude-sonnet-4-6".into(),
             model_fallbacks: Vec::new(),
             vision_default: None,
-            image_generation_default: "auto".into(),
+            image_generation_default: None,
             model_catalog: Vec::new(),
             unknown_model_fallback_configured: false,
             runtime_max_output_tokens: 8192,

--- a/web-gui/app/src/features/settings/SettingsPage.test.ts
+++ b/web-gui/app/src/features/settings/SettingsPage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildImageGenerationConfigUpdates,
   buildSearchProviderConfigUpdates,
   buildVisionConfigUpdates,
   sortProvidersForSettings,
@@ -67,6 +68,18 @@ describe("buildVisionConfigUpdates", () => {
 
   it("unsets Vision default when left empty for auto-discovery", () => {
     expect(buildVisionConfigUpdates("   ")).toEqual([{ key: "vision.default", unset: true }]);
+  });
+});
+
+describe("buildImageGenerationConfigUpdates", () => {
+  it("persists a trimmed image generation default model", () => {
+    expect(buildImageGenerationConfigUpdates(" openai/gpt-image-1 ")).toEqual([
+      { key: "image_generation.default", value: "openai/gpt-image-1" },
+    ]);
+  });
+
+  it("unsets image generation default when left empty for auto-selection", () => {
+    expect(buildImageGenerationConfigUpdates("   ")).toEqual([{ key: "image_generation.default", unset: true }]);
   });
 });
 

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -461,7 +461,7 @@ const en = {
     apiKeyRemoved: "API key removed from credential store.",
     apiKeySaved: "API key saved to credential store.",
     visionAutoDiscoverHint: "Leave empty to let ViewImage auto-discover an authenticated image-capable model.",
-    imageGenAutoDiscoverHint: "Use \"auto\" to let GenerateImage select the first configured model that supports image generation.",
+    imageGenAutoDiscoverHint: "Leave empty to let GenerateImage select the first configured model that supports image generation. The legacy \"auto\" alias is still accepted.",
     modelCatalogDesc: "The editable provider accounts above are the primary configuration surface. Use this catalog only to inspect runtime model availability.",
     confirmRemoveSearchProvider: "Remove {{provider}} from web.providers in config.json? This does not delete credentials.",
     confirmRemoveProvider: "Remove {{provider}} from config.json? This only removes persisted provider config; it does not delete credentials or disable built-in provider defaults.",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -463,7 +463,7 @@ const zh: Record<string, any> = {
     apiKeyRemoved: "API 密钥已从凭证存储中删除。",
     apiKeySaved: "API 密钥已保存到凭证存储。",
     visionAutoDiscoverHint: "留空则让 ViewImage 自动发现已认证的图像模型。",
-    imageGenAutoDiscoverHint: "使用 \"auto\" 让 GenerateImage 自动选择第一个支持图像生成的已配置模型。",
+    imageGenAutoDiscoverHint: "留空则让 GenerateImage 自动选择第一个支持图像生成的已配置模型；仍兼容旧的 \"auto\" 别名。",
     modelCatalogDesc: "上方的可编辑提供商账户是主要配置入口。此目录仅用于查看运行时模型可用性。",
     confirmRemoveSearchProvider: "从 config.json 的 web.providers 中移除 {{provider}}？此操作不会删除凭证。",
     confirmRemoveProvider: "从 config.json 中移除 {{provider}}？此操作仅移除持久化的提供商配置；不会删除凭证或禁用内置提供商默认值。",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -439,7 +439,7 @@ interface RuntimeConfigSurfaceDto {
   model_default?: string;
   model_fallbacks?: string[];
   vision_default?: string | null;
-  image_generation_default?: string;
+  image_generation_default?: string | null;
   model_catalog?: string[];
   unknown_model_fallback_configured?: boolean;
   runtime_max_output_tokens?: number;
@@ -1740,7 +1740,7 @@ function projectRuntimeConfigSurface(surface: RuntimeConfigSurfaceDto): RuntimeC
     modelDefault: surface.model_default ?? "",
     modelFallbacks: surface.model_fallbacks ?? [],
     visionDefault: surface.vision_default ?? undefined,
-    imageGenerationDefault: surface.image_generation_default ?? "auto",
+    imageGenerationDefault: surface.image_generation_default ?? undefined,
     modelCatalog: surface.model_catalog ?? [],
     unknownModelFallbackConfigured: surface.unknown_model_fallback_configured ?? false,
     defaultToolOutputTokens: surface.default_tool_output_tokens ?? 0,

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -284,7 +284,7 @@ export interface RuntimeConfigSurface {
   modelDefault: string;
   modelFallbacks: string[];
   visionDefault?: string;
-  imageGenerationDefault: string;
+  imageGenerationDefault?: string;
   modelCatalog: string[];
   unknownModelFallbackConfigured: boolean;
   defaultToolOutputTokens: number;


### PR DESCRIPTION
## Summary
- make vision.default and image_generation.default both expose null/empty as the canonical auto mode
- keep the legacy "auto" alias accepted for compatibility
- update Settings UI hints/types/tests so image generation can be left empty for auto-selection

## Verification
- cargo fmt --all -- --check
- cargo test visual_model_defaults_use_null_for_auto
- cd web-gui/app && npx tsc --noEmit
- cd web-gui/app && npx vitest run src/features/settings/SettingsPage.test.ts