### PR TITLE
fix: require turn id for turn ownership

### DIFF
--- a/docs/rfcs/turn-based-context-projection.md
+++ b/docs/rfcs/turn-based-context-projection.md
@@ -219,6 +219,18 @@ Turn V:
 This is preferable to separately rendering a recent operator message list and a
 recent brief list with no guaranteed linkage.
 
+Turn ownership is determined only by a non-empty, exact `turn_id` match.
+`message_seq`, `turn_index`, and materialized object ids remain useful for
+ordering, display, and lookup, but they are not ownership keys and must not be
+used as compatibility fallbacks. In particular, equal numeric values from the
+message and turn ledgers do not establish a causal relation.
+
+Prompt projection must revalidate each materialized message, brief, and tool
+reference against the referenced object's own `turn_id`. A missing, blank, or
+different object `turn_id` makes the reference ineligible for that turn even
+when the object id appears in `TurnRecord`. This protects prompt assembly from
+already-persisted cross-turn references.
+
 ### 5.4 Classify Current Input Relation Before Rendering History
 
 Every prompt should make the current turn relation explicit:
@@ -451,6 +463,13 @@ An LLM may be used for:
 An LLM must not be the sole judge of authority, trust, or source replacement.
 
 ## 7. Migration Path
+
+Existing polluted `TurnRecord` rows are not rewritten as part of the
+turn-ownership fix. Normal settlement stops creating sequence-based
+associations, while prompt hydration and rendering ignore historical
+references whose object provenance does not match the record. Any offline
+audit or deterministic rebuild facility should be designed separately rather
+than coupled to startup or prompt assembly.
 
 ### Phase 1: Turn Projection Without New Storage
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -496,8 +496,17 @@ fn hydrate_recent_turn_references(
                 continue;
             }
             if let Some(message) = storage.read_message_by_id(message_id)? {
-                message_ids.insert(message.id.clone());
-                messages.push(message);
+                if turn_record_owns_object(record, message.turn_id.as_deref()) {
+                    message_ids.insert(message.id.clone());
+                    messages.push(message);
+                } else {
+                    tracing::warn!(
+                        turn_id = %record.turn_id,
+                        message_id = %message_id,
+                        object_turn_id = ?message.turn_id,
+                        "recent_turns ignored cross-turn input message reference"
+                    );
+                }
             } else {
                 tracing::warn!(
                     turn_id = %record.turn_id,
@@ -514,8 +523,17 @@ fn hydrate_recent_turn_references(
         {
             if !message_ids.contains(message_id) {
                 if let Some(message) = storage.read_message_by_id(message_id)? {
-                    message_ids.insert(message.id.clone());
-                    messages.push(message);
+                    if turn_record_owns_object(record, message.turn_id.as_deref()) {
+                        message_ids.insert(message.id.clone());
+                        messages.push(message);
+                    } else {
+                        tracing::warn!(
+                            turn_id = %record.turn_id,
+                            message_id = %message_id,
+                            object_turn_id = ?message.turn_id,
+                            "recent_turns ignored cross-turn trigger message reference"
+                        );
+                    }
                 } else {
                     tracing::warn!(
                         turn_id = %record.turn_id,
@@ -531,8 +549,17 @@ fn hydrate_recent_turn_references(
                 continue;
             }
             if let Some(brief) = storage.read_brief_by_id(brief_id)? {
-                brief_ids.insert(brief.id.clone());
-                briefs.push(brief);
+                if turn_record_owns_object(record, brief.turn_id.as_deref()) {
+                    brief_ids.insert(brief.id.clone());
+                    briefs.push(brief);
+                } else {
+                    tracing::warn!(
+                        turn_id = %record.turn_id,
+                        brief_id = %brief_id,
+                        object_turn_id = ?brief.turn_id,
+                        "recent_turns ignored cross-turn brief reference"
+                    );
+                }
             } else {
                 tracing::warn!(
                     turn_id = %record.turn_id,
@@ -547,8 +574,17 @@ fn hydrate_recent_turn_references(
                 continue;
             }
             if let Some(tool) = storage.read_tool_execution_by_id(tool_id)? {
-                tool_ids.insert(tool.id.clone());
-                tools.push(tool);
+                if turn_record_owns_object(record, tool.turn_id.as_deref()) {
+                    tool_ids.insert(tool.id.clone());
+                    tools.push(tool);
+                } else {
+                    tracing::warn!(
+                        turn_id = %record.turn_id,
+                        tool_id = %tool_id,
+                        object_turn_id = ?tool.turn_id,
+                        "recent_turns ignored cross-turn tool execution reference"
+                    );
+                }
             } else {
                 tracing::warn!(
                     turn_id = %record.turn_id,
@@ -1844,13 +1880,39 @@ fn render_turn_record_projection(
     let trigger_message = record
         .input_message_ids
         .iter()
-        .find_map(|id| messages.iter().find(|message| message.id == *id))
+        .find_map(|id| {
+            messages.iter().find(|message| {
+                message.id == *id && turn_record_owns_object(record, message.turn_id.as_deref())
+            })
+        })
         .or_else(|| {
             record
                 .trigger
                 .as_ref()
                 .and_then(|trigger| trigger.message_id.as_ref())
-                .and_then(|id| messages.iter().find(|message| message.id == *id))
+                .and_then(|id| {
+                    messages.iter().find(|message| {
+                        message.id == *id
+                            && turn_record_owns_object(record, message.turn_id.as_deref())
+                    })
+                })
+        });
+    let trigger_summary_is_valid = record
+        .trigger
+        .as_ref()
+        .and_then(|trigger| trigger.message_id.as_ref())
+        .is_none_or(|message_id| match storage.read_message_by_id(message_id) {
+            Ok(Some(message)) => turn_record_owns_object(record, message.turn_id.as_deref()),
+            Ok(None) => true,
+            Err(error) => {
+                tracing::warn!(
+                    turn_id = %record.turn_id,
+                    message_id = %message_id,
+                    %error,
+                    "recent_turns could not validate persisted trigger summary"
+                );
+                false
+            }
         });
     let mut lines = vec![format!(
         "- Turn {}:",
@@ -1866,11 +1928,15 @@ fn render_turn_record_projection(
             "  - trigger: {}",
             turn_trigger_label(trigger_message)
         ));
-    } else if let Some(trigger) = &record.trigger {
-        lines.push(format!(
-            "  - trigger: {}",
-            turn_trigger_summary_label(trigger)
-        ));
+    } else if trigger_summary_is_valid {
+        if let Some(trigger) = &record.trigger {
+            lines.push(format!(
+                "  - trigger: {}",
+                turn_trigger_summary_label(trigger)
+            ));
+        } else {
+            lines.push("  - trigger: unavailable".to_string());
+        }
     } else {
         lines.push("  - trigger: unavailable".to_string());
     }
@@ -1902,11 +1968,11 @@ fn render_turn_record_projection(
 
     let mut related_briefs = Vec::new();
     let mut brief_budget = budget.saturating_sub(estimate_text_tokens(&lines.join("\n")));
-    for brief in record
-        .produced_brief_ids
-        .iter()
-        .filter_map(|id| briefs.iter().find(|brief| brief.id == *id))
-    {
+    for brief in record.produced_brief_ids.iter().filter_map(|id| {
+        briefs.iter().find(|brief| {
+            brief.id == *id && turn_record_owns_object(record, brief.turn_id.as_deref())
+        })
+    }) {
         if let Some(rendered) = render_recent_turn_brief_line(storage, brief, mode, brief_budget) {
             brief_budget = brief_budget.saturating_sub(estimate_text_tokens(&rendered));
             related_briefs.push(rendered);
@@ -1920,7 +1986,11 @@ fn render_turn_record_projection(
     let related_tools = record
         .tool_execution_ids
         .iter()
-        .filter_map(|id| tools.iter().find(|tool| tool.id == *id))
+        .filter_map(|id| {
+            tools.iter().find(|tool| {
+                tool.id == *id && turn_record_owns_object(record, tool.turn_id.as_deref())
+            })
+        })
         .collect::<Vec<_>>();
     if !related_tools.is_empty() {
         lines.push("  - tool executions:".to_string());
@@ -1984,22 +2054,15 @@ fn render_current_continuation_turn_record_projection(
 }
 
 fn turn_record_matches_message(record: &TurnRecord, message: &MessageEnvelope) -> bool {
-    if let Some(turn_id) = message.turn_id.as_deref().map(str::trim) {
-        if !turn_id.is_empty() {
-            if turn_id == record.turn_id.trim() {
-                return true;
-            }
-            return false;
-        }
-    }
+    turn_record_owns_object(record, message.turn_id.as_deref())
+}
 
-    record.input_message_ids.iter().any(|id| id == &message.id)
-        || record
-            .trigger
-            .as_ref()
-            .and_then(|trigger| trigger.message_id.as_ref())
-            .is_some_and(|id| id == &message.id)
-        || record.turn_index != 0 && message.message_seq == Some(record.turn_index)
+fn turn_record_owns_object(record: &TurnRecord, object_turn_id: Option<&str>) -> bool {
+    let record_turn_id = record.turn_id.trim();
+    object_turn_id.is_some_and(|object_turn_id| {
+        let object_turn_id = object_turn_id.trim();
+        !record_turn_id.is_empty() && !object_turn_id.is_empty() && object_turn_id == record_turn_id
+    })
 }
 
 fn turn_trigger_label(message: &MessageEnvelope) -> &'static str {
@@ -2782,9 +2845,12 @@ mod tests {
         turn_id: &str,
         turn_index: usize,
     ) -> TurnRecord {
+        let mut message = message.clone();
+        message.turn_id = Some(turn_id.to_string());
+        storage.append_message(&message).unwrap();
         let mut turn = TurnRecord::new(&message.agent_id, turn_id, turn_index as u64);
         turn.input_message_ids = vec![message.id.clone()];
-        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(message));
+        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
         storage.append_turn(&turn).unwrap();
         turn
     }
@@ -2951,6 +3017,97 @@ mod tests {
         assert!(recent_turns.contains(&format!("message_ref=message:{}", operator.id)));
         assert!(recent_turns.contains("Rendered from DB turn record."));
         assert!(recent_turns.contains("brief_ref=brief:brief-db-context"));
+    }
+
+    #[test]
+    fn recent_turns_ignores_persisted_cross_turn_references() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let turn_id = "turn-owned";
+        let turn_index = 9;
+
+        let mut cross_turn_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "cross-turn operator input must stay hidden".into(),
+            },
+        );
+        cross_turn_message.turn_id = Some("turn-other".into());
+        cross_turn_message.message_seq = Some(turn_index);
+        storage.append_message(&cross_turn_message).unwrap();
+
+        let mut owned_brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "owned result remains visible",
+            None,
+            None,
+        );
+        owned_brief.id = "brief-owned".into();
+        owned_brief.turn_id = Some(turn_id.into());
+        owned_brief.turn_index = Some(99);
+        storage.append_brief(&owned_brief).unwrap();
+
+        let mut cross_turn_brief = owned_brief.clone();
+        cross_turn_brief.id = "brief-cross-turn".into();
+        cross_turn_brief.text = "cross-turn result must stay hidden".into();
+        cross_turn_brief.turn_id = Some("turn-other".into());
+        cross_turn_brief.turn_index = Some(turn_index);
+        storage.append_brief(&cross_turn_brief).unwrap();
+
+        let owned_tool = ToolExecutionRecord {
+            id: "tool-owned".into(),
+            agent_id: "default".into(),
+            work_item_id: None,
+            turn_index: 99,
+            turn_id: Some(turn_id.into()),
+            tool_name: "ExecCommand".into(),
+            created_at: chrono::Utc::now(),
+            completed_at: Some(chrono::Utc::now()),
+            duration_ms: 1,
+            authority_class: AuthorityClass::RuntimeInstruction,
+            status: ToolExecutionStatus::Success,
+            input: json!({}),
+            output: json!({}),
+            summary: "owned tool".into(),
+            invocation_surface: None,
+        };
+        storage.append_tool_execution(&owned_tool).unwrap();
+
+        let mut cross_turn_tool = owned_tool.clone();
+        cross_turn_tool.id = "tool-cross-turn".into();
+        cross_turn_tool.turn_index = turn_index;
+        cross_turn_tool.turn_id = Some("turn-other".into());
+        storage.append_tool_execution(&cross_turn_tool).unwrap();
+
+        let mut turn = TurnRecord::new("default", turn_id, turn_index);
+        turn.input_message_ids = vec![cross_turn_message.id.clone()];
+        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(
+            &cross_turn_message,
+        ));
+        turn.produced_brief_ids = vec![owned_brief.id.clone(), cross_turn_brief.id.clone()];
+        turn.tool_execution_ids = vec![owned_tool.id.clone(), cross_turn_tool.id.clone()];
+        storage.append_turn(&turn).unwrap();
+
+        let context = context_for_storage(&storage, "default");
+        let recent_turns = context
+            .sections
+            .iter()
+            .find(|section| section.name == "recent_turns")
+            .expect("recent_turns section")
+            .content
+            .clone();
+
+        assert!(recent_turns.contains("  - trigger: unavailable"));
+        assert!(recent_turns.contains("owned result remains visible"));
+        assert!(recent_turns.contains("tool_execution:tool-owned:output"));
+        assert!(!recent_turns.contains("cross-turn operator input must stay hidden"));
+        assert!(!recent_turns.contains("cross-turn result must stay hidden"));
+        assert!(!recent_turns.contains("tool_execution:tool-cross-turn:output"));
     }
 
     #[test]
@@ -3172,7 +3329,7 @@ mod tests {
             "Please preserve this operator input in recent turns.".repeat(8)
         );
 
-        let operator = MessageEnvelope::new(
+        let mut operator = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
             MessageOrigin::Operator {
@@ -3184,6 +3341,7 @@ mod tests {
                 text: operator_text.clone(),
             },
         );
+        operator.turn_id = Some("turn-full-operator-input".into());
         storage.append_message(&operator).unwrap();
         let mut brief = BriefRecord::new(
             "default",
@@ -3193,6 +3351,7 @@ mod tests {
             None,
         );
         brief.id = "brief-full-operator-input".into();
+        brief.turn_id = Some("turn-full-operator-input".into());
         storage.append_brief(&brief).unwrap();
         let mut turn = TurnRecord::new("default", "turn-full-operator-input", 1);
         turn.input_message_ids = vec![operator.id.clone()];
@@ -3246,7 +3405,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let long_tail = "older-operator-tail-hidden-behind-message-ref";
-        let message = MessageEnvelope::new(
+        let mut message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
             MessageOrigin::Operator { actor_id: None },
@@ -3256,13 +3415,15 @@ mod tests {
                 text: format!("{} {long_tail}", "older operator input. ".repeat(40)),
             },
         );
-        let brief = BriefRecord::new(
+        message.turn_id = Some("turn-old-message-preview".into());
+        let mut brief = BriefRecord::new(
             "default",
             BriefKind::Result,
             "brief anchor remains visible",
             Some(message.id.clone()),
             None,
         );
+        brief.turn_id = Some("turn-old-message-preview".into());
         let mut turn = TurnRecord::new("default", "turn-old-message-preview", 1);
         turn.input_message_ids = vec![message.id.clone()];
         turn.produced_brief_ids = vec![brief.id.clone()];
@@ -3293,7 +3454,7 @@ mod tests {
     fn recent_turns_resolves_transcript_backed_brief_content() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
-        let message = MessageEnvelope::new(
+        let mut message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
             MessageOrigin::Operator { actor_id: None },
@@ -3303,6 +3464,7 @@ mod tests {
                 text: "summarize from transcript".to_string(),
             },
         );
+        message.turn_id = Some("turn-transcript-backed".into());
         let entry = TranscriptEntry::new(
             "default",
             TranscriptEntryKind::AssistantRound,
@@ -3319,6 +3481,7 @@ mod tests {
             None,
         );
         brief.id = "brief-transcript-backed".into();
+        brief.turn_id = Some("turn-transcript-backed".into());
         brief.content_source = BriefContentSource::TranscriptEntry {
             entry_id: entry.id.clone(),
             relation: BriefContentSourceRelation::DerivedFrom,
@@ -3510,13 +3673,14 @@ mod tests {
         prior_message.turn_id = Some("turn-benchmark".to_string());
         storage.append_message(&prior_message).unwrap();
 
-        let result_brief = BriefRecord::new(
+        let mut result_brief = BriefRecord::new(
             "default",
             BriefKind::Result,
             "Updated benchmark summary reporting and verified cargo test.",
             Some(prior_message.id.clone()),
             None,
         );
+        result_brief.turn_id = Some("turn-benchmark".into());
         storage.append_brief(&result_brief).unwrap();
 
         let tool_record = ToolExecutionRecord {
@@ -4026,7 +4190,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
-        let prior_message = MessageEnvelope::new(
+        let mut prior_message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
             MessageOrigin::Operator { actor_id: None },
@@ -4036,22 +4200,25 @@ mod tests {
                 text: "previous request".to_string(),
             },
         );
+        prior_message.turn_id = Some("turn-previous".into());
         storage.append_message(&prior_message).unwrap();
-        let ack = BriefRecord::new(
+        let mut ack = BriefRecord::new(
             "default",
             BriefKind::Ack,
             "Acknowledged the request. Queued work: previous request",
             Some(prior_message.id.clone()),
             None,
         );
+        ack.turn_id = Some("turn-previous".into());
         storage.append_brief(&ack).unwrap();
-        let result = BriefRecord::new(
+        let mut result = BriefRecord::new(
             "default",
             BriefKind::Result,
             "Unique latest result content.",
             Some(prior_message.id.clone()),
             None,
         );
+        result.turn_id = Some("turn-previous".into());
         storage.append_brief(&result).unwrap();
         let mut turn = TurnRecord::new("default", "turn-previous", 1);
         turn.input_message_ids = vec![prior_message.id.clone()];
@@ -4117,7 +4284,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let tail = "latest-result-tail-visible-after-old-preview-limit";
-        let prior_message = MessageEnvelope::new(
+        let mut prior_message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
             MessageOrigin::Operator { actor_id: None },
@@ -4127,8 +4294,9 @@ mod tests {
                 text: "derive the final principle".to_string(),
             },
         );
+        prior_message.turn_id = Some("turn-latest-result-full".into());
         storage.append_message(&prior_message).unwrap();
-        let result = BriefRecord::new(
+        let mut result = BriefRecord::new(
             "default",
             BriefKind::Result,
             format!(
@@ -4138,6 +4306,7 @@ mod tests {
             Some(prior_message.id.clone()),
             None,
         );
+        result.turn_id = Some("turn-latest-result-full".into());
         storage.append_brief(&result).unwrap();
         let mut turn = TurnRecord::new("default", "turn-latest-result-full", 1);
         turn.input_message_ids = vec![prior_message.id.clone()];
@@ -4188,7 +4357,7 @@ mod tests {
     fn continuity_result_truncation_keeps_explicit_brief_ref() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
-        let message = MessageEnvelope::new(
+        let mut message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
             MessageOrigin::Operator { actor_id: None },
@@ -4198,6 +4367,7 @@ mod tests {
                 text: "summarize the long result".to_string(),
             },
         );
+        message.turn_id = Some("turn-long-continuity".into());
         let mut brief = BriefRecord::new(
             "default",
             BriefKind::Result,
@@ -4206,6 +4376,7 @@ mod tests {
             None,
         );
         brief.id = "brief-long-continuity".into();
+        brief.turn_id = Some("turn-long-continuity".into());
         let mut turn = TurnRecord::new("default", "turn-long-continuity", 1);
         turn.input_message_ids = vec![message.id.clone()];
         turn.produced_brief_ids = vec![brief.id.clone()];
@@ -4254,7 +4425,7 @@ mod tests {
         let mut turns = Vec::new();
 
         for idx in 1..=4 {
-            let message = MessageEnvelope::new(
+            let mut message = MessageEnvelope::new(
                 "default",
                 MessageKind::OperatorPrompt,
                 MessageOrigin::Operator { actor_id: None },
@@ -4264,6 +4435,8 @@ mod tests {
                     text: format!("turn {idx} request"),
                 },
             );
+            let turn_id = format!("turn-nearby-{idx}");
+            message.turn_id = Some(turn_id.clone());
             let tail = match idx {
                 1 => "older-tail-after-compact-preview",
                 2 => "nearby-two-tail-after-compact-preview",
@@ -4278,7 +4451,8 @@ mod tests {
                 None,
             );
             brief.id = format!("brief-nearby-{idx}");
-            let mut turn = TurnRecord::new("default", format!("turn-nearby-{idx}"), idx);
+            brief.turn_id = Some(turn_id.clone());
+            let mut turn = TurnRecord::new("default", turn_id, idx);
             turn.input_message_ids = vec![message.id.clone()];
             turn.produced_brief_ids = vec![brief.id.clone()];
             turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
@@ -4497,13 +4671,14 @@ mod tests {
         prior_message.turn_id = Some("turn-wake-path".to_string());
         storage.append_message(&prior_message).unwrap();
 
-        let brief = BriefRecord::new(
+        let mut brief = BriefRecord::new(
             "default",
             BriefKind::Failure,
             "Tried cargo test wake_path, but the result is still inconclusive.",
             Some(prior_message.id.clone()),
             None,
         );
+        brief.turn_id = Some("turn-wake-path".into());
         storage.append_brief(&brief).unwrap();
         let tool = ToolExecutionRecord {
             id: "tool-raw-evidence".to_string(),
@@ -7354,7 +7529,7 @@ mod tests {
     }
 
     #[test]
-    fn turn_record_matches_message_uses_turn_id_then_legacy_turn_index_and_input_ids() {
+    fn turn_record_matches_message_requires_matching_non_empty_turn_id() {
         let mut message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -7377,17 +7552,22 @@ mod tests {
 
         record.turn_id = String::new();
         message.turn_id = None;
-        assert!(turn_record_matches_message(&record, &message));
+        assert!(!turn_record_matches_message(&record, &message));
 
-        message.message_seq = Some(5);
+        record.turn_id = "turn-current".into();
+        message.message_seq = Some(4);
         assert!(!turn_record_matches_message(&record, &message));
 
         record.input_message_ids = vec![message.id.clone()];
+        record.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
+        assert!(!turn_record_matches_message(&record, &message));
+
+        message.turn_id = Some(" turn-current ".into());
         assert!(turn_record_matches_message(&record, &message));
     }
 
     #[test]
-    fn turn_record_matches_message_ignores_zero_legacy_turn_index() {
+    fn turn_record_matches_message_ignores_sequence_collision() {
         let mut message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -7398,9 +7578,9 @@ mod tests {
                 text: "run tests".into(),
             },
         );
-        message.message_seq = Some(0);
+        message.message_seq = Some(4);
 
-        let record = TurnRecord::new("default", "", 4);
+        let record = TurnRecord::new("default", "turn-current", 4);
 
         assert!(!turn_record_matches_message(&record, &message));
     }

--- a/src/runtime/tests/mod.rs
+++ b/src/runtime/tests/mod.rs
@@ -2,7 +2,7 @@ mod agent_and_tools;
 mod message_dispatch;
 mod runtime_state;
 mod scheduler;
-mod support;
+pub(crate) mod support;
 mod task_recovery;
 mod tasks;
 mod timers;

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -178,10 +178,7 @@ impl RuntimeHandle {
 
         let input_messages = messages
             .iter()
-            .filter(|message| {
-                turn_optional_id_matches(message.turn_id.as_deref(), turn_id)
-                    || message.message_seq == Some(terminal.turn_index)
-            })
+            .filter(|message| turn_optional_id_matches(message.turn_id.as_deref(), turn_id))
             .collect::<Vec<_>>();
 
         let mut record = TurnRecord::new(agent_id, turn_id, terminal.turn_index);
@@ -196,26 +193,19 @@ impl RuntimeHandle {
             .collect();
         record.tool_execution_ids = tools
             .iter()
-            .filter(|tool| {
-                turn_optional_id_matches(tool.turn_id.as_deref(), turn_id)
-                    || tool.turn_index == terminal.turn_index
-            })
+            .filter(|tool| turn_optional_id_matches(tool.turn_id.as_deref(), turn_id))
             .map(|tool| tool.id.clone())
             .collect();
         record.produced_brief_ids = briefs
             .iter()
-            .filter(|brief| {
-                turn_optional_id_matches(brief.turn_id.as_deref(), turn_id)
-                    || brief.turn_index == Some(terminal.turn_index)
-            })
+            .filter(|brief| turn_optional_id_matches(brief.turn_id.as_deref(), turn_id))
             .map(|brief| brief.id.clone())
             .collect();
         record.completed_work_item_ids = briefs
             .iter()
             .filter(|brief| {
                 brief.kind == BriefKind::Result
-                    && (turn_optional_id_matches(brief.turn_id.as_deref(), turn_id)
-                        || brief.turn_index == Some(terminal.turn_index))
+                    && turn_optional_id_matches(brief.turn_id.as_deref(), turn_id)
             })
             .filter_map(|brief| brief.work_item_id.clone())
             .collect::<std::collections::BTreeSet<_>>()

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -39,6 +39,134 @@ fn fixture_plan_artifact(
     }
 }
 
+#[tokio::test]
+async fn persist_turn_record_uses_turn_id_not_numeric_sequence_collisions() {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        std::sync::Arc::new(crate::provider::StubProvider::new("unused")),
+        "default".into(),
+        crate::runtime::tests::support::context_config(),
+    )
+    .unwrap();
+    let turn_id = "turn-owned";
+    let turn_index = 7;
+
+    let mut owned_message = MessageEnvelope::new(
+        "default",
+        crate::types::MessageKind::OperatorPrompt,
+        crate::types::MessageOrigin::Operator { actor_id: None },
+        crate::types::AuthorityClass::OperatorInstruction,
+        crate::types::Priority::Normal,
+        crate::types::MessageBody::Text {
+            text: "owned input".into(),
+        },
+    );
+    owned_message.turn_id = Some(turn_id.into());
+    owned_message.message_seq = Some(99);
+    runtime.storage().append_message(&owned_message).unwrap();
+
+    let mut colliding_message = owned_message.clone();
+    colliding_message.id = "message-collision".into();
+    colliding_message.turn_id = Some("turn-other".into());
+    colliding_message.message_seq = Some(turn_index);
+    runtime
+        .storage()
+        .append_message(&colliding_message)
+        .unwrap();
+
+    let mut missing_turn_message = owned_message.clone();
+    missing_turn_message.id = "message-missing-turn".into();
+    missing_turn_message.turn_id = None;
+    missing_turn_message.message_seq = Some(turn_index);
+    runtime
+        .storage()
+        .append_message(&missing_turn_message)
+        .unwrap();
+
+    let owned_tool = crate::types::ToolExecutionRecord {
+        id: "tool-owned".into(),
+        agent_id: "default".into(),
+        work_item_id: None,
+        turn_index: 99,
+        turn_id: Some(turn_id.into()),
+        tool_name: "ExecCommand".into(),
+        created_at: Utc::now(),
+        completed_at: Some(Utc::now()),
+        duration_ms: 1,
+        authority_class: crate::types::AuthorityClass::RuntimeInstruction,
+        status: crate::types::ToolExecutionStatus::Success,
+        input: serde_json::json!({}),
+        output: serde_json::json!({}),
+        summary: "owned".into(),
+        invocation_surface: None,
+    };
+    runtime
+        .storage()
+        .append_tool_execution(&owned_tool)
+        .unwrap();
+    let mut colliding_tool = owned_tool.clone();
+    colliding_tool.id = "tool-collision".into();
+    colliding_tool.turn_index = turn_index;
+    colliding_tool.turn_id = Some("turn-other".into());
+    runtime
+        .storage()
+        .append_tool_execution(&colliding_tool)
+        .unwrap();
+
+    let mut owned_brief = crate::types::BriefRecord::new(
+        "default",
+        BriefKind::Result,
+        "owned result",
+        Some(owned_message.id.clone()),
+        None,
+    );
+    owned_brief.id = "brief-owned".into();
+    owned_brief.turn_index = Some(99);
+    owned_brief.turn_id = Some(turn_id.into());
+    owned_brief.work_item_id = Some("work-owned".into());
+    runtime.storage().append_brief(&owned_brief).unwrap();
+    let mut colliding_brief = owned_brief.clone();
+    colliding_brief.id = "brief-collision".into();
+    colliding_brief.turn_index = Some(turn_index);
+    colliding_brief.turn_id = Some("turn-other".into());
+    colliding_brief.work_item_id = Some("work-other".into());
+    runtime.storage().append_brief(&colliding_brief).unwrap();
+
+    runtime
+        .persist_turn_record(&TurnTerminalRecord {
+            turn_id: turn_id.into(),
+            turn_index,
+            kind: TurnTerminalKind::Completed,
+            reason: None,
+            last_assistant_message: None,
+            checkpoint: None,
+            completed_at: Utc::now(),
+            duration_ms: 1,
+        })
+        .await
+        .unwrap();
+
+    let record = runtime
+        .storage()
+        .read_recent_turns(1)
+        .unwrap()
+        .pop()
+        .expect("persisted turn");
+    assert_eq!(record.input_message_ids, vec![owned_message.id.clone()]);
+    assert_eq!(
+        record.trigger.and_then(|trigger| trigger.message_id),
+        Some(owned_message.id)
+    );
+    assert_eq!(record.tool_execution_ids, vec![owned_tool.id]);
+    assert_eq!(record.produced_brief_ids, vec![owned_brief.id]);
+    assert_eq!(record.completed_work_item_ids, vec!["work-owned"]);
+}
+
 #[test]
 fn truncated_mutation_recovery_hint_is_tool_specific() {
     let apply_patch = truncated_mutation_recovery_hint("ApplyPatch");

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -397,9 +397,12 @@ fn append_turn_for_message(
     turn_id: &str,
     turn_index: u64,
 ) -> Result<TurnRecord> {
+    let mut message = message.clone();
+    message.turn_id = Some(turn_id.into());
+    storage.append_message(&message)?;
     let mut turn = TurnRecord::new(&message.agent_id, turn_id, turn_index);
     turn.input_message_ids = vec![message.id.clone()];
-    turn.trigger = Some(TurnTriggerSummary::from_message(message));
+    turn.trigger = Some(TurnTriggerSummary::from_message(&message));
     storage.append_turn(&turn)?;
     Ok(turn)
 }
@@ -435,6 +438,7 @@ fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
         None,
     );
     result_brief.id = "brief_focused_prompt_projection".into();
+    result_brief.turn_id = Some("turn-focused-prompt".into());
     storage.append_brief(&result_brief)?;
     let mut turn = append_turn_for_message(&storage, &previous_operator, "turn-focused-prompt", 1)?;
     turn.produced_brief_ids = vec![result_brief.id.clone()];
@@ -536,6 +540,7 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
     );
     turn_index_brief.id = "brief_completion_report_promotion".into();
     turn_index_brief.turn_index = Some(1);
+    turn_index_brief.turn_id = Some("turn_op_test".into());
     storage.append_brief(&turn_index_brief)?;
     storage.append_tool_execution(&ToolExecutionRecord {
         id: "tool_exec_1".into(),
@@ -625,7 +630,7 @@ runtime flow
 
 ## continuation_anchor
 Continuation anchor:
-Latest trusted operator input: message_seq 1.
+Latest trusted operator input: message_seq 2.
 Current input relation: current_input is a task-result continuation, not a new operator request. Continue the latest trusted operator input above unless the current WorkItem projection is more specific.
 
 ## recent_turns
@@ -633,7 +638,7 @@ Recent turns:
 - Turn turn_index 1:
   - turn_id: turn_op_test
   - trigger: trusted operator input
-  - continues input: message_seq 1
+  - continues input: message_seq 2
   - continuation trigger: a task-result continuation
   - operator input full: Run cargo test runtime_flow and report back. message_ref=message:msg_runtime_flow_operator
   - produced briefs:
@@ -1770,6 +1775,7 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         None,
     );
     first_brief.id = "brief_context_eval_started".into();
+    first_brief.turn_id = Some("turn_context_eval_start".into());
     storage.append_brief(&first_brief)?;
 
     storage.append_tool_execution(&ToolExecutionRecord {
@@ -1819,6 +1825,7 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         Some("task_context_eval".into()),
     );
     task_brief.id = "brief_context_eval_diagnostics".into();
+    task_brief.turn_id = Some("turn_context_eval_tool".into());
     storage.append_brief(&task_brief)?;
     let mut task_turn =
         append_turn_for_message(&storage, &task_result, "turn_context_eval_tool", 2)?;
@@ -1997,6 +2004,7 @@ fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_disc
         None,
     );
     first_brief.id = "brief_issue_list_initial".into();
+    first_brief.turn_id = Some("turn_issue_list_analysis".into());
     storage.append_brief(&first_brief)?;
     let mut first_turn =
         append_turn_for_message(&storage, &first_operator, "turn_issue_list_analysis", 1)?;
@@ -2046,6 +2054,7 @@ fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_disc
             None,
         );
         brief.turn_index = Some((turn_index + 2) as u64);
+        brief.turn_id = Some(format!("turn_issue_list_discussion_{}", turn_index + 1));
         storage.append_brief(&brief)?;
         let mut turn = append_turn_for_message(
             &storage,
@@ -2184,6 +2193,7 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
         None,
     );
     recent_brief.id = "brief_active_resume".into();
+    recent_brief.turn_id = Some("turn_active_resume".into());
     storage.append_brief(&recent_brief)?;
     let mut recent_turn =
         append_turn_for_message(&storage, &recent_operator, "turn_active_resume", 2)?;


### PR DESCRIPTION
Closes #2278

## Summary

- require non-empty exact `turn_id` matches for message, tool execution, brief, and wait ownership when persisting `TurnRecord`
- validate persisted recent-turn references against each referenced object's own `turn_id`, ignoring historical cross-turn contamination
- remove numeric `message_seq` / `turn_index` ownership fallbacks and document the contract in the turn-based context projection RFC
- add regression coverage for numeric collisions and polluted persisted records

## Verification

- `cargo test persist_turn_record_uses_turn_id_not_numeric_sequence_collisions --lib`
- `cargo test turn_record_matches_message_ --lib`
- `cargo test recent_turns_ignores_persisted_cross_turn_references --lib`
- `cargo test context::tests --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
