### PR TITLE
fix: calibrate Moonshot model catalog

### DIFF
--- a/docs/implementation-decisions/071-moonshot-model-catalog.md
+++ b/docs/implementation-decisions/071-moonshot-model-catalog.md
@@ -1,0 +1,41 @@
+# 071 Moonshot Model Catalog
+
+## Choice
+
+Keep the built-in direct Moonshot catalog aligned with the models accepted by
+the current Chat Completions schema:
+
+- `kimi-k2.7-code`
+- `kimi-k2.7-code-highspeed`
+- `kimi-k2.6`
+- `kimi-k2.5`
+- the text, vision preview, and automatic-routing Moonshot V1 variants
+
+Remove the Kimi K2 Thinking and Turbo entries that are no longer in the current
+model list. Mark the four current Kimi models as reasoning and image-input
+capable. Do not expose reasoning effort options.
+
+## Reason
+
+Moonshot discontinued the Kimi K2 Thinking series on May 25, 2026. Its current
+model list and Chat Completions schema instead advertise K2.7 Code, K2.6, K2.5,
+and Moonshot V1.
+
+K2.7 Code always thinks, while K2.6 and K2.5 accept Moonshot's
+provider-specific `thinking` object. Holon's OpenAI-compatible transport does
+not implement that control, so intrinsic reasoning remains visible without
+claiming an unsupported effort-level contract.
+
+Moonshot documents the Kimi models as native multimodal models accepting text,
+image, and video. Holon currently models image input but not video input.
+
+## Sources
+
+Verified 2026-07-12:
+
+- <https://platform.kimi.ai/docs/models.md>
+- <https://platform.kimi.ai/docs/api/chat.md>
+- <https://platform.kimi.ai/docs/api/models-overview.md>
+- <https://platform.kimi.ai/docs/pricing/chat-k25.md>
+- <https://platform.kimi.ai/docs/pricing/chat-k26.md>
+- <https://platform.kimi.ai/docs/pricing/chat-k27-code.md>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -82,3 +82,4 @@ Current decision notes:
 - [068 Gemini Model Catalog](./068-gemini-model-catalog.md)
 - [069 DeepSeek Model Catalog](./069-deepseek-model-catalog.md)
 - [070 MiniMax Model Catalog](./070-minimax-model-catalog.md)
