### PR TITLE
fix: calibrate Kilocode model catalog

### DIFF
--- a/docs/implementation-decisions/089-kilocode-model-catalog.md
+++ b/docs/implementation-decisions/089-kilocode-model-catalog.md
@@ -1,0 +1,29 @@
+# Kilocode model catalog
+
+Holon treats Kilocode as a dynamic OpenAI-compatible aggregation gateway. The
+built-in catalog keeps the four current virtual routing models:
+`kilo-auto/frontier`, `kilo-auto/balanced`, `kilo-auto/efficient`, and
+`kilo-auto/free`. The previous `kilo/auto` entry is removed because it is not a
+current model id in the official Gateway documentation or public model list.
+
+The public `GET https://api.kilo.ai/api/gateway/models` endpoint is the
+authoritative discovery source. Holon projects model ids, names, descriptions,
+context windows, maximum completion tokens, image input, and reasoning support
+from its structured fields. Tool support does not establish portable parallel
+tool-call semantics. Reasoning effort controls are exposed only when the model
+declares the `reasoning_effort` parameter and its OpenCode metadata publishes
+standard effort-named variants.
+
+The model directory can be refreshed without credentials, while inference
+still requires `KILOCODE_API_KEY`. Static entries are intentionally limited to
+the stable auto virtual models; the upstream provider catalog remains dynamic
+and comes from discovery.
+
+Sources reviewed on 2026-07-13:
+
+- <https://kilo.ai/docs/gateway>
+- <https://kilo.ai/docs/gateway/quickstart>
+- <https://kilo.ai/docs/gateway/models-and-providers>
+- <https://kilo.ai/docs/gateway/api-reference>
+- <https://api.kilo.ai/api/gateway/models>
+

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -100,3 +100,4 @@ Current decision notes:
 - [086 Synthetic Model Catalog](./086-synthetic-model-catalog.md)
 - [087 Arcee Model Catalog](./087-arcee-model-catalog.md)
 - [088 Hugging Face Model Catalog](./088-huggingface-model-catalog.md)
