### PR TITLE
fix: calibrate Gemini model catalog

### DIFF
--- a/docs/implementation-decisions/068-gemini-model-catalog.md
+++ b/docs/implementation-decisions/068-gemini-model-catalog.md
@@ -1,0 +1,44 @@
+# 068 Gemini Model Catalog
+
+## Choice
+
+Keep the built-in Gemini catalog limited to current general-purpose
+`generateContent` model codes documented by the Gemini API:
+
+- `gemini-3.5-flash`
+- `gemini-3.1-pro-preview`
+- `gemini-3.1-flash-lite`
+- `gemini-2.5-pro`
+- `gemini-2.5-flash`
+- `gemini-2.5-flash-lite`
+
+Remove the undocumented `gemini-3-pro` and `gemini-3-flash` aliases. Prefer the
+stable `gemini-3.5-flash` route over the preview Pro route.
+
+The catalog records image input and thinking as intrinsic model capabilities.
+The current `gemini_generate_content` transport does not lower image input or a
+thinking control, so resolved routes must not advertise vision observation or
+`reasoning_effort` until those transport features are implemented.
+
+## Reason
+
+Google's model pages document the listed model codes with 1,048,576 input
+tokens, 65,536 output tokens, multimodal input, function calling, and thinking.
+The previous Gemini 3 names were product-family labels rather than current API
+model codes and could produce invalid requests.
+
+This change deliberately does not add Gemini OAuth or image-generation models.
+Those require separate authentication and transport decisions rather than
+catalog-only metadata.
+
+## Sources
+
+Verified 2026-07-12:
+
+- <https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash>
+- <https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview>
+- <https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite>
+- <https://ai.google.dev/gemini-api/docs/models/gemini-2.5-pro>
+- <https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash>
+- <https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-lite>
+- <https://ai.google.dev/gemini-api/docs/deprecations>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -79,3 +79,4 @@ Current decision notes:
 - [065 xAI Grok API and X Login Boundary](./065-xai-grok-api-and-login-boundary.md)
 - [066 Anthropic Model Catalog](./066-anthropic-model-catalog.md)
 - [067 xAI Model Catalog](./067-xai-model-catalog.md)
