### PR TITLE
fix: calibrate NVIDIA model catalog

### DIFF
--- a/docs/implementation-decisions/081-nvidia-model-catalog.md
+++ b/docs/implementation-decisions/081-nvidia-model-catalog.md
@@ -1,0 +1,36 @@
+# NVIDIA model catalog
+
+Holon snapshots models currently returned by NVIDIA's hosted
+`https://integrate.api.nvidia.com/v1/models` endpoint and verifies their
+capabilities against the corresponding Build.NVIDIA.com model cards. The
+snapshot was verified on 2026-07-13.
+
+The current built-in picker contains Nemotron 3 Super 120B, Kimi K2.6,
+MiniMax M2.7, MiniMax M3, and GLM-5.2. The former Kimi K2.5, MiniMax M2.5,
+and `z-ai/glm5` identifiers are no longer returned by the hosted model
+directory and are not retained as defaults. Users may still configure an
+arbitrary NVIDIA model ID explicitly.
+
+Context windows and input modalities follow the individual NVIDIA model
+cards. Kimi K2.6 and MiniMax M3 accept image input; the other current entries
+are text-input models. All five cards describe reasoning behavior, but only
+Nemotron, Kimi, and GLM document thinking controls. Holon therefore records
+the intrinsic reasoning capability without inventing portable effort levels
+for NVIDIA's route.
+
+The hosted model cards do not publish a distinct maximum generation-token
+limit for these API routes. Holon leaves the output limit unset rather than
+reusing a context length or deployment example as an API constraint.
+
+Sources:
+
+- NVIDIA hosted model directory:
+  `https://integrate.api.nvidia.com/v1/models`
+- NVIDIA model catalog:
+  `https://build.nvidia.com/models`
+- Current hosted model cards:
+  `https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b`
+  `https://build.nvidia.com/moonshotai/kimi-k2.6`
+  `https://build.nvidia.com/minimaxai/minimax-m2.7`
+  `https://build.nvidia.com/minimaxai/minimax-m3`
+  `https://build.nvidia.com/z-ai/glm-5.2`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -92,3 +92,4 @@ Current decision notes:
 - [078 Xiaomi Model Catalog](./078-xiaomi-model-catalog.md)
 - [079 Chutes Model Catalog](./079-chutes-model-catalog.md)
 - [080 Fireworks Model Catalog](./080-fireworks-model-catalog.md)
+- [081 NVIDIA Model Catalog](./081-nvidia-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **223 models**.
+across **40 endpoints** and **224 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -190,10 +190,11 @@ and capabilities.
 | `nearai` | `Qwen/Qwen3.6-35B-A3B-FP8` | `nearai/Qwen/Qwen3.6-35B-A3B-FP8` | 262144 | 65536 | ✅ | — |
 | `nearai` | `google/gemma-4-31B-it` | `nearai/google/gemma-4-31B-it` | 262144 | 32768 | — | — |
 | `nearai` | `zai-org/GLM-5.1-FP8` | `nearai/zai-org/GLM-5.1-FP8` | 202752 | 131072 | ✅ | — |
-| `nvidia` | `minimaxai/minimax-m2.5` | `nvidia/minimaxai/minimax-m2.5` | 196608 | 8192 | — | — |
-| `nvidia` | `moonshotai/kimi-k2.5` | `nvidia/moonshotai/kimi-k2.5` | 262144 | 8192 | — | — |
-| `nvidia` | `nvidia/nemotron-3-super-120b-a12b` | `nvidia/nvidia/nemotron-3-super-120b-a12b` | 262144 | 8192 | — | — |
-| `nvidia` | `z-ai/glm5` | `nvidia/z-ai/glm5` | 202752 | 8192 | — | — |
+| `nvidia` | `minimaxai/minimax-m2.7` | `nvidia/minimaxai/minimax-m2.7` | 204800 | — | ✅ | — |
+| `nvidia` | `minimaxai/minimax-m3` | `nvidia/minimaxai/minimax-m3` | 1000000 | — | ✅ | ✅ |
+| `nvidia` | `moonshotai/kimi-k2.6` | `nvidia/moonshotai/kimi-k2.6` | 262144 | — | ✅ | ✅ |
+| `nvidia` | `nvidia/nemotron-3-super-120b-a12b` | `nvidia/nvidia/nemotron-3-super-120b-a12b` | 1000000 | — | ✅ | — |
+| `nvidia` | `z-ai/glm-5.2` | `nvidia/z-ai/glm-5.2` | 1000000 | — | ✅ | — |
 | `openai` | `gpt-5.3` | `openai/gpt-5.3` | 128000 | — | ✅ | ✅ |
 | `openai` | `gpt-5.4` | `openai/gpt-5.4` | 272000 | — | ✅ | ✅ |
 | `openai` | `gpt-5.4-mini` | `openai/gpt-5.4-mini` | 128000 | — | ✅ | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -838,6 +838,39 @@ fn fireworks_model(
     }
 }
 
