### PR TITLE
fix: calibrate OpenCode Go model catalog

### DIFF
--- a/docs/implementation-decisions/090-opencode-go-model-catalog.md
+++ b/docs/implementation-decisions/090-opencode-go-model-catalog.md
@@ -1,0 +1,23 @@
+# OpenCode Go model catalog
+
+Holon models OpenCode Go as one canonical provider with two transport
+endpoints. The default endpoint uses OpenAI Chat Completions, while the
+`messages` endpoint uses Anthropic Messages. Models remain addressable as
+`opencode-go/<model>` and the catalog selects the transport published in the
+official OpenCode Go endpoint table.
+
+The public `GET https://opencode.ai/zen/go/v1/models` response contains only
+model identifiers and currently includes entries that are not present in the
+endpoint table. Discovery therefore acts as a conservative intersection: it
+keeps only endpoint-table models and assigns each accepted identifier to its
+published transport. It does not infer capabilities or limits from names.
+
+Static limits and intrinsic capabilities are reused only where the same model
+has already been calibrated from an official upstream source. Missing output
+limits remain unset. Reasoning support does not imply configurable effort
+levels because OpenCode Go does not publish portable reasoning controls.
+
+Sources reviewed on 2026-07-13:
+
+- <https://opencode.ai/docs/go/>
+- <https://opencode.ai/zen/go/v1/models>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -101,3 +101,4 @@ Current decision notes:
 - [087 Arcee Model Catalog](./087-arcee-model-catalog.md)
 - [088 Hugging Face Model Catalog](./088-huggingface-model-catalog.md)
 - [089 Kilocode Model Catalog](./089-kilocode-model-catalog.md)
