### PR TITLE
fix: calibrate Fireworks model catalog

### DIFF
--- a/docs/implementation-decisions/080-fireworks-model-catalog.md
+++ b/docs/implementation-decisions/080-fireworks-model-catalog.md
@@ -5,7 +5,9 @@ Holon snapshots Fireworks AI models that the official model library marks
 function calling or image input. The snapshot was verified on 2026-07-13.
 
 The built-in catalog records context windows and image input only when the
-individual Fireworks model page publishes them. Fireworks does not publish a
+individual Fireworks model page publishes them. This makes `kimi-k2p6`
+image-capable in the current snapshot, matching its Fireworks model page.
+Fireworks does not publish a
 maximum output-token limit on those pages, so Holon leaves that limit unset
 rather than treating the context window as a generation limit. Qwen 3.6 Plus
 currently reports its context length as `N/A`, which is also kept unknown.
@@ -13,7 +15,7 @@ currently reports its context length as `N/A`, which is also kept unknown.
 Reasoning controls follow the Fireworks chat-completions API contract where it
 names model-family behavior. DeepSeek V4 exposes `none`, `low`, `medium`,
 `high`, `xhigh`, and `max`; GLM 5.2 exposes disabled, High, and Max tiers; GPT
-OSS 120B and MiniMax M2 accept `low`, `medium`, and `high`. Other reasoning
+OSS 120B and MiniMax M2.7 accept `low`, `medium`, and `high`. Other reasoning
 models remain marked as reasoning-capable without claiming adjustable effort
 levels that Fireworks does not explicitly document for that route.
 

--- a/docs/implementation-decisions/080-fireworks-model-catalog.md
+++ b/docs/implementation-decisions/080-fireworks-model-catalog.md
@@ -1,0 +1,34 @@
+# Fireworks model catalog
+
+Holon snapshots Fireworks AI models that the official model library marks
+`Ready`, exposes through the serverless API, and documents as supporting
+function calling or image input. The snapshot was verified on 2026-07-13.
+
+The built-in catalog records context windows and image input only when the
+individual Fireworks model page publishes them. Fireworks does not publish a
+maximum output-token limit on those pages, so Holon leaves that limit unset
+rather than treating the context window as a generation limit. Qwen 3.6 Plus
+currently reports its context length as `N/A`, which is also kept unknown.
+
+Reasoning controls follow the Fireworks chat-completions API contract where it
+names model-family behavior. DeepSeek V4 exposes `none`, `low`, `medium`,
+`high`, `xhigh`, and `max`; GLM 5.2 exposes disabled, High, and Max tiers; GPT
+OSS 120B and MiniMax M2 accept `low`, `medium`, and `high`. Other reasoning
+models remain marked as reasoning-capable without claiming adjustable effort
+levels that Fireworks does not explicitly document for that route.
+
+The former Kimi K2.5 Turbo Fire Pass router is not retained in the default
+serverless model picker because its historical router page is not part of the
+current ready serverless model set. Users may still configure arbitrary
+Fireworks model or router IDs explicitly.
+
+Sources:
+
+- Fireworks model library sitemap: `https://fireworks.ai/sitemap.xml`
+- Fireworks platform model availability:
+  `https://docs.fireworks.ai/faq/models/availability/platform-models`
+- Fireworks reasoning guide: `https://docs.fireworks.ai/guides/reasoning`
+- Fireworks chat completions API:
+  `https://docs.fireworks.ai/api-reference/post-chatcompletions`
+- Individual current model pages under:
+  `https://fireworks.ai/models/fireworks/`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -91,3 +91,4 @@ Current decision notes:
 - [077 StepFun Model Catalog](./077-stepfun-model-catalog.md)
 - [078 Xiaomi Model Catalog](./078-xiaomi-model-catalog.md)
 - [079 Chutes Model Catalog](./079-chutes-model-catalog.md)
