### PR TITLE
docs: restructure README and docs homepage — TUI + Web parity, onboard-first provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,6 @@ Holon is a **local workbench for agents doing continuous work**.
 
 Holon itself is not an agent. It provides a local working environment for multiple agents. Agents understand goals and drive execution; Holon treats "work" as the core unit, preserving state, organizing context, recording waits and wakes, so tasks that span sessions, commands, human confirmation, or external events can resume at the right time and eventually deliver results back to the operator.
 
-## Table of contents
-
-- [What does Holon provide?](#what-does-holon-provide)
-- [Install](#install)
-- [Provider setup](#provider-setup)
-- [Quickstart](#quickstart)
-- [Core concepts](#core-concepts)
-- [Status and compatibility](#status-and-compatibility)
-- [Project boundaries](#project-boundaries)
-- [Documentation](#documentation)
-- [Build from source](#build-from-source)
-
 ## What does Holon provide?
 
 | Capability | What it means |
@@ -32,9 +20,51 @@ Holon itself is not an agent. It provides a local working environment for multip
 
 > Keep agent work alive in your local workspace.
 
-## Install
+## Quickstart
 
-Install the latest release with Homebrew:
+Holon provides two interaction modes: **TUI** (terminal) and **Web GUI** (browser).
+
+### 1. Install
+
+```bash
+brew tap holon-run/tap && brew install holon
+```
+
+Or download binaries from [GitHub Releases](https://github.com/holon-run/holon/releases/latest).
+
+### 2. Configure a provider
+
+```bash
+holon onboard
+```
+
+This walks through provider credential setup interactively. You can also
+configure providers through the Web GUI **Settings** page after starting the
+daemon. See [Configuration Reference](docs/website/reference/configuration.md)
+and [Web GUI guide](docs/website/guides/web-gui.md) for more.
+
+### 3. Start the daemon
+
+```bash
+holon daemon start
+```
+
+### 4a. TUI (terminal)
+
+```bash
+holon tui
+```
+
+Select an agent and start working. Agents keep running after you disconnect.
+
+### 4b. Web GUI (browser)
+
+Open <http://localhost:7878>. Create an agent and work through a chat interface
+with built-in file browser, task tracking, and more.
+
+For more: [TUI guide](docs/website/guides/tui.md) · [Web GUI guide](docs/website/guides/web-gui.md) · [First agent](docs/website/getting-started/first-agent.md)
+
+## Install
 
 ```bash
 brew tap holon-run/tap
@@ -49,212 +79,56 @@ The examples below assume `holon` is installed on `PATH`.
 
 ## Provider setup
 
-Holon needs a model provider before it can run agents. It mainly supports three
-setup paths:
+Holon needs a model provider before it can run agents. The recommended path is:
 
-- **Local credential storage**: recommended for daily use. Manage API keys
-  through credential profiles, avoiding dependence on environment variables that
-  must be injected before the daemon starts.
-- **Built-in providers**: supports common providers such as Anthropic, OpenAI,
-  DeepSeek, OpenRouter, Qwen, GLM, Xiaomi, Kimi, and MiniMax.
-- **External login / custom providers**: `openai-codex/...` can reuse a local
-  `codex login` session and supports Codex subscriptions. You can also connect
-  custom providers with compatible protocols.
+- **`holon onboard`** — interactive CLI setup that guides you through provider
+  credential configuration without echoing secrets.
+- **Web GUI Settings** — after starting the daemon, open
+  <http://localhost:7878> and configure providers through the Settings page.
 
-For an interactive first run or repair flow, use:
-
-```bash
-holon onboard
-```
-
-In a TTY this guides you through the default provider credential setup without
-echoing the credential material. In scripts, use `holon onboard --json` for the
-secret-safe diagnostic report.
-
-The equivalent manual setup is to save the API key first, then point the
-provider at the corresponding credential profile:
-
-```bash
-printf '%s' "$DEEPSEEK_API_KEY" \
-  | holon config credentials set --kind api_key --stdin deepseek
-
-holon config providers set deepseek \
-  --credential-source credential_profile \
-  --credential-kind api_key \
-  --credential-profile deepseek
-
-holon config set model.default "deepseek@default/deepseek-v4-pro"
-
-# Or use a local Codex login session / Codex subscription
-holon config set model.default "openai-codex@default/gpt-5.5"
-```
-
-Inspect the configured state with:
-
-```bash
-holon onboard
-holon config doctor
-holon config models list
-```
-
-For more about providers, credential profiles, custom providers, and the model
-catalog, see:
-
-- [Configuration Reference](docs/website/reference/configuration.md)
-- [Supported Models](docs/website/reference/models.md)
-
-## Quickstart
-
-### 1. Start the daemon
-
-Start the long-running local runtime first:
-
-```bash
-holon daemon start
-holon daemon status
-```
-
-### 2. Connect the TUI
-
-Connect the TUI:
-
-```bash
-holon tui
-```
-
-### 3. Select or create an agent
-
-Holon automatically provides a default main agent. There are two ways to create
-a new agent:
-
-- Tell the main agent in the TUI and let it create one for you.
-- Or create one through the CLI:
-
-```bash
-holon agent create builder
-holon agent list
-```
-
-After that, select an agent in the TUI and start working. After the TUI
-disconnects, the agent continues running in the daemon.
-
-For more operations, see the [TUI command reference](docs/website/reference/cli.md#terminal-ui)
-and [Daemon management](docs/website/reference/cli.md#daemon-management).
-
-### Remote Web UI access
-
-Browser-based Web UIs that run on another host or port must be allowed by the
-HTTP API CORS configuration. For LAN access, start the daemon on a reachable
-bind address and list the Web UI origin explicitly:
-
-```bash
-holon daemon start --access lan --host 0.0.0.0 --port 7878 --token-file ~/.config/holon/remote.token
-holon config set api.cors.enabled true
-holon config set api.cors.allowed_origins '["http://192.168.1.10:5173"]'
-```
-
-Holon does not enable wildcard browser access by default. If
-`api.cors.allow_credentials` is true, `api.cors.allowed_origins` must list
-specific origins rather than `"*"`.
+Holon supports common providers such as Anthropic, OpenAI, DeepSeek, OpenRouter,
+Qwen, GLM, Xiaomi, Kimi, and MiniMax. For advanced setup including credential
+profiles, custom providers, and Codex subscriptions, see
+[Configuration Reference](docs/website/reference/configuration.md) and
+[Supported Models](docs/website/reference/models.md).
 
 ## Core concepts
 
 Holon breaks agent work into a few explicit runtime objects:
 
-- **Agent** is a long-lived local identity with its own queue, state, history,
-  and working context.
-- **WorkItem** represents a continuously advanceable goal, including a plan,
-  progress, blockers, wait conditions, and a completion report.
-- **Task** represents supervised asynchronous execution, such as a command,
-  background task, or child agent.
-- **WaitFor / wake** lets an agent explicitly declare that it is waiting for a
-  task result, external event, or operator input, and resume when the condition
-  is satisfied.
-- **Workspace / worktree** lets agents execute in local repositories and isolate
-  coding tasks into managed worktrees.
-- **Origin / brief** preserves input origin and trust information while keeping
-  internal execution traces separate from operator-visible delivery.
-
-Together, these concepts solve one problem: agent work should not depend on a
-single chat or terminal connection. It should be observable, resumable,
-waitable, delegable, and deliverable.
+- **Agent** — long-lived local identity with its own queue, state, and working
+  context.
+- **WorkItem** — continuously advanceable goal with a plan, progress, blockers,
+  wait conditions, and a completion report.
+- **Task** — supervised asynchronous execution (command, background task, or
+  child agent).
+- **WaitFor / wake** — explicit declaration of waiting for a task result,
+  external event, or operator input, and resuming when the condition is
+  satisfied.
+- **Workspace / worktree** — execute in local repositories and isolate coding
+  tasks into managed worktrees.
+- **Origin / brief** — preserves input origin and trust information while
+  keeping execution traces separate from operator-visible delivery.
 
 For more detailed explanations, see [Concepts](docs/website/concepts/).
 
-## Current release
-
-The current recommended release is
-[`v0.29.1`](https://github.com/holon-run/holon/releases/tag/v0.29.1).
-
-`v0.15.0` is the baseline release where the Holon Rust runtime enters public
-compatibility maintenance. Starting from this version, the project will maintain
-compatibility for the CLI, daemon/API semantics, and local persistent storage.
-
-See the full changes in the
-[v0.29.1 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.29.1).
-
 ## Status and compatibility
 
-Holon is under active development. Starting from `v0.15.0`, the project treats
-the following surfaces as public contracts that need compatibility maintenance:
-
-- **CLI**: common commands, arguments, and structured output should remain
-  migratable; breaking changes should be documented with release notes and
-  migration paths.
-- **Interfaces**: daemon client APIs, event semantics, and runtime object fields
-  should remain backward compatible or provide clear versioned evolution paths.
-- **Persistent storage**: local data such as agent state, ledgers, messages,
-  transcripts, WorkItems, and tasks should support upgrades and read
-  compatibility.
+Holon is under active development. The current recommended release is
+[`v0.29.1`](https://github.com/holon-run/holon/releases/tag/v0.29.1).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and
 structured delivery.
 
-## Project boundaries
-
-Holon focuses on runtime semantics: agent identity, work continuity, execution
-state, local workspace projection, and operator-visible results.
-
-Adjacent Holon Run projects cover other layers:
-
-- **[AgentInbox](https://github.com/holon-run/agentinbox)** — source hosting,
-  activation, and delivery
-- **[UXC](https://github.com/holon-run/uxc)** — unified capability and tool
-  access
-- **[WebMCP Bridge](https://github.com/holon-run/webmcp-bridge)** — browser and
-  web-app edge access
-
-When used together, AgentInbox delivers external events to wake Holon; Holon
-decides what those events mean inside the runtime.
-
 ## Documentation
 
-Holon's documentation is organized into three layers. See
-[documentation layers](docs/website/concepts/documentation-layers.md).
-
-**Using Holon:**
-
-- [Website docs](https://holon.run) — install, getting started, concepts,
-  guides, and current reference
-- [Security and execution boundaries](docs/website/concepts/security-and-execution-boundaries.md)
-
-**Integrating and operating Holon:**
-
-- [Local operator troubleshooting](docs/local-operator-troubleshooting.md)
+- [Website docs](https://holon.run) — install, getting started, concepts, guides, reference
+- [Documentation layers](docs/website/concepts/documentation-layers.md)
+- [Architecture overview](docs/architecture-overview.md)
+- [RFCs](docs/rfcs/README.md)
+- [Implementation decisions](docs/implementation-decisions/README.md)
 - [Release process](docs/release.md)
-
-**Contributing to the runtime:**
-
-- [Architecture overview](docs/architecture-overview.md) — start here
-- [RFCs](docs/rfcs/README.md) — specification and design contracts
-- [Implementation decisions](docs/implementation-decisions/README.md) — design
-  rationale
-
-## Community
-
-- [GitHub Discussions](https://github.com/holon-run/holon/discussions)
-- [GitHub Issues](https://github.com/holon-run/holon/issues)
 
 ## Build from source
 
@@ -297,6 +171,11 @@ cd benchmark
 npm install
 npm test
 ```
+
+## Community
+
+- [GitHub Discussions](https://github.com/holon-run/holon/discussions)
+- [GitHub Issues](https://github.com/holon-run/holon/issues)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,19 +6,7 @@
 
 Holon 是 **为 Agent 提供持续工作环境的本地工作台**。
 
-Holon 本身不是 Agent，而是为多个 Agent 提供本地工作环境。Agent 负责理解目标并推进执行；Holon 把“工作”作为基本单位，负责保存状态、组织上下文、记录等待与唤醒，让跨会话、跨命令、跨人工确认或外部事件的任务能够在合适的时间恢复，并最终把结果交付给操作者。
-
-## 目录
-
-- [Holon 提供什么？](#holon-提供什么)
-- [安装](#安装)
-- [Provider 配置](#provider-配置)
-- [快速开始](#快速开始)
-- [核心概念](#核心概念)
-- [状态与兼容性](#状态与兼容性)
-- [项目边界](#项目边界)
-- [文档](#文档)
-- [从源码构建](#从源码构建)
+Holon 本身不是 Agent，而是为多个 Agent 提供本地工作环境。Agent 负责理解目标并推进执行；Holon 把"工作"作为基本单位，负责保存状态、组织上下文、记录等待与唤醒，让跨会话、跨命令、跨人工确认或外部事件的任务能够在合适的时间恢复，并最终把结果交付给操作者。
 
 ## Holon 提供什么？
 
@@ -32,9 +20,51 @@ Holon 本身不是 Agent，而是为多个 Agent 提供本地工作环境。Agen
 
 > Keep agent work alive in your local workspace.
 
-## 安装
+## 快速开始
 
-通过 Homebrew 安装最新版本：
+Holon 提供两种交互方式：**TUI**（终端）和 **Web GUI**（浏览器）。
+
+### 1. 安装
+
+```bash
+brew tap holon-run/tap && brew install holon
+```
+
+或从 [GitHub Releases](https://github.com/holon-run/holon/releases/latest) 下载预编译二进制。
+
+### 2. 配置 Provider
+
+```bash
+holon onboard
+```
+
+交互式引导配置 Provider 凭据。也可以在启动 daemon 后通过 Web GUI 的
+**Settings** 页面配置 Provider。详见
+[Configuration Reference](docs/website/reference/configuration.md) 和
+[Web GUI 指南](docs/website/guides/web-gui.md)。
+
+### 3. 启动 daemon
+
+```bash
+holon daemon start
+```
+
+### 4a. TUI（终端）
+
+```bash
+holon tui
+```
+
+选择 Agent 即可开始工作。TUI 断开后 Agent 仍会在 daemon 中继续运行。
+
+### 4b. Web GUI（浏览器）
+
+打开 <http://localhost:7878>，创建 Agent 并通过聊天界面工作，
+内置文件浏览器、任务跟踪等功能。
+
+更多：[TUI 指南](docs/website/guides/tui.md) · [Web GUI 指南](docs/website/guides/web-gui.md) · [首个 Agent](docs/website/getting-started/first-agent.md)
+
+## 安装
 
 ```bash
 brew tap holon-run/tap
@@ -49,171 +79,71 @@ holon --help
 
 ## Provider 配置
 
-Holon 需要配置模型提供商后才能运行 Agent。主要支持三类方式：
+Holon 需要配置模型提供商后才能运行 Agent。推荐方式：
 
-- **本地凭据存储**：推荐日常使用，通过 credential profile 管理 API key，
-  避免依赖 daemon 启动前已经注入的环境变量。
-- **内置 provider**：支持 Anthropic、OpenAI、DeepSeek、OpenRouter、Qwen、
-  GLM、Xiaomi、Kimi、MiniMax 等常见 provider。
-- **外部登录 / 自定义 provider**：`openai-codex/...` 可复用本地 `codex login`
-  会话，支持 Codex 订阅；也可以接入兼容协议的自定义 provider。
+- **`holon onboard`** — 交互式 CLI 引导，安全配置 Provider 凭据，不会回显密钥。
+- **Web GUI Settings** — 启动 daemon 后打开 <http://localhost:7878>，
+  通过 Settings 页面配置 Provider。
 
-推荐的本地配置方式是先保存 API key，再把 provider 指向对应的 credential profile：
-
-```bash
-printf '%s' "$DEEPSEEK_API_KEY" \
-  | holon config credentials set --kind api_key --stdin deepseek
-
-holon config providers set deepseek \
-  --credential-source credential_profile \
-  --credential-kind api_key \
-  --credential-profile deepseek
-
-holon config set model.default "deepseek/deepseek-v4-pro"
-
-# 或使用本地 Codex 登录会话 / Codex 订阅
-holon config set model.default "openai-codex/gpt-5.5"
-```
-
-检查配置状态：
-
-```bash
-holon config doctor
-holon config models list
-```
-
-更多 provider、credential profile、自定义 provider 和模型目录，请看：
-
-- [Configuration Reference](docs/website/reference/configuration.md)
-- [Supported Models](docs/website/reference/models.md)
-
-## 快速开始
-
-### 1. 启动 daemon
-
-先启动本地常驻运行时：
-
-```bash
-holon daemon start
-holon daemon status
-```
-
-### 2. 连接 TUI
-
-连接 TUI：
-
-```bash
-holon tui
-```
-
-### 3. 选择或创建 Agent
-
-Holon 会自动提供默认的 main Agent。创建新 Agent 有两种方式：
-
-- 在 TUI 中告诉 main Agent，让它为你创建。
-- 也可以通过 CLI 创建：
-
-```bash
-holon agent create builder --template holon-developer
-holon agent list
-```
-
-之后在 TUI 中选择 Agent 开始工作即可。TUI 断开后，Agent 仍会在 daemon
-中继续运行。
-
-更多操作请看 [TUI 命令参考](docs/website/reference/cli.md#terminal-ui) 和 [Daemon 管理](docs/website/reference/cli.md#daemon-management)。
+Holon 支持 Anthropic、OpenAI、DeepSeek、OpenRouter、Qwen、GLM、Xiaomi、Kimi、
+MiniMax 等常见 Provider。高级配置（credential profile、自定义 Provider、
+Codex 订阅等）请看
+[Configuration Reference](docs/website/reference/configuration.md) 和
+[Supported Models](docs/website/reference/models.md)。
 
 ## 核心概念
 
 Holon 把 Agent 工作拆成几个明确的运行时对象：
 
-- **Agent** 是长期存在的本地身份，拥有自己的队列、状态、历史和工作现场。
-- **WorkItem** 表达一个可持续推进的目标，包含计划、进度、阻塞、等待条件和完成报告。
-- **Task** 表达可监督的异步执行，例如命令、后台任务或子 Agent。
-- **WaitFor / wake** 让 Agent 显式声明正在等待任务结果、外部事件或操作者输入，并在条件满足时恢复。
-- **Workspace / worktree** 让 Agent 在本地仓库中执行，并可把编码任务隔离到托管 worktree。
-- **Origin / brief** 保留输入来源和信任信息，并把内部执行痕迹与操作者可见交付分开。
-
-这些概念共同解决的是同一个问题：让 Agent 的工作不依赖某一次聊天或终端连接，而是可以被观察、恢复、等待、委托和交付。
+- **Agent** — 长期存在的本地身份，拥有自己的队列、状态和工作现场。
+- **WorkItem** — 可持续推进的目标，包含计划、进度、阻塞、等待条件和完成报告。
+- **Task** — 可监督的异步执行（命令、后台任务或子 Agent）。
+- **WaitFor / wake** — 显式声明等待任务结果、外部事件或操作者输入，条件满足时恢复。
+- **Workspace / worktree** — 在本地仓库中执行，把编码任务隔离到托管 worktree。
+- **Origin / brief** — 保留输入来源和信任信息，把执行痕迹与操作者可见交付分开。
 
 更详细的概念说明请看 [Concepts](docs/website/concepts/)。
 
-## 当前版本
-
-当前推荐版本为
-[`v0.15.1`](https://github.com/holon-run/holon/releases/tag/v0.15.1)。
-
-`v0.15.0` 是 Holon Rust runtime 进入公开兼容性维护阶段的基线版本。
-从该版本开始，项目会开始维护 CLI、daemon/API 语义和本地持久化存储的兼容性。
-
-完整变更请查看
-[v0.15.1 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.15.1)。
-
 ## 状态与兼容性
 
-Holon 正在积极开发中。从 `v0.15.0` 开始，项目会把以下内容作为需要维护兼容性的公开契约：
+Holon 正在积极开发中。当前推荐版本为
+[`v0.29.0`](https://github.com/holon-run/holon/releases/tag/v0.29.0)。
 
-- **CLI**：常用命令、参数和结构化输出需要保持可迁移；破坏性调整应通过发布说明和迁移路径说明。
-- **接口**：daemon 客户端 API、事件语义和运行时对象字段需要保持向后兼容或提供明确的版本化演进方式。
-- **持久化存储**：agent 状态、账本、消息、transcript、WorkItem 和 task 等本地数据需要支持升级与读取兼容。
-
-当前项目重心仍是 Rust 运行时：agent 生命周期、队列、WaitFor/wake、task、WorkItem、信任边界、
-本地 workspace 和结构化交付。
-
-## 项目边界
-
-Holon 聚焦于运行时语义：Agent 身份、工作延续性、执行状态、本地工作区投影和操作者可见结果。
-
-相邻的 Holon Run 项目覆盖其他层：
-
-- **[AgentInbox](https://github.com/holon-run/agentinbox)** — source hosting、activation 和 delivery
-- **[UXC](https://github.com/holon-run/uxc)** — unified capability 和 tool access
-- **[WebMCP Bridge](https://github.com/holon-run/webmcp-bridge)** — browser 与 web-app edge access
-
-组合使用时，AgentInbox 负责把外部事件送达和唤醒 Holon；Holon 负责决定这些事件在运行时中的含义。
+当前项目重心仍是 Rust 运行时：agent 生命周期、队列、WaitFor/wake、task、WorkItem、
+信任边界、本地 workspace 和结构化交付。
 
 ## 文档
 
-Holon 的文档分为三个层次，详见
-[documentation layers](docs/website/concepts/documentation-layers.md)。
-
-**使用 Holon：**
-
-- [Website docs](https://holon.run) — 安装、入门、概念、指南和当前参考
-- [Security and execution boundaries](docs/website/concepts/security-and-execution-boundaries.md)
-
-**集成与运维：**
-
-- [Local operator troubleshooting](docs/local-operator-troubleshooting.md)
+- [Website docs](https://holon.run) — 安装、入门、概念、指南和参考
+- [Documentation layers](docs/website/concepts/documentation-layers.md)
+- [Architecture overview](docs/architecture-overview.md)
+- [RFCs](docs/rfcs/README.md)
+- [Implementation decisions](docs/implementation-decisions/README.md)
 - [Release process](docs/release.md)
-
-**贡献运行时：**
-
-- [Architecture overview](docs/architecture-overview.md) — 从这里开始
-- [RFCs](docs/rfcs/README.md) — 规范设计契约
-- [Implementation decisions](docs/implementation-decisions/README.md) — 设计理由
-
-## 社区
-
-- [GitHub Discussions](https://github.com/holon-run/holon/discussions)
-- [GitHub Issues](https://github.com/holon-run/holon/issues)
 
 ## 从源码构建
 
+Rust 二进制在编译时通过 `rust-embed` 嵌入 Web GUI 资源。先构建前端再编译二进制：
+
 ```bash
-cargo install --path .
+make all
 holon --help
 ```
 
-## 开发
+或分步：
+
+```bash
+make web    # 构建 Web GUI（需要 Node.js）
+make build  # 构建 Rust 二进制
+```
 
 运行检查：
 
 ```bash
-cargo fmt --all -- --check
-RUSTFLAGS="-D warnings" cargo check --all-targets
-cargo test --all-targets -- --test-threads=1
+make ci
 ```
+
+完整目标列表见 `make help`。
 
 运行基准测试：
 
@@ -222,6 +152,11 @@ cd benchmark
 npm install
 npm test
 ```
+
+## 社区
+
+- [GitHub Discussions](https://github.com/holon-run/holon/discussions)
+- [GitHub Issues](https://github.com/holon-run/holon/issues)
 
 ## 许可证
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -29,49 +29,54 @@ operator.
 
 ## Try Holon
 
-Install the latest release with Homebrew:
+Holon provides two interaction modes: **TUI** (terminal) and **Web GUI** (browser).
+
+### Install
 
 ```bash
-brew tap holon-run/tap
-brew install holon
+brew tap holon-run/tap && brew install holon
 holon --help
 ```
 
-Then configure a model provider, start the local daemon, and connect the TUI:
+Or download binaries from [GitHub Releases](https://github.com/holon-run/holon/releases/latest).
+
+### Configure a provider
 
 ```bash
-# Recommended: save an API key in a local credential profile
-printf '%s' "$DEEPSEEK_API_KEY" \
-  | holon config credentials set --kind api_key --stdin deepseek
+holon onboard
+```
 
-holon config providers set deepseek \
-  --credential-source credential_profile \
-  --credential-kind api_key \
-  --credential-profile deepseek
+This walks through provider credential setup interactively. You can also
+configure providers through the Web GUI **Settings** page after starting the
+daemon. See [Configuration Reference](/reference/configuration) and
+[Web GUI guide](/guides/web-gui) for more.
 
-holon config set model.default "deepseek/deepseek-v4-pro"
+### Start the daemon
 
-# Or use a local Codex login session / Codex subscription
-holon config set model.default "openai-codex/gpt-5.5"
-
-holon config doctor
-
+```bash
 holon daemon start
-holon daemon status
+```
+
+### TUI (terminal)
+
+```bash
 holon tui
 ```
 
-Holon automatically provides a default main agent. You can also create a more
-specialized agent after syncing or installing templates:
+Select an agent and start working. Agents keep running after you disconnect.
 
-```bash
-holon agent create builder --template holon-developer
-holon agent list
-```
+### Web GUI (browser)
 
-Holon supports built-in providers such as Anthropic, OpenAI, DeepSeek,
-OpenRouter, Qwen, GLM, Xiaomi, Kimi, and MiniMax. For a fuller setup path, see
-[Getting started](/getting-started/), the
+Open <http://localhost:7878>. Create an agent and work through a chat interface
+with built-in file browser, task tracking, and more.
+
+Holon automatically provides a default main agent. You can create more
+specialized agents through the TUI or Web GUI. For more:
+[Getting started](/getting-started/) · [TUI guide](/guides/tui) ·
+[Web GUI guide](/guides/web-gui)
+
+Holon supports providers such as Anthropic, OpenAI, DeepSeek, OpenRouter, Qwen,
+GLM, Xiaomi, Kimi, and MiniMax. For advanced setup, see the
 [configuration reference](/reference/configuration), and
 [supported models](/reference/models).
 

--- a/docs/website/guides/webfetch-websearch.md
+++ b/docs/website/guides/webfetch-websearch.md
@@ -86,9 +86,6 @@ Holon uses a provider-based search model with multiple provider options:
 - **Model-native search** — Some model providers (OpenAI, Anthropic) support
   native web search through their own APIs. In "Auto" mode, Holon prefers
   these when available.
-- **Bing Web Search** — Microsoft Bing Web Search API. Requires an API key
-  set via credential profile. Configure with
-  `holon config set providers bing --kind bing --credential-profile <profile>`.
 
 Search results from all providers are standardized into a consistent format
 with title, URL, and snippet text. Citations are preserved so agents can


### PR DESCRIPTION
## Summary

Restructure README (EN + ZH) and docs homepage to make Web GUI a first-class interaction mode alongside TUI, simplify provider setup to use `holon onboard` as the primary path, and trim redundant content.

## Changes

### README.md (EN): 296 → 173 lines
- **Quickstart now leads**: Install → `holon onboard` → daemon → TUI **or** Web GUI
- **Provider setup**: compressed to `holon onboard` + Web GUI Settings reference
- **Removed**: Table of Contents, Current Release (merged into Status), Project Boundaries (redundant with Core Concepts + docs), Development (merged into Build from source), Remote Web UI CORS section (belongs in reference docs)

### README.zh-CN.md: 228 → 163 lines
- Same structural changes as EN version
- **Fixed**: outdated version v0.15.1 → v0.29.0
- Added `holon onboard` (previously missing from ZH version)

### docs/website/README.md: 160 → 165 lines
- **Try Holon** section: replaced manual credential setup with `holon onboard` + Web GUI Settings link
- Added parallel TUI + Web GUI paths
- Fixed outdated version v0.26.0 → v0.29.0

## Key design decisions

1. **TUI and Web GUI as equal paths** — both are first-class interaction modes
2. **`holon onboard` as primary provider setup** — simpler than manual credential commands; references Web GUI Settings for GUI users
3. **Detailed config moved to docs** — API key manual setup, CORS, LAN access belong in reference/guides, not README