### PR TITLE
fix: calibrate Chutes model catalog

### DIFF
--- a/docs/implementation-decisions/079-chutes-model-catalog.md
+++ b/docs/implementation-decisions/079-chutes-model-catalog.md
@@ -1,0 +1,30 @@
+# Chutes model catalog
+
+Holon snapshots Chutes's public live model directory for its built-in model
+picker. Chutes documents unauthenticated `GET /v1/models` as the source of truth
+for model IDs, context and output limits, modalities, supported features, and
+confidential-compute status.
+
+The snapshot was verified on 2026-07-13. Holon records `reasoning` as a fixed
+model capability because the directory advertises the feature but does not
+publish an adjustable reasoning-effort parameter. Image input is enabled only
+when the Chutes entry explicitly lists the `image` input modality. Video input
+is not represented because Holon's current model capability contract has no
+video modality.
+
+The live `unsloth/Mistral-Nemo-Instruct-2407-TEE` entry publishes only its
+context length and confidential-compute flag. Holon therefore keeps it with
+conservative metadata: no inferred reasoning or image capability and no
+claimed output limit.
+
+Chutes is a dynamic aggregation endpoint. Models no longer present in the
+public live directory are removed from the built-in picker rather than retained
+from upstream model-family assumptions. Users may still configure arbitrary
+Chutes model IDs explicitly.
+
+Sources:
+
+- Chutes LLM-friendly documentation index:
+  `https://chutes.ai/llms.txt`
+- Chutes public live model directory:
+  `https://llm.chutes.ai/v1/models`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -90,3 +90,4 @@ Current decision notes:
 - [076 DashScope Model Catalog](./076-dashscope-model-catalog.md)
 - [077 StepFun Model Catalog](./077-stepfun-model-catalog.md)
 - [078 Xiaomi Model Catalog](./078-xiaomi-model-catalog.md)
+- [079 Chutes Model Catalog](./079-chutes-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **204 models**.
+across **40 endpoints** and **213 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -99,10 +99,19 @@ and capabilities.
 | `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 204800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 204800 | 131072 | ✅ | ✅ |
+| `chutes` | `MiniMaxAI/MiniMax-M2.5-TEE` | `chutes/MiniMaxAI/MiniMax-M2.5-TEE` | 196608 | 65536 | ✅ | — |
+| `chutes` | `Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | `chutes/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | 262144 | 262144 | ✅ | — |
+| `chutes` | `Qwen/Qwen3-32B-TEE` | `chutes/Qwen/Qwen3-32B-TEE` | 40960 | 40960 | ✅ | — |
+| `chutes` | `Qwen/Qwen3.5-397B-A17B-TEE` | `chutes/Qwen/Qwen3.5-397B-A17B-TEE` | 262144 | 65536 | ✅ | ✅ |
+| `chutes` | `Qwen/Qwen3.6-27B-TEE` | `chutes/Qwen/Qwen3.6-27B-TEE` | 262144 | 65536 | ✅ | ✅ |
 | `chutes` | `deepseek-ai/DeepSeek-V3.2-TEE` | `chutes/deepseek-ai/DeepSeek-V3.2-TEE` | 131072 | 65536 | ✅ | — |
+| `chutes` | `google/gemma-4-31B-turbo-TEE` | `chutes/google/gemma-4-31B-turbo-TEE` | 131072 | 65536 | ✅ | ✅ |
 | `chutes` | `moonshotai/Kimi-K2.5-TEE` | `chutes/moonshotai/Kimi-K2.5-TEE` | 262144 | 65535 | ✅ | ✅ |
-| `chutes` | `openai/gpt-oss-120b-TEE` | `chutes/openai/gpt-oss-120b-TEE` | 131072 | 65536 | ✅ | — |
-| `chutes` | `zai-org/GLM-4.7-TEE` | `chutes/zai-org/GLM-4.7-TEE` | 202752 | 65535 | ✅ | — |
+| `chutes` | `moonshotai/Kimi-K2.6-TEE` | `chutes/moonshotai/Kimi-K2.6-TEE` | 262144 | 65535 | ✅ | ✅ |
+| `chutes` | `unsloth/Mistral-Nemo-Instruct-2407-TEE` | `chutes/unsloth/Mistral-Nemo-Instruct-2407-TEE` | 131072 | — | — | — |
+| `chutes` | `zai-org/GLM-5-TEE` | `chutes/zai-org/GLM-5-TEE` | 202752 | 65535 | ✅ | — |
+| `chutes` | `zai-org/GLM-5.1-TEE` | `chutes/zai-org/GLM-5.1-TEE` | 202752 | 65535 | ✅ | — |
+| `chutes` | `zai-org/GLM-5.2-TEE` | `chutes/zai-org/GLM-5.2-TEE` | 1048576 | 65535 | ✅ | — |
 | `dashscope` | `MiniMax-M2.5` | `dashscope/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
 | `dashscope` | `MiniMax/MiniMax-M3` | `dashscope/MiniMax/MiniMax-M3` | 196608 | 32768 | ✅ | — |
 | `dashscope` | `ZHIPU/GLM-5.2` | `dashscope/ZHIPU/GLM-5.2` | 1000000 | 131072 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -772,6 +772,32 @@ fn catalog_model(
     }
 }
 
