### PR TITLE
fix: calibrate Anthropic model catalog

### DIFF
--- a/docs/implementation-decisions/066-anthropic-model-catalog.md
+++ b/docs/implementation-decisions/066-anthropic-model-catalog.md
@@ -1,0 +1,34 @@
+# Anthropic Model Catalog
+
+## Choice
+
+The built-in `anthropic` catalog follows the generally available models in
+Anthropic's official model overview:
+
+- `claude-fable-5`
+- `claude-opus-4-8`
+- `claude-sonnet-5`
+- `claude-haiku-4-5`
+
+The first three use a 1M-token context window and 128k-token synchronous output
+limit. Haiku uses a 200k-token context window and 64k-token output limit. All
+four accept image input and expose reasoning capability.
+
+## Reason
+
+This list was verified against
+<https://platform.claude.com/docs/en/about-claude/models/overview> on
+2026-07-12. Older Opus 4.5/4.6/4.7 and Sonnet 4.5/4.6 entries are omitted from
+the conservative built-in catalog because they are no longer in the current
+generally available comparison table.
+
+The Haiku entry uses Anthropic's supported `claude-haiku-4-5` API alias rather
+than pinning Holon's default catalog to the dated
+`claude-haiku-4-5-20251001` snapshot. Invitation-only Mythos models are not
+included.
+
+## Preserved boundary
+
+`supports_reasoning` records intrinsic model capability. The Anthropic
+transport can lower configured reasoning effort to a thinking budget, but this
+catalog update does not introduce new user-selectable effort levels.

--- a/docs/implementation-decisions/066-anthropic-model-catalog.md
+++ b/docs/implementation-decisions/066-anthropic-model-catalog.md
@@ -27,6 +27,19 @@ than pinning Holon's default catalog to the dated
 `claude-haiku-4-5-20251001` snapshot. Invitation-only Mythos models are not
 included.
 
+Compatible providers retain independently published legacy Claude routes where
+their own catalogs still expose them. A model's removal from the native
+`anthropic` catalog does not imply that a LiteLLM, Venice, or Vercel AI Gateway
+route with a similar name is unavailable.
+
+## Migration
+
+Users whose native Anthropic configuration pins a removed model should update
+it to one of `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-5`, or
+`claude-haiku-4-5`. Otherwise the unknown model remains addressable but uses
+fallback metadata rather than the calibrated context, output, capability, and
+compaction limits.
+
 ## Preserved boundary
 
 `supports_reasoning` records intrinsic model capability. The Anthropic

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -77,3 +77,4 @@ Current decision notes:
 - [057 OpenAI Codex OAuth Refresh Boundary](./057-openai-codex-oauth-refresh-boundary.md)
 - [059 Bounded Performance Diagnostics](./059-bounded-performance-diagnostics.md)
 - [065 xAI Grok API and X Login Boundary](./065-xai-grok-api-and-login-boundary.md)
