### PR TITLE
fix: validate Codex reasoning effort by model capability

### DIFF
--- a/docs/implementation-decisions/094-openai-codex-reasoning-effort.md
+++ b/docs/implementation-decisions/094-openai-codex-reasoning-effort.md
@@ -1,0 +1,12 @@
+# OpenAI Codex reasoning effort is model-specific
+
+Holon uses each Codex model's catalog policy as the source of accepted
+`reasoning_effort` values. Configuration parsing accepts the shared Codex
+vocabulary through `max`, while provider construction and runtime model
+overrides validate the value against the selected model.
+
+`max` is exposed only for Codex models whose metadata declares it. `ultra` is
+not exposed as an effort value because its upstream meaning includes execution
+orchestration that Holon does not implement. If that behavior is added later,
+it should be represented as an explicit execution capability rather than a
+string passed through as ordinary reasoning effort.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -105,3 +105,4 @@ Current decision notes:
 - [091 Tencent TokenHub Model Catalog](./091-tencent-tokenhub-model-catalog.md)
 - [092 Venice Model Catalog](./092-venice-model-catalog.md)
 - [093 Image Generation Route Calibration](./093-image-generation-route-calibration.md)
+- [094 OpenAI Codex Reasoning Effort](./094-openai-codex-reasoning-effort.md)

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -296,7 +296,7 @@ Breaking migration from the removed projection contract:
 | `POST` | `/control/agents/:agent_id/workspace/attach` | `{ path, authority_class? }` | `{ ok, agent_id, workspace_id, workspace_anchor }` | Candidate stable | `path` is converted into a workspace entry. |
 | `POST` | `/control/agents/:agent_id/workspace/exit` | `{ authority_class? }` | `{ ok, agent_id }` | Candidate stable | Returns agent to default workspace behavior. |
 | `POST` | `/control/agents/:agent_id/workspace/detach` | `{ workspace_id, authority_class? }` | `{ ok, agent_id, workspace_id }` | Candidate stable | `workspace_id` is trimmed before use. |
