### PR TITLE
fix(web): recover global event gaps from contiguous cursor

### DIFF
--- a/web-gui/app/src/runtime/event-gap-recovery.test.ts
+++ b/web-gui/app/src/runtime/event-gap-recovery.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { EventGapRecoveryTracker, recoverEventGap, type SequencedEvent } from "./event-gap-recovery";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function event(event_seq: number): SequencedEvent {
+  return { event_seq };
+}
+
+describe("EventGapRecoveryTracker", () => {
+  it("keeps the contiguous cursor behind an observed high watermark", () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 10);
+
+    expect(tracker.observe("agent-a", 13)).toEqual({
+      contiguousSeq: 10,
+      highestObservedSeq: 13,
+      recovering: true,
+    });
+    expect(tracker.observe("agent-a", 10)).toEqual({
+      contiguousSeq: 10,
+      highestObservedSeq: 13,
+      recovering: true,
+    });
+  });
+
+  it("captures the old cursor and continues when another gap arrives during backfill", async () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 10);
+    tracker.observe("agent-a", 13);
+    const firstPage = deferred<SequencedEvent[]>();
+    const fetchPage = vi
+      .fn<(afterSeq: number) => Promise<SequencedEvent[]>>()
+      .mockImplementationOnce(() => firstPage.promise)
+      .mockResolvedValueOnce([event(14), event(15)])
+      .mockResolvedValueOnce([]);
+    const applied: number[][] = [];
+
+    const recovery = recoverEventGap(tracker, "agent-a", {
+      limit: 100,
+      fetchPage,
+      applyEvents: (events) => applied.push(events.map((item) => item.event_seq as number)),
+    });
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 10);
+
+    tracker.observe("agent-a", 15);
+    firstPage.resolve([event(11), event(12), event(13)]);
+    await recovery;
+
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 13);
+    expect(applied).toEqual([
+      [11, 12, 13],
+      [14, 15],
+    ]);
+    expect(tracker.snapshotFor("agent-a")).toEqual({
+      contiguousSeq: 15,
+      highestObservedSeq: 15,
+      recovering: false,
+    });
+  });
+
+  it("paginates without skipping, ignores duplicates, and does not run concurrent backfills", async () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 20);
+    tracker.observe("agent-a", 24);
+    const firstPage = deferred<SequencedEvent[]>();
+    const fetchPage = vi
+      .fn<(afterSeq: number) => Promise<SequencedEvent[]>>()
+      .mockImplementationOnce(() => firstPage.promise)
+      .mockResolvedValueOnce([event(23), event(24)])
+      .mockResolvedValueOnce([]);
+
+    const firstRecovery = recoverEventGap(tracker, "agent-a", {
+      limit: 2,
+      fetchPage,
+      applyEvents: () => undefined,
+    });
+    await recoverEventGap(tracker, "agent-a", {
+      limit: 2,
+      fetchPage,
+      applyEvents: () => undefined,
+    });
+    firstPage.resolve([event(21), event(21), event(22)]);
+    await firstRecovery;
+
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 20);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 22);
+    expect(fetchPage).toHaveBeenNthCalledWith(3, 24);
+    expect(tracker.snapshotFor("agent-a")?.contiguousSeq).toBe(24);
+  });
+
+  it("keeps a failed gap recoverable and clears unregistered state", async () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 30);
+    tracker.observe("agent-a", 32);
+
+    await expect(
+      recoverEventGap(tracker, "agent-a", {
+        limit: 100,
+        fetchPage: async () => {
+          throw new Error("temporary failure");
+        },
+        applyEvents: () => undefined,
+      }),
+    ).rejects.toThrow("temporary failure");
+    expect(tracker.snapshotFor("agent-a")?.recovering).toBe(true);
+
+    await recoverEventGap(tracker, "agent-a", {
+      limit: 100,
+      fetchPage: async () => [event(31), event(32)],
+      applyEvents: () => undefined,
+    });
+    expect(tracker.snapshotFor("agent-a")?.recovering).toBe(false);
+
+    tracker.unregister("agent-a");
+    expect(tracker.snapshotFor("agent-a")).toBeUndefined();
+  });
+
+  it("does not let a stale backfill mutate a re-registered agent", async () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 40);
+    tracker.observe("agent-a", 42);
+    const page = deferred<SequencedEvent[]>();
+
+    const recovery = recoverEventGap(tracker, "agent-a", {
+      limit: 100,
+      fetchPage: () => page.promise,
+      applyEvents: () => undefined,
+    });
+    tracker.unregister("agent-a");
+    tracker.register("agent-a", 100);
+    page.resolve([event(41), event(42)]);
+    await recovery;
+
+    expect(tracker.snapshotFor("agent-a")).toEqual({
+      contiguousSeq: 100,
+      highestObservedSeq: 100,
+      recovering: false,
+    });
+  });
+});

