### PR TITLE
feat: add execution root registry for durable worktree file link resolution

### DIFF
--- a/docs/rfcs/workspace-execution-root-registry.md
+++ b/docs/rfcs/workspace-execution-root-registry.md
@@ -1,0 +1,96 @@
+---
+title: RFC: Execution Root Registry
+date: 2026-07-14
+status: draft
+issue:
+  - 2238
+---
+
+# RFC: Execution Root Registry
+
+## Summary
+
+Extend `workspace://` file reference URIs with an optional `?root=`
+query parameter carrying an opaque `execution_root_id`, backed by a durable
+runtime_db registry that maps root IDs to filesystem paths. This lets
+worktree-generated links resolve correctly even after the agent switches to
+a different execution root.
+
+## Motivation
+
+`workspace://<workspace_id>/<relative_path>` URIs only identify the logical
+workspace, not the concrete execution root. When multiple worktrees share
+the same `workspace_id`, a link generated in one worktree resolves against
+the canonical or currently active root — opening the wrong path or failing.
+
+The HTTP file API scanned all agents' `active_workspace_entry` to find a
+matching `execution_root_id`, which is fragile and breaks when agents switch
+roots.
+
+## Design
+
+### URI Format
+
+```
+workspace://<workspace_id>/<relative_path>?root=<execution_root_id>
+```
+
+- `?root=` is **optional**. When absent, resolves to the canonical root
+  (backward compatible with all existing `workspace://` links).
+- When present, the value is percent-encoded and treated as an **opaque
+  lookup key** — the resolver never parses embedded path information.
+- Canonical-root links omit `?root=` and stay backward-compatible.
+
+### Execution Root Registry
+
+New `execution_root_entries` table in runtime_db:
+
+```sql
+CREATE TABLE execution_root_entries (
+  execution_root_id TEXT PRIMARY KEY,
+  workspace_id      TEXT NOT NULL,
+  filesystem_path   TEXT NOT NULL,
+  root_kind         TEXT NOT NULL,
+  created_at        TEXT NOT NULL,
+  removed_at        TEXT,
+  payload_json      TEXT NOT NULL
+);
+```
+
+Lifecycle:
+- **Canonical root**: registered lazily when the agent enters a workspace.
+  `removed_at` is always `None`.
+- **Worktree root**: registered when `enter_workspace` (GitWorktreeRoot) or
+  `enter_existing_git_worktree` is called.
+- **Worktree cleanup**: `exit_worktree` marks `removed_at` (soft-delete).
+- **Resolution**: look up by `execution_root_id`; if `removed_at` is set →
+  HTTP 410 Gone; if not found → 404 Not Found.
+
+### HTTP File API
+
+`resolve_workspace_root` now looks up the registry instead of scanning agent
+state. Accepts both `?root=` and `?execution_root_id=` query parameters.
+
+### Provider Turn Resolver
+
+`resolve_markdown_image_src` parses `?root=` from `workspace://` URIs and
+resolves via `ExecutionSnapshot.execution_roots`, which is populated from
+the registry for the agent's attached workspaces.
+
+## Security Model
+
+- `execution_root_id` is an **opaque lookup key**. The resolver never parses
+  embedded path information from it.
+- Fabricating an ID does not grant filesystem access — the registry must
+  contain a matching entry with a valid, existing path.
+- Only roots registered through the trusted worktree lifecycle are
+  resolvable.
+- Removed worktree roots return 410 Gone, not the path.
+
+## Backward Compatibility
+
+- All existing `workspace://` URIs without `?root=` continue to resolve to
+  the canonical workspace anchor.
+- `ExecutionSnapshot.execution_roots` defaults to empty vec; existing
+  deserialization is unaffected.
+- The HTTP file API `?execution_root_id=` query param continues to work.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7521,6 +7521,7 @@ mod tests {
                 .worktree_session
                 .as_ref()
                 .map(|worktree| worktree.worktree_path.clone()),
+            execution_roots: Vec::new(),
         }
     }
 

