### PR TITLE
fix: discover LiteLLM and vLLM deployment models

### DIFF
--- a/docs/implementation-decisions/092-local-openai-compatible-model-discovery.md
+++ b/docs/implementation-decisions/092-local-openai-compatible-model-discovery.md
@@ -1,0 +1,28 @@
+# Local OpenAI-Compatible Model Discovery
+
+LiteLLM Proxy and vLLM are deployment surfaces, not hosted catalogs with a
+stable Holon-chosen model. Their configured model ids or aliases are determined
+by the running server.
+
+Holon therefore keeps built-in endpoint and authentication defaults for these
+providers but does not ship a representative static model. Both providers use
+their OpenAI-compatible `GET /v1/models` endpoint to populate the discovery
+cache. LiteLLM exposes both `/models` and `/v1/models`; Holon uses the versioned
+route consistently. Discovered ids receive conservative unknown-model policy
+and no inferred capabilities or token limits because the standard model-list
+shape does not describe those properties.
+
+LiteLLM keeps `LITELLM_API_KEY` bearer authentication because a proxy configured
+with a master key protects its OpenAI-compatible routes. vLLM remains
+unauthenticated by default; operators can override provider authentication when
+starting vLLM with `--api-key` or `VLLM_API_KEY`.
+
+Primary references:
+
+- LiteLLM Proxy quick start: <https://docs.litellm.ai/docs/proxy/quick_start>
+- LiteLLM Proxy route inventory:
+  <https://github.com/BerriAI/litellm/blob/main/litellm/proxy/README.md>
+- vLLM OpenAI-compatible server:
+  <https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html>
+- vLLM security and API-key scope:
+  <https://docs.vllm.ai/en/latest/usage/security.html#api-key-authentication-limitations>

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **33 provider accounts**
-across **42 endpoints** and **253 models**.
+across **42 endpoints** and **251 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -165,7 +165,6 @@ and capabilities.
 | `kilocode` | `kilo-auto/efficient` | `kilocode/kilo-auto/efficient` | 1000000 | — | ✅ | ✅ |
 | `kilocode` | `kilo-auto/free` | `kilocode/kilo-auto/free` | 256000 | — | ✅ | — |
 | `kilocode` | `kilo-auto/frontier` | `kilocode/kilo-auto/frontier` | 1000000 | — | ✅ | ✅ |
