### PR TITLE
fix: calibrate BytePlus model catalog

### DIFF
--- a/docs/implementation-decisions/075-byteplus-model-catalog.md
+++ b/docs/implementation-decisions/075-byteplus-model-catalog.md
@@ -1,0 +1,30 @@
+# BytePlus model catalog
+
+Holon keeps BytePlus ModelArk's general and Coding Plan endpoints as built-in
+provider routes, but does not currently ship static BytePlus model metadata.
+
+BytePlus publishes a "Get Model ID" surface and separate ModelArk management
+APIs for listing foundation models and versions. The publicly accessible
+documentation does not provide a stable, complete model table from which Holon
+can verify the current model IDs, lifecycle state, modalities, reasoning
+controls, context windows, and output limits.
+
+BytePlus metadata is therefore maintained independently from Volcengine Ark.
+Matching product or model-family names are not evidence that the two endpoints
+expose the same IDs or capabilities. Holon also does not claim that BytePlus's
+OpenAI-compatible inference endpoints implement an OpenAI-style model-list
+endpoint.
+
+Users can still select a BytePlus model ID explicitly. Holon will resolve
+unknown model limits through normal runtime fallback and user configuration
+rather than presenting unverified built-in metadata.
+
+Sources:
+
+- BytePlus ModelArk model ID guide:
+  `https://docs.byteplus.com/en/docs/modelark/model_id`
+- BytePlus Seed 1.6 model documentation:
+  `https://docs.byteplus.com/en/docs/modelark/1593702`
+- BytePlus ModelArk API reference navigation, including
+  `ListFoundationModels` and `ListFoundationModelVersions`:
+  `https://docs.byteplus.com/en/docs/modelark`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -86,3 +86,4 @@ Current decision notes:
 - [072 Mistral Model Catalog](./072-mistral-model-catalog.md)
 - [073 Z.AI and BigModel Model Catalog](./073-zai-bigmodel-model-catalog.md)
 - [074 Qianfan Model Catalog](./074-qianfan-model-catalog.md)
+- [075 BytePlus Model Catalog](./075-byteplus-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **211 models**.
+across **40 endpoints** and **206 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -99,11 +99,6 @@ and capabilities.
 | `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 204800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 204800 | 131072 | ✅ | ✅ |
-| `byteplus` | `ark-code-latest` | `byteplus/ark-code-latest` | 256000 | 65536 | ✅ | — |
-| `byteplus` | `moonshotai/kimi-k2.5` | `byteplus/moonshotai/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
-| `byteplus` | `seed-1-8-251228` | `byteplus/seed-1-8-251228` | 256000 | 4096 | — | ✅ |
-| `byteplus` | `seed-2-0-pro-260215` | `byteplus/seed-2-0-pro-260215` | 256000 | 4096 | — | ✅ |
-| `byteplus` | `zai-org/glm-4.7` | `byteplus/zai-org/glm-4.7` | 204800 | 131072 | ✅ | — |
 | `chutes` | `deepseek-ai/DeepSeek-V3.2-TEE` | `chutes/deepseek-ai/DeepSeek-V3.2-TEE` | 131072 | 65536 | ✅ | — |
 | `chutes` | `moonshotai/Kimi-K2.5-TEE` | `chutes/moonshotai/Kimi-K2.5-TEE` | 262144 | 65535 | ✅ | ✅ |
 | `chutes` | `openai/gpt-oss-120b-TEE` | `chutes/openai/gpt-oss-120b-TEE` | 131072 | 65536 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -3697,13 +3697,16 @@ mod tests {
     #[test]
     fn byteplus_catalog_does_not_infer_models_from_volcengine() {
         let catalog = BuiltInModelCatalog::new();
-        let byteplus = ProviderId::parse("byteplus").unwrap();
+        let byteplus_providers = [
+            ProviderId::parse("byteplus").unwrap(),
+            ProviderId::parse("byteplus-coding").unwrap(),
+        ];
 
         assert!(
             catalog
                 .list()
                 .into_iter()
-                .all(|entry| entry.model_ref.provider != byteplus),
+                .all(|entry| !byteplus_providers.contains(&entry.model_ref.provider)),
             "BytePlus model IDs and metadata require independent BytePlus documentation"
         );
     }

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1196,51 +1196,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "byteplus",
-            "seed-1-8-251228",
-            "Seed 1.8",
-            256_000,
-            4_096,
-            false,
-            true,
-        ),
-        catalog_model(
-            "byteplus",
-            "seed-2-0-pro-260215",
-            "Seed 2.0 Pro",
-            256_000,
-            4_096,
-            false,
-            true,
-        ),
-        catalog_model(
-            "byteplus",
-            "moonshotai/kimi-k2.5",
-            "Kimi K2.5",
-            262_144,
-            32_768,
-            true,
-            true,
-        ),
-        catalog_model(
-            "byteplus",
-            "zai-org/glm-4.7",
-            "GLM-4.7",
-            204_800,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "byteplus-coding",
-            "ark-code-latest",
-            "Ark Code Latest",
-            256_000,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
             "chutes",
             "zai-org/GLM-4.7-TEE",
             "zai-org/GLM-4.7-TEE",
@@ -3737,6 +3692,20 @@ mod tests {
             assert_eq!(metadata.capabilities.supports_reasoning, reasoning);
             assert_eq!(metadata.capabilities.image_input, image_input);
         }
+    }
+
+    #[test]
+    fn byteplus_catalog_does_not_infer_models_from_volcengine() {
+        let catalog = BuiltInModelCatalog::new();
+        let byteplus = ProviderId::parse("byteplus").unwrap();
+
+        assert!(
+            catalog
+                .list()
+                .into_iter()
+                .all(|entry| entry.model_ref.provider != byteplus),
+            "BytePlus model IDs and metadata require independent BytePlus documentation"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove BytePlus catalog entries whose current model IDs and capabilities cannot be independently verified from BytePlus ModelArk documentation
- keep BytePlus endpoint metadata separate from Volcengine Ark models with similar names
- add a focused implementation decision, regression coverage, and regenerate the model reference

## Verification

- `cargo test byteplus_catalog_does_not_infer_models_from_volcengine`
- `cargo test --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Live test

No usable local BytePlus credential was available, so a real route smoke test was not run.