+- [080 Fireworks Model Catalog](./080-fireworks-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **213 models**.
+across **40 endpoints** and **223 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -141,8 +141,18 @@ and capabilities.
 | `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `deepseek` | `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
-| `fireworks` | `accounts/fireworks/models/kimi-k2p6` | `fireworks/accounts/fireworks/models/kimi-k2p6` | 262144 | 262144 | — | ✅ |
-| `fireworks` | `accounts/fireworks/routers/kimi-k2p5-turbo` | `fireworks/accounts/fireworks/routers/kimi-k2p5-turbo` | 256000 | 256000 | — | ✅ |
+| `fireworks` | `accounts/fireworks/models/deepseek-v4-flash` | `fireworks/accounts/fireworks/models/deepseek-v4-flash` | 1048576 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/deepseek-v4-pro` | `fireworks/accounts/fireworks/models/deepseek-v4-pro` | 1048576 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/glm-5p1` | `fireworks/accounts/fireworks/models/glm-5p1` | 202752 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/glm-5p2` | `fireworks/accounts/fireworks/models/glm-5p2` | 1048576 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/gpt-oss-120b` | `fireworks/accounts/fireworks/models/gpt-oss-120b` | 131072 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/kimi-k2p6` | `fireworks/accounts/fireworks/models/kimi-k2p6` | 262144 | — | ✅ | ✅ |
+| `fireworks` | `accounts/fireworks/models/kimi-k2p7-code` | `fireworks/accounts/fireworks/models/kimi-k2p7-code` | 262144 | — | ✅ | ✅ |
+| `fireworks` | `accounts/fireworks/models/minimax-m2p7` | `fireworks/accounts/fireworks/models/minimax-m2p7` | 196608 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/minimax-m3` | `fireworks/accounts/fireworks/models/minimax-m3` | 524288 | — | ✅ | ✅ |
+| `fireworks` | `accounts/fireworks/models/nemotron-3-ultra-nvfp4` | `fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4` | 262144 | — | ✅ | — |
+| `fireworks` | `accounts/fireworks/models/qwen3p6-plus` | `fireworks/accounts/fireworks/models/qwen3p6-plus` | — | — | ✅ | ✅ |
+| `fireworks` | `accounts/fireworks/models/qwen3p7-plus` | `fireworks/accounts/fireworks/models/qwen3p7-plus` | 262144 | — | ✅ | ✅ |
 | `gemini` | `gemini-2.5-flash` | `gemini/gemini-2.5-flash` | 1048576 | 65536 | ✅ | ✅ |
 | `gemini` | `gemini-2.5-flash-lite` | `gemini/gemini-2.5-flash-lite` | 1048576 | 65536 | ✅ | ✅ |
 | `gemini` | `gemini-2.5-pro` | `gemini/gemini-2.5-pro` | 1048576 | 65536 | ✅ | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -723,6 +723,13 @@ fn reasoning_effort_options(
         ("xai", "grok-4.5") => &["low", "medium", "high"][..],
         ("stepfun", "step-3.7-flash") => &["low", "medium", "high"][..],
         ("stepfun", "step-3.5-flash-2603") => &["low", "high"][..],
+        ("fireworks", "accounts/fireworks/models/deepseek-v4-flash")
+        | ("fireworks", "accounts/fireworks/models/deepseek-v4-pro") => {
+            &["none", "low", "medium", "high", "xhigh", "max"][..]
+        }
+        ("fireworks", "accounts/fireworks/models/glm-5p2") => &["none", "high", "max"][..],
+        ("fireworks", "accounts/fireworks/models/gpt-oss-120b")
+        | ("fireworks", "accounts/fireworks/models/minimax-m2p7") => &["low", "medium", "high"][..],
         ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
         ("xiaomi" | "xiaomi-token-plan", "mimo-v2.5-pro" | "mimo-v2.5") => &["none", "high"][..],
         ("volcengine", _)
@@ -793,6 +800,39 @@ fn chutes_model_without_published_capabilities(
             DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
         ),
         capabilities: ModelCapabilityFlags::default(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
+fn fireworks_model(
+    model: &str,
+    display_name: &str,
+    context_window_tokens: Option<usize>,
+    supports_reasoning: bool,
+    image_input: bool,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("fireworks"), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the Fireworks serverless {model} model."
+        ),
+        context_window_tokens,
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            image_input,
+            supports_reasoning,
+            ..ModelCapabilityFlags::default()
+        },
         source: ModelMetadataSource::ConservativeBuiltin,
         endpoint: None,
     }
@@ -1296,22 +1336,88 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             false,
         ),