--- a/web-gui/app/src/runtime/event-gap-recovery.ts
+++ b/web-gui/app/src/runtime/event-gap-recovery.ts
@@ -1,0 +1,176 @@
+export interface SequencedEvent {
+  event_seq?: number;
+}
+
+interface AgentRecoveryState {
+  generation: number;
+  contiguousSeq: number;
+  highestObservedSeq: number;
+  observationVersion: number;
+  backfillInFlight: boolean;
+}
+
+export interface AgentRecoverySnapshot {
+  contiguousSeq: number;
+  highestObservedSeq: number;
+  recovering: boolean;
+}
+
+interface RecoveryCycle {
+  generation: number;
+  afterSeq: number;
+  observationVersion: number;
+}
+
+export class EventGapRecoveryTracker {
+  private readonly states = new Map<string, AgentRecoveryState>();
+  private nextGeneration = 1;
+
+  clear(): void {
+    this.states.clear();
+  }
+
+  register(agentId: string, baselineSeq?: number): void {
+    if (baselineSeq == null || this.states.has(agentId)) return;
+    this.states.set(agentId, {
+      generation: this.nextGeneration++,
+      contiguousSeq: baselineSeq,
+      highestObservedSeq: baselineSeq,
+      observationVersion: 0,
+      backfillInFlight: false,
+    });
+  }
+
+  unregister(agentId: string): void {
+    this.states.delete(agentId);
+  }
+
+  observe(agentId: string, seq: number): AgentRecoverySnapshot {
+    let state = this.states.get(agentId);
+    if (!state) {
+      state = {
+        generation: this.nextGeneration++,
+        contiguousSeq: seq,
+        highestObservedSeq: seq,
+        observationVersion: 0,
+        backfillInFlight: false,
+      };
+      this.states.set(agentId, state);
+      return this.snapshot(state);
+    }
+
+    state.observationVersion += 1;
+    state.highestObservedSeq = Math.max(state.highestObservedSeq, seq);
+    if (seq === state.contiguousSeq + 1) {
+      state.contiguousSeq = seq;
+    }
+    return this.snapshot(state);
+  }
+
+  snapshotFor(agentId: string): AgentRecoverySnapshot | undefined {
+    const state = this.states.get(agentId);
+    return state ? this.snapshot(state) : undefined;
+  }
+
+  beginBackfill(agentId: string, force: boolean): RecoveryCycle | undefined {
+    const state = this.states.get(agentId);
+    if (!state || state.backfillInFlight || (!force && state.highestObservedSeq <= state.contiguousSeq)) {
+      return undefined;
+    }
+    state.backfillInFlight = true;
+    return {
+      generation: state.generation,
+      afterSeq: state.contiguousSeq,
+      observationVersion: state.observationVersion,
+    };
+  }
+
+  acceptBackfill(
+    agentId: string,
+    cycle: RecoveryCycle,
+    seqs: number[],
+  ): AgentRecoverySnapshot | undefined {
+    const state = this.states.get(agentId);
+    if (!state || state.generation !== cycle.generation) return undefined;
+
+    for (const seq of Array.from(new Set(seqs)).sort((left, right) => left - right)) {
+      state.highestObservedSeq = Math.max(state.highestObservedSeq, seq);
+      if (seq === state.contiguousSeq + 1) {
+        state.contiguousSeq = seq;
+      }
+    }
+    return this.snapshot(state);
+  }
+
+  nextCycle(agentId: string, previous: RecoveryCycle): RecoveryCycle | undefined {
+    const state = this.states.get(agentId);
+    if (
+      !state ||
+      state.generation !== previous.generation ||
+      state.highestObservedSeq <= state.contiguousSeq ||
+      (state.contiguousSeq <= previous.afterSeq && state.observationVersion === previous.observationVersion)
+    ) {
+      return undefined;
+    }
+    return {
+      generation: state.generation,
+      afterSeq: state.contiguousSeq,
+      observationVersion: state.observationVersion,
+    };
+  }
+
+  endBackfill(agentId: string, cycle: RecoveryCycle): AgentRecoverySnapshot | undefined {
+    const state = this.states.get(agentId);
+    if (!state || state.generation !== cycle.generation) return undefined;
+    state.backfillInFlight = false;
+    return this.snapshot(state);
+  }
+
+  private snapshot(state: AgentRecoveryState): AgentRecoverySnapshot {
+    return {
+      contiguousSeq: state.contiguousSeq,
+      highestObservedSeq: state.highestObservedSeq,
+      recovering: state.highestObservedSeq > state.contiguousSeq,
+    };
+  }
+}
+
+export async function recoverEventGap<T extends SequencedEvent>(
+  tracker: EventGapRecoveryTracker,
+  agentId: string,
+  options: {
+    force?: boolean;
+    limit: number;
+    fetchPage: (afterSeq: number) => Promise<T[]>;
+    applyEvents: (events: T[]) => void;
+  },
+): Promise<void> {
+  let cycle = tracker.beginBackfill(agentId, options.force ?? false);
+  if (!cycle) return;
+  const initialCycle = cycle;
+
+  try {
+    while (cycle) {
+      let cursor = cycle.afterSeq;
+      let hasMore = true;
+      while (hasMore) {
+        const events = (await options.fetchPage(cursor)).filter((event) => event.event_seq != null);
+        if (!events.length) break;
+
+        const snapshot = tracker.acceptBackfill(
+          agentId,
+          cycle,
+          events.map((event) => event.event_seq as number),
+        );
+        if (!snapshot) return;
+        options.applyEvents(events);
+        const nextCursor = snapshot.contiguousSeq;
+        hasMore = events.length >= options.limit && nextCursor > cursor;
+        cursor = nextCursor;
+      }
+      cycle = tracker.nextCycle(agentId, cycle);
+    }
+  } finally {
+    tracker.endBackfill(agentId, initialCycle);
+  }
+}

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -6,6 +6,7 @@ import {
   type OperatorPromptAttachment,
   type StreamEventEnvelopeDto,
 } from "./client";