-| `POST` | `/control/agents/:agent_id/model` | `{ model, reasoning_effort?, authority_class? }` | `{ ok, agent_id, model }` | Experimental | `reasoning_effort` must be `low`, `medium`, `high`, or `xhigh`. |
+| `POST` | `/control/agents/:agent_id/model` | `{ model, reasoning_effort?, authority_class? }` | `{ ok, agent_id, model }` | Experimental | `reasoning_effort` is validated against the selected model's catalog metadata. Codex models may expose `max`; `ultra` is unavailable until Holon implements its orchestration semantics. |
 | `POST` | `/control/agents/:agent_id/model/clear` | `{ authority_class? }` | `{ ok, agent_id, model }` | Experimental | Clears the agent-level model override. |
 
 ### Operator transport integration

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1594,10 +1594,27 @@ pub(crate) fn materialize_provider_config(
 
 pub(crate) fn validate_openai_reasoning_effort(value: &str) -> Result<()> {
     match value {
-        "low" | "medium" | "high" | "xhigh" => Ok(()),
-        _ => Err(anyhow!(
-            "invalid OpenAI Codex reasoning_effort '{value}'; must be one of low, medium, high, xhigh"
+        "low" | "medium" | "high" | "xhigh" | "max" => Ok(()),
+        "ultra" => Err(anyhow!(
+            "OpenAI Codex reasoning_effort 'ultra' is unavailable; \
+             Holon does not yet implement the required orchestration semantics"
         )),
+        _ => Err(anyhow!(
+            "invalid OpenAI Codex reasoning_effort '{value}'; \
+             must be one of low, medium, high, xhigh, max"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod reasoning_effort_tests {
+    use super::validate_openai_reasoning_effort;
+
+    #[test]
+    fn codex_reasoning_effort_vocabulary_allows_max_but_not_ultra() {
+        validate_openai_reasoning_effort("max").unwrap();
+        let error = validate_openai_reasoning_effort("ultra").unwrap_err();
+        assert!(error.to_string().contains("orchestration semantics"));
     }
 }
 

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -656,10 +656,8 @@ pub async fn set_agent_model(
     Json(request): Json<SetAgentModelRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    if let Some(reasoning_effort) = request.reasoning_effort.as_deref() {
-        validate_reasoning_effort(reasoning_effort)?;
-    }
-    let model = ModelRouteRef::parse_compatible(&request.model).map_err(error_response)?;
+    let model = ModelRouteRef::parse_compatible(&request.model)
+        .map_err(|error| bad_request(error.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -668,21 +666,12 @@ pub async fn set_agent_model(
     let model_state = runtime
         .set_model_override(model.clone(), request.reasoning_effort.clone())
         .await
-        .map_err(error_response)?;
+        .map_err(agent_model_override_error)?;
     Ok(Json(json!({
         "ok": true,
         "agent_id": agent_id,
         "model": model_state,
     })))
-}
-
-pub(super) fn validate_reasoning_effort(value: &str) -> Result<(), (StatusCode, Json<Value>)> {
-    match value {
-        "low" | "medium" | "high" | "xhigh" => Ok(()),
-        _ => Err(bad_request(format!(
-            "invalid reasoning_effort '{value}'; must be one of low, medium, high, xhigh"
-        ))),
-    }
 }
 
 pub async fn clear_agent_model(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -895,6 +895,13 @@ pub(crate) fn work_item_lifecycle_error(error: anyhow::Error) -> (StatusCode, Js
     }
 }
 
+pub(crate) fn agent_model_override_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    match error.downcast::<crate::model_catalog::ReasoningEffortValidationError>() {
+        Ok(error) => bad_request(error.to_string()),
+        Err(error) => error_response(error),
+    }
+}
+
 pub(crate) fn normalize_optional_non_empty(value: Option<String>) -> Option<String> {
     value.and_then(|inner| {
         let trimmed = inner.trim().to_string();

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -268,6 +268,27 @@ pub struct ResolvedRuntimeModelPolicy {
     pub source: ModelMetadataSource,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReasoningEffortValidationError {
+    message: String,
+}
+
+impl ReasoningEffortValidationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ReasoningEffortValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ReasoningEffortValidationError {}
+
 impl Default for ResolvedRuntimeModelPolicy {
     fn default() -> Self {
         Self {
@@ -297,6 +318,38 @@ impl Default for ResolvedRuntimeModelPolicy {
             reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::UnknownFallback,
         }
+    }
+}
+
+impl ResolvedRuntimeModelPolicy {
+    pub fn validate_reasoning_effort(
+        &self,
+        value: &str,
+    ) -> Result<(), ReasoningEffortValidationError> {
+        if self
+            .reasoning_effort_options
+            .iter()
+            .any(|option| option == value)
+        {
+            return Ok(());
+        }
+
+        let model = self.model_ref.as_string();
+        if value == "ultra" && self.model_ref.provider == ProviderId::openai_codex() {
+            return Err(ReasoningEffortValidationError::new(format!(
+                "reasoning_effort 'ultra' is unavailable for model {model}; \
+                 Holon does not yet implement the required orchestration semantics"
+            )));
+        }
+        if self.reasoning_effort_options.is_empty() {
+            return Err(ReasoningEffortValidationError::new(format!(
+                "model {model} does not support configurable reasoning_effort"
+            )));
+        }
+        Err(ReasoningEffortValidationError::new(format!(
+            "reasoning_effort '{value}' is not supported by model {model}; supported values: {}",
+            self.reasoning_effort_options.join(", ")
+        )))
     }
 }
 
@@ -726,7 +779,7 @@ fn reasoning_effort_options(
 
     let options = match (model_ref.provider.as_str(), model_ref.model.as_str()) {
         ("openai-codex", "gpt-5.6-sol" | "gpt-5.6-terra") => {
-            &["low", "medium", "high", "xhigh", "max", "ultra"][..]
+            &["low", "medium", "high", "xhigh", "max"][..]
         }
         ("openai-codex", "gpt-5.6-luna") => &["low", "medium", "high", "xhigh", "max"][..],
         ("openai", _) | ("openai-codex", _) => &["low", "medium", "high", "xhigh"][..],
@@ -3925,8 +3978,36 @@ mod tests {
                 codex_sol.endpoint.as_ref(),
                 &codex_sol.capabilities,
             ),
-            ["low", "medium", "high", "xhigh", "max", "ultra"]
+            ["low", "medium", "high", "xhigh", "max"]
         );
+        let codex_luna = catalog.resolve_policy(
+            &ModelRef::parse("openai-codex/gpt-5.6-luna").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert!(codex_luna.validate_reasoning_effort("max").is_ok());
+        assert!(codex_luna
+            .validate_reasoning_effort("ultra")
+            .unwrap_err()
+            .to_string()
+            .contains("orchestration semantics"));
+        let codex_55 = catalog.resolve_policy(
+            &ModelRef::parse("openai-codex/gpt-5.5").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        let unsupported = codex_55
+            .validate_reasoning_effort("max")
+            .unwrap_err()
+            .to_string();
+        assert!(unsupported.contains("openai-codex/gpt-5.5"));
+        assert!(unsupported.contains("low, medium, high, xhigh"));
         assert!(catalog
             .get(&ModelRef::parse("openai/gpt-5.5").unwrap())
             .is_none());

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -81,6 +81,11 @@ pub(crate) fn build_candidate_from_model_route(
     let model_ref = &route.model_ref;
     let provider_config = route.provider_config();
     let resolved_policy = &route.policy;
+    if provider_config.transport == ProviderTransportKind::OpenAiCodexResponses {
+        if let Some(reasoning_effort) = provider_config.reasoning_effort.as_deref() {
+            resolved_policy.validate_reasoning_effort(reasoning_effort)?;
+        }
+    }
     let openai_compaction_policy = OpenAiCompactionPolicy {
         trigger_input_tokens: resolved_policy.compaction_trigger_estimated_tokens as u64,
     };
@@ -172,5 +177,82 @@ fn base_context_config_for_candidate(config: &AppConfig) -> ContextConfig {
         recent_episode_candidates: config.recent_episode_candidates,
         max_relevant_episodes: config.max_relevant_episodes,
         ..ContextConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{provider_registry_for_tests, ControlAuthMode};
+    use tempfile::tempdir;
+
+    fn codex_config(model: &str, reasoning_effort: &str) -> AppConfig {
+        let home = tempdir().unwrap().keep();
+        let workspace = tempdir().unwrap().keep();
+        let route = ModelRouteRef::parse_compatible(&format!("openai-codex/{model}")).unwrap();
+        let mut providers =
+            provider_registry_for_tests(None, None, home.join("missing-codex-home"));
+        let provider = providers
+            .get_mut(&crate::config::ProviderId::openai_codex())
+            .unwrap();
+        provider.reasoning_effort = Some(reasoning_effort.into());
+        provider.credential = Some(
+            r#"{"tokens":{"access_token":"test-token","refresh_token":"test-refresh","account_id":"test-account"}}"#
+                .into(),
+        );
+        AppConfig {
+            default_agent_id: "default".into(),
+            http_addr: "127.0.0.1:0".into(),
+            callback_base_url: "http://127.0.0.1:0".into(),
+            home_dir: home.clone(),
+            data_dir: home.clone(),
+            socket_path: home.join("holon.sock"),
+            workspace_dir: workspace,
+            context_window_messages: 8,
+            context_window_briefs: 8,
+            compaction_trigger_messages: 10,
+            compaction_keep_recent_messages: 4,
+            prompt_budget_estimated_tokens: 4096,
+            compaction_trigger_estimated_tokens: 2048,
+            compaction_keep_recent_estimated_tokens: 768,
+            recent_episode_candidates: 12,
+            max_relevant_episodes: 3,
+            control_token: Some("secret".into()),
+            control_auth_mode: ControlAuthMode::Auto,
+            api_cors: Default::default(),
+            config_file_path: home.join("config.json"),
+            stored_config: Default::default(),
+            default_model: route,
+            fallback_models: Vec::new(),
+            vision_model: None,
+            image_generation_model: None,
+            vision_candidate_models: Vec::new(),
+            runtime_max_output_tokens: 8192,
+            default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
+            max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
+            disable_provider_fallback: false,
+            tui_alternate_screen: crate::config::AltScreenMode::Auto,
+            validated_model_overrides: Default::default(),
+            validated_unknown_model_fallback: None,
+            model_discovery_cache: Default::default(),
+            providers,
+            web_config: Default::default(),
+        }
+    }
+
+    #[test]
+    fn codex_provider_build_validates_effort_against_model_policy() {
+        let supported = codex_config("gpt-5.6-luna", "max");
+        if let Err(error) = build_provider_from_model_chain(&supported, &supported.provider_chain())
+        {
+            panic!("supported effort should build provider: {error:#}");
+        }
+
+        let unsupported = codex_config("gpt-5.5", "max");
+        let error = build_provider_from_model_chain(&unsupported, &unsupported.provider_chain())
+            .err()
+            .expect("unsupported effort should fail provider construction");
+        assert!(error.to_string().contains("openai-codex/gpt-5.5"));
+        assert!(error.to_string().contains("low, medium, high, xhigh"));
     }
 }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -756,6 +756,14 @@ impl RuntimeHandle {
         model_override: crate::config::ModelRouteRef,
         reasoning_effort: Option<String>,
     ) -> Result<crate::types::AgentModelState> {
+        if model_override.provider == crate::config::ProviderId::openai_codex() {
+            if let Some(reasoning_effort) = reasoning_effort.as_deref() {
+                let snap = self.inner.config_snapshot.load();
+                snap.model_catalog
+                    .resolved_model_policy(&snap.base_context_config, Some(&model_override))
+                    .validate_reasoning_effort(reasoning_effort)?;
+            }
+        }
         let mut next_state = self.agent_state().await?;
         next_state.model_override = Some(model_override.clone());
         next_state.model_override_reasoning_effort = reasoning_effort.clone();

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -30,6 +30,7 @@ http_async_tests!(
     skill_library_add_remove_and_agent_enable_disable_are_separate,
     skill_library_reconcile_and_check_lock_file,
     control_agent_model_override_set_and_clear_updates_status,
+    control_agent_model_override_validates_codex_reasoning_effort,
     control_prompt_requires_bearer_token_when_required,
     control_prompt_rejects_oversized_body,
     remote_tcp_surfaces_require_bearer_token_when_required,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1187,6 +1187,64 @@ pub async fn control_agent_model_override_set_and_clear_updates_status() -> Resu
     Ok(())
 }
 
+pub async fn control_agent_model_override_validates_codex_reasoning_effort() -> Result<()> {
+    let mut config = test_config();
+    config.default_model =
+        holon::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap();
+    config
+        .providers
+        .get_mut(&holon::config::ProviderId::anthropic())
+        .unwrap()
+        .credential = Some("dummy".into());
+    config
+        .providers
+        .get_mut(&holon::config::ProviderId::openai_codex())
+        .unwrap()
+        .credential = Some(
+        r#"{"tokens":{"access_token":"test-token","refresh_token":"test-refresh","account_id":"test-account"}}"#
+            .into(),
+    );
+    let (_host, base, server) = spawn_server_with_runtime_config(config).await?;
+    let client = reqwest::Client::new();
+
+    let supported = client
+        .post(format!("{base}/api/control/agents/default/model"))
+        .json(&serde_json::json!({
+            "model": "openai-codex/gpt-5.6-luna",
+            "reasoning_effort": "max"
+        }))
+        .send()
+        .await?;
+    assert!(supported.status().is_success());
+
+    let unsupported = client
+        .post(format!("{base}/api/control/agents/default/model"))
+        .json(&serde_json::json!({
+            "model": "openai-codex/gpt-5.5",
+            "reasoning_effort": "max"
+        }))
+        .send()
+        .await?;
+    assert_eq!(unsupported.status(), reqwest::StatusCode::BAD_REQUEST);
+    let unsupported_body = unsupported.text().await?;
+    assert!(unsupported_body.contains("openai-codex/gpt-5.5"));
+    assert!(unsupported_body.contains("low, medium, high, xhigh"));
+
+    let ultra = client
+        .post(format!("{base}/api/control/agents/default/model"))
+        .json(&serde_json::json!({
+            "model": "openai-codex/gpt-5.6-luna",
+            "reasoning_effort": "ultra"
+        }))
+        .send()
+        .await?;
+    assert_eq!(ultra.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert!(ultra.text().await?.contains("orchestration semantics"));
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn control_prompt_requires_bearer_token_when_required() -> Result<()> {
     let config = test_config_with_paths(
         tempdir().unwrap().keep(),


### PR DESCRIPTION
## 摘要

- 将 openai-codex reasoning effort 改为按模型 catalog 能力校验，并让 provider 构建、runtime override 与 HTTP control 共用同一校验契约
- 允许明确支持的模型使用 `max`，在尚无对应编排语义时不再把 `ultra` 暴露为普通 `reasoning_effort`
- 为不支持的模型/档位组合提供包含模型名与可用档位的诊断，并将该类 HTTP override 错误稳定映射为 400
- 补充模型级能力、配置/provider、HTTP control 回归测试及实现决策文档

## 验证

- `cargo test codex_reasoning_effort_vocabulary_allows_max_but_not_ultra --lib`
- `cargo test codex_provider_build_validates_effort_against_model_policy --lib`
- `cargo test resolves_compatible_provider_model_policy --lib`
- `cargo test control_agent_model_override_validates_codex_reasoning_effort --test http_control -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2279
