### PR TITLE
fix: calibrate Qianfan model catalog

### DIFF
--- a/docs/implementation-decisions/074-qianfan-model-catalog.md
+++ b/docs/implementation-decisions/074-qianfan-model-catalog.md
@@ -1,0 +1,32 @@
+# Qianfan model catalog
+
+Holon's `qianfan` provider uses Baidu AI Cloud Qianfan's OpenAI-compatible V2
+Chat Completions endpoint at `https://qianfan.baidubce.com/v2`.
+
+The built-in catalog records a conservative current subset of model IDs exposed
+by Qianfan's official V2 model listing: ERNIE 5.0, ERNIE 5.1, ERNIE X1.1, and
+DeepSeek V3.2 variants whose limits and modalities are explicitly documented.
+It does not retain historical ERNIE IDs merely because they appeared in older
+release notes.
+
+Qianfan publishes separate `context_length`, prompt, and completion limits.
+Holon's `context_window_tokens` is the total context window, so the catalog uses
+`context_length` rather than the smaller prompt-only limit. Output limits use
+the documented maximum completion-token value.
+
+Thinking and X1 model IDs are marked as fixed reasoning models. This does not
+claim that Qianfan accepts OpenAI's `reasoning_effort` parameter; no reasoning
+effort options are projected for Qianfan. Standard model IDs remain
+non-reasoning unless the official model metadata explicitly identifies them as
+thinking models.
+
+Sources:
+
+- Qianfan V2 API and model list:
+  `https://cloud.baidu.com/doc/qianfan-api/s/Dmba8k71y`
+- Qianfan model documentation:
+  `https://cloud.baidu.com/doc/qianfan/s/qmh4sv5vi`
+- Qianfan model retirement history:
+  `https://cloud.baidu.com/doc/qianfan/s/Kmh4stnjp`
+- Qianfan Responses API:
+  `https://cloud.baidu.com/doc/qianfan-api/s/vmhejnuy8`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -85,3 +85,4 @@ Current decision notes:
 - [071 Moonshot Model Catalog](./071-moonshot-model-catalog.md)
 - [072 Mistral Model Catalog](./072-mistral-model-catalog.md)
 - [073 Z.AI and BigModel Model Catalog](./073-zai-bigmodel-model-catalog.md)
