### PR TITLE
fix: 右侧 work item 面板频繁消失问题

### DIFF
--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -140,7 +140,9 @@ async function fetchAgentDetail(
       events: [],
       has_older: false,
     })),
-    fetchAgentWorkItems(baseUrl, fetchImpl, headers, agentId, { limit: 50 }).catch((): WorkItemDto[] => []),
+    // Return undefined on failure so projectAgent falls back to state.work_items.
+    // Returning [] would shadow the state endpoint's work_items (empty array is not nullish).
+    fetchAgentWorkItems(baseUrl, fetchImpl, headers, agentId, { limit: 50 }).catch(() => undefined),
   ]);
   const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
   const transcriptEntriesById = await fetchTranscriptEntriesForEvents(baseUrl, fetchImpl, headers, agentId, events.events ?? []);

--- a/web-gui/app/src/runtime/runtime-selectors.ts
+++ b/web-gui/app/src/runtime/runtime-selectors.ts
@@ -1,11 +1,44 @@
 import type { AgentSummary } from "./types";
 import type { RuntimeStoreState } from "./runtime-store";
 
+/**
+ * Cache for the enriched agent. refreshBootstrap replaces bootstrap agents
+ * every ~1s with fresh /agents/list data (which carries no work items).
+ * Without enrichment, the panel flickers to "no work items" whenever the
+ * cached merge momentarily loses them. The cache avoids creating a new object
+ * on every store update when the underlying references haven't changed.
+ */
+let enrichedAgent: AgentSummary | undefined;
+let enrichedBootstrapRef: AgentSummary | undefined;
+let enrichedSessionRef: AgentSummary | undefined;
+
 export function selectSelectedAgent(state: RuntimeStoreState): AgentSummary | undefined {
-  if (state.selectedAgentId) {
-    return state.bootstrap.agents.find((agent) => agent.id === state.selectedAgentId);
+  const bootstrapAgent = state.selectedAgentId
+    ? state.bootstrap.agents.find((agent) => agent.id === state.selectedAgentId)
+    : state.bootstrap.agents[0];
+  if (!bootstrapAgent) {
+    enrichedAgent = undefined;
+    return undefined;
   }
-  return state.bootstrap.agents[0];
+  // Bootstrap carries work items only when merged from cached state.
+  // When missing, enrich from session detail (which always has accurate data).
+  const sessionAgent = state.sessionsByAgentId[bootstrapAgent.id]?.detail?.agent;
+  if (!sessionAgent || bootstrapAgent.workItems?.length) {
+    enrichedAgent = undefined;
+    return bootstrapAgent;
+  }
+  // Return cached enriched agent when underlying references are unchanged.
+  if (enrichedBootstrapRef === bootstrapAgent && enrichedSessionRef === sessionAgent && enrichedAgent) {
+    return enrichedAgent;
+  }
+  enrichedBootstrapRef = bootstrapAgent;
+  enrichedSessionRef = sessionAgent;
+  enrichedAgent = {
+    ...bootstrapAgent,
+    workItems: sessionAgent.workItems?.length ? sessionAgent.workItems : bootstrapAgent.workItems,
+    currentWork: bootstrapAgent.currentWork ?? sessionAgent.currentWork,
+  };
+  return enrichedAgent;
 }
 
 export function selectSelectedAgentDetail(state: RuntimeStoreState) {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -3302,6 +3302,8 @@ function isAgentStateCacheInvalidationEvent(event: StreamEventEnvelopeDto): bool
   return (
     event.type === "agent_state_changed" ||
     event.type === "state_changed" ||
+    event.type === "message_processing_started" ||
+    event.type === "turn_terminal" ||
     event.type === "work_item_written" ||
     event.type === "task_created" ||
     event.type === "task_status_updated" ||


### PR DESCRIPTION
## 问题

右侧 Agent Overview 的 work item 面板经常自动消失，显示「无当前工作项」。

## 根因

多个竞态条件路径导致 `bootstrap.agents[i].workItems` 变为空数组：

1. **`fetchAgentDetail` 的 fallback 失效**：`/work-items` 端点失败时 catch 返回 `[]`，而 `projectAgent` 中 `workItemRecords ?? state?.work_items` 因为 `[]` 不是 nullish 值，永远不会 fallback 到 state 端点的 work_items。

2. **`refreshBootstrap` 每 ~1 秒用 `/agents/list` 数据替换 bootstrap agents**：该端点不包含 work items，依赖 cached merge 保留。一旦级联效应启动（bootstrap 和 session detail 的 workItems 同时为空），就会持续为空。

3. **`selectSelectedAgent` 只从 `bootstrap.agents` 读取**：没有 fallback 到拥有更准确 workItems 数据的 session detail。

4. **`isAgentStateCacheInvalidationEvent` 缺少 turn 边界事件**：长 turn 期间如果没有 `work_item_written` 事件，workItems 不会被恢复。

## 修复

- **client.ts**: `fetchAgentWorkItems().catch()` 返回 `undefined` 而非 `[]`，使 `projectAgent` 的 `??` fallback 正确工作
- **runtime-selectors.ts**: `selectSelectedAgent` 在 bootstrap 缺少 workItems 时从 session detail 补充，使用模块级缓存避免不必要的 re-render
- **runtime-store.ts**: `isAgentStateCacheInvalidationEvent` 增加 `message_processing_started` 和 `turn_terminal`，在 turn 边界触发状态刷新

## 验证

- `npx tsc --noEmit` 通过