### PR TITLE
feat: calibrate Venice model catalog

### DIFF
--- a/docs/implementation-decisions/092-venice-model-catalog.md
+++ b/docs/implementation-decisions/092-venice-model-catalog.md
@@ -1,0 +1,22 @@
+# Venice model catalog
+
+Holon models Venice as an OpenAI Chat Completions provider at
+`https://api.venice.ai/api/v1`. The built-in catalog contains only the current
+stable text models marked by Venice with the `default`, `default_reasoning`,
+`default_vision`, `default_code`, or `most_uncensored` traits. This avoids
+copying Venice's large, fast-changing recommendation and beta inventory into
+static runtime data.
+
+Runtime discovery uses `GET /models?type=text`. It imports only online text
+models that have not reached their published removal time and maps context,
+output limit, vision, reasoning, and reasoning-effort options only when Venice
+reports those fields. Image, video, audio, embedding, upscale, and inpaint
+model types remain excluded because they require task-specific transports
+rather than Chat Completions.
+
+Sources:
+
+- <https://docs.venice.ai/api-reference/endpoint/chat/completions>
+- <https://docs.venice.ai/api-reference/endpoint/models/list>
+- <https://docs.venice.ai/models/text>
+- <https://docs.venice.ai/overview/deprecations>

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -103,3 +103,4 @@ Current decision notes:
 - [089 Kilocode Model Catalog](./089-kilocode-model-catalog.md)
 - [090 OpenCode Go Model Catalog](./090-opencode-go-model-catalog.md)
 - [091 Tencent TokenHub Model Catalog](./091-tencent-tokenhub-model-catalog.md)
+- [092 Venice Model Catalog](./092-venice-model-catalog.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -285,8 +285,11 @@ and capabilities.
 | `together` | `nvidia/nemotron-3-ultra-550b-a55b` | `together/nvidia/nemotron-3-ultra-550b-a55b` | 512300 | — | ✅ | — |
 | `together` | `openai/gpt-oss-120b` | `together/openai/gpt-oss-120b` | 128000 | — | ✅ | — |
 | `together` | `zai-org/GLM-5.2` | `together/zai-org/GLM-5.2` | 262144 | — | — | — |
-| `venice` | `claude-opus-4-6` | `venice/claude-opus-4-6` | 1000000 | 128000 | ✅ | ✅ |
-| `venice` | `claude-sonnet-4-6` | `venice/claude-sonnet-4-6` | 1000000 | 128000 | ✅ | ✅ |
+| `venice` | `qwen3-235b-a22b-thinking-2507` | `venice/qwen3-235b-a22b-thinking-2507` | 128000 | 16384 | ✅ | — |
+| `venice` | `qwen3-coder-480b-a35b-instruct-turbo` | `venice/qwen3-coder-480b-a35b-instruct-turbo` | 256000 | 65536 | — | — |
+| `venice` | `qwen3-vl-235b-a22b` | `venice/qwen3-vl-235b-a22b` | 128000 | 16384 | — | ✅ |
+| `venice` | `venice-uncensored-1-2` | `venice/venice-uncensored-1-2` | 128000 | 8192 | — | ✅ |
+| `venice` | `zai-org-glm-4.7` | `venice/zai-org-glm-4.7` | 198000 | 16384 | ✅ | — |
 | `vercel-ai-gateway` | `anthropic/claude-opus-4.6` | `vercel-ai-gateway/anthropic/claude-opus-4.6` | 1000000 | 128000 | ✅ | ✅ |
 | `vercel-ai-gateway` | `moonshotai/kimi-k2.6` | `vercel-ai-gateway/moonshotai/kimi-k2.6` | 262000 | 262000 | ✅ | ✅ |
 | `vercel-ai-gateway` | `openai/gpt-5.4` | `vercel-ai-gateway/openai/gpt-5.4` | 1050000 | 128000 | ✅ | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -736,6 +736,9 @@ fn reasoning_effort_options(
         ("fireworks", "accounts/fireworks/models/gpt-oss-120b")
         | ("fireworks", "accounts/fireworks/models/minimax-m2p7") => &["low", "medium", "high"][..],
         ("huggingface", "openai/gpt-oss-120b") => &["low", "medium", "high"][..],
+        ("venice", "zai-org-glm-4.7" | "qwen3-235b-a22b-thinking-2507") => {
+            &["low", "medium", "high"][..]
+        }
         ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
         ("xiaomi" | "xiaomi-token-plan", "mimo-v2.5-pro" | "mimo-v2.5") => &["none", "high"][..],
         ("volcengine", _)
@@ -821,6 +824,42 @@ fn opencode_go_model(
         endpoint: endpoint.map(|endpoint| {
             ProviderEndpointId::parse(endpoint).expect("valid OpenCode Go endpoint id")
         }),
+    }
+}
+
+fn venice_model(
+    model: &str,
+    display_name: &str,
+    context_window_tokens: usize,
+    max_output_tokens: u32,
+    supports_reasoning: bool,
+    image_input: bool,
+) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id("venice"), model);
+    let capabilities = ModelCapabilityFlags {
+        image_input,
+        supports_reasoning,
+        ..ModelCapabilityFlags::default()
+    };
+    BuiltInModelMetadata {
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref: model_ref.clone(),
+        display_name: display_name.into(),
+        description: format!(
+            "Holon conservative built-in metadata for the Venice {model} text model."
+        ),
+        context_window_tokens: Some(context_window_tokens),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: None,
+        default_max_output_tokens: Some(max_output_tokens),
+        max_output_tokens_upper_limit: Some(max_output_tokens),
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        reasoning_effort_options: reasoning_effort_options(&model_ref, None, &capabilities),
+        capabilities,
+        source: ModelMetadataSource::ConservativeBuiltin,
+        endpoint: None,
     }
 }
 
