### PR TITLE
fix: authenticate workspace file downloads

### DIFF
--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -41,6 +41,8 @@ interface SelectedFile {
   error?: string;
 }
 
+const FILE_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+
 function fileIcon(entry: WorkspaceFileEntry): LucideIcon {
   if (entry.type === "directory") return Folder;
   if (entry.type === "symlink") return Link;
@@ -182,6 +184,8 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
       contentScrollRef.current.scrollTop = 0;
     }
     setShowRendered(true);
+    downloadRequestRef.current += 1;
+    setDownloadState(undefined);
   }, [selectedFile?.path]);
 
   const highlightedHtml = useShikiHighlight(selectedFile?.content, selectedFile?.path);
@@ -302,7 +306,10 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
     const requestId = ++downloadRequestRef.current;
     setDownloadState({ path, loading: true });
     try {
-      const blob = await fetchWorkspaceFileBlob(workspaceId, path, executionRootId, { download: true });
+      const blob = await fetchWorkspaceFileBlob(workspaceId, path, executionRootId, {
+        download: true,
+        timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
+      });
       triggerBlobDownload(blob, path.split("/").pop() ?? path);
     } catch (err) {
       if (downloadRequestRef.current === requestId) {

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -21,6 +21,7 @@ import type { WorkspaceDirectoryListing, WorkspaceFileEntry } from "../../runtim
 import { useRuntimeStore } from "../../runtime/runtime-store";
 import { useTranslation } from "react-i18next";
 import { parseWorkspaceImageRef, resolveWorkspaceRelativePath, WorkspaceImage } from "../../components/MarkdownContent";
+import { triggerBlobDownload } from "./download";
 
 interface FileBrowserPanelProps {
   workspaceId: string;
@@ -156,7 +157,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const { t } = useTranslation();
   const browseWorkspaceDir = useRuntimeStore((s) => s.browseWorkspaceDir);
   const readWorkspaceFile = useRuntimeStore((s) => s.readWorkspaceFile);
-  const workspaceFileUrl = useRuntimeStore((s) => s.workspaceFileUrl);
+  const fetchWorkspaceFileBlob = useRuntimeStore((s) => s.fetchWorkspaceFileBlob);
 
   const effectiveInitialPath =
     initialPath ?? (initialFilePath ? initialFilePath.split("/").slice(0, -1).join("/") : "");
@@ -166,6 +167,8 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const [error, setError] = useState<string>();
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
   const [showHidden, setShowHidden] = useState(false);
+  const [downloadState, setDownloadState] = useState<{ path: string; loading: boolean; error?: string }>();
+  const downloadRequestRef = useRef(0);
   const autoOpenedRef = useRef(false);
   const contentScrollRef = useRef<HTMLDivElement>(null);
   const [showRendered, setShowRendered] = useState(true);
@@ -290,6 +293,31 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
         loading: false,
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+  };
+
+  const downloadSelectedFile = async () => {
+    if (!selectedFile?.path) return;
+    const path = selectedFile.path;
+    const requestId = ++downloadRequestRef.current;
+    setDownloadState({ path, loading: true });
+    try {
+      const blob = await fetchWorkspaceFileBlob(workspaceId, path, executionRootId, { download: true });
+      triggerBlobDownload(blob, path.split("/").pop() ?? path);
+    } catch (err) {
+      if (downloadRequestRef.current === requestId) {
+        setDownloadState({
+          path,
+          loading: false,
+          error: t("fileBrowser.downloadFailed", {
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        });
+      }
+      return;
+    }
+    if (downloadRequestRef.current === requestId) {
+      setDownloadState({ path, loading: false });
     }
   };
 
@@ -475,16 +503,26 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
               )}
             </>
           ) : (
-            <p className="inspector-muted">
-              Binary file ({selectedFile.mimeType ?? "unknown type"}).
-              {" "}
-              <a
-                href={workspaceFileUrl(workspaceId, selectedFile.path, true, executionRootId)}
-                download
-              >
-                Download
-              </a>
-            </p>
+            <div>
+              <p className="inspector-muted">
+                {selectedFile.mimeType
+                  ? t("fileBrowser.binaryFile", { type: selectedFile.mimeType })
+                  : t("fileBrowser.binaryFileUnknown")}
+                {" "}
+                <button
+                  type="button"
+                  disabled={downloadState?.path === selectedFile.path && downloadState.loading}
+                  onClick={() => void downloadSelectedFile()}
+                >
+                  {downloadState?.path === selectedFile.path && downloadState.loading
+                    ? t("fileBrowser.downloading")
+                    : t("fileBrowser.download")}
+                </button>
+              </p>
+              {downloadState?.path === selectedFile.path && downloadState.error ? (
+                <p className="inspector-error">{downloadState.error}</p>
+              ) : null}
+            </div>
           )}
         </div>
       ) : null}

