### PR TITLE
fix: calibrate image generation routes

### DIFF
--- a/docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md
+++ b/docs/implementation-decisions/064-canonical-model-ref-legacy-alias.md
@@ -5,7 +5,7 @@
 Built-in models are cataloged once under their **canonical provider id**.
 Endpoint- and plan-specific availability, limits, capabilities, and preferred
 selection are indexed separately by `ModelRouteRef` (`provider@endpoint/model`).
-This applies both to image routes such as Volcengine `image-openai` and to
+This applies both to legacy image aliases such as Volcengine `image-openai` and to
 flattened plan providers such as `volcengine-agent`,
 `dashscope-token-plan`, and `xiaomi-token-plan`.
 
@@ -15,6 +15,11 @@ to the canonical form `volcengine/doubao-seedream-5.0-lite`. Catalog
 construction also derives aliases for flattened built-in provider ids, while
 preserving their exact endpoint as a route. Existing user configs therefore
 continue to resolve without manual migration.
+
+The legacy Volcengine image alias resolves to the standard `default` endpoint:
+Seedream uses Ark's `/api/v3/images/generations` API, not the Agent Plan
+`/api/plan/v3` endpoint. `VOLCENGINE_IMAGE_OPENAI_API_KEY` remains accepted as a
+backward-compatible credential fallback for the standard endpoint.
 
 ## Reason
 

--- a/docs/implementation-decisions/093-image-generation-route-calibration.md
+++ b/docs/implementation-decisions/093-image-generation-route-calibration.md
@@ -1,0 +1,25 @@
+# Image Generation Route Calibration
+
+## Choice
+
+Only models confirmed to accept the OpenAI Responses `image_generation` hosted
+tool advertise Codex image generation. `gpt-5.3-codex-spark` does not advertise
+that capability because the live Codex endpoint rejects the tool for that
+model.
+
+Volcengine Seedream uses the canonical `volcengine@default` route and Ark's
+standard `/api/v3/images/generations` endpoint. The Agent Plan endpoint is not
+an image-generation route.
+
+## Reason
+
+Image generation is both a model capability and a transport/endpoint contract.
+Advertising either against an unsupported model or the wrong endpoint makes
+automatic route selection deterministic but invalid.
+
+## Preserved boundary
+
+The legacy `volcengine-image-openai/doubao-seedream-5.0-lite` model ref and
+`VOLCENGINE_IMAGE_OPENAI_API_KEY` remain accepted. They now normalize to the
+standard Volcengine endpoint rather than preserving the historical incorrect
+Agent Plan route.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -104,3 +104,4 @@ Current decision notes:
 - [090 OpenCode Go Model Catalog](./090-opencode-go-model-catalog.md)
 - [091 Tencent TokenHub Model Catalog](./091-tencent-tokenhub-model-catalog.md)
 - [092 Venice Model Catalog](./092-venice-model-catalog.md)
+- [093 Image Generation Route Calibration](./093-image-generation-route-calibration.md)

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -59,8 +59,8 @@ used in existing `provider/model` refs and config shortcuts.
 | `venice` | `default` | `venice` | OpenAI Chat Completions | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
 | `vercel-ai-gateway` | `default` | `vercel-ai-gateway` | Anthropic Messages | `https://ai-gateway.vercel.sh` | `VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY or VERCEL_AI_GATEWAY_API_KEY` |
 | `vllm` | `default` | `vllm` | OpenAI Chat Completions | `http://127.0.0.1:8000/v1` | `—` |
