### PR TITLE
fix: calibrate Synthetic model catalog

### DIFF
--- a/docs/implementation-decisions/086-synthetic-model-catalog.md
+++ b/docs/implementation-decisions/086-synthetic-model-catalog.md
@@ -1,0 +1,32 @@
+# Synthetic model catalog
+
+Holon keeps Synthetic's four stable `syn:` aliases plus the currently
+published always-on models in the built-in picker. The snapshot was verified
+against the Synthetic Models page and public Models API on 2026-07-13.
+Synthetic recommends the aliases because pinned `hf:` model names can be
+rotated out; Holon therefore prefers `syn:large:text` and does not retain older
+fixed models after they leave the always-on set.
+
+Synthetic discovery uses the public
+`https://api.synthetic.new/openai/v1/models` endpoint even though inference
+continues to use the provider's documented Anthropic Messages transport.
+Discovery includes only entries whose `always_on` value is explicitly `true`
+and maps `context_length`, `max_output_length`, `input_modalities`, and
+`supported_features` into remote route metadata.
+
+The Models API exposes reasoning as a feature but does not publish a portable
+discrete reasoning-effort vocabulary, so Holon marks reasoning capability
+without inventing effort controls. Image input is enabled only when the API
+lists the `image` input modality. Metadata refresh does not require a
+configured Synthetic credential even though inference does.
+
+Sources:
+
+- Synthetic available models:
+  `https://dev.synthetic.new/docs/api/models`
+- Synthetic OpenAI Models API:
+  `https://dev.synthetic.new/docs/openai/models`
+- Synthetic Anthropic Messages API:
+  `https://dev.synthetic.new/docs/anthropic/messages`
+- Synthetic Models API:
+  `https://api.synthetic.new/openai/v1/models`

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -96,3 +96,5 @@ Current decision notes:
 - [082 Together AI Model Catalog](./082-together-model-catalog.md)
 - [083 OpenRouter Model Catalog](./083-openrouter-model-catalog.md)
 - [084 Vercel AI Gateway Model Catalog](./084-vercel-ai-gateway-model-catalog.md)
