### PR TITLE
fix: share reasoning effort route validation

### DIFF
--- a/docs/implementation-decisions/094-openai-codex-reasoning-effort.md
+++ b/docs/implementation-decisions/094-openai-codex-reasoning-effort.md
@@ -10,3 +10,8 @@ not exposed as an effort value because its upstream meaning includes execution
 orchestration that Holon does not implement. If that behavior is added later,
 it should be represented as an explicit execution capability rather than a
 string passed through as ordinary reasoning effort.
+
+For non-Codex routes, Holon retains generic vocabulary validation at the
+runtime override and provider-construction boundaries, but does not infer
+model-specific support. Provider-specific semantics remain delegated to the
+selected transport and upstream API.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::model_catalog::ReasoningEffortValidationError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModelRef {
@@ -297,6 +298,22 @@ impl ResolvedModelRoute {
 
     pub fn provider_name(&self) -> &str {
         self.endpoint.provider.as_str()
+    }
+
+    pub fn validate_reasoning_effort(
+        &self,
+        value: &str,
+    ) -> Result<(), ReasoningEffortValidationError> {
+        if self.provider_config().transport == ProviderTransportKind::OpenAiCodexResponses {
+            return self.policy.validate_reasoning_effort(value);
+        }
+
+        match value {
+            "low" | "medium" | "high" | "xhigh" | "max" => Ok(()),
+            _ => Err(ReasoningEffortValidationError::new(format!(
+                "invalid reasoning_effort '{value}'; must be one of low, medium, high, xhigh, max"
+            ))),
+        }
     }
 }
 

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -274,7 +274,7 @@ pub struct ReasoningEffortValidationError {
 }
 
 impl ReasoningEffortValidationError {
-    fn new(message: impl Into<String>) -> Self {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
         }

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -81,10 +81,8 @@ pub(crate) fn build_candidate_from_model_route(
     let model_ref = &route.model_ref;
     let provider_config = route.provider_config();
     let resolved_policy = &route.policy;
-    if provider_config.transport == ProviderTransportKind::OpenAiCodexResponses {
-        if let Some(reasoning_effort) = provider_config.reasoning_effort.as_deref() {
-            resolved_policy.validate_reasoning_effort(reasoning_effort)?;
-        }
+    if let Some(reasoning_effort) = provider_config.reasoning_effort.as_deref() {
+        route.validate_reasoning_effort(reasoning_effort)?;
     }
     let openai_compaction_policy = OpenAiCompactionPolicy {
         trigger_input_tokens: resolved_policy.compaction_trigger_estimated_tokens as u64,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -756,12 +756,14 @@ impl RuntimeHandle {
         model_override: crate::config::ModelRouteRef,
         reasoning_effort: Option<String>,
     ) -> Result<crate::types::AgentModelState> {
-        if model_override.provider == crate::config::ProviderId::openai_codex() {
-            if let Some(reasoning_effort) = reasoning_effort.as_deref() {
-                let snap = self.inner.config_snapshot.load();
-                snap.model_catalog
-                    .resolved_model_policy(&snap.base_context_config, Some(&model_override))
-                    .validate_reasoning_effort(reasoning_effort)?;
+        if let Some(reasoning_effort) = reasoning_effort.as_deref() {
+            let snap = self.inner.config_snapshot.load();
+            if let Some(route) = snap.model_catalog.resolve_explicit_model_route(
+                &snap.base_context_config,
+                &model_override,
+                crate::config::ModelRouteCapability::Turn,
+            ) {
+                route.validate_reasoning_effort(reasoning_effort)?;
             }
         }
         let mut next_state = self.agent_state().await?;

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1241,6 +1241,20 @@ pub async fn control_agent_model_override_validates_codex_reasoning_effort() -> 
     assert_eq!(ultra.status(), reqwest::StatusCode::BAD_REQUEST);
     assert!(ultra.text().await?.contains("orchestration semantics"));
 
+    let invalid_non_codex = client
+        .post(format!("{base}/api/control/agents/default/model"))
+        .json(&serde_json::json!({
+            "model": "anthropic/claude-haiku-4-5",
+            "reasoning_effort": "arbitrary"
+        }))
+        .send()
+        .await?;
+    assert_eq!(invalid_non_codex.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert!(invalid_non_codex
+        .text()
+        .await?
+        .contains("must be one of low, medium, high, xhigh, max"));
+
     server.abort();
     Ok(())
 }


### PR DESCRIPTION
## Summary

- restore early generic reasoning-effort vocabulary validation for non-Codex routes
- move Codex model-policy selection onto `ResolvedModelRoute` transport metadata
- make provider construction and runtime overrides share the same route-level validator
- add regression coverage and document the preserved boundary

## Verification

- `cargo test control_agent_model_override_validates_codex_reasoning_effort --test http_control -- --nocapture`
- `cargo test codex_provider_build_validates_effort_against_model_policy --lib`
- `cargo test resolves_compatible_reasoning_effort_for_non_codex_route --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2282.
Follow-up to #2281.
