### PR TITLE
fix: use full prompt budget for continuations

### DIFF
--- a/docs/rfcs/turn-based-context-projection.md
+++ b/docs/rfcs/turn-based-context-projection.md
@@ -384,6 +384,14 @@ would allocate `64000` estimated tokens to turn projection after applying the
 ceiling. For a small fallback model or an unresolved default policy, the floor
 keeps recent semantic turns from collapsing below `4096` estimated tokens.
 
+This bounded budget applies only to the cross-turn `recent_turns` region in the
+initial context projection. It is not the budget for a complete provider
+request. Turn-local continuation projection uses the model's resolved
+`prompt_budget_estimated_tokens` as the complete request budget, then deducts
+tool overhead and the continuation safety margin before checking retained
+turn-local rounds. Reusing the bounded `recent_turns` budget for continuation
+would incorrectly cap large-context models at the history ceiling.
+
 The budget should be spent by retention priority, continuation-chain
 membership, and semantic turn value, not by physical-turn FIFO order. Current
 input and pinned turn anchors are mandatory and may borrow from the free pool

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -374,6 +374,10 @@ impl BaselineOverBudgetProbeProvider {
     }
 }
 
+pub(crate) struct LargeBudgetContinuationProbeProvider {
+    pub(crate) calls: Mutex<usize>,
+}
+
 pub(crate) struct ContextLengthExceededProvider;
 
 pub(crate) struct DeferredFallbackProvider;
@@ -688,6 +692,46 @@ impl AgentProvider for BaselineOverBudgetProbeProvider {
                 request_diagnostics: None,
             }),
             _ => panic!("continuation request should not be sent after baseline-over-budget"),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentProvider for LargeBudgetContinuationProbeProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        match *calls {
+            1 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::ToolUse {
+                    id: "exec-large-budget-continuation".into(),
+                    name: "ExecCommand".into(),
+                    input: serde_json::json!({
+                        "cmd": "printf 'large-budget-continuation'"
+                    }),
+                    kind: crate::provider::ModelToolCallKind::Function,
+                }],
+                stop_reason: Some("tool_use".into()),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
+                request_diagnostics: None,
+            }),
+            2 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text {
+                    text: "Finished within the resolved model prompt budget.".into(),
+                }],
+                stop_reason: Some("end_turn".into()),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
+                request_diagnostics: None,
+            }),
+            _ => panic!("large-budget continuation should finish on the second provider call"),
         }
     }
 }

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -876,6 +876,73 @@ async fn turn_local_compaction_fails_fast_when_baseline_exceeds_budget() {
 }
 
 #[tokio::test]
