### PR TITLE
feat: canonicalize model catalog routes

### DIFF
--- a/docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md
+++ b/docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md
@@ -1,28 +1,34 @@
-# Canonical Model Ref with Legacy Alias
+# Canonical Model Catalog with Route Metadata
 
 ## Choice
 
-Built-in image generation models that belong to a multi-endpoint provider
-(e.g. Volcengine Seedream under the `image-openai` endpoint) are now cataloged
-under their **canonical provider id** (`volcengine`) with an explicit `endpoint`
-field, instead of under the legacy flattened provider id
-(`volcengine-image-openai`).
+Built-in models are cataloged once under their **canonical provider id**.
+Endpoint- and plan-specific availability, limits, capabilities, and preferred
+selection are indexed separately by `ModelRouteRef` (`provider@endpoint/model`).
+This applies both to image routes such as Volcengine `image-openai` and to
+flattened plan providers such as `volcengine-agent`,
+`dashscope-token-plan`, and `xiaomi-token-plan`.
 
 A legacy alias map (`BuiltInModelCatalog::legacy_aliases`) transparently
 resolves old model refs like `volcengine-image-openai/doubao-seedream-5.0-lite`
-to the canonical form `volcengine/doubao-seedream-5.0-lite` inside
-`resolve_model_route`, so existing user configs continue to work without
-manual migration.
+to the canonical form `volcengine/doubao-seedream-5.0-lite`. Catalog
+construction also derives aliases for flattened built-in provider ids, while
+preserving their exact endpoint as a route. Existing user configs therefore
+continue to resolve without manual migration.
 
 ## Reason
 
-The catalog, docgen, and settings UI should all present one canonical
-provider identity. Keeping the legacy id as a separate catalog entry created
-provider sprawl and made the three-column (provider / endpoint / legacy)
-identity visible only in docs, not in the runtime model ref itself.
+The catalog, diagnostics, and settings surfaces should present one canonical
+model identity. Keeping plan or endpoint ids as separate catalog providers
+duplicates intrinsic model metadata and can silently mix route-specific limits
+when the same model is available through multiple endpoints. Separate route
+metadata keeps model identity stable while retaining exact transport and plan
+contracts.
 
 ## Preserved boundary
 
 Legacy provider ids remain valid as configuration keys and as model ref input;
-they are normalized to canonical form at route resolution time. No user-facing
-breaking change; old configs work unchanged.
+they are normalized to canonical form at route resolution time. Explicit route
+selection continues to use `provider@endpoint/model`, and legacy implicit
+selection uses the catalog's preferred route for that provider or model. No
+user-facing breaking change; old configs and selectable routes work unchanged.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -10,9 +10,15 @@ pub(crate) fn authenticated_model_route_candidates(
     providers: &ProviderRegistry,
     model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
 ) -> Vec<ModelRouteRef> {
-    authenticated_model_candidates(providers, model_overrides)
-        .iter()
-        .map(ModelRouteRef::from_legacy_model_ref)
+    let catalog = BuiltInModelCatalog::default();
+    authenticated_provider_ids(providers)
+        .into_iter()
+        .filter_map(|provider| {
+            catalog.preferred_route_for_provider(&provider).or_else(|| {
+                preferred_override_model_for_provider(&provider, model_overrides)
+                    .map(|model_ref| ModelRouteRef::from_legacy_model_ref(&model_ref))
+            })
+        })
         .collect()
 }
 
@@ -139,8 +145,8 @@ impl ModelRouteRef {
             route_endpoint
         } else {
             catalog
-                .get(&model_ref)
-                .and_then(|metadata| metadata.endpoint.clone())
+                .preferred_route_for_model(&model_ref)
+                .map(|route| route.endpoint)
                 .unwrap_or(route_endpoint)
         };
         Self::new(route_provider, endpoint, model_ref.model)
@@ -376,8 +382,8 @@ impl RuntimeModelCatalog {
             model_ref.model.clone(),
         );
 