@@ -2798,22 +2837,44 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
             false,
         ),
-        catalog_model(
-            "venice",
-            "claude-opus-4-6",
-            "Claude Opus 4.6 (via Venice)",
-            1_000_000,
-            128_000,
+        venice_model(
+            "zai-org-glm-4.7",
+            "GLM 4.7 (via Venice)",
+            198_000,
+            16_384,
             true,
+            false,
+        ),
+        venice_model(
+            "qwen3-235b-a22b-thinking-2507",
+            "Qwen3 235B A22B Thinking 2507 (via Venice)",
+            128_000,
+            16_384,
+            true,
+            false,
+        ),
+        venice_model(
+            "qwen3-vl-235b-a22b",
+            "Qwen3 VL 235B (via Venice)",
+            128_000,
+            16_384,
+            false,
             true,
         ),
-        catalog_model(
-            "venice",
-            "claude-sonnet-4-6",
-            "Claude Sonnet 4.6 (via Venice)",
-            1_000_000,
+        venice_model(
+            "qwen3-coder-480b-a35b-instruct-turbo",
+            "Qwen3 Coder 480B Turbo (via Venice)",
+            256_000,
+            65_536,
+            false,
+            false,
+        ),
+        venice_model(
+            "venice-uncensored-1-2",
+            "Venice Uncensored 1.2",
             128_000,
-            true,
+            8_192,
+            false,
             true,
         ),
         catalog_model(
@@ -5276,5 +5337,49 @@ mod tests {
                 .get(&ModelRef::new(provider.clone(), retired_or_unsupported))
                 .is_none());
         }
+    }
+
+    #[test]
+    fn venice_catalog_tracks_stable_trait_defaults() {
+        let catalog = BuiltInModelCatalog::new();
+        let provider = provider_id("venice");
+        let models = catalog
+            .list()
+            .into_iter()
+            .filter(|model| model.model_ref.provider == provider)
+            .collect::<Vec<_>>();
+
+        assert_eq!(models.len(), 5);
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.model_ref.model.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "zai-org-glm-4.7",
+                "qwen3-235b-a22b-thinking-2507",
+                "qwen3-coder-480b-a35b-instruct-turbo",
+                "qwen3-vl-235b-a22b",
+                "venice-uncensored-1-2",
+            ]
+        );
+        assert!(models
+            .iter()
+            .all(|model| model.source == ModelMetadataSource::ConservativeBuiltin));
+
+        let default = catalog
+            .get(&ModelRef::new(provider.clone(), "zai-org-glm-4.7"))
+            .unwrap();
+        assert_eq!(default.context_window_tokens, Some(198_000));
+        assert_eq!(default.max_output_tokens_upper_limit, Some(16_384));
+        assert!(default.capabilities.supports_reasoning);
+        assert!(!default.capabilities.image_input);
+        assert_eq!(default.reasoning_effort_options, ["low", "medium", "high"]);
+
+        let vision = catalog
+            .get(&ModelRef::new(provider, "qwen3-vl-235b-a22b"))
+            .unwrap();
+        assert!(vision.capabilities.image_input);
+        assert!(!vision.capabilities.supports_reasoning);
     }
 }

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -466,6 +466,7 @@ impl VeniceModel {
         now: DateTime<Utc>,
     ) -> Option<BuiltInModelMetadata> {
         let id = self.id.trim();
+        // Exclude models at or past their removal time.
         if id.is_empty()
             || self.model_type != "text"
             || self.model_spec.offline

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -97,6 +97,7 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
             | "openrouter"
             | "synthetic"
             | "tencent-tokenhub"
+            | "venice"
             | "vercel-ai-gateway"
     )
 }