+async fn turn_local_continuation_uses_full_prompt_budget_above_history_ceiling() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(LargeBudgetContinuationProbeProvider {
+        calls: Mutex::new(0),
+    });
+    let available_tools = crate::tool::ToolRegistry::new(workspace.path().to_path_buf())
+        .tool_specs_with_families()
+        .unwrap()
+        .into_iter()
+        .filter(|(family, _)| {
+            AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
+        })
+        .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
+        .map(|(_, tool)| tool)
+        .collect::<Vec<_>>();
+    let prompt_budget_estimated_tokens = turn::estimate_tool_specs_tokens(&available_tools)
+        + turn::CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS
+        + 70_000;
+    let context_config = ContextConfig {
+        prompt_budget_estimated_tokens,
+        turn_projection_budget_ratio: 1.0,
+        turn_projection_min_budget: 0,
+        turn_projection_max_budget: 64_000,
+        callback_base_url: String::new(),
+        ..context_config()
+    };
+    assert_eq!(context_config.turn_projection_budget(), 64_000);
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config,
+    )
+    .unwrap();
+    let mut prompt = test_effective_prompt();
+    prompt.rendered_system_prompt = "system ".repeat(36_000);
+
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            prompt,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*provider.calls.lock().await, 2);
+    assert_eq!(outcome.terminal_kind, TurnTerminalKind::Completed);
+    assert!(outcome
+        .final_text
+        .contains("Finished within the resolved model prompt budget."));
+    assert!(runtime
+        .storage()
+        .read_recent_events(20)
+        .unwrap()
+        .iter()
+        .all(|event| event.kind != "turn_local_baseline_over_budget"));
+}
+
+#[tokio::test]
 async fn context_length_exceeded_turn_fails_fast_without_runtime_error() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -800,11 +800,13 @@ impl TurnExecution<'_> {
                 let stale_work_item_reminder = if let Some((work_item, reminder)) =
                     stale_work_item_reminder
                 {
-                    let turn_projection_budget = context_config.turn_projection_budget();
+                    // Continuation reminders are part of the complete provider request, so this
+                    // check uses the model prompt budget rather than the recent-turns sub-budget.
+                    let request_prompt_budget = context_config.prompt_budget_estimated_tokens;
                     if runtime_reminder_fits_baseline(
                         &prompt_frame,
                         &available_tools,
-                        turn_projection_budget,
+                        request_prompt_budget,
                         &reminder,
                     ) {
                         Some((work_item, reminder))
@@ -884,7 +886,9 @@ impl TurnExecution<'_> {
                     &available_tools,
                     &checkpoint_state,
                     checkpoint_request_id,
-                    context_config.turn_projection_budget(),
+                    // Turn-local continuation projection covers the complete provider request.
+                    // The bounded turn projection budget only applies to initial recent_turns.
+                    context_config.prompt_budget_estimated_tokens,
                     context_config.compaction_keep_recent_estimated_tokens,
                     runtime_reminder.as_deref(),
                 ) {

--- a/src/runtime/turn/projection.rs
+++ b/src/runtime/turn/projection.rs
@@ -525,7 +525,7 @@ pub(super) fn build_turn_local_projection(
     available_tools: &[ToolSpec],
     checkpoint_state: &TurnLocalCheckpointState,
     checkpoint_request_id: Option<String>,
-    prompt_budget: usize,
+    request_prompt_budget: usize,
     keep_recent_budget: usize,
 ) -> TurnLocalProjectionOutcome {
     build_turn_local_projection_with_runtime_reminder(
@@ -534,7 +534,7 @@ pub(super) fn build_turn_local_projection(
         available_tools,
         checkpoint_state,
         checkpoint_request_id,
-        prompt_budget,
+        request_prompt_budget,
         keep_recent_budget,
         None,
     )
@@ -546,7 +546,7 @@ pub(super) fn build_turn_local_projection_with_runtime_reminder(
     available_tools: &[ToolSpec],
     checkpoint_state: &TurnLocalCheckpointState,
     checkpoint_request_id: Option<String>,
-    prompt_budget: usize,
+    request_prompt_budget: usize,
     keep_recent_budget: usize,
     runtime_reminder: Option<&str>,
 ) -> TurnLocalProjectionOutcome {
@@ -557,7 +557,7 @@ pub(super) fn build_turn_local_projection_with_runtime_reminder(
     let runtime_reminder_estimated_tokens = runtime_reminder
         .map(estimate_text_tokens)
         .unwrap_or_default();
-    let effective_budget_estimated_tokens = prompt_budget
+    let effective_budget_estimated_tokens = request_prompt_budget
         .saturating_sub(tool_overhead_estimated_tokens)
         .saturating_sub(CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS);
     let estimated_baseline_tokens = system_prompt_estimated_tokens

--- a/src/runtime/turn/reminders.rs
+++ b/src/runtime/turn/reminders.rs
@@ -194,10 +194,10 @@ pub(super) fn truncate_reminder_to_token_budget(reminder: &str, max_tokens: usiz
 pub(super) fn runtime_reminder_fits_baseline(
     prompt_frame: &ProviderPromptFrame,
     available_tools: &[ToolSpec],
-    prompt_budget: usize,
+    request_prompt_budget: usize,
     reminder: &str,
 ) -> bool {
-    let effective_budget_estimated_tokens = prompt_budget
+    let effective_budget_estimated_tokens = request_prompt_budget
         .saturating_sub(estimate_tool_specs_tokens(available_tools))
         .saturating_sub(CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS);
     let baseline_with_reminder = estimate_prompt_frame_tokens(prompt_frame)


### PR DESCRIPTION
## Summary

- keep the bounded `turn_projection_budget()` policy for initial `recent_turns` history
- use the resolved full prompt budget for turn-local continuation reminder preflight and projection
- clarify continuation projector budget naming and document the split budget semantics
- add regressions for large-window continuation requests and the existing history ceiling

## Verification

- `cargo fmt --all -- --check`
- `cargo test turn_local_continuation_uses_full_prompt_budget_above_history_ceiling -- --nocapture`
- `cargo test turn_local_compaction_fails_fast_when_baseline_exceeds_budget -- --nocapture`
- `cargo test turn_projection_budget_applies_ratio_floor_and_ceiling -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

## Deferred

This PR intentionally does not add a retry that re-renders `recent_turns` when the minimum exact round itself exceeds the continuation budget.