+- [089 Kilocode Model Catalog](./089-kilocode-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **212 models**.
+across **40 endpoints** and **215 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -159,7 +159,10 @@ and capabilities.
 | `gemini` | `gemini-3.1-pro-preview` | `gemini/gemini-3.1-pro-preview` | 1048576 | 65536 | ✅ | ✅ |
 | `gemini` | `gemini-3.5-flash` | `gemini/gemini-3.5-flash` | 1048576 | 65536 | ✅ | ✅ |
 | `huggingface` | `openai/gpt-oss-120b` | `huggingface/openai/gpt-oss-120b` | 131072 | — | ✅ | — |
-| `kilocode` | `kilo/auto` | `kilocode/kilo/auto` | 1000000 | 128000 | ✅ | ✅ |
+| `kilocode` | `kilo-auto/balanced` | `kilocode/kilo-auto/balanced` | 1000000 | — | ✅ | ✅ |
+| `kilocode` | `kilo-auto/efficient` | `kilocode/kilo-auto/efficient` | 1000000 | — | ✅ | ✅ |
+| `kilocode` | `kilo-auto/free` | `kilocode/kilo-auto/free` | 256000 | — | ✅ | — |
+| `kilocode` | `kilo-auto/frontier` | `kilocode/kilo-auto/frontier` | 1000000 | — | ✅ | ✅ |
 | `litellm` | `claude-opus-4-6` | `litellm/claude-opus-4-6` | 200000 | 128000 | ✅ | ✅ |
 | `minimax` | `MiniMax-M2` | `minimax/MiniMax-M2` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M2.1` | `minimax/MiniMax-M2.1` | 204800 | 128000 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -864,6 +864,40 @@ fn huggingface_gpt_oss_model() -> BuiltInModelMetadata {
     }
 }
 
+fn kilocode_auto_model(
+    model: &str,
+    display_name: &str,
+    context_window_tokens: usize,
+    max_output_tokens: u32,
+    image_input: bool,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("kilocode"), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the Kilo Gateway {display_name} virtual model."
+        ),
+        context_window_tokens: Some(context_window_tokens),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: None,
+        max_output_tokens_upper_limit: Some(max_output_tokens),
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            image_input,
+            supports_reasoning: true,
+            ..ModelCapabilityFlags::default()
+        },
+        reasoning_effort_options: Vec::new(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
 fn fireworks_model(
     model: &str,
     display_name: &str,
@@ -1540,14 +1574,33 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
         ),
         huggingface_gpt_oss_model(),
-        catalog_model(
-            "kilocode",
-            "kilo/auto",
-            "Kilo Auto",
+        kilocode_auto_model(
+            "kilo-auto/frontier",
+            "Kilo Auto Frontier",
             1_000_000,
             128_000,
             true,
+        ),
+        kilocode_auto_model(
+            "kilo-auto/balanced",
+            "Kilo Auto Balanced",
+            1_000_000,
+            65_536,
             true,
+        ),
+        kilocode_auto_model(
+            "kilo-auto/efficient",
+            "Kilo Auto Efficient",
+            1_000_000,
+            65_536,
+            true,
+        ),
+        kilocode_auto_model(
+            "kilo-auto/free",
+            "Kilo Auto Free",
+            256_000,
+            10_000,
+            false,
         ),
         catalog_model(
             "litellm",
@@ -3986,6 +4039,34 @@ mod tests {
         assert_eq!(model.source, ModelMetadataSource::ConservativeBuiltin);
         assert!(catalog
             .get(&ModelRef::parse("huggingface/moonshotai/Kimi-K2-Instruct").unwrap())
+            .is_none());
+    }
+
+    #[test]
+    fn kilocode_catalog_tracks_the_current_auto_virtual_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let expected = [
+            ("kilo-auto/frontier", 1_000_000, 128_000, true),
+            ("kilo-auto/balanced", 1_000_000, 65_536, true),
+            ("kilo-auto/efficient", 1_000_000, 65_536, true),
+            ("kilo-auto/free", 256_000, 10_000, false),
+        ];
+
+        for (model, context, output, image_input) in expected {
+            let metadata = catalog
+                .get(&ModelRef::parse(&format!("kilocode/{model}")).unwrap())
+                .unwrap_or_else(|| panic!("{model} should be registered"));
+            assert_eq!(metadata.context_window_tokens, Some(context));
+            assert!(metadata.default_max_output_tokens.is_none());
+            assert_eq!(metadata.max_output_tokens_upper_limit, Some(output));
+            assert_eq!(metadata.capabilities.image_input, image_input);
+            assert!(metadata.capabilities.supports_reasoning);
+            assert!(metadata.reasoning_effort_options.is_empty());
+            assert_eq!(metadata.source, ModelMetadataSource::ConservativeBuiltin);
+        }
+
+        assert!(catalog
+            .get(&ModelRef::parse("kilocode/kilo/auto").unwrap())
             .is_none());
     }
 

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -86,14 +86,20 @@ pub fn discovery_cache_path(home_dir: &Path) -> PathBuf {
 pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bool {
     matches!(
         provider.id.as_str(),
-        "arcee" | "huggingface" | "nearai" | "openrouter" | "synthetic" | "vercel-ai-gateway"
+        "arcee"
+            | "huggingface"
+            | "kilocode"
+            | "nearai"
+            | "openrouter"
+            | "synthetic"
+            | "vercel-ai-gateway"
     )
 }
 
 fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig) -> bool {
     !matches!(
         provider.id.as_str(),
-        "huggingface" | "nearai" | "synthetic" | "vercel-ai-gateway"
+        "huggingface" | "kilocode" | "nearai" | "synthetic" | "vercel-ai-gateway"
     )
 }
 
@@ -222,6 +228,9 @@ pub async fn refresh_provider_models(
         "huggingface" => serde_json::from_slice::<HuggingFaceModelsResponse>(&raw)
             .context("failed to parse Hugging Face model discovery response")?
             .into_model_metadata(&provider.id),
+        "kilocode" => serde_json::from_slice::<KiloModelsResponse>(&raw)
+            .context("failed to parse Kilo Gateway model discovery response")?
+            .into_model_metadata(&provider.id),
         "nearai" => serde_json::from_slice::<NearAiModelsResponse>(&raw)
             .context("failed to parse NEAR AI model discovery response")?
             .into_model_metadata(&provider.id),
@@ -263,6 +272,7 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
     match provider.id.as_str() {
         "arcee" => Ok("https://api.arcee.ai/api/v1/models".to_string()),
         "huggingface" => openai_compatible_models_url(&provider.base_url),
+        "kilocode" => openai_compatible_models_url(&provider.base_url),
         "nearai" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
         "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
@@ -774,6 +784,131 @@ struct OpenRouterTopProvider {
 }
 
 #[derive(Debug, Deserialize)]
+struct KiloModelsResponse {
+    #[serde(default)]
+    data: Vec<KiloModel>,
+}
+
+impl KiloModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct KiloModel {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    context_length: Option<usize>,
+    #[serde(default)]
+    architecture: Option<OpenRouterArchitecture>,
+    #[serde(default)]
+    top_provider: Option<OpenRouterTopProvider>,
+    #[serde(default)]
+    supported_parameters: Vec<String>,
+    #[serde(default)]
+    opencode: Option<KiloOpenCodeMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KiloOpenCodeMetadata {
+    #[serde(default)]
+    variants: BTreeMap<String, serde_json::Value>,
+}
+
+impl KiloModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        let display_name = self
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(id)
+            .to_string();
+        let description = self
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("Remote discovered Kilo Gateway model metadata.")
+            .to_string();
+        let has_parameter = |expected: &str| {
+            self.supported_parameters
+                .iter()
+                .any(|parameter| parameter == expected)
+        };
+        let image_input = self.architecture.as_ref().is_some_and(|architecture| {
+            architecture
+                .input_modalities
+                .iter()
+                .any(|value| value.eq_ignore_ascii_case("image"))
+        });
+        let reasoning_effort_options = if has_parameter("reasoning_effort") {
+            self.opencode
+                .as_ref()
+                .map(|metadata| {
+                    metadata
+                        .variants
+                        .keys()
+                        .filter(|variant| {
+                            matches!(
+                                variant.as_str(),
+                                "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
+                            )
+                        })
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name,
+            description,
+            context_window_tokens: self.context_length,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: self
+                .top_provider
+                .and_then(|provider| provider.max_completion_tokens),
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags {
+                image_input,
+                supports_reasoning: has_parameter("reasoning")
+                    || has_parameter("reasoning_effort")
+                    || has_parameter("include_reasoning"),
+                ..ModelCapabilityFlags::default()
+            },
+            reasoning_effort_options,
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
 struct VercelModelsResponse {
     #[serde(default)]
     data: Vec<VercelModel>,
@@ -957,6 +1092,30 @@ mod tests {
             auth: crate::config::ProviderAuthConfig {
                 source: crate::config::CredentialSource::Env,
                 kind: crate::config::CredentialKind::BearerToken,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
+    fn kilocode_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("kilocode").unwrap(),
+            route_provider: ProviderId::parse("kilocode").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://api.kilo.ai/api/gateway".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
                 env: None,
                 profile: None,
                 external: None,
@@ -1273,6 +1432,59 @@ mod tests {
     }
 
     #[test]
+    fn maps_kilocode_models_from_published_gateway_metadata() {
+        let payload: KiloModelsResponse = serde_json::from_str(
+            r#"{"data":[
+                {
+                    "id":"kilo-auto/balanced",
+                    "name":"Auto Balanced",
+                    "description":"test",
+                    "context_length":1000000,
+                    "architecture":{"input_modalities":["text","image"]},
+                    "top_provider":{"max_completion_tokens":65536},
+                    "supported_parameters":["reasoning","include_reasoning"]
+                },
+                {
+                    "id":"example/reasoning-model",
+                    "context_length":262144,
+                    "architecture":{"input_modalities":["text"]},
+                    "top_provider":{"max_completion_tokens":32768},
+                    "supported_parameters":["reasoning","reasoning_effort"],
+                    "opencode":{"variants":{
+                        "none":{"reasoning":{"enabled":false}},
+                        "low":{"reasoning":{"effort":"low"}},
+                        "high":{"reasoning":{"effort":"high"}},
+                        "thinking":{"reasoning":{"enabled":true}}
+                    }}
+                },
+                {"id":" "}
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("kilocode").unwrap());
+
+        assert_eq!(models.len(), 2);
+        let balanced = models
+            .iter()
+            .find(|model| model.model_ref.model == "kilo-auto/balanced")
+            .unwrap();
+        assert_eq!(balanced.context_window_tokens, Some(1_000_000));
+        assert_eq!(balanced.max_output_tokens_upper_limit, Some(65_536));
+        assert!(balanced.capabilities.image_input);
+        assert!(balanced.capabilities.supports_reasoning);
+        assert!(balanced.reasoning_effort_options.is_empty());
+
+        let reasoning = models
+            .iter()
+            .find(|model| model.model_ref.model == "example/reasoning-model")
+            .unwrap();
+        assert_eq!(reasoning.reasoning_effort_options, ["high", "low", "none"]);
+        assert!(!reasoning.capabilities.image_input);
+        assert_eq!(reasoning.source, ModelMetadataSource::RemoteDiscovered);
+    }
+
+    #[test]
     fn maps_only_ready_nearai_models_from_published_metadata() {
         let payload: NearAiModelsResponse = serde_json::from_str(
             r#"{"data":[
@@ -1417,6 +1629,27 @@ mod tests {
         assert_eq!(
             vercel_models_url(&provider.base_url).unwrap(),
             "https://ai-gateway.vercel.sh/v1/models"
+        );
+    }
+
+    #[test]
+    fn kilocode_discovery_is_public_but_inference_still_requires_authentication() {
+        let provider = kilocode_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Missing);
+        assert!(discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://api.kilo.ai/api/gateway/models"
         );
     }
 


### PR DESCRIPTION
## Summary

- replace the stale Kilocode static model list with the four currently documented `kilo-auto/*` virtual routes
- map Kilocode gateway discovery metadata into intrinsic capabilities, limits, and reasoning controls while keeping discovery public and inference authenticated
- record official-source evidence, add focused catalog/discovery tests, and regenerate the model reference

## Verification

- `cargo fmt --all -- --check`
- focused Kilocode model catalog and discovery tests
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

No local `KILOCODE_API_KEY` (or compatible alias) was available, so a live inference test was not run.