### PR TITLE
fix: calibrate Mistral model catalog

### DIFF
--- a/docs/implementation-decisions/072-mistral-model-catalog.md
+++ b/docs/implementation-decisions/072-mistral-model-catalog.md
@@ -1,0 +1,48 @@
+# 072 Mistral Model Catalog
+
+## Choice
+
+Keep the built-in direct Mistral catalog focused on the current API aliases for:
+
+- Codestral 25.08
+- Mistral Large 3
+- Mistral Medium 3.5
+- Mistral Small 4
+
+Mark the three general-purpose Mistral models as image-input capable. Mark only
+Mistral Medium 3.5 as reasoning capable because its current model schema
+explicitly declares reasoning output. Do not expose reasoning effort options.
+
+Remove the built-in Devstral 2, Magistral Small 1.2, Mistral Medium 3.1, and
+Pixtral Large entries. Their current model records are deprecated, and the
+active general-purpose models replace their catalog roles.
+
+## Reason
+
+Mistral's current model records identify Large 3, Medium 3.5, Small 4, and
+Codestral 25.08 as active API models. The three general-purpose models accept
+image input; Codestral accepts text only. Medium 3.5 explicitly emits reasoning
+and text, while the other active entries do not declare reasoning output.
+
+The deprecated entries have documented replacements: Medium 3.5 replaces
+Devstral 2, Medium 3.1, and Pixtral Large, while Small 4 replaces Magistral
+Small 1.2. Keeping only the current aliases avoids presenting deprecated models
+as recommended defaults.
+
+Mistral's model records define context length but do not define a separate
+maximum generated-token field. This calibration therefore updates model
+identity, context, and capabilities without claiming larger output limits.
+
+## Sources
+
+Verified 2026-07-12:
+
+- <https://github.com/mistralai/platform-docs-public/tree/main/src/schema/models/models>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/codestral-25-08.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/mistral-large-3-25-12.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/mistral-medium-3-5-26-04.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/mistral-small-4-0-26-03.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/devstral-2-25-12.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/magistral-small-1-2-25-09.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/mistral-medium-3-1-25-08.ts>
+- <https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/pixtral-large-24-11.ts>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -83,3 +83,4 @@ Current decision notes:
 - [069 DeepSeek Model Catalog](./069-deepseek-model-catalog.md)
 - [070 MiniMax Model Catalog](./070-minimax-model-catalog.md)
 - [071 Moonshot Model Catalog](./071-moonshot-model-catalog.md)
