### PR TITLE
fix: calibrate xAI model catalog

### DIFF
--- a/docs/implementation-decisions/067-xai-model-catalog.md
+++ b/docs/implementation-decisions/067-xai-model-catalog.md
@@ -1,0 +1,43 @@
+# xAI Model Catalog
+
+## Choice
+
+The built-in `xai` catalog follows xAI's current recommended general-purpose
+models:
+
+- `grok-4.3`
+- `grok-4.5`
+
+Grok 4.3 uses a 1M-token context window and accepts text and image input. It
+supports `none`, `low`, `medium`, and `high` reasoning effort. Grok 4.5 uses a
+500k-token context window, accepts text and image input, and supports `low`,
+`medium`, and `high` reasoning effort; reasoning cannot be disabled.
+
+xAI's current model pages do not publish a maximum output-token limit for
+either model. The catalog therefore does not invent an upper limit and leaves
+the runtime output budget controlled by Holon's configured default.
+
+## Reason
+
+This list was verified against xAI's official model pages, reasoning guide, and
+May 15 retirement guide on 2026-07-12.
+
+The retirement guide states that `grok-3`, `grok-4-0709`,
+`grok-4-fast-reasoning`, `grok-4-fast-non-reasoning`,
+`grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, and
+`grok-code-fast-1` were retired on 2026-05-15. Requests to most retired slugs
+are redirects to Grok 4.3 rather than distinct model contracts. Early Grok 3
+and Grok 4 variants that are absent from the current model surface are also
+omitted from the conservative built-in catalog.
+
+## Migration
+
+Users pinning an omitted xAI model should select `xai/grok-4.3` or
+`xai/grok-4.5`. An omitted slug remains addressable as an unknown model but
+uses fallback metadata instead of calibrated context, image, reasoning, and
+compaction behavior.
+
+## Preserved boundary
+
+Grok Build and Imagine use distinct product or API contracts and are not added
+to the ordinary text-model catalog by this calibration.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -78,3 +78,4 @@ Current decision notes:
 - [059 Bounded Performance Diagnostics](./059-bounded-performance-diagnostics.md)
 - [065 xAI Grok API and X Login Boundary](./065-xai-grok-api-and-login-boundary.md)
 - [066 Anthropic Model Catalog](./066-anthropic-model-catalog.md)
+- [067 xAI Model Catalog](./067-xai-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **201 models**.
+across **40 endpoints** and **193 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -244,16 +244,8 @@ and capabilities.
 | `volcengine` | `glm-5.2` | `volcengine/glm-5.2` | 204800 | 128000 | ✅ | — |
 | `volcengine` | `kimi-k2.6` | `volcengine/kimi-k2.6` | 262144 | 32768 | ✅ | — |
 | `volcengine` | `kimi-k2.7-code` | `volcengine/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
