### PR TITLE
fix: calibrate Arcee model catalog

### DIFF
--- a/docs/implementation-decisions/087-arcee-model-catalog.md
+++ b/docs/implementation-decisions/087-arcee-model-catalog.md
@@ -1,0 +1,29 @@
+# Arcee model catalog
+
+Holon keeps only `trinity-mini` and `trinity-large-preview` in Arcee's
+built-in picker. Arcee's hosted Models API and Models Overview listed those
+models when the snapshot was verified on 2026-07-13. Both hosted model pages
+publish a 128K context window. `trinity-large-thinking` is not retained because
+the current hosted API does not list it.
+
+The public documentation does not publish hosted output-token limits or
+portable capability metadata for the two listed models, so Holon does not
+infer output limits, reasoning, vision, or parallel tool-call support.
+
+Arcee inference uses the documented OpenAI-compatible
+`https://api.arcee.ai/v1` base URL. Model discovery uses the separate
+`https://api.arcee.ai/api/v1/models` endpoint, requires the configured
+`ARCEE_API_KEY`, and conservatively maps only model identifiers. Known hosted
+models retain their documented 128K context window; newly discovered model
+identifiers remain otherwise unspecified.
+
+Sources:
+
+- Arcee Models API:
+  `https://docs.arcee.ai/api-reference/models`
+- Arcee Models Overview:
+  `https://docs.arcee.ai/get-started/models-overview`
+- Trinity Mini:
+  `https://docs.arcee.ai/models/trinity-mini`
+- Trinity Large Preview:
+  `https://docs.arcee.ai/models/trinity-large-preview`

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **213 models**.
+across **40 endpoints** and **212 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -25,7 +25,7 @@ used in existing `provider/model` refs and config shortcuts.
 | Provider Account | Endpoint | Legacy Provider Ref | Transport | Base URL | Auth Env Variable(s) |
 |------------------|----------|---------------------|-----------|----------|----------------------|
 | `anthropic` | `default` | `anthropic` | Anthropic Messages | `https://api.anthropic.com` | `ANTHROPIC_AUTH_TOKEN` |
-| `arcee` | `default` | `arcee` | OpenAI Chat Completions | `https://api.arcee.ai/api/v1` | `ARCEE_API_KEY` |
+| `arcee` | `default` | `arcee` | OpenAI Chat Completions | `https://api.arcee.ai/v1` | `ARCEE_API_KEY` |
 | `bigmodel` | `default` | `bigmodel` | Anthropic Messages | `https://open.bigmodel.cn/api/anthropic` | `BIGMODEL_API_KEY` |
 | `byteplus` | `default` | `byteplus` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/v3` | `BYTEPLUS_API_KEY` |
 | `byteplus` | `coding` | `byteplus-coding` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/coding/v3` | `BYTEPLUS_CODING_API_KEY or BYTEPLUS_API_KEY` |
@@ -76,9 +76,8 @@ and capabilities.
 | `anthropic` | `claude-haiku-4-5` | `anthropic/claude-haiku-4-5` | 200000 | 64000 | ✅ | ✅ |
 | `anthropic` | `claude-opus-4-8` | `anthropic/claude-opus-4-8` | 1000000 | 128000 | ✅ | ✅ |
 | `anthropic` | `claude-sonnet-5` | `anthropic/claude-sonnet-5` | 1000000 | 128000 | ✅ | ✅ |
