### PR TITLE
feat: calibrate Hugging Face model catalog

### DIFF
--- a/docs/implementation-decisions/088-huggingface-model-catalog.md
+++ b/docs/implementation-decisions/088-huggingface-model-catalog.md
@@ -1,0 +1,28 @@
+# Hugging Face model catalog
+
+Holon treats the Hugging Face OpenAI-compatible Router as a chat-only
+aggregation endpoint. The built-in picker keeps only
+`openai/gpt-oss-120b`, the current model used throughout the official
+Inference Providers quick start. The previous unversioned
+`moonshotai/Kimi-K2-Instruct` entry is removed because the current official
+examples use other model ids and Router availability is dynamic.
+
+The public `GET https://router.huggingface.co/v1/models` endpoint is the
+authoritative discovery source. Holon keeps models with at least one provider
+whose status is `live`, takes the largest published context length among live
+routes, and projects image input from the model architecture. Provider tool
+support does not establish portable parallel tool-call semantics, and the
+Router response does not publish output limits or a general reasoning field,
+so those values remain unset.
+
+The official gpt-oss guide explicitly documents `low`, `medium`, and `high`
+reasoning effort for the OpenAI-compatible Chat Completions API. Holon exposes
+those controls only for the two gpt-oss model ids. Inference still requires
+`HUGGINGFACE_API_KEY` or `HF_TOKEN`; public model discovery does not.
+
+Sources reviewed on 2026-07-13:
+
+- <https://huggingface.co/docs/inference-providers/index>
+- <https://huggingface.co/docs/inference-providers/hub-api>
+- <https://huggingface.co/docs/inference-providers/guides/gpt-oss>
+- <https://huggingface.co/openai/gpt-oss-120b>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -98,3 +98,5 @@ Current decision notes:
 - [084 Vercel AI Gateway Model Catalog](./084-vercel-ai-gateway-model-catalog.md)
 - [085 NEAR AI Cloud Model Catalog](./085-nearai-model-catalog.md)
 - [086 Synthetic Model Catalog](./086-synthetic-model-catalog.md)
+- [087 Arcee Model Catalog](./087-arcee-model-catalog.md)
+- [088 Hugging Face Model Catalog](./088-huggingface-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -158,7 +158,7 @@ and capabilities.
 | `gemini` | `gemini-3.1-flash-lite` | `gemini/gemini-3.1-flash-lite` | 1048576 | 65536 | ✅ | ✅ |
 | `gemini` | `gemini-3.1-pro-preview` | `gemini/gemini-3.1-pro-preview` | 1048576 | 65536 | ✅ | ✅ |
 | `gemini` | `gemini-3.5-flash` | `gemini/gemini-3.5-flash` | 1048576 | 65536 | ✅ | ✅ |
-| `huggingface` | `moonshotai/Kimi-K2-Instruct` | `huggingface/moonshotai/Kimi-K2-Instruct` | 262144 | 32768 | — | — |
+| `huggingface` | `openai/gpt-oss-120b` | `huggingface/openai/gpt-oss-120b` | 131072 | — | ✅ | — |
 | `kilocode` | `kilo/auto` | `kilocode/kilo/auto` | 1000000 | 128000 | ✅ | ✅ |
 | `litellm` | `claude-opus-4-6` | `litellm/claude-opus-4-6` | 200000 | 128000 | ✅ | ✅ |
 | `minimax` | `MiniMax-M2` | `minimax/MiniMax-M2` | 204800 | 128000 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -735,6 +735,7 @@ fn reasoning_effort_options(
         ("fireworks", "accounts/fireworks/models/glm-5p2") => &["none", "high", "max"][..],
         ("fireworks", "accounts/fireworks/models/gpt-oss-120b")
         | ("fireworks", "accounts/fireworks/models/minimax-m2p7") => &["low", "medium", "high"][..],
+        ("huggingface", "openai/gpt-oss-120b") => &["low", "medium", "high"][..],
         ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
         ("xiaomi" | "xiaomi-token-plan", "mimo-v2.5-pro" | "mimo-v2.5") => &["none", "high"][..],
         ("volcengine", _)
@@ -831,6 +832,33 @@ fn arcee_model(model: &str, display_name: &str) -> BuiltInModelMetadata {
         ),
         capabilities: ModelCapabilityFlags::default(),
         reasoning_effort_options: Vec::new(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
+fn huggingface_gpt_oss_model() -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("huggingface"), "openai/gpt-oss-120b");
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: "OpenAI GPT OSS 120B".into(),
+        description:
+            "Holon conservative built-in metadata for the Hugging Face Inference Providers quick-start chat model."
+                .into(),
+        context_window_tokens: Some(131_072),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            supports_reasoning: true,
+            ..ModelCapabilityFlags::default()
+        },
+        reasoning_effort_options: vec!["low".into(), "medium".into(), "high".into()],
         source: ModelMetadataSource::ConservativeBuiltin,
         endpoint: None,
     }
