### PR TITLE
fix: calibrate ZAI and BigModel model catalogs

### DIFF
--- a/docs/implementation-decisions/073-zai-bigmodel-model-catalog.md
+++ b/docs/implementation-decisions/073-zai-bigmodel-model-catalog.md
@@ -1,0 +1,22 @@
+# Z.AI and BigModel model catalogs
+
+Holon keeps separate built-in model lists for the international `zai` provider
+and the mainland China `bigmodel` provider.
+
+Both services expose Anthropic-compatible endpoints and share several current
+GLM models, but their official model overviews are not identical. Z.AI lists
+models such as `glm-4.5-x`, `glm-4.5v`, and `glm-4.6v-flashx`; BigModel instead
+lists domestic-only or differently versioned entries such as `glm-4-long`,
+`glm-4-flashx-250414`, and `glm-4.1v-thinking-flashx`.
+
+The catalog therefore records only chat-completion models present in each
+service's current official overview rather than cloning one provider's list
+onto the other. Shared model names remain separate entries so later endpoint
+changes do not silently alter the other provider.
+
+Sources:
+
+- Z.AI model overview: `https://docs.z.ai/guides/overview/overview`
+- Z.AI GLM-5.2 guide: `https://docs.z.ai/guides/llm/glm-5.2`
+- BigModel model overview:
+  `https://docs.bigmodel.cn/cn/guide/start/model-overview`

--- a/docs/implementation-decisions/073-zai-bigmodel-model-catalog.md
+++ b/docs/implementation-decisions/073-zai-bigmodel-model-catalog.md
@@ -14,6 +14,16 @@ service's current official overview rather than cloning one provider's list
 onto the other. Shared model names remain separate entries so later endpoint
 changes do not silently alter the other provider.
 
+Context limits also follow each service's own documentation. Z.AI publishes
+the affected shared models with decimal `200K` or `128K` limits, while
+BigModel documents the corresponding limits as `204,800` or `131,072`.
+Holon preserves that provider-specific distinction instead of normalizing the
+values merely because the model names match.
+
+This calibration removes the no-longer-listed `bigmodel/glm-4.5` and
+`bigmodel/glm-4.5v` model refs. Configurations using those refs must select a
+model that remains in BigModel's current official overview.
+
 Sources:
 
 - Z.AI model overview: `https://docs.z.ai/guides/overview/overview`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -84,3 +84,4 @@ Current decision notes:
 - [070 MiniMax Model Catalog](./070-minimax-model-catalog.md)
 - [071 Moonshot Model Catalog](./071-moonshot-model-catalog.md)
 - [072 Mistral Model Catalog](./072-mistral-model-catalog.md)