+fn nvidia_model(
+    model: &str,
+    display_name: &str,
+    context_window_tokens: usize,
+    supports_reasoning: bool,
+    image_input: bool,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("nvidia"), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the NVIDIA-hosted {model} model."
+        ),
+        context_window_tokens: Some(context_window_tokens),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            image_input,
+            supports_reasoning,
+            ..ModelCapabilityFlags::default()
+        },
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
 fn stepfun_model(
     provider: &str,
     model: &str,
@@ -1699,34 +1732,35 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
             false,
         ),
-        catalog_model(
-            "nvidia",
+        nvidia_model(
             "nvidia/nemotron-3-super-120b-a12b",
             "NVIDIA Nemotron 3 Super 120B",
+            1_000_000,
+            true,
+            false,
+        ),
+        nvidia_model(
+            "moonshotai/kimi-k2.6",
+            "Kimi K2.6",
             262_144,
-            8_192,
-            false,
+            true,
+            true,
+        ),
+        nvidia_model(
+            "minimaxai/minimax-m2.7",
+            "MiniMax M2.7",
+            204_800,
+            true,
             false,
         ),
-        catalog_model(
-            "nvidia",
-            "moonshotai/kimi-k2.5",
-            "Kimi K2.5",
-            262_144,
-            8_192,
-            false,
-            false,
+        nvidia_model(
+            "minimaxai/minimax-m3",
+            "MiniMax M3",
+            1_000_000,
+            true,
+            true,
         ),
-        catalog_model(
-            "nvidia",
-            "minimaxai/minimax-m2.5",
-            "MiniMax M2.5",
-            196_608,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model("nvidia", "z-ai/glm5", "GLM-5", 202_752, 8_192, false, false),
+        nvidia_model("z-ai/glm-5.2", "GLM-5.2", 1_000_000, true, false),
         catalog_model(
             "opencode-go",
             "deepseek-v4-pro",
@@ -3889,6 +3923,46 @@ mod tests {
             deepseek.reasoning_effort_options,
             ["none", "low", "medium", "high", "xhigh", "max"]
         );
+    }
+
+    #[test]
+    fn nvidia_catalog_tracks_the_public_hosted_model_directory() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            ("nvidia/nemotron-3-super-120b-a12b", 1_000_000, false),
+            ("moonshotai/kimi-k2.6", 262_144, true),
+            ("minimaxai/minimax-m2.7", 204_800, false),
+            ("minimaxai/minimax-m3", 1_000_000, true),
+            ("z-ai/glm-5.2", 1_000_000, false),
+        ];
+
+        for (model, context_window, image_input) in expected {
+            let metadata = catalog
+                .get(&ModelRef::parse(&format!("nvidia/{model}")).unwrap())
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(
+                metadata.context_window_tokens,
+                Some(context_window),
+                "{model}"
+            );
+            assert_eq!(metadata.capabilities.image_input, image_input, "{model}");
+            assert!(metadata.capabilities.supports_reasoning, "{model}");
+            assert!(metadata.max_output_tokens_upper_limit.is_none(), "{model}");
+            assert_eq!(metadata.source, ModelMetadataSource::ConservativeBuiltin);
+        }
+
+        for retired in [
+            "moonshotai/kimi-k2.5",
+            "minimaxai/minimax-m2.5",
+            "z-ai/glm5",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::parse(&format!("nvidia/{retired}")).unwrap())
+                    .is_none(),
+                "{retired} should not remain in the built-in catalog"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 概要

- 按 NVIDIA NIM 公开 `/v1/models` 与官方模型卡校准当前 hosted 模型集合
- 更新 intrinsic capability、reasoning controls、上下文边界及保守的未知输出上限
- 移除不再由当前公开 endpoint 暴露的旧模型，并补充回归测试与来源决策记录
- 重新生成模型参考文档

## 验证

- `cargo test model_catalog::tests::nvidia_catalog_tracks_the_public_hosted_model_directory`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

当前环境未提供 `NVIDIA_API_KEY`，因此未执行真实 route livetest。