+import { EventGapRecoveryTracker, recoverEventGap } from "./event-gap-recovery";
 import { cacheClearRemote } from "./idb-cache";
 import {
   currentRemoteKey,
@@ -409,8 +410,7 @@ let globalStreamReconnectTimer: number | undefined;
 let globalStreamStaleTimer: number | undefined;
 let globalStreamReconnectAttempt = 0;
 const globalStreamSubscribedAgents = new Set<string>();
-const agentLastSeenSeq = new Map<string, number>();
-const backfillInFlight = new Set<string>();
+const globalEventRecovery = new EventGapRecoveryTracker();
 const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
@@ -1042,8 +1042,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       globalStreamStaleTimer = undefined;
     }
     globalStreamSubscribedAgents.clear();
-    agentLastSeenSeq.clear();
-    backfillInFlight.clear();
+    globalEventRecovery.clear();
     globalStreamReconnectAttempt = 0;
     messageHydrationInFlight.clear();
     transcriptHydrationInFlight.clear();
@@ -2247,7 +2246,7 @@ function startGlobalEventStream(get: () => RuntimeStoreState, set: StoreSet): vo
       scheduleGlobalStaleWatchdog(get, set);
       // Backfill all registered agents on (re)connect.
       for (const agentId of globalStreamSubscribedAgents) {
-        void backfillAgentEvents(set, agentId);
+        void backfillAgentEvents(set, agentId, true);
       }
     },
     onActivity: () => {
@@ -2287,11 +2286,9 @@ function registerAgentForEvents(get: () => RuntimeStoreState, set: StoreSet, age
   globalStreamSubscribedAgents.add(agentId);
   // Initialize seq tracking from existing session state.
   const session = wasSubscribed ? undefined : get().sessionsByAgentId[agentId];
-  if (session && !agentLastSeenSeq.has(agentId)) {
+  if (session && !globalEventRecovery.snapshotFor(agentId)) {
     const lastSeq = highestSeq(session.eventSeqs) ?? session.newestSeq;
-    if (lastSeq != null) {
-      agentLastSeenSeq.set(agentId, lastSeq);
-    }
+    globalEventRecovery.register(agentId, lastSeq);
   }
   // Start global stream if not running.
   startGlobalEventStream(get, set);
@@ -2301,7 +2298,7 @@ function registerAgentForEvents(get: () => RuntimeStoreState, set: StoreSet, age
 
 function unregisterAgentForEvents(agentId: string): void {
   globalStreamSubscribedAgents.delete(agentId);
-  agentLastSeenSeq.delete(agentId);
+  globalEventRecovery.unregister(agentId);
 }
 
 function syncGlobalEventRoster(get: () => RuntimeStoreState, set: StoreSet): void {
@@ -2320,53 +2317,43 @@ function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto)
 
   const seq = event.event_seq;
   if (seq != null) {
-    const lastSeq = agentLastSeenSeq.get(agentId);
-    if (lastSeq != null && seq > lastSeq + 1) {
-      // Gap detected — trigger backfill.
+    const recovery = globalEventRecovery.observe(agentId, seq);
+    if (recovery.recovering) {
+      setAgentLiveStatus(set, agentId, "recovering");
       void backfillAgentEvents(set, agentId);
     }
-    agentLastSeenSeq.set(agentId, Math.max(seq, lastSeq ?? 0));
   }
 
   enqueueStreamEvent(set, agentId, event);
   scheduleBootstrapRefresh(useRuntimeStore.getState);
 }
 
-async function backfillAgentEvents(set: StoreSet, agentId: string): Promise<void> {
-  if (backfillInFlight.has(agentId)) return;
-  const afterSeq = agentLastSeenSeq.get(agentId);
-  if (afterSeq == null) return; // No seq baseline yet; initial fetch handles this.
-  backfillInFlight.add(agentId);
+async function backfillAgentEvents(set: StoreSet, agentId: string, force = false): Promise<void> {
   try {
-    let cursor = afterSeq;
-    let hasMore = true;
-    while (hasMore) {
-      const page = await runtimeClient.getAgentEvents(agentId, {
-        afterSeq: cursor,
-        order: "asc",
-        limit: GLOBAL_BACKFILL_LIMIT,
-      });
-      const events = (page.events ?? []).filter((e) => e.event_seq != null);
-      if (!events.length) break;
-      // Convert EventEnvelopeDto to StreamEventEnvelopeDto for the reducer.
-      const streamEvents: StreamEventEnvelopeDto[] = events.map((e) => ({
-        id: e.id,
-        event_seq: e.event_seq,
-        ts: e.ts,
-        agent_id: agentId,
-        type: e.type,
-        payload: e.payload,
-      }));
-      applyStreamEvents(set, agentId, streamEvents);
-      const maxSeq = events.reduce((max, e) => Math.max(max, e.event_seq!), 0);
-      agentLastSeenSeq.set(agentId, Math.max(maxSeq, agentLastSeenSeq.get(agentId) ?? 0));
-      cursor = maxSeq;
-      hasMore = events.length >= GLOBAL_BACKFILL_LIMIT;
-    }
+    await recoverEventGap(globalEventRecovery, agentId, {
+      force,
+      limit: GLOBAL_BACKFILL_LIMIT,
+      fetchPage: async (afterSeq) => {
+        const page = await runtimeClient.getAgentEvents(agentId, {
+          afterSeq,
+          order: "asc",
+          limit: GLOBAL_BACKFILL_LIMIT,
+        });
+        return (page.events ?? [])
+          .filter((event) => event.event_seq != null)
+          .map((event) => ({
+            id: event.id,
+            event_seq: event.event_seq,
+            ts: event.ts,
+            agent_id: agentId,
+            type: event.type,
+            payload: event.payload,
+          }));
+      },
+      applyEvents: (events) => applyStreamEvents(set, agentId, events),
+    });
   } catch {
     // Silently ignore backfill errors; the stream will retry.
-  } finally {
-    backfillInFlight.delete(agentId);
   }
 }
 
@@ -3208,6 +3195,7 @@ async function catchUpAgentEvents(
 function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEnvelopeDto[]): void {
   const incomingEvents = events.filter((event) => event.event_seq != null);
   if (!incomingEvents.length) return;
+  const liveStatus = globalEventRecovery.snapshotFor(agentId)?.recovering ? "recovering" : "streaming";
 
   set((state) => {
     const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
@@ -3218,7 +3206,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
           ...state.sessionsByAgentId,
           [agentId]: {
             ...current,
-            liveStatus: "streaming",
+            liveStatus,
             error: undefined,
           },
         },
@@ -3275,7 +3263,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
           eventSeqs,
           newestSeq: Math.max(highestIncomingSeq, current.newestSeq ?? 0),
           oldestSeq: current.oldestSeq ?? eventSeqs[0],
-          liveStatus: "streaming",
+          liveStatus,
           error: undefined,
         },
       },


### PR DESCRIPTION
## Summary

- 将 Web global event 游标拆分为连续游标与最高已观察序列，避免 live gap 提前推进 backfill 起点
- 提取纯逻辑 gap recovery state，确保恢复期间出现的新 gap 会继续触发补洞循环
- 按连续序列分页推进 cursor，并覆盖重复、乱序、多页、失败重试及 cleanup

## Verification

- `source "$HOME/.nvm/nvm.sh" && nvm use 24 >/dev/null && npm test -- --run src/runtime/event-gap-recovery.test.ts && npm run typecheck`
- `source "$HOME/.nvm/nvm.sh" && nvm use 24 >/dev/null && npm test && npm run build`
- 完整结果：20 个测试文件、172 个测试通过，TypeScript 检查和生产构建通过

Closes #2251
