### PR TITLE
ci: add runtime lifecycle concurrency job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,25 @@ jobs:
         run: make lint
         env:
           RUSTFLAGS: ""
+
+  rust-concurrent:
+    name: Rust Concurrent
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Test concurrent runtime lifecycles
+        run: make test-concurrent
+
+      - name: Repeat core lifecycle tests on main
+        if: github.event_name == 'push'
+        run: make test-concurrent-repeat CONCURRENT_REPEATS=2
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Thanks for contributing to Holon. This file captures the baseline expectations f
 - Summarize behavior changes and highlight any user-visible impact.
 - Validation:
   - Required: `make test`
+  - Runtime lifecycle, task, wait, SSE, or HTTP task changes:
+    `make test-concurrent`
   - Run focused `cargo test ...` commands for the Rust modules or integration
     tests touched by the change when a full test run is too broad.
   - If you cannot run a required check, state why in the PR description.
@@ -21,6 +23,12 @@ make build
 
 # Run Rust tests
 make test
+
+# Run selected runtime lifecycle integration tests with Rust's default threads
+make test-concurrent
+
+# Stress the core concurrent lifecycle suite; stops at the first failure
+make test-concurrent-repeat CONCURRENT_REPEATS=3
 
 # Run live-provider tests when credentials are configured
 make test-live

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-.PHONY: help web build all test test-live fmt fmt-check lint check ci run clean
+.PHONY: help web build all test test-concurrent test-concurrent-repeat test-live fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
+CONCURRENT_REPEATS ?= 3
+CONCURRENT_LIFECYCLE_TESTS := \
+	runtime_tasks \
+	runtime_waiting_and_reactivation \
+	runtime_waiting_and_delivery_regressions \
+	http_events \
+	http_tasks
+CONCURRENT_TESTS := $(CONCURRENT_LIFECYCLE_TESTS) wt204_parallel_worktree_workflow
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -15,10 +23,27 @@ build: ## Build all Rust targets (cargo build --all-targets)
 
 all: web build ## Build everything: web GUI then Rust
 
-test:
+test: ## Run the full Rust test suite serially
 	cargo test --all-targets -- --test-threads=1
 
-test-live:
+test-concurrent: ## Run runtime lifecycle integration tests with Rust's default test threads
+	@set -eu; \
+	for test_target in $(CONCURRENT_TESTS); do \
+		cargo test --test "$$test_target"; \
+	done
+
+test-concurrent-repeat: ## Repeat core concurrent lifecycle tests (CONCURRENT_REPEATS=3)
+	@set -eu; \
+	repeat=1; \
+	while [ "$$repeat" -le "$(CONCURRENT_REPEATS)" ]; do \
+		echo "Concurrent lifecycle test pass $$repeat/$(CONCURRENT_REPEATS)"; \
+		for test_target in $(CONCURRENT_LIFECYCLE_TESTS); do \
+			cargo test --test "$$test_target"; \
+		done; \
+		repeat=$$((repeat + 1)); \
+	done
+
+test-live: ## Run live-provider tests
 	cargo test live_ -- --nocapture
 
 fmt:


### PR DESCRIPTION
## Summary
- keep the standard `make test` baseline single-threaded
- add runtime lifecycle integration suites that use Rust's default test thread count
- add a dedicated `rust-concurrent` CI job, with a bounded fail-fast repeat on `main`
- document the local concurrent and repeat test entry points

## Verification
- `make test-concurrent`
- `make test-concurrent-repeat CONCURRENT_REPEATS=2`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `actionlint .github/workflows/ci.yml`

Closes #2257