+- [066 Anthropic Model Catalog](./066-anthropic-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **248 models**.
+across **40 endpoints** and **201 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -72,12 +72,10 @@ and capabilities.
 
 | Provider | Model | Usage | Context Window | Max Output | Reasoning | Image |
 |----------|-------|-------|----------------|------------|-----------|-------|
-| `anthropic` | `claude-haiku-4-5` | `anthropic/claude-haiku-4-5` | 200000 | 32000 | ✅ | ✅ |
-| `anthropic` | `claude-opus-4-5` | `anthropic/claude-opus-4-5` | 200000 | 64000 | ✅ | ✅ |
-| `anthropic` | `claude-opus-4-6` | `anthropic/claude-opus-4-6` | 1000000 | 128000 | ✅ | ✅ |
-| `anthropic` | `claude-opus-4-7` | `anthropic/claude-opus-4-7` | 1000000 | 128000 | ✅ | ✅ |
-| `anthropic` | `claude-sonnet-4-5` | `anthropic/claude-sonnet-4-5` | 200000 | 64000 | ✅ | ✅ |
-| `anthropic` | `claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` | 200000 | 32000 | ✅ | ✅ |
+| `anthropic` | `claude-fable-5` | `anthropic/claude-fable-5` | 1000000 | 128000 | ✅ | ✅ |
+| `anthropic` | `claude-haiku-4-5` | `anthropic/claude-haiku-4-5` | 200000 | 64000 | ✅ | ✅ |
+| `anthropic` | `claude-opus-4-8` | `anthropic/claude-opus-4-8` | 1000000 | 128000 | ✅ | ✅ |
+| `anthropic` | `claude-sonnet-5` | `anthropic/claude-sonnet-5` | 1000000 | 128000 | ✅ | ✅ |
 | `arcee` | `trinity-large-preview` | `arcee/trinity-large-preview` | 131072 | 16384 | — | — |
 | `arcee` | `trinity-large-thinking` | `arcee/trinity-large-thinking` | 262144 | 80000 | ✅ | — |
 | `arcee` | `trinity-mini` | `arcee/trinity-mini` | 131072 | 80000 | — | — |
@@ -95,11 +93,11 @@ and capabilities.
 | `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 202800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |
+| `byteplus` | `ark-code-latest` | `byteplus/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `byteplus` | `moonshotai/kimi-k2.5` | `byteplus/moonshotai/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
 | `byteplus` | `seed-1-8-251228` | `byteplus/seed-1-8-251228` | 256000 | 4096 | — | ✅ |
 | `byteplus` | `seed-2-0-pro-260215` | `byteplus/seed-2-0-pro-260215` | 256000 | 4096 | — | ✅ |
 | `byteplus` | `zai-org/glm-4.7` | `byteplus/zai-org/glm-4.7` | 204800 | 131072 | ✅ | — |
-| `byteplus-coding` | `ark-code-latest` | `byteplus-coding/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `chutes` | `deepseek-ai/DeepSeek-V3.2-TEE` | `chutes/deepseek-ai/DeepSeek-V3.2-TEE` | 131072 | 65536 | ✅ | — |
 | `chutes` | `moonshotai/Kimi-K2.5-TEE` | `chutes/moonshotai/Kimi-K2.5-TEE` | 262144 | 65535 | ✅ | ✅ |
 | `chutes` | `openai/gpt-oss-120b-TEE` | `chutes/openai/gpt-oss-120b-TEE` | 131072 | 65536 | ✅ | — |
@@ -107,14 +105,16 @@ and capabilities.
 | `dashscope` | `MiniMax-M2.5` | `dashscope/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
 | `dashscope` | `MiniMax/MiniMax-M3` | `dashscope/MiniMax/MiniMax-M3` | 1000000 | 32768 | ✅ | ✅ |
 | `dashscope` | `ZHIPU/GLM-5.2` | `dashscope/ZHIPU/GLM-5.2` | 1000000 | 131072 | ✅ | — |
-| `dashscope` | `deepseek-v4-flash` | `dashscope/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
-| `dashscope` | `deepseek-v4-pro` | `dashscope/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `dashscope` | `deepseek-v3.2` | `dashscope/deepseek-v3.2` | 128000 | 32768 | ✅ | — |
+| `dashscope` | `deepseek-v4-flash` | `dashscope/deepseek-v4-flash` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `deepseek-v4-pro` | `dashscope/deepseek-v4-pro` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `glm-4.7` | `dashscope/glm-4.7` | 202752 | 16384 | — | — |
-| `dashscope` | `glm-5` | `dashscope/glm-5` | 202752 | 16384 | — | — |
-| `dashscope` | `glm-5.1` | `dashscope/glm-5.1` | 202752 | 131072 | ✅ | — |
-| `dashscope` | `kimi-k2.5` | `dashscope/kimi-k2.5` | 262144 | 32768 | — | ✅ |
-| `dashscope` | `kimi-k2.6` | `dashscope/kimi-k2.6` | 262144 | 98304 | ✅ | — |
-| `dashscope` | `kimi-k2.7-code` | `dashscope/kimi-k2.7-code` | 262144 | 98304 | ✅ | ✅ |
+| `dashscope` | `glm-5` | `dashscope/glm-5` | 202752 | 16384 | ✅ | — |
+| `dashscope` | `glm-5.1` | `dashscope/glm-5.1` | 202752 | 65536 | ✅ | — |
+| `dashscope` | `glm-5.2` | `dashscope/glm-5.2` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `kimi-k2.5` | `dashscope/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
+| `dashscope` | `kimi-k2.6` | `dashscope/kimi-k2.6` | 262144 | 65536 | ✅ | ✅ |
+| `dashscope` | `kimi-k2.7-code` | `dashscope/kimi-k2.7-code` | 262144 | 65536 | ✅ | ✅ |
 | `dashscope` | `mimo-v2.5-pro` | `dashscope/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
 | `dashscope` | `qwen3-coder-flash` | `dashscope/qwen3-coder-flash` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3-coder-next` | `dashscope/qwen3-coder-next` | 262144 | 65536 | — | — |
@@ -129,30 +129,6 @@ and capabilities.
 | `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-plus` | `dashscope/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope-coding-plan` | `MiniMax-M2.5` | `dashscope-coding-plan/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
-| `dashscope-coding-plan` | `glm-4.7` | `dashscope-coding-plan/glm-4.7` | 202752 | 16384 | — | — |
-| `dashscope-coding-plan` | `glm-5` | `dashscope-coding-plan/glm-5` | 202752 | 16384 | ✅ | — |
-| `dashscope-coding-plan` | `kimi-k2.5` | `dashscope-coding-plan/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
-| `dashscope-coding-plan` | `qwen3-coder-next` | `dashscope-coding-plan/qwen3-coder-next` | 262144 | 65536 | — | — |
-| `dashscope-coding-plan` | `qwen3-coder-plus` | `dashscope-coding-plan/qwen3-coder-plus` | 1000000 | 65536 | — | — |
-| `dashscope-coding-plan` | `qwen3-max-2026-01-23` | `dashscope-coding-plan/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
-| `dashscope-coding-plan` | `qwen3.5-plus` | `dashscope-coding-plan/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
-| `dashscope-coding-plan` | `qwen3.6-plus` | `dashscope-coding-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope-coding-plan` | `qwen3.7-plus` | `dashscope-coding-plan/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope-token-plan` | `MiniMax-M2.5` | `dashscope-token-plan/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
-| `dashscope-token-plan` | `deepseek-v3.2` | `dashscope-token-plan/deepseek-v3.2` | 128000 | 32768 | ✅ | — |
-| `dashscope-token-plan` | `deepseek-v4-flash` | `dashscope-token-plan/deepseek-v4-flash` | 1000000 | 65536 | ✅ | — |
-| `dashscope-token-plan` | `deepseek-v4-pro` | `dashscope-token-plan/deepseek-v4-pro` | 1000000 | 65536 | ✅ | — |
-| `dashscope-token-plan` | `glm-5` | `dashscope-token-plan/glm-5` | 202752 | 16384 | ✅ | — |
-| `dashscope-token-plan` | `glm-5.1` | `dashscope-token-plan/glm-5.1` | 202752 | 65536 | ✅ | — |
-| `dashscope-token-plan` | `glm-5.2` | `dashscope-token-plan/glm-5.2` | 1000000 | 65536 | ✅ | — |
-| `dashscope-token-plan` | `kimi-k2.5` | `dashscope-token-plan/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
-| `dashscope-token-plan` | `kimi-k2.6` | `dashscope-token-plan/kimi-k2.6` | 262144 | 65536 | ✅ | ✅ |
-| `dashscope-token-plan` | `kimi-k2.7-code` | `dashscope-token-plan/kimi-k2.7-code` | 262144 | 65536 | ✅ | ✅ |
-| `dashscope-token-plan` | `qwen3.6-flash` | `dashscope-token-plan/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope-token-plan` | `qwen3.6-plus` | `dashscope-token-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope-token-plan` | `qwen3.7-max` | `dashscope-token-plan/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
-| `dashscope-token-plan` | `qwen3.7-plus` | `dashscope-token-plan/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `deepseek` | `deepseek-chat` | `deepseek/deepseek-chat` | 131072 | 8192 | — | — |
 | `deepseek` | `deepseek-reasoner` | `deepseek/deepseek-reasoner` | 131072 | 65536 | ✅ | — |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
@@ -195,24 +171,20 @@ and capabilities.
 | `nvidia` | `moonshotai/kimi-k2.5` | `nvidia/moonshotai/kimi-k2.5` | 262144 | 8192 | — | — |
 | `nvidia` | `nvidia/nemotron-3-super-120b-a12b` | `nvidia/nvidia/nemotron-3-super-120b-a12b` | 262144 | 8192 | — | — |
 | `nvidia` | `z-ai/glm5` | `nvidia/z-ai/glm5` | 202752 | 8192 | — | — |
-| `openai` | `gpt-5.2` | `openai/gpt-5.2` | 272000 | 128000 | ✅ | ✅ |
 | `openai` | `gpt-5.3` | `openai/gpt-5.3` | 128000 | — | ✅ | ✅ |
 | `openai` | `gpt-5.4` | `openai/gpt-5.4` | 272000 | — | ✅ | ✅ |
 | `openai` | `gpt-5.4-mini` | `openai/gpt-5.4-mini` | 128000 | — | ✅ | ✅ |
-| `openai` | `gpt-5.5` | `openai/gpt-5.5` | 272000 | 128000 | ✅ | ✅ |
-| `openai` | `gpt-5.6-luna` | `openai/gpt-5.6-luna` | 272000 | 128000 | ✅ | ✅ |
-| `openai` | `gpt-5.6-sol` | `openai/gpt-5.6-sol` | 272000 | 128000 | ✅ | ✅ |
-| `openai` | `gpt-5.6-terra` | `openai/gpt-5.6-terra` | 272000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-5.6-luna` | `openai/gpt-5.6-luna` | 372000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-5.6-sol` | `openai/gpt-5.6-sol` | 372000 | 128000 | ✅ | ✅ |
+| `openai` | `gpt-5.6-terra` | `openai/gpt-5.6-terra` | 372000 | 128000 | ✅ | ✅ |
 | `openai` | `gpt-image-2` | `openai/gpt-image-2` | — | — | — | — |
-| `openai-codex` | `gpt-5.2` | `openai-codex/gpt-5.2` | 272000 | 128000 | ✅ | ✅ |
-| `openai-codex` | `gpt-5.3-codex` | `openai-codex/gpt-5.3-codex` | 272000 | — | ✅ | ✅ |
-| `openai-codex` | `gpt-5.3-codex-spark` | `openai-codex/gpt-5.3-codex-spark` | 128000 | — | ✅ | ✅ |
+| `openai-codex` | `gpt-5.3-codex-spark` | `openai-codex/gpt-5.3-codex-spark` | 128000 | — | ✅ | — |
 | `openai-codex` | `gpt-5.4` | `openai-codex/gpt-5.4` | 272000 | — | ✅ | ✅ |
-| `openai-codex` | `gpt-5.4-mini` | `openai-codex/gpt-5.4-mini` | 272000 | 128000 | ✅ | ✅ |
+| `openai-codex` | `gpt-5.4-mini` | `openai-codex/gpt-5.4-mini` | 272000 | — | ✅ | ✅ |
 | `openai-codex` | `gpt-5.5` | `openai-codex/gpt-5.5` | 272000 | — | ✅ | ✅ |
-| `openai-codex` | `gpt-5.6-luna` | `openai-codex/gpt-5.6-luna` | 272000 | 128000 | ✅ | ✅ |
-| `openai-codex` | `gpt-5.6-sol` | `openai-codex/gpt-5.6-sol` | 272000 | 128000 | ✅ | ✅ |
-| `openai-codex` | `gpt-5.6-terra` | `openai-codex/gpt-5.6-terra` | 272000 | 128000 | ✅ | ✅ |
+| `openai-codex` | `gpt-5.6-luna` | `openai-codex/gpt-5.6-luna` | 372000 | — | ✅ | ✅ |
+| `openai-codex` | `gpt-5.6-sol` | `openai-codex/gpt-5.6-sol` | 372000 | — | ✅ | ✅ |
+| `openai-codex` | `gpt-5.6-terra` | `openai-codex/gpt-5.6-terra` | 372000 | — | ✅ | ✅ |
 | `opencode-go` | `deepseek-v4-flash` | `opencode-go/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `opencode-go` | `deepseek-v4-pro` | `opencode-go/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
 | `openrouter` | `auto` | `openrouter/auto` | 200000 | 8192 | — | ✅ |
@@ -222,8 +194,7 @@ and capabilities.
 | `qianfan` | `deepseek-v3.2` | `qianfan/deepseek-v3.2` | 98304 | 32768 | ✅ | — |
 | `qianfan` | `ernie-5.0-thinking-preview` | `qianfan/ernie-5.0-thinking-preview` | 119000 | 64000 | ✅ | ✅ |
 | `stepfun` | `step-3.5-flash` | `stepfun/step-3.5-flash` | 262144 | 65536 | ✅ | — |
-| `stepfun-plan` | `step-3.5-flash` | `stepfun-plan/step-3.5-flash` | 262144 | 65536 | ✅ | — |
-| `stepfun-plan` | `step-3.5-flash-2603` | `stepfun-plan/step-3.5-flash-2603` | 262144 | 65536 | ✅ | — |
+| `stepfun` | `step-3.5-flash-2603` | `stepfun/step-3.5-flash-2603` | 262144 | 65536 | ✅ | — |
 | `synthetic` | `hf:MiniMaxAI/MiniMax-M2.5` | `synthetic/hf:MiniMaxAI/MiniMax-M2.5` | 192000 | 65536 | — | — |
 | `synthetic` | `hf:Qwen/Qwen3-235B-A22B-Instruct-2507` | `synthetic/hf:Qwen/Qwen3-235B-A22B-Instruct-2507` | 256000 | 8192 | — | — |
 | `synthetic` | `hf:Qwen/Qwen3-235B-A22B-Thinking-2507` | `synthetic/hf:Qwen/Qwen3-235B-A22B-Thinking-2507` | 256000 | 8192 | ✅ | — |
@@ -261,32 +232,18 @@ and capabilities.
 | `vercel-ai-gateway` | `openai/gpt-5.4` | `vercel-ai-gateway/openai/gpt-5.4` | 200000 | 128000 | ✅ | ✅ |
 | `vercel-ai-gateway` | `openai/gpt-5.4-pro` | `vercel-ai-gateway/openai/gpt-5.4-pro` | 200000 | 128000 | ✅ | ✅ |
 | `vllm` | `meta-llama/Meta-Llama-3-8B-Instruct` | `vllm/meta-llama/Meta-Llama-3-8B-Instruct` | 131072 | 8192 | — | — |
-| `volcengine` | `deepseek-v3-2-251201` | `volcengine/deepseek-v3-2-251201` | 128000 | 4096 | — | ✅ |
+| `volcengine` | `ark-code-latest` | `volcengine/ark-code-latest` | 256000 | 65536 | ✅ | — |
+| `volcengine` | `deepseek-v3-2-251201` | `volcengine/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
+| `volcengine` | `deepseek-v4-flash` | `volcengine/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
+| `volcengine` | `deepseek-v4-pro` | `volcengine/deepseek-v4-pro` | 1000000 | 8192 | ✅ | — |
 | `volcengine` | `doubao-seed-1-8-251228` | `volcengine/doubao-seed-1-8-251228` | 256000 | 4096 | — | ✅ |
 | `volcengine` | `doubao-seed-2-0-code-preview-260215` | `volcengine/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | ✅ |
 | `volcengine` | `doubao-seed-2-0-lite-260215` | `volcengine/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
-| `volcengine` | `doubao-seed-2-0-pro-260215` | `volcengine/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | ✅ |
+| `volcengine` | `doubao-seed-2-0-pro-260215` | `volcengine/doubao-seed-2-0-pro-260215` | 256000 | 4096 | ✅ | ✅ |
 | `volcengine` | `doubao-seedream-5.0-lite` | `volcengine/doubao-seedream-5.0-lite` | — | — | — | — |
-| `volcengine-agent` | `ark-code-latest` | `volcengine-agent/ark-code-latest` | 256000 | 65536 | ✅ | — |
-| `volcengine-agent` | `deepseek-v3-2-251201` | `volcengine-agent/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
-| `volcengine-agent` | `deepseek-v4-flash` | `volcengine-agent/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
-| `volcengine-agent` | `deepseek-v4-pro` | `volcengine-agent/deepseek-v4-pro` | 1000000 | 8192 | ✅ | — |
-| `volcengine-agent` | `doubao-seed-2-0-code-preview-260215` | `volcengine-agent/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | — |
-| `volcengine-agent` | `doubao-seed-2-0-lite-260215` | `volcengine-agent/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
-| `volcengine-agent` | `doubao-seed-2-0-pro-260215` | `volcengine-agent/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | — |
-| `volcengine-agent` | `glm-5.2` | `volcengine-agent/glm-5.2` | 204800 | 128000 | ✅ | — |
-| `volcengine-agent` | `kimi-k2.6` | `volcengine-agent/kimi-k2.6` | 262144 | 32768 | ✅ | — |
-| `volcengine-agent` | `kimi-k2.7-code` | `volcengine-agent/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
-| `volcengine-coding` | `ark-code-latest` | `volcengine-coding/ark-code-latest` | 256000 | 65536 | ✅ | — |
-| `volcengine-coding` | `deepseek-v3-2-251201` | `volcengine-coding/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
-| `volcengine-coding` | `deepseek-v4-flash` | `volcengine-coding/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |
-| `volcengine-coding` | `deepseek-v4-pro` | `volcengine-coding/deepseek-v4-pro` | 1000000 | 8192 | ✅ | — |
-| `volcengine-coding` | `doubao-seed-2-0-code-preview-260215` | `volcengine-coding/doubao-seed-2-0-code-preview-260215` | 256000 | 4096 | — | — |
-| `volcengine-coding` | `doubao-seed-2-0-lite-260215` | `volcengine-coding/doubao-seed-2-0-lite-260215` | 256000 | 4096 | — | — |
-| `volcengine-coding` | `doubao-seed-2-0-pro-260215` | `volcengine-coding/doubao-seed-2-0-pro-260215` | 256000 | 4096 | — | — |
-| `volcengine-coding` | `glm-5.2` | `volcengine-coding/glm-5.2` | 204800 | 128000 | ✅ | — |
-| `volcengine-coding` | `kimi-k2.6` | `volcengine-coding/kimi-k2.6` | 262144 | 32768 | ✅ | — |
-| `volcengine-coding` | `kimi-k2.7-code` | `volcengine-coding/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
+| `volcengine` | `glm-5.2` | `volcengine/glm-5.2` | 204800 | 128000 | ✅ | — |
+| `volcengine` | `kimi-k2.6` | `volcengine/kimi-k2.6` | 262144 | 32768 | ✅ | — |
+| `volcengine` | `kimi-k2.7-code` | `volcengine/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
 | `xai` | `grok-3` | `xai/grok-3` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-fast` | `xai/grok-3-fast` | 131072 | 8192 | — | — |
 | `xai` | `grok-3-mini` | `xai/grok-3-mini` | 131072 | 8192 | ✅ | — |
@@ -302,10 +259,6 @@ and capabilities.
 | `xiaomi` | `mimo-v2-pro` | `xiaomi/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
 | `xiaomi` | `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
 | `xiaomi` | `mimo-v2.5-pro-ultraspeed` | `xiaomi/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
-| `xiaomi-token-plan` | `mimo-v2-omni` | `xiaomi-token-plan/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
-| `xiaomi-token-plan` | `mimo-v2-pro` | `xiaomi-token-plan/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
-| `xiaomi-token-plan` | `mimo-v2.5-pro` | `xiaomi-token-plan/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
-| `xiaomi-token-plan` | `mimo-v2.5-pro-ultraspeed` | `xiaomi-token-plan/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-4.5` | `zai/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-air` | `zai/glm-4.5-air` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-flash` | `zai/glm-4.5-flash` | 131072 | 98304 | ✅ | — |

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1740,7 +1740,7 @@ fn model_selection_derives_from_authenticated_providers() {
             .into_iter()
             .map(|model| model.as_string())
             .collect::<Vec<_>>(),
-        vec!["anthropic@default/claude-sonnet-4-6"]
+        vec!["anthropic@default/claude-fable-5"]
     );
 }
 
@@ -2560,8 +2560,8 @@ fn view_image_vision_selection_uses_configured_custom_auto_discovery_capabilitie
 
 #[test]
 fn view_image_vision_selection_uses_anthropic_messages_when_image_capable() {
-    let mut fixture = test_app_config("anthropic/claude-sonnet-4-6", &[]);
-    fixture.config.vision_candidate_models = vec![route_ref("anthropic/claude-sonnet-4-6")];
+    let mut fixture = test_app_config("anthropic/claude-sonnet-5", &[]);
+    fixture.config.vision_candidate_models = vec![route_ref("anthropic/claude-sonnet-5")];
     let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
     let selection = catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
@@ -2571,12 +2571,9 @@ fn view_image_vision_selection_uses_anthropic_messages_when_image_capable() {
         crate::types::ViewImageSelectedMode::NativeImageWithObservation
     );
     assert_eq!(selection.primary_provider.as_deref(), Some("anthropic"));
-    assert_eq!(
-        selection.primary_model.as_deref(),
-        Some("claude-sonnet-4-6")
-    );
+    assert_eq!(selection.primary_model.as_deref(), Some("claude-sonnet-5"));
     assert_eq!(selection.vision_provider.as_deref(), Some("anthropic"));
-    assert_eq!(selection.vision_model.as_deref(), Some("claude-sonnet-4-6"));
+    assert_eq!(selection.vision_model.as_deref(), Some("claude-sonnet-5"));
     assert_eq!(
         selection.selection_reason,
         "current_primary_model_supports_image_input"

--- a/src/host.rs
+++ b/src/host.rs
@@ -2374,7 +2374,7 @@ mod tests {
             api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
-            default_model: ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap(),
+            default_model: ModelRouteRef::parse_compatible("anthropic/claude-sonnet-5").unwrap(),
             fallback_models: Vec::new(),
             vision_model: None,
             image_generation_model: None,
@@ -3062,7 +3062,7 @@ mod tests {
         );
         assert_eq!(
             inherited.model.effective_model.as_string(),
-            "anthropic@default/claude-sonnet-4-6"
+            "anthropic@default/claude-sonnet-5"
         );
         assert!(inherited.model.override_model.is_none());
         assert_eq!(
@@ -3070,7 +3070,7 @@ mod tests {
                 .model
                 .resolved_policy
                 .prompt_budget_estimated_tokens,
-            180_000
+            900_000
         );
 
         let updated = runtime
@@ -3090,7 +3090,7 @@ mod tests {
         );
         assert_eq!(
             updated.runtime_default_model.as_string(),
-            "anthropic@default/claude-sonnet-4-6"
+            "anthropic@default/claude-sonnet-5"
         );
         assert_eq!(
             updated
@@ -3098,7 +3098,7 @@ mod tests {
                 .iter()
                 .map(|model| model.as_string())
                 .collect::<Vec<_>>(),
-            vec!["anthropic@default/claude-sonnet-4-6"]
+            vec!["anthropic@default/claude-sonnet-5"]
         );
         assert_eq!(
             updated.resolved_policy.prompt_budget_estimated_tokens,
@@ -3121,11 +3121,11 @@ mod tests {
         assert!(cleared.override_model.is_none());
         assert_eq!(
             cleared.effective_model.as_string(),
-            "anthropic@default/claude-sonnet-4-6"
+            "anthropic@default/claude-sonnet-5"
         );
         assert_eq!(
             cleared.resolved_policy.prompt_budget_estimated_tokens,
-            180_000
+            900_000
         );
     }
 
@@ -3165,7 +3165,7 @@ mod tests {
             runtime.current_provider().await.configured_model_refs(),
             vec![
                 "anthropic@default/claude-haiku-4-5".to_string(),
-                "anthropic@default/claude-sonnet-4-6".to_string(),
+                "anthropic@default/claude-sonnet-5".to_string(),
             ]
         );
     }
@@ -3216,7 +3216,7 @@ mod tests {
             child.current_provider().await.configured_model_refs(),
             vec![
                 "anthropic@default/claude-haiku-4-5".to_string(),
-                "anthropic@default/claude-sonnet-4-6".to_string(),
+                "anthropic@default/claude-sonnet-5".to_string(),
             ]
         );
     }
@@ -4337,7 +4337,7 @@ mod tests {
             .contains("no available providers for configured model chain"));
         assert!(err
             .to_string()
-            .contains("anthropic@default/claude-sonnet-4-6"));
+            .contains("anthropic@default/claude-sonnet-5"));
     }
 
     #[tokio::test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -782,13 +782,51 @@ fn mirror_catalog_models(
 fn built_in_entries() -> Vec<BuiltInModelMetadata> {
     let mut entries = vec![
         BuiltInModelMetadata {
-            model_ref: ModelRef::new(ProviderId::anthropic(), "claude-sonnet-4-6"),
-            display_name: "Claude Sonnet 4.6".into(),
-            description: "Anthropic Sonnet 4.6 runtime defaults mirrored from local Claude Code rules.".into(),
-            context_window_tokens: Some(200_000),
+            model_ref: ModelRef::new(ProviderId::anthropic(), "claude-fable-5"),
+            display_name: "Claude Fable 5".into(),
+            description: "Anthropic Claude Fable 5 runtime defaults aligned with the official model overview.".into(),
+            context_window_tokens: Some(1_000_000),
             effective_context_window_percent: 90,
-            auto_compact_token_limit: Some(180_000),
-            default_max_output_tokens: Some(32_000),
+            auto_compact_token_limit: Some(900_000),
+            default_max_output_tokens: Some(128_000),
+            max_output_tokens_upper_limit: Some(128_000),
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                supports_reasoning: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
+        },
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(ProviderId::anthropic(), "claude-opus-4-8"),
+            display_name: "Claude Opus 4.8".into(),
+            description: "Anthropic Claude Opus 4.8 runtime defaults aligned with the official model overview.".into(),
+            context_window_tokens: Some(1_000_000),
+            effective_context_window_percent: 90,
+            auto_compact_token_limit: Some(900_000),
+            default_max_output_tokens: Some(128_000),
+            max_output_tokens_upper_limit: Some(128_000),
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                supports_reasoning: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
+        },
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(ProviderId::anthropic(), "claude-sonnet-5"),
+            display_name: "Claude Sonnet 5".into(),
+            description: "Anthropic Claude Sonnet 5 runtime defaults aligned with the official model overview.".into(),
+            context_window_tokens: Some(1_000_000),
+            effective_context_window_percent: 90,
+            auto_compact_token_limit: Some(900_000),
+            default_max_output_tokens: Some(128_000),
             max_output_tokens_upper_limit: Some(128_000),
             default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
@@ -803,11 +841,11 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
         BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::anthropic(), "claude-haiku-4-5"),
             display_name: "Claude Haiku 4.5".into(),
-            description: "Anthropic Haiku 4.5 runtime defaults mirrored from local Claude Code rules.".into(),
+            description: "Anthropic Claude Haiku 4.5 runtime defaults aligned with the official model overview.".into(),
             context_window_tokens: Some(200_000),
             effective_context_window_percent: 90,
             auto_compact_token_limit: Some(180_000),
-            default_max_output_tokens: Some(32_000),
+            default_max_output_tokens: Some(64_000),
             max_output_tokens_upper_limit: Some(64_000),
             default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
@@ -1051,42 +1089,6 @@ fn default_verbosity_for_model(model_ref: &ModelRef) -> Option<ModelVerbosity> {
 
 fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
     let mut entries = vec![
-        catalog_model(
-            "anthropic",
-            "claude-opus-4-7",
-            "Claude Opus 4.7",
-            1_000_000,
-            128_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "anthropic",
-            "claude-opus-4-6",
-            "Claude Opus 4.6",
-            1_000_000,
-            128_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "anthropic",
-            "claude-opus-4-5",
-            "Claude Opus 4.5",
-            200_000,
-            64_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "anthropic",
-            "claude-sonnet-4-5",
-            "Claude Sonnet 4.5",
-            200_000,
-            64_000,
-            true,
-            true,
-        ),
         catalog_model(
             "openai",
             "gpt-5.6-sol",
@@ -2986,6 +2988,49 @@ mod tests {
     }
 
     #[test]
+    fn anthropic_catalog_tracks_current_generally_available_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            ("claude-fable-5", 1_000_000, 128_000),
+            ("claude-opus-4-8", 1_000_000, 128_000),
+            ("claude-sonnet-5", 1_000_000, 128_000),
+            ("claude-haiku-4-5", 200_000, 64_000),
+        ];
+
+        for (model, context_window, max_output) in expected {
+            let metadata = catalog
+                .get(&ModelRef::new(ProviderId::anthropic(), model))
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, Some(context_window));
+            assert_eq!(metadata.default_max_output_tokens, Some(max_output));
+            assert_eq!(metadata.max_output_tokens_upper_limit, Some(max_output));
+            assert!(metadata.capabilities.image_input);
+            assert!(metadata.capabilities.supports_reasoning);
+            assert!(reasoning_effort_options(
+                &metadata.model_ref,
+                metadata.endpoint.as_ref(),
+                &metadata.capabilities,
+            )
+            .is_empty());
+        }
+
+        for removed_model in [
+            "claude-opus-4-5",
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4-6",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::new(ProviderId::anthropic(), removed_model))
+                    .is_none(),
+                "{removed_model} should not be registered"
+            );
+        }
+    }
+
+    #[test]
     fn resolves_compatible_provider_model_policy() {
         let catalog = BuiltInModelCatalog::new();
         let policy = catalog.resolve_policy(
@@ -3380,7 +3425,7 @@ mod tests {
         let catalog = BuiltInModelCatalog::new();
         let mut overrides = HashMap::new();
         overrides.insert(
-            ModelRef::new(ProviderId::anthropic(), "claude-sonnet-4-6"),
+            ModelRef::new(ProviderId::anthropic(), "claude-haiku-4-5"),
             ModelRuntimeOverride {
                 prompt_budget_estimated_tokens: Some(32_000),
                 runtime_max_output_tokens: Some(4_096),
@@ -3388,7 +3433,7 @@ mod tests {
             },
         );
         let policy = catalog.resolve_policy(
-            &ModelRef::new(ProviderId::anthropic(), "claude-sonnet-4-6"),
+            &ModelRef::new(ProviderId::anthropic(), "claude-haiku-4-5"),
             &overrides,
             &HashMap::new(),
             None,


### PR DESCRIPTION
## 概要
- 按 Anthropic 官方模型概览更新内建 Claude catalog
- 保守移除不再出现在当前 GA 对比表中的旧 Opus/Sonnet 条目
- 校准 context/output、vision/reasoning 能力并补充回归测试与来源记录
- 重新生成模型参考文档

## 验证
- `cargo test --lib model_catalog::tests`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Livetest
- 当前环境无 `ANTHROPIC_API_KEY` 或 Claude OAuth 凭据，未执行 Anthropic livetest。