@@ -104,7 +105,13 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
 fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig) -> bool {
     !matches!(
         provider.id.as_str(),
-        "huggingface" | "kilocode" | "nearai" | "opencode-go" | "synthetic" | "vercel-ai-gateway"
+        "huggingface"
+            | "kilocode"
+            | "nearai"
+            | "opencode-go"
+            | "synthetic"
+            | "venice"
+            | "vercel-ai-gateway"
     )
 }
 
@@ -251,6 +258,9 @@ pub async fn refresh_provider_models(
         "tencent-tokenhub" => serde_json::from_slice::<TencentTokenHubModelsResponse>(&raw)
             .context("failed to parse Tencent TokenHub model discovery response")?
             .into_model_metadata(&provider.id),
+        "venice" => serde_json::from_slice::<VeniceModelsResponse>(&raw)
+            .context("failed to parse Venice model discovery response")?
+            .into_model_metadata(&provider.id, Utc::now()),
         "vercel-ai-gateway" => serde_json::from_slice::<VercelModelsResponse>(&raw)
             .context("failed to parse Vercel AI Gateway model discovery response")?
             .into_model_metadata(&provider.id),
@@ -289,6 +299,7 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
         "openrouter" => openrouter_models_url(&provider.base_url),
         "synthetic" => Ok(SYNTHETIC_MODELS_URL.to_string()),
         "tencent-tokenhub" => openai_compatible_models_url(&provider.base_url),
+        "venice" => venice_models_url(&provider.base_url),
         "vercel-ai-gateway" => vercel_models_url(&provider.base_url),
         _ => Err(anyhow!(
             "provider {} does not support model discovery yet",
@@ -299,6 +310,13 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
 
 fn openrouter_models_url(base_url: &str) -> Result<String> {
     openai_compatible_models_url(base_url)
+}
+
+fn venice_models_url(base_url: &str) -> Result<String> {
+    Ok(format!(
+        "{}?type=text",
+        openai_compatible_models_url(base_url)?
+    ))
 }
 
 fn openai_compatible_models_url(base_url: &str) -> Result<String> {
@@ -362,6 +380,146 @@ impl TencentTokenHubModel {
             tool_output_truncation_estimated_tokens: None,
             capabilities: ModelCapabilityFlags::default(),
             reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct VeniceModelsResponse {
+    #[serde(default)]
+    data: Vec<VeniceModel>,
+}
+
+impl VeniceModelsResponse {
+    fn into_model_metadata(
+        self,
+        provider: &ProviderId,
+        now: DateTime<Utc>,
+    ) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider, now))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct VeniceModel {
+    id: String,
+    #[serde(rename = "type")]
+    model_type: String,
+    #[serde(default)]
+    context_length: Option<usize>,
+    #[serde(default)]
+    model_spec: VeniceModelSpec,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct VeniceModelSpec {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default, rename = "availableContextTokens")]
+    available_context_tokens: Option<usize>,
+    #[serde(default, rename = "maxCompletionTokens")]
+    max_completion_tokens: Option<u32>,
+    #[serde(default)]
+    offline: bool,
+    #[serde(default)]
+    capabilities: VeniceModelCapabilities,
+    #[serde(default)]
+    deprecation: Option<VeniceModelDeprecation>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct VeniceModelCapabilities {
+    #[serde(default, rename = "supportsVision")]
+    supports_vision: bool,
+    #[serde(default, rename = "supportsReasoning")]
+    supports_reasoning: bool,
+    #[serde(default, rename = "supportsReasoningEffort")]
+    supports_reasoning_effort: bool,
+    #[serde(default, rename = "reasoningEffortOptions")]
+    reasoning_effort_options: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VeniceModelDeprecation {
+    #[serde(default, rename = "removesAt")]
+    removes_at: Option<DateTime<Utc>>,
+}
+
+impl VeniceModel {
+    fn into_model_metadata(
+        self,
+        provider: &ProviderId,
+        now: DateTime<Utc>,
+    ) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        if id.is_empty()
+            || self.model_type != "text"
+            || self.model_spec.offline
+            || self
+                .model_spec
+                .deprecation
+                .as_ref()
+                .and_then(|deprecation| deprecation.removes_at)
+                .is_some_and(|removes_at| removes_at <= now)
+        {
+            return None;
+        }
+        let display_name = self
+            .model_spec
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(id)
+            .to_string();
+        let description = self
+            .model_spec
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("Remote discovered Venice text model metadata.")
+            .to_string();
+        let reasoning_effort_options = self
+            .model_spec
+            .capabilities
+            .supports_reasoning_effort
+            .then_some(self.model_spec.capabilities.reasoning_effort_options)
+            .unwrap_or_default();
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name,
+            description,
+            context_window_tokens: self
+                .model_spec
+                .available_context_tokens
+                .or(self.context_length),
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: self.model_spec.max_completion_tokens,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags {
+                image_input: self.model_spec.capabilities.supports_vision,
+                supports_reasoning: self.model_spec.capabilities.supports_reasoning,
+                ..ModelCapabilityFlags::default()
+            },
+            reasoning_effort_options,
             source: ModelMetadataSource::RemoteDiscovered,
             endpoint: None,
         })
@@ -1321,6 +1479,30 @@ mod tests {
         }
     }
 
+    fn venice_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("venice").unwrap(),
+            route_provider: ProviderId::parse("venice").unwrap(),
+            route_endpoint: crate::config::ProviderEndpointId::default_endpoint(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://api.venice.ai/api/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
     fn tencent_tokenhub_provider() -> ProviderRuntimeConfig {
         ProviderRuntimeConfig {
             id: ProviderId::parse("tencent-tokenhub").unwrap(),
@@ -1471,6 +1653,81 @@ mod tests {
             provider_models_url(&provider).unwrap(),
             "https://router.huggingface.co/v1/models"
         );
+    }
+
+    #[test]
+    fn maps_only_available_venice_text_models_and_reported_capabilities() {
+        let payload: VeniceModelsResponse = serde_json::from_str(
+            r#"{"data":[
+                {
+                    "id":"zai-org-glm-4.7",
+                    "type":"text",
+                    "context_length":128000,
+                    "model_spec":{
+                        "name":"GLM 4.7",
+                        "description":"default",
+                        "availableContextTokens":198000,
+                        "maxCompletionTokens":16384,
+                        "offline":false,
+                        "capabilities":{
+                            "supportsVision":false,
+                            "supportsReasoning":true,
+                            "supportsReasoningEffort":true,
+                            "reasoningEffortOptions":["low","medium","high"]
+                        }
+                    }
+                },
+                {
+                    "id":"qwen3-vl-235b-a22b",
+                    "type":"text",
+                    "context_length":128000,
+                    "model_spec":{
+                        "name":"Qwen3 VL 235B",
+                        "maxCompletionTokens":16384,
+                        "capabilities":{
+                            "supportsVision":true,
+                            "supportsReasoning":false,
+                            "supportsReasoningEffort":false,
+                            "reasoningEffortOptions":["low"]
+                        }
+                    }
+                },
+                {"id":"offline","type":"text","model_spec":{"offline":true}},
+                {"id":"image-model","type":"image","model_spec":{}},
+                {
+                    "id":"removed",
+                    "type":"text",
+                    "model_spec":{"deprecation":{"removesAt":"2025-01-01T00:00:00Z"}}
+                }
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(
+            &ProviderId::parse("venice").unwrap(),
+            DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+
+        assert_eq!(models.len(), 2);
+        let glm = models
+            .iter()
+            .find(|model| model.model_ref.model == "zai-org-glm-4.7")
+            .unwrap();
+        assert_eq!(glm.context_window_tokens, Some(198_000));
+        assert_eq!(glm.max_output_tokens_upper_limit, Some(16_384));
+        assert!(!glm.capabilities.image_input);
+        assert!(glm.capabilities.supports_reasoning);
+        assert_eq!(glm.reasoning_effort_options, ["low", "medium", "high"]);
+
+        let vision = models
+            .iter()
+            .find(|model| model.model_ref.model == "qwen3-vl-235b-a22b")
+            .unwrap();
+        assert!(vision.capabilities.image_input);
+        assert!(!vision.capabilities.supports_reasoning);
+        assert!(vision.reasoning_effort_options.is_empty());
     }
 
     #[test]
@@ -1935,6 +2192,27 @@ mod tests {
         assert_eq!(
             provider_models_url(&provider).unwrap(),
             "https://tokenhub.tencentmaas.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn venice_discovery_is_public_and_filters_to_text_models() {
+        let provider = venice_provider();
+        let cache = ModelDiscoveryCacheFile::default();
+        let status =
+            discovery_cache_status_for_provider(&provider, &cache, Duration::from_secs(60), false);
+
+        assert!(status.supports_auto_refresh);
+        assert!(!status.credential_configured);
+        assert_eq!(status.state, ModelDiscoveryCacheState::Missing);
+        assert!(discovery_cache_needs_refresh(
+            &provider,
+            &cache,
+            Duration::from_secs(60)
+        ));
+        assert_eq!(
+            provider_models_url(&provider).unwrap(),
+            "https://api.venice.ai/api/v1/models?type=text"
         );
     }
 


### PR DESCRIPTION
## Summary
- replace stale Venice Claude defaults with five current stable trait-selected text models
- map Venice's public `GET /models?type=text` response into remote catalog metadata, filtering offline, non-text, and removed models
- document the conservative support boundary and update the generated model reference

## Runtime concept
Venice remains an OpenAI Chat Completions provider. Static metadata is limited to Venice's stable trait defaults, while dynamic discovery imports the provider-reported text inventory and capability/limit fields without admitting image, video, audio, embedding, upscale, or inpaint transports.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib venice` (3 passed)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- public discovery livetest: `venice`, 100 models cached from `GET /models?type=text`