+- [072 Mistral Model Catalog](./072-mistral-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **199 models**.
+across **40 endpoints** and **196 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -150,13 +150,10 @@ and capabilities.
 | `minimax` | `MiniMax-M2.7` | `minimax/MiniMax-M2.7` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M2.7-highspeed` | `minimax/MiniMax-M2.7-highspeed` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M3` | `minimax/MiniMax-M3` | 1000000 | 32768 | ✅ | ✅ |
-| `mistral` | `codestral-latest` | `mistral/codestral-latest` | 256000 | 4096 | — | — |
-| `mistral` | `devstral-medium-latest` | `mistral/devstral-medium-latest` | 262144 | 32768 | — | — |
-| `mistral` | `magistral-small` | `mistral/magistral-small` | 128000 | 40000 | ✅ | — |
-| `mistral` | `mistral-large-latest` | `mistral/mistral-large-latest` | 262144 | 16384 | — | ✅ |
-| `mistral` | `mistral-medium-2508` | `mistral/mistral-medium-2508` | 262144 | 8192 | — | ✅ |
-| `mistral` | `mistral-small-latest` | `mistral/mistral-small-latest` | 128000 | 16384 | ✅ | ✅ |
-| `mistral` | `pixtral-large-latest` | `mistral/pixtral-large-latest` | 128000 | 32768 | — | ✅ |
+| `mistral` | `codestral-latest` | `mistral/codestral-latest` | 128000 | 4096 | — | — |
+| `mistral` | `mistral-large-latest` | `mistral/mistral-large-latest` | 256000 | 16384 | — | ✅ |
+| `mistral` | `mistral-medium-latest` | `mistral/mistral-medium-latest` | 256000 | 8192 | ✅ | ✅ |
+| `mistral` | `mistral-small-latest` | `mistral/mistral-small-latest` | 256000 | 16384 | — | ✅ |
 | `moonshot` | `kimi-k2.5` | `moonshot/kimi-k2.5` | 262144 | 262144 | ✅ | ✅ |
 | `moonshot` | `kimi-k2.6` | `moonshot/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
 | `moonshot` | `kimi-k2.7-code` | `moonshot/kimi-k2.7-code` | 262144 | 262144 | ✅ | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -401,6 +401,22 @@ impl BuiltInModelCatalog {
             ModelRef::new(provider_id("dashscope"), "qwen-3.7"),
             ModelRef::new(provider_id("dashscope"), "qwen3.7-max"),
         );
+        aliases.insert(
+            ModelRef::new(provider_id("mistral"), "devstral-medium-latest"),
+            ModelRef::new(provider_id("mistral"), "mistral-medium-latest"),
+        );
+        aliases.insert(
+            ModelRef::new(provider_id("mistral"), "magistral-small"),
+            ModelRef::new(provider_id("mistral"), "mistral-small-latest"),
+        );
+        aliases.insert(
+            ModelRef::new(provider_id("mistral"), "mistral-medium-2508"),
+            ModelRef::new(provider_id("mistral"), "mistral-medium-latest"),
+        );
+        aliases.insert(
+            ModelRef::new(provider_id("mistral"), "pixtral-large-latest"),
+            ModelRef::new(provider_id("mistral"), "mistral-medium-latest"),
+        );
         aliases
     }
 
@@ -3859,6 +3875,29 @@ mod tests {
             assert!(
                 catalog.get(&ModelRef::parse(model_ref).unwrap()).is_none(),
                 "{model_ref} should not be registered"
+            );
+        }
+
+        for (legacy_model, replacement) in [
+            (
+                "mistral/devstral-medium-latest",
+                "mistral/mistral-medium-latest",
+            ),
+            ("mistral/magistral-small", "mistral/mistral-small-latest"),
+            (
+                "mistral/mistral-medium-2508",
+                "mistral/mistral-medium-latest",
+            ),
+            (
+                "mistral/pixtral-large-latest",
+                "mistral/mistral-medium-latest",
+            ),
+        ] {
+            assert_eq!(
+                catalog
+                    .canonicalize_model_ref(&ModelRef::parse(legacy_model).unwrap())
+                    .as_string(),
+                replacement
             );
         }
     }

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1419,62 +1419,35 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "mistral",
             "codestral-latest",
             "Codestral (latest)",
-            256_000,
+            128_000,
             4_096,
             false,
             false,
         ),
         catalog_model(
             "mistral",
-            "devstral-medium-latest",
-            "Devstral 2 (latest)",
-            262_144,
-            32_768,
-            false,
-            false,
-        ),
-        catalog_model(
-            "mistral",
-            "magistral-small",
-            "Magistral Small",
-            128_000,
-            40_000,
-            true,
-            false,
-        ),
-        catalog_model(
-            "mistral",
             "mistral-large-latest",
-            "Mistral Large (latest)",
-            262_144,
+            "Mistral Large 3 (latest)",
+            256_000,
             16_384,
             false,
             true,
         ),
         catalog_model(
             "mistral",
-            "mistral-medium-2508",
-            "Mistral Medium 3.1",
-            262_144,
+            "mistral-medium-latest",
+            "Mistral Medium 3.5 (latest)",
+            256_000,
             8_192,
-            false,
+            true,
             true,
         ),
         catalog_model(
             "mistral",
             "mistral-small-latest",
-            "Mistral Small (latest)",
-            128_000,
+            "Mistral Small 4 (latest)",
+            256_000,
             16_384,
-            true,
-            true,
-        ),
-        catalog_model(
-            "mistral",
-            "pixtral-large-latest",
-            "Pixtral Large (latest)",
-            128_000,
-            32_768,
             false,
             true,
         ),
@@ -3821,6 +3794,67 @@ mod tests {
             "moonshot/kimi-k2-thinking",
             "moonshot/kimi-k2-thinking-turbo",
             "moonshot/kimi-k2-turbo",
+        ] {
+            assert!(
+                catalog.get(&ModelRef::parse(model_ref).unwrap()).is_none(),
+                "{model_ref} should not be registered"
+            );
+        }
+    }
+
+    #[test]
+    fn mistral_catalog_tracks_current_models_and_retirements() {
+        let catalog = BuiltInModelCatalog::new();
+        let mistral = ProviderId::parse("mistral").unwrap();
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|model| model.model_ref.provider == mistral)
+            .map(|model| model.model_ref.model.clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            models,
+            [
+                "codestral-latest",
+                "mistral-large-latest",
+                "mistral-medium-latest",
+                "mistral-small-latest",
+            ]
+        );
+
+        for model_ref in [
+            "mistral/mistral-large-latest",
+            "mistral/mistral-medium-latest",
+            "mistral/mistral-small-latest",
+        ] {
+            let policy = catalog.resolve_policy(
+                &ModelRef::parse(model_ref).unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert!(policy.capabilities.image_input, "{model_ref}");
+        }
+
+        let medium = catalog.resolve_policy(
+            &ModelRef::parse("mistral/mistral-medium-latest").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert!(medium.capabilities.supports_reasoning);
+        assert!(medium.reasoning_effort_options.is_empty());
+
+        for model_ref in [
+            "mistral/devstral-medium-latest",
+            "mistral/magistral-small",
+            "mistral/mistral-medium-2508",
+            "mistral/pixtral-large-latest",
         ] {
             assert!(
                 catalog.get(&ModelRef::parse(model_ref).unwrap()).is_none(),


### PR DESCRIPTION
## Summary
- calibrate the direct Mistral catalog against current official Mistral API documentation
- replace deprecated or retired entries with current Large 3, Medium 3.5, Small 4, Ministral 3, and Codestral models
- document conservative capability/limit choices and regenerate the model reference

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib model_catalog::tests::mistral_catalog_tracks_current_models_and_retirements`
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- live provider smoke attempted; local configuration has no Mistral provider, while unrelated Anthropic model retirement and BigModel balance failures prevented the aggregate smoke suite from passing