+- [085 NEAR AI Cloud Model Catalog](./085-nearai-model-catalog.md)
+- [086 Synthetic Model Catalog](./086-synthetic-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **223 models**.
+across **40 endpoints** and **213 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -221,27 +221,17 @@ and capabilities.
 | `stepfun` | `step-3.5-flash` | `stepfun/step-3.5-flash` | 262144 | — | ✅ | — |
 | `stepfun` | `step-3.5-flash-2603` | `stepfun/step-3.5-flash-2603` | 262144 | — | ✅ | — |
 | `stepfun` | `step-3.7-flash` | `stepfun/step-3.7-flash` | 262144 | — | ✅ | ✅ |
-| `synthetic` | `hf:MiniMaxAI/MiniMax-M2.5` | `synthetic/hf:MiniMaxAI/MiniMax-M2.5` | 192000 | 65536 | — | — |
-| `synthetic` | `hf:Qwen/Qwen3-235B-A22B-Instruct-2507` | `synthetic/hf:Qwen/Qwen3-235B-A22B-Instruct-2507` | 256000 | 8192 | — | — |
-| `synthetic` | `hf:Qwen/Qwen3-235B-A22B-Thinking-2507` | `synthetic/hf:Qwen/Qwen3-235B-A22B-Thinking-2507` | 256000 | 8192 | ✅ | — |
-| `synthetic` | `hf:Qwen/Qwen3-Coder-480B-A35B-Instruct` | `synthetic/hf:Qwen/Qwen3-Coder-480B-A35B-Instruct` | 256000 | 8192 | — | — |
-| `synthetic` | `hf:Qwen/Qwen3-VL-235B-A22B-Instruct` | `synthetic/hf:Qwen/Qwen3-VL-235B-A22B-Instruct` | 250000 | 8192 | — | ✅ |
-| `synthetic` | `hf:deepseek-ai/DeepSeek-R1-0528` | `synthetic/hf:deepseek-ai/DeepSeek-R1-0528` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:deepseek-ai/DeepSeek-V3` | `synthetic/hf:deepseek-ai/DeepSeek-V3` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:deepseek-ai/DeepSeek-V3-0324` | `synthetic/hf:deepseek-ai/DeepSeek-V3-0324` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:deepseek-ai/DeepSeek-V3.1` | `synthetic/hf:deepseek-ai/DeepSeek-V3.1` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:deepseek-ai/DeepSeek-V3.1-Terminus` | `synthetic/hf:deepseek-ai/DeepSeek-V3.1-Terminus` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:deepseek-ai/DeepSeek-V3.2` | `synthetic/hf:deepseek-ai/DeepSeek-V3.2` | 159000 | 8192 | — | — |
-| `synthetic` | `hf:meta-llama/Llama-3.3-70B-Instruct` | `synthetic/hf:meta-llama/Llama-3.3-70B-Instruct` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | `synthetic/hf:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | 524000 | 8192 | — | — |
-| `synthetic` | `hf:moonshotai/Kimi-K2-Instruct-0905` | `synthetic/hf:moonshotai/Kimi-K2-Instruct-0905` | 256000 | 8192 | — | — |
-| `synthetic` | `hf:moonshotai/Kimi-K2-Thinking` | `synthetic/hf:moonshotai/Kimi-K2-Thinking` | 256000 | 8192 | ✅ | — |
-| `synthetic` | `hf:moonshotai/Kimi-K2.5` | `synthetic/hf:moonshotai/Kimi-K2.5` | 256000 | 8192 | ✅ | ✅ |
-| `synthetic` | `hf:openai/gpt-oss-120b` | `synthetic/hf:openai/gpt-oss-120b` | 128000 | 8192 | — | — |
-| `synthetic` | `hf:zai-org/GLM-4.5` | `synthetic/hf:zai-org/GLM-4.5` | 128000 | 128000 | — | — |
-| `synthetic` | `hf:zai-org/GLM-4.6` | `synthetic/hf:zai-org/GLM-4.6` | 198000 | 128000 | — | — |
-| `synthetic` | `hf:zai-org/GLM-4.7` | `synthetic/hf:zai-org/GLM-4.7` | 198000 | 128000 | — | — |
-| `synthetic` | `hf:zai-org/GLM-5` | `synthetic/hf:zai-org/GLM-5` | 256000 | 128000 | ✅ | ✅ |
+| `synthetic` | `hf:MiniMaxAI/MiniMax-M3` | `synthetic/hf:MiniMaxAI/MiniMax-M3` | 262144 | 65536 | ✅ | ✅ |
+| `synthetic` | `hf:Qwen/Qwen3.6-27B` | `synthetic/hf:Qwen/Qwen3.6-27B` | 262144 | 65536 | ✅ | ✅ |
+| `synthetic` | `hf:moonshotai/Kimi-K2.7-Code` | `synthetic/hf:moonshotai/Kimi-K2.7-Code` | 262144 | 65536 | ✅ | ✅ |
+| `synthetic` | `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | `synthetic/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | 262144 | 65536 | ✅ | — |
+| `synthetic` | `hf:openai/gpt-oss-120b` | `synthetic/hf:openai/gpt-oss-120b` | 131072 | 65536 | ✅ | — |
+| `synthetic` | `hf:zai-org/GLM-4.7-Flash` | `synthetic/hf:zai-org/GLM-4.7-Flash` | 196608 | 65536 | ✅ | — |
+| `synthetic` | `hf:zai-org/GLM-5.2` | `synthetic/hf:zai-org/GLM-5.2` | 524288 | 65536 | ✅ | — |
+| `synthetic` | `syn:large:text` | `synthetic/syn:large:text` | 524288 | 65536 | ✅ | — |
+| `synthetic` | `syn:large:vision` | `synthetic/syn:large:vision` | 262144 | 65536 | ✅ | ✅ |
+| `synthetic` | `syn:small:text` | `synthetic/syn:small:text` | 196608 | 65536 | ✅ | — |
+| `synthetic` | `syn:small:vision` | `synthetic/syn:small:vision` | 262144 | 65536 | ✅ | ✅ |
 | `tencent-tokenhub` | `hy3-preview` | `tencent-tokenhub/hy3-preview` | 256000 | 64000 | ✅ | — |
 | `together` | `MiniMaxAI/MiniMax-M2.7` | `together/MiniMaxAI/MiniMax-M2.7` | 202752 | — | ✅ | — |
 | `together` | `MiniMaxAI/MiniMax-M3` | `together/MiniMaxAI/MiniMax-M3` | 524288 | — | — | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2273,195 +2273,17 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "Step 3.5 Flash",
             false,
         ),