-| `arcee` | `trinity-large-preview` | `arcee/trinity-large-preview` | 131072 | 16384 | — | — |
-| `arcee` | `trinity-large-thinking` | `arcee/trinity-large-thinking` | 262144 | 80000 | ✅ | — |
-| `arcee` | `trinity-mini` | `arcee/trinity-mini` | 131072 | 80000 | — | — |
+| `arcee` | `trinity-large-preview` | `arcee/trinity-large-preview` | 131072 | — | — | — |
+| `arcee` | `trinity-mini` | `arcee/trinity-mini` | 131072 | — | — | — |
 | `bigmodel` | `glm-4-flash-250414` | `bigmodel/glm-4-flash-250414` | 131072 | 16384 | — | — |
 | `bigmodel` | `glm-4-flashx-250414` | `bigmodel/glm-4-flashx-250414` | 131072 | 16384 | — | — |
 | `bigmodel` | `glm-4-long` | `bigmodel/glm-4-long` | 1000000 | 4096 | — | — |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -991,7 +991,7 @@ pub(crate) fn populate_built_in_provider_catalog(
     insert_openai_compatible_provider(
         catalog,
         "arcee",
-        "https://api.arcee.ai/api/v1",
+        "https://api.arcee.ai/v1",
         &["ARCEE_API_KEY"],
         settings_env,
     )?;

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -812,6 +812,30 @@ fn chutes_model_without_published_capabilities(
     }
 }
 
