### PR TITLE
fix: preserve queue and wait terminal states

### DIFF
--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -106,6 +106,58 @@ impl fmt::Display for RuntimeDbRetryableError {
 
 impl StdError for RuntimeDbRetryableError {}
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeStateTransitionConflict {
+    domain: &'static str,
+    record_id: String,
+    existing_status: String,
+    incoming_status: String,
+}
+
+impl RuntimeStateTransitionConflict {
+    pub(crate) fn new(
+        domain: &'static str,
+        record_id: impl Into<String>,
+        existing_status: impl Into<String>,
+        incoming_status: impl Into<String>,
+    ) -> Self {
+        Self {
+            domain,
+            record_id: record_id.into(),
+            existing_status: existing_status.into(),
+            incoming_status: incoming_status.into(),
+        }
+    }
+
+    pub fn domain(&self) -> &'static str {
+        self.domain
+    }
+
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+
+    pub fn existing_status(&self) -> &str {
+        &self.existing_status
+    }
+
+    pub fn incoming_status(&self) -> &str {
+        &self.incoming_status
+    }
+}
+
+impl fmt::Display for RuntimeStateTransitionConflict {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "conflicting {} transition for {}: {} -> {}",
+            self.domain, self.record_id, self.existing_status, self.incoming_status
+        )
+    }
+}
+
+impl StdError for RuntimeStateTransitionConflict {}
+
 #[derive(Clone)]
 pub struct RuntimeDb {
     path: PathBuf,

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -12,7 +12,8 @@ use crate::runtime_db::index_outbox::RuntimeIndexChange;
 use crate::runtime_db::types::*;
 use crate::runtime_db::write_queue::RuntimeDbWriteContext;
 use crate::runtime_db::{
-    CONTEXT_EPISODE_ANCHORS_DOMAIN, TASK_PAYLOAD_ARRAY_LIMIT, TASK_PAYLOAD_STRING_LIMIT,
+    RuntimeStateTransitionConflict, CONTEXT_EPISODE_ANCHORS_DOMAIN, TASK_PAYLOAD_ARRAY_LIMIT,
+    TASK_PAYLOAD_STRING_LIMIT,
 };
 use crate::types::*;
 
@@ -1267,11 +1268,12 @@ impl WaitConditionRepository<'_> {
         }
         self.db
             .run_storage_domain_import("wait_conditions", "jsonl", "db", |tx| {
-                let latest = reduce_wait_condition_records(records);
-                for record in latest.values() {
-                    upsert_wait_condition_tx(tx, record)?;
+                let mut imported_ids = BTreeMap::<String, ()>::new();
+                for record in records {
+                    imported_ids.insert(record.id.clone(), ());
+                    upsert_wait_condition_tx(tx, &record)?;
                 }
-                Ok(serde_json::json!({ "imported_records": latest.len() }))
+                Ok(serde_json::json!({ "imported_records": imported_ids.len() }))
             })
     }
 
@@ -1396,11 +1398,12 @@ impl QueueEntryRepository<'_> {
         }
         self.db
             .run_storage_domain_import("queue_entries", "jsonl", "db", |tx| {
-                let imported_records = records.len();
+                let mut imported_ids = BTreeMap::<String, ()>::new();
                 for record in records {
+                    imported_ids.insert(record.message_id.clone(), ());
                     upsert_queue_entry_tx(tx, &record)?;
                 }
-                Ok(serde_json::json!({ "imported_records": imported_records }))
+                Ok(serde_json::json!({ "imported_records": imported_ids.len() }))
             })
     }
 
@@ -2966,6 +2969,22 @@ pub(crate) fn task_status_phase(status: &TaskStatus) -> u8 {
 }
 
 fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM wait_conditions WHERE wait_condition_id = ?1",
+            [&record.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| decode_wait_condition_payload(&payload))
+        .transpose()?;
+    if let Some(existing) = existing.as_ref() {
+        match wait_condition_transition(existing, record)? {
+            StateTransitionOutcome::Applied => {}
+            StateTransitionOutcome::Idempotent => return Ok(()),
+        }
+    }
+
     let payload_json = serde_json::to_string(record)?;
     let status = enum_string(&record.status)?;
     let kind = enum_string(&record.kind)?;