-        catalog_model(
-            "synthetic",
-            "hf:MiniMaxAI/MiniMax-M2.5",
-            "MiniMax M2.5",
-            192_000,
-            65_536,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:moonshotai/Kimi-K2-Thinking",
-            "Kimi K2 Thinking",
-            256_000,
-            8_192,
-            true,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:zai-org/GLM-4.7",
-            "GLM-4.7",
-            198_000,
-            128_000,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:deepseek-ai/DeepSeek-R1-0528",
-            "DeepSeek R1 0528",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:deepseek-ai/DeepSeek-V3-0324",
-            "DeepSeek V3 0324",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:deepseek-ai/DeepSeek-V3.1",
-            "DeepSeek V3.1",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:deepseek-ai/DeepSeek-V3.1-Terminus",
-            "DeepSeek V3.1 Terminus",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:deepseek-ai/DeepSeek-V3.2",
-            "DeepSeek V3.2",
-            159_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:meta-llama/Llama-3.3-70B-Instruct",
-            "Llama 3.3 70B Instruct",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-            "Llama 4 Maverick 17B 128E Instruct FP8",
-            524_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:moonshotai/Kimi-K2-Instruct-0905",
-            "Kimi K2 Instruct 0905",
-            256_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:moonshotai/Kimi-K2.5",
-            "Kimi K2.5",
-            256_000,
-            8_192,
-            true,
-            true,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:openai/gpt-oss-120b",
-            "GPT OSS 120B",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:Qwen/Qwen3-235B-A22B-Instruct-2507",
-            "Qwen3 235B A22B Instruct 2507",
-            256_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:Qwen/Qwen3-Coder-480B-A35B-Instruct",
-            "Qwen3 Coder 480B A35B Instruct",
-            256_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:Qwen/Qwen3-VL-235B-A22B-Instruct",
-            "Qwen3 VL 235B A22B Instruct",
-            250_000,
-            8_192,
-            false,
-            true,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:zai-org/GLM-4.5",
-            "GLM-4.5",
-            128_000,
-            128_000,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:zai-org/GLM-4.6",
-            "GLM-4.6",
-            198_000,
-            128_000,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:zai-org/GLM-5",
-            "GLM-5",
-            256_000,
-            128_000,
-            true,
-            true,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:deepseek-ai/DeepSeek-V3",
-            "DeepSeek V3",
-            128_000,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "synthetic",
-            "hf:Qwen/Qwen3-235B-A22B-Thinking-2507",
-            "Qwen3 235B A22B Thinking 2507",
-            256_000,
-            8_192,
-            true,
-            false,
-        ),
+        catalog_model("synthetic", "syn:large:text", "Synthetic Large Text", 524_288, 65_536, true, false),
+        catalog_model("synthetic", "syn:small:text", "Synthetic Small Text", 196_608, 65_536, true, false),
+        catalog_model("synthetic", "syn:large:vision", "Synthetic Large Vision", 262_144, 65_536, true, true),
+        catalog_model("synthetic", "syn:small:vision", "Synthetic Small Vision", 262_144, 65_536, true, true),
+        catalog_model("synthetic", "hf:openai/gpt-oss-120b", "OpenAI GPT OSS 120B", 131_072, 65_536, true, false),
+        catalog_model("synthetic", "hf:zai-org/GLM-5.2", "Z.ai GLM-5.2", 524_288, 65_536, true, false),
+        catalog_model("synthetic", "hf:moonshotai/Kimi-K2.7-Code", "Moonshot AI Kimi K2.7 Code", 262_144, 65_536, true, true),
+        catalog_model("synthetic", "hf:Qwen/Qwen3.6-27B", "Qwen3.6 27B", 262_144, 65_536, true, true),
+        catalog_model("synthetic", "hf:MiniMaxAI/MiniMax-M3", "MiniMax M3", 262_144, 65_536, true, true),
+        catalog_model("synthetic", "hf:zai-org/GLM-4.7-Flash", "Z.ai GLM-4.7 Flash", 196_608, 65_536, true, false),
+        catalog_model("synthetic", "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4", "NVIDIA Nemotron 3 Super 120B A12B NVFP4", 262_144, 65_536, true, false),
         catalog_model(
             "tencent-tokenhub",
             "hy3-preview",
@@ -4099,6 +3921,59 @@ mod tests {
                 "{dynamic_or_removed} should come from discovery or explicit configuration"
             );
         }