+- [068 Gemini Model Catalog](./068-gemini-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **193 models**.
+across **40 endpoints** and **195 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -135,10 +135,12 @@ and capabilities.
 | `deepseek` | `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
 | `fireworks` | `accounts/fireworks/models/kimi-k2p6` | `fireworks/accounts/fireworks/models/kimi-k2p6` | 262144 | 262144 | — | ✅ |
 | `fireworks` | `accounts/fireworks/routers/kimi-k2p5-turbo` | `fireworks/accounts/fireworks/routers/kimi-k2p5-turbo` | 256000 | 256000 | — | ✅ |
-| `gemini` | `gemini-2.5-flash` | `gemini/gemini-2.5-flash` | 1000000 | 65536 | ✅ | ✅ |
-| `gemini` | `gemini-2.5-pro` | `gemini/gemini-2.5-pro` | 1000000 | 65536 | ✅ | ✅ |
-| `gemini` | `gemini-3-flash` | `gemini/gemini-3-flash` | 1000000 | 65536 | ✅ | ✅ |
-| `gemini` | `gemini-3-pro` | `gemini/gemini-3-pro` | 1000000 | 65536 | ✅ | ✅ |
+| `gemini` | `gemini-2.5-flash` | `gemini/gemini-2.5-flash` | 1048576 | 65536 | ✅ | ✅ |
+| `gemini` | `gemini-2.5-flash-lite` | `gemini/gemini-2.5-flash-lite` | 1048576 | 65536 | ✅ | ✅ |
+| `gemini` | `gemini-2.5-pro` | `gemini/gemini-2.5-pro` | 1048576 | 65536 | ✅ | ✅ |
+| `gemini` | `gemini-3.1-flash-lite` | `gemini/gemini-3.1-flash-lite` | 1048576 | 65536 | ✅ | ✅ |
+| `gemini` | `gemini-3.1-pro-preview` | `gemini/gemini-3.1-pro-preview` | 1048576 | 65536 | ✅ | ✅ |
+| `gemini` | `gemini-3.5-flash` | `gemini/gemini-3.5-flash` | 1048576 | 65536 | ✅ | ✅ |
 | `huggingface` | `moonshotai/Kimi-K2-Instruct` | `huggingface/moonshotai/Kimi-K2-Instruct` | 262144 | 32768 | — | — |
 | `kilocode` | `kilo/auto` | `kilocode/kilo/auto` | 1000000 | 128000 | ✅ | ✅ |
 | `litellm` | `claude-opus-4-6` | `litellm/claude-opus-4-6` | 200000 | 128000 | ✅ | ✅ |

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1147,6 +1147,36 @@ mod tests {
     }
 
     #[test]
+    fn gemini_transport_does_not_advertise_unimplemented_vision_or_reasoning_controls() {
+        let catalog = crate::model_catalog::BuiltInModelCatalog::new();
+        let policy = catalog.resolve_policy(
+            &ModelRef::parse("gemini/gemini-3.5-flash").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &crate::config::ContextConfig::default(),
+            8192,
+        );
+
+        assert!(policy.capabilities.image_input);
+        assert!(policy.capabilities.supports_reasoning);
+        assert!(policy.reasoning_effort_options.is_empty());
+
+        let capabilities = ResolvedModelCapabilities::resolve(
+            &policy,
+            ProviderTransportKind::GeminiGenerateContent,
+        );
+        assert!(!capabilities.transport.image_input);
+        assert!(!capabilities.image_input);
+        assert!(!capabilities.supports(ModelRouteCapability::VisionObservation));
+        assert!(capabilities
+            .endpoint
+            .accepted_parameters
+            .iter()
+            .all(|parameter| parameter.name != "reasoning_effort"));
+    }
+
+    #[test]
     fn resolved_capabilities_preserve_reasoning_effort_allowed_values() {
         let policy = ResolvedRuntimeModelPolicy {
             reasoning_effort_options: vec!["low".into(), "high".into()],

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1120,18 +1120,27 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "gemini",
-            "gemini-3-pro",
-            "Gemini 3 Pro",
-            1_000_000,
+            "gemini-3.5-flash",
+            "Gemini 3.5 Flash",
+            1_048_576,
             65_536,
             true,
             true,
         ),
         catalog_model(
             "gemini",
-            "gemini-3-flash",
-            "Gemini 3 Flash",
-            1_000_000,
+            "gemini-3.1-pro-preview",
+            "Gemini 3.1 Pro Preview",
+            1_048_576,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "gemini",
+            "gemini-3.1-flash-lite",
+            "Gemini 3.1 Flash-Lite",
+            1_048_576,
             65_536,
             true,
             true,
@@ -1140,7 +1149,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "gemini",
             "gemini-2.5-pro",
             "Gemini 2.5 Pro",
-            1_000_000,
+            1_048_576,
             65_536,
             true,
             true,
@@ -1149,7 +1158,16 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "gemini",
             "gemini-2.5-flash",
             "Gemini 2.5 Flash",
-            1_000_000,
+            1_048_576,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "gemini",
+            "gemini-2.5-flash-lite",
+            "Gemini 2.5 Flash-Lite",
+            1_048_576,
             65_536,
             true,
             true,
@@ -2992,6 +3010,45 @@ mod tests {
             assert!(
                 catalog
                     .get(&ModelRef::new(ProviderId::anthropic(), removed_model))
+                    .is_none(),
+                "{removed_model} should not be registered"
+            );
+        }
+    }
+
+    #[test]
+    fn gemini_catalog_tracks_current_generate_content_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            "gemini-3.5-flash",
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-lite",
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+        ];
+
+        for model in expected {
+            let metadata = catalog
+                .get(&ModelRef::new(ProviderId::gemini(), model))
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, Some(1_048_576));
+            assert_eq!(metadata.default_max_output_tokens, Some(65_536));
+            assert_eq!(metadata.max_output_tokens_upper_limit, Some(65_536));
+            assert!(metadata.capabilities.image_input);
+            assert!(metadata.capabilities.supports_reasoning);
+            assert!(reasoning_effort_options(
+                &metadata.model_ref,
+                metadata.endpoint.as_ref(),
+                &metadata.capabilities,
+            )
+            .is_empty());
+        }
+
+        for removed_model in ["gemini-3-pro", "gemini-3-flash"] {
+            assert!(
+                catalog
+                    .get(&ModelRef::new(ProviderId::gemini(), removed_model))
                     .is_none(),
                 "{removed_model} should not be registered"
             );


### PR DESCRIPTION
## Summary
- calibrate the built-in Gemini catalog against current Google Gemini API model and deprecation documentation
- keep advertised capabilities aligned with the native transport by avoiding unsupported vision/reasoning claims
- add catalog/config regression tests, source records, and refresh the generated model reference

## Scope
- no Gemini OAuth support
- no Nano Banana or image-generation integration

## Verification
- `cargo fmt --all -- --check`
- targeted Gemini catalog/config tests
- `cargo test --lib` (2168 tests)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- live endpoint test not run because no usable `GEMINI_API_KEY` was available in the environment
