### PR TITLE
test: cover reasoning effort route fallback diagnostics

### DIFF
--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2090,6 +2090,22 @@ fn provider_chain_with_override_inserts_override_before_runtime_default() {
 }
 
 #[test]
+fn resolves_compatible_reasoning_effort_for_non_codex_route() {
+    let fixture = test_app_config("anthropic@default/claude-sonnet-4-6", &[]);
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+    let route = catalog
+        .resolve_explicit_model_route(
+            &ContextConfig::default(),
+            &route_ref("anthropic@default/claude-sonnet-4-6"),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+
+    assert!(route.validate_reasoning_effort("xhigh").is_ok());
+    assert!(route.validate_reasoning_effort("arbitrary").is_err());
+}
+
+#[test]
 fn provider_chain_for_turn_starts_at_pending_fallback_model() {
     let fixture = test_app_config(
         "openai@default/gpt-5.4",

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -764,6 +764,13 @@ impl RuntimeHandle {
                 crate::config::ModelRouteCapability::Turn,
             ) {
                 route.validate_reasoning_effort(reasoning_effort)?;
+            } else {
+                tracing::debug!(
+                    provider = model_override.provider.as_str(),
+                    endpoint = model_override.endpoint.as_str(),
+                    model = model_override.model,
+                    "model override route not resolvable; skipping early reasoning effort validation"
+                );
             }
         }
         let mut next_state = self.agent_state().await?;

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -95,6 +95,45 @@ fn append_state_changed_events_emits_single_lightweight_agent_event() {
     assert!(payload.get("context_summary").is_none());
 }
 
+#[tokio::test]
+async fn model_override_defers_reasoning_effort_validation_for_unresolved_route() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_run_id = Some("run-1".into());
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+    let model_override = crate::config::ModelRouteRef::parse("unconfigured@default/model").unwrap();
+
+    let model_state = runtime
+        .set_model_override(model_override.clone(), Some("arbitrary".into()))
+        .await
+        .unwrap();
+
+    assert_eq!(model_state.override_model, Some(model_override.clone()));
+    assert_eq!(
+        model_state.override_reasoning_effort.as_deref(),
+        Some("arbitrary")
+    );
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.model_override, Some(model_override));
+    assert_eq!(
+        state.model_override_reasoning_effort.as_deref(),
+        Some("arbitrary")
+    );
+}
+
 #[test]
 fn runtime_projection_cache_rebuilds_current_agent_active_task_projection() {
     let now = Utc::now();


### PR DESCRIPTION
## Summary

- add focused unit coverage for generic reasoning-effort validation on a resolved non-Codex route
- log at debug level when a runtime override route cannot be resolved and early validation is intentionally deferred

## Context

This follows up on two review suggestions that arrived as PR #2283 was being merged. The behavior remains unchanged: unresolved routes are still accepted at the runtime override boundary and fail later during provider construction, but that path is now diagnosable.

## Verification

- `cargo fmt --all -- --check`
- `cargo test resolves_compatible_reasoning_effort_for_non_codex_route --lib`
- `cargo test control_agent_model_override_validates_codex_reasoning_effort --test http_control -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2284.
