### PR TITLE
fix: calibrate Xiaomi model catalog

### DIFF
--- a/docs/implementation-decisions/078-xiaomi-model-catalog.md
+++ b/docs/implementation-decisions/078-xiaomi-model-catalog.md
@@ -1,0 +1,34 @@
+# 077 Xiaomi Model Catalog
+
+## Decision
+
+The built-in `xiaomi` catalog exposes `mimo-v2.5-pro` and `mimo-v2.5` on both
+the pay-as-you-go and Token Plan endpoints. Both routes use the OpenAI
+Responses transport.
+
+Both models use the documented 1,048,576-token context window and
+131,072-token maximum output. `mimo-v2.5` supports image input while
+`mimo-v2.5-pro` is text-only. Their selectable reasoning efforts are `none`
+and `high`.
+
+The retired MiMo V2 models are removed. `mimo-v2.5-pro-ultraspeed` is also
+omitted because its official access is approval-based and capacity-limited,
+not generally available through either built-in route.
+
+## Sources
+
+- Xiaomi MiMo, “Models”
+  (`https://mimo.mi.com/docs/en-US/quick-start/summary/model`, updated
+  2026-06-29).
+- Xiaomi MiMo, “OpenAI Responses API”
+  (`https://mimo.mi.com/docs/en-US/api/chat/responses`).
+- Xiaomi MiMo, “Codex Configuration”
+  (`https://mimo.mi.com/docs/en-US/tokenplan/integration/codex-configuration`).
+- Xiaomi MiMo, “MiMo-V2.5-Pro-UltraSpeed”
+  (`https://mimo.mi.com/models/zh-CN/mimo-v2.5-pro-ultraspeed`).
+
+## Preserved Boundary
+
+Intrinsic model capability remains separate from route availability. A model
+with an official product page is not added to the general catalog unless the
+documented endpoint is available without a separate approval workflow.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -89,3 +89,4 @@ Current decision notes:
 - [075 BytePlus Model Catalog](./075-byteplus-model-catalog.md)
 - [076 DashScope Model Catalog](./076-dashscope-model-catalog.md)
 - [077 StepFun Model Catalog](./077-stepfun-model-catalog.md)
