### PR TITLE
fix: calibrate DeepSeek model catalog

### DIFF
--- a/docs/implementation-decisions/069-deepseek-model-catalog.md
+++ b/docs/implementation-decisions/069-deepseek-model-catalog.md
@@ -1,0 +1,40 @@
+# 069 DeepSeek Model Catalog
+
+## Choice
+
+Keep the built-in direct DeepSeek catalog limited to the current API models:
+
+- `deepseek-v4-flash`
+- `deepseek-v4-pro`
+
+Both models use a 1,000,000-token context window and support up to 384,000
+output tokens. Record reasoning as an intrinsic capability, but do not expose
+reasoning effort options through the current Anthropic-compatible route.
+
+Remove `deepseek-chat` and `deepseek-reasoner` from the selectable catalog.
+They are compatibility names mapped to the non-thinking and thinking modes of
+`deepseek-v4-flash`, and DeepSeek has scheduled their deprecation for
+2026-07-24 15:59 UTC.
+
+## Reason
+
+DeepSeek's current model table lists only the V4 Flash and Pro model codes.
+Keeping the compatibility names selectable would duplicate one underlying
+model and retain aliases with an announced retirement date.
+
+The Anthropic-compatible endpoint supports thinking and accepts
+`output_config.effort`, but Holon's Anthropic transport currently lowers
+`reasoning_effort` to Anthropic `thinking.budget_tokens`. DeepSeek explicitly
+ignores `budget_tokens`, so advertising adjustable effort would overstate the
+implemented route contract.
+
+Image and document message blocks are not supported by DeepSeek's Anthropic
+endpoint, so neither model is a vision candidate.
+
+## Sources
+
+Verified 2026-07-12:
+
+- <https://api-docs.deepseek.com/quick_start/pricing/>
+- <https://api-docs.deepseek.com/guides/thinking_mode/>
+- <https://api-docs.deepseek.com/guides/anthropic_api/>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -80,3 +80,4 @@ Current decision notes:
 - [066 Anthropic Model Catalog](./066-anthropic-model-catalog.md)
 - [067 xAI Model Catalog](./067-xai-model-catalog.md)
 - [068 Gemini Model Catalog](./068-gemini-model-catalog.md)
+- [069 DeepSeek Model Catalog](./069-deepseek-model-catalog.md)

--- a/docs/providers/openai-chat-completions.md
+++ b/docs/providers/openai-chat-completions.md
@@ -321,7 +321,7 @@ Model references: `together/mixtral-8x7b-instruct-v0-1`
 }
 ```
 
-Model references: `deepseek/deepseek-chat`
+Model references: `deepseek/deepseek-v4-flash`
 
 ## Troubleshooting
 

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -129,8 +129,6 @@ and capabilities.
 | `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-plus` | `dashscope/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
-| `deepseek` | `deepseek-chat` | `deepseek/deepseek-chat` | 131072 | 8192 | — | — |
-| `deepseek` | `deepseek-reasoner` | `deepseek/deepseek-reasoner` | 131072 | 65536 | ✅ | — |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `deepseek` | `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
 | `fireworks` | `accounts/fireworks/models/kimi-k2p6` | `fireworks/accounts/fireworks/models/kimi-k2p6` | 262144 | 262144 | — | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1299,24 +1299,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "deepseek",
-            "deepseek-chat",
-            "DeepSeek Chat",
-            131_072,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "deepseek",
-            "deepseek-reasoner",
-            "DeepSeek Reasoner",
-            131_072,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
             "fireworks",
             "accounts/fireworks/models/kimi-k2p6",
             "Kimi K2.6",
@@ -3100,6 +3082,37 @@ mod tests {
             assert!(
                 catalog
                     .get(&ModelRef::new(provider_id("xai"), removed_model))
+                    .is_none(),
+                "{removed_model} should not be registered"
+            );
+        }
+    }
+
+    #[test]
+    fn deepseek_catalog_tracks_current_api_models() {
+        let catalog = BuiltInModelCatalog::new();
+
+        for model in ["deepseek-v4-flash", "deepseek-v4-pro"] {
+            let metadata = catalog
+                .get(&ModelRef::new(provider_id("deepseek"), model))
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, Some(1_000_000));
+            assert_eq!(metadata.default_max_output_tokens, Some(384_000));
+            assert_eq!(metadata.max_output_tokens_upper_limit, Some(384_000));
+            assert!(metadata.capabilities.supports_reasoning);
+            assert!(!metadata.capabilities.image_input);
+            assert!(reasoning_effort_options(
+                &metadata.model_ref,
+                metadata.endpoint.as_ref(),
+                &metadata.capabilities,
+            )
+            .is_empty());
+        }
+
+        for removed_model in ["deepseek-chat", "deepseek-reasoner"] {
+            assert!(
+                catalog
+                    .get(&ModelRef::new(provider_id("deepseek"), removed_model))
                     .is_none(),
                 "{removed_model} should not be registered"
             );

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -2546,7 +2546,7 @@ mod tests {
             "provider_round_completed",
             &json!({
                 "round": 2,
-                "active_model": "deepseek-chat",
+                "active_model": "deepseek-v4-flash",
                 "stop_reason": "tool_use",
                 "input_tokens": 12,
                 "output_tokens": 7,
@@ -2559,7 +2559,7 @@ mod tests {
         assert_eq!(provider.category, OperatorEventCategory::AssistantProgress);
         assert_eq!(
             provider.summary,
-            "Provider round 2: model=deepseek-chat; stop=tool_use; 12/7 tokens; tools=1"
+            "Provider round 2: model=deepseek-v4-flash; stop=tool_use; 12/7 tokens; tools=1"
         );
         assert_eq!(provider.title, "Provider round completed");
     }

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -252,7 +252,7 @@ mod tests {
                     }),
                 },
                 ProviderCandidate {
-                    model_ref: "deepseek/deepseek-chat".into(),
+                    model_ref: "deepseek/deepseek-v4-flash".into(),
                     provider_name: "deepseek".into(),
                     provider: Arc::new(SearchProvider { capability: None }),
                 },

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -402,11 +402,11 @@ async fn live_configured_model_chain_builtin_web_search_support() -> Result<()> 
 }
 
 #[tokio::test]
-#[ignore = "requires DEEPSEEK_API_KEY and network access"]
+#[ignore = "requires a configured DeepSeek credential and network access"]
 async fn live_deepseek_anthropic_accepts_context_management() -> Result<()> {
     provider_accepts_context_management(
-        "deepseek-anthropic",
-        &provider_model_env("deepseek-anthropic", "deepseek-chat"),
+        "deepseek",
+        &provider_model_env("deepseek", "deepseek-v4-flash"),
     )
     .await
 }


### PR DESCRIPTION
## Summary
- align the direct DeepSeek catalog with the current `deepseek-v4-flash` and `deepseek-v4-pro` API models
- remove retiring compatibility aliases and document context/output/reasoning/vision boundaries from official DeepSeek sources
- add catalog regression coverage, refresh the model reference, and update the DeepSeek live route probe

## Verification
- `cargo fmt --all -- --check`
- targeted DeepSeek catalog and Anthropic-compatible policy tests
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- configured-credential live test for `deepseek/deepseek-v4-flash`