-        let policy = self.built_in_catalog.resolve_policy(
-            model_ref,
+        let policy = self.built_in_catalog.resolve_route_policy(
+            &route_ref,
             &self.model_overrides,
             &self.discovered_models,
             self.unknown_model_fallback.as_ref(),
@@ -405,12 +411,20 @@ impl RuntimeModelCatalog {
         route_ref: &ModelRouteRef,
         requested_capability: ModelRouteCapability,
     ) -> Option<ResolvedModelRoute> {
-        let model_ref = route_ref.model_ref();
+        let canonical_model_ref = self
+            .built_in_catalog
+            .canonicalize_model_ref(&route_ref.model_ref());
+        let canonical_route_ref = ModelRouteRef::new(
+            route_ref.provider.clone(),
+            route_ref.endpoint.clone(),
+            canonical_model_ref.model.clone(),
+        );
         let endpoint = self.provider_endpoints.values().find(|endpoint| {
-            endpoint.provider == route_ref.provider && endpoint.endpoint == route_ref.endpoint
+            endpoint.provider == canonical_route_ref.provider
+                && endpoint.endpoint == canonical_route_ref.endpoint
         })?;
-        let policy = self.built_in_catalog.resolve_policy(
-            &model_ref,
+        let policy = self.built_in_catalog.resolve_route_policy(
+            &canonical_route_ref,
             &self.model_overrides,
             &self.discovered_models,
             self.unknown_model_fallback.as_ref(),
@@ -423,8 +437,8 @@ impl RuntimeModelCatalog {
             return None;
         }
         Some(ResolvedModelRoute {
-            route_ref: route_ref.clone(),
-            model_ref,
+            route_ref: canonical_route_ref,
+            model_ref: canonical_model_ref,
             endpoint: endpoint.clone(),
             policy,
             capabilities,
@@ -433,22 +447,22 @@ impl RuntimeModelCatalog {
     }
 
     /// Resolve the provider endpoint config for a (possibly canonical) model ref.
-    /// Uses the model metadata's endpoint field when available to find the
-    /// correct endpoint among multiple endpoints under the same canonical provider.
+    /// Uses the canonical model's preferred route when available to find the
+    /// correct endpoint among multiple endpoints under the same provider.
     fn resolve_endpoint_for_model(
         &self,
         model_ref: &ModelRef,
     ) -> Option<&ResolvedProviderEndpointConfig> {
         let model_endpoint = self
             .built_in_catalog
-            .get(model_ref)
-            .and_then(|metadata| metadata.endpoint.as_ref());
+            .preferred_route_for_model(model_ref)
+            .map(|route| route.endpoint);
         match model_endpoint {
             // Model declares a specific non-default endpoint: find by (provider, endpoint)
             Some(endpoint) => self
                 .provider_endpoints
                 .values()
-                .find(|e| e.provider == model_ref.provider && &e.endpoint == endpoint),
+                .find(|e| e.provider == model_ref.provider && e.endpoint == endpoint),
             // Default endpoint or no catalog metadata: direct key lookup
             None => self.provider_endpoints.get(&model_ref.provider),
         }
@@ -498,9 +512,9 @@ impl RuntimeModelCatalog {
         base_context_config: &ContextConfig,
         model_override: Option<&ModelRouteRef>,
     ) -> ResolvedRuntimeModelPolicy {
-        let model_ref = self.effective_model(model_override).model_ref();
-        self.built_in_catalog.resolve_policy(
-            &model_ref,
+        let route_ref = self.effective_model(model_override);
+        self.built_in_catalog.resolve_route_policy(
+            &route_ref,
             &self.model_overrides,
             &self.discovered_models,
             self.unknown_model_fallback.as_ref(),
@@ -995,11 +1009,7 @@ pub(crate) fn resolve_vision_model(
     Ok(None)
 }
 
-pub(crate) fn authenticated_model_candidates(
-    providers: &ProviderRegistry,
-    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
-) -> Vec<ModelRef> {
-    let catalog = BuiltInModelCatalog::default();
+fn authenticated_provider_ids(providers: &ProviderRegistry) -> Vec<ProviderId> {
     let mut provider_ids = providers
         .values()
         .filter(|provider| provider_has_usable_auth(provider))
@@ -1011,16 +1021,7 @@ pub(crate) fn authenticated_model_candidates(
             .then_with(|| left.as_str().cmp(right.as_str()))
     });
 
-    let mut candidates = provider_ids
-        .into_iter()
-        .filter_map(|provider| {
-            catalog
-                .preferred_model_for_provider(&provider)
-                .or_else(|| preferred_override_model_for_provider(&provider, model_overrides))
-        })
-        .collect::<Vec<_>>();
-    candidates.dedup();
-    candidates
+    provider_ids
 }
 
 pub(crate) fn provider_has_usable_auth(provider: &ProviderRuntimeConfig) -> bool {

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{ModelRef, ProviderEndpointId, ProviderId};
+use crate::config::{
+    built_in_provider_endpoint_identity, ModelRef, ModelRouteRef, ProviderEndpointId, ProviderId,
+};
 use crate::context::ContextConfig;
 
 const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 95;
@@ -300,6 +302,9 @@ impl Default for ResolvedRuntimeModelPolicy {
 pub struct BuiltInModelCatalog {
     entries: HashMap<ModelRef, BuiltInModelMetadata>,
     preferred_models: HashMap<ProviderId, ModelRef>,
+    route_entries: HashMap<ModelRouteRef, BuiltInModelMetadata>,
+    preferred_routes: HashMap<ProviderId, ModelRouteRef>,
+    preferred_routes_by_model: HashMap<ModelRef, ModelRouteRef>,
     aliases: HashMap<ModelRef, ModelRef>,
 }
 
@@ -307,18 +312,60 @@ impl BuiltInModelCatalog {
     pub fn new() -> Self {
         let mut entries = HashMap::new();
         let mut preferred_models = HashMap::new();
-        let aliases = Self::legacy_aliases();
-        for entry in built_in_entries() {
+        let mut route_entries = HashMap::new();
+        let mut preferred_routes = HashMap::new();
+        let mut preferred_routes_by_model = HashMap::new();
+        let mut aliases = Self::legacy_aliases();
+        for mut entry in built_in_entries() {
+            let legacy_model_ref = entry.model_ref.clone();
+            let (provider, provider_endpoint) =
+                built_in_provider_endpoint_identity(&legacy_model_ref.provider)
+                    .expect("built-in provider identity must be valid");
+            let endpoint = if provider_endpoint == ProviderEndpointId::default_endpoint() {
+                entry
+                    .endpoint
+                    .clone()
+                    .unwrap_or_else(ProviderEndpointId::default_endpoint)
+            } else {
+                provider_endpoint
+            };
+            let canonical_model_ref = ModelRef::new(provider.clone(), &legacy_model_ref.model);
+            let route_ref =
+                ModelRouteRef::new(provider, endpoint, canonical_model_ref.model.clone());
+            if legacy_model_ref != canonical_model_ref {
+                aliases.insert(legacy_model_ref.clone(), canonical_model_ref.clone());
+            }
             if is_turn_default_candidate(&entry) {
                 preferred_models
-                    .entry(entry.model_ref.provider.clone())
-                    .or_insert_with(|| entry.model_ref.clone());
+                    .entry(legacy_model_ref.provider.clone())
+                    .or_insert_with(|| canonical_model_ref.clone());
+                preferred_routes
+                    .entry(legacy_model_ref.provider)
+                    .or_insert_with(|| route_ref.clone());
             }
-            entries.entry(entry.model_ref.clone()).or_insert(entry);
+            entry.model_ref = canonical_model_ref.clone();
+            entry.endpoint = None;
+            route_entries
+                .entry(route_ref.clone())
+                .or_insert_with(|| entry.clone());
+            preferred_routes_by_model
+                .entry(canonical_model_ref.clone())
+                .and_modify(|preferred: &mut ModelRouteRef| {
+                    if preferred.endpoint != ProviderEndpointId::default_endpoint()
+                        && route_ref.endpoint == ProviderEndpointId::default_endpoint()
+                    {
+                        *preferred = route_ref.clone();
+                    }
+                })
+                .or_insert(route_ref);
+            entries.entry(canonical_model_ref).or_insert(entry);
         }
         Self {
             entries,
             preferred_models,
+            route_entries,
+            preferred_routes,
+            preferred_routes_by_model,
             aliases,
         }
     }
@@ -350,6 +397,10 @@ impl BuiltInModelCatalog {
             ModelRef::new(provider_id("dashscope-token-plan"), "qwen-3.7"),
             ModelRef::new(provider_id("dashscope"), "qwen3.7-max"),
         );
+        aliases.insert(
+            ModelRef::new(provider_id("dashscope"), "qwen-3.7"),
+            ModelRef::new(provider_id("dashscope"), "qwen3.7-max"),
+        );
         aliases
     }
 
@@ -367,6 +418,40 @@ impl BuiltInModelCatalog {
         self.preferred_models.get(provider).cloned()
     }
 
+    pub fn preferred_route_for_provider(&self, provider: &ProviderId) -> Option<ModelRouteRef> {
+        self.preferred_routes.get(provider).cloned()
+    }
+
+    pub fn preferred_route_for_model(&self, model_ref: &ModelRef) -> Option<ModelRouteRef> {
+        self.preferred_routes_by_model.get(model_ref).cloned()
+    }
+
+    pub fn get_route(&self, route_ref: &ModelRouteRef) -> Option<&BuiltInModelMetadata> {
+        self.route_entries.get(route_ref)
+    }
+
+    pub fn resolve_route_policy(
+        &self,
+        route_ref: &ModelRouteRef,
+        overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+        discovered_models: &HashMap<ModelRef, BuiltInModelMetadata>,
+        unknown_fallback: Option<&ModelRuntimeOverride>,
+        base_context_config: &ContextConfig,
+        configured_runtime_max_output_tokens: u32,
+    ) -> ResolvedRuntimeModelPolicy {
+        let model_ref = route_ref.model_ref();
+        self.resolve_policy_with_builtin(
+            &model_ref,
+            self.route_entries.get(route_ref),
+            overrides,
+            discovered_models,
+            unknown_fallback,
+            base_context_config,
+            configured_runtime_max_output_tokens,
+            Some(&route_ref.endpoint),
+        )
+    }
+
     pub fn resolve_policy(
         &self,
         model_ref: &ModelRef,
@@ -376,8 +461,32 @@ impl BuiltInModelCatalog {
         base_context_config: &ContextConfig,
         configured_runtime_max_output_tokens: u32,
     ) -> ResolvedRuntimeModelPolicy {
+        self.resolve_policy_with_builtin(
+            model_ref,
+            self.get(model_ref),
+            overrides,
+            discovered_models,
+            unknown_fallback,
+            base_context_config,
+            configured_runtime_max_output_tokens,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_policy_with_builtin(
+        &self,
+        model_ref: &ModelRef,
+        route_builtin: Option<&BuiltInModelMetadata>,
+        overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+        discovered_models: &HashMap<ModelRef, BuiltInModelMetadata>,
+        unknown_fallback: Option<&ModelRuntimeOverride>,
+        base_context_config: &ContextConfig,
+        configured_runtime_max_output_tokens: u32,
+        endpoint: Option<&ProviderEndpointId>,
+    ) -> ResolvedRuntimeModelPolicy {
         let discovered = discovered_models.get(model_ref);
-        let built_in = discovered.or_else(|| self.get(model_ref));
+        let built_in = discovered.or(route_builtin);
         let override_config = overrides.get(model_ref);
         let fallback_override = if built_in.is_none() {
             unknown_fallback
@@ -500,7 +609,7 @@ impl BuiltInModelCatalog {
         {
             override_capabilities.apply_to(&mut capabilities);
         }
-        let reasoning_effort_options = reasoning_effort_options(model_ref, &capabilities);
+        let reasoning_effort_options = reasoning_effort_options(model_ref, endpoint, &capabilities);
 
         ResolvedRuntimeModelPolicy {
             model_ref: model_ref.clone(),
@@ -581,6 +690,7 @@ fn provider_id(provider: &str) -> ProviderId {
 
 fn reasoning_effort_options(
     model_ref: &ModelRef,
+    endpoint: Option<&ProviderEndpointId>,
     capabilities: &ModelCapabilityFlags,
 ) -> Vec<String> {
     if !capabilities.supports_reasoning {
@@ -589,8 +699,10 @@ fn reasoning_effort_options(
 
     let options = match model_ref.provider.as_str() {
         "openai" | "openai-codex" => &["low", "medium", "high", "xhigh"][..],
-        "volcengine" | "volcengine-agent" | "volcengine-coding"
-            if !matches!(model_ref.model.as_str(), "kimi-k2.6" | "kimi-k2.7-code") =>
+        "volcengine"
+            if endpoint.is_none_or(|endpoint| {
+                matches!(endpoint.as_str(), "default" | "coding" | "plan")
+            }) && !matches!(model_ref.model.as_str(), "kimi-k2.6" | "kimi-k2.7-code") =>
         {
             &["low", "medium", "high"][..]
         }
@@ -3118,7 +3230,7 @@ mod tests {
     }
 
     #[test]
-    fn dashscope_plan_providers_have_separate_exact_model_catalogs() {
+    fn dashscope_plan_providers_share_canonical_models_with_exact_routes() {
         let catalog = BuiltInModelCatalog::new();
 
         assert_eq!(
@@ -3126,41 +3238,43 @@ mod tests {
                 .preferred_model_for_provider(&ProviderId::parse("dashscope-token-plan").unwrap())
                 .unwrap()
                 .as_string(),
-            "dashscope-token-plan/qwen3.7-max"
+            "dashscope/qwen3.7-max"
         );
         assert_eq!(
             catalog
                 .preferred_model_for_provider(&ProviderId::parse("dashscope-coding-plan").unwrap())
                 .unwrap()
                 .as_string(),
-            "dashscope-coding-plan/qwen3.7-plus"
+            "dashscope/qwen3.7-plus"
         );
 
-        for model_ref in [
-            "dashscope-token-plan/qwen3.7-max",
-            "dashscope-token-plan/kimi-k2.7-code",
-            "dashscope-token-plan/glm-5.2",
-            "dashscope-token-plan/MiniMax-M2.5",
-            "dashscope-coding-plan/qwen3-coder-plus",
-            "dashscope-coding-plan/glm-5",
-            "dashscope-coding-plan/kimi-k2.5",
-            "dashscope-coding-plan/MiniMax-M2.5",
+        for route_ref in [
+            "dashscope@token-plan/qwen3.7-max",
+            "dashscope@token-plan/kimi-k2.7-code",
+            "dashscope@token-plan/glm-5.2",
+            "dashscope@token-plan/MiniMax-M2.5",
+            "dashscope@coding-plan/qwen3-coder-plus",
+            "dashscope@coding-plan/glm-5",
+            "dashscope@coding-plan/kimi-k2.5",
+            "dashscope@coding-plan/MiniMax-M2.5",
         ] {
             assert!(
-                catalog.get(&ModelRef::parse(model_ref).unwrap()).is_some(),
-                "{model_ref} should be registered"
+                catalog
+                    .get_route(&ModelRouteRef::parse(route_ref).unwrap())
+                    .is_some(),
+                "{route_ref} should be registered"
             );
         }
 
         for unsupported in [
-            "dashscope-token-plan/ZHIPU/GLM-5.2",
-            "dashscope-token-plan/MiniMax/MiniMax-M3",
-            "dashscope-coding-plan/glm-5.2",
-            "dashscope-coding-plan/kimi-k2.7-code",
+            "dashscope@token-plan/ZHIPU/GLM-5.2",
+            "dashscope@token-plan/MiniMax/MiniMax-M3",
+            "dashscope@coding-plan/glm-5.2",
+            "dashscope@coding-plan/kimi-k2.7-code",
         ] {
             assert!(
                 catalog
-                    .get(&ModelRef::parse(unsupported).unwrap())
+                    .get_route(&ModelRouteRef::parse(unsupported).unwrap())
                     .is_none(),
                 "{unsupported} should not be inferred from another DashScope catalog"
             );
@@ -3327,19 +3441,9 @@ mod tests {
             );
         }
 
-        for entry in catalog.list() {
-            if entry.model_ref.provider.as_str() == "volcengine-agent" {
-                assert!(
-                    entry.max_output_tokens_upper_limit <= Some(128_000),
-                    "{} should not exceed Volcengine Agent Plan Anthropic-compatible max_tokens limit",
-                    entry.model_ref.as_string()
-                );
-            }
-        }
-
-        for model_ref in ["volcengine-agent/glm-5.2"] {
-            let policy = catalog.resolve_policy(
-                &ModelRef::parse(model_ref).unwrap(),
+        for route_ref in ["volcengine@plan/glm-5.2"] {
+            let policy = catalog.resolve_route_policy(
+                &ModelRouteRef::parse(route_ref).unwrap(),
                 &HashMap::new(),
                 &HashMap::new(),
                 None,
@@ -3355,13 +3459,13 @@ mod tests {
     fn volcengine_reasoning_effort_options_follow_route_contract() {
         let catalog = BuiltInModelCatalog::new();
 
-        for model_ref in [
-            "volcengine/doubao-seed-2-0-pro-260215",
-            "volcengine-coding/glm-5.2",
-            "volcengine-agent/glm-5.2",
+        for route_ref in [
+            "volcengine@default/doubao-seed-2-0-pro-260215",
+            "volcengine@coding/glm-5.2",
+            "volcengine@plan/glm-5.2",
         ] {
-            let policy = catalog.resolve_policy(
-                &ModelRef::parse(model_ref).unwrap(),
+            let policy = catalog.resolve_route_policy(
+                &ModelRouteRef::parse(route_ref).unwrap(),
                 &HashMap::new(),
                 &HashMap::new(),
                 None,
@@ -3371,24 +3475,24 @@ mod tests {
             assert_eq!(
                 policy.reasoning_effort_options,
                 ["low", "medium", "high"],
-                "{model_ref}"
+                "{route_ref}"
             );
         }
 
-        for model_ref in [
-            "volcengine-coding/kimi-k2.6",
-            "volcengine-agent/kimi-k2.7-code",
+        for route_ref in [
+            "volcengine@coding/kimi-k2.6",
+            "volcengine@plan/kimi-k2.7-code",
         ] {
-            let policy = catalog.resolve_policy(
-                &ModelRef::parse(model_ref).unwrap(),
+            let policy = catalog.resolve_route_policy(
+                &ModelRouteRef::parse(route_ref).unwrap(),
                 &HashMap::new(),
                 &HashMap::new(),
                 None,
                 &base_context(),
                 8192,
             );
-            assert!(policy.capabilities.supports_reasoning, "{model_ref}");
-            assert!(policy.reasoning_effort_options.is_empty(), "{model_ref}");
+            assert!(policy.capabilities.supports_reasoning, "{route_ref}");
+            assert!(policy.reasoning_effort_options.is_empty(), "{route_ref}");
         }
     }
 


### PR DESCRIPTION
## Summary

- canonicalize model metadata by intrinsic provider/model identity instead of duplicating entries for endpoint or plan aliases
- preserve endpoint and plan differences as route metadata/overrides, including legacy provider/model resolution to a preferred route
- update migration, deduplication, compatibility, projection tests, and the model reference implementation decision

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
