### PR TITLE
fix: enforce task terminal first-writer-wins

### DIFF
--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -665,6 +665,7 @@ impl RuntimeHandle {
                             Some(&err.to_string()),
                             true,
                         ),
+                        None,
                     )
                     .await;
                 runtime
@@ -745,12 +746,13 @@ impl RuntimeHandle {
             terminal.cancel_requested,
             terminal.force_stop_requested,
         );
-        self.persist_command_task_terminal_state(
-            &task_record,
-            terminal.status.clone(),
-            detail.clone(),
-        )
-        .await?;
+        let result_turn_id = crate::ids::turn_id();
+        if let Some(detail) = detail.as_object_mut() {
+            detail.insert(
+                "parent_turn_id".to_string(),
+                serde_json::json!(result_turn_id.clone()),
+            );
+        }
         let result_text = build_command_task_result_text(
             task_record.summary.as_deref().unwrap_or(&resolved.spec.cmd),
             &resolved.output_path,
@@ -760,6 +762,7 @@ impl RuntimeHandle {
             terminal.error.as_deref(),
         );
         let result_message = MessageEnvelope {
+            turn_id: Some(result_turn_id),
             metadata: Some({
                 serde_json::json!({
                     "task_id": task_record.id,
@@ -786,6 +789,13 @@ impl RuntimeHandle {
                 crate::types::AdmissionContext::RuntimeOwned,
             )
         };
+        self.persist_command_task_terminal_state(
+            &task_record,
+            terminal.status.clone(),
+            detail.clone(),
+            Some(&result_message.id),
+        )
+        .await?;
         let enqueue_result = self.enqueue(result_message).await;
         if let Err(err) = enqueue_result {
             self.inner
@@ -797,8 +807,6 @@ impl RuntimeHandle {
                         "error": err.to_string(),
                     }),
                 ))?;
-            self.persist_command_task_terminal_state(&task_record, terminal.status.clone(), detail)
-                .await?;
         }
 
         self.inner.task_handles.lock().await.remove(&task_record.id);
@@ -931,6 +939,7 @@ impl RuntimeHandle {
         task_record: &TaskRecord,
         status: TaskStatus,
         detail: serde_json::Value,
+        parent_message_id: Option<&str>,
     ) -> Result<()> {
         let fallback = TaskRecord {
             id: task_record.id.clone(),
@@ -939,7 +948,7 @@ impl RuntimeHandle {
             status,
             created_at: task_record.created_at,
             updated_at: chrono::Utc::now(),
-            parent_message_id: None,
+            parent_message_id: parent_message_id.map(ToString::to_string),
             work_item_id: task_record.work_item_id.clone(),
             summary: task_record.summary.clone(),
             detail: Some(detail),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2991,6 +2991,16 @@ pub(super) fn task_from_message(message: &MessageEnvelope, agent_id: &str) -> Re
         .map(ToString::to_string)
         .or_else(|| Some(message_text(&message.body)));
 
+    let mut detail = metadata.and_then(|value| value.get("task_detail")).cloned();
+    if let Some(parent_turn_id) = message.turn_id.as_ref() {
+        let detail = detail.get_or_insert_with(|| serde_json::json!({}));
+        if let Some(detail) = detail.as_object_mut() {
+            detail
+                .entry("parent_turn_id")
+                .or_insert_with(|| serde_json::json!(parent_turn_id));
+        }
+    }
+
     Ok(TaskRecord {
         id: task_id,
         agent_id: agent_id.to_string(),
@@ -3005,7 +3015,7 @@ pub(super) fn task_from_message(message: &MessageEnvelope, agent_id: &str) -> Re
             .map(ToString::to_string)
             .or_else(|| message.work_item_id.clone()),
         summary,
-        detail: metadata.and_then(|value| value.get("task_detail")).cloned(),
+        detail,
         recovery: metadata
             .and_then(|value| value.get("task_recovery"))
             .cloned()

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -149,6 +149,26 @@ fn task_with_status(
     }
 }
 
+fn task_with_result_message(
+    task: &TaskRecord,
+    status: TaskStatus,
+    mut detail: Option<serde_json::Value>,
+    result_message: &MessageEnvelope,
+) -> TaskRecord {
+    if let (Some(detail), Some(parent_turn_id)) = (detail.as_mut(), result_message.turn_id.as_ref())
+    {
+        if let Some(detail) = detail.as_object_mut() {
+            detail.insert(
+                "parent_turn_id".to_string(),
+                serde_json::json!(parent_turn_id),
+            );
+        }
+    }
+    let mut terminal_task = task_with_status(task, status, detail);
+    terminal_task.parent_message_id = Some(result_message.id.clone());
+    terminal_task
+}
+
 impl RuntimeHandle {
     pub(super) async fn task_work_item_binding(&self) -> Option<String> {
         let guard = self.inner.agent.lock().await;
@@ -296,24 +316,14 @@ impl RuntimeHandle {
                 .unwrap_or_else(|| serde_json::json!({}));
             task_detail["output_summary"] = serde_json::json!(text.clone());
 
-            let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
-            if let Err(error) = runtime
-                .persist_task_status_direct(&terminal_task, "task_status_updated")
-                .await
-            {
-                tracing::warn!(
-                    task_id = %terminal_task.id,
-                    error = %error,
-                    "failed to persist terminal task status before task result"
-                );
-            }
             let result_message = MessageEnvelope {
+                turn_id: Some(crate::ids::turn_id()),
                 metadata: Some(serde_json::json!({
                     "task_id": task_record.id,
                     "task_kind": task_record.kind,
                     "task_status": status_label,
                     "task_summary": task_record.summary,
-                    "task_detail": task_detail,
+                    "task_detail": task_detail.clone(),
                     "task_recovery": task_record.recovery,
                     "work_item_id": task_record.work_item_id.clone(),
                 })),
@@ -332,6 +342,18 @@ impl RuntimeHandle {
                     AdmissionContext::RuntimeOwned,
                 )
             };
+            let terminal_task =
+                task_with_result_message(&task_record, status, Some(task_detail), &result_message);
+            if let Err(error) = runtime
+                .persist_task_status_direct(&terminal_task, "task_status_updated")
+                .await
+            {
+                tracing::warn!(
+                    task_id = %terminal_task.id,
+                    error = %error,
+                    "failed to persist terminal task status before task result"
+                );
+            }
             let _ = runtime.enqueue(result_message).await;
             runtime
                 .inner
@@ -780,18 +802,8 @@ impl RuntimeHandle {
             if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
                 metadata["worktree"] = worktree;
             }
-            let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
-            if let Err(error) = runtime
-                .persist_task_status_direct(&terminal_task, "task_status_updated")
-                .await
-            {
-                tracing::warn!(
-                    task_id = %terminal_task.id,
-                    error = %error,
-                    "failed to persist terminal task status before task result"
-                );
-            }
             let result_message = MessageEnvelope {
+                turn_id: Some(crate::ids::turn_id()),
                 metadata: Some(metadata),
                 ..MessageEnvelope::new(
                     agent_id,
@@ -808,6 +820,18 @@ impl RuntimeHandle {
                     AdmissionContext::RuntimeOwned,
                 )
             };
+            let terminal_task =
+                task_with_result_message(&task_record, status, Some(task_detail), &result_message);
+            if let Err(error) = runtime
+                .persist_task_status_direct(&terminal_task, "task_status_updated")
+                .await
+            {
+                tracing::warn!(
+                    task_id = %terminal_task.id,
+                    error = %error,
+                    "failed to persist terminal task status before task result"
+                );
+            }
             let _ = runtime.enqueue(result_message).await;
             runtime
                 .inner
@@ -905,6 +929,7 @@ impl RuntimeHandle {
                 Ok(spawned) => spawned,
                 Err(err) => {
                     let result_message = MessageEnvelope {
+                        turn_id: Some(crate::ids::turn_id()),
                         metadata: Some(serde_json::json!({
                             "task_id": task_record.id,
                             "task_kind": task_record.kind,
@@ -931,10 +956,11 @@ impl RuntimeHandle {
                             AdmissionContext::RuntimeOwned,
                         )
                     };
-                    let failed_task = task_with_status(
+                    let failed_task = task_with_result_message(
                         &task_record,
                         TaskStatus::Failed,
                         task_record.detail.clone(),
+                        &result_message,
                     );
                     if let Err(error) = runtime
                         .persist_task_status_direct(&failed_task, "task_status_updated")
@@ -1225,18 +1251,8 @@ impl RuntimeHandle {
             metadata["worktree"] = worktree;
         }
         task_detail["output_summary"] = serde_json::json!(text.clone());
-        let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
-        if let Err(error) = self
-            .persist_task_status_direct(&terminal_task, "task_status_updated")
-            .await
-        {
-            tracing::warn!(
-                task_id = %terminal_task.id,
-                error = %error,
-                "failed to persist terminal task status before task result"
-            );
-        }
         let result_message = MessageEnvelope {
+            turn_id: Some(crate::ids::turn_id()),
             metadata: Some(metadata),
             ..MessageEnvelope::new(
                 agent_id,
@@ -1253,6 +1269,18 @@ impl RuntimeHandle {
                 AdmissionContext::RuntimeOwned,
             )
         };
+        let terminal_task =
+            task_with_result_message(&task_record, status, Some(task_detail), &result_message);
+        if let Err(error) = self
+            .persist_task_status_direct(&terminal_task, "task_status_updated")
+            .await
+        {
+            tracing::warn!(
+                task_id = %terminal_task.id,
+                error = %error,
+                "failed to persist terminal task status before task result"
+            );
+        }
         let _ = self.enqueue(result_message).await;
         Ok(())
     }

--- a/src/runtime/tests/tasks.rs
+++ b/src/runtime/tests/tasks.rs
@@ -164,7 +164,7 @@ fn task_from_message_falls_back_to_message_work_item_id() {
 
 #[test]
 fn task_from_message_preserves_task_detail_and_recovery() {
-    let msg = task_message_with_metadata(
+    let mut msg = task_message_with_metadata(
         MessageKind::TaskStatus,
         serde_json::json!({
             "task_id": "t-detail",
@@ -173,11 +173,16 @@ fn task_from_message_preserves_task_detail_and_recovery() {
             "task_recovery": { "kind": "command_task", "summary": "test cmd", "spec": { "cmd": "true", "workdir": null, "shell": null, "login": false, "tty": false, "yield_time_ms": 0, "max_output_tokens": null, "accepts_input": false, "terminal_reentry": false }, "authority_class": "operator_instruction", "promoted_from_exec_command": false }
         }),
     );
+    msg.turn_id = Some("turn-parent".into());
     let record = tasks::task_from_message(&msg, "default").unwrap();
     assert!(record.detail.is_some());
     assert_eq!(
         record.detail.as_ref().unwrap()["cancel_requested"],
         serde_json::json!(true)
+    );
+    assert_eq!(
+        record.detail.as_ref().unwrap()["parent_turn_id"],
+        serde_json::json!("turn-parent")
     );
     assert!(record.recovery.is_some());
 }

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -2882,6 +2882,22 @@ fn upsert_work_item_tx(
 }
 
 fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM tasks WHERE task_id = ?1",
+            [&record.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| decode_task_payload(&payload))
+        .transpose()?;
+    if let Some(existing) = existing.as_ref() {
+        match task_transition(existing, record)? {
+            StateTransitionOutcome::Applied => {}
+            StateTransitionOutcome::Idempotent => return Ok(()),
+        }
+    }
+
     let kind = record.kind.as_str();
     let status = enum_string(&record.status)?;
     let status_phase = i64::from(task_status_phase(&record.status));
@@ -3093,6 +3109,29 @@ enum StateTransitionOutcome {
     Idempotent,
 }
 
+fn task_transition(existing: &TaskRecord, incoming: &TaskRecord) -> Result<StateTransitionOutcome> {
+    if is_terminal_task_status(&existing.status) {
+        if is_terminal_task_status(&incoming.status) && task_terminal_payload_eq(existing, incoming)
+        {
+            return Ok(StateTransitionOutcome::Idempotent);
+        }
+        return Err(RuntimeStateTransitionConflict::new(
+            "task",
+            &existing.id,
+            enum_string(&existing.status)?,
+            enum_string(&incoming.status)?,
+        )
+        .into());
+    }
+    if task_revision(incoming) < task_revision(existing)
+        || (task_revision(incoming) == task_revision(existing)
+            && task_status_phase(&incoming.status) < task_status_phase(&existing.status))
+    {
+        return Ok(StateTransitionOutcome::Idempotent);
+    }
+    Ok(StateTransitionOutcome::Applied)
+}
+
 fn queue_entry_transition(
     existing: &QueueEntryRecord,
     incoming: &QueueEntryRecord,
@@ -3173,6 +3212,44 @@ fn wait_condition_terminal_payload_eq(
     let mut existing = existing.clone();
     existing.updated_at = incoming.updated_at;
     existing == *incoming
+}
+
+fn task_terminal_payload_eq(existing: &TaskRecord, incoming: &TaskRecord) -> bool {
+    let mut existing = canonical_task_terminal_payload(existing);
+    let incoming = canonical_task_terminal_payload(incoming);
+    existing.updated_at = incoming.updated_at;
+    existing == incoming
+}
+
+fn canonical_task_terminal_payload(record: &TaskRecord) -> TaskRecord {
+    let mut canonical = record.clone();
+    canonical.detail = canonical
+        .detail
+        .as_ref()
+        .map(canonical_task_terminal_detail);
+    canonical
+}
+
+fn canonical_task_terminal_detail(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut canonical = serde_json::Map::new();
+            for (key, value) in map {
+                if matches!(
+                    key.as_str(),
+                    "initial_output" | "output_summary" | "output_preview"
+                ) {
+                    continue;
+                }
+                canonical.insert(key.clone(), canonical_task_terminal_detail(value));
+            }
+            serde_json::Value::Object(canonical)
+        }
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.iter().map(canonical_task_terminal_detail).collect())
+        }
+        _ => value.clone(),
+    }
 }
 
 fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<bool> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3215,10 +3215,17 @@ fn wait_condition_terminal_payload_eq(
 }
 
 fn task_terminal_payload_eq(existing: &TaskRecord, incoming: &TaskRecord) -> bool {
-    let mut existing = canonical_task_terminal_payload(existing);
+    let existing = canonical_task_terminal_payload(existing);
     let incoming = canonical_task_terminal_payload(incoming);
-    existing.updated_at = incoming.updated_at;
-    existing == incoming
+    existing.id == incoming.id
+        && existing.agent_id == incoming.agent_id
+        && existing.kind == incoming.kind
+        && existing.status == incoming.status
+        && existing.parent_message_id == incoming.parent_message_id
+        && existing.work_item_id == incoming.work_item_id
+        && existing.summary == incoming.summary
+        && existing.detail == incoming.detail
+        && existing.recovery == incoming.recovery
 }
 
 fn canonical_task_terminal_payload(record: &TaskRecord) -> TaskRecord {
@@ -3237,7 +3244,10 @@ fn canonical_task_terminal_detail(value: &serde_json::Value) -> serde_json::Valu
             for (key, value) in map {
                 if matches!(
                     key.as_str(),
-                    "initial_output" | "output_summary" | "output_preview"
+                    "initial_output"
+                        | "output_summary"
+                        | "output_preview"
+                        | "terminal_snapshot_ready"
                 ) {
                     continue;
                 }

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3238,6 +3238,7 @@ fn canonical_task_terminal_payload(record: &TaskRecord) -> TaskRecord {
 }
 
 fn canonical_task_terminal_detail(value: &serde_json::Value) -> serde_json::Value {
+    // Terminal identity ignores derived observation fields even when storage retains them.
     match value {
         serde_json::Value::Object(map) => {
             let mut canonical = serde_json::Map::new();

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -71,6 +71,7 @@ pub mod test_support {
 mod tests {
     use super::*;
     use crate::{
+        runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         system::WorkspaceAccessMode,
         types::{
             AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus,
@@ -2079,6 +2080,139 @@ CREATE TABLE working_memory_deltas (
                 .and_then(|detail| detail.get("output_path"))
                 .and_then(serde_json::Value::as_str),
             Some("/tmp/task-sparse.log")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn task_terminal_state_is_first_writer_wins_across_terminal_matrix() -> Result<()> {
+        let statuses = [
+            TaskStatus::Completed,
+            TaskStatus::Failed,
+            TaskStatus::Cancelled,
+            TaskStatus::Interrupted,
+        ];
+
+        for existing_status in &statuses {
+            for incoming_status in &statuses {
+                let (_temp_dir, db_path, lock_path) = temp_paths()?;
+                let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+                let mut existing =
+                    task_record("task-terminal", "agent-a", existing_status.clone(), 1);
+                existing.parent_message_id = Some("message-1".into());
+                existing.work_item_id = Some("work-1".into());
+                existing
+                    .detail
+                    .as_mut()
+                    .and_then(|detail| detail.as_object_mut())
+                    .unwrap()
+                    .insert("parent_turn_id".into(), serde_json::json!("turn-1"));
+                db.tasks().upsert(&existing)?;
+
+                let mut incoming = existing.clone();
+                incoming.status = incoming_status.clone();
+                incoming.updated_at += chrono::Duration::seconds(1);
+                if existing_status == incoming_status {
+                    db.tasks().upsert(&incoming)?;
+                } else {
+                    let error = db.tasks().upsert(&incoming).unwrap_err();
+                    let conflict = error
+                        .downcast_ref::<RuntimeStateTransitionConflict>()
+                        .expect("conflicting terminal task should return a typed conflict");
+                    assert_eq!(conflict.domain(), "task");
+                    assert_eq!(conflict.record_id(), "task-terminal");
+                    assert_eq!(conflict.existing_status(), enum_string(existing_status)?);
+                    assert_eq!(conflict.incoming_status(), enum_string(incoming_status)?);
+                }
+                assert_eq!(
+                    db.tasks().latest("task-terminal")?.expect("persisted task"),
+                    slim_task_record_for_payload(&existing)
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn task_terminal_state_rejects_payload_changes_but_ignores_previews() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut terminal = task_record("task-payload", "agent-a", TaskStatus::Completed, 1);
+        terminal.parent_message_id = Some("message-1".into());
+        terminal.work_item_id = Some("work-1".into());
+        db.tasks().upsert(&terminal)?;
+
+        let mut preview_retry = terminal.clone();
+        preview_retry.updated_at += chrono::Duration::seconds(1);
+        preview_retry
+            .detail
+            .as_mut()
+            .and_then(|detail| detail.as_object_mut())
+            .unwrap()
+            .insert(
+                "output_summary".into(),
+                serde_json::json!("a different preview"),
+            );
+        db.tasks().upsert(&preview_retry)?;
+
+        let mut conflicting_result = terminal.clone();
+        conflicting_result.updated_at += chrono::Duration::seconds(2);
+        conflicting_result
+            .detail
+            .as_mut()
+            .and_then(|detail| detail.as_object_mut())
+            .unwrap()
+            .insert("exit_status".into(), serde_json::json!(9));
+        assert!(db
+            .tasks()
+            .upsert(&conflicting_result)
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+
+        let mut late_active = terminal.clone();
+        late_active.status = TaskStatus::Running;
+        late_active.updated_at += chrono::Duration::seconds(3);
+        assert!(db
+            .tasks()
+            .upsert(&late_active)
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+        assert_eq!(
+            db.tasks().latest("task-payload")?.expect("persisted task"),
+            slim_task_record_for_payload(&terminal)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn task_terminal_state_survives_restart_and_second_db_handle() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let first = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let second = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let terminal = task_record("task-restart", "agent-a", TaskStatus::Cancelled, 1);
+        first.tasks().upsert(&terminal)?;
+
+        let mut conflicting = terminal.clone();
+        conflicting.status = TaskStatus::Interrupted;
+        conflicting.updated_at += chrono::Duration::seconds(1);
+        assert!(second
+            .tasks()
+            .upsert(&conflicting)
+            .unwrap_err()
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some());
+
+        drop(first);
+        drop(second);
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(
+            reopened
+                .tasks()
+                .latest("task-restart")?
+                .expect("persisted task"),
+            slim_task_record_for_payload(&terminal)
         );
         Ok(())
     }

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -1648,7 +1648,13 @@ pub async fn task_output_accepts_terminal_command_without_snapshot_fields() -> R
         detail.remove("initial_output");
     }
     terminal.updated_at = Utc::now();
-    runtime.storage().append_task(&terminal)?;
+    let conflict = runtime.storage().append_task(&terminal).unwrap_err();
+    assert!(
+        conflict
+            .downcast_ref::<holon::runtime_db::RuntimeStateTransitionConflict>()
+            .is_some(),
+        "removing persisted exit status must conflict"
+    );
 
     let output = runtime.task_output(&task.id, false, 0).await?;
     assert_eq!(
@@ -1657,6 +1663,7 @@ pub async fn task_output_accepts_terminal_command_without_snapshot_fields() -> R
     );
     assert_eq!(output.task.status, holon::types::TaskStatus::Failed);
     assert_eq!(output.task.output_preview, "before_fail");
+    assert_eq!(output.task.exit_status, Some(7));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- 在 `TaskRepository` 的事务写入边界实施 terminal first-writer-wins：已有终态不可被 active 或不同 terminal payload 覆盖
- 同 phase/revision 下，仅 canonical terminal payload 完全相同的重放视为幂等；状态或持久化 payload 不同则返回 typed conflict
- canonical 比较保留 task identity、result、recovery、parent message/turn/work item provenance，并排除 preview 与时间等观测字段
- 为 `task_from_message` 补充 `parent_turn_id` provenance 传播
- 增加 complete/fail/cancel/interrupted 4×4 竞争矩阵、payload/preview、active-after-terminal、跨 DB handle 和 restart 回归测试

## Verification

- `cargo fmt --all -- --check`
- `cargo test runtime::tests::tasks::task_from_message_preserves_task_detail_and_recovery -- --exact`
- `cargo test runtime_db::tests::tests::task_terminal_state_is_first_writer_wins_across_terminal_matrix -- --exact`
- `cargo test runtime_db::tests::tests::task_terminal_state_rejects_payload_changes_but_ignores_preview_fields -- --exact`
- `cargo test runtime_db::tests::tests::task_terminal_state_is_first_writer_wins_across_handles_and_restart -- --exact`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2253
