### PR TITLE
docs: update for v0.28.0 + v0.29.0 — image generation, XSearch, Web GUI improvements

### DIFF
--- a/docs/website/guides/image-generation.md
+++ b/docs/website/guides/image-generation.md
@@ -1,0 +1,160 @@
+---
+title: Image Generation guide
+summary: Agent tool for generating images from text prompts — model selection, size and format options, output management, and caching.
+order: 47
+---
+
+# Image Generation Guide
+
+`GenerateImage` lets Holon agents create images from text prompts using a
+configured image-generation model. The runtime saves generated images to
+`agent_home/media/generated` and returns durable workspace URIs.
+
+## What GenerateImage does
+
+When an agent calls GenerateImage, the runtime:
+
+1. **Validates the prompt and parameters** — ensures the prompt is non-empty
+   and any optional parameters use supported values.
+2. **Routes to an image-generation model** — uses the configured
+   `image_generation.default` provider/model, or auto-discovers the first
+   configured turn model that supports `image_generation`.
+3. **Saves the image** — writes the generated image bytes under
+   `agent_home/media/generated` with a unique filename.
+4. **Records durable metadata** — computes SHA-256, detects dimensions and
+   MIME type, and returns a `workspace://` URI.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `prompt` | yes | Detailed image-generation prompt |
+| `size` | no | One of `1024x1024`, `1536x1024`, or `1024x1536` |
+| `background` | no | One of `auto`, `transparent`, or `opaque` |
+| `output_format` | no | One of `png`, `jpeg`, or `webp` |
+| `name` | no | Filename stem for the saved image |
+
+## Supported sizes
+
+| Size | Ratio | Typical use |
+|------|-------|-------------|
+| `1024x1024` | 1:1 | Square images, icons, social media posts |
+| `1536x1024` | 3:2 | Landscape, banners, hero images |
+| `1024x1536` | 2:3 | Portrait, posters, mobile screens |
+
+## What GenerateImage returns
+
+Each generated image includes durable metadata:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Stable reference ID (e.g., `img_abc123`) |
+| `uri` | `workspace://` URI for use in markdown and agent messages |
+| `mime` | Media type (e.g., `image/png`) |
+| `byte_count` | File size in bytes |
+| `sha256` | Content hash |
+| `size` | Image dimensions (width × height) when detectable |
+| `created_at` | Generation timestamp |
+
+The result also includes provider/model provenance and the original prompt.
+
+## Image routing
+
+### Explicit configuration
+
+Set a dedicated image-generation model:
+
+```bash
+holon config set image_generation.default "openai/dall-e-3"
+```
+
+When `image_generation.default` is configured, GenerateImage uses that model
+for all image generation requests. Use a model route ref that includes the
+endpoint for unambiguous routing:
+
+```bash
+holon config set image_generation.default "volcengine@image-openai/seedream-4.0"
+```
+
+### Auto-discovery
+
+If `image_generation.default` is not set, the runtime selects the first
+configured turn model that advertises `image_generation` capability. This
+lets agents generate images without dedicated image-generation configuration
+when the active conversation model supports it.
+
+### Fallback provider
+
+When a model does not natively support image generation, `GenerateImage`
+falls back to the first configured image-generation enabled model. This is
+transparent to the agent.
+
+## Supported providers
+
+Image generation is supported through providers whose models advertise the
+`image_generation` capability:
+
+| Provider | Model | Notes |
+|----------|-------|-------|
+| OpenAI | dall-e-3, dall-e-2 | Native image generation |
+| Volcengine | seedream-4.0 | Via Volcengine Ark plan endpoint |
+
+> See [Models reference](/reference/models.md) for the current list of
+> image-generation capable models.
+
+## Volcengine Seedream setup
+
+To use Volcengine's Seedream model for image generation, configure a
+dedicated plan endpoint:
+
+```bash
+holon config set providers.volcengine.endpoints.image-openai.transport openai_chat_completions
+holon config set providers.volcengine.endpoints.image-openai.base_url "https://ark.cn-beijing.volces.com/api/plan/v3"
+holon config set providers.volcengine.plans.image-openai.endpoint image-openai
+```
+
+Then set the image generation default:
+
+```bash
+holon config set image_generation.default "volcengine@image-openai/seedream-4.0"
+```
+
+## Output management
+
+Generated images are saved under `agent_home/media/generated/` with
+timestamped filenames. When a `name` is provided, the filename uses that
+stem; otherwise it defaults to `generated_<timestamp>`.
+
+The returned `workspace://` URI can be used in agent markdown output for
+in-conversation rendering. Images are accessible through the Web GUI file
+browser and workspace file API.
+
+## When agents use GenerateImage
+
+Agents call GenerateImage when a task involves visual creation:
+
+- **Data visualization** — generate charts, diagrams, or infographics from
+  data descriptions.
+- **UI mockups** — create visual representations of interface concepts.
+- **Logo and icon design** — generate branding assets or icons.
+- **Illustration** — create visual aids for documentation or presentations.
+
+The tool is part of the `LocalEnvironment` capability family and is available
+to every agent by default.
+
+## CLI verification
+
+GenerateImage is a model-facing tool; it is not directly callable from the
+CLI. Agents use it through the normal tool-calling mechanism. The image
+generation model routing can be inspected with:
+
+```bash
+holon config get image_generation.default
+```
+
+## See also
+
+- [Model tool schema inventory](/reference/model-tool-schema-inventory.md) — tool registration and stability
+- [Models reference](/reference/models.md) — supported providers and image generation availability
+- [Configuration reference](/reference/configuration.md) — `image_generation.default` and provider setup
+- [Web GUI guide](/guides/web-gui.md) — image generation settings in the browser

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -52,6 +52,12 @@ Select an agent from the Dashboard to open its conversation page:
 - **Input bar** — send operator messages to the selected agent.
 - **Event timeline** — a sidebar timeline of recent events including turns,
   tool executions, and state transitions.