+fn arcee_model(model: &str, display_name: &str) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("arcee"), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the Arcee hosted {model} model."
+        ),
+        context_window_tokens: Some(131_072),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags::default(),
+        reasoning_effort_options: Vec::new(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
 fn fireworks_model(
     model: &str,
     display_name: &str,
@@ -1359,33 +1383,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
-        catalog_model(
-            "arcee",
-            "trinity-mini",
-            "Trinity Mini 26B",
-            131_072,
-            80_000,
-            false,
-            false,
-        ),
-        catalog_model(
-            "arcee",
-            "trinity-large-preview",
-            "Trinity Large Preview",
-            131_072,
-            16_384,
-            false,
-            false,
-        ),
-        catalog_model(
-            "arcee",
-            "trinity-large-thinking",
-            "Trinity Large Thinking",
-            262_144,
-            80_000,
-            true,
-            false,
-        ),
+        arcee_model("trinity-mini", "Trinity Mini 26B"),
+        arcee_model("trinity-large-preview", "Trinity Large Preview"),
         catalog_model(
             "chutes",
             "moonshotai/Kimi-K2.6-TEE",
@@ -3156,6 +3155,34 @@ mod tests {
         assert_eq!(policy.compaction_trigger_estimated_tokens, 109_440);
         assert_eq!(policy.compaction_keep_recent_estimated_tokens, 41_587);
         assert_eq!(policy.source, ModelMetadataSource::BuiltInCatalog);
+    }
+
+    #[test]
+    fn arcee_catalog_tracks_current_hosted_models_conservatively() {
+        let catalog = BuiltInModelCatalog::new();
+        let arcee = ProviderId::parse("arcee").unwrap();
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|entry| entry.model_ref.provider == arcee)
+            .collect::<Vec<_>>();
+
+        assert_eq!(models.len(), 2);
+        for model in models {
+            assert!(matches!(
+                model.model_ref.model.as_str(),
+                "trinity-mini" | "trinity-large-preview"
+            ));
+            assert_eq!(model.context_window_tokens, Some(131_072));
+            assert!(model.default_max_output_tokens.is_none());
+            assert!(model.max_output_tokens_upper_limit.is_none());
+            assert_eq!(model.capabilities, ModelCapabilityFlags::default());
+            assert!(model.reasoning_effort_options.is_empty());
+            assert_eq!(model.source, ModelMetadataSource::ConservativeBuiltin);
+        }
+        assert!(catalog
+            .get(&ModelRef::new(arcee, "trinity-large-thinking"))
+            .is_none());
     }
 
     #[test]

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -86,7 +86,7 @@ pub fn discovery_cache_path(home_dir: &Path) -> PathBuf {
 pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bool {
     matches!(
         provider.id.as_str(),
-        "nearai" | "openrouter" | "synthetic" | "vercel-ai-gateway"
+        "arcee" | "nearai" | "openrouter" | "synthetic" | "vercel-ai-gateway"
     )
 }
 
@@ -216,6 +216,9 @@ pub async fn refresh_provider_models(
     })?;
     let response_hash = format!("sha256:{}", sha256_hex(&raw));
     let models = match provider.id.as_str() {
+        "arcee" => serde_json::from_slice::<ArceeModelsResponse>(&raw)
+            .context("failed to parse Arcee model discovery response")?
+            .into_model_metadata(&provider.id),
         "nearai" => serde_json::from_slice::<NearAiModelsResponse>(&raw)
             .context("failed to parse NEAR AI model discovery response")?
             .into_model_metadata(&provider.id),
@@ -255,6 +258,7 @@ pub async fn refresh_provider_models(
 
 fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
     match provider.id.as_str() {
+        "arcee" => Ok("https://api.arcee.ai/api/v1/models".to_string()),
         "nearai" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
         "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
@@ -285,6 +289,63 @@ fn vercel_models_url(base_url: &str) -> Result<String> {
     let path = url.path().trim_end_matches('/');
     url.set_path(&format!("{path}/v1/models"));
     Ok(url.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct ArceeModelsResponse {
+    #[serde(default)]
+    data: Vec<ArceeModel>,
+}
+
+impl ArceeModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ArceeModel {
+    id: String,
+}
+
+impl ArceeModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        let (display_name, context_window_tokens) = match id {
+            "trinity-mini" => ("Trinity Mini 26B", Some(131_072)),
+            "trinity-large-preview" => ("Trinity Large Preview", Some(131_072)),
+            _ => (id, None),
+        };
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name: display_name.to_string(),
+            description: "Remote discovered Arcee hosted model metadata.".to_string(),
+            context_window_tokens,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags::default(),
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -713,6 +774,30 @@ fn sha256_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn arcee_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("arcee").unwrap(),
+            route_provider: ProviderId::parse("arcee").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://api.arcee.ai/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
     fn openrouter_provider() -> ProviderRuntimeConfig {
         ProviderRuntimeConfig {
             id: ProviderId::parse("openrouter").unwrap(),
@@ -807,6 +892,60 @@ mod tests {
             context_management: Default::default(),
             builtin_web_search: None,
         }
+    }
+
+    #[test]
+    fn maps_arcee_models_without_inventing_capabilities_or_output_limits() {
+        let payload: ArceeModelsResponse = serde_json::from_str(
+            r#"{"object":"list","data":[
+                {"id":"trinity-mini","object":"model","owned_by":"arcee-ai"},
+                {"id":"trinity-large-preview","object":"model","owned_by":"arcee-ai"},
+                {"id":"future-model","object":"model","owned_by":"arcee-ai"},
+                {"id":" ","object":"model","owned_by":"arcee-ai"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("arcee").unwrap());
+
+        assert_eq!(models.len(), 3);
+        let mini = models
+            .iter()
+            .find(|model| model.model_ref.model == "trinity-mini")
+            .unwrap();
+        assert_eq!(mini.context_window_tokens, Some(131_072));
+        assert!(mini.default_max_output_tokens.is_none());
+        assert!(mini.max_output_tokens_upper_limit.is_none());
+        assert_eq!(mini.capabilities, ModelCapabilityFlags::default());
+        assert_eq!(mini.source, ModelMetadataSource::RemoteDiscovered);
+
+        let unknown = models
+            .iter()
+            .find(|model| model.model_ref.model == "future-model")
+            .unwrap();
+        assert!(unknown.context_window_tokens.is_none());
+        assert_eq!(unknown.capabilities, ModelCapabilityFlags::default());
+    }
+
+    #[test]
+    fn arcee_discovery_requires_a_credential_and_uses_its_models_api() {
+        let provider = arcee_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Unauthenticated);
+        assert!(!discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://api.arcee.ai/api/v1/models"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- align the Arcee provider endpoint and built-in catalog with current official Arcee model/API documentation
- conservatively expose only the currently documented hosted models and avoid inferred capabilities or output limits
- add authenticated Models API discovery projection, source decision record, generated model reference updates, and focused tests

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib model_discovery::tests`
- `cargo test --lib model_catalog::tests::arcee_catalog_tracks_current_hosted_models_conservatively`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

## Livetest
- `ARCEE_API_KEY` is not available locally, so authenticated Models API/inference livetesting could not be run.