+- [073 Z.AI and BigModel Model Catalog](./073-zai-bigmodel-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **196 models**.
+across **40 endpoints** and **207 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -79,20 +79,26 @@ and capabilities.
 | `arcee` | `trinity-large-preview` | `arcee/trinity-large-preview` | 131072 | 16384 | — | — |
 | `arcee` | `trinity-large-thinking` | `arcee/trinity-large-thinking` | 262144 | 80000 | ✅ | — |
 | `arcee` | `trinity-mini` | `arcee/trinity-mini` | 131072 | 80000 | — | — |
-| `bigmodel` | `glm-4.5` | `bigmodel/glm-4.5` | 131072 | 98304 | ✅ | — |
+| `bigmodel` | `glm-4-flash-250414` | `bigmodel/glm-4-flash-250414` | 131072 | 16384 | — | — |
+| `bigmodel` | `glm-4-flashx-250414` | `bigmodel/glm-4-flashx-250414` | 131072 | 16384 | — | — |
+| `bigmodel` | `glm-4-long` | `bigmodel/glm-4-long` | 1000000 | 4096 | — | — |
+| `bigmodel` | `glm-4.1v-thinking-flash` | `bigmodel/glm-4.1v-thinking-flash` | 65536 | 16384 | ✅ | ✅ |
+| `bigmodel` | `glm-4.1v-thinking-flashx` | `bigmodel/glm-4.1v-thinking-flashx` | 65536 | 16384 | ✅ | ✅ |
 | `bigmodel` | `glm-4.5-air` | `bigmodel/glm-4.5-air` | 131072 | 98304 | ✅ | — |
+| `bigmodel` | `glm-4.5-airx` | `bigmodel/glm-4.5-airx` | 131072 | 98304 | ✅ | — |
 | `bigmodel` | `glm-4.5-flash` | `bigmodel/glm-4.5-flash` | 131072 | 98304 | ✅ | — |
-| `bigmodel` | `glm-4.5v` | `bigmodel/glm-4.5v` | 64000 | 16384 | ✅ | ✅ |
 | `bigmodel` | `glm-4.6` | `bigmodel/glm-4.6` | 204800 | 131072 | ✅ | — |
-| `bigmodel` | `glm-4.6v` | `bigmodel/glm-4.6v` | 128000 | 32768 | ✅ | ✅ |
+| `bigmodel` | `glm-4.6v` | `bigmodel/glm-4.6v` | 131072 | 32768 | ✅ | ✅ |
+| `bigmodel` | `glm-4.6v-flash` | `bigmodel/glm-4.6v-flash` | 131072 | 32768 | ✅ | ✅ |
 | `bigmodel` | `glm-4.7` | `bigmodel/glm-4.7` | 204800 | 131072 | ✅ | — |
-| `bigmodel` | `glm-4.7-flash` | `bigmodel/glm-4.7-flash` | 200000 | 131072 | ✅ | — |
-| `bigmodel` | `glm-4.7-flashx` | `bigmodel/glm-4.7-flashx` | 200000 | 128000 | ✅ | — |
-| `bigmodel` | `glm-5` | `bigmodel/glm-5` | 202800 | 131072 | ✅ | — |
-| `bigmodel` | `glm-5-turbo` | `bigmodel/glm-5-turbo` | 202800 | 131072 | ✅ | — |
-| `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 202800 | 131072 | ✅ | — |
+| `bigmodel` | `glm-4.7-flash` | `bigmodel/glm-4.7-flash` | 204800 | 131072 | ✅ | — |
+| `bigmodel` | `glm-4.7-flashx` | `bigmodel/glm-4.7-flashx` | 204800 | 131072 | ✅ | — |
+| `bigmodel` | `glm-4v-flash` | `bigmodel/glm-4v-flash` | 16384 | 1024 | — | ✅ |
+| `bigmodel` | `glm-5` | `bigmodel/glm-5` | 204800 | 131072 | ✅ | — |
+| `bigmodel` | `glm-5-turbo` | `bigmodel/glm-5-turbo` | 204800 | 131072 | ✅ | — |
+| `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 204800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
-| `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |
+| `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 204800 | 131072 | ✅ | ✅ |
 | `byteplus` | `ark-code-latest` | `byteplus/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `byteplus` | `moonshotai/kimi-k2.5` | `byteplus/moonshotai/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
 | `byteplus` | `seed-1-8-251228` | `byteplus/seed-1-8-251228` | 256000 | 4096 | — | ✅ |
@@ -254,12 +260,17 @@ and capabilities.
 | `xiaomi` | `mimo-v2-pro` | `xiaomi/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
 | `xiaomi` | `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
 | `xiaomi` | `mimo-v2.5-pro-ultraspeed` | `xiaomi/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
+| `zai` | `glm-4-32b-0414-128k` | `zai/glm-4-32b-0414-128k` | 131072 | 16384 | — | — |
 | `zai` | `glm-4.5` | `zai/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-air` | `zai/glm-4.5-air` | 131072 | 98304 | ✅ | — |
+| `zai` | `glm-4.5-airx` | `zai/glm-4.5-airx` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-flash` | `zai/glm-4.5-flash` | 131072 | 98304 | ✅ | — |
+| `zai` | `glm-4.5-x` | `zai/glm-4.5-x` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5v` | `zai/glm-4.5v` | 64000 | 16384 | ✅ | ✅ |
 | `zai` | `glm-4.6` | `zai/glm-4.6` | 204800 | 131072 | ✅ | — |
 | `zai` | `glm-4.6v` | `zai/glm-4.6v` | 128000 | 32768 | ✅ | ✅ |
+| `zai` | `glm-4.6v-flash` | `zai/glm-4.6v-flash` | 128000 | 32768 | ✅ | ✅ |
+| `zai` | `glm-4.6v-flashx` | `zai/glm-4.6v-flashx` | 128000 | 32768 | ✅ | ✅ |
 | `zai` | `glm-4.7` | `zai/glm-4.7` | 204800 | 131072 | ✅ | — |
 | `zai` | `glm-4.7-flash` | `zai/glm-4.7-flash` | 200000 | 131072 | ✅ | — |
 | `zai` | `glm-4.7-flashx` | `zai/glm-4.7-flashx` | 200000 | 128000 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -721,6 +721,7 @@ fn reasoning_effort_options(
         ("openai", _) | ("openai-codex", _) => &["low", "medium", "high", "xhigh"][..],
         ("xai", "grok-4.3") => &["none", "low", "medium", "high"][..],
         ("xai", "grok-4.5") => &["low", "medium", "high"][..],
+        ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
         ("volcengine", _)
             if endpoint.is_none_or(|endpoint| {
                 matches!(endpoint.as_str(), "default" | "coding" | "plan")
@@ -774,27 +775,6 @@ fn is_turn_default_candidate(entry: &BuiltInModelMetadata) -> bool {
         || entry.capabilities.image_input
         || entry.capabilities.supports_reasoning
         || entry.capabilities.interactive_exec
-}
-
-fn mirror_catalog_models(
-    entries: &[BuiltInModelMetadata],
-    source_provider: &str,
-    target_provider: &str,
-) -> Vec<BuiltInModelMetadata> {
-    let source_provider = provider_id(source_provider);
-    let target_provider = provider_id(target_provider);
-    entries
-        .iter()
-        .filter(|entry| entry.model_ref.provider == source_provider)
-        .map(|entry| {
-            let mut mirrored = entry.clone();
-            mirrored.model_ref = ModelRef::new(target_provider.clone(), &entry.model_ref.model);
-            mirrored.description = mirrored
-                .description
-                .replace(source_provider.as_str(), target_provider.as_str());
-            mirrored
-        })
-        .collect()
 }
 
 fn built_in_entries() -> Vec<BuiltInModelMetadata> {
@@ -2829,6 +2809,24 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "zai",
+            "glm-4.5-x",
+            "GLM-4.5 X",
+            131_072,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "zai",
+            "glm-4.5-airx",
+            "GLM-4.5 AirX",
+            131_072,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "zai",
             "glm-4.5-flash",
             "GLM-4.5 Flash",
             131_072,
@@ -2837,9 +2835,177 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model("zai", "glm-4.5v", "GLM-4.5V", 64_000, 16_384, true, true),
+        catalog_model(
+            "zai",
+            "glm-4.6v-flashx",
+            "GLM-4.6V FlashX",
+            128_000,
+            32_768,
+            true,
+            true,
+        ),
+        catalog_model(
+            "zai",
+            "glm-4.6v-flash",
+            "GLM-4.6V Flash",
+            128_000,
+            32_768,
+            true,
+            true,
+        ),
+        catalog_model(
+            "zai",
+            "glm-4-32b-0414-128k",
+            "GLM-4 32B 0414 128K",
+            131_072,
+            16_384,
+            false,
+            false,
+        ),
     ];
-    entries.extend(mirror_catalog_models(&entries, "zai", "bigmodel"));
     entries.extend([
+        catalog_model(
+            "bigmodel", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false,
+        ),
+        catalog_model(
+            "bigmodel", "glm-5.1", "GLM-5.1", 204_800, 131_072, true, false,
+        ),
+        catalog_model("bigmodel", "glm-5", "GLM-5", 204_800, 131_072, true, false),
+        catalog_model(
+            "bigmodel",
+            "glm-5-turbo",
+            "GLM-5 Turbo",
+            204_800,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-5v-turbo",
+            "GLM-5V Turbo",
+            204_800,
+            131_072,
+            true,
+            true,
+        ),
+        catalog_model(
+            "bigmodel", "glm-4.7", "GLM-4.7", 204_800, 131_072, true, false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.7-flashx",
+            "GLM-4.7 FlashX",
+            204_800,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.7-flash",
+            "GLM-4.7 Flash",
+            204_800,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "bigmodel", "glm-4.6", "GLM-4.6", 204_800, 131_072, true, false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.5-air",
+            "GLM-4.5 Air",
+            131_072,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.5-airx",
+            "GLM-4.5 AirX",
+            131_072,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.5-flash",
+            "GLM-4.5 Flash",
+            131_072,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4-long",
+            "GLM-4 Long",
+            1_000_000,
+            4_096,
+            false,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4-flashx-250414",
+            "GLM-4 FlashX 250414",
+            131_072,
+            16_384,
+            false,
+            false,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4-flash-250414",
+            "GLM-4 Flash 250414",
+            131_072,
+            16_384,
+            false,
+            false,
+        ),
+        catalog_model(
+            "bigmodel", "glm-4.6v", "GLM-4.6V", 131_072, 32_768, true, true,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.6v-flash",
+            "GLM-4.6V Flash",
+            131_072,
+            32_768,
+            true,
+            true,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.1v-thinking-flashx",
+            "GLM-4.1V Thinking FlashX",
+            65_536,
+            16_384,
+            true,
+            true,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4.1v-thinking-flash",
+            "GLM-4.1V Thinking Flash",
+            65_536,
+            16_384,
+            true,
+            true,
+        ),
+        catalog_model(
+            "bigmodel",
+            "glm-4v-flash",
+            "GLM-4V Flash",
+            16_384,
+            1_024,
+            false,
+            true,
+        ),
         catalog_model(
             "dashscope",
             "deepseek-v4-pro",
@@ -3325,6 +3491,7 @@ mod tests {
         assert_eq!(zai.display_name, "GLM-5.2");
         assert_eq!(zai.context_window_tokens, Some(1_000_000));
         assert_eq!(zai.runtime_max_output_tokens, 131_072);
+        assert_eq!(zai.reasoning_effort_options, ["high", "max"]);
         assert_eq!(zai.source, ModelMetadataSource::BuiltInCatalog);
 
         let bigmodel = catalog.resolve_policy(
@@ -3338,6 +3505,7 @@ mod tests {
         assert_eq!(bigmodel.display_name, "GLM-5.2");
         assert_eq!(bigmodel.context_window_tokens, Some(1_000_000));
         assert_eq!(bigmodel.runtime_max_output_tokens, 131_072);
+        assert_eq!(bigmodel.reasoning_effort_options, ["high", "max"]);
         assert_eq!(bigmodel.source, ModelMetadataSource::BuiltInCatalog);
 
         assert_eq!(
@@ -3355,23 +3523,43 @@ mod tests {
             "bigmodel/glm-5.2"
         );
 
-        let zai_provider = ProviderId::parse("zai").unwrap();
-        let bigmodel_provider = ProviderId::parse("bigmodel").unwrap();
-        let zai_models = catalog
-            .list()
-            .into_iter()
-            .filter(|model| model.model_ref.provider == zai_provider)
-            .collect::<Vec<_>>();
-        assert!(zai_models.len() >= 10);
-        for zai_model in zai_models {
-            let bigmodel_ref = ModelRef::new(bigmodel_provider.clone(), &zai_model.model_ref.model);
-            assert!(
-                catalog.get(&bigmodel_ref).is_some(),
-                "{} should mirror {}",
-                bigmodel_ref.as_string(),
-                zai_model.model_ref.as_string()
-            );
+        for model in ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.6"] {
+            assert!(catalog
+                .get(&ModelRef::new(ProviderId::parse("zai").unwrap(), model))
+                .is_some());
+            assert!(catalog
+                .get(&ModelRef::new(
+                    ProviderId::parse("bigmodel").unwrap(),
+                    model
+                ))
+                .is_some());
         }
+
+        assert!(catalog
+            .get(&ModelRef::parse("zai/glm-4.5-x").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("zai/glm-4.5v").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("bigmodel/glm-4.5-x").unwrap())
+            .is_none());
+        assert!(catalog
+            .get(&ModelRef::parse("bigmodel/glm-4.5v").unwrap())
+            .is_none());
+
+        assert!(catalog
+            .get(&ModelRef::parse("bigmodel/glm-4-long").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("bigmodel/glm-4.1v-thinking-flashx").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("zai/glm-4-long").unwrap())
+            .is_none());
+        assert!(catalog
+            .get(&ModelRef::parse("zai/glm-4.1v-thinking-flashx").unwrap())
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split the international Z.AI and mainland BigModel catalogs instead of mirroring one model list
- calibrate current text/vision models, context/output limits, image input, and GLM-5.2 reasoning options from official provider documentation
- add provider-boundary regression coverage, an implementation decision, and regenerated model reference docs

## Verification
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Anthropic-compatible live tests: skipped before request because `zai-anthropic` and `bigmodel-anthropic` are not configured locally
- direct BigModel smoke reached `glm-5.2` and returned HTTP 429 insufficient balance, confirming credential, endpoint, and model routing; aggregate smoke also encountered an unrelated stale Anthropic model configuration