+- **Virtual scrolling** — message lists use virtualized rendering for
+  smooth performance across long conversations without DOM overhead.
+- **Tool execution details** — expand individual tool calls in the message
+  stream to inspect request/response payloads, timing, and metadata.
+  Tool result panels show structured output alongside raw data, making
+  it easier to debug agent behavior.
 
 ### Search
 
@@ -110,6 +116,14 @@ add a skill via the browser, the install runs as a background job (see
 status, and the job state persists in localStorage so you can track it
 across page reloads.
 
+The Skills page also supports **updating** installed skills. A skill that
+has a newer version published in its remote source shows an update button.
+Clicking it queues a catalog update job that fetches the latest version.
+Success and error feedback appears inline after the job completes, and
+update jobs run as background tasks (see [Job API](#job-monitoring)).
+Skill catalog updates also run as jobs, with progress tracked in the job
+list.
+
 For CLI-based skill management, see [Skills Guide](/guides/skills.md).
 
 ### Workspace File Browser
@@ -122,8 +136,16 @@ sidebar when a workspace is attached:
 - **File preview** — Click a file to preview its content in the main
   panel. Text files render inline with syntax highlighting; binary and
   image files display metadata and a download link.
+- **Image rendering** — Image files render inline in the preview panel
+  and in conversation messages via `workspace://` URIs. Supported formats
+  include PNG, JPEG, GIF, and WebP.
 - **Resizable panels** — Drag the divider between the file tree and
   content panel to adjust the layout.
+- **Drag-and-drop attachments** — Drag files from the file browser or
+  your desktop into the agent input bar to attach them as operator
+  messages. Images and text files are attached inline; other file types
+  appear as metadata references. A drop hint appears when dragging
+  files over the conversation area.
 - **Dedicated file viewer page** — Open files in a full-page viewer for
   a larger reading surface, accessible via the file tree context menu.
 
@@ -155,7 +177,8 @@ The Web GUI includes several navigation and usability enhancements:
 Configure Holon from the browser:
 
 - **Model settings** — view and change the default model, override per-agent
-  models, and set reasoning effort.
+  models, and set reasoning effort. The fallback model list uses a chip
+  component with drag-to-reorder support for easy priority adjustment.
 - **API keys** — add or update provider credentials (API keys) through the
   credential store without editing JSON files. The settings page
   automatically determines the right credential method for each provider
@@ -165,6 +188,10 @@ Configure Holon from the browser:
   English (EN) and Simplified Chinese (ZH-CN). All UI text — navigation,
   buttons, labels, and status messages — updates in real time without a
   page reload.
+- **Image generation** — configure the default image-generation model
+  (`image_generation.default`) directly from the Settings page. The
+  model selector shows only models that support image generation
+  capability.
 - **Runtime configuration** — view the current execution environment,
   attached workspaces, and policy snapshot.
 
@@ -176,6 +203,9 @@ Chinese. All interface text — including navigation items, button labels, form
 hints, status messages, and error pages — translates instantly on selection.
 Translation resources are compiled into the embedded build alongside the UI
 assets, so no external files or network access are required.
+
+The Settings page also includes a **search provider** section for configuring
+web search and native search providers through the browser.
 
 ### UI Icons
 

--- a/docs/website/guides/webfetch-websearch.md
+++ b/docs/website/guides/webfetch-websearch.md
@@ -72,7 +72,7 @@ structured results with citations.
 
 ### Search providers
 
-Holon uses a provider-based search model:
+Holon uses a provider-based search model with multiple provider options:
 
 - **DuckDuckGo (managed)** — Holon's built-in managed search provider. No
   API key required. Enabled during onboarding with "Managed DuckDuckGo" or
@@ -86,6 +86,13 @@ Holon uses a provider-based search model:
 - **Model-native search** — Some model providers (OpenAI, Anthropic) support
   native web search through their own APIs. In "Auto" mode, Holon prefers
   these when available.
+- **Bing Web Search** — Microsoft Bing Web Search API. Requires an API key
+  set via credential profile. Configure with
+  `holon config set providers bing --kind bing --credential-profile <profile>`.
+
+Search results from all providers are standardized into a consistent format
+with title, URL, and snippet text. Citations are preserved so agents can
+follow up with `WebFetch` for full page content.
 
 Search configuration is part of onboarding and can be changed later with
 `holon config set`.
@@ -133,6 +140,72 @@ patterns:
 
 The runtime exposes both tools in the model-facing tool schema, and the agent
 selects them through normal tool-calling when the task requires web access.
+
+## XSearch
+
+`XSearch` searches public X (Twitter) posts using xAI's hosted `x_search`
+endpoint. It operates as an isolated provider request — independent of the
+main conversation model — and returns durable text with citations.
+
+### When to use XSearch
+
+Use XSearch for X-specific content, accounts, or discussions. Use `WebSearch`
+for the general web.
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | yes | Search query string |
+| `allowed_x_handles` | no | Restrict results to these X handles (max 10, without `@`) |
+| `excluded_x_handles` | no | Exclude results from these X handles (max 10, without `@`) |
+| `from_date` | no | Start date in `YYYY-MM-DD` format |
+| `to_date` | no | End date in `YYYY-MM-DD` format |
+
+### What XSearch returns
+
+| Field | Description |
+|-------|-------------|
+| `text` | Search result text from the model response |
+| `citations` | Structured citations with URL, title, and text position indices |
+| `provider` | Always `xai` |
+| `backend` | Always `x_search` |
+| `model` | xAI model used for the search |
+| `diagnostics` | Provider request ID, latency, and hosted item type counts |
+
+### Prerequisites
+
+XSearch requires:
+
+1. **xAI provider configured** with `openai_responses` transport and
+   valid credentials (OAuth device login through Codex, or API key).
+2. **XSearch enabled** (enabled by default when xAI credentials are
+   available).
+
+To disable XSearch:
+
+```bash
+holon config set x_search.enabled false
+```
+
+### Configuration
+
+XSearch configuration uses these keys:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `x_search.enabled` | boolean | `true` | Enable XSearch when xAI credentials are available |
+| `x_search.model` | model_ref | `grok-4.3` | xAI model route for isolated XSearch requests |
+| `x_search.timeout_seconds` | integer | `60` | Request timeout in seconds |
+
+The default model is `grok-4.3`. XSearch uses the xAI provider's OAuth
+credentials and refreshes tokens only on 401 Unauthorized responses.
+
+### Example usage
+
+```
+XSearch { query: "Holon runtime agent framework", from_date: "2026-01-01" }
+```
 
 ## Configuration
 

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -31,6 +31,8 @@ and description.
 
 | Key | Type | Description |
 |-----|------|-------------|
+| `vision.default` | model_route_ref | Route ref for ViewImage visual observation. Unset auto-discovers an image-capable provider |
+| `image_generation.default` | model_route_ref | Route ref for GenerateImage requests. Unset selects the first turn model that supports image generation |
 | `model.default` | model_route_ref | Default executable route, e.g. `"anthropic@default/claude-sonnet-4-6"` |
 | `model.fallbacks` | model_route_ref_list | Ordered executable fallback routes |
 | `runtime.disable_provider_fallback` | boolean | Disable provider/model fallback; require deterministic single-provider execution |


### PR DESCRIPTION
## Summary

Updates documentation for v0.28.0 and v0.29.0 features.

### New guide

- **image-generation.md** — GenerateImage tool guide covering parameters, model routing, Volcengine Seedream setup, and output management

### Updated guides

- **webfetch-websearch.md** — 
  - Added XSearch section (parameters, prerequisites, configuration, example usage)
  - Added Bing Web Search provider to search providers list
  - Noted standardized search results across providers

- **web-gui.md** — 
  - Virtual scrolling for smooth long-conversation performance
  - Tool execution details (expandable tool call panels with request/response inspection)
  - Skill update UI and feedback (inline update buttons, catalog update jobs)
  - Workspace image rendering and drag-and-drop file attachments
  - Image generation settings in the Settings page
  - Fallback model chip with drag-to-reorder in Settings
  - Native search providers in Settings

### Updated reference

- **configuration.md** — Added `vision.default` and `image_generation.default` config keys to Model & Provider Settings table

### Changes

| File | Status |
|------|--------|
| docs/website/guides/image-generation.md | New |
| docs/website/guides/webfetch-websearch.md | +75/-1 |
| docs/website/guides/web-gui.md | +32/-1 |
| docs/website/reference/configuration.md | +2 |