-| `volcengine` | `default` | `volcengine` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/v3` | `VOLCENGINE_API_KEY` |
-| `volcengine` | `plan` | `volcengine-agent` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_AGENT_API_KEY or VOLCENGINE_IMAGE_OPENAI_API_KEY` |
+| `volcengine` | `default` | `volcengine` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/v3` | `VOLCENGINE_API_KEY or VOLCENGINE_IMAGE_OPENAI_API_KEY` |
+| `volcengine` | `plan` | `volcengine-agent` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/plan/v3` | `VOLCENGINE_AGENT_API_KEY` |
 | `volcengine` | `coding` | `volcengine-coding` | OpenAI Responses | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY` |
 | `xai` | `default` | `xai` | OpenAI Responses | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `xiaomi` | `default` | `xiaomi` | OpenAI Responses | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -847,7 +847,7 @@ pub(crate) fn built_in_provider_endpoint_identity(
         "tencent-tokenhub-messages" => ("tencent-tokenhub", "messages"),
         "volcengine-coding" => ("volcengine", "coding"),
         "volcengine-agent" => ("volcengine", "plan"),
-        "volcengine-image-openai" => ("volcengine", "plan"),
+        "volcengine-image-openai" => ("volcengine", "default"),
         "xiaomi-token-plan" => ("xiaomi", "token-plan"),
         _ => {
             return Ok((
@@ -1192,7 +1192,7 @@ pub(crate) fn populate_built_in_provider_catalog(
         "volcengine",
         ProviderTransportKind::OpenAiResponses,
         "https://ark.cn-beijing.volces.com/api/v3",
-        &["VOLCENGINE_API_KEY"],
+        &["VOLCENGINE_API_KEY", "VOLCENGINE_IMAGE_OPENAI_API_KEY"],
         settings_env,
     )?;
     // Coding Plan tier — OpenAI Responses at /api/coding/v3 (independent plan, isolated key).
@@ -1204,16 +1204,13 @@ pub(crate) fn populate_built_in_provider_catalog(
         &["VOLCENGINE_CODING_API_KEY"],
         settings_env,
     )?;
-    // Agent Plan tier — OpenAI Responses at /api/plan/v3 (text + image generation, isolated key, no cross-tier fallback).
+    // Agent Plan tier — OpenAI Responses at /api/plan/v3 (isolated key, no cross-tier fallback).
     insert_builtin_http_provider(
         catalog,
         "volcengine-agent",
         ProviderTransportKind::OpenAiResponses,
         "https://ark.cn-beijing.volces.com/api/plan/v3",
-        &[
-            "VOLCENGINE_AGENT_API_KEY",
-            "VOLCENGINE_IMAGE_OPENAI_API_KEY",
-        ],
+        &["VOLCENGINE_AGENT_API_KEY"],
         settings_env,
     )?;
     insert_builtin_http_provider(

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1232,7 +1232,7 @@ mod tests {
             ModelRouteRef::parse_compatible("volcengine-image-openai/doubao-seedream-5.0-lite")
                 .unwrap();
         assert_eq!(route_ref.provider.as_str(), "volcengine");
-        assert_eq!(route_ref.endpoint.as_str(), "plan");
+        assert_eq!(route_ref.endpoint.as_str(), "default");
         assert_eq!(route_ref.model, "doubao-seedream-5.0-lite");
     }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1410,8 +1410,8 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         "https://gemini.example/v1beta".to_string(),
     );
     settings_env.insert(
-        "VOLCENGINE_AGENT_API_KEY".to_string(),
-        "volcengine-agent-key".to_string(),
+        "VOLCENGINE_API_KEY".to_string(),
+        "volcengine-key".to_string(),
     );
     settings_env.insert(
         "HOLON_VOLCENGINE_AGENT_BASE_URL".to_string(),
@@ -1500,23 +1500,17 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
         Some("dashscope-coding-plan-key")
     );
 
-    let volcengine_agent = providers
-        .get(&ProviderId::parse("volcengine-agent").unwrap())
+    let volcengine = providers
+        .get(&ProviderId::parse("volcengine").unwrap())
         .unwrap();
+    assert_eq!(volcengine.transport, ProviderTransportKind::OpenAiResponses);
     assert_eq!(
-        volcengine_agent.transport,
-        ProviderTransportKind::OpenAiResponses
+        volcengine.base_url,
+        "https://ark.cn-beijing.volces.com/api/v3"
     );
-    assert_eq!(volcengine_agent.base_url, "https://ark.example/api/v3");
-    assert_eq!(
-        volcengine_agent.auth.env.as_deref(),
-        Some("VOLCENGINE_AGENT_API_KEY")
-    );
-    assert_eq!(
-        volcengine_agent.credential.as_deref(),
-        Some("volcengine-agent-key")
-    );
-    // Backward compat: VOLCENGINE_IMAGE_OPENAI_API_KEY still works as fallback.
+    assert_eq!(volcengine.auth.env.as_deref(), Some("VOLCENGINE_API_KEY"));
+    assert_eq!(volcengine.credential.as_deref(), Some("volcengine-key"));
+    // Backward compat: the old image-specific key now targets the standard endpoint.
     let mut volcengine_image_openai_only_env = HashMap::new();
     volcengine_image_openai_only_env.insert(
         "VOLCENGINE_IMAGE_OPENAI_API_KEY".to_string(),
@@ -1524,15 +1518,15 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
     );
     let volcengine_image_openai_only_providers =
         super::built_in_provider_registry_with_settings(&volcengine_image_openai_only_env).unwrap();
-    let volcengine_agent = volcengine_image_openai_only_providers
-        .get(&ProviderId::parse("volcengine-agent").unwrap())
+    let volcengine = volcengine_image_openai_only_providers
+        .get(&ProviderId::parse("volcengine").unwrap())
         .unwrap();
     assert_eq!(
-        volcengine_agent.auth.env.as_deref(),
+        volcengine.auth.env.as_deref(),
         Some("VOLCENGINE_IMAGE_OPENAI_API_KEY")
     );
     assert_eq!(
-        volcengine_agent.credential.as_deref(),
+        volcengine.credential.as_deref(),
         Some("volcengine-image-key")
     );
 
@@ -2851,7 +2845,7 @@ fn runtime_model_catalog_resolves_image_generation_route() {
 #[test]
 fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
     let mut fixture = test_app_config("openai/gpt-5.4", &["volcengine/doubao-seedream-5.0-lite"]);
-    let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
+    let legacy_provider = ProviderId::parse("volcengine").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
         legacy_provider.clone(),
@@ -2872,11 +2866,8 @@ fn runtime_model_catalog_resolves_legacy_multi_endpoint_provider_identity() {
         ModelRouteCapability::ImageGeneration
     );
     assert_eq!(route.endpoint.provider.as_str(), "volcengine");
-    assert_eq!(route.endpoint.endpoint.as_str(), "plan");
-    assert_eq!(
-        route.endpoint.runtime_config.id.as_str(),
-        "volcengine-agent"
-    );
+    assert_eq!(route.endpoint.endpoint.as_str(), "default");
+    assert_eq!(route.endpoint.runtime_config.id.as_str(), "volcengine");
 }
 
 #[test]
@@ -2975,9 +2966,9 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
         ProviderRuntimeConfig {
             id: ProviderId::parse("volcengine-image-openai").unwrap(),
             route_provider: ProviderId::parse("volcengine").unwrap(),
-            route_endpoint: ProviderEndpointId::parse("plan").unwrap(),
+            route_endpoint: ProviderEndpointId::default_endpoint(),
             transport: ProviderTransportKind::OpenAiResponses,
-            base_url: "https://ark.cn-beijing.volces.com/api/plan/v3".into(),
+            base_url: "https://ark.cn-beijing.volces.com/api/v3".into(),
             auth: ProviderAuthConfig::default(),
             credential: None,
             credential_store_path: None,
@@ -2996,7 +2987,7 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
 
     assert_eq!(
         selected.as_string(),
-        "volcengine@plan/doubao-seedream-5.0-lite"
+        "volcengine@default/doubao-seedream-5.0-lite"
     );
 }
 
@@ -3004,8 +2995,8 @@ fn generate_image_selection_accepts_volcengine_image_openai_seedream() {
 fn generate_image_selection_accepts_canonical_volcengine_seedream() {
     let mut fixture = test_app_config("openai@default/gpt-5.4", &[]);
     fixture.config.image_generation_model =
-        Some(route_ref("volcengine@plan/doubao-seedream-5.0-lite"));
-    let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
+        Some(route_ref("volcengine@default/doubao-seedream-5.0-lite"));
+    let legacy_provider = ProviderId::parse("volcengine").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
         legacy_provider.clone(),
@@ -3019,7 +3010,7 @@ fn generate_image_selection_accepts_canonical_volcengine_seedream() {
 
     assert_eq!(
         selected.as_string(),
-        "volcengine@plan/doubao-seedream-5.0-lite"
+        "volcengine@default/doubao-seedream-5.0-lite"
     );
 }
 
@@ -3027,8 +3018,8 @@ fn generate_image_selection_accepts_canonical_volcengine_seedream() {
 fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
     let mut fixture = test_app_config("openai@default/gpt-5.4", &[]);
     fixture.config.image_generation_model =
-        Some(route_ref("volcengine@plan/doubao-seedream-5.0-lite"));
-    let legacy_provider = ProviderId::parse("volcengine-agent").unwrap();
+        Some(route_ref("volcengine@default/doubao-seedream-5.0-lite"));
+    let legacy_provider = ProviderId::parse("volcengine").unwrap();
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
     fixture.config.providers.insert(
         legacy_provider.clone(),
@@ -3045,11 +3036,8 @@ fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
         "volcengine/doubao-seedream-5.0-lite"
     );
     assert_eq!(route.endpoint.provider.as_str(), "volcengine");
-    assert_eq!(route.endpoint.endpoint.as_str(), "plan");
-    assert_eq!(
-        route.endpoint.runtime_config.id.as_str(),
-        "volcengine-agent"
-    );
+    assert_eq!(route.endpoint.endpoint.as_str(), "default");
+    assert_eq!(route.endpoint.runtime_config.id.as_str(), "volcengine");
 }
 
 #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1574,7 +1574,6 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             default_verbosity: Some(ModelVerbosity::Low),
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
-                image_generation: true,
                 interactive_exec: true,
                 supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
@@ -3153,7 +3152,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             },
             reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::BuiltInCatalog,
-            endpoint: Some(ProviderEndpointId::parse("plan").expect("valid built-in endpoint id")),
+            endpoint: Some(ProviderEndpointId::default_endpoint()),
         },
         catalog_model(
             "xiaomi",
@@ -3926,6 +3925,7 @@ mod tests {
             .unwrap();
         assert_eq!(codex_spark.context_window_tokens, Some(128_000));
         assert!(!codex_spark.capabilities.image_input);
+        assert!(!codex_spark.capabilities.image_generation);
 
         let nearai = catalog.resolve_policy(
             &ModelRef::parse("nearai/zai-org/GLM-5.1-FP8").unwrap(),

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -751,10 +751,10 @@ mod tests {
     #[test]
     fn resolved_model_projection_preserves_canonical_provider_endpoint_and_route_provider() {
         let mut fixture = test_config(Some("openai-key"));
-        let route_provider = ProviderId::parse("volcengine-agent").unwrap();
+        let route_provider = ProviderId::parse("volcengine").unwrap();
         let built_ins = crate::config::built_in_provider_registry_with_settings(
             &std::collections::HashMap::from([(
-                "VOLCENGINE_AGENT_API_KEY".to_string(),
+                "VOLCENGINE_API_KEY".to_string(),
                 "volcengine-key".to_string(),
             )]),
         )
@@ -775,24 +775,24 @@ mod tests {
             .expect("canonical Volcengine model");
         assert_eq!(seedream.provider, "volcengine");
         assert_eq!(seedream.provider_family, "volcengine");
-        assert_eq!(seedream.endpoint, "plan");
-        assert_eq!(seedream.route_provider, "volcengine-agent");
+        assert_eq!(seedream.endpoint, "default");
+        assert_eq!(seedream.route_provider, "volcengine");
         assert!(seedream.policy.capabilities.image_generation);
 
         let providers = resolved_model_providers(&fixture.config);
         let volcengine = providers
             .iter()
-            .find(|entry| entry.provider_family == "volcengine" && entry.endpoint == "plan")
-            .expect("Volcengine plan provider");
-        assert_eq!(volcengine.id, "volcengine:plan");
-        assert_eq!(volcengine.route_provider, "volcengine-agent");
+            .find(|entry| entry.provider_family == "volcengine" && entry.endpoint == "default")
+            .expect("Volcengine default provider");
+        assert_eq!(volcengine.id, "volcengine");
+        assert_eq!(volcengine.route_provider, "volcengine");
 
-        let models = resolved_provider_models(&fixture.config, "volcengine:plan");
+        let models = resolved_provider_models(&fixture.config, "volcengine");
         assert!(models.iter().any(|entry| {
             entry.model_ref == "volcengine/doubao-seedream-5.0-lite"
                 && entry.provider_family == "volcengine"
-                && entry.endpoint == "plan"
-                && entry.route_provider == "volcengine-agent"
+                && entry.endpoint == "default"
+                && entry.route_provider == "volcengine"
         }));
     }
 

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -20,8 +20,7 @@ fn live_openai_codex_model() -> String {
 }
 
 fn live_openai_codex_image_model() -> String {
-    std::env::var("HOLON_LIVE_OPENAI_CODEX_IMAGE_MODEL")
-        .unwrap_or_else(|_| live_openai_codex_model())
+    std::env::var("HOLON_LIVE_OPENAI_CODEX_IMAGE_MODEL").unwrap_or_else(|_| "gpt-5.5".into())
 }
 
 fn probe_tool_spec() -> ToolSpec {

--- a/tests/live_volcengine_image.rs
+++ b/tests/live_volcengine_image.rs
@@ -13,11 +13,11 @@ fn live_volcengine_image_model() -> String {
 #[ignore = "requires a Volcengine Ark image generation credential profile and network access"]
 async fn live_volcengine_ark_seedream_generates_image_with_openai_images_api() -> Result<()> {
     let config = AppConfig::load()?;
-    let provider_id = ProviderId::parse("volcengine-agent")?;
+    let provider_id = ProviderId::parse("volcengine")?;
     let provider_config = config
         .providers
         .get(&provider_id)
-        .ok_or_else(|| anyhow::anyhow!("missing volcengine-agent provider config"))?;
+        .ok_or_else(|| anyhow::anyhow!("missing volcengine provider config"))?;
     let model = live_volcengine_image_model();
     let provider = OpenAiChatCompletionsProvider::from_runtime_config(
         provider_config,
@@ -34,7 +34,7 @@ async fn live_volcengine_ark_seedream_generates_image_with_openai_images_api() -
         })
         .await?;
 
-    assert_eq!(output.provider.as_str(), "volcengine-agent");
+    assert_eq!(output.provider.as_str(), "volcengine");
     assert_eq!(output.model, model);
     assert_eq!(output.images.len(), 1);
     assert!(


### PR DESCRIPTION
## Summary
- remove `image_generation` from `openai-codex/gpt-5.3-codex-spark`, which rejects the hosted tool
- route `volcengine/doubao-seedream-5.0-lite` through Ark's standard `volcengine@default` `/api/v3` Images API instead of Agent Plan
- preserve the legacy `volcengine-image-openai` alias and `VOLCENGINE_IMAGE_OPENAI_API_KEY` as compatibility inputs for the canonical route
- update catalog/config/diagnostics regression coverage and document the route calibration

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets` (all route-related tests passed; one unrelated timing test failed in the full run and passed immediately when rerun alone)
- `cargo test --test runtime_tasks exec_command_batch_does_not_wait_for_background_pipe_holders -- --nocapture`
- `cargo test --test wt201_multiple_worktree_tasks -- --nocapture`
- `cargo test --test live_codex live_openai_codex_generates_image_with_responses_tool -- --ignored --nocapture` (`gpt-5.5`, passed)
- Volcengine Seedream livetest reached the explicit credential guard and could not call the endpoint because this environment has neither `VOLCENGINE_API_KEY` nor `VOLCENGINE_IMAGE_OPENAI_API_KEY`