+- [071 Moonshot Model Catalog](./071-moonshot-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **193 models**.
+across **40 endpoints** and **199 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -157,11 +157,17 @@ and capabilities.
 | `mistral` | `mistral-medium-2508` | `mistral/mistral-medium-2508` | 262144 | 8192 | — | ✅ |
 | `mistral` | `mistral-small-latest` | `mistral/mistral-small-latest` | 128000 | 16384 | ✅ | ✅ |
 | `mistral` | `pixtral-large-latest` | `mistral/pixtral-large-latest` | 128000 | 32768 | — | ✅ |
-| `moonshot` | `kimi-k2-thinking` | `moonshot/kimi-k2-thinking` | 262144 | 262144 | ✅ | — |
-| `moonshot` | `kimi-k2-thinking-turbo` | `moonshot/kimi-k2-thinking-turbo` | 262144 | 262144 | ✅ | — |
-| `moonshot` | `kimi-k2-turbo` | `moonshot/kimi-k2-turbo` | 256000 | 16384 | — | — |
-| `moonshot` | `kimi-k2.5` | `moonshot/kimi-k2.5` | 262144 | 262144 | — | ✅ |
-| `moonshot` | `kimi-k2.6` | `moonshot/kimi-k2.6` | 262144 | 262144 | — | ✅ |
+| `moonshot` | `kimi-k2.5` | `moonshot/kimi-k2.5` | 262144 | 262144 | ✅ | ✅ |
+| `moonshot` | `kimi-k2.6` | `moonshot/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
+| `moonshot` | `kimi-k2.7-code` | `moonshot/kimi-k2.7-code` | 262144 | 262144 | ✅ | ✅ |
+| `moonshot` | `kimi-k2.7-code-highspeed` | `moonshot/kimi-k2.7-code-highspeed` | 262144 | 262144 | ✅ | ✅ |
+| `moonshot` | `moonshot-v1-128k` | `moonshot/moonshot-v1-128k` | 131072 | 131072 | — | — |
+| `moonshot` | `moonshot-v1-128k-vision-preview` | `moonshot/moonshot-v1-128k-vision-preview` | 131072 | 131072 | — | ✅ |
+| `moonshot` | `moonshot-v1-32k` | `moonshot/moonshot-v1-32k` | 32768 | 32768 | — | — |
+| `moonshot` | `moonshot-v1-32k-vision-preview` | `moonshot/moonshot-v1-32k-vision-preview` | 32768 | 32768 | — | ✅ |
+| `moonshot` | `moonshot-v1-8k` | `moonshot/moonshot-v1-8k` | 8192 | 8192 | — | — |
+| `moonshot` | `moonshot-v1-8k-vision-preview` | `moonshot/moonshot-v1-8k-vision-preview` | 8192 | 8192 | — | ✅ |
+| `moonshot` | `moonshot-v1-auto` | `moonshot/moonshot-v1-auto` | 131072 | 131072 | — | — |
 | `nearai` | `Qwen/Qwen3-VL-30B-A3B-Instruct` | `nearai/Qwen/Qwen3-VL-30B-A3B-Instruct` | 256000 | 65536 | ✅ | ✅ |
 | `nearai` | `Qwen/Qwen3.5-122B-A10B` | `nearai/Qwen/Qwen3.5-122B-A10B` | 131072 | 65536 | ✅ | — |
 | `nearai` | `Qwen/Qwen3.6-35B-A3B-FP8` | `nearai/Qwen/Qwen3.6-35B-A3B-FP8` | 262144 | 65536 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1480,11 +1480,29 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "moonshot",
+            "kimi-k2.7-code",
+            "Kimi K2.7 Code",
+            262_144,
+            262_144,
+            true,
+            true,
+        ),
+        catalog_model(
+            "moonshot",
+            "kimi-k2.7-code-highspeed",
+            "Kimi K2.7 Code HighSpeed",
+            262_144,
+            262_144,
+            true,
+            true,
+        ),
+        catalog_model(
+            "moonshot",
             "kimi-k2.6",
             "Kimi K2.6",
             262_144,
             262_144,
-            false,
+            true,
             true,
         ),
         catalog_model(
@@ -1493,35 +1511,71 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "Kimi K2.5",
             262_144,
             262_144,
+            true,
+            true,
+        ),
+        catalog_model(
+            "moonshot",
+            "moonshot-v1-8k",
+            "Moonshot V1 8K",
+            8_192,
+            8_192,
+            false,
+            false,
+        ),
+        catalog_model(
+            "moonshot",
+            "moonshot-v1-32k",
+            "Moonshot V1 32K",
+            32_768,
+            32_768,
+            false,
+            false,
+        ),
+        catalog_model(
+            "moonshot",
+            "moonshot-v1-128k",
+            "Moonshot V1 128K",
+            131_072,
+            131_072,
+            false,
+            false,
+        ),
+        catalog_model(
+            "moonshot",
+            "moonshot-v1-auto",
+            "Moonshot V1 Auto",
+            131_072,
+            131_072,
+            false,
+            false,
+        ),
+        catalog_model(
+            "moonshot",
+            "moonshot-v1-8k-vision-preview",
+            "Moonshot V1 8K Vision Preview",
+            8_192,
+            8_192,
             false,
             true,
         ),
         catalog_model(
             "moonshot",
-            "kimi-k2-thinking",
-            "Kimi K2 Thinking",
-            262_144,
-            262_144,
-            true,
+            "moonshot-v1-32k-vision-preview",
+            "Moonshot V1 32K Vision Preview",
+            32_768,
+            32_768,
             false,
+            true,
         ),
         catalog_model(
             "moonshot",
-            "kimi-k2-thinking-turbo",
-            "Kimi K2 Thinking Turbo",
-            262_144,
-            262_144,
+            "moonshot-v1-128k-vision-preview",
+            "Moonshot V1 128K Vision Preview",
+            131_072,
+            131_072,
+            false,
             true,
-            false,
-        ),
-        catalog_model(
-            "moonshot",
-            "kimi-k2-turbo",
-            "Kimi K2 Turbo",
-            256_000,
-            16_384,
-            false,
-            false,
         ),
         catalog_model(
             "nearai",
@@ -3713,6 +3767,65 @@ mod tests {
                 8192,
             );
             assert!(!policy.capabilities.image_input, "{model_ref}");
+        }
+    }
+
+    #[test]
+    fn moonshot_catalog_tracks_current_models_and_retirements() {
+        let catalog = BuiltInModelCatalog::new();
+        let moonshot = ProviderId::parse("moonshot").unwrap();
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|model| model.model_ref.provider == moonshot)
+            .map(|model| model.model_ref.model.clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            models,
+            [
+                "kimi-k2.5",
+                "kimi-k2.6",
+                "kimi-k2.7-code",
+                "kimi-k2.7-code-highspeed",
+                "moonshot-v1-128k",
+                "moonshot-v1-128k-vision-preview",
+                "moonshot-v1-32k",
+                "moonshot-v1-32k-vision-preview",
+                "moonshot-v1-8k",
+                "moonshot-v1-8k-vision-preview",
+                "moonshot-v1-auto",
+            ]
+        );
+
+        for model_ref in [
+            "moonshot/kimi-k2.5",
+            "moonshot/kimi-k2.6",
+            "moonshot/kimi-k2.7-code",
+            "moonshot/kimi-k2.7-code-highspeed",
+        ] {
+            let policy = catalog.resolve_policy(
+                &ModelRef::parse(model_ref).unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert!(policy.capabilities.supports_reasoning, "{model_ref}");
+            assert!(policy.capabilities.image_input, "{model_ref}");
+            assert!(policy.reasoning_effort_options.is_empty(), "{model_ref}");
+        }
+
+        for model_ref in [
+            "moonshot/kimi-k2-thinking",
+            "moonshot/kimi-k2-thinking-turbo",
+            "moonshot/kimi-k2-turbo",
+        ] {
+            assert!(
+                catalog.get(&ModelRef::parse(model_ref).unwrap()).is_none(),
+                "{model_ref} should not be registered"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- calibrate the direct `moonshot` catalog against current Moonshot AI API documentation
- add Kimi K2.7 Code/HighSpeed, K2.6, and K2.5 metadata while removing retired K2 Thinking entries
- preserve Moonshot V1 limits, document source decisions, and regenerate the model reference
- add catalog invariants covering current models, retirements, ordering, modalities, and reasoning/tool capabilities

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib model_catalog::tests::moonshot_catalog_tracks_current_models_and_retirements`
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

## Live provider check
The local provider smoke configuration did not include a `moonshot` route, so a real Moonshot request could not be executed. The generic smoke run reached unrelated providers and failed only because an Anthropic model was no longer available and the configured BigModel account lacked balance; those failures are unrelated to this catalog change.