--- a/web-gui/app/src/features/right-panel/download.test.ts
+++ b/web-gui/app/src/features/right-panel/download.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { triggerBlobDownload } from "./download";
+
+function downloadEnvironment(click: () => void) {
+  const anchor = {
+    href: "",
+    download: "",
+    click: vi.fn(click),
+    remove: vi.fn(),
+  };
+  const appendChild = vi.fn();
+  const documentRef = {
+    body: { appendChild },
+    createElement: vi.fn(() => anchor),
+  } as unknown as Pick<Document, "body" | "createElement">;
+  const urlRef = {
+    createObjectURL: vi.fn(() => "blob:download"),
+    revokeObjectURL: vi.fn(),
+  };
+
+  return { anchor, appendChild, documentRef, urlRef };
+}
+
+describe("triggerBlobDownload", () => {
+  it("clicks a temporary object URL anchor with the requested filename", () => {
+    const environment = downloadEnvironment(() => undefined);
+    const blob = new Blob(["report"]);
+
+    triggerBlobDownload(blob, "report.bin", environment.documentRef, environment.urlRef);
+
+    expect(environment.urlRef.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(environment.anchor.href).toBe("blob:download");
+    expect(environment.anchor.download).toBe("report.bin");
+    expect(environment.appendChild).toHaveBeenCalledWith(environment.anchor);
+    expect(environment.anchor.click).toHaveBeenCalledOnce();
+    expect(environment.anchor.remove).toHaveBeenCalledOnce();
+    expect(environment.urlRef.revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+
+  it("cleans up the anchor and object URL when clicking fails", () => {
+    const environment = downloadEnvironment(() => {
+      throw new Error("click failed");
+    });
+
+    expect(() =>
+      triggerBlobDownload(new Blob(["report"]), "report.bin", environment.documentRef, environment.urlRef)
+    ).toThrow("click failed");
+    expect(environment.anchor.remove).toHaveBeenCalledOnce();
+    expect(environment.urlRef.revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+});

--- a/web-gui/app/src/features/right-panel/download.ts
+++ b/web-gui/app/src/features/right-panel/download.ts
@@ -1,0 +1,19 @@
+export function triggerBlobDownload(
+  blob: Blob,
+  filename: string,
+  documentRef: Pick<Document, "body" | "createElement"> = document,
+  urlRef: Pick<typeof URL, "createObjectURL" | "revokeObjectURL"> = URL,
+): void {
+  const objectUrl = urlRef.createObjectURL(blob);
+  const anchor = documentRef.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+
+  try {
+    documentRef.body.appendChild(anchor);
+    anchor.click();
+  } finally {
+    anchor.remove();
+    urlRef.revokeObjectURL(objectUrl);
+  }
+}

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -622,6 +622,8 @@ const en = {
     binaryFile: "Binary file ({{type}}).",
     binaryFileUnknown: "Binary file (unknown type).",
     download: "Download",
+    downloading: "Downloading…",
+    downloadFailed: "Download failed: {{error}}",
     openInFileBrowser: "Open in file browser",
     markdownView: "Markdown view mode",
     pathBreadcrumb: "Path breadcrumb",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -624,6 +624,8 @@ const zh: Record<string, any> = {
     binaryFile: "二进制文件（{{type}}）。",
     binaryFileUnknown: "二进制文件（未知类型）。",
     download: "下载",
+    downloading: "下载中…",
+    downloadFailed: "下载失败：{{error}}",
     openInFileBrowser: "在文件浏览器中打开",
     markdownView: "Markdown 查看模式",
     pathBreadcrumb: "路径面包屑导航",

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createRuntimeClient, projectModelOptions } from "./client";
 
@@ -248,6 +248,41 @@ describe("createRuntimeClient", () => {
         accept: "*/*",
       },
     ]);
+  });
+
+  it("honors a custom workspace file blob timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const request: { signal?: AbortSignal } = {};
+      const fetchImpl = async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        request.signal = init?.signal instanceof AbortSignal ? init.signal : undefined;
+        return await new Promise<Response>((_resolve, reject) => {
+          request.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        });
+      };
+      const client = createRuntimeClient({
+        mode: "remote",
+        baseUrl: "http://example.test:7878",
+        token: "secret-token",
+        fetchImpl: fetchImpl as typeof fetch,
+      });
+
+      const blobRequest = client.fetchWorkspaceFileBlob("workspace", "large.bin", undefined, {
+        download: true,
+        timeoutMs: 60_000,
+      });
+      const rejection = expect(blobRequest).rejects.toThrow("aborted");
+
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(request.signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(request.signal?.aborted).toBe(true);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("sends generic file attachments in operator prompts", async () => {

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -233,12 +233,17 @@ describe("createRuntimeClient", () => {
       fetchImpl: fetchImpl as typeof fetch,
     });
 
-    const blob = await client.fetchWorkspaceFileBlob("ws/one", "outputs/chart 1.png", "root:ws");
+    const blob = await client.fetchWorkspaceFileBlob(
+      "ws/one",
+      "outputs/chart 1.png",
+      "root:ws",
+      { download: true },
+    );
 
     expect(blob.type).toBe("image/png");
     expect(seen).toEqual([
       {
-        url: "http://example.test:7878/api/workspaces/ws%2Fone/files/outputs/chart%201.png?execution_root_id=root%3Aws",
+        url: "http://example.test:7878/api/workspaces/ws%2Fone/files/outputs/chart%201.png?download=true&execution_root_id=root%3Aws",
         authorization: "Bearer secret-token",
         accept: "*/*",
       },

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1178,26 +1178,26 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         content: response.content,
       };
     },
-    async fetchWorkspaceFileBlob(workspaceId: string, path: string, executionRootId?: string): Promise<Blob> {
+    async fetchWorkspaceFileBlob(
+      workspaceId: string,
+      path: string,
+      executionRootId?: string,
+      options?: { download?: boolean },
+    ): Promise<Blob> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
       const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-      const query = executionRootId ? `?execution_root_id=${encodeURIComponent(executionRootId)}` : "";
+      const params = new URLSearchParams();
+      if (options?.download) params.set("download", "true");
+      if (executionRootId) params.set("execution_root_id", executionRootId);
+      const query = params.toString();
       return getBlob(
         fetchImpl,
         baseUrl,
-        `/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}${query}`,
+        `/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}${query ? `?${query}` : ""}`,
         { headers: requestHeaders },
       );
-    },
-    workspaceFileUrl(workspaceId: string, path: string, download?: boolean, executionRootId?: string): string {
-      const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-      const params = new URLSearchParams();
-      if (download) params.set("download", "true");
-      if (executionRootId) params.set("execution_root_id", executionRootId);
-      const query = params.toString();
-      return `${baseUrl}/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}${query ? `?${query}` : ""}`;
     },
   };
 }

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1182,7 +1182,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       workspaceId: string,
       path: string,
       executionRootId?: string,
-      options?: { download?: boolean },
+      options?: { download?: boolean; timeoutMs?: number },
     ): Promise<Blob> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
@@ -1196,7 +1196,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         fetchImpl,
         baseUrl,
         `/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}${query ? `?${query}` : ""}`,
-        { headers: requestHeaders },
+        { headers: requestHeaders, timeoutMs: options?.timeoutMs },
       );
     },
   };

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -279,9 +279,13 @@ export interface RuntimeStoreState {
   showFileBrowser: (agentId: string, workspaceId: string, initialPath?: string, executionRootId?: string, initialFilePath?: string) => void;
   browseWorkspaceDir: (workspaceId: string, path?: string, executionRootId?: string) => Promise<WorkspaceDirectoryListing>;
   readWorkspaceFile: (workspaceId: string, path: string, executionRootId?: string) => Promise<WorkspaceFileContent>;
-  fetchWorkspaceFileBlob: (workspaceId: string, path: string, executionRootId?: string) => Promise<Blob>;
+  fetchWorkspaceFileBlob: (
+    workspaceId: string,
+    path: string,
+    executionRootId?: string,
+    options?: { download?: boolean },
+  ) => Promise<Blob>;
   navigateBack: () => void;
-  workspaceFileUrl: (workspaceId: string, path: string, download?: boolean, executionRootId?: string) => string;
   toggleRightPanel: () => void;
   toggleNavCollapsed: () => void;
   setRuntimeConnection: (config: RuntimeConnectionConfig) => Promise<void>;
@@ -925,8 +929,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }),
   browseWorkspaceDir: (workspaceId, path, executionRootId) => runtimeClient.browseWorkspaceDir(workspaceId, path, executionRootId),
   readWorkspaceFile: (workspaceId, path, executionRootId) => runtimeClient.readWorkspaceFile(workspaceId, path, executionRootId),
-  fetchWorkspaceFileBlob: (workspaceId, path, executionRootId) => runtimeClient.fetchWorkspaceFileBlob(workspaceId, path, executionRootId),
-  workspaceFileUrl: (workspaceId, path, download, executionRootId) => runtimeClient.workspaceFileUrl(workspaceId, path, download, executionRootId),
+  fetchWorkspaceFileBlob: (workspaceId, path, executionRootId, options) =>
+    runtimeClient.fetchWorkspaceFileBlob(workspaceId, path, executionRootId, options),
   inspectActivity: (agentId, activity) => {
     // Use relatedStateObjectRef as fallback for task/work_item navigation,
     // since their child activities (status_updated, result_received, etc.)

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -283,7 +283,7 @@ export interface RuntimeStoreState {
     workspaceId: string,
     path: string,
     executionRootId?: string,
-    options?: { download?: boolean },
+    options?: { download?: boolean; timeoutMs?: number },
   ) => Promise<Blob>;
   navigateBack: () => void;
   toggleRightPanel: () => void;


### PR DESCRIPTION
## Summary

- route file-browser downloads through the existing authenticated `RuntimeClient` blob fetch path
- trigger browser saves from a temporary object URL without placing the control token in URLs or persistent DOM
- show downloading and retryable error states for binary files
- preserve encoded workspace paths and optional `execution_root_id`, and add focused regression coverage

## Verification

- `npm test -- src/features/right-panel/download.test.ts src/runtime/client.test.ts` (21 tests passed)
- `npm run build` (typecheck and production build passed; existing Vite large-chunk warning remains)
- `git diff --check origin/main...HEAD`

## Known baseline failure

- The full `npm test` run currently has one unrelated failure in `src/runtime/session-reducer.test.ts`: `projects ViewImage tools with image context instead of duration-only summaries` (159 other tests passed). This change does not touch that reducer or its fixtures.
