### PR TITLE
fix: calibrate OpenRouter model catalog

### DIFF
--- a/docs/implementation-decisions/083-openrouter-model-catalog.md
+++ b/docs/implementation-decisions/083-openrouter-model-catalog.md
@@ -1,0 +1,32 @@
+# OpenRouter model catalog
+
+Holon keeps only OpenRouter's `openrouter/auto` router as a built-in picker
+default. The snapshot was verified against the official Models API on
+2026-07-13. The former Hunter Alpha and Healer Alpha entries are no longer
+returned by that API, while ordinary upstream model availability changes too
+frequently to maintain as a second static OpenRouter catalog.
+
+The Auto Router exposes a 2,000,000-token context window and accepts image
+input and the `reasoning` parameter. Its selected upstream model and provider
+remain dynamic, so Holon leaves the output limit and adjustable reasoning
+effort list unset rather than projecting one routed model's limits onto the
+aggregate endpoint.
+
+OpenRouter discovery maps the Models API's `context_length`,
+`top_provider.max_completion_tokens`, `architecture.input_modalities`,
+`supported_parameters`, and `reasoning` object into remote route metadata.
+Reasoning is advertised when the endpoint accepts the `reasoning` parameter or
+the reasoning object marks it enabled or mandatory. Adjustable effort values
+are exposed only when `reasoning_effort` is accepted and the API supplies an
+explicit `supported_efforts` list.
+
+Sources:
+
+- OpenRouter Models API:
+  `https://openrouter.ai/api/v1/models`
+- OpenRouter model routing:
+  `https://openrouter.ai/docs/features/model-routing`
+- OpenRouter reasoning tokens:
+  `https://openrouter.ai/docs/use-cases/reasoning-tokens`
+- OpenRouter multimodal overview:
+  `https://openrouter.ai/docs/features/multimodal/overview`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -94,3 +94,4 @@ Current decision notes:
 - [080 Fireworks Model Catalog](./080-fireworks-model-catalog.md)
 - [081 NVIDIA Model Catalog](./081-nvidia-model-catalog.md)
 - [082 Together AI Model Catalog](./082-together-model-catalog.md)
