### PR TITLE
fix: refresh agent state on workspace change events

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -88,7 +88,8 @@ function mergeCachedAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummar
     activeTaskCount: httpAgent.tasks?.length ? httpAgent.activeTaskCount : Math.max(cachedAgent.activeTaskCount ?? 0, httpAgent.activeTaskCount ?? 0),
     waitingCount: Math.max(httpAgent.waitingCount, cachedAgent.waitingCount),
     pending: Math.max(httpAgent.pending, cachedAgent.pending),
-    workspaceSummary: cachedAgent.workspaceSummary ?? httpAgent.workspaceSummary,
+    // Trust HTTP state for workspace — it changes via UseWorkspace and must reflect fresh data.
+    workspaceSummary: httpAgent.workspaceSummary ?? cachedAgent.workspaceSummary,
     // Unified workspaces array from /state endpoint; fall back to cache when
     // the HTTP source is stale (e.g., bootstrap list without full state).
     attachedWorkspaces: httpAgent.attachedWorkspaces?.length
@@ -3296,7 +3297,14 @@ function isAgentStateCacheInvalidationEvent(event: StreamEventEnvelopeDto): bool
     event.type === "work_item_written" ||
     event.type === "task_created" ||
     event.type === "task_status_updated" ||
-    event.type === "task_result_received"
+    event.type === "task_result_received" ||
+    event.type === "workspace_entered" ||
+    event.type === "workspace_used" ||
+    event.type === "workspace_attached" ||
+    event.type === "workspace_detached" ||
+    event.type === "workspace_exited" ||
+    event.type === "worktree_entered" ||
+    event.type === "worktree_exited"
   );
 }
 


### PR DESCRIPTION
## 问题

切换 workspace 后，右侧 agent overview 的 workspaces 列表没有变化。

## 根因

1. **workspace 事件未触发状态刷新**：后端执行 `UseWorkspace` 时发出 `workspace_entered`/`workspace_used` 等事件，但前端的 `isAgentStateCacheInvalidationEvent` 只检查 `agent_state_changed`、`task_*`、`work_item_written` 等类型，不包含 workspace 相关事件。

2. **merge 逻辑优先缓存**：`mergeCachedAgentState` 中 `workspaceSummary` 使用 `cached ?? http`（缓存优先），即使后端返回了新 workspace 数据也会被旧缓存覆盖。`attachedWorkspaces` 已经是正确的 `http ?? cached` 策略，`workspaceSummary` 是不一致的。

## 修复

- 在 `isAgentStateCacheInvalidationEvent` 中添加 `workspace_entered`、`workspace_used`、`workspace_attached`、`workspace_detached`、`workspace_exited`、`worktree_entered`、`worktree_exited`
- `workspaceSummary` merge 改为 `http ?? cached`，与 `attachedWorkspaces` 一致