+- [074 Qianfan Model Catalog](./074-qianfan-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **207 models**.
+across **40 endpoints** and **211 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -200,8 +200,12 @@ and capabilities.
 | `openrouter` | `moonshotai/kimi-k2.6` | `openrouter/moonshotai/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
 | `openrouter` | `openrouter/healer-alpha` | `openrouter/openrouter/healer-alpha` | 262144 | 65536 | ✅ | ✅ |
 | `openrouter` | `openrouter/hunter-alpha` | `openrouter/openrouter/hunter-alpha` | 1048576 | 65536 | ✅ | — |
-| `qianfan` | `deepseek-v3.2` | `qianfan/deepseek-v3.2` | 98304 | 32768 | ✅ | — |
-| `qianfan` | `ernie-5.0-thinking-preview` | `qianfan/ernie-5.0-thinking-preview` | 119000 | 64000 | ✅ | ✅ |
+| `qianfan` | `deepseek-v3.2` | `qianfan/deepseek-v3.2` | 131072 | 32768 | — | — |
+| `qianfan` | `deepseek-v3.2-think` | `qianfan/deepseek-v3.2-think` | 163840 | 65536 | ✅ | — |
+| `qianfan` | `ernie-5.0` | `qianfan/ernie-5.0` | 248832 | 65536 | — | ✅ |
+| `qianfan` | `ernie-5.0-thinking-preview` | `qianfan/ernie-5.0-thinking-preview` | 248832 | 65536 | ✅ | ✅ |
+| `qianfan` | `ernie-5.1` | `qianfan/ernie-5.1` | 248832 | 65536 | — | — |
+| `qianfan` | `ernie-x1.1` | `qianfan/ernie-x1.1` | 121856 | 65536 | ✅ | — |
 | `stepfun` | `step-3.5-flash` | `stepfun/step-3.5-flash` | 262144 | 65536 | ✅ | — |
 | `stepfun` | `step-3.5-flash-2603` | `stepfun/step-3.5-flash-2603` | 262144 | 65536 | ✅ | — |
 | `synthetic` | `hf:MiniMaxAI/MiniMax-M2.5` | `synthetic/hf:MiniMaxAI/MiniMax-M2.5` | 192000 | 65536 | — | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1677,19 +1677,55 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "qianfan",
             "deepseek-v3.2",
             "DEEPSEEK V3.2",
-            98_304,
+            131_072,
             32_768,
+            false,
+            false,
+        ),
+        catalog_model(
+            "qianfan",
+            "deepseek-v3.2-think",
+            "DEEPSEEK V3.2 Think",
+            163_840,
+            65_536,
             true,
             false,
         ),
         catalog_model(
             "qianfan",
+            "ernie-5.0",
+            "ERNIE 5.0",
+            248_832,
+            65_536,
+            false,
+            true,
+        ),
+        catalog_model(
+            "qianfan",
             "ernie-5.0-thinking-preview",
-            "ERNIE-5.0-Thinking-Preview",
-            119_000,
-            64_000,
+            "ERNIE 5.0 Thinking Preview",
+            248_832,
+            65_536,
             true,
             true,
+        ),
+        catalog_model(
+            "qianfan",
+            "ernie-5.1",
+            "ERNIE 5.1",
+            248_832,
+            65_536,
+            false,
+            false,
+        ),
+        catalog_model(
+            "qianfan",
+            "ernie-x1.1",
+            "ERNIE X1.1",
+            121_856,
+            65_536,
+            true,
+            false,
         ),
         catalog_model(
             "dashscope",
@@ -3656,6 +3692,50 @@ mod tests {
             assert_eq!(model.max_output_tokens_upper_limit, Some(128_000));
             assert!(model.capabilities.supports_reasoning);
             assert!(!model.capabilities.image_input);
+        }
+    }
+
+    #[test]
+    fn qianfan_catalog_tracks_current_v2_models_limits_and_modalities() {
+        let catalog = BuiltInModelCatalog::new();
+        let qianfan = ProviderId::parse("qianfan").unwrap();
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|entry| entry.model_ref.provider == qianfan)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            models
+                .iter()
+                .map(|entry| entry.model_ref.model.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "deepseek-v3.2",
+                "deepseek-v3.2-think",
+                "ernie-5.0",
+                "ernie-5.0-thinking-preview",
+                "ernie-5.1",
+                "ernie-x1.1",
+            ]
+        );
+
+        let expected = [
+            ("deepseek-v3.2", 131_072, 32_768, false, false),
+            ("deepseek-v3.2-think", 163_840, 65_536, true, false),
+            ("ernie-5.0", 248_832, 65_536, false, true),
+            ("ernie-5.0-thinking-preview", 248_832, 65_536, true, true),
+            ("ernie-5.1", 248_832, 65_536, false, false),
+            ("ernie-x1.1", 121_856, 65_536, true, false),
+        ];
+        for (model, context_window, max_output, reasoning, image_input) in expected {
+            let metadata = catalog
+                .get(&ModelRef::parse(&format!("qianfan/{model}")).unwrap())
+                .unwrap();
+            assert_eq!(metadata.context_window_tokens, Some(context_window));
+            assert_eq!(metadata.max_output_tokens_upper_limit, Some(max_output));
+            assert_eq!(metadata.capabilities.supports_reasoning, reasoning);
+            assert_eq!(metadata.capabilities.image_input, image_input);
         }
     }
 


### PR DESCRIPTION
## Summary
- calibrate the direct Qianfan V2 catalog against current Baidu AI Cloud documentation
- add current ERNIE, X1, DeepSeek chat/reasoning models with conservative modality and limit metadata
- make capability corrections explicit: base `deepseek-v3.2` is non-reasoning in favor of `deepseek-v3.2-think`, and `ernie-5.1` vision remains disabled because current official metadata does not document image input
- record source boundaries and regenerate the model reference

## Verification
- `cargo test qianfan_catalog_tracks_current_v2_models_limits_and_modalities`
- `cargo test --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Livetest
- Not run: no Qianfan/Baidu credentials were present in environment variables, Holon provider configuration, or credential profiles.
