### PR TITLE
feat: calibrate Tencent TokenHub model catalog

### DIFF
--- a/docs/implementation-decisions/091-tencent-tokenhub-model-catalog.md
+++ b/docs/implementation-decisions/091-tencent-tokenhub-model-catalog.md
@@ -1,0 +1,33 @@
+# Tencent TokenHub model catalog
+
+Holon models Tencent TokenHub as one canonical provider with two compatible
+transport endpoints. The default endpoint uses OpenAI Chat Completions at
+`https://tokenhub.tencentmaas.com/v1`, while the `messages` endpoint uses
+Anthropic Messages at `https://tokenhub.tencentmaas.com`. Models remain
+addressable as `tencent-tokenhub/<model>` and have routes through both
+endpoints.
+
+The static catalog follows the current official TokenHub model table and keeps
+only language, reasoning, coding, role-play, translation, and image
+understanding models usable through Holon's existing turn transports. Image,
+video, and 3D generation models, embedding models, and retired language models
+are excluded because their task contracts are either unsupported by those
+transports or no longer current.
+
+Published context and output limits are recorded when the official table states
+them. Unknown limits remain unset. Reasoning support is intrinsic model
+metadata, but TokenHub does not publish one portable reasoning-effort control
+shared by both transports, so Holon does not invent effort levels.
+
+Authenticated `GET /v1/models` discovery returns model identifiers without
+portable capability or limit metadata. Discovery therefore acts as a
+conservative intersection with the reviewed static table and does not infer
+capabilities from names. Static metadata remains responsible for intrinsic
+capabilities and limits.
+
+Sources reviewed on 2026-07-13:
+
+- <https://cloud.tencent.com/document/product/1823/130051>
+- <https://cloud.tencent.com/document/product/1823/132252>
+- <https://cloud.tencent.com/document/product/1823/130078>
+- <https://tokenhub.tencentmaas.com/v1/models>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -102,3 +102,4 @@ Current decision notes:
 - [088 Hugging Face Model Catalog](./088-huggingface-model-catalog.md)
 - [089 Kilocode Model Catalog](./089-kilocode-model-catalog.md)
 - [090 OpenCode Go Model Catalog](./090-opencode-go-model-catalog.md)
