### PR TITLE
fix: calibrate StepFun model catalog

### DIFF
--- a/docs/implementation-decisions/077-stepfun-model-catalog.md
+++ b/docs/implementation-decisions/077-stepfun-model-catalog.md
@@ -1,0 +1,40 @@
+# StepFun model catalog
+
+Holon models the StepFun pay-as-you-go and Step Plan surfaces as routes of the
+canonical `stepfun` provider. The legacy `stepfun-plan` provider remains an
+alias for the `plan` endpoint so existing configuration continues to resolve
+to canonical `stepfun/*` model references.
+
+The chat catalog contains the three current models documented for both
+surfaces: `step-3.7-flash`, `step-3.5-flash-2603`, and `step-3.5-flash`.
+Step Plan also documents audio, image-editing, and router models, but Holon's
+OpenAI Chat Completions provider does not project models whose primary
+contracts use other endpoints.
+
+`step-3.7-flash` supports text, image, and video input. Holon's current
+modality model records its image-input capability and its documented
+`low` / `medium` / `high` reasoning effort values. The
+`step-3.5-flash-2603` variant records its documented `low` / `high` values.
+The base `step-3.5-flash` remains a fixed reasoning model because StepFun does
+not publish a named effort selector for it.
+
+All three models have a documented 256K total context window. StepFun does not
+publish a separate maximum output-token limit on these model pages, so Holon
+does not retain the previous inferred 65,536-token output limit.
+
+The built-in endpoints use StepFun's current `api.stepfun.com` host. The older
+`api.stepfun.ai` host is not retained because it is absent from the current
+official API and Step Plan documentation.
+
+Sources (checked 2026-07-12):
+
+- Model capability overview:
+  `https://platform.stepfun.com/docs/zh/guides/models/overview`
+- Step 3.7 Flash:
+  `https://platform.stepfun.com/docs/zh/guides/models/step-3.7-flash`
+- Step 3.5 Flash and 2603 variant:
+  `https://platform.stepfun.com/docs/zh/guides/models/step-3.5-flash`
+- Reasoning model overview:
+  `https://platform.stepfun.com/docs/zh/guides/models/reasoning`
+- Step Plan overview and model allowlist:
+  `https://platform.stepfun.com/docs/zh/step-plan/overview`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -88,3 +88,4 @@ Current decision notes:
 - [074 Qianfan Model Catalog](./074-qianfan-model-catalog.md)
 - [075 BytePlus Model Catalog](./075-byteplus-model-catalog.md)
 - [076 DashScope Model Catalog](./076-dashscope-model-catalog.md)