+- [083 OpenRouter Model Catalog](./083-openrouter-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **226 models**.
+across **40 endpoints** and **223 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -211,10 +211,7 @@ and capabilities.
 | `openai-codex` | `gpt-5.6-terra` | `openai-codex/gpt-5.6-terra` | 372000 | — | ✅ | ✅ |
 | `opencode-go` | `deepseek-v4-flash` | `opencode-go/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `opencode-go` | `deepseek-v4-pro` | `opencode-go/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
-| `openrouter` | `auto` | `openrouter/auto` | 200000 | 8192 | — | ✅ |
-| `openrouter` | `moonshotai/kimi-k2.6` | `openrouter/moonshotai/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
-| `openrouter` | `openrouter/healer-alpha` | `openrouter/openrouter/healer-alpha` | 262144 | 65536 | ✅ | ✅ |
-| `openrouter` | `openrouter/hunter-alpha` | `openrouter/openrouter/hunter-alpha` | 1048576 | 65536 | ✅ | — |
+| `openrouter` | `auto` | `openrouter/auto` | 2000000 | — | ✅ | ✅ |
 | `qianfan` | `deepseek-v3.2` | `qianfan/deepseek-v3.2` | 131072 | 32768 | — | — |
 | `qianfan` | `deepseek-v3.2-think` | `qianfan/deepseek-v3.2-think` | 163840 | 65536 | ✅ | — |
 | `qianfan` | `ernie-5.0` | `qianfan/ernie-5.0` | 248832 | 65536 | — | ✅ |

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -596,6 +596,9 @@ impl RuntimeModelCatalog {
                     base.map(|model| &model.capabilities),
                     override_config.capabilities.as_ref(),
                 ),
+                reasoning_effort_options: base
+                    .map(|model| model.reasoning_effort_options.clone())
+                    .unwrap_or_default(),
                 source: crate::model_catalog::ModelMetadataSource::ConfigOverride,
                 endpoint: None,
             });

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2961,6 +2961,7 @@ fn runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins() {
                 default_verbosity: None,
                 tool_output_truncation_estimated_tokens: None,
                 capabilities: Default::default(),
+                reasoning_effort_options: Vec::new(),
                 source: ModelMetadataSource::RemoteDiscovered,
                 endpoint: None,
             }],

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -168,6 +168,8 @@ pub struct BuiltInModelMetadata {
     pub tool_output_truncation_estimated_tokens: Option<usize>,
     #[serde(default)]
     pub capabilities: ModelCapabilityFlags,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasoning_effort_options: Vec<String>,
     pub source: ModelMetadataSource,
     /// Non-default endpoint this model belongs to under its canonical provider.
     /// When `None`, the model uses the provider's default endpoint.
@@ -625,7 +627,10 @@ impl BuiltInModelCatalog {
         {
             override_capabilities.apply_to(&mut capabilities);
         }
-        let reasoning_effort_options = reasoning_effort_options(model_ref, endpoint, &capabilities);
+        let reasoning_effort_options = built_in
+            .map(|entry| entry.reasoning_effort_options.clone())
+            .filter(|options| !options.is_empty())
+            .unwrap_or_else(|| reasoning_effort_options(model_ref, endpoint, &capabilities));
 
         ResolvedRuntimeModelPolicy {
             model_ref: model_ref.clone(),
@@ -774,6 +779,7 @@ fn catalog_model(
             supports_reasoning,
             ..ModelCapabilityFlags::default()
         },
+        reasoning_effort_options: Vec::new(),
         source: ModelMetadataSource::BuiltInCatalog,
         endpoint: None,
     }
@@ -800,6 +806,7 @@ fn chutes_model_without_published_capabilities(
             DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
         ),
         capabilities: ModelCapabilityFlags::default(),
+        reasoning_effort_options: Vec::new(),
         source: ModelMetadataSource::ConservativeBuiltin,
         endpoint: None,
     }
@@ -833,6 +840,7 @@ fn fireworks_model(
             supports_reasoning,
             ..ModelCapabilityFlags::default()
         },
+        reasoning_effort_options: Vec::new(),
         source: ModelMetadataSource::ConservativeBuiltin,
         endpoint: None,
     }
@@ -866,6 +874,7 @@ fn nvidia_model(
             supports_reasoning,
             ..ModelCapabilityFlags::default()
         },
+        reasoning_effort_options: Vec::new(),
         source: ModelMetadataSource::ConservativeBuiltin,
         endpoint: None,
     }
@@ -899,6 +908,7 @@ fn together_model(
             supports_reasoning,
             ..ModelCapabilityFlags::default()
         },
+        reasoning_effort_options: Vec::new(),
         source: ModelMetadataSource::ConservativeBuiltin,
         endpoint: None,
     }
@@ -929,6 +939,7 @@ fn stepfun_model(
             supports_reasoning: true,
             ..ModelCapabilityFlags::default()
         },
+        reasoning_effort_options: Vec::new(),
         source: ModelMetadataSource::BuiltInCatalog,
         endpoint: None,
     }
@@ -960,6 +971,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -979,6 +991,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -998,6 +1011,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1017,6 +1031,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1038,6 +1053,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1059,6 +1075,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1080,6 +1097,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1101,6 +1119,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1122,6 +1141,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1143,6 +1163,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1163,6 +1184,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1181,6 +1203,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 image_generation: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -1200,6 +1223,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::ConservativeBuiltin,
             endpoint: None,
         },
@@ -1219,6 +1243,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::ConservativeBuiltin,
             endpoint: None,
         },
@@ -1238,6 +1263,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::ConservativeBuiltin,
             endpoint: None,
         },
@@ -1812,42 +1838,28 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             false,
         ),
-        catalog_model(
-            "openrouter",
-            "auto",
-            "OpenRouter Auto",
-            200_000,
-            8_192,
-            false,
-            true,
-        ),
-        catalog_model(
-            "openrouter",
-            "openrouter/hunter-alpha",
-            "Hunter Alpha",
-            1_048_576,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "openrouter",
-            "openrouter/healer-alpha",
-            "Healer Alpha",
-            262_144,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "openrouter",
-            "moonshotai/kimi-k2.6",
-            "MoonshotAI: Kimi K2.6",
-            262_144,
-            262_144,
-            true,
-            true,
-        ),
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider_id("openrouter"), "auto"),
+            display_name: "OpenRouter Auto".into(),
+            description: "OpenRouter Auto Router metadata aligned with the official Models API; the selected upstream model and provider are dynamic.".into(),
+            context_window_tokens: Some(2_000_000),
+            effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(
+                DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+            ),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                supports_reasoning: true,
+                ..ModelCapabilityFlags::default()
+            },
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::ConservativeBuiltin,
+            endpoint: None,
+        },
         catalog_model(
             "qianfan",
             "deepseek-v3.2",
@@ -2833,6 +2845,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
                 image_generation: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: Some(ProviderEndpointId::parse("plan").expect("valid built-in endpoint id")),
         },
@@ -2889,6 +2902,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -2909,6 +2923,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
@@ -4053,6 +4068,35 @@ mod tests {
                     .get(&ModelRef::parse(&format!("together/{retired}")).unwrap())
                     .is_none(),
                 "{retired} should not remain in the built-in catalog"
+            );
+        }
+    }
+
+    #[test]
+    fn openrouter_catalog_keeps_only_the_dynamic_auto_router_default() {
+        let catalog = BuiltInModelCatalog::new();
+        let auto = catalog
+            .get(&ModelRef::parse("openrouter/auto").unwrap())
+            .expect("OpenRouter auto router should be registered");
+
+        assert_eq!(auto.context_window_tokens, Some(2_000_000));
+        assert!(auto.default_max_output_tokens.is_none());
+        assert!(auto.max_output_tokens_upper_limit.is_none());
+        assert!(auto.capabilities.image_input);
+        assert!(auto.capabilities.supports_reasoning);
+        assert!(auto.reasoning_effort_options.is_empty());
+        assert_eq!(auto.source, ModelMetadataSource::ConservativeBuiltin);
+
+        for dynamic_or_removed in [
+            "moonshotai/kimi-k2.6",
+            "openrouter/healer-alpha",
+            "openrouter/hunter-alpha",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::parse(&format!("openrouter/{dynamic_or_removed}")).unwrap())
+                    .is_none(),
+                "{dynamic_or_removed} should come from discovery or explicit configuration"
             );
         }
     }

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -266,6 +266,20 @@ struct OpenRouterModel {
     architecture: Option<OpenRouterArchitecture>,
     #[serde(default)]
     top_provider: Option<OpenRouterTopProvider>,
+    #[serde(default)]
+    supported_parameters: Vec<String>,
+    #[serde(default)]
+    reasoning: Option<OpenRouterReasoning>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterReasoning {
+    #[serde(default)]
+    mandatory: bool,
+    #[serde(default)]
+    default_enabled: bool,
+    #[serde(default)]
+    supported_efforts: Vec<String>,
 }
 
 impl OpenRouterModel {
@@ -302,6 +316,25 @@ impl OpenRouterModel {
                     .any(|value| value.eq_ignore_ascii_case("image"))
             })
             .unwrap_or(false);
+        let supports_reasoning = self
+            .supported_parameters
+            .iter()
+            .any(|parameter| parameter == "reasoning")
+            || self.reasoning.as_ref().is_some_and(|reasoning| {
+                reasoning.mandatory
+                    || reasoning.default_enabled
+                    || !reasoning.supported_efforts.is_empty()
+            });
+        let reasoning_effort_options = self
+            .reasoning
+            .as_ref()
+            .filter(|_| {
+                self.supported_parameters
+                    .iter()
+                    .any(|parameter| parameter == "reasoning_effort")
+            })
+            .map(|reasoning| reasoning.supported_efforts.clone())
+            .unwrap_or_default();
         Some(BuiltInModelMetadata {
             model_ref: ModelRef::new(provider.clone(), id.to_string()),
             display_name,
@@ -315,8 +348,10 @@ impl OpenRouterModel {
             tool_output_truncation_estimated_tokens: None,
             capabilities: ModelCapabilityFlags {
                 image_input,
+                supports_reasoning,
                 ..ModelCapabilityFlags::default()
             },
+            reasoning_effort_options,
             source: ModelMetadataSource::RemoteDiscovered,
             endpoint: None,
         })
@@ -373,23 +408,65 @@ mod tests {
     #[test]
     fn maps_openrouter_models_to_remote_metadata() {
         let payload: OpenRouterModelsResponse = serde_json::from_str(
-            r#"{"data":[{"id":"anthropic/claude-3.5-sonnet","name":"Claude 3.5 Sonnet","description":"test","context_length":200000,"architecture":{"input_modalities":["text","image"]},"top_provider":{"max_completion_tokens":8192}}]}"#,
+            r#"{"data":[
+                {
+                    "id":"openrouter/auto",
+                    "name":"Auto Router",
+                    "context_length":2000000,
+                    "architecture":{"input_modalities":["text","image","audio","file","video"]},
+                    "top_provider":{"max_completion_tokens":null},
+                    "supported_parameters":["reasoning","reasoning_effort"],
+                    "reasoning":null
+                },
+                {
+                    "id":"anthropic/claude-sonnet-5",
+                    "name":"Claude Sonnet 5",
+                    "description":"test",
+                    "context_length":1000000,
+                    "architecture":{"input_modalities":["text","image"]},
+                    "top_provider":{"max_completion_tokens":128000},
+                    "supported_parameters":["reasoning","reasoning_effort"],
+                    "reasoning":{
+                        "mandatory":false,
+                        "default_enabled":true,
+                        "supported_efforts":["max","xhigh","high","medium","low"]
+                    }
+                }
+            ]}"#,
         )
         .unwrap();
 
         let models = payload.into_model_metadata(&ProviderId::parse("openrouter").unwrap());
 
-        assert_eq!(models.len(), 1);
-        let model = &models[0];
+        assert_eq!(models.len(), 2);
+        let model = models
+            .iter()
+            .find(|model| model.model_ref.model == "anthropic/claude-sonnet-5")
+            .unwrap();
         assert_eq!(
             model.model_ref.as_string(),
-            "openrouter/anthropic/claude-3.5-sonnet"
+            "openrouter/anthropic/claude-sonnet-5"
         );
-        assert_eq!(model.display_name, "Claude 3.5 Sonnet");
-        assert_eq!(model.context_window_tokens, Some(200_000));
-        assert_eq!(model.max_output_tokens_upper_limit, Some(8192));
+        assert_eq!(model.display_name, "Claude Sonnet 5");
+        assert_eq!(model.context_window_tokens, Some(1_000_000));
+        assert_eq!(model.max_output_tokens_upper_limit, Some(128_000));
         assert!(model.capabilities.image_input);
+        assert!(model.capabilities.supports_reasoning);
+        assert_eq!(
+            model.reasoning_effort_options,
+            ["max", "xhigh", "high", "medium", "low"]
+        );
         assert_eq!(model.source, ModelMetadataSource::RemoteDiscovered);
+
+        let auto = models
+            .iter()
+            .find(|model| model.model_ref.model == "openrouter/auto")
+            .unwrap();
+        assert_eq!(auto.context_window_tokens, Some(2_000_000));
+        assert!(auto.max_output_tokens_upper_limit.is_none());
+        assert!(auto.capabilities.image_input);
+        assert!(auto.capabilities.supports_reasoning);
+        assert!(auto.reasoning_effort_options.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## 概要

- 将 OpenRouter 内建静态 catalog 收敛为聚合路由 `openrouter/auto`，避免固化易过时的上游模型快照
- 按 OpenRouter Models API 投影动态模型的模态、上下文/输出限制、支持参数与 endpoint 明确暴露的 reasoning effort 枚举
- 将 reasoning effort 保持为 route-level 元数据；仅在官方 endpoint 数据明确提供枚举时声明可调级别，静态映射仅作兼容回退
- 补充来源/决策记录、配置与 discovery 测试，并重新生成模型参考文档

## 验证

- `cargo test openrouter --all-targets`（2/2 通过）
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

本地未配置 `OPENROUTER_API_KEY`，Holon 配置中也没有可用 OpenRouter 凭据，因此未执行真实 API livetest。