+- [091 Tencent TokenHub Model Catalog](./091-tencent-tokenhub-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **41 endpoints** and **227 models**.
+across **42 endpoints** and **253 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -54,6 +54,7 @@ used in existing `provider/model` refs and config shortcuts.
 | `stepfun` | `plan` | `stepfun-plan` | OpenAI Chat Completions | `https://api.stepfun.com/step_plan/v1` | `STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY` |
 | `synthetic` | `default` | `synthetic` | Anthropic Messages | `https://api.synthetic.new/anthropic` | `SYNTHETIC_API_KEY` |
 | `tencent-tokenhub` | `default` | `tencent-tokenhub` | OpenAI Chat Completions | `https://tokenhub.tencentmaas.com/v1` | `TOKENHUB_API_KEY` |
+| `tencent-tokenhub` | `messages` | `tencent-tokenhub-messages` | Anthropic Messages | `https://tokenhub.tencentmaas.com` | `TOKENHUB_API_KEY` |
 | `together` | `default` | `together` | OpenAI Chat Completions | `https://api.together.xyz/v1` | `TOGETHER_API_KEY` |
 | `venice` | `default` | `venice` | OpenAI Chat Completions | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
 | `vercel-ai-gateway` | `default` | `vercel-ai-gateway` | Anthropic Messages | `https://ai-gateway.vercel.sh` | `VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY or VERCEL_AI_GATEWAY_API_KEY` |
@@ -247,7 +248,33 @@ and capabilities.
 | `synthetic` | `syn:large:vision` | `synthetic/syn:large:vision` | 262144 | 65536 | ✅ | ✅ |
 | `synthetic` | `syn:small:text` | `synthetic/syn:small:text` | 196608 | 65536 | ✅ | — |
 | `synthetic` | `syn:small:vision` | `synthetic/syn:small:vision` | 262144 | 65536 | ✅ | ✅ |
-| `tencent-tokenhub` | `hy3-preview` | `tencent-tokenhub/hy3-preview` | 256000 | 64000 | ✅ | — |
+| `tencent-tokenhub` | `deepseek-v3.2` | `tencent-tokenhub/deepseek-v3.2` | 128000 | 32768 | ✅ | — |
+| `tencent-tokenhub` | `deepseek-v4-flash` | `tencent-tokenhub/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
+| `tencent-tokenhub` | `deepseek-v4-pro` | `tencent-tokenhub/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `tencent-tokenhub` | `glm-5` | `tencent-tokenhub/glm-5` | 202800 | 131072 | ✅ | — |
+| `tencent-tokenhub` | `glm-5-turbo` | `tencent-tokenhub/glm-5-turbo` | 202800 | 131072 | ✅ | — |
+| `tencent-tokenhub` | `glm-5.1` | `tencent-tokenhub/glm-5.1` | 202800 | 131072 | ✅ | — |
+| `tencent-tokenhub` | `glm-5.2` | `tencent-tokenhub/glm-5.2` | 1000000 | 131072 | ✅ | — |
+| `tencent-tokenhub` | `glm-5v-turbo` | `tencent-tokenhub/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |
+| `tencent-tokenhub` | `hunyuan-role-latest` | `tencent-tokenhub/hunyuan-role-latest` | — | — | — | — |
+| `tencent-tokenhub` | `hunyuan-t1-vision-20250916` | `tencent-tokenhub/hunyuan-t1-vision-20250916` | — | — | ✅ | ✅ |
+| `tencent-tokenhub` | `hy-mt2-lite` | `tencent-tokenhub/hy-mt2-lite` | — | — | — | — |
+| `tencent-tokenhub` | `hy-mt2-plus` | `tencent-tokenhub/hy-mt2-plus` | — | — | — | — |
+| `tencent-tokenhub` | `hy-mt2-pro` | `tencent-tokenhub/hy-mt2-pro` | — | — | — | — |
+| `tencent-tokenhub` | `hy-role` | `tencent-tokenhub/hy-role` | — | — | — | — |
+| `tencent-tokenhub` | `hy-vision-2.0-instruct` | `tencent-tokenhub/hy-vision-2.0-instruct` | — | — | — | ✅ |
+| `tencent-tokenhub` | `hy3` | `tencent-tokenhub/hy3` | 256000 | 128000 | ✅ | — |
+| `tencent-tokenhub` | `hy3-preview` | `tencent-tokenhub/hy3-preview` | 256000 | 128000 | ✅ | — |
+| `tencent-tokenhub` | `kimi-k2.5` | `tencent-tokenhub/kimi-k2.5` | 262144 | 262144 | ✅ | ✅ |
+| `tencent-tokenhub` | `kimi-k2.6` | `tencent-tokenhub/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
+| `tencent-tokenhub` | `kimi-k2.7-code` | `tencent-tokenhub/kimi-k2.7-code` | 262144 | 262144 | ✅ | ✅ |
+| `tencent-tokenhub` | `kimi-k2.7-code-highspeed` | `tencent-tokenhub/kimi-k2.7-code-highspeed` | 262144 | 262144 | ✅ | ✅ |
+| `tencent-tokenhub` | `minimax-m2.5` | `tencent-tokenhub/minimax-m2.5` | 196608 | 32768 | ✅ | — |
+| `tencent-tokenhub` | `minimax-m2.7` | `tencent-tokenhub/minimax-m2.7` | 204800 | — | ✅ | — |
+| `tencent-tokenhub` | `minimax-m3` | `tencent-tokenhub/minimax-m3` | 1000000 | — | ✅ | ✅ |
+| `tencent-tokenhub` | `qwen3.5-flash` | `tencent-tokenhub/qwen3.5-flash` | 1000000 | 65536 | ✅ | ✅ |
+| `tencent-tokenhub` | `qwen3.5-plus` | `tencent-tokenhub/qwen3.5-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `tencent-tokenhub` | `youtu-vita` | `tencent-tokenhub/youtu-vita` | — | — | — | ✅ |
 | `together` | `MiniMaxAI/MiniMax-M2.7` | `together/MiniMaxAI/MiniMax-M2.7` | 202752 | — | ✅ | — |
 | `together` | `MiniMaxAI/MiniMax-M3` | `together/MiniMaxAI/MiniMax-M3` | 524288 | — | — | ✅ |
 | `together` | `Qwen/Qwen3.5-9B` | `together/Qwen/Qwen3.5-9B` | 262144 | — | ✅ | ✅ |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -844,6 +844,7 @@ pub(crate) fn built_in_provider_endpoint_identity(
         "dashscope-coding-plan" => ("dashscope", "coding-plan"),
         "opencode-go-messages" => ("opencode-go", "messages"),
         "stepfun-plan" => ("stepfun", "plan"),
+        "tencent-tokenhub-messages" => ("tencent-tokenhub", "messages"),
         "volcengine-coding" => ("volcengine", "coding"),
         "volcengine-agent" => ("volcengine", "plan"),
         "volcengine-image-openai" => ("volcengine", "plan"),
@@ -1154,6 +1155,13 @@ pub(crate) fn populate_built_in_provider_catalog(
         catalog,
         "tencent-tokenhub",
         "https://tokenhub.tencentmaas.com/v1",
+        &["TOKENHUB_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        catalog,
+        "tencent-tokenhub-messages",
+        "https://tokenhub.tencentmaas.com",
         &["TOKENHUB_API_KEY"],
         settings_env,
     )?;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -332,6 +332,42 @@ fn opencode_go_registers_chat_and_messages_endpoints() {
 }
 
 #[test]
+fn tencent_tokenhub_registers_chat_and_messages_endpoints() {
+    let entries = built_in_provider_doc_entries().unwrap();
+    let mut endpoints = entries
+        .into_iter()
+        .filter(|entry| entry.provider.as_str() == "tencent-tokenhub")
+        .map(|entry| {
+            (
+                entry.endpoint.as_str().to_string(),
+                entry.legacy_provider.as_str().to_string(),
+                entry.transport,
+                entry.base_url,
+            )
+        })
+        .collect::<Vec<_>>();
+    endpoints.sort_by(|left, right| left.0.cmp(&right.0));
+
+    assert_eq!(
+        endpoints,
+        [
+            (
+                "default".to_string(),
+                "tencent-tokenhub".to_string(),
+                ProviderTransportKind::OpenAiChatCompletions,
+                "https://tokenhub.tencentmaas.com/v1".to_string(),
+            ),
+            (
+                "messages".to_string(),
+                "tencent-tokenhub-messages".to_string(),
+                ProviderTransportKind::AnthropicMessages,
+                "https://tokenhub.tencentmaas.com".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
 fn app_config_load_materializes_openai_codex_profile_from_existing_store() {
     let dir = tempdir().unwrap();
     let _agent_guard = EnvVarGuard::unset("HOLON_AGENT_ID");

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1069,6 +1069,225 @@ fn stepfun_model(
     }
 }
 
+fn tencent_tokenhub_model(
+    provider: &str,
+    model: &str,
+    display_name: &str,
+    context_window_tokens: Option<usize>,
+    max_output_tokens: Option<u32>,
+    supports_reasoning: bool,
+    image_input: bool,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id(provider), model);
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the Tencent TokenHub {model} model."
+        ),
+        context_window_tokens,
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: max_output_tokens,
+        max_output_tokens_upper_limit: max_output_tokens,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities: ModelCapabilityFlags {
+            image_input,
+            supports_reasoning,
+            ..ModelCapabilityFlags::default()
+        },
+        reasoning_effort_options: Vec::new(),
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
+    }
+}
+
+fn tencent_tokenhub_model_entries() -> Vec<BuiltInModelMetadata> {
+    let models = [
+        ("hy3", "Hy3", Some(256_000), Some(128_000), true, false),
+        (
+            "hy3-preview",
+            "Hy3 Preview",
+            Some(256_000),
+            Some(128_000),
+            true,
+            false,
+        ),
+        ("hy-mt2-pro", "Hy-MT2-Pro", None, None, false, false),
+        ("hy-mt2-plus", "Hy-MT2-Plus", None, None, false, false),
+        ("hy-mt2-lite", "Hy-MT2-Lite", None, None, false, false),
+        (
+            "hunyuan-role-latest",
+            "Hy-Role-Latest",
+            None,
+            None,
+            false,
+            false,
+        ),
+        ("hy-role", "Hy-Role", None, None, false, false),
+        (
+            "deepseek-v4-flash",
+            "DeepSeek V4 Flash",
+            Some(1_000_000),
+            Some(384_000),
+            true,
+            false,
+        ),
+        (
+            "deepseek-v4-pro",
+            "DeepSeek V4 Pro",
+            Some(1_000_000),
+            Some(384_000),
+            true,
+            false,
+        ),
+        (
+            "deepseek-v3.2",
+            "DeepSeek V3.2",
+            Some(128_000),
+            Some(32_768),
+            true,
+            false,
+        ),
+        (
+            "glm-5.2",
+            "GLM-5.2",
+            Some(1_000_000),
+            Some(131_072),
+            true,
+            false,
+        ),
+        (
+            "glm-5.1",
+            "GLM-5.1",
+            Some(202_800),
+            Some(131_072),
+            true,
+            false,
+        ),
+        (
+            "glm-5v-turbo",
+            "GLM-5V Turbo",
+            Some(202_800),
+            Some(131_072),
+            true,
+            true,
+        ),
+        (
+            "glm-5-turbo",
+            "GLM-5 Turbo",
+            Some(202_800),
+            Some(131_072),
+            true,
+            false,
+        ),
+        ("glm-5", "GLM-5", Some(202_800), Some(131_072), true, false),
+        (
+            "kimi-k2.7-code-highspeed",
+            "Kimi K2.7 Code HighSpeed",
+            Some(262_144),
+            Some(262_144),
+            true,
+            true,
+        ),
+        (
+            "kimi-k2.7-code",
+            "Kimi K2.7 Code",
+            Some(262_144),
+            Some(262_144),
+            true,
+            true,
+        ),
+        (
+            "kimi-k2.6",
+            "Kimi K2.6",
+            Some(262_144),
+            Some(262_144),
+            true,
+            true,
+        ),
+        (
+            "kimi-k2.5",
+            "Kimi K2.5",
+            Some(262_144),
+            Some(262_144),
+            true,
+            true,
+        ),
+        (
+            "minimax-m3",
+            "MiniMax M3",
+            Some(1_000_000),
+            None,
+            true,
+            true,
+        ),
+        (
+            "minimax-m2.7",
+            "MiniMax M2.7",
+            Some(204_800),
+            None,
+            true,
+            false,
+        ),
+        (
+            "minimax-m2.5",
+            "MiniMax M2.5",
+            Some(196_608),
+            Some(32_768),
+            true,
+            false,
+        ),
+        (
+            "qwen3.5-flash",
+            "Qwen3.5 Flash",
+            Some(1_000_000),
+            Some(65_536),
+            true,
+            true,
+        ),
+        (
+            "qwen3.5-plus",
+            "Qwen3.5 Plus",
+            Some(1_000_000),
+            Some(65_536),
+            true,
+            true,
+        ),
+        ("youtu-vita", "YT-VITA", None, None, false, true),
+        (
+            "hy-vision-2.0-instruct",
+            "HY-Vision-2.0-Instruct",
+            None,
+            None,
+            false,
+            true,
+        ),
+        (
+            "hunyuan-t1-vision-20250916",
+            "HY-Vision-1.5-Thinking",
+            None,
+            None,
+            true,
+            true,
+        ),
+    ];
+
+    ["tencent-tokenhub", "tencent-tokenhub-messages"]
+        .into_iter()
+        .flat_map(|provider| {
+            models.iter().map(move |model| {
+                tencent_tokenhub_model(
+                    provider, model.0, model.1, model.2, model.3, model.4, model.5,
+                )
+            })
+        })
+        .collect()
+}
+
 fn is_turn_default_candidate(entry: &BuiltInModelMetadata) -> bool {
     entry.context_window_tokens.is_some()
         || entry.capabilities.parallel_tool_calls
@@ -2502,15 +2721,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         catalog_model("synthetic", "hf:MiniMaxAI/MiniMax-M3", "MiniMax M3", 262_144, 65_536, true, true),
         catalog_model("synthetic", "hf:zai-org/GLM-4.7-Flash", "Z.ai GLM-4.7 Flash", 196_608, 65_536, true, false),
         catalog_model("synthetic", "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4", "NVIDIA Nemotron 3 Super 120B A12B NVFP4", 262_144, 65_536, true, false),
-        catalog_model(
-            "tencent-tokenhub",
-            "hy3-preview",
-            "Hy3 preview (TokenHub)",
-            256_000,
-            64_000,
-            true,
-            false,
-        ),
         together_model(
             "MiniMaxAI/MiniMax-M3",
             "MiniMax M3",
@@ -3319,6 +3529,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
         ),
     ]);
+    entries.extend(tencent_tokenhub_model_entries());
     entries
 }
 
@@ -4987,6 +5198,70 @@ mod tests {
                 "messages",
                 "{model}"
             );
+        }
+    }
+
+    #[test]
+    fn tencent_tokenhub_catalog_tracks_current_language_and_image_understanding_models() {
+        let catalog = BuiltInModelCatalog::new();
+        let provider = provider_id("tencent-tokenhub");
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|model| model.model_ref.provider == provider)
+            .collect::<Vec<_>>();
+
+        assert_eq!(models.len(), 27);
+        for model in &models {
+            assert_eq!(model.source, ModelMetadataSource::ConservativeBuiltin);
+            assert!(model.reasoning_effort_options.is_empty());
+            assert_eq!(
+                catalog
+                    .preferred_route_for_model(&model.model_ref)
+                    .unwrap()
+                    .endpoint,
+                ProviderEndpointId::default_endpoint()
+            );
+            assert!(catalog
+                .get_route(&ModelRouteRef::new(
+                    provider.clone(),
+                    ProviderEndpointId::parse("messages").unwrap(),
+                    model.model_ref.model.clone(),
+                ))
+                .is_some());
+        }
+
+        let hy3 = catalog
+            .get(&ModelRef::new(provider.clone(), "hy3"))
+            .unwrap();
+        assert_eq!(hy3.context_window_tokens, Some(256_000));
+        assert_eq!(hy3.max_output_tokens_upper_limit, Some(128_000));
+
+        for vision in [
+            "glm-5v-turbo",
+            "youtu-vita",
+            "hy-vision-2.0-instruct",
+            "hunyuan-t1-vision-20250916",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::new(provider.clone(), vision))
+                    .unwrap()
+                    .capabilities
+                    .image_input
+            );
+        }
+        for retired_or_unsupported in [
+            "deepseek-v3.1-terminus",
+            "deepseek-r1-0528",
+            "deepseek-v3-0324",
+            "HY-Image-V3.0",
+            "hunyuan-turbos-vision-video-20250728",
+            "kinfra-text-embedding-0.6b",
+        ] {
+            assert!(catalog
+                .get(&ModelRef::new(provider.clone(), retired_or_unsupported))
+                .is_none());
         }
     }
 }

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -93,6 +93,7 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
             | "opencode-go"
             | "openrouter"
             | "synthetic"
+            | "tencent-tokenhub"
             | "vercel-ai-gateway"
     )
 }
@@ -244,6 +245,9 @@ pub async fn refresh_provider_models(
         "synthetic" => serde_json::from_slice::<SyntheticModelsResponse>(&raw)
             .context("failed to parse Synthetic model discovery response")?
             .into_model_metadata(&provider.id),
+        "tencent-tokenhub" => serde_json::from_slice::<TencentTokenHubModelsResponse>(&raw)
+            .context("failed to parse Tencent TokenHub model discovery response")?
+            .into_model_metadata(&provider.id),
         "vercel-ai-gateway" => serde_json::from_slice::<VercelModelsResponse>(&raw)
             .context("failed to parse Vercel AI Gateway model discovery response")?
             .into_model_metadata(&provider.id),
@@ -281,6 +285,7 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
         "opencode-go" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
         "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
+        "tencent-tokenhub" => openai_compatible_models_url(&provider.base_url),
         "vercel-ai-gateway" => vercel_models_url(&provider.base_url),
         _ => Err(anyhow!(
             "provider {} does not support model discovery yet",
@@ -308,6 +313,85 @@ fn vercel_models_url(base_url: &str) -> Result<String> {
     let path = url.path().trim_end_matches('/');
     url.set_path(&format!("{path}/v1/models"));
     Ok(url.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct TencentTokenHubModelsResponse {
+    #[serde(default)]
+    data: Vec<TencentTokenHubModel>,
+}
+
+impl TencentTokenHubModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| left.model_ref.model.cmp(&right.model_ref.model));
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TencentTokenHubModel {
+    id: String,
+}
+
+impl TencentTokenHubModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        if !matches!(
+            id,
+            "hy3"
+                | "hy3-preview"
+                | "hy-mt2-pro"
+                | "hy-mt2-plus"
+                | "hy-mt2-lite"
+                | "hunyuan-role-latest"
+                | "hy-role"
+                | "deepseek-v4-flash"
+                | "deepseek-v4-pro"
+                | "deepseek-v3.2"
+                | "glm-5.2"
+                | "glm-5.1"
+                | "glm-5v-turbo"
+                | "glm-5-turbo"
+                | "glm-5"
+                | "kimi-k2.7-code-highspeed"
+                | "kimi-k2.7-code"
+                | "kimi-k2.6"
+                | "kimi-k2.5"
+                | "minimax-m3"
+                | "minimax-m2.7"
+                | "minimax-m2.5"
+                | "qwen3.5-flash"
+                | "qwen3.5-plus"
+                | "youtu-vita"
+                | "hy-vision-2.0-instruct"
+                | "hunyuan-t1-vision-20250916"
+        ) {
+            return None;
+        }
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name: id.to_string(),
+            description:
+                "Remote discovered Tencent TokenHub model confirmed by the official model table."
+                    .to_string(),
+            context_window_tokens: None,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags::default(),
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1263,6 +1347,30 @@ mod tests {
         }
     }
 
+    fn tencent_tokenhub_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("tencent-tokenhub").unwrap(),
+            route_provider: ProviderId::parse("tencent-tokenhub").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://tokenhub.tencentmaas.com/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
     #[test]
     fn maps_arcee_models_without_inventing_capabilities_or_output_limits() {
         let payload: ArceeModelsResponse = serde_json::from_str(
@@ -1617,6 +1725,35 @@ mod tests {
     }
 
     #[test]
+    fn maps_only_current_tencent_tokenhub_turn_models() {
+        let payload: TencentTokenHubModelsResponse = serde_json::from_str(
+            r#"{"data":[
+                {"id":"hy3"},
+                {"id":"glm-5v-turbo"},
+                {"id":"deepseek-r1-0528"},
+                {"id":"HY-Image-V3.0"},
+                {"id":"future-model"},
+                {"id":" "}
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("tencent-tokenhub").unwrap());
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.model_ref.model.as_str())
+                .collect::<Vec<_>>(),
+            ["glm-5v-turbo", "hy3"]
+        );
+        assert!(models.iter().all(|model| {
+            model.endpoint.is_none()
+                && model.source == ModelMetadataSource::RemoteDiscovered
+                && model.capabilities == ModelCapabilityFlags::default()
+        }));
+    }
+
+    #[test]
     fn maps_only_ready_nearai_models_from_published_metadata() {
         let payload: NearAiModelsResponse = serde_json::from_str(
             r#"{"data":[
@@ -1803,6 +1940,27 @@ mod tests {
         assert_eq!(
             provider_models_url(&provider).unwrap(),
             "https://opencode.ai/zen/go/v1/models"
+        );
+    }
+
+    #[test]
+    fn tencent_tokenhub_discovery_requires_a_credential_and_uses_its_models_endpoint() {
+        let provider = tencent_tokenhub_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Unauthenticated);
+        assert!(!discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://tokenhub.tencentmaas.com/v1/models"
         );
     }
 


### PR DESCRIPTION
## Summary
- calibrate Tencent Cloud TokenHub to the current OpenAI-compatible chat/completions transports
- publish a conservative 27-model language and multimodal-understanding catalog with explicit capabilities, limits, and reasoning controls
- restrict dynamic discovery to the documented static intersection, excluding unsupported image/video/3D generation and embedding tasks
- add routing/catalog/discovery tests, an implementation decision, and regenerated model reference documentation

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib tencent_tokenhub`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

`TOKENHUB_API_KEY` was not available locally, so live discovery and inference tests were not run.