@@ -3024,6 +3043,22 @@ fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) 
 }
 
 fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM queue_entries WHERE message_id = ?1",
+            [&record.message_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| decode_queue_entry_payload(&payload))
+        .transpose()?;
+    if let Some(existing) = existing.as_ref() {
+        match queue_entry_transition(existing, record)? {
+            StateTransitionOutcome::Applied => {}
+            StateTransitionOutcome::Idempotent => return Ok(()),
+        }
+    }
+
     let payload_json = serde_json::to_string(record)?;
     let priority = enum_string(&record.priority)?;
     let status = enum_string(&record.status)?;
@@ -3050,6 +3085,91 @@ fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Res
         ],
     )?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StateTransitionOutcome {
+    Applied,
+    Idempotent,
+}
+
+fn queue_entry_transition(
+    existing: &QueueEntryRecord,
+    incoming: &QueueEntryRecord,
+) -> Result<StateTransitionOutcome> {
+    if is_terminal_queue_entry_status(&existing.status) {
+        if is_terminal_queue_entry_status(&incoming.status)
+            && queue_entry_terminal_payload_eq(existing, incoming)
+        {
+            return Ok(StateTransitionOutcome::Idempotent);
+        }
+        return Err(RuntimeStateTransitionConflict::new(
+            "queue entry",
+            &existing.message_id,
+            enum_string(&existing.status)?,
+            enum_string(&incoming.status)?,
+        )
+        .into());
+    }
+    if incoming.updated_at < existing.updated_at {
+        return Ok(StateTransitionOutcome::Idempotent);
+    }
+    Ok(StateTransitionOutcome::Applied)
+}
+
+fn wait_condition_transition(
+    existing: &WaitConditionRecord,
+    incoming: &WaitConditionRecord,
+) -> Result<StateTransitionOutcome> {
+    if is_terminal_wait_condition_status(&existing.status) {
+        if is_terminal_wait_condition_status(&incoming.status)
+            && wait_condition_terminal_payload_eq(existing, incoming)
+        {
+            return Ok(StateTransitionOutcome::Idempotent);
+        }
+        return Err(RuntimeStateTransitionConflict::new(
+            "wait condition",
+            &existing.id,
+            enum_string(&existing.status)?,
+            enum_string(&incoming.status)?,
+        )
+        .into());
+    }
+    if incoming.updated_at < existing.updated_at {
+        return Ok(StateTransitionOutcome::Idempotent);
+    }
+    Ok(StateTransitionOutcome::Applied)
+}
+
+fn is_terminal_queue_entry_status(status: &QueueEntryStatus) -> bool {
+    matches!(
+        status,
+        QueueEntryStatus::Processed | QueueEntryStatus::Aborted | QueueEntryStatus::Dropped
+    )
+}
+
+fn is_terminal_wait_condition_status(status: &WaitConditionStatus) -> bool {
+    !matches!(status, WaitConditionStatus::Active)
+}
+
+fn queue_entry_terminal_payload_eq(
+    existing: &QueueEntryRecord,
+    incoming: &QueueEntryRecord,
+) -> bool {
+    let mut existing = existing.clone();
+    let incoming = incoming.clone();
+    existing.updated_at = incoming.updated_at;
+    existing == incoming
+}
+
+fn wait_condition_terminal_payload_eq(
+    existing: &WaitConditionRecord,
+    incoming: &WaitConditionRecord,
+) -> bool {
+    let mut existing = existing.clone();
+    let incoming = incoming.clone();
+    existing.updated_at = incoming.updated_at;
+    existing == incoming
 }
 
 fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<bool> {
@@ -3360,33 +3480,6 @@ pub(crate) fn newer_work_item_record(
         .cmp(&existing.revision)
         .then_with(|| candidate.updated_at.cmp(&existing.updated_at))
         .then_with(|| candidate.created_at.cmp(&existing.created_at))
-        .is_gt()
-}
-
-pub(crate) fn reduce_wait_condition_records(
-    records: Vec<WaitConditionRecord>,
-) -> BTreeMap<String, WaitConditionRecord> {
-    let mut latest = BTreeMap::<String, WaitConditionRecord>::new();
-    for record in records {
-        if latest
-            .get(&record.id)
-            .is_none_or(|existing| newer_wait_condition_record(&record, existing))
-        {
-            latest.insert(record.id.clone(), record);
-        }
-    }
-    latest
-}
-
-pub(crate) fn newer_wait_condition_record(
-    candidate: &WaitConditionRecord,
-    existing: &WaitConditionRecord,
-) -> bool {
-    candidate
-        .updated_at
-        .cmp(&existing.updated_at)
-        .then_with(|| candidate.created_at.cmp(&existing.created_at))
-        .then_with(|| candidate.id.cmp(&existing.id))
         .is_gt()
 }
 
@@ -3791,6 +3884,10 @@ pub(crate) fn decode_wait_condition_row(row: &rusqlite::Row<'_>) -> Result<WaitC
 
 pub(crate) fn decode_queue_entry_payload(payload: &str) -> Result<QueueEntryRecord> {
     serde_json::from_str(payload).context("decoding queue entry payload from runtime db")
+}
+
+pub(crate) fn decode_wait_condition_payload(payload: &str) -> Result<WaitConditionRecord> {
+    serde_json::from_str(payload).context("decoding wait condition payload from runtime db")
 }
 
 pub(crate) fn decode_timer_payload(payload: &str) -> Result<TimerRecord> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3149,7 +3149,12 @@ fn is_terminal_queue_entry_status(status: &QueueEntryStatus) -> bool {
 }
 
 fn is_terminal_wait_condition_status(status: &WaitConditionStatus) -> bool {
-    !matches!(status, WaitConditionStatus::Active)
+    matches!(
+        status,
+        WaitConditionStatus::Resolved
+            | WaitConditionStatus::Cancelled
+            | WaitConditionStatus::Expired
+    )
 }
 
 fn queue_entry_terminal_payload_eq(
@@ -3157,9 +3162,8 @@ fn queue_entry_terminal_payload_eq(
     incoming: &QueueEntryRecord,
 ) -> bool {
     let mut existing = existing.clone();
-    let incoming = incoming.clone();
     existing.updated_at = incoming.updated_at;
-    existing == incoming
+    existing == *incoming
 }
 
 fn wait_condition_terminal_payload_eq(
@@ -3167,9 +3171,8 @@ fn wait_condition_terminal_payload_eq(
     incoming: &WaitConditionRecord,
 ) -> bool {
     let mut existing = existing.clone();
-    let incoming = incoming.clone();
     existing.updated_at = incoming.updated_at;
-    existing == incoming
+    existing == *incoming
 }
 
 fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<bool> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -13,14 +13,16 @@ use crate::runtime_db::migrations::{
 use crate::runtime_db::storage_domain::upsert_storage_domain;
 #[cfg(test)]
 use crate::runtime_db::{
-    RuntimeDb, RuntimeDbRetryableError, TASK_PAYLOAD_ARRAY_LIMIT, TASK_PAYLOAD_STRING_LIMIT,
+    RuntimeDb, RuntimeDbRetryableError, RuntimeStateTransitionConflict, TASK_PAYLOAD_ARRAY_LIMIT,
+    TASK_PAYLOAD_STRING_LIMIT,
 };
 #[cfg(test)]
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, CallbackDeliveryMode,
     ExecutionRootEntry, ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus,
     MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus,
-    ToolExecutionRecord, WorkItemRecord, WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
+    ToolExecutionRecord, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
+    WorkItemRecord, WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 #[cfg(test)]
 use anyhow::{anyhow, bail, Context, Result};
@@ -1077,6 +1079,240 @@ CREATE TABLE working_memory_deltas (
         claim.updated_at = now + chrono::Duration::seconds(2);
         assert!(!db.queue_entries().try_claim_queued_message(&claim)?);
 
+        Ok(())
+    }
+
+    #[test]
+    fn queue_terminal_state_rejects_late_updates_and_allows_identical_retries() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let terminal = QueueEntryRecord {
+            message_id: "message-terminal".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Processed,
+            created_at: now,
+            updated_at: now + chrono::Duration::seconds(1),
+        };
+        db.queue_entries().upsert(&terminal)?;
+
+        let mut identical_retry = terminal.clone();
+        identical_retry.updated_at = now + chrono::Duration::seconds(2);
+        db.queue_entries().upsert(&identical_retry)?;
+        assert_eq!(db.queue_entries().latest_all()?, vec![terminal.clone()]);
+
+        let mut late_active = terminal.clone();
+        late_active.status = QueueEntryStatus::Interrupted;
+        late_active.updated_at = now + chrono::Duration::seconds(3);
+        let error = db.queue_entries().upsert(&late_active).unwrap_err();
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("late queue update should return a typed conflict");
+        assert_eq!(conflict.domain(), "queue entry");
+        assert_eq!(conflict.record_id(), terminal.message_id);
+        assert_eq!(conflict.existing_status(), "processed");
+        assert_eq!(conflict.incoming_status(), "interrupted");
+
+        let mut conflicting_terminal = terminal.clone();
+        conflicting_terminal.status = QueueEntryStatus::Dropped;
+        conflicting_terminal.updated_at = now + chrono::Duration::seconds(4);
+        assert!(db
+            .queue_entries()
+            .upsert(&conflicting_terminal)
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+        assert_eq!(db.queue_entries().latest_all()?, vec![terminal]);
+        Ok(())
+    }
+
+    #[test]
+    fn wait_terminal_state_rejects_late_updates_and_allows_identical_retries() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let terminal = WaitConditionRecord {
+            id: "wait-terminal".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some("work-1".into()),
+            status: WaitConditionStatus::Resolved,
+            kind: WaitConditionKind::Task,
+            source: Some("task".into()),
+            subject_ref: Some("task-1".into()),
+            waiting_for: "task result".into(),
+            wake_sources: Vec::new(),
+            continuation: None,
+            created_at: now,
+            updated_at: now + chrono::Duration::seconds(1),
+            expires_at: None,
+            resolved_at: Some(now + chrono::Duration::seconds(1)),
+            cancelled_at: None,
+            turn_id: Some("turn-1".into()),
+        };
+        db.wait_conditions().upsert(&terminal)?;
+        let persisted_terminal = db.wait_conditions().latest_all()?;
+
+        let mut identical_retry = terminal.clone();
+        identical_retry.updated_at = now + chrono::Duration::seconds(2);
+        db.wait_conditions().upsert(&identical_retry)?;
+        assert_eq!(db.wait_conditions().latest_all()?, persisted_terminal);
+
+        let mut late_active = terminal.clone();
+        late_active.status = WaitConditionStatus::Active;
+        late_active.updated_at = now + chrono::Duration::seconds(3);
+        late_active.resolved_at = None;
+        let error = db.wait_conditions().upsert(&late_active).unwrap_err();
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("late wait update should return a typed conflict");
+        assert_eq!(conflict.domain(), "wait condition");
+        assert_eq!(conflict.record_id(), terminal.id);
+        assert_eq!(conflict.existing_status(), "resolved");
+        assert_eq!(conflict.incoming_status(), "active");
+
+        let mut conflicting_terminal = terminal.clone();
+        conflicting_terminal.status = WaitConditionStatus::Cancelled;
+        conflicting_terminal.updated_at = now + chrono::Duration::seconds(4);
+        conflicting_terminal.resolved_at = None;
+        conflicting_terminal.cancelled_at = Some(now + chrono::Duration::seconds(4));
+        assert!(db
+            .wait_conditions()
+            .upsert(&conflicting_terminal)
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+        assert_eq!(db.wait_conditions().latest_all()?, persisted_terminal);
+        Ok(())
+    }
+
+    #[test]
+    fn queue_and_wait_terminal_state_survive_restart_and_second_db_handle() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let first = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let second = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let queue_terminal = QueueEntryRecord {
+            message_id: "message-restart".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Aborted,
+            created_at: now,
+            updated_at: now,
+        };
+        let wait_terminal = WaitConditionRecord {
+            id: "wait-restart".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: None,
+            status: WaitConditionStatus::Expired,
+            kind: WaitConditionKind::Timer,
+            source: Some("timer".into()),
+            subject_ref: Some("timer-1".into()),
+            waiting_for: "timer".into(),
+            wake_sources: Vec::new(),
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: Some(now),
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        };
+        first.queue_entries().upsert(&queue_terminal)?;
+        first.wait_conditions().upsert(&wait_terminal)?;
+        let persisted_queue_terminal = first.queue_entries().latest_all()?;
+        let persisted_wait_terminal = first.wait_conditions().latest_all()?;
+
+        let mut queue_late = queue_terminal.clone();
+        queue_late.status = QueueEntryStatus::Queued;
+        queue_late.updated_at = now + chrono::Duration::seconds(1);
+        let mut wait_late = wait_terminal.clone();
+        wait_late.status = WaitConditionStatus::Active;
+        wait_late.updated_at = now + chrono::Duration::seconds(1);
+        assert!(second.queue_entries().upsert(&queue_late).is_err());
+        assert!(second.wait_conditions().upsert(&wait_late).is_err());
+
+        drop(first);
+        drop(second);
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(
+            reopened.queue_entries().latest_all()?,
+            persisted_queue_terminal
+        );
+        assert_eq!(
+            reopened.wait_conditions().latest_all()?,
+            persisted_wait_terminal
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn queue_and_wait_legacy_import_reject_terminal_regressions() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let queue_terminal = QueueEntryRecord {
+            message_id: "message-import".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Processed,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut queue_late = queue_terminal.clone();
+        queue_late.status = QueueEntryStatus::Queued;
+        queue_late.updated_at = now + chrono::Duration::seconds(1);
+        assert!(db
+            .queue_entries()
+            .import_legacy(vec![queue_terminal.clone(), queue_late])
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+        assert!(db.queue_entries().latest_all()?.is_empty());
+
+        let mut queue_retry = queue_terminal.clone();
+        queue_retry.updated_at = now + chrono::Duration::seconds(2);
+        db.queue_entries()
+            .import_legacy(vec![queue_terminal.clone(), queue_retry])?;
+        assert_eq!(db.queue_entries().latest_all()?, vec![queue_terminal]);
+
+        let wait_terminal = WaitConditionRecord {
+            id: "wait-import".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: None,
+            status: WaitConditionStatus::Cancelled,
+            kind: WaitConditionKind::Operator,
+            source: Some("operator".into()),
+            subject_ref: None,
+            waiting_for: "operator input".into(),
+            wake_sources: Vec::new(),
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: Some(now),
+            turn_id: None,
+        };
+        let mut wait_late = wait_terminal.clone();
+        wait_late.status = WaitConditionStatus::Active;
+        wait_late.updated_at = now + chrono::Duration::seconds(1);
+        wait_late.cancelled_at = None;
+        assert!(db
+            .wait_conditions()
+            .import_legacy(vec![wait_terminal.clone(), wait_late])
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+        assert!(db.wait_conditions().latest_all()?.is_empty());
+
+        let mut wait_retry = wait_terminal.clone();
+        wait_retry.updated_at = now + chrono::Duration::seconds(2);
+        db.wait_conditions()
+            .import_legacy(vec![wait_terminal, wait_retry])?;
+        let imported_waits = db.wait_conditions().latest_all()?;
+        assert_eq!(imported_waits.len(), 1);
+        assert_eq!(imported_waits[0].status, WaitConditionStatus::Cancelled);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- 在 SQLite repository 边界统一 Queue/Wait terminal transition 判定
- 阻止 terminal row 被迟到或同时间戳的 active/non-terminal 更新回退
- 允许 canonical terminal payload 的幂等重试，并将不同 terminal payload/state 返回为 typed conflict
- 让 legacy import 按原始序列复用相同规则，冲突时回滚整个导入事务
- 增加同时间戳、迟到更新、重启、双 DB handle 与 legacy import 回归测试

## Verification

- `cargo test runtime_db::tests::tests::`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2252
