### PR TITLE
fix: skip empty result briefs for tool-only waits

### DIFF
--- a/docs/rfcs/runtime-object-and-reference-model.md
+++ b/docs/rfcs/runtime-object-and-reference-model.md
@@ -435,6 +435,12 @@ Until then, it remains the correct place for the provider-visible mapping.
 
 ## Brief Rules
 
+An ordinary result brief represents an actual operator-facing delivery and its
+resolved text must not be empty or whitespace-only. A successfully completed
+turn may therefore produce no result brief when it has no operator-facing
+assistant text, such as a tool-only `WaitFor` turn. The turn record and wait
+condition still preserve the terminal and scheduling state in that case.
+
 ### Inline Briefs
 
 An inline brief owns its `text`.

--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -237,6 +237,9 @@ WaitFor {
 Rules:
 
 - `reason` is required and must be non-empty.
+- `reason` is scheduling metadata, not operator-facing assistant text. A
+  tool-only `WaitFor` turn does not promote it into a result brief; waiting
+  state remains authoritative in the wait condition and WorkItem projection.
 - `wake=task_result` requires `resource=<task_id>`.
 - `wake=external` may include `resource=<stable external object>`, such as a
   URL or `github:holon-run/holon#1435`; omitting `resource` means any external

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -110,12 +110,13 @@ impl RuntimeHandle {
                 outcome.final_text_source_assistant_round_id.as_deref(),
             );
             self.persist_brief(&brief).await?;
-        } else {
+        } else if !outcome.final_text.trim().is_empty() {
             // Always generate the normal result brief (no longer suppressed for
             // promoted completion reports). The same turn supports multiple briefs,
             // and the normal brief and promoted completion reports serve different
-            // purposes — the former records the turn-level result, the latter records
-            // the work-item-level completion.
+            // purposes — the former records the turn-level operator delivery, the
+            // latter records the work-item-level completion. A tool-only waiting turn
+            // has no operator delivery, so it must not create an empty result brief.
             let mut brief =
                 brief::make_result(&message.agent_id, message, outcome.final_text.clone());
             brief.turn_index = Some(outcome.turn_index);

--- a/tests/runtime_waiting_and_reactivation.rs
+++ b/tests/runtime_waiting_and_reactivation.rs
@@ -20,6 +20,8 @@ fn policy_blocks_mismatched_origin() {
 }
 
 runtime_async_tests!(
+    tool_only_wait_for_persists_turn_without_result_brief,
+    wait_for_with_assistant_text_persists_result_brief,
     turn_execution_boundary_persists_queue_transcript_and_briefs,
     message_processing_creates_briefs_and_sleeps,
     terminal_brief_uses_last_assistant_message_without_terminal_delivery_round,

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -34,7 +34,7 @@ use holon::{
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority,
         QueueEntryStatus, TaskStatus, TodoItem, TodoItemState, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, WaitingReason, WorkItemState,
+        TranscriptEntryKind, TurnTerminalKind, WaitConditionKind, WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;
@@ -62,6 +62,187 @@ use crate::support::{
 
 // ============================================================================
 // Runtime waiting and reactivation domain test support
+
+struct WaitForDispatchProvider {
+    calls: Mutex<usize>,
+    assistant_text: Option<&'static str>,
+}
+
+impl WaitForDispatchProvider {
+    fn new(assistant_text: Option<&'static str>) -> Self {
+        Self {
+            calls: Mutex::new(0),
+            assistant_text,
+        }
+    }
+
+    async fn calls(&self) -> usize {
+        *self.calls.lock().await
+    }
+}
+
+#[async_trait]
+impl AgentProvider for WaitForDispatchProvider {
+    async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        if *calls > 1 {
+            anyhow::bail!("WaitFor should complete the turn without another provider call");
+        }
+        assert!(
+            request.tools.iter().any(|tool| tool.name == "WaitFor"),
+            "WaitFor must be exposed to the provider tool surface"
+        );
+
+        let mut blocks = Vec::new();
+        if let Some(text) = self.assistant_text {
+            blocks.push(ModelBlock::Text { text: text.into() });
+        }
+        blocks.push(ModelBlock::ToolUse {
+            id: "wait-for-dispatch".into(),
+            name: "WaitFor".into(),
+            input: json!({
+                "reason": "waiting for PR checks",
+                "wake": "external",
+                "resource": "github:holon-run/holon#2237"
+            }),
+            kind: holon::provider::ModelToolCallKind::Function,
+        });
+
+        Ok(ProviderTurnResponse {
+            blocks,
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
+pub async fn tool_only_wait_for_persists_turn_without_result_brief() -> Result<()> {
+    let provider = Arc::new(WaitForDispatchProvider::new(None));
+    let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
+    let runtime = host.default_runtime().await?;
+    let message = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "wait for the checks".into(),
+            },
+        ))
+        .await?;
+
+    wait_until(|| {
+        Ok(runtime
+            .storage()
+            .read_recent_turns(10)?
+            .iter()
+            .any(|turn| turn.input_message_ids.contains(&message.id)))
+    })
+    .await?;
+
+    assert_eq!(provider.calls().await, 1);
+    let waits = runtime
+        .storage()
+        .active_wait_conditions_for_agent("default")?;
+    assert_eq!(waits.len(), 1);
+    assert_eq!(waits[0].kind, WaitConditionKind::External);
+    assert_eq!(waits[0].waiting_for, "waiting for PR checks");
+    assert_eq!(
+        waits[0].subject_ref.as_deref(),
+        Some("github:holon-run/holon#2237")
+    );
+
+    let turns = runtime.storage().read_recent_turns(10)?;
+    let turn = turns
+        .iter()
+        .find(|turn| turn.input_message_ids.contains(&message.id))
+        .expect("tool-only WaitFor turn should be persisted");
+    assert_eq!(
+        turn.terminal.as_ref().map(|terminal| terminal.kind),
+        Some(TurnTerminalKind::Completed)
+    );
+    assert!(turn.produced_brief_ids.is_empty());
+    assert_eq!(turn.waiting_condition_ids, vec![waits[0].id.clone()]);
+
+    let briefs = runtime.storage().read_recent_briefs(10)?;
+    assert!(briefs.iter().all(|brief| {
+        brief.related_message_id.as_deref() != Some(message.id.as_str())
+            || brief.kind != BriefKind::Result
+    }));
+    let events = runtime.recent_events(100).await?;
+    assert!(events.iter().all(|event| {
+        event.kind != "brief_created"
+            || event.data["related_message_id"].as_str() != Some(message.id.as_str())
+    }));
+
+    Ok(())
+}
+
+pub async fn wait_for_with_assistant_text_persists_result_brief() -> Result<()> {
+    const DELIVERY: &str = "Checks are still running; I will wait for an update.";
+
+    let provider = Arc::new(WaitForDispatchProvider::new(Some(DELIVERY)));
+    let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
+    let runtime = host.default_runtime().await?;
+    let message = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "wait for the checks and tell me".into(),
+            },
+        ))
+        .await?;
+
+    wait_until(|| {
+        Ok(runtime
+            .storage()
+            .read_recent_turns(10)?
+            .iter()
+            .any(|turn| turn.input_message_ids.contains(&message.id)))
+    })
+    .await?;
+
+    assert_eq!(provider.calls().await, 1);
+    let waits = runtime
+        .storage()
+        .active_wait_conditions_for_agent("default")?;
+    assert_eq!(waits.len(), 1);
+
+    let briefs = runtime.storage().read_recent_briefs(10)?;
+    let result_briefs = briefs
+        .iter()
+        .filter(|brief| {
+            brief.kind == BriefKind::Result
+                && brief.related_message_id.as_deref() == Some(message.id.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(result_briefs.len(), 1);
+    assert_eq!(result_briefs[0].text, DELIVERY);
+    assert!(result_briefs[0].finalizes_assistant_round_id.is_some());
+
+    let turns = runtime.storage().read_recent_turns(10)?;
+    let turn = turns
+        .iter()
+        .find(|turn| turn.input_message_ids.contains(&message.id))
+        .expect("text plus WaitFor turn should be persisted");
+    assert_eq!(turn.produced_brief_ids, vec![result_briefs[0].id.clone()]);
+    assert_eq!(turn.waiting_condition_ids, vec![waits[0].id.clone()]);
+
+    Ok(())
+}
+
 pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> Result<()> {
     let host = RuntimeHost::new_with_provider(
         test_config(),

--- a/web-gui/app/src/features/agent/timeline-utils.test.ts
+++ b/web-gui/app/src/features/agent/timeline-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentTimelineItem } from "../../runtime/types";
+import { groupTimelineTurns } from "./timeline-utils";
+
+function timelineItem(overrides: Partial<AgentTimelineItem>): AgentTimelineItem {
+  return {
+    id: "event",
+    kind: "system",
+    label: "Event",
+    body: "",
+    timestamp: "2026-07-14T00:00:00Z",
+    meta: "event",
+    minDisplayLevel: "info",
+    sourceIds: [],
+    ...overrides,
+  };
+}
+
+describe("groupTimelineTurns", () => {
+  it("filters a turn boundary with no visible items", () => {
+    const turns = groupTimelineTurns([
+      timelineItem({
+        id: "turn-started",
+        label: "Turn started",
+        body: "Operator input",
+        meta: "turn_started · event #1",
+      }),
+    ]);
+
+    expect(turns).toEqual([]);
+  });
+
+  it("keeps the waiting state without requiring a result brief", () => {
+    const waiting = timelineItem({
+      id: "agent-waiting",
+      label: "Waiting",
+      body: "waiting for PR checks",
+      meta: "agent_waiting · event #2",
+    });
+    const turns = groupTimelineTurns([
+      timelineItem({
+        id: "turn-started",
+        label: "Turn started",
+        body: "Operator input",
+        meta: "turn_started · event #1",
+      }),
+      waiting,
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.items).toEqual([waiting]);
+    expect(turns[0]?.items.some((item) => item.meta.startsWith("brief_created"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- skip ordinary result brief persistence when a successful turn has no operator-facing assistant text
- preserve turn terminal and wait-condition projections for tool-only `WaitFor` turns
- retain normal result briefs when assistant text accompanies `WaitFor`
- document the result-brief and wait-reason contracts and lock Web GUI empty-turn grouping behavior

Closes #2237.

## Verification

- `cargo test --test runtime_waiting_and_reactivation tool_only_wait_for_persists_turn_without_result_brief -- --nocapture`
- `cargo test --test runtime_waiting_and_reactivation wait_for_with_assistant_text_persists_result_brief -- --nocapture`
- `cargo test wait_for_only_tool_round_completes_without_extra_provider_turn -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm test -- src/features/agent/timeline-utils.test.ts` (`web-gui/app`)
- `npm run typecheck` (`web-gui/app`)