+    }
+
+    #[test]
+    fn synthetic_catalog_tracks_current_always_on_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let synthetic = ProviderId::parse("synthetic").unwrap();
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|entry| entry.model_ref.provider == synthetic)
+            .collect::<Vec<_>>();
+
+        assert_eq!(models.len(), 11);
+        for model in &models {
+            assert!(model.capabilities.supports_reasoning);
+            assert_eq!(
+                model.max_output_tokens_upper_limit,
+                Some(65_536),
+                "{:?}",
+                model.model_ref
+            );
+            assert!(
+                model.reasoning_effort_options.is_empty(),
+                "{:?} should not expose undocumented effort controls",
+                model.model_ref
+            );
+        }
+        for vision in [
+            "syn:large:vision",
+            "syn:small:vision",
+            "hf:moonshotai/Kimi-K2.7-Code",
+            "hf:Qwen/Qwen3.6-27B",
+            "hf:MiniMaxAI/MiniMax-M3",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::parse(&format!("synthetic/{vision}")).unwrap())
+                    .unwrap()
+                    .capabilities
+                    .image_input,
+                "{vision}"
+            );
+        }
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&synthetic)
+                .unwrap()
+                .as_string(),
+            "synthetic/syn:large:text"
+        );
+        assert!(catalog
+            .get(&ModelRef::parse("synthetic/hf:moonshotai/Kimi-K2.5").unwrap())
+            .is_none());
     }
 
     #[test]

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 const OPENAI_COMPATIBLE_MODELS_PATH: &str = "/models";
+const SYNTHETIC_MODELS_URL: &str = "https://api.synthetic.new/openai/v1/models";
 pub const DEFAULT_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -85,12 +86,15 @@ pub fn discovery_cache_path(home_dir: &Path) -> PathBuf {
 pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bool {
     matches!(
         provider.id.as_str(),
-        "nearai" | "openrouter" | "vercel-ai-gateway"
+        "nearai" | "openrouter" | "synthetic" | "vercel-ai-gateway"
     )
 }
 
 fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig) -> bool {
-    !matches!(provider.id.as_str(), "nearai" | "vercel-ai-gateway")
+    !matches!(
+        provider.id.as_str(),
+        "nearai" | "synthetic" | "vercel-ai-gateway"
+    )
 }
 
 pub fn discovery_cache_status_for_provider(
@@ -218,6 +222,9 @@ pub async fn refresh_provider_models(
         "openrouter" => serde_json::from_slice::<OpenRouterModelsResponse>(&raw)
             .context("failed to parse OpenRouter model discovery response")?
             .into_model_metadata(&provider.id),
+        "synthetic" => serde_json::from_slice::<SyntheticModelsResponse>(&raw)
+            .context("failed to parse Synthetic model discovery response")?
+            .into_model_metadata(&provider.id),
         "vercel-ai-gateway" => serde_json::from_slice::<VercelModelsResponse>(&raw)
             .context("failed to parse Vercel AI Gateway model discovery response")?
             .into_model_metadata(&provider.id),
@@ -250,6 +257,7 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
     match provider.id.as_str() {
         "nearai" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
+        "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
         "vercel-ai-gateway" => vercel_models_url(&provider.base_url),
         _ => Err(anyhow!(
             "provider {} does not support model discovery yet",
@@ -504,6 +512,94 @@ impl NearAiModel {
 }
 
 #[derive(Debug, Deserialize)]
+struct SyntheticModelsResponse {
+    #[serde(default)]
+    data: Vec<SyntheticModel>,
+}
+
+impl SyntheticModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SyntheticModel {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    always_on: bool,
+    #[serde(default)]
+    context_length: Option<usize>,
+    #[serde(default)]
+    max_output_length: Option<u32>,
+    #[serde(default)]
+    input_modalities: Vec<String>,
+    #[serde(default)]
+    supported_features: Vec<String>,
+}
+
+impl SyntheticModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        if !self.always_on {
+            return None;
+        }
+        let id = self.id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        let display_name = self
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(id)
+            .to_string();
+        let has_input_modality = |expected: &str| {
+            self.input_modalities
+                .iter()
+                .any(|modality| modality.eq_ignore_ascii_case(expected))
+        };
+        let has_feature = |expected: &str| {
+            self.supported_features
+                .iter()
+                .any(|feature| feature.eq_ignore_ascii_case(expected))
+        };
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name,
+            description: "Remote discovered Synthetic always-on model metadata.".to_string(),
+            context_window_tokens: self.context_length,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: self.max_output_length,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags {
+                image_input: has_input_modality("image"),
+                supports_reasoning: has_feature("reasoning"),
+                ..ModelCapabilityFlags::default()
+            },
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
 struct OpenRouterArchitecture {
     #[serde(default)]
     input_modalities: Vec<String>,
@@ -672,6 +768,30 @@ mod tests {
             route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
             transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
             base_url: "https://cloud-api.near.ai/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
+    fn synthetic_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("synthetic").unwrap(),
+            route_provider: ProviderId::parse("synthetic").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::AnthropicMessages,
+            base_url: "https://api.synthetic.new/anthropic".into(),
             auth: crate::config::ProviderAuthConfig {
                 source: crate::config::CredentialSource::Env,
                 kind: crate::config::CredentialKind::ApiKey,
@@ -860,6 +980,46 @@ mod tests {
     }
 
     #[test]
+    fn maps_only_synthetic_always_on_models_from_published_metadata() {
+        let payload: SyntheticModelsResponse = serde_json::from_str(
+            r#"{"data":[
+                {
+                    "id":"syn:large:vision",
+                    "name":"syn:large:vision",
+                    "always_on":true,
+                    "context_length":262144,
+                    "max_output_length":65536,
+                    "input_modalities":["text","image"],
+                    "supported_features":["tools","structured_outputs","reasoning"]
+                },
+                {
+                    "id":"hf:rotating/model",
+                    "name":"Rotating Model",
+                    "always_on":false,
+                    "context_length":131072,
+                    "max_output_length":8192,
+                    "input_modalities":["text"],
+                    "supported_features":["tools"]
+                }
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("synthetic").unwrap());
+
+        assert_eq!(models.len(), 1);
+        let model = &models[0];
+        assert_eq!(model.model_ref.as_string(), "synthetic/syn:large:vision");
+        assert_eq!(model.context_window_tokens, Some(262_144));
+        assert_eq!(model.default_max_output_tokens, None);
+        assert_eq!(model.max_output_tokens_upper_limit, Some(65_536));
+        assert!(model.capabilities.image_input);
+        assert!(model.capabilities.supports_reasoning);
+        assert!(model.reasoning_effort_options.is_empty());
+        assert_eq!(model.source, ModelMetadataSource::RemoteDiscovered);
+    }
+
+    #[test]
     fn nearai_discovery_is_public_but_inference_remains_unauthenticated() {
         let provider = nearai_provider();
         let cache = ModelDiscoveryCacheFile::default();
@@ -877,6 +1037,27 @@ mod tests {
         assert_eq!(
             provider_models_url(&provider).unwrap(),
             "https://cloud-api.near.ai/v1/models"
+        );
+    }
+
+    #[test]
+    fn synthetic_discovery_is_public_and_uses_the_openai_models_endpoint() {
+        let provider = synthetic_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Missing);
+        assert!(discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://api.synthetic.new/openai/v1/models"
         );
     }
 


### PR DESCRIPTION
## 概要

- 以稳定的 `syn:` alias 和 Synthetic 当前 always-on 模型替换已轮换的静态目录
- 按 `/openai/v1/models` 的结构化 metadata 投影 context/output limits、reasoning 与 vision capability
- 保留 Anthropic messages transport，补充 catalog/discovery 回归测试、来源决策记录并重新生成模型参考页

## 验证

- `cargo test --lib model_discovery::tests`
- `cargo test --lib model_catalog::tests::synthetic_catalog_tracks_current_always_on_models`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

## Livetest

- 已请求公开 `https://api.synthetic.new/openai/v1/models`：返回 11 个 always-on 模型，结构化字段与静态 catalog 一致
- 本地未配置 `SYNTHETIC_API_KEY`，因此未执行鉴权 inference livetest