+- [078 Xiaomi Model Catalog](./078-xiaomi-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **207 models**.
+across **40 endpoints** and **204 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -61,8 +61,8 @@ used in existing `provider/model` refs and config shortcuts.
 | `volcengine` | `plan` | `volcengine-agent` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_IMAGE_OPENAI_API_KEY` |
 | `volcengine` | `coding` | `volcengine-coding` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY` |
 | `xai` | `default` | `xai` | OpenAI Responses | `https://api.x.ai/v1` | `XAI_API_KEY` |
-| `xiaomi` | `default` | `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
-| `xiaomi` | `token-plan` | `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
+| `xiaomi` | `default` | `xiaomi` | OpenAI Responses | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
+| `xiaomi` | `token-plan` | `xiaomi-token-plan` | OpenAI Responses | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
 | `zai` | `default` | `zai` | Anthropic Messages | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
 
 ## Model Catalog
@@ -255,11 +255,8 @@ and capabilities.
 | `volcengine` | `kimi-k2.7-code` | `volcengine/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
 | `xai` | `grok-4.3` | `xai/grok-4.3` | 1000000 | — | ✅ | ✅ |
 | `xai` | `grok-4.5` | `xai/grok-4.5` | 500000 | — | ✅ | ✅ |
-| `xiaomi` | `mimo-v2-flash` | `xiaomi/mimo-v2-flash` | 262144 | 8192 | — | — |
-| `xiaomi` | `mimo-v2-omni` | `xiaomi/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
-| `xiaomi` | `mimo-v2-pro` | `xiaomi/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
-| `xiaomi` | `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
-| `xiaomi` | `mimo-v2.5-pro-ultraspeed` | `xiaomi/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
+| `xiaomi` | `mimo-v2.5` | `xiaomi/mimo-v2.5` | 1048576 | 131072 | ✅ | ✅ |
+| `xiaomi` | `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | 1048576 | 131072 | ✅ | — |
 | `zai` | `glm-4-32b-0414-128k` | `zai/glm-4-32b-0414-128k` | 131072 | 16384 | — | — |
 | `zai` | `glm-4.5` | `zai/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-air` | `zai/glm-4.5-air` | 131072 | 98304 | ✅ | — |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1200,16 +1200,18 @@ pub(crate) fn populate_built_in_provider_catalog(
         ],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_builtin_http_provider(
         catalog,
         "xiaomi",
+        ProviderTransportKind::OpenAiResponses,
         "https://api.xiaomimimo.com/v1",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_builtin_http_provider(
         catalog,
         "xiaomi-token-plan",
+        ProviderTransportKind::OpenAiResponses,
         "https://token-plan-cn.xiaomimimo.com/v1",
         &["XIAOMI_TOKEN_PLAN_API_KEY"],
         settings_env,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1504,10 +1504,7 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
     let xiaomi = providers
         .get(&ProviderId::parse("xiaomi").unwrap())
         .unwrap();
-    assert_eq!(
-        xiaomi.transport,
-        ProviderTransportKind::OpenAiChatCompletions
-    );
+    assert_eq!(xiaomi.transport, ProviderTransportKind::OpenAiResponses);
     assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
     assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
 
@@ -1516,7 +1513,7 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         .unwrap();
     assert_eq!(
         xiaomi_token_plan.transport,
-        ProviderTransportKind::OpenAiChatCompletions
+        ProviderTransportKind::OpenAiResponses
     );
     assert_eq!(
         xiaomi_token_plan.base_url,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -724,6 +724,7 @@ fn reasoning_effort_options(
         ("stepfun", "step-3.7-flash") => &["low", "medium", "high"][..],
         ("stepfun", "step-3.5-flash-2603") => &["low", "high"][..],
         ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
+        ("xiaomi" | "xiaomi-token-plan", "mimo-v2.5-pro" | "mimo-v2.5") => &["none", "high"][..],
         ("volcengine", _)
             if endpoint.is_none_or(|endpoint| {
                 matches!(endpoint.as_str(), "default" | "coding" | "plan")
@@ -2660,44 +2661,17 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "xiaomi",
             "mimo-v2.5-pro",
             "Xiaomi MiMo V2.5 Pro",
-            1_000_000,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "xiaomi",
-            "mimo-v2.5-pro-ultraspeed",
-            "Xiaomi MiMo V2.5 Pro UltraSpeed",
-            1_000_000,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "xiaomi",
-            "mimo-v2-flash",
-            "Xiaomi MiMo V2 Flash",
-            262_144,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "xiaomi",
-            "mimo-v2-pro",
-            "Xiaomi MiMo V2 Pro",
             1_048_576,
-            32_000,
+            131_072,
             true,
             false,
         ),
         catalog_model(
             "xiaomi",
-            "mimo-v2-omni",
-            "Xiaomi MiMo V2 Omni",
-            262_144,
-            32_000,
+            "mimo-v2.5",
+            "Xiaomi MiMo V2.5",
+            1_048_576,
+            131_072,
             true,
             true,
         ),
@@ -2705,35 +2679,17 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "xiaomi-token-plan",
             "mimo-v2.5-pro",
             "Xiaomi MiMo V2.5 Pro",
-            1_000_000,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "xiaomi-token-plan",
-            "mimo-v2.5-pro-ultraspeed",
-            "Xiaomi MiMo V2.5 Pro UltraSpeed",
-            1_000_000,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "xiaomi-token-plan",
-            "mimo-v2-pro",
-            "Xiaomi MiMo V2 Pro",
             1_048_576,
-            32_000,
+            131_072,
             true,
             false,
         ),
         catalog_model(
             "xiaomi-token-plan",
-            "mimo-v2-omni",
-            "Xiaomi MiMo V2 Omni",
-            262_144,
-            32_000,
+            "mimo-v2.5",
+            "Xiaomi MiMo V2.5",
+            1_048_576,
+            131_072,
             true,
             true,
         ),
@@ -3467,34 +3423,49 @@ mod tests {
             8192,
         );
         assert_eq!(xiaomi.display_name, "Xiaomi MiMo V2.5 Pro");
-        assert_eq!(xiaomi.context_window_tokens, Some(1_000_000));
+        assert_eq!(xiaomi.context_window_tokens, Some(1_048_576));
         assert_eq!(xiaomi.runtime_max_output_tokens, 131_072);
         assert!(xiaomi.capabilities.supports_reasoning);
+        assert!(!xiaomi.capabilities.image_input);
+        assert_eq!(xiaomi.reasoning_effort_options, ["none", "high"]);
         assert_eq!(xiaomi.source, ModelMetadataSource::BuiltInCatalog);
 
-        let xiaomi_ultraspeed = catalog.resolve_policy(
-            &ModelRef::parse("xiaomi/mimo-v2.5-pro-ultraspeed").unwrap(),
+        let xiaomi_omni = catalog.resolve_policy(
+            &ModelRef::parse("xiaomi/mimo-v2.5").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
             8192,
         );
-        assert_eq!(
-            xiaomi_ultraspeed.display_name,
-            "Xiaomi MiMo V2.5 Pro UltraSpeed"
-        );
-        assert_eq!(xiaomi_ultraspeed.context_window_tokens, Some(1_000_000));
-        assert_eq!(xiaomi_ultraspeed.runtime_max_output_tokens, 131_072);
-        assert!(xiaomi_ultraspeed.capabilities.supports_reasoning);
-        assert_eq!(
-            xiaomi_ultraspeed.source,
-            ModelMetadataSource::BuiltInCatalog
-        );
+        assert_eq!(xiaomi_omni.display_name, "Xiaomi MiMo V2.5");
+        assert_eq!(xiaomi_omni.context_window_tokens, Some(1_048_576));
+        assert_eq!(xiaomi_omni.runtime_max_output_tokens, 131_072);
+        assert!(xiaomi_omni.capabilities.supports_reasoning);
+        assert!(xiaomi_omni.capabilities.image_input);
+        assert_eq!(xiaomi_omni.reasoning_effort_options, ["none", "high"]);
 
         assert!(catalog
             .get(&ModelRef::parse("xiaomi/mimo-v2-pro").unwrap())
-            .is_some());
+            .is_none());
+        assert!(catalog
+            .get(&ModelRef::parse("xiaomi/mimo-v2.5-pro-ultraspeed").unwrap())
+            .is_none());
+        assert_eq!(
+            catalog
+                .canonicalize_model_ref(&ModelRef::parse("xiaomi-token-plan/mimo-v2.5").unwrap()),
+            ModelRef::parse("xiaomi/mimo-v2.5").unwrap()
+        );
+        let token_plan = catalog.resolve_route_policy(
+            &ModelRouteRef::parse("xiaomi@token-plan/mimo-v2.5").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert!(token_plan.capabilities.image_input);
+        assert_eq!(token_plan.reasoning_effort_options, ["none", "high"]);
         assert!(catalog
             .get(&ModelRef::parse("xiaomi-token-plan/mimo-v2-flash").unwrap())
             .is_none());


### PR DESCRIPTION
## Summary
- calibrate Xiaomi MiMo catalog to the current `mimo-v2.5-pro` and multimodal `mimo-v2.5` models
- move default and Token Plan routes to Responses API with route-level reasoning and availability metadata
- remove retired or non-generally-available entries, document the UltraSpeed approval boundary, and regenerate model references

## Verification
- `cargo test --lib model_catalog::tests::resolves_anthropic_compatible_provider_model_policy`
- `cargo test --lib config::tests::built_in_provider`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- Xiaomi/MiMo livetest not run: no local credentials configured