@@ -1511,15 +1539,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
-        catalog_model(
-            "huggingface",
-            "moonshotai/Kimi-K2-Instruct",
-            "MoonshotAI Kimi K2 Instruct",
-            262_144,
-            32_768,
-            false,
-            false,
-        ),
+        huggingface_gpt_oss_model(),
         catalog_model(
             "kilocode",
             "kilo/auto",
@@ -3948,6 +3968,25 @@ mod tests {
                 "{dynamic_or_removed} should come from discovery or explicit configuration"
             );
         }
+    }
+
+    #[test]
+    fn huggingface_catalog_keeps_the_current_official_quick_start_default() {
+        let catalog = BuiltInModelCatalog::new();
+        let model = catalog
+            .get(&ModelRef::parse("huggingface/openai/gpt-oss-120b").unwrap())
+            .expect("Hugging Face quick-start model should be registered");
+
+        assert_eq!(model.context_window_tokens, Some(131_072));
+        assert!(model.default_max_output_tokens.is_none());
+        assert!(model.max_output_tokens_upper_limit.is_none());
+        assert!(model.capabilities.supports_reasoning);
+        assert!(!model.capabilities.image_input);
+        assert_eq!(model.reasoning_effort_options, ["low", "medium", "high"]);
+        assert_eq!(model.source, ModelMetadataSource::ConservativeBuiltin);
+        assert!(catalog
+            .get(&ModelRef::parse("huggingface/moonshotai/Kimi-K2-Instruct").unwrap())
+            .is_none());
     }
 
     #[test]

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -86,14 +86,14 @@ pub fn discovery_cache_path(home_dir: &Path) -> PathBuf {
 pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bool {
     matches!(
         provider.id.as_str(),
-        "arcee" | "nearai" | "openrouter" | "synthetic" | "vercel-ai-gateway"
+        "arcee" | "huggingface" | "nearai" | "openrouter" | "synthetic" | "vercel-ai-gateway"
     )
 }
 
 fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig) -> bool {
     !matches!(
         provider.id.as_str(),
-        "nearai" | "synthetic" | "vercel-ai-gateway"
+        "huggingface" | "nearai" | "synthetic" | "vercel-ai-gateway"
     )
 }
 