--- a/src/http/workspace_files.rs
+++ b/src/http/workspace_files.rs
@@ -13,6 +13,8 @@ pub(crate) struct FileQueryParams {
     #[serde(default)]
     execution_root_id: Option<String>,
     #[serde(default)]
+    root: Option<String>,
+    #[serde(default)]
     download: Option<bool>,
     #[serde(default)]
     meta: Option<bool>,
@@ -62,7 +64,7 @@ struct FileContent {
 async fn resolve_workspace_root(
     state: &AppState,
     workspace_id: &str,
-    execution_root_id: Option<&str>,
+    root_id: Option<&str>,
 ) -> Result<PathBuf, (StatusCode, Json<Value>)> {
     let entries = state.host.workspace_entries().map_err(error_response)?;
     let workspace = entries
@@ -71,38 +73,40 @@ async fn resolve_workspace_root(
         .ok_or_else(|| not_found(format!("workspace '{workspace_id}' not found")))?;
 
     // Resolve the filesystem root from server-side state, never from the
-    // client-provided execution_root_id string. The execution_root_id is
-    // treated as an opaque server-issued token.
-    let root = match execution_root_id {
-        // No execution_root_id: use the workspace anchor from the registry.
+    // client-provided root_id string. The root_id is treated as an opaque
+    // server-issued token.
+    let root = match root_id {
+        // No root_id: use the workspace anchor from the registry.
         None => workspace.workspace_anchor.clone(),
         // canonical_root:{workspace_id} also resolves to the anchor. The
         // path comes from the server-side registry, not the client string.
         Some(id) if id.starts_with("canonical_root:") => workspace.workspace_anchor.clone(),
-        // For git_worktree_root and any other format, look up the
-        // execution_root_id in active workspace entries stored in agent
-        // state. The embedded path in the ID is never trusted or parsed.
+        // For git_worktree_root and any other format, look up the root_id
+        // in the execution root registry (runtime_db). The embedded path
+        // in the ID is never trusted or parsed.
         Some(id) => {
-            let agents = state.host.list_agents().await.map_err(error_response)?;
-            let matched = agents.iter().find_map(|agent| {
-                agent
-                    .agent
-                    .active_workspace_entry
-                    .as_ref()
-                    .filter(|entry| entry.execution_root_id == id)
-            });
-            match matched {
+            let repo = state.host.runtime_db().execution_root_entries();
+            match repo.get(id).map_err(error_response)? {
+                Some(entry) if entry.removed_at.is_some() => {
+                    return Err((
+                        StatusCode::GONE,
+                        Json(json!({
+                            "error": "execution root has been removed",
+                            "execution_root_id": id,
+                        })),
+                    ));
+                }
                 Some(entry) => {
                     if entry.workspace_id != workspace_id {
                         return Err(forbidden(format!(
                             "execution_root_id does not belong to workspace '{workspace_id}'"
                         )));
                     }
-                    entry.execution_root.clone()
+                    entry.filesystem_path
                 }
                 None => {
-                    return Err(bad_request(format!(
-                        "execution_root_id not found in active workspace state: '{id}'"
+                    return Err(not_found(format!(
+                        "execution_root_id not found in registry: '{id}'"
                     )));
                 }
             }
@@ -240,8 +244,12 @@ async fn workspace_files_inner(
 ) -> Result<AxumResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
 
-    let root =
-        resolve_workspace_root(&state, &workspace_id, params.execution_root_id.as_deref()).await?;
+    let root = resolve_workspace_root(
+        &state,
+        &workspace_id,
+        params.root.or(params.execution_root_id).as_deref(),
+    )
+    .await?;
     let full_path = resolve_and_validate_path(&root, &path)?;
 
     let relative = path.trim_start_matches('/');

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1047,6 +1047,7 @@ mod tests {
             projection_kind: Some(crate::system::types::WorkspaceProjectionKind::CanonicalRoot),
             access_mode: Some(crate::system::types::WorkspaceAccessMode::SharedRead),
             worktree_root: None,
+            execution_roots: Vec::new(),
         }
     }
 
@@ -2190,6 +2191,7 @@ mod tests {
                 projection_kind: Some(crate::system::types::WorkspaceProjectionKind::CanonicalRoot),
                 access_mode: Some(crate::system::types::WorkspaceAccessMode::SharedRead),
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             loaded_agents_md: LoadedAgentsMd {
                 user_global_source: None,
@@ -2303,6 +2305,7 @@ mod tests {
                 projection_kind: Some(crate::system::types::WorkspaceProjectionKind::CanonicalRoot),
                 access_mode: Some(crate::system::types::WorkspaceAccessMode::SharedRead),
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             loaded_agents_md: LoadedAgentsMd {
                 user_global_source: None,

--- a/src/prompt/tool_guidance/tool_workspace.md
+++ b/src/prompt/tool_guidance/tool_workspace.md
@@ -2,6 +2,16 @@ Workspace is explicit runtime state, not just a shell directory. The active work
 
 `workspace://<workspace_id>/<relative/path>` is Holon's Markdown/file-reference URI for files inside an attached workspace, including agent-home workspace ids such as `agent_home:<agent_id>`. Treat it as a local workspace reference, not a remote URL. The path is percent-decoded relative to the named workspace root and must not be absolute or escape with `..`. Use this form for durable Markdown references to local media when the runtime, provider lowering, or Web GUI needs to resolve the file with workspace authority/auth instead of relying on unauthenticated HTML file URLs.
 
+When the agent operates in a git worktree (not the canonical workspace root),
+file references may include an optional `?root=<execution_root_id>` query
+parameter: `workspace://<workspace_id>/<path>?root=<execution_root_id>`.
+This parameter is an opaque server-issued token that identifies the specific
+worktree execution root. When absent, the URI resolves to the canonical
+workspace anchor (backward compatible). When present, the resolver looks up
+the root in the runtime's execution root registry — the value is never parsed
+for path information. A future tool that writes to a worktree root should
+include `?root=` by calling `build_execution_root_id` and appending it.
+
 Use UseWorkspace to make the right workspace active when you will inspect, edit, or verify a project over more than a one-off explicit path. Call `UseWorkspace({"path":"/repo/or/subdir"})` when the operator gave you a project path or you need to discover/adopt a directory. Call `UseWorkspace({"workspace_id":"agent_home"})` to return to AgentHome, or `UseWorkspace({"workspace_id":"ws-..."})` to switch to a known workspace id from agent state. Provide exactly one of `path` or `workspace_id`. Use `mode="isolated"` only when you need a runtime-managed isolated execution root, and provide an `isolation_label` as an intent/branch hint rather than inventing a worktree path.
 
 Shell `cd` affects only that shell command process. It does not redefine the active workspace, instruction root, AGENTS.md loading scope, or relative ApplyPatch base. Switching workspaces does not delete files, remove bindings, or clean up retained isolated roots; cleanup is a separate explicit lifecycle action.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1003,12 +1003,30 @@ impl RuntimeHandle {
         workspace: &WorkspaceView,
         attached_workspace_ids: &[String],
     ) -> ExecutionSnapshot {
-        workspace::execution_snapshot_for_view(
+        let mut snapshot = workspace::execution_snapshot_for_view(
             profile,
             workspace,
             attached_workspace_ids,
             &self.inner.storage,
-        )
+        );
+        // Populate execution_roots from the runtime DB registry for all
+        // attached workspaces, so the provider turn resolver can resolve
+        // `?root=` parameters in workspace:// URIs.
+        let repo = self.inner.runtime_db.execution_root_entries();
+        let mut roots = Vec::new();
+        for ws_id in attached_workspace_ids {
+            if let Ok(entries) = repo.active_for_workspace(ws_id) {
+                for entry in entries {
+                    roots.push(crate::system::ExecutionRootRef {
+                        execution_root_id: entry.execution_root_id,
+                        workspace_id: entry.workspace_id,
+                        filesystem_path: entry.filesystem_path,
+                    });
+                }
+            }
+        }
+        snapshot.execution_roots = roots;
+        snapshot
     }
 
     fn workspace_anchor_for_state_ref<'a>(&self, state: &'a AgentState) -> Option<&'a Path> {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -5,9 +5,9 @@ use crate::runtime::closure::{derive_closure_decision, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
     AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
-    ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskRecord, TaskStatus, TokenUsage,
-    WaitingReason, WorkItemState, WorkspaceOccupancyRecord, WorkspaceProjectionMetadata,
-    WorktreeSession,
+    ChildAgentObservabilitySnapshot, ChildAgentPhase, ExecutionRootEntry, TaskRecord, TaskStatus,
+    TokenUsage, WaitingReason, WorkItemState, WorkspaceOccupancyRecord,
+    WorkspaceProjectionMetadata, WorktreeSession,
 };
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {
@@ -1310,6 +1310,22 @@ impl RuntimeHandle {
         let new_occupancy_id = entry.occupancy_id.clone();
         let worktree_cleanup_session = worktree_session.clone();
 
+        // Register the execution root in the durable registry so that
+        // workspace:// URIs with ?root= can resolve even after the agent
+        // switches to a different root.
+        let _ = self
+            .inner
+            .runtime_db
+            .execution_root_entries()
+            .upsert(&ExecutionRootEntry {
+                execution_root_id: execution_root_id.clone(),
+                workspace_id: workspace.workspace_id.clone(),
+                filesystem_path: execution_root.clone(),
+                root_kind: projection_kind,
+                created_at: chrono::Utc::now(),
+                removed_at: None,
+            });
+
         let write_result: Result<()> = async {
             let mut guard = self.inner.agent.lock().await;
             guard.state.active_workspace_entry = Some(entry.clone());
@@ -1433,6 +1449,20 @@ impl RuntimeHandle {
             .as_ref()
             .and_then(|existing_entry| existing_entry.occupancy_id.clone());
         let new_occupancy_id = entry.occupancy_id.clone();
+
+        // Register the execution root in the durable registry.
+        let _ = self
+            .inner
+            .runtime_db
+            .execution_root_entries()
+            .upsert(&ExecutionRootEntry {
+                execution_root_id: execution_root_id.clone(),
+                workspace_id: workspace.workspace_id.clone(),
+                filesystem_path: execution_root.clone(),
+                root_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+                created_at: chrono::Utc::now(),
+                removed_at: None,
+            });
 
         let write_result: Result<()> = async {
             let mut guard = self.inner.agent.lock().await;

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1313,18 +1313,26 @@ impl RuntimeHandle {
         // Register the execution root in the durable registry so that
         // workspace:// URIs with ?root= can resolve even after the agent
         // switches to a different root.
-        let _ = self
-            .inner
-            .runtime_db
-            .execution_root_entries()
-            .upsert(&ExecutionRootEntry {
-                execution_root_id: execution_root_id.clone(),
-                workspace_id: workspace.workspace_id.clone(),
-                filesystem_path: execution_root.clone(),
-                root_kind: projection_kind,
-                created_at: chrono::Utc::now(),
-                removed_at: None,
-            });
+        if let Err(error) =
+            self.inner
+                .runtime_db
+                .execution_root_entries()
+                .upsert(&ExecutionRootEntry {
+                    execution_root_id: execution_root_id.clone(),
+                    workspace_id: workspace.workspace_id.clone(),
+                    filesystem_path: execution_root.clone(),
+                    root_kind: projection_kind,
+                    created_at: chrono::Utc::now(),
+                    removed_at: None,
+                })
+        {
+            tracing::warn!(
+                execution_root_id,
+                workspace_id = %workspace.workspace_id,
+                error = %error,
+                "failed to register execution root"
+            );
+        }
 
         let write_result: Result<()> = async {
             let mut guard = self.inner.agent.lock().await;
@@ -1451,18 +1459,26 @@ impl RuntimeHandle {
         let new_occupancy_id = entry.occupancy_id.clone();
 
         // Register the execution root in the durable registry.
-        let _ = self
-            .inner
-            .runtime_db
-            .execution_root_entries()
-            .upsert(&ExecutionRootEntry {
-                execution_root_id: execution_root_id.clone(),
-                workspace_id: workspace.workspace_id.clone(),
-                filesystem_path: execution_root.clone(),
-                root_kind: WorkspaceProjectionKind::GitWorktreeRoot,
-                created_at: chrono::Utc::now(),
-                removed_at: None,
-            });
+        if let Err(error) =
+            self.inner
+                .runtime_db
+                .execution_root_entries()
+                .upsert(&ExecutionRootEntry {
+                    execution_root_id: execution_root_id.clone(),
+                    workspace_id: workspace.workspace_id.clone(),
+                    filesystem_path: execution_root.clone(),
+                    root_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+                    created_at: chrono::Utc::now(),
+                    removed_at: None,
+                })
+        {
+            tracing::warn!(
+                execution_root_id,
+                workspace_id = %workspace.workspace_id,
+                error = %error,
+                "failed to register execution root"
+            );
+        }
 
         let write_result: Result<()> = async {
             let mut guard = self.inner.agent.lock().await;

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -221,8 +221,20 @@ fn markdown_image_message(
 fn resolve_markdown_image_src(src: &str, execution: &ExecutionSnapshot) -> Option<PathBuf> {
     if let Some(rest) = src.strip_prefix("workspace://") {
         let (workspace_id, relative) = rest.split_once('/')?;
-        let root = workspace_root_for_id(workspace_id, execution)?;
-        return resolve_relative_path(root, relative);
+        // Parse ?root=<execution_root_id> from the relative path.
+        // When absent, resolves to the canonical workspace anchor (backward compatible).
+        let (relative_path, root_param) = split_root_query(relative);
+        let root = if let Some(root_id) = root_param {
+            // Look up the root_id in the execution_roots registry from the snapshot.
+            let root_ref = execution
+                .execution_roots
+                .iter()
+                .find(|r| r.execution_root_id == root_id)?;
+            root_ref.filesystem_path.as_path()
+        } else {
+            workspace_root_for_id(workspace_id, execution)?
+        };
+        return resolve_relative_path(root, relative_path);
     }
     if src.contains("://") {
         return None;
@@ -288,6 +300,19 @@ fn path_is_within(path: &Path, root: &Path) -> bool {
         return canonical.starts_with(canonical_root);
     }
     true
+}
+
+/// Split a `workspace://` relative path into the path portion and the
+/// `?root=` query parameter value. Returns `(path, None)` when no `?root=`
+/// is present (backward compatible with canonical-root links).
+fn split_root_query(relative: &str) -> (&str, Option<String>) {
+    if let Some(idx) = relative.find("?root=") {
+        let path = &relative[..idx];
+        let root_value = percent_decode_path(&relative[idx + 6..]);
+        (path, Some(root_value))
+    } else {
+        (relative, None)
+    }
 }
 
 fn percent_decode_path(path: &str) -> String {
@@ -362,6 +387,7 @@ mod tests {
     use crate::{
         prompt::{PromptCacheIdentity, PromptSection, PromptStability},
         system::ExecutionProfile,
+        system::ExecutionRootRef,
         system::ExecutionSnapshot,
         types::{
             AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
@@ -545,6 +571,7 @@ mod tests {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             loaded_agents_md: LoadedAgentsMd::default(),
             loaded_agent_memory: LoadedAgentMemory::default(),
@@ -594,6 +621,7 @@ mod tests {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             loaded_agents_md: LoadedAgentsMd::default(),
             loaded_agent_memory: LoadedAgentMemory::default(),
@@ -725,5 +753,65 @@ mod tests {
         );
         assert_eq!(request.conversation.len(), 2);
         assert_eq!(request.tools.len(), 1);
+    }
+
+    #[test]
+    fn split_root_query_no_param() {
+        let (path, root) = split_root_query("media/generated/image.png");
+        assert_eq!(path, "media/generated/image.png");
+        assert!(root.is_none());
+    }
+
+    #[test]
+    fn split_root_query_with_param() {
+        let (path, root) = split_root_query("media/img.png?root=git_worktree_root:ws_abc:/tmp/wt");
+        assert_eq!(path, "media/img.png");
+        assert_eq!(root.as_deref(), Some("git_worktree_root:ws_abc:/tmp/wt"));
+    }
+
+    #[test]
+    fn split_root_query_url_encoded() {
+        let (path, root) = split_root_query("img.png?root=git%5Fworktree%3Aws");
+        assert_eq!(path, "img.png");
+        assert_eq!(root.as_deref(), Some("git_worktree:ws"));
+    }
+
+    #[test]
+    fn resolve_markdown_image_src_with_root_param() {
+        let mut execution = ExecutionSnapshot {
+            profile: ExecutionProfile::default(),
+            policy: ExecutionProfile::default().policy_snapshot(),
+            attached_workspaces: vec![],
+            workspace_id: Some("ws_abc".into()),
+            workspace_anchor: PathBuf::from("/tmp/canonical"),
+            execution_root: PathBuf::from("/tmp/canonical"),
+            cwd: PathBuf::from("/tmp/canonical"),
+            execution_root_id: Some("canonical_root:ws_abc".into()),
+            projection_kind: Some(crate::system::WorkspaceProjectionKind::CanonicalRoot),
+            access_mode: None,
+            worktree_root: None,
+            execution_roots: vec![ExecutionRootRef {
+                execution_root_id: "git_worktree_root:ws_abc:/tmp/wt".into(),
+                workspace_id: "ws_abc".into(),
+                filesystem_path: PathBuf::from("/tmp/wt"),
+            }],
+        };
+
+        // With ?root=, resolves to the worktree path.
+        let path = resolve_markdown_image_src(
+            "workspace://ws_abc/media/img.png?root=git_worktree_root:ws_abc:/tmp/wt",
+            &execution,
+        );
+        assert_eq!(path, Some(PathBuf::from("/tmp/wt/media/img.png")));
+
+        // Without ?root=, resolves to canonical anchor (backward compatible).
+        let path = resolve_markdown_image_src("workspace://ws_abc/media/img.png", &execution);
+        assert_eq!(path, Some(PathBuf::from("/tmp/canonical/media/img.png")));
+
+        // Unknown root_id -> None.
+        execution.execution_roots.clear();
+        let path =
+            resolve_markdown_image_src("workspace://ws_abc/media/img.png?root=unknown", &execution);
+        assert_eq!(path, None);
     }
 }

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1323,7 +1323,8 @@ fn current_input_summary_extracts_body_from_context_section() {
             execution_root_id: None,
             projection_kind: None,
             access_mode: None,
-            worktree_root: None
+            worktree_root: None,
+            execution_roots: Vec::new(),
         },
         loaded_agents_md: LoadedAgentsMd::default(),
         loaded_agent_memory: LoadedAgentMemory::default(),

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -163,6 +163,7 @@ pub(crate) fn test_effective_prompt() -> EffectivePrompt {
             projection_kind: None,
             access_mode: None,
             worktree_root: None,
+            execution_roots: Vec::new(),
         },
         loaded_agents_md: LoadedAgentsMd::default(),
         loaded_agent_memory: LoadedAgentMemory::default(),

--- a/src/runtime/tests/tui_pipeline_e2e.rs
+++ b/src/runtime/tests/tui_pipeline_e2e.rs
@@ -79,6 +79,7 @@ fn minimal_agent_summary(agent_id: &str) -> AgentSummary {
             projection_kind: None,
             access_mode: None,
             worktree_root: None,
+            execution_roots: Vec::new(),
         },
         active_workspace_occupancy: None::<WorkspaceOccupancyRecord>,
         loaded_agents_md: LoadedAgentsMdView::default(),

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -322,6 +322,7 @@ pub(crate) fn execution_snapshot_for_view(
         },
         access_mode: workspace.access_mode(),
         worktree_root: workspace.worktree_root().map(|path| path.to_path_buf()),
+        execution_roots: Vec::new(),
     }
 }
 

--- a/src/runtime/worktree.rs
+++ b/src/runtime/worktree.rs
@@ -300,12 +300,17 @@ impl RuntimeHandle {
     }
 
     pub async fn exit_worktree(&self, original_cwd: PathBuf, removed: bool) -> Result<()> {
-        let (worktree_session, occupancy_id) = {
+        let (worktree_session, occupancy_id, prev_execution_root_id) = {
             let mut guard = self.inner.agent.lock().await;
             let session = guard.state.worktree_session.take();
             if session.is_none() {
                 return Err(anyhow!("no active managed worktree to exit"));
             }
+            let prev_execution_root_id = guard
+                .state
+                .active_workspace_entry
+                .as_ref()
+                .map(|entry| entry.execution_root_id.clone());
             let occupancy_id = guard
                 .state
                 .active_workspace_entry
@@ -331,8 +336,21 @@ impl RuntimeHandle {
                 });
             }
             guard.persist_state(&self.inner.storage)?;
-            (session, occupancy_id)
+            (session, occupancy_id, prev_execution_root_id)
         };
+        // Soft-delete the worktree execution root entry from the registry
+        // when the worktree was physically removed.
+        if removed {
+            if let Some(root_id) = prev_execution_root_id.as_deref() {
+                if !root_id.starts_with("canonical_root:") {
+                    let _ = self
+                        .inner
+                        .runtime_db
+                        .execution_root_entries()
+                        .mark_removed(root_id);
+                }
+            }
+        }
         if let Some(occupancy_id) = occupancy_id.as_deref() {
             if let Some(bridge) = self.inner.host_bridge.as_ref() {
                 let _ = bridge.release_workspace_occupancy(occupancy_id).await?;

--- a/src/runtime/worktree.rs
+++ b/src/runtime/worktree.rs
@@ -343,11 +343,18 @@ impl RuntimeHandle {
         if removed {
             if let Some(root_id) = prev_execution_root_id.as_deref() {
                 if !root_id.starts_with("canonical_root:") {
-                    let _ = self
+                    if let Err(error) = self
                         .inner
                         .runtime_db
                         .execution_root_entries()
-                        .mark_removed(root_id);
+                        .mark_removed(root_id)
+                    {
+                        tracing::warn!(
+                            execution_root_id = root_id,
+                            error = %error,
+                            "failed to mark execution root as removed"
+                        );
+                    }
                 }
             }
         }

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -11,7 +11,7 @@ use crate::runtime_db::index_outbox::RuntimeIndexChange;
 use crate::runtime_db::EVIDENCE_PREVIEW_LIMIT;
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, DeliverySummaryRecord,
-    MessageEnvelope, ToolExecutionRecord, TranscriptEntry, WorkspaceEntry,
+    ExecutionRootEntry, MessageEnvelope, ToolExecutionRecord, TranscriptEntry, WorkspaceEntry,
     WorkspaceOccupancyRecord,
 };
 
@@ -236,6 +236,37 @@ pub(crate) fn upsert_workspace_occupancy_tx(
             access_mode,
             timestamp(record.acquired_at),
             record.released_at.map(timestamp),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn upsert_execution_root_entry_tx(
+    tx: &Transaction<'_>,
+    record: &ExecutionRootEntry,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let root_kind = enum_string(&record.root_kind)?;
+    tx.execute(
+        "INSERT INTO execution_root_entries (
+            execution_root_id, workspace_id, filesystem_path, root_kind,
+            created_at, removed_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(execution_root_id) DO UPDATE SET
+            workspace_id = excluded.workspace_id,
+            filesystem_path = excluded.filesystem_path,
+            root_kind = excluded.root_kind,
+            created_at = excluded.created_at,
+            removed_at = excluded.removed_at,
+            payload_json = excluded.payload_json",
+        params![
+            record.execution_root_id,
+            record.workspace_id,
+            record.filesystem_path.display().to_string(),
+            root_kind,
+            timestamp(record.created_at),
+            record.removed_at.map(timestamp),
             payload_json,
         ],
     )?;

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -860,6 +860,24 @@ CREATE INDEX IF NOT EXISTS idx_agent_template_remote_source_syncs_status
   ON agent_template_remote_source_syncs(status);
 "#,
     },
+    Migration {
+        version: 24,
+        name: "execution_root_entries",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS execution_root_entries (
+  execution_root_id TEXT PRIMARY KEY,
+  workspace_id       TEXT NOT NULL,
+  filesystem_path    TEXT NOT NULL,
+  root_kind          TEXT NOT NULL,
+  created_at         TEXT NOT NULL,
+  removed_at         TEXT,
+  payload_json       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_execution_root_entries_workspace
+  ON execution_root_entries(workspace_id);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -30,11 +30,12 @@ pub use crate::runtime_db::index_outbox::{
 pub use crate::runtime_db::storage_domain::{ExpectedStorageDomain, StorageDomainSnapshot};
 pub use crate::runtime_db::types::{
     AgentIdentityRepository, AgentStateRepository, AuditEventSink, ContextEpisodeRepository,
-    EvidenceRepository, ExternalTriggerRepository, MessageRepository, OperatorDeliveryRepository,
-    OperatorNotificationRepository, OperatorTransportBindingRepository, QueueEntryRepository,
-    TaskRepository, TimerRepository, TranscriptRepository, TurnRecordRepository,
-    WaitConditionRepository, WorkItemContinuationRepository, WorkItemDelegationRepository,
-    WorkItemRepository, WorkspaceEntryRepository, WorkspaceOccupancyRepository,
+    EvidenceRepository, ExecutionRootEntryRepository, ExternalTriggerRepository, MessageRepository,
+    OperatorDeliveryRepository, OperatorNotificationRepository, OperatorTransportBindingRepository,
+    QueueEntryRepository, TaskRepository, TimerRepository, TranscriptRepository,
+    TurnRecordRepository, WaitConditionRepository, WorkItemContinuationRepository,
+    WorkItemDelegationRepository, WorkItemRepository, WorkspaceEntryRepository,
+    WorkspaceOccupancyRepository,
 };
 #[cfg(test)]
 mod tests;
@@ -243,6 +244,10 @@ impl RuntimeDb {
 
     pub fn workspace_occupancies(&self) -> WorkspaceOccupancyRepository<'_> {
         WorkspaceOccupancyRepository { db: self }
+    }
+
+    pub fn execution_root_entries(&self) -> ExecutionRootEntryRepository<'_> {
+        ExecutionRootEntryRepository { db: self }
     }
 
     pub fn agent_identities(&self) -> AgentIdentityRepository<'_> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -375,6 +375,72 @@ impl WorkspaceOccupancyRepository<'_> {
     }
 }
 
+impl ExecutionRootEntryRepository<'_> {
+    pub fn upsert(&self, record: &ExecutionRootEntry) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_execution_root_entry_tx(tx, record))
+    }
+
+    /// Look up an execution root entry by its `execution_root_id`.
+    pub fn get(&self, execution_root_id: &str) -> Result<Option<ExecutionRootEntry>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM execution_root_entries
+                 WHERE execution_root_id = ?1",
+                [execution_root_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_execution_root_entry_payload(&payload))
+            .transpose()
+    }
+
+    /// Soft-delete: mark an execution root entry as removed.
+    pub fn mark_removed(&self, execution_root_id: &str) -> Result<bool> {
+        let now = crate::runtime_db::migrations::timestamp(Utc::now());
+        let affected = self.db.transaction(|tx| {
+            // Read the current payload, set removed_at, and write it back
+            // so that reads via decode_execution_root_entry_payload see the change.
+            let payload: Option<String> = tx
+                .query_row(
+                    "SELECT payload_json FROM execution_root_entries
+                     WHERE execution_root_id = ?1 AND removed_at IS NULL",
+                    [execution_root_id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            let Some(payload) = payload else {
+                return Ok(0);
+            };
+            let mut json: serde_json::Value = serde_json::from_str(&payload)?;
+            json["removed_at"] = serde_json::Value::String(now.clone());
+            let updated_payload = serde_json::to_string(&json)?;
+            let n = tx.execute(
+                "UPDATE execution_root_entries
+                 SET removed_at = ?1, payload_json = ?2
+                 WHERE execution_root_id = ?3 AND removed_at IS NULL",
+                params![now, updated_payload, execution_root_id],
+            )?;
+            Ok(n)
+        })?;
+        Ok(affected > 0)
+    }
+
+    /// Return all non-removed entries for a workspace.
+    pub fn active_for_workspace(&self, workspace_id: &str) -> Result<Vec<ExecutionRootEntry>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json FROM execution_root_entries
+                 WHERE workspace_id = ?1 AND removed_at IS NULL
+                 ORDER BY created_at ASC",
+        )?;
+        let rows = statement.query_map([workspace_id], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_execution_root_entry_payload(&row?))
+            .collect()
+    }
+}
+
 impl AgentIdentityRepository<'_> {
     pub fn import_legacy(&self, records: Vec<AgentIdentityRecord>) -> Result<()> {
         if self
@@ -3594,6 +3660,10 @@ pub(crate) fn decode_workspace_occupancy_payload(
     payload: &str,
 ) -> Result<WorkspaceOccupancyRecord> {
     serde_json::from_str(payload).context("decoding workspace occupancy payload from runtime db")
+}
+
+pub(crate) fn decode_execution_root_entry_payload(payload: &str) -> Result<ExecutionRootEntry> {
+    serde_json::from_str(payload).context("decoding execution root entry payload from runtime db")
 }
 
 pub(crate) fn decode_agent_identity_payload(payload: &str) -> Result<AgentIdentityRecord> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -18,9 +18,9 @@ use crate::runtime_db::{
 #[cfg(test)]
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, CallbackDeliveryMode,
-    ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus, MessageEnvelope,
-    QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus, ToolExecutionRecord,
-    WorkItemRecord, WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
+    ExecutionRootEntry, ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus,
+    MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus,
+    ToolExecutionRecord, WorkItemRecord, WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 #[cfg(test)]
 use anyhow::{anyhow, bail, Context, Result};
@@ -2236,6 +2236,108 @@ CREATE TABLE working_memory_deltas (
 
         let conn = rusqlite::Connection::open(&db_path)?;
         super::backfill_work_item_recheck_columns(&conn)?;
+        Ok(())
+    }
+
+    #[test]
+    fn execution_root_entry_upsert_and_get() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        std::fs::create_dir_all(db_path.parent().unwrap())?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let repo = db.execution_root_entries();
+
+        let entry = ExecutionRootEntry {
+            execution_root_id: "git_worktree_root:ws_abc:/tmp/wt".into(),
+            workspace_id: "ws_abc".into(),
+            filesystem_path: PathBuf::from("/tmp/wt"),
+            root_kind: crate::system::WorkspaceProjectionKind::GitWorktreeRoot,
+            created_at: Utc::now(),
+            removed_at: None,
+        };
+        repo.upsert(&entry)?;
+
+        let fetched = repo.get("git_worktree_root:ws_abc:/tmp/wt")?.unwrap();
+        assert_eq!(fetched.workspace_id, "ws_abc");
+        assert_eq!(fetched.filesystem_path, PathBuf::from("/tmp/wt"));
+        assert!(fetched.removed_at.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn execution_root_entry_mark_removed() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        std::fs::create_dir_all(db_path.parent().unwrap())?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let repo = db.execution_root_entries();
+
+        let entry = ExecutionRootEntry {
+            execution_root_id: "git_worktree_root:ws_xyz:/tmp/wt2".into(),
+            workspace_id: "ws_xyz".into(),
+            filesystem_path: PathBuf::from("/tmp/wt2"),
+            root_kind: crate::system::WorkspaceProjectionKind::GitWorktreeRoot,
+            created_at: Utc::now(),
+            removed_at: None,
+        };
+        repo.upsert(&entry)?;
+        assert!(repo.mark_removed("git_worktree_root:ws_xyz:/tmp/wt2")?);
+        let fetched = repo.get("git_worktree_root:ws_xyz:/tmp/wt2")?.unwrap();
+        assert!(fetched.removed_at.is_some());
+
+        // Double mark is a no-op.
+        assert!(!repo.mark_removed("git_worktree_root:ws_xyz:/tmp/wt2")?);
+        Ok(())
+    }
+
+    #[test]
+    fn execution_root_entry_active_for_workspace() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        std::fs::create_dir_all(db_path.parent().unwrap())?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let repo = db.execution_root_entries();
+
+        // Two roots for the same workspace
+        for path in ["/tmp/wt_a", "/tmp/wt_b"] {
+            repo.upsert(&ExecutionRootEntry {
+                execution_root_id: format!("git_worktree_root:ws_multi:{}", path),
+                workspace_id: "ws_multi".into(),
+                filesystem_path: PathBuf::from(path),
+                root_kind: crate::system::WorkspaceProjectionKind::GitWorktreeRoot,
+                created_at: Utc::now(),
+                removed_at: None,
+            })?;
+        }
+
+        // One root for a different workspace
+        repo.upsert(&ExecutionRootEntry {
+            execution_root_id: "git_worktree_root:ws_other:/tmp/wt_c".into(),
+            workspace_id: "ws_other".into(),
+            filesystem_path: PathBuf::from("/tmp/wt_c"),
+            root_kind: crate::system::WorkspaceProjectionKind::GitWorktreeRoot,
+            created_at: Utc::now(),
+            removed_at: None,
+        })?;
+
+        // Mark one of ws_multi's roots as removed
+        repo.mark_removed("git_worktree_root:ws_multi:/tmp/wt_a")?;
+
+        let active = repo.active_for_workspace("ws_multi")?;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].filesystem_path, PathBuf::from("/tmp/wt_b"));
+
+        let other = repo.active_for_workspace("ws_other")?;
+        assert_eq!(other.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn execution_root_entry_get_not_found() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        std::fs::create_dir_all(db_path.parent().unwrap())?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let repo = db.execution_root_entries();
+
+        let result = repo.get("nonexistent")?;
+        assert!(result.is_none());
         Ok(())
     }
 }

--- a/src/runtime_db/types.rs
+++ b/src/runtime_db/types.rs
@@ -58,6 +58,10 @@ pub struct WorkspaceOccupancyRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }
 
+pub struct ExecutionRootEntryRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}
+
 pub struct AgentIdentityRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -17,10 +17,10 @@ pub use types::{
     execution_backend_label, execution_guarantee_label, workspace_access_mode_kind_label,
     workspace_access_mode_label, workspace_projection_kind_label, workspace_projection_label,
     CaptureSpec, DirEntry, EditOptions, EffectiveExecution, ExecutionBackendKind,
-    ExecutionGuaranteeLevel, ExecutionPolicySnapshot, ExecutionProfile, ExecutionScopeKind,
-    ExecutionSnapshot, FileContent, FileRead, FileStat, ProcessExecutionCapabilitySnapshot,
-    ProcessPurpose, ProcessRequest, ProcessResult, ProgramInvocation, RemoveOptions,
-    ResourceAuthoritySnapshot, RunningProcessExitStatus, StdioSpec, StopSignal,
-    WorkspaceAccessMode, WorkspaceProjectionKind, WriteOptions,
+    ExecutionGuaranteeLevel, ExecutionPolicySnapshot, ExecutionProfile, ExecutionRootRef,
+    ExecutionScopeKind, ExecutionSnapshot, FileContent, FileRead, FileStat,
+    ProcessExecutionCapabilitySnapshot, ProcessPurpose, ProcessRequest, ProcessResult,
+    ProgramInvocation, RemoveOptions, ResourceAuthoritySnapshot, RunningProcessExitStatus,
+    StdioSpec, StopSignal, WorkspaceAccessMode, WorkspaceProjectionKind, WriteOptions,
 };
 pub use workspace::WorkspaceView;

--- a/src/system/types.rs
+++ b/src/system/types.rs
@@ -185,6 +185,17 @@ pub struct ExecutionSnapshot {
     pub access_mode: Option<WorkspaceAccessMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_root: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub execution_roots: Vec<ExecutionRootRef>,
+}
+
+/// Lightweight reference to an execution root, used by the provider turn
+/// resolver to resolve `?root=` parameters in `workspace://` URIs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionRootRef {
+    pub execution_root_id: String,
+    pub workspace_id: String,
+    pub filesystem_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -207,6 +218,8 @@ struct ExecutionSnapshotSerde {
     pub access_mode: Option<WorkspaceAccessMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_root: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub execution_roots: Vec<ExecutionRootRef>,
 }
 
 impl<'de> Deserialize<'de> for ExecutionSnapshot {
@@ -230,6 +243,7 @@ impl<'de> Deserialize<'de> for ExecutionSnapshot {
             projection_kind: snapshot.projection_kind,
             access_mode: snapshot.access_mode,
             worktree_root: snapshot.worktree_root,
+            execution_roots: snapshot.execution_roots,
         })
     }
 }
@@ -252,6 +266,7 @@ impl EffectiveExecution {
                 .workspace
                 .worktree_root()
                 .map(|path| path.to_path_buf()),
+            execution_roots: Vec::new(),
         }
     }
 }

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -1278,6 +1278,7 @@ mod tests {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             active_workspace_occupancy: None,
             loaded_agents_md: Default::default(),

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -361,6 +361,7 @@ mod tests {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             active_workspace_occupancy: None,
             loaded_agents_md: LoadedAgentsMdView::default(),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -3548,6 +3548,7 @@ mod tests {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             active_workspace_occupancy: None,
             loaded_agents_md: LoadedAgentsMdView::default(),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1143,6 +1143,7 @@ mod tests {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             },
             active_workspace_occupancy: None,
             loaded_agents_md: LoadedAgentsMdView::default(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -270,6 +270,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
             projection_kind: None,
             access_mode: None,
             worktree_root: None,
+            execution_roots: Vec::new(),
         },
         active_workspace_occupancy: None,
         loaded_agents_md: LoadedAgentsMdView::default(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -223,6 +223,20 @@ pub struct WorkspaceOccupancyRecord {
     pub released_at: Option<DateTime<Utc>>,
 }
 
+/// Durable registry entry mapping an `execution_root_id` to its filesystem
+/// path. Independent of any agent's `active_workspace_entry`, so links
+/// remain resolvable after the agent switches roots.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionRootEntry {
+    pub execution_root_id: String,
+    pub workspace_id: String,
+    pub filesystem_path: PathBuf,
+    pub root_kind: WorkspaceProjectionKind,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub removed_at: Option<DateTime<Utc>>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentKind {
@@ -5035,6 +5049,7 @@ impl AgentListEntry {
                 projection_kind: Some(entry.projection_kind),
                 access_mode: Some(entry.access_mode),
                 worktree_root: None,
+                execution_roots: Vec::new(),
             }
         } else {
             ExecutionSnapshot {
@@ -5049,6 +5064,7 @@ impl AgentListEntry {
                 projection_kind: None,
                 access_mode: None,
                 worktree_root: None,
+                execution_roots: Vec::new(),
             }
         };
 

--- a/tests/http_workspace.rs
+++ b/tests/http_workspace.rs
@@ -20,7 +20,7 @@ http_async_tests!(
     workspace_files_reads_text_file,
     workspace_files_path_traversal_rejected,
     workspace_files_symlink_escape_rejected,
-    workspace_files_execution_root_id_rejected,
+    workspace_files_execution_root_id_resolves_registered_root,
     workspace_files_returns_404_for_missing_file,
     workspace_files_metadata_only,
     workspace_files_unknown_workspace_404,

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -81,6 +81,7 @@ fn sample_execution() -> ExecutionSnapshot {
         projection_kind: Some(WorkspaceProjectionKind::CanonicalRoot),
         access_mode: Some(WorkspaceAccessMode::SharedRead),
         worktree_root: None,
+        execution_roots: Vec::new(),
     }
 }
 

--- a/tests/support/http_workspace.rs
+++ b/tests/support/http_workspace.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use anyhow::Result;
+use chrono::Utc;
 use holon::{
     client::{EventStreamRequest, LocalClient},
     config::{AppConfig, ControlAuthMode},
@@ -21,8 +22,8 @@ use holon::{
     types::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
-        ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TodoItem, TodoItemState, WorkItemState,
+        ExecutionRootEntry, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
+        MessageKind, MessageOrigin, OperatorDeliveryStatus, TodoItem, TodoItemState, WorkItemState,
     },
 };
 use reqwest::Client;
@@ -354,22 +355,32 @@ pub async fn workspace_files_symlink_escape_rejected() -> Result<()> {
     Ok(())
 }
 
-pub async fn workspace_files_execution_root_id_rejected() -> Result<()> {
-    let (_host, base, server) = spawn_server().await?;
+pub async fn workspace_files_execution_root_id_resolves_registered_root() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
 
     let workspace_id = "agent_home:default";
+    let execution_root_id = "test-worktree-root";
+    let execution_root = tempdir()?;
+    std::fs::write(execution_root.path().join("from-worktree.txt"), "worktree")?;
+    host.runtime_db()
+        .execution_root_entries()
+        .upsert(&ExecutionRootEntry {
+            execution_root_id: execution_root_id.into(),
+            workspace_id: workspace_id.into(),
+            filesystem_path: execution_root.path().to_path_buf(),
+            root_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+            created_at: Utc::now(),
+            removed_at: None,
+        })?;
+
     let response = client
         .get(format!(
-            "{base}/api/workspaces/{workspace_id}/files?execution_root_id=git_worktree_root:ws-1"
+            "{base}/api/workspaces/{workspace_id}/files/from-worktree.txt?root={execution_root_id}"
         ))
         .send()
         .await?;
-    assert_eq!(
-        response.status(),
-        400,
-        "execution_root_id should return 400 until supported"
-    );
+    assert_eq!(response.status(), 200, "{}", response.text().await?);
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary

Implements Issue #2238: extends the `workspace://` file reference contract with an optional `?root=<execution_root_id>` query parameter, backed by a durable runtime_db registry that maps root IDs to filesystem paths.

## Problem

`workspace://<workspace_id>/<relative_path>` URIs only identify the logical workspace, not the concrete execution root. When multiple worktrees share the same `workspace_id`, a link generated in one worktree resolves against the canonical or currently active root — opening the wrong path or failing.

The HTTP file API scanned all agents' `active_workspace_entry` to find a matching `execution_root_id`, which is fragile and breaks when agents switch roots.

## Changes

### Data Layer
- **New migration (v24)**: `execution_root_entries` table with `execution_root_id`, `workspace_id`, `filesystem_path`, `root_kind`, `created_at`, `removed_at`, `payload_json`
- **`ExecutionRootEntry` type** (`src/types.rs`): durable registry record
- **`ExecutionRootEntryRepository`** (`src/runtime_db/`): `upsert`, `get`, `mark_removed` (soft-delete), `active_for_workspace`

### URI Format Extension
- `workspace://<workspace_id>/<relative_path>?root=<execution_root_id>` — `?root=` is optional and treated as an opaque lookup key
- `split_root_query()` helper parses `?root=` from the URI path
- When `?root=` is absent, resolves to canonical workspace anchor (backward compatible)

### Lifecycle Hooks
- **`enter_workspace`** (CanonicalRoot & GitWorktreeRoot): registers execution root in registry
- **`enter_existing_git_worktree`**: registers execution root in registry
- **`exit_worktree`**: soft-deletes (marks `removed_at`) when worktree is physically removed

### HTTP File API (`src/http/workspace_files.rs`)
- `resolve_workspace_root` now looks up the registry instead of scanning agent state
- Accepts both `?root=` and `?execution_root_id=` query parameters
- Returns `410 Gone` for removed roots, `404 Not Found` for unknown IDs

### Provider Turn Resolver (`src/runtime/provider_turn.rs`)
- `resolve_markdown_image_src` parses `?root=` and resolves via `ExecutionSnapshot.execution_roots`
- Falls back to canonical workspace anchor when `?root=` is absent

### ExecutionSnapshot Extension (`src/system/types.rs`)
- New `execution_roots: Vec<ExecutionRootRef>` field (defaults to empty, `skip_serializing_if`)
- Populated from registry for attached workspaces in `RuntimeHandle::execution_snapshot_for_view`

### Documentation
- RFC: `docs/rfcs/workspace-execution-root-registry.md`
- Updated `src/prompt/tool_guidance/tool_workspace.md` with `?root=` parameter guidance

### Tests
- Registry: upsert/get, mark_removed, active_for_workspace, get_not_found
- URI parsing: split_root_query with/without param, URL-encoded values
- Provider turn: resolve_markdown_image_src with ?root=, backward compatibility, unknown root

## Security Model

- `execution_root_id` is an opaque lookup key — the resolver never parses embedded path information
- Fabricating an ID does not grant filesystem access — the registry must contain a matching entry
- Only roots registered through the trusted worktree lifecycle are resolvable
- Removed worktree roots return 410 Gone, not the path

## Backward Compatibility

- All existing `workspace://` URIs without `?root=` continue to resolve to the canonical workspace anchor
- `ExecutionSnapshot.execution_roots` defaults to empty vec; existing deserialization is unaffected
- HTTP file API `?execution_root_id=` query param continues to work

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test -p holon --lib` (2227 tests) ✅
- `cargo test -p holon --test prompt_context_snapshots` (17 tests) ✅