+- [090 OpenCode Go Model Catalog](./090-opencode-go-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **40 endpoints** and **215 models**.
+across **41 endpoints** and **227 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -47,6 +47,7 @@ used in existing `provider/model` refs and config shortcuts.
 | `openai` | `default` | `openai` | OpenAI Responses | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
 | `openai-codex` | `default` | `openai-codex` | OpenAI Codex | `https://chatgpt.com/backend-api/codex` | `—` |
 | `opencode-go` | `default` | `opencode-go` | OpenAI Chat Completions | `https://opencode.ai/zen/go/v1` | `OPENCODE_GO_API_KEY` |
+| `opencode-go` | `messages` | `opencode-go-messages` | Anthropic Messages | `https://opencode.ai/zen/go/v1` | `OPENCODE_GO_API_KEY` |
 | `openrouter` | `default` | `openrouter` | OpenAI Chat Completions | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
 | `qianfan` | `default` | `qianfan` | OpenAI Chat Completions | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
 | `stepfun` | `default` | `stepfun` | OpenAI Chat Completions | `https://api.stepfun.com/v1` | `STEPFUN_API_KEY` |
@@ -213,6 +214,18 @@ and capabilities.
 | `openai-codex` | `gpt-5.6-terra` | `openai-codex/gpt-5.6-terra` | 372000 | — | ✅ | ✅ |
 | `opencode-go` | `deepseek-v4-flash` | `opencode-go/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `opencode-go` | `deepseek-v4-pro` | `opencode-go/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `opencode-go` | `glm-5.1` | `opencode-go/glm-5.1` | 202800 | 131072 | ✅ | — |
+| `opencode-go` | `glm-5.2` | `opencode-go/glm-5.2` | 1000000 | 131072 | ✅ | — |
+| `opencode-go` | `kimi-k2.6` | `opencode-go/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
+| `opencode-go` | `kimi-k2.7-code` | `opencode-go/kimi-k2.7-code` | 262144 | 262144 | ✅ | ✅ |
+| `opencode-go` | `mimo-v2.5` | `opencode-go/mimo-v2.5` | 1048576 | 131072 | ✅ | ✅ |
+| `opencode-go` | `mimo-v2.5-pro` | `opencode-go/mimo-v2.5-pro` | 1048576 | 131072 | ✅ | — |
+| `opencode-go` | `minimax-m2.5` | `opencode-go/minimax-m2.5` | 196608 | 32768 | ✅ | — |
+| `opencode-go` | `minimax-m2.7` | `opencode-go/minimax-m2.7` | 204800 | — | ✅ | — |
+| `opencode-go` | `minimax-m3` | `opencode-go/minimax-m3` | 1000000 | — | ✅ | ✅ |
+| `opencode-go` | `qwen3.6-plus` | `opencode-go/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `opencode-go` | `qwen3.7-max` | `opencode-go/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
+| `opencode-go` | `qwen3.7-plus` | `opencode-go/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `openrouter` | `auto` | `openrouter/auto` | 2000000 | — | ✅ | ✅ |
 | `qianfan` | `deepseek-v3.2` | `qianfan/deepseek-v3.2` | 131072 | 32768 | — | — |
 | `qianfan` | `deepseek-v3.2-think` | `qianfan/deepseek-v3.2-think` | 163840 | 65536 | ✅ | — |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -842,6 +842,7 @@ pub(crate) fn built_in_provider_endpoint_identity(
         "byteplus-coding" => ("byteplus", "coding"),
         "dashscope-token-plan" => ("dashscope", "token-plan"),
         "dashscope-coding-plan" => ("dashscope", "coding-plan"),
+        "opencode-go-messages" => ("opencode-go", "messages"),
         "stepfun-plan" => ("stepfun", "plan"),
         "volcengine-coding" => ("volcengine", "coding"),
         "volcengine-agent" => ("volcengine", "plan"),
@@ -1103,6 +1104,13 @@ pub(crate) fn populate_built_in_provider_catalog(
     insert_openai_compatible_provider(
         catalog,
         "opencode-go",
+        "https://opencode.ai/zen/go/v1",
+        &["OPENCODE_GO_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        catalog,
+        "opencode-go-messages",
         "https://opencode.ai/zen/go/v1",
         &["OPENCODE_GO_API_KEY"],
         settings_env,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -296,6 +296,42 @@ fn built_in_openai_codex_defaults_to_holon_oauth_profile() {
 }
 
 #[test]
+fn opencode_go_registers_chat_and_messages_endpoints() {
+    let entries = built_in_provider_doc_entries().unwrap();
+    let mut endpoints = entries
+        .into_iter()
+        .filter(|entry| entry.provider.as_str() == "opencode-go")
+        .map(|entry| {
+            (
+                entry.endpoint.as_str().to_string(),
+                entry.legacy_provider.as_str().to_string(),
+                entry.transport,
+                entry.base_url,
+            )
+        })
+        .collect::<Vec<_>>();
+    endpoints.sort_by(|left, right| left.0.cmp(&right.0));
+
+    assert_eq!(
+        endpoints,
+        [
+            (
+                "default".to_string(),
+                "opencode-go".to_string(),
+                ProviderTransportKind::OpenAiChatCompletions,
+                "https://opencode.ai/zen/go/v1".to_string(),
+            ),
+            (
+                "messages".to_string(),
+                "opencode-go-messages".to_string(),
+                ProviderTransportKind::AnthropicMessages,
+                "https://opencode.ai/zen/go/v1".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
 fn app_config_load_materializes_openai_codex_profile_from_existing_store() {
     let dir = tempdir().unwrap();
     let _agent_guard = EnvVarGuard::unset("HOLON_AGENT_ID");
@@ -2713,6 +2749,48 @@ fn runtime_model_catalog_materializes_legacy_provider_as_default_route_endpoint(
     assert_eq!(
         route.endpoint.runtime_config.transport,
         ProviderTransportKind::OpenAiResponses
+    );
+}
+
+#[test]
+fn runtime_model_catalog_routes_opencode_go_models_by_published_transport() {
+    let mut fixture = test_app_config("opencode-go/minimax-m3", &[]);
+    let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+    for legacy_provider in ["opencode-go", "opencode-go-messages"] {
+        let provider = ProviderId::parse(legacy_provider).unwrap();
+        fixture
+            .config
+            .providers
+            .insert(provider.clone(), built_ins.get(&provider).unwrap().clone());
+    }
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let messages = catalog
+        .resolve_model_route(
+            &ContextConfig::default(),
+            &ModelRef::parse("opencode-go/minimax-m3").unwrap(),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+    assert_eq!(messages.endpoint.provider.as_str(), "opencode-go");
+    assert_eq!(messages.endpoint.endpoint.as_str(), "messages");
+    assert_eq!(
+        messages.endpoint.runtime_config.transport,
+        ProviderTransportKind::AnthropicMessages
+    );
+
+    let chat = catalog
+        .resolve_model_route(
+            &ContextConfig::default(),
+            &ModelRef::parse("opencode-go/kimi-k2.7-code").unwrap(),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+    assert_eq!(chat.endpoint.provider.as_str(), "opencode-go");
+    assert_eq!(chat.endpoint.endpoint.as_str(), "default");
+    assert_eq!(
+        chat.endpoint.runtime_config.transport,
+        ProviderTransportKind::OpenAiChatCompletions
     );
 }
 

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -786,6 +786,44 @@ fn catalog_model(
     }
 }
 
+fn opencode_go_model(
+    model: &str,
+    display_name: &str,
+    context_window_tokens: usize,
+    max_output_tokens: Option<u32>,
+    supports_reasoning: bool,
+    image_input: bool,
+    endpoint: Option<&str>,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("opencode-go"), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the OpenCode Go {model} route."
+        ),
+        context_window_tokens: Some(context_window_tokens),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: max_output_tokens,
+        max_output_tokens_upper_limit: max_output_tokens,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            image_input,
+            supports_reasoning,
+            ..ModelCapabilityFlags::default()
+        },
+        reasoning_effort_options: Vec::new(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: endpoint.map(|endpoint| {
+            ProviderEndpointId::parse(endpoint).expect("valid OpenCode Go endpoint id")
+        }),
+    }
+}
+
 fn chutes_model_without_published_capabilities(
     model: &str,
     context_window_tokens: usize,
@@ -1892,23 +1930,131 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
         ),
         nvidia_model("z-ai/glm-5.2", "GLM-5.2", 1_000_000, true, false),
-        catalog_model(
-            "opencode-go",
+        opencode_go_model(
             "deepseek-v4-pro",
             "DeepSeek V4 Pro",
             1_000_000,
-            384_000,
+            Some(384_000),
             true,
             false,
+            None,
         ),
-        catalog_model(
-            "opencode-go",
+        opencode_go_model(
             "deepseek-v4-flash",
             "DeepSeek V4 Flash",
             1_000_000,
-            384_000,
+            Some(384_000),
             true,
             false,
+            None,
+        ),
+        opencode_go_model(
+            "glm-5.2",
+            "GLM-5.2",
+            1_000_000,
+            Some(131_072),
+            true,
+            false,
+            None,
+        ),
+        opencode_go_model(
+            "glm-5.1",
+            "GLM-5.1",
+            202_800,
+            Some(131_072),
+            true,
+            false,
+            None,
+        ),
+        opencode_go_model(
+            "kimi-k2.7-code",
+            "Kimi K2.7 Code",
+            262_144,
+            Some(262_144),
+            true,
+            true,
+            None,
+        ),
+        opencode_go_model(
+            "kimi-k2.6",
+            "Kimi K2.6",
+            262_144,
+            Some(262_144),
+            true,
+            true,
+            None,
+        ),
+        opencode_go_model(
+            "mimo-v2.5-pro",
+            "MiMo V2.5 Pro",
+            1_048_576,
+            Some(131_072),
+            true,
+            false,
+            None,
+        ),
+        opencode_go_model(
+            "mimo-v2.5",
+            "MiMo V2.5",
+            1_048_576,
+            Some(131_072),
+            true,
+            true,
+            None,
+        ),
+        opencode_go_model(
+            "minimax-m3",
+            "MiniMax M3",
+            1_000_000,
+            None,
+            true,
+            true,
+            Some("messages"),
+        ),
+        opencode_go_model(
+            "minimax-m2.7",
+            "MiniMax M2.7",
+            204_800,
+            None,
+            true,
+            false,
+            Some("messages"),
+        ),
+        opencode_go_model(
+            "minimax-m2.5",
+            "MiniMax M2.5",
+            196_608,
+            Some(32_768),
+            true,
+            false,
+            Some("messages"),
+        ),
+        opencode_go_model(
+            "qwen3.7-max",
+            "Qwen3.7 Max",
+            1_000_000,
+            Some(65_536),
+            true,
+            false,
+            Some("messages"),
+        ),
+        opencode_go_model(
+            "qwen3.7-plus",
+            "Qwen3.7 Plus",
+            1_000_000,
+            Some(65_536),
+            true,
+            true,
+            Some("messages"),
+        ),
+        opencode_go_model(
+            "qwen3.6-plus",
+            "Qwen3.6 Plus",
+            1_000_000,
+            Some(65_536),
+            true,
+            true,
+            Some("messages"),
         ),
         BuiltInModelMetadata {
             model_ref: ModelRef::new(provider_id("openrouter"), "auto"),
@@ -4784,6 +4930,62 @@ mod tests {
                     .canonicalize_model_ref(&ModelRef::parse(legacy_model).unwrap())
                     .as_string(),
                 replacement
+            );
+        }
+    }
+
+    #[test]
+    fn opencode_go_catalog_tracks_the_current_dual_transport_model_table() {
+        let catalog = BuiltInModelCatalog::new();
+        let provider = provider_id("opencode-go");
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|model| model.model_ref.provider == provider)
+            .collect::<Vec<_>>();
+
+        assert_eq!(models.len(), 14);
+        for model in &models {
+            assert!(model.capabilities.supports_reasoning);
+            assert!(model.reasoning_effort_options.is_empty());
+            assert_eq!(model.source, ModelMetadataSource::ConservativeBuiltin);
+        }
+
+        for model in [
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+            "glm-5.2",
+            "glm-5.1",
+            "kimi-k2.7-code",
+            "kimi-k2.6",
+            "mimo-v2.5-pro",
+            "mimo-v2.5",
+        ] {
+            assert_eq!(
+                catalog
+                    .preferred_route_for_model(&ModelRef::new(provider.clone(), model))
+                    .unwrap()
+                    .endpoint,
+                ProviderEndpointId::default_endpoint(),
+                "{model}"
+            );
+        }
+        for model in [
+            "minimax-m3",
+            "minimax-m2.7",
+            "minimax-m2.5",
+            "qwen3.7-max",
+            "qwen3.7-plus",
+            "qwen3.6-plus",
+        ] {
+            assert_eq!(
+                catalog
+                    .preferred_route_for_model(&ModelRef::new(provider.clone(), model))
+                    .unwrap()
+                    .endpoint
+                    .as_str(),
+                "messages",
+                "{model}"
             );
         }
     }

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::{ModelRef, ProviderId, ProviderRuntimeConfig},
+    config::{ModelRef, ProviderEndpointId, ProviderId, ProviderRuntimeConfig},
     model_catalog::{BuiltInModelMetadata, ModelCapabilityFlags, ModelMetadataSource},
 };
 
@@ -90,6 +90,7 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
             | "huggingface"
             | "kilocode"
             | "nearai"
+            | "opencode-go"
             | "openrouter"
             | "synthetic"
             | "vercel-ai-gateway"
@@ -99,7 +100,7 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
 fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig) -> bool {
     !matches!(
         provider.id.as_str(),
-        "huggingface" | "kilocode" | "nearai" | "synthetic" | "vercel-ai-gateway"
+        "huggingface" | "kilocode" | "nearai" | "opencode-go" | "synthetic" | "vercel-ai-gateway"
     )
 }
 
@@ -234,6 +235,9 @@ pub async fn refresh_provider_models(
         "nearai" => serde_json::from_slice::<NearAiModelsResponse>(&raw)
             .context("failed to parse NEAR AI model discovery response")?
             .into_model_metadata(&provider.id),
+        "opencode-go" => serde_json::from_slice::<OpenCodeGoModelsResponse>(&raw)
+            .context("failed to parse OpenCode Go model discovery response")?
+            .into_model_metadata(&provider.id),
         "openrouter" => serde_json::from_slice::<OpenRouterModelsResponse>(&raw)
             .context("failed to parse OpenRouter model discovery response")?
             .into_model_metadata(&provider.id),
@@ -274,6 +278,7 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
         "huggingface" => openai_compatible_models_url(&provider.base_url),
         "kilocode" => openai_compatible_models_url(&provider.base_url),
         "nearai" => openai_compatible_models_url(&provider.base_url),
+        "opencode-go" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
         "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
         "vercel-ai-gateway" => vercel_models_url(&provider.base_url),
@@ -303,6 +308,62 @@ fn vercel_models_url(base_url: &str) -> Result<String> {
     let path = url.path().trim_end_matches('/');
     url.set_path(&format!("{path}/v1/models"));
     Ok(url.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeGoModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenCodeGoModel>,
+}
+
+impl OpenCodeGoModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| left.model_ref.model.cmp(&right.model_ref.model));
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeGoModel {
+    id: String,
+}
+
+impl OpenCodeGoModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        let endpoint = match id {
+            "deepseek-v4-pro" | "deepseek-v4-flash" | "glm-5.2" | "glm-5.1" | "kimi-k2.7-code"
+            | "kimi-k2.6" | "mimo-v2.5-pro" | "mimo-v2.5" => None,
+            "minimax-m3" | "minimax-m2.7" | "minimax-m2.5" | "qwen3.7-max" | "qwen3.7-plus"
+            | "qwen3.6-plus" => {
+                Some(ProviderEndpointId::parse("messages").expect("valid OpenCode Go endpoint id"))
+            }
+            _ => return None,
+        };
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name: id.to_string(),
+            description:
+                "Remote discovered OpenCode Go route confirmed by the official endpoint table."
+                    .to_string(),
+            context_window_tokens: None,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags::default(),
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1130,6 +1191,30 @@ mod tests {
         }
     }
 
+    fn opencode_go_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("opencode-go").unwrap(),
+            route_provider: ProviderId::parse("opencode-go").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://opencode.ai/zen/go/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
     fn nearai_provider() -> ProviderRuntimeConfig {
         ProviderRuntimeConfig {
             id: ProviderId::parse("nearai").unwrap(),
@@ -1485,6 +1570,53 @@ mod tests {
     }
 
     #[test]
+    fn maps_opencode_go_models_to_the_published_transport_endpoints() {
+        let payload: OpenCodeGoModelsResponse = serde_json::from_str(
+            r#"{"data":[
+                {"id":"minimax-m3"},
+                {"id":"kimi-k2.7-code"},
+                {"id":"qwen3.7-plus"},
+                {"id":"glm-5"},
+                {"id":"kimi-k2.5"},
+                {"id":" "}
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("opencode-go").unwrap());
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.model_ref.model.as_str())
+                .collect::<Vec<_>>(),
+            ["kimi-k2.7-code", "minimax-m3", "qwen3.7-plus"]
+        );
+        assert_eq!(
+            models
+                .iter()
+                .find(|model| model.model_ref.model == "kimi-k2.7-code")
+                .unwrap()
+                .endpoint,
+            None
+        );
+        for model in ["minimax-m3", "qwen3.7-plus"] {
+            assert_eq!(
+                models
+                    .iter()
+                    .find(|metadata| metadata.model_ref.model == model)
+                    .unwrap()
+                    .endpoint
+                    .as_ref()
+                    .map(ProviderEndpointId::as_str),
+                Some("messages")
+            );
+        }
+        assert!(models
+            .iter()
+            .all(|model| model.source == ModelMetadataSource::RemoteDiscovered));
+    }
+
+    #[test]
     fn maps_only_ready_nearai_models_from_published_metadata() {
         let payload: NearAiModelsResponse = serde_json::from_str(
             r#"{"data":[
@@ -1650,6 +1782,27 @@ mod tests {
         assert_eq!(
             provider_models_url(&provider).unwrap(),
             "https://api.kilo.ai/api/gateway/models"
+        );
+    }
+
+    #[test]
+    fn opencode_go_discovery_is_public_and_uses_the_openai_models_endpoint() {
+        let provider = opencode_go_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Missing);
+        assert!(discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://opencode.ai/zen/go/v1/models"
         );
     }
 


### PR DESCRIPTION
## Summary
- register OpenCode Go Chat Completions and Anthropic Messages transports
- calibrate the static model catalog and conservative dynamic discovery mapping against the published model/endpoint data
- document source differences and regenerate the model reference

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib opencode_go`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

## Livetest
- Not run: `OPENCODE_GO_API_KEY` is not configured locally.