@@ -219,6 +219,9 @@ pub async fn refresh_provider_models(
         "arcee" => serde_json::from_slice::<ArceeModelsResponse>(&raw)
             .context("failed to parse Arcee model discovery response")?
             .into_model_metadata(&provider.id),
+        "huggingface" => serde_json::from_slice::<HuggingFaceModelsResponse>(&raw)
+            .context("failed to parse Hugging Face model discovery response")?
+            .into_model_metadata(&provider.id),
         "nearai" => serde_json::from_slice::<NearAiModelsResponse>(&raw)
             .context("failed to parse NEAR AI model discovery response")?
             .into_model_metadata(&provider.id),
@@ -259,6 +262,7 @@ pub async fn refresh_provider_models(
 fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
     match provider.id.as_str() {
         "arcee" => Ok("https://api.arcee.ai/api/v1/models".to_string()),
+        "huggingface" => openai_compatible_models_url(&provider.base_url),
         "nearai" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
         "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
@@ -342,6 +346,103 @@ impl ArceeModel {
             tool_output_truncation_estimated_tokens: None,
             capabilities: ModelCapabilityFlags::default(),
             reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct HuggingFaceModelsResponse {
+    #[serde(default)]
+    data: Vec<HuggingFaceModel>,
+}
+
+impl HuggingFaceModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct HuggingFaceModel {
+    id: String,
+    #[serde(default)]
+    architecture: Option<HuggingFaceArchitecture>,
+    #[serde(default)]
+    providers: Vec<HuggingFaceProvider>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HuggingFaceArchitecture {
+    #[serde(default)]
+    input_modalities: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HuggingFaceProvider {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    context_length: Option<usize>,
+}
+
+impl HuggingFaceModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let live_providers = self
+            .providers
+            .iter()
+            .filter(|route| route.status.as_deref() == Some("live"))
+            .collect::<Vec<_>>();
+        if live_providers.is_empty() {
+            return None;
+        }
+        let id = self.id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        let image_input = self.architecture.as_ref().is_some_and(|architecture| {
+            architecture
+                .input_modalities
+                .iter()
+                .any(|modality| modality.eq_ignore_ascii_case("image"))
+        });
+        let gpt_oss = matches!(id, "openai/gpt-oss-120b" | "openai/gpt-oss-20b");
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name: id.to_string(),
+            description: "Remote discovered Hugging Face Inference Providers chat model metadata."
+                .to_string(),
+            context_window_tokens: live_providers
+                .into_iter()
+                .filter_map(|route| route.context_length)
+                .max(),
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags {
+                image_input,
+                supports_reasoning: gpt_oss,
+                ..ModelCapabilityFlags::default()
+            },
+            reasoning_effort_options: if gpt_oss {
+                vec!["low".into(), "medium".into(), "high".into()]
+            } else {
+                Vec::new()
+            },
             source: ModelMetadataSource::RemoteDiscovered,
             endpoint: None,
         })
@@ -822,6 +923,30 @@ mod tests {
         }
     }
 
+    fn huggingface_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("huggingface").unwrap(),
+            route_provider: ProviderId::parse("huggingface").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://router.huggingface.co/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
     fn vercel_provider() -> ProviderRuntimeConfig {
         ProviderRuntimeConfig {
             id: ProviderId::parse("vercel-ai-gateway").unwrap(),
@@ -945,6 +1070,80 @@ mod tests {
         assert_eq!(
             provider_models_url(&provider).unwrap(),
             "https://api.arcee.ai/api/v1/models"
+        );
+    }
+
+    #[test]
+    fn maps_only_live_huggingface_routes_conservatively() {
+        let payload: HuggingFaceModelsResponse = serde_json::from_str(
+            r#"{"data":[
+                {
+                    "id":"openai/gpt-oss-120b",
+                    "architecture":{"input_modalities":["text"]},
+                    "providers":[
+                        {"provider":"groq","status":"live","context_length":131072,"supports_tools":true},
+                        {"provider":"example","status":"error","context_length":262144}
+                    ]
+                },
+                {
+                    "id":"Qwen/Qwen-VL",
+                    "architecture":{"input_modalities":["text","image"]},
+                    "providers":[
+                        {"provider":"example","status":"live","context_length":65536}
+                    ]
+                },
+                {
+                    "id":"offline/model",
+                    "providers":[
+                        {"provider":"example","status":"error","context_length":32768}
+                    ]
+                }
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("huggingface").unwrap());
+
+        assert_eq!(models.len(), 2);
+        let gpt_oss = models
+            .iter()
+            .find(|model| model.model_ref.model == "openai/gpt-oss-120b")
+            .unwrap();
+        assert_eq!(gpt_oss.context_window_tokens, Some(131_072));
+        assert!(gpt_oss.capabilities.supports_reasoning);
+        assert!(!gpt_oss.capabilities.parallel_tool_calls);
+        assert_eq!(gpt_oss.reasoning_effort_options, ["low", "medium", "high"]);
+        assert!(gpt_oss.max_output_tokens_upper_limit.is_none());
+
+        let vision = models
+            .iter()
+            .find(|model| model.model_ref.model == "Qwen/Qwen-VL")
+            .unwrap();
+        assert!(vision.capabilities.image_input);
+        assert!(!vision.capabilities.supports_reasoning);
+        assert!(!models
+            .iter()
+            .any(|model| model.model_ref.model == "offline/model"));
+    }
+
+    #[test]
+    fn huggingface_discovery_is_public_but_inference_still_requires_authentication() {
+        let provider = huggingface_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Missing);
+        assert!(discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://router.huggingface.co/v1/models"
         );
     }
 


### PR DESCRIPTION
## Summary
- keep the Hugging Face built-in catalog conservative around the current official Inference Providers quick-start default
- project live router discovery metadata into route availability, limits, and reasoning controls without inventing unsupported capabilities
- document the catalog boundary and regenerate the model reference

## Verification
- `cargo fmt --all -- --check`
- targeted Hugging Face catalog and discovery tests
- `cargo test --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo run --bin holon-docgen -- models > docs/website/reference/models.md`
- `git diff --check`

## Livetest
Not run: no `HF_TOKEN`, `HUGGINGFACE_API_KEY`, or `HUGGING_FACE_HUB_TOKEN` is configured locally.