+fn chutes_model_without_published_capabilities(
+    model: &str,
+    context_window_tokens: usize,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("chutes"), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: model.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the Chutes {model} model; the public model entry does not publish complete capability fields."
+        ),
+        context_window_tokens: Some(context_window_tokens),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags::default(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
 fn stepfun_model(
     provider: &str,
     model: &str,
@@ -1230,39 +1256,27 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "chutes",
-            "zai-org/GLM-4.7-TEE",
-            "zai-org/GLM-4.7-TEE",
-            202_752,
-            65_535,
-            true,
-            false,
-        ),
-        catalog_model(
-            "chutes",
-            "deepseek-ai/DeepSeek-V3.2-TEE",
-            "deepseek-ai/DeepSeek-V3.2-TEE",
-            131_072,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "chutes",
-            "moonshotai/Kimi-K2.5-TEE",
-            "moonshotai/Kimi-K2.5-TEE",
+            "moonshotai/Kimi-K2.6-TEE",
+            "moonshotai/Kimi-K2.6-TEE",
             262_144,
             65_535,
             true,
             true,
         ),
-        catalog_model(
-            "chutes",
-            "openai/gpt-oss-120b-TEE",
-            "openai/gpt-oss-120b-TEE",
+        catalog_model("chutes", "zai-org/GLM-5.2-TEE", "zai-org/GLM-5.2-TEE", 1_048_576, 65_535, true, false),
+        catalog_model("chutes", "zai-org/GLM-5.1-TEE", "zai-org/GLM-5.1-TEE", 202_752, 65_535, true, false),
+        catalog_model("chutes", "zai-org/GLM-5-TEE", "zai-org/GLM-5-TEE", 202_752, 65_535, true, false),
+        catalog_model("chutes", "deepseek-ai/DeepSeek-V3.2-TEE", "deepseek-ai/DeepSeek-V3.2-TEE", 131_072, 65_536, true, false),
+        catalog_model("chutes", "MiniMaxAI/MiniMax-M2.5-TEE", "MiniMaxAI/MiniMax-M2.5-TEE", 196_608, 65_536, true, false),
+        catalog_model("chutes", "moonshotai/Kimi-K2.5-TEE", "moonshotai/Kimi-K2.5-TEE", 262_144, 65_535, true, true),
+        catalog_model("chutes", "Qwen/Qwen3.6-27B-TEE", "Qwen/Qwen3.6-27B-TEE", 262_144, 65_536, true, true),
+        catalog_model("chutes", "Qwen/Qwen3.5-397B-A17B-TEE", "Qwen/Qwen3.5-397B-A17B-TEE", 262_144, 65_536, true, true),
+        catalog_model("chutes", "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE", "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE", 262_144, 262_144, true, false),
+        catalog_model("chutes", "Qwen/Qwen3-32B-TEE", "Qwen/Qwen3-32B-TEE", 40_960, 40_960, true, false),
+        catalog_model("chutes", "google/gemma-4-31B-turbo-TEE", "google/gemma-4-31B-turbo-TEE", 131_072, 65_536, true, true),
+        chutes_model_without_published_capabilities(
+            "unsloth/Mistral-Nemo-Instruct-2407-TEE",
             131_072,
-            65_536,
-            true,
-            false,
         ),
         catalog_model(
             "deepseek",
@@ -3638,6 +3652,62 @@ mod tests {
                 "{model} image input"
             );
         }
+    }
+
+    #[test]
+    fn chutes_catalog_tracks_the_public_live_model_directory() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            ("moonshotai/Kimi-K2.6-TEE", 262_144, Some(65_535), true),
+            ("zai-org/GLM-5.2-TEE", 1_048_576, Some(65_535), false),
+            (
+                "deepseek-ai/DeepSeek-V3.2-TEE",
+                131_072,
+                Some(65_536),
+                false,
+            ),
+            ("Qwen/Qwen3.6-27B-TEE", 262_144, Some(65_536), true),
+            ("google/gemma-4-31B-turbo-TEE", 131_072, Some(65_536), true),
+            (
+                "unsloth/Mistral-Nemo-Instruct-2407-TEE",
+                131_072,
+                None,
+                false,
+            ),
+        ];
+
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("chutes").unwrap())
+                .unwrap()
+                .as_string(),
+            "chutes/moonshotai/Kimi-K2.6-TEE"
+        );
+
+        for (model, context_window, max_output, image_input) in expected {
+            let metadata = catalog
+                .get(&ModelRef::parse(&format!("chutes/{model}")).unwrap())
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, Some(context_window));
+            assert_eq!(metadata.max_output_tokens_upper_limit, max_output);
+            assert_eq!(metadata.capabilities.image_input, image_input);
+        }
+
+        for retired in ["zai-org/GLM-4.7-TEE", "openai/gpt-oss-120b-TEE"] {
+            assert!(
+                catalog
+                    .get(&ModelRef::parse(&format!("chutes/{retired}")).unwrap())
+                    .is_none(),
+                "{retired} should not remain in the built-in catalog"
+            );
+        }
+
+        let mistral = catalog
+            .get(&ModelRef::parse("chutes/unsloth/Mistral-Nemo-Instruct-2407-TEE").unwrap())
+            .unwrap();
+        assert_eq!(mistral.source, ModelMetadataSource::ConservativeBuiltin);
+        assert!(!mistral.capabilities.supports_reasoning);
+        assert!(mistral.max_output_tokens_upper_limit.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- calibrate the built-in Chutes catalog against the public live `/v1/models` directory
- track the 14 currently exposed models and remove two entries no longer present in that directory
- keep conservative metadata for models whose public records do not declare capability fields
- document the source date, evidence boundaries, and retirement policy, then regenerate the model reference

## Verification

- `cargo test --lib model_catalog::tests::chutes_catalog_tracks_the_public_live_model_directory`
- `cargo test --lib config::tests::built_in_provider`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

## Livetest

No Chutes credential was available in the local environment, so a real API livetest was not run.