-| `litellm` | `claude-opus-4-6` | `litellm/claude-opus-4-6` | 200000 | 128000 | ✅ | ✅ |
 | `minimax` | `MiniMax-M2` | `minimax/MiniMax-M2` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M2.1` | `minimax/MiniMax-M2.1` | 204800 | 128000 | ✅ | — |
 | `minimax` | `MiniMax-M2.1-highspeed` | `minimax/MiniMax-M2.1-highspeed` | 204800 | 128000 | ✅ | — |
@@ -294,7 +293,6 @@ and capabilities.
 | `vercel-ai-gateway` | `moonshotai/kimi-k2.6` | `vercel-ai-gateway/moonshotai/kimi-k2.6` | 262000 | 262000 | ✅ | ✅ |
 | `vercel-ai-gateway` | `openai/gpt-5.4` | `vercel-ai-gateway/openai/gpt-5.4` | 1050000 | 128000 | ✅ | ✅ |
 | `vercel-ai-gateway` | `openai/gpt-5.4-pro` | `vercel-ai-gateway/openai/gpt-5.4-pro` | 1050000 | 128000 | ✅ | ✅ |
-| `vllm` | `meta-llama/Meta-Llama-3-8B-Instruct` | `vllm/meta-llama/Meta-Llama-3-8B-Instruct` | 131072 | 8192 | — | — |
 | `volcengine` | `ark-code-latest` | `volcengine/ark-code-latest` | 256000 | 65536 | ✅ | — |
 | `volcengine` | `deepseek-v3-2-251201` | `volcengine/deepseek-v3-2-251201` | 128000 | 4096 | — | — |
 | `volcengine` | `deepseek-v4-flash` | `volcengine/deepseek-v4-flash` | 1000000 | 8192 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1912,15 +1912,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "litellm",
-            "claude-opus-4-6",
-            "Claude Opus 4.6",
-            200_000,
-            128_000,
-            true,
-            true,
-        ),
-        catalog_model(
             "minimax",
             "MiniMax-M3",
             "MiniMax M3",
@@ -2914,15 +2905,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
         ),
         catalog_model(
-            "vllm",
-            "meta-llama/Meta-Llama-3-8B-Instruct",
-            "Meta Llama 3 8B Instruct",
-            131_072,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
             "volcengine",
             "doubao-seed-1-8-251228",
             "Doubao Seed 1.8",
@@ -3687,6 +3669,22 @@ mod tests {
         assert!(catalog
             .get(&ModelRef::new(arcee, "trinity-large-thinking"))
             .is_none());
+    }
+
+    #[test]
+    fn deployment_defined_openai_compatible_providers_have_no_static_models() {
+        let catalog = BuiltInModelCatalog::new();
+
+        for provider in ["litellm", "vllm"] {
+            let provider = ProviderId::parse(provider).unwrap();
+            assert!(
+                catalog
+                    .list()
+                    .into_iter()
+                    .all(|entry| entry.model_ref.provider != provider),
+                "{provider:?} models must come from deployment discovery"
+            );
+        }
     }
 
     #[test]

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -92,6 +92,7 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
         "arcee"
             | "huggingface"
             | "kilocode"
+            | "litellm"
             | "nearai"
             | "opencode-go"
             | "openrouter"
@@ -99,6 +100,7 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
             | "tencent-tokenhub"
             | "venice"
             | "vercel-ai-gateway"
+            | "vllm"
     )
 }
 
@@ -112,6 +114,7 @@ fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig
             | "synthetic"
             | "venice"
             | "vercel-ai-gateway"
+            | "vllm"
     )
 }
 
@@ -243,6 +246,9 @@ pub async fn refresh_provider_models(
         "kilocode" => serde_json::from_slice::<KiloModelsResponse>(&raw)
             .context("failed to parse Kilo Gateway model discovery response")?
             .into_model_metadata(&provider.id),
+        "litellm" | "vllm" => serde_json::from_slice::<OpenAiCompatibleModelsResponse>(&raw)
+            .context("failed to parse OpenAI-compatible model discovery response")?
+            .into_model_metadata(&provider.id),
         "nearai" => serde_json::from_slice::<NearAiModelsResponse>(&raw)
             .context("failed to parse NEAR AI model discovery response")?
             .into_model_metadata(&provider.id),
@@ -294,6 +300,7 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
         "arcee" => Ok("https://api.arcee.ai/api/v1/models".to_string()),
         "huggingface" => openai_compatible_models_url(&provider.base_url),
         "kilocode" => openai_compatible_models_url(&provider.base_url),
+        "litellm" => openai_v1_models_url(&provider.base_url),
         "nearai" => openai_compatible_models_url(&provider.base_url),
         "opencode-go" => openai_compatible_models_url(&provider.base_url),
         "openrouter" => openrouter_models_url(&provider.base_url),
@@ -301,11 +308,25 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
         "tencent-tokenhub" => openai_compatible_models_url(&provider.base_url),
         "venice" => venice_models_url(&provider.base_url),
         "vercel-ai-gateway" => vercel_models_url(&provider.base_url),
+        "vllm" => openai_compatible_models_url(&provider.base_url),
         _ => Err(anyhow!(
             "provider {} does not support model discovery yet",
             provider.id.as_str()
         )),
     }
+}
+
+fn openai_v1_models_url(base_url: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(base_url)
+        .with_context(|| format!("invalid OpenAI-compatible base_url {base_url:?}"))?;
+    let path = url.path().trim_end_matches('/');
+    // LiteLLM commonly omits `/v1`; avoid duplicating it for providers that include it.
+    if path.ends_with("/v1") {
+        url.set_path(&format!("{path}/models"));
+    } else {
+        url.set_path(&format!("{path}/v1/models"));
+    }
+    Ok(url.to_string())
 }
 
 fn openrouter_models_url(base_url: &str) -> Result<String> {
@@ -334,6 +355,54 @@ fn vercel_models_url(base_url: &str) -> Result<String> {
     let path = url.path().trim_end_matches('/');
     url.set_path(&format!("{path}/v1/models"));
     Ok(url.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiCompatibleModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenAiCompatibleModel>,
+}
+
+impl OpenAiCompatibleModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| left.model_ref.model.cmp(&right.model_ref.model));
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiCompatibleModel {
+    id: String,
+}
+
+impl OpenAiCompatibleModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name: id.to_string(),
+            description: "Remote discovered OpenAI-compatible model.".to_string(),
+            context_window_tokens: None,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags::default(),
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -2215,6 +2284,62 @@ mod tests {
             provider_models_url(&provider).unwrap(),
             "https://api.venice.ai/api/v1/models?type=text"
         );
+    }
+
+    #[test]
+    fn local_openai_compatible_servers_use_deployment_model_discovery() {
+        let providers =
+            crate::config::built_in_provider_registry_with_settings(&Default::default()).unwrap();
+        let litellm = providers
+            .get(&ProviderId::parse("litellm").unwrap())
+            .unwrap();
+        let vllm = providers.get(&ProviderId::parse("vllm").unwrap()).unwrap();
+        let cache = ModelDiscoveryCacheFile::default();
+
+        assert_eq!(
+            discovery_cache_status_for_provider(litellm, &cache, Duration::from_secs(60), false)
+                .state,
+            ModelDiscoveryCacheState::Unauthenticated
+        );
+        assert_eq!(
+            provider_models_url(litellm).unwrap(),
+            "http://localhost:4000/v1/models"
+        );
+        assert_eq!(
+            discovery_cache_status_for_provider(vllm, &cache, Duration::from_secs(60), false).state,
+            ModelDiscoveryCacheState::Missing
+        );
+        assert_eq!(
+            provider_models_url(vllm).unwrap(),
+            "http://127.0.0.1:8000/v1/models"
+        );
+    }
+
+    #[test]
+    fn openai_compatible_discovery_keeps_only_non_empty_server_model_ids() {
+        let payload: OpenAiCompatibleModelsResponse = serde_json::from_str(
+            r#"{"object":"list","data":[
+                {"id":"deployment-alias","object":"model"},
+                {"id":"org/model","object":"model"},
+                {"id":" ","object":"model"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("vllm").unwrap());
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.model_ref.model.as_str())
+                .collect::<Vec<_>>(),
+            vec!["deployment-alias", "org/model"]
+        );
+        assert!(models
+            .iter()
+            .all(|model| model.source == ModelMetadataSource::RemoteDiscovered));
+        assert!(models
+            .iter()
+            .all(|model| model.capabilities == ModelCapabilityFlags::default()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove deployment-specific LiteLLM and vLLM entries from the static model catalog
- discover deployed model IDs through each provider's OpenAI-compatible `/v1/models` endpoint with conservative unknown capabilities and limits
- document the deployment-defined catalog policy and regenerate the model reference

## Provider contracts

- LiteLLM defaults to `http://localhost:4000`, uses `LITELLM_API_KEY`, and resolves discovery to `/v1/models`
- vLLM defaults to `http://127.0.0.1:8000/v1`, requires no authentication by default, and resolves discovery to `/v1/models`

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib model_discovery::tests`
- `cargo test --lib deployment_defined_openai_compatible_providers_have_no_static_models`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- local endpoint probes: no LiteLLM or vLLM server was reachable on the documented default ports, so no live model listing was available