+- [077 StepFun Model Catalog](./077-stepfun-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **206 models**.
+across **40 endpoints** and **207 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -49,8 +49,8 @@ used in existing `provider/model` refs and config shortcuts.
 | `opencode-go` | `default` | `opencode-go` | OpenAI Chat Completions | `https://opencode.ai/zen/go/v1` | `OPENCODE_GO_API_KEY` |
 | `openrouter` | `default` | `openrouter` | OpenAI Chat Completions | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
 | `qianfan` | `default` | `qianfan` | OpenAI Chat Completions | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
-| `stepfun` | `default` | `stepfun` | OpenAI Chat Completions | `https://api.stepfun.ai/v1` | `STEPFUN_API_KEY` |
-| `stepfun` | `plan` | `stepfun-plan` | OpenAI Chat Completions | `https://api.stepfun.ai/step_plan/v1` | `STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY` |
+| `stepfun` | `default` | `stepfun` | OpenAI Chat Completions | `https://api.stepfun.com/v1` | `STEPFUN_API_KEY` |
+| `stepfun` | `plan` | `stepfun-plan` | OpenAI Chat Completions | `https://api.stepfun.com/step_plan/v1` | `STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY` |
 | `synthetic` | `default` | `synthetic` | Anthropic Messages | `https://api.synthetic.new/anthropic` | `SYNTHETIC_API_KEY` |
 | `tencent-tokenhub` | `default` | `tencent-tokenhub` | OpenAI Chat Completions | `https://tokenhub.tencentmaas.com/v1` | `TOKENHUB_API_KEY` |
 | `together` | `default` | `together` | OpenAI Chat Completions | `https://api.together.xyz/v1` | `TOGETHER_API_KEY` |
@@ -201,8 +201,9 @@ and capabilities.
 | `qianfan` | `ernie-5.0-thinking-preview` | `qianfan/ernie-5.0-thinking-preview` | 248832 | 65536 | ✅ | ✅ |
 | `qianfan` | `ernie-5.1` | `qianfan/ernie-5.1` | 248832 | 65536 | — | — |
 | `qianfan` | `ernie-x1.1` | `qianfan/ernie-x1.1` | 121856 | 65536 | ✅ | — |
-| `stepfun` | `step-3.5-flash` | `stepfun/step-3.5-flash` | 262144 | 65536 | ✅ | — |
-| `stepfun` | `step-3.5-flash-2603` | `stepfun/step-3.5-flash-2603` | 262144 | 65536 | ✅ | — |
+| `stepfun` | `step-3.5-flash` | `stepfun/step-3.5-flash` | 262144 | — | ✅ | — |
+| `stepfun` | `step-3.5-flash-2603` | `stepfun/step-3.5-flash-2603` | 262144 | — | ✅ | — |
+| `stepfun` | `step-3.7-flash` | `stepfun/step-3.7-flash` | 262144 | — | ✅ | ✅ |
 | `synthetic` | `hf:MiniMaxAI/MiniMax-M2.5` | `synthetic/hf:MiniMaxAI/MiniMax-M2.5` | 192000 | 65536 | — | — |
 | `synthetic` | `hf:Qwen/Qwen3-235B-A22B-Instruct-2507` | `synthetic/hf:Qwen/Qwen3-235B-A22B-Instruct-2507` | 256000 | 8192 | — | — |
 | `synthetic` | `hf:Qwen/Qwen3-235B-A22B-Thinking-2507` | `synthetic/hf:Qwen/Qwen3-235B-A22B-Thinking-2507` | 256000 | 8192 | ✅ | — |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1124,14 +1124,14 @@ pub(crate) fn populate_built_in_provider_catalog(
     insert_openai_compatible_provider(
         catalog,
         "stepfun",
-        "https://api.stepfun.ai/v1",
+        "https://api.stepfun.com/v1",
         &["STEPFUN_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
         catalog,
         "stepfun-plan",
-        "https://api.stepfun.ai/step_plan/v1",
+        "https://api.stepfun.com/step_plan/v1",
         &["STEPFUN_PLAN_API_KEY", "STEPFUN_API_KEY"],
         settings_env,
     )?;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1479,8 +1479,19 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         .get(&ProviderId::parse("stepfun-plan").unwrap())
         .unwrap();
     assert_eq!(
+        stepfun_plan.base_url,
+        "https://api.stepfun.com/step_plan/v1"
+    );
+    assert_eq!(
         stepfun_plan.auth.env.as_deref(),
         Some("STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY")
+    );
+    assert_eq!(
+        providers
+            .get(&ProviderId::parse("stepfun").unwrap())
+            .unwrap()
+            .base_url,
+        "https://api.stepfun.com/v1"
     );
 
     let deepseek = providers

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -721,6 +721,8 @@ fn reasoning_effort_options(
         ("openai", _) | ("openai-codex", _) => &["low", "medium", "high", "xhigh"][..],
         ("xai", "grok-4.3") => &["none", "low", "medium", "high"][..],
         ("xai", "grok-4.5") => &["low", "medium", "high"][..],
+        ("stepfun", "step-3.7-flash") => &["low", "medium", "high"][..],
+        ("stepfun", "step-3.5-flash-2603") => &["low", "high"][..],
         ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
         ("volcengine", _)
             if endpoint.is_none_or(|endpoint| {
@@ -762,6 +764,36 @@ fn catalog_model(
         capabilities: ModelCapabilityFlags {
             image_input,
             supports_reasoning,
+            ..ModelCapabilityFlags::default()
+        },
+        source: ModelMetadataSource::BuiltInCatalog,
+        endpoint: None,
+    }
+}
+
+fn stepfun_model(
+    provider: &str,
+    model: &str,
+    display_name: &str,
+    image_input: bool,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id(provider), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!("Holon built-in runtime metadata for the StepFun {model} model."),
+        context_window_tokens: Some(262_144),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            image_input,
+            supports_reasoning: true,
             ..ModelCapabilityFlags::default()
         },
         source: ModelMetadataSource::BuiltInCatalog,
@@ -2015,31 +2047,30 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
-        catalog_model(
+        stepfun_model("stepfun", "step-3.7-flash", "Step 3.7 Flash", true),
+        stepfun_model(
             "stepfun",
-            "step-3.5-flash",
-            "Step 3.5 Flash",
-            262_144,
-            65_536,
-            true,
+            "step-3.5-flash-2603",
+            "Step 3.5 Flash 2603",
             false,
         ),
-        catalog_model(
+        stepfun_model("stepfun", "step-3.5-flash", "Step 3.5 Flash", false),
+        stepfun_model(
             "stepfun-plan",
-            "step-3.5-flash",
-            "Step 3.5 Flash",
-            262_144,
-            65_536,
+            "step-3.7-flash",
+            "Step 3.7 Flash",
             true,
-            false,
         ),
-        catalog_model(
+        stepfun_model(
             "stepfun-plan",
             "step-3.5-flash-2603",
             "Step 3.5 Flash 2603",
-            262_144,
-            65_536,
-            true,
+            false,
+        ),
+        stepfun_model(
+            "stepfun-plan",
+            "step-3.5-flash",
+            "Step 3.5 Flash",
             false,
         ),
         catalog_model(
@@ -3636,6 +3667,92 @@ mod tests {
                 "{model} image input"
             );
         }
+    }
+
+    #[test]
+    fn stepfun_catalog_tracks_current_chat_models_and_reasoning_controls() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            ("step-3.7-flash", true, &["low", "medium", "high"][..]),
+            ("step-3.5-flash-2603", false, &["low", "high"][..]),
+            ("step-3.5-flash", false, &[][..]),
+        ];
+
+        for (model, image_input, reasoning_options) in expected {
+            let metadata = catalog
+                .get(&ModelRef::parse(&format!("stepfun/{model}")).unwrap())
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(
+                metadata.context_window_tokens,
+                Some(262_144),
+                "{model} context window"
+            );
+            assert_eq!(
+                metadata.capabilities.image_input, image_input,
+                "{model} image input"
+            );
+            assert!(
+                metadata.capabilities.supports_reasoning,
+                "{model} reasoning"
+            );
+            assert_eq!(metadata.default_max_output_tokens, None);
+            assert_eq!(metadata.max_output_tokens_upper_limit, None);
+            assert_eq!(
+                reasoning_effort_options(
+                    &metadata.model_ref,
+                    metadata.endpoint.as_ref(),
+                    &metadata.capabilities,
+                ),
+                reasoning_options,
+                "{model} reasoning controls"
+            );
+        }
+    }
+
+    #[test]
+    fn stepfun_plan_shares_canonical_models_with_exact_routes() {
+        let catalog = BuiltInModelCatalog::new();
+
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("stepfun").unwrap())
+                .unwrap()
+                .as_string(),
+            "stepfun/step-3.7-flash"
+        );
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("stepfun-plan").unwrap())
+                .unwrap()
+                .as_string(),
+            "stepfun/step-3.7-flash"
+        );
+
+        for route_ref in [
+            "stepfun@default/step-3.7-flash",
+            "stepfun@default/step-3.5-flash-2603",
+            "stepfun@default/step-3.5-flash",
+            "stepfun@plan/step-3.7-flash",
+            "stepfun@plan/step-3.5-flash-2603",
+            "stepfun@plan/step-3.5-flash",
+        ] {
+            assert!(
+                catalog
+                    .get_route(&ModelRouteRef::parse(route_ref).unwrap())
+                    .is_some(),
+                "{route_ref} should be registered"
+            );
+        }
+
+        assert!(catalog
+            .get(&ModelRef::parse("stepfun-plan/step-3.7-flash").unwrap())
+            .is_none());
+        assert_eq!(
+            catalog
+                .canonicalize_model_ref(&ModelRef::parse("stepfun-plan/step-3.7-flash").unwrap())
+                .as_string(),
+            "stepfun/step-3.7-flash"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- calibrate the StepFun catalog against current official model and Step Plan documentation
- canonicalize Step Plan models onto the `stepfun` provider with route-level availability and limits
- update StepFun API base URLs, regression coverage, source decision record, and generated model reference

## Verification
- `cargo test --lib model_catalog::tests::stepfun_`
- `cargo test --lib config::tests::built_in_provider`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

## Livetest
- not run: neither `STEPFUN_API_KEY` nor `STEPFUN_PLAN_API_KEY` is set locally