-| `xai` | `grok-3` | `xai/grok-3` | 131072 | 8192 | — | — |
-| `xai` | `grok-3-fast` | `xai/grok-3-fast` | 131072 | 8192 | — | — |
-| `xai` | `grok-3-mini` | `xai/grok-3-mini` | 131072 | 8192 | ✅ | — |
-| `xai` | `grok-3-mini-fast` | `xai/grok-3-mini-fast` | 131072 | 8192 | ✅ | — |
-| `xai` | `grok-4` | `xai/grok-4` | 256000 | 64000 | ✅ | — |
-| `xai` | `grok-4-1-fast` | `xai/grok-4-1-fast` | 2000000 | 30000 | ✅ | ✅ |
-| `xai` | `grok-4-fast` | `xai/grok-4-fast` | 2000000 | 30000 | ✅ | ✅ |
-| `xai` | `grok-4-fast-non-reasoning` | `xai/grok-4-fast-non-reasoning` | 2000000 | 30000 | — | ✅ |
-| `xai` | `grok-4.5` | `xai/grok-4.5` | 500000 | 64000 | ✅ | ✅ |
-| `xai` | `grok-code-fast-1` | `xai/grok-code-fast-1` | 256000 | 10000 | ✅ | — |
+| `xai` | `grok-4.3` | `xai/grok-4.3` | 1000000 | — | ✅ | ✅ |
+| `xai` | `grok-4.5` | `xai/grok-4.5` | 500000 | — | ✅ | ✅ |
 | `xiaomi` | `mimo-v2-flash` | `xiaomi/mimo-v2-flash` | 262144 | 8192 | — | — |
 | `xiaomi` | `mimo-v2-omni` | `xiaomi/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi` | `mimo-v2-pro` | `xiaomi/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |

--- a/src/config/x_search.rs
+++ b/src/config/x_search.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 
 use super::{AppConfig, ModelRouteRef, ProviderId, ProviderRuntimeConfig, ProviderTransportKind};
 
-pub const DEFAULT_X_SEARCH_MODEL: &str = "grok-4-1-fast";
+pub const DEFAULT_X_SEARCH_MODEL: &str = "grok-4.3";
 pub const DEFAULT_X_SEARCH_TIMEOUT_SECONDS: u64 = 60;
 
 #[derive(Debug, Clone)]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -703,6 +703,8 @@ fn reasoning_effort_options(
         }
         ("openai-codex", "gpt-5.6-luna") => &["low", "medium", "high", "xhigh", "max"][..],
         ("openai", _) | ("openai-codex", _) => &["low", "medium", "high", "xhigh"][..],
+        ("xai", "grok-4.3") => &["none", "low", "medium", "high"][..],
+        ("xai", "grok-4.5") => &["low", "medium", "high"][..],
         ("volcengine", _)
             if endpoint.is_none_or(|endpoint| {
                 matches!(endpoint.as_str(), "default" | "coding" | "plan")
@@ -2690,80 +2692,46 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
-        catalog_model("xai", "grok-3", "Grok 3", 131_072, 8_192, false, false),
-        catalog_model(
-            "xai",
-            "grok-3-fast",
-            "Grok 3 Fast",
-            131_072,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "xai",
-            "grok-3-mini",
-            "Grok 3 Mini",
-            131_072,
-            8_192,
-            true,
-            false,
-        ),
-        catalog_model(
-            "xai",
-            "grok-3-mini-fast",
-            "Grok 3 Mini Fast",
-            131_072,
-            8_192,
-            true,
-            false,
-        ),
-        catalog_model("xai", "grok-4", "Grok 4", 256_000, 64_000, true, false),
-        catalog_model(
-            "xai",
-            "grok-4.5",
-            "Grok 4.5",
-            500_000,
-            64_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "xai",
-            "grok-4-fast",
-            "Grok 4 Fast",
-            2_000_000,
-            30_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "xai",
-            "grok-4-fast-non-reasoning",
-            "Grok 4 Fast (Non-Reasoning)",
-            2_000_000,
-            30_000,
-            false,
-            true,
-        ),
-        catalog_model(
-            "xai",
-            "grok-4-1-fast",
-            "Grok 4.1 Fast",
-            2_000_000,
-            30_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "xai",
-            "grok-code-fast-1",
-            "Grok Code Fast 1",
-            256_000,
-            10_000,
-            true,
-            false,
-        ),
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider_id("xai"), "grok-4.3"),
+            display_name: "Grok 4.3".into(),
+            description:
+                "xAI Grok 4.3 runtime defaults aligned with the official model page.".into(),
+            context_window_tokens: Some(1_000_000),
+            effective_context_window_percent: 90,
+            auto_compact_token_limit: Some(900_000),
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                supports_reasoning: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
+        },
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider_id("xai"), "grok-4.5"),
+            display_name: "Grok 4.5".into(),
+            description:
+                "xAI Grok 4.5 runtime defaults aligned with the official model page.".into(),
+            context_window_tokens: Some(500_000),
+            effective_context_window_percent: 90,
+            auto_compact_token_limit: Some(450_000),
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                supports_reasoning: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+            endpoint: None,
+        },
         catalog_model("zai", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false),
         catalog_model("zai", "glm-5.1", "GLM-5.1", 202_800, 131_072, true, false),
         catalog_model("zai", "glm-5", "GLM-5", 202_800, 131_072, true, false),
@@ -3024,6 +2992,57 @@ mod tests {
             assert!(
                 catalog
                     .get(&ModelRef::new(ProviderId::anthropic(), removed_model))
+                    .is_none(),
+                "{removed_model} should not be registered"
+            );
+        }
+    }
+
+    #[test]
+    fn xai_catalog_tracks_current_recommended_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            (
+                "grok-4.3",
+                1_000_000,
+                &["none", "low", "medium", "high"][..],
+            ),
+            ("grok-4.5", 500_000, &["low", "medium", "high"][..]),
+        ];
+
+        for (model, context_window, reasoning_options) in expected {
+            let metadata = catalog
+                .get(&ModelRef::new(provider_id("xai"), model))
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, Some(context_window));
+            assert_eq!(metadata.default_max_output_tokens, None);
+            assert_eq!(metadata.max_output_tokens_upper_limit, None);
+            assert!(metadata.capabilities.image_input);
+            assert!(metadata.capabilities.supports_reasoning);
+            assert_eq!(
+                reasoning_effort_options(
+                    &metadata.model_ref,
+                    metadata.endpoint.as_ref(),
+                    &metadata.capabilities,
+                ),
+                reasoning_options
+            );
+        }
+
+        for removed_model in [
+            "grok-3",
+            "grok-3-fast",
+            "grok-3-mini",
+            "grok-3-mini-fast",
+            "grok-4",
+            "grok-4-fast",
+            "grok-4-fast-non-reasoning",
+            "grok-4-1-fast",
+            "grok-code-fast-1",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::new(provider_id("xai"), removed_model))
                     .is_none(),
                 "{removed_model} should not be registered"
             );

--- a/src/x_search.rs
+++ b/src/x_search.rs
@@ -279,10 +279,10 @@ mod tests {
                 from_date: Some("2026-07-01".into()),
                 to_date: None,
             },
-            "grok-4-1-fast",
+            "grok-4.3",
         );
 
-        assert_eq!(body["model"], "grok-4-1-fast");
+        assert_eq!(body["model"], "grok-4.3");
         assert_eq!(body["input"], "Holon updates");
         assert_eq!(body["store"], false);
         assert_eq!(body["tools"][0]["type"], "x_search");

--- a/tests/live_xai.rs
+++ b/tests/live_xai.rs
@@ -9,7 +9,7 @@ use holon::{
 };
 
 fn live_xai_model() -> String {
-    std::env::var("HOLON_LIVE_XAI_MODEL").unwrap_or_else(|_| "grok-4-1-fast".into())
+    std::env::var("HOLON_LIVE_XAI_MODEL").unwrap_or_else(|_| "grok-4.3".into())
 }
 
 fn live_xai_provider(config: &AppConfig) -> Result<OpenAiProvider> {


### PR DESCRIPTION
## Summary
- replace retired or unsupported built-in xAI entries with the current recommended Grok models documented by xAI
- record conservative context, vision, and reasoning capabilities without inventing undocumented output limits
- regenerate the model reference and document sources, retirement evidence, and compatibility boundaries

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- xAI live test skipped because `XAI_API_KEY` is not available in the environment