-        catalog_model(
-            "fireworks",
+        fireworks_model(
             "accounts/fireworks/models/kimi-k2p6",
             "Kimi K2.6",
-            262_144,
-            262_144,
-            false,
+            Some(262_144),
+            true,
             true,
         ),
-        catalog_model(
-            "fireworks",
-            "accounts/fireworks/routers/kimi-k2p5-turbo",
-            "Kimi K2.5 Turbo (Fire Pass)",
-            256_000,
-            256_000,
+        fireworks_model(
+            "accounts/fireworks/models/kimi-k2p7-code",
+            "Kimi K2.7 Code",
+            Some(262_144),
+            true,
+            true,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/deepseek-v4-flash",
+            "DeepSeek V4 Flash",
+            Some(1_048_576),
+            true,
             false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/deepseek-v4-pro",
+            "DeepSeek V4 Pro",
+            Some(1_048_576),
+            true,
+            false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/glm-5p1",
+            "GLM 5.1",
+            Some(202_752),
+            true,
+            false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/glm-5p2",
+            "GLM 5.2",
+            Some(1_048_576),
+            true,
+            false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/gpt-oss-120b",
+            "GPT-OSS 120B",
+            Some(131_072),
+            true,
+            false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/minimax-m2p7",
+            "MiniMax M2.7",
+            Some(196_608),
+            true,
+            false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/minimax-m3",
+            "MiniMax M3",
+            Some(524_288),
+            true,
+            true,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+            "Nemotron 3 Ultra NVFP4",
+            Some(262_144),
+            true,
+            false,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/qwen3p6-plus",
+            "Qwen 3.6 Plus",
+            None,
+            true,
+            true,
+        ),
+        fireworks_model(
+            "accounts/fireworks/models/qwen3p7-plus",
+            "Qwen 3.7 Plus",
+            Some(262_144),
+            true,
             true,
         ),
         catalog_model(
@@ -3708,6 +3814,81 @@ mod tests {
         assert_eq!(mistral.source, ModelMetadataSource::ConservativeBuiltin);
         assert!(!mistral.capabilities.supports_reasoning);
         assert!(mistral.max_output_tokens_upper_limit.is_none());
+    }
+
+    #[test]
+    fn fireworks_catalog_tracks_current_serverless_chat_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            (
+                "accounts/fireworks/models/deepseek-v4-flash",
+                Some(1_048_576),
+                false,
+            ),
+            (
+                "accounts/fireworks/models/deepseek-v4-pro",
+                Some(1_048_576),
+                false,
+            ),
+            ("accounts/fireworks/models/glm-5p1", Some(202_752), false),
+            ("accounts/fireworks/models/glm-5p2", Some(1_048_576), false),
+            (
+                "accounts/fireworks/models/gpt-oss-120b",
+                Some(131_072),
+                false,
+            ),
+            ("accounts/fireworks/models/kimi-k2p6", Some(262_144), true),
+            (
+                "accounts/fireworks/models/kimi-k2p7-code",
+                Some(262_144),
+                true,
+            ),
+            (
+                "accounts/fireworks/models/minimax-m2p7",
+                Some(196_608),
+                false,
+            ),
+            ("accounts/fireworks/models/minimax-m3", Some(524_288), true),
+            (
+                "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+                Some(262_144),
+                false,
+            ),
+            ("accounts/fireworks/models/qwen3p6-plus", None, true),
+            (
+                "accounts/fireworks/models/qwen3p7-plus",
+                Some(262_144),
+                true,
+            ),
+        ];
+
+        for (model, context_window, image_input) in expected {
+            let metadata = catalog
+                .get(&ModelRef::parse(&format!("fireworks/{model}")).unwrap())
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, context_window, "{model}");
+            assert_eq!(metadata.capabilities.image_input, image_input, "{model}");
+            assert!(metadata.capabilities.supports_reasoning, "{model}");
+            assert!(metadata.max_output_tokens_upper_limit.is_none(), "{model}");
+            assert_eq!(metadata.source, ModelMetadataSource::ConservativeBuiltin);
+        }
+
+        assert!(catalog
+            .get(&ModelRef::parse("fireworks/accounts/fireworks/routers/kimi-k2p5-turbo").unwrap())
+            .is_none());
+
+        let deepseek = catalog.resolve_policy(
+            &ModelRef::parse("fireworks/accounts/fireworks/models/deepseek-v4-flash").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(
+            deepseek.reasoning_effort_options,
+            ["none", "low", "medium", "high", "xhigh", "max"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the stale Fireworks catalog with 12 currently documented serverless chat/generative models
- remove the legacy Fire Pass router and conservatively expose vision/reasoning controls only where Fireworks currently documents them
- record source provenance and regenerate the model reference

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib model_catalog::tests::fireworks_catalog_tracks_current_serverless_chat_models`
- `cargo test --lib config::tests::built_in_provider`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

## Live test
Not run: `FIREWORKS_API_KEY` is not available in the local environment.
