### PR TITLE
fix: calibrate MiniMax model catalog

### DIFF
--- a/docs/implementation-decisions/070-minimax-model-catalog.md
+++ b/docs/implementation-decisions/070-minimax-model-catalog.md
@@ -1,0 +1,43 @@
+# 070 MiniMax Model Catalog
+
+## Choice
+
+Keep the built-in direct MiniMax catalog limited to the eight models currently
+listed for the Anthropic-compatible endpoint:
+
+- `MiniMax-M3`
+- `MiniMax-M2.7`
+- `MiniMax-M2.7-highspeed`
+- `MiniMax-M2.5`
+- `MiniMax-M2.5-highspeed`
+- `MiniMax-M2.1`
+- `MiniMax-M2.1-highspeed`
+- `MiniMax-M2`
+
+Mark only `MiniMax-M3` as accepting image input. Keep reasoning as an intrinsic
+capability for all eight models, but do not expose reasoning effort options.
+
+Retain the existing context and output limits. MiniMax documents a
+1,000,000-token context window for M3 and 204,800 tokens for M2.x. Its current
+public model pages do not provide a replacement for the existing output limits.
+
+## Reason
+
+MiniMax's Anthropic compatibility documentation explicitly lists all eight
+models, so there is no official basis to remove the older M2.x entries.
+
+The endpoint accepts image and video content only for M3. Holon currently
+models image input but not video input, so M3 becomes a vision candidate while
+M2.x remains text-only.
+
+MiniMax thinking control does not map to Holon's reasoning effort contract:
+M3 supports adaptive thinking on or off, while M2.x thinking cannot be
+disabled. Advertising effort levels would therefore overstate the implemented
+Anthropic route.
+
+## Sources
+
+Verified 2026-07-12:
+
+- <https://platform.minimax.io/docs/api-reference/text-anthropic-api>
+- <https://platform.minimax.io/docs/guides/text-generation>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -81,3 +81,4 @@ Current decision notes:
 - [067 xAI Model Catalog](./067-xai-model-catalog.md)
 - [068 Gemini Model Catalog](./068-gemini-model-catalog.md)
 - [069 DeepSeek Model Catalog](./069-deepseek-model-catalog.md)
+- [070 MiniMax Model Catalog](./070-minimax-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **195 models**.
+across **40 endpoints** and **193 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -149,7 +149,7 @@ and capabilities.
 | `minimax` | `MiniMax-M2.5-highspeed` | `minimax/MiniMax-M2.5-highspeed` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M2.7` | `minimax/MiniMax-M2.7` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M2.7-highspeed` | `minimax/MiniMax-M2.7-highspeed` | 204800 | 128000 | ✅ | — |
-| `minimax` | `MiniMax-M3` | `minimax/MiniMax-M3` | 1000000 | 32768 | ✅ | — |
+| `minimax` | `MiniMax-M3` | `minimax/MiniMax-M3` | 1000000 | 32768 | ✅ | ✅ |
 | `mistral` | `codestral-latest` | `mistral/codestral-latest` | 256000 | 4096 | — | — |
 | `mistral` | `devstral-medium-latest` | `mistral/devstral-medium-latest` | 262144 | 32768 | — | — |
 | `mistral` | `magistral-small` | `mistral/magistral-small` | 128000 | 40000 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1350,7 +1350,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             1_000_000,
             32_768,
             true,
-            false,
+            true,
         ),
         catalog_model(
             "minimax",
@@ -3380,6 +3380,52 @@ mod tests {
         assert!(catalog
             .get(&ModelRef::parse("dashscope-openai/MiniMax-M2.5").unwrap())
             .is_none());
+    }
+
+    #[test]
+    fn minimax_catalog_tracks_current_anthropic_models_and_modalities() {
+        let catalog = BuiltInModelCatalog::new();
+        let minimax = ProviderId::parse("minimax").unwrap();
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|entry| entry.model_ref.provider == minimax)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            models
+                .iter()
+                .map(|entry| entry.model_ref.model.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "MiniMax-M2",
+                "MiniMax-M2.1",
+                "MiniMax-M2.1-highspeed",
+                "MiniMax-M2.5",
+                "MiniMax-M2.5-highspeed",
+                "MiniMax-M2.7",
+                "MiniMax-M2.7-highspeed",
+                "MiniMax-M3",
+            ]
+        );
+
+        let m3 = catalog
+            .get(&ModelRef::parse("minimax/MiniMax-M3").unwrap())
+            .unwrap();
+        assert_eq!(m3.context_window_tokens, Some(1_000_000));
+        assert_eq!(m3.max_output_tokens_upper_limit, Some(32_768));
+        assert!(m3.capabilities.supports_reasoning);
+        assert!(m3.capabilities.image_input);
+
+        for model in models
+            .into_iter()
+            .filter(|entry| entry.model_ref.model != "MiniMax-M3")
+        {
+            assert_eq!(model.context_window_tokens, Some(204_800));
+            assert_eq!(model.max_output_tokens_upper_limit, Some(128_000));
+            assert!(model.capabilities.supports_reasoning);
+            assert!(!model.capabilities.image_input);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- calibrate the direct MiniMax catalog against current official API documentation
- mark the MiniMax M3 family as accepting image input while preserving the documented text-only M2.x capabilities and current limits
- add a catalog invariant test, source/decision record, and regenerate the model reference

The generated reference count changes from 195 to 193 even though this PR does not remove models. The checked-in reference on `main` was stale; rerunning the repository's official docgen synchronizes it with the current 193-entry catalog.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test live_anthropic_compatible live_minimax_anthropic_accepts_context_management -- --ignored --exact --nocapture`
- `git diff --check`
