### PR TITLE
fix: complete missing search providers and fix native search base_url display

### DIFF
--- a/web-gui/app/src/features/settings/SettingsPage.test.ts
+++ b/web-gui/app/src/features/settings/SettingsPage.test.ts
@@ -111,4 +111,17 @@ describe("buildSearchProviderConfigUpdates", () => {
       { key: "web.providers.searxng.credential_profile", value: "" },
     ]);
   });
+
+  it("omits base_url for native search providers that do not need one", () => {
+    expect(
+      buildSearchProviderConfigUpdates("openai-native", {
+        kind: "open_ai_native",
+        baseUrl: "",
+        credentialProfile: "",
+      }),
+    ).toEqual([
+      { key: "web.providers.openai-native.kind", value: "open_ai_native" },
+      { key: "web.providers.openai-native.credential_profile", value: "" },
+    ]);
+  });
 });

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -75,6 +75,7 @@ type StandardSearchProviderDefinition = {
   label: string;
   description: string;
   requiresApiKey: boolean;
+  requiresBaseUrl?: boolean;
   defaultCredentialProfile?: string;
   baseUrlPlaceholder?: string;
 };
@@ -83,6 +84,8 @@ const webSearchProviderKinds = [
   "duck_duck_go",
   "searxng",
   "brave",
+  "tencent_cloud_wsa",
+  "bocha",
   "tavily",
   "exa",
   "perplexity",
@@ -135,11 +138,28 @@ const standardSearchProviders: StandardSearchProviderDefinition[] = [
     defaultCredentialProfile: "firecrawl:default",
   },
   {
+    id: "tencent-cloud-wsa",
+    kind: "tencent_cloud_wsa",
+    label: "Tencent Cloud WSA",
+    description: "Tencent Cloud WSA SearchPro — research-quality web search with domain filter and freshness support. Requires a Tencent Cloud API key.",
+    requiresApiKey: true,
+    defaultCredentialProfile: "tencent_cloud_wsa:default",
+  },
+  {
+    id: "bocha",
+    kind: "bocha",
+    label: "Bocha AI Search",
+    description: "Bocha AI search optimized for Chinese-language queries with freshness support. Requires a Bocha API key.",
+    requiresApiKey: true,
+    defaultCredentialProfile: "bocha:default",
+  },
+  {
     id: "searxng",
     kind: "searxng",
     label: "SearXNG",
     description: "Use a self-hosted or trusted SearXNG instance. No API key is needed.",
     requiresApiKey: false,
+    requiresBaseUrl: true,
     baseUrlPlaceholder: "https://search.example.com",
   },
   {
@@ -188,11 +208,16 @@ function defaultSearchProviderDraft(providerId: string): SearchProviderDraft {
 }
 
 export function buildSearchProviderConfigUpdates(providerId: string, draft: SearchProviderDraft): Array<{ key: string; value?: unknown; unset?: boolean }> {
-  return [
+  const definition = standardSearchProviderById.get(providerId);
+  const shouldSendBaseUrl = !definition || definition.requiresApiKey || Boolean(definition.requiresBaseUrl);
+  const updates: Array<{ key: string; value?: unknown; unset?: boolean }> = [
     { key: `web.providers.${providerId}.kind`, value: draft.kind },
-    { key: `web.providers.${providerId}.base_url`, value: draft.baseUrl?.trim() ?? "" },
     { key: `web.providers.${providerId}.credential_profile`, value: draft.credentialProfile?.trim() ?? "" },
   ];
+  if (shouldSendBaseUrl) {
+    updates.splice(1, 0, { key: `web.providers.${providerId}.base_url`, value: draft.baseUrl?.trim() ?? "" });
+  }
+  return updates;
 }
 
 export function SettingsPage({
@@ -1164,10 +1189,10 @@ export function SettingsPage({
                       </div>
                       <StatusChip className={`settings-status ${providerReady ? "available" : "unavailable"}`} tone={providerReady ? "success" : "error"} iconOnly title={providerReady ? t("settings.readyLabel") : definition.requiresApiKey ? t("settings.keyNeededLabel") : t("settings.notConfigured")} />
                     </header>
-                    {!definition.requiresApiKey ? (
+                    {definition.requiresBaseUrl ? (
                       <div className="settings-form-row">
                         <label>
-                          <span>{t("settings.baseUrl")}</span>
+                          <span>{t("settings.baseUrl")} *</span>
                           <input
                             value={draft.baseUrl ?? ""}
                             onChange={(event) => updateSearchProviderDraft(definition.id, { baseUrl: event.target.value })}


### PR DESCRIPTION
## Summary

Fixes three issues in Web UI search settings:

### Phase 1: Add missing providers (P0)
- Added **Tencent Cloud WSA** (`tencent_cloud_wsa`) and **Bocha AI Search** (`bocha`) to `standardSearchProviders` and `webSearchProviderKinds`
- Both are already fully implemented in the backend (capabilities, search functions, tests) but were invisible in the UI

### Phase 2: Fix native search base_url display (P0)
- Added `requiresBaseUrl` field to `StandardSearchProviderDefinition`
- Only **SearXNG** (self-hosted) now shows the base_url input — marked as required (`*`)
- Native search providers (OpenAI/Anthropic/Gemini) no longer show base_url, since they use model provider credentials and endpoints
- `buildSearchProviderConfigUpdates` omits `base_url` for native providers; API-key providers and SearXNG still send it

## Changes
- `web-gui/app/src/features/settings/SettingsPage.tsx` — provider definitions, type, UI condition, config builder
- `web-gui/app/src/features/settings/SettingsPage.test.ts` — added test for native provider base_url omission

## Verification
- `tsc --noEmit` ✅
- `vitest run SettingsPage.test.ts` — 9/9 tests pass ✅