### PR TITLE
fix: recover continuations by shrinking recent turns

### DIFF
--- a/docs/rfcs/turn-based-context-projection.md
+++ b/docs/rfcs/turn-based-context-projection.md
@@ -404,6 +404,35 @@ tool overhead and the continuation safety margin before checking retained
 turn-local rounds. Reusing the bounded `recent_turns` budget for continuation
 would incorrectly cap large-context models at the history ceiling.
 
+If a continuation still reports `minimum_exact_round_unfit` under that complete
+request budget, the runtime may reclaim space from the initial `recent_turns`
+region before terminating the turn. Recovery must re-run the semantic
+recent-turn selection with a smaller token budget rather than truncating the
+rendered section as an opaque string. System instructions, current input,
+continuation anchors, current WorkItem state, runtime-owned continuation
+context, and the newest turn-local round remain outside this recovery target.
+
+The first retry budget should be derived from the measured deficit:
+
+```text
+deficit =
+  minimum_projection_estimated_tokens
+  - effective_budget_estimated_tokens
+
+next_recent_turns_budget =
+  current_recent_turns_budget
+  - deficit
+  - bounded_safety_margin
+```
+
+Recovery is bounded. Each successful reprojection rebuilds the prompt frame and
+its context fingerprint, then repeats turn-local projection. If no smaller
+semantic `recent_turns` projection exists, the retry limit is reached, or the
+minimum continuation still does not fit after history is exhausted, the
+runtime records the normal `baseline_over_budget` terminal with retry
+diagnostics. A successful recovery is runtime-internal and should not surface
+an operator-facing error.
+
 The budget should be spent by retention priority, continuation-chain
 membership, and semantic turn value, not by physical-turn FIFO order. Current
 input and pinned turn anchors are mandatory and may borrow from the free pool

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -91,6 +91,42 @@ impl ContextConfig {
 #[derive(Debug, Clone)]
 pub struct BuiltContext {
     pub sections: Vec<PromptSection>,
+    pub(crate) recent_turns_reprojection: Option<RecentTurnsReprojection>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecentTurnsReprojection {
+    turn_records: Vec<TurnRecord>,
+    messages: Vec<MessageEnvelope>,
+    briefs: Vec<BriefRecord>,
+    tools: Vec<ToolExecutionRecord>,
+    current_message: MessageEnvelope,
+    current_work_item: Option<WorkItemRecord>,
+    initial_budget: usize,
+}
+
+impl RecentTurnsReprojection {
+    pub(crate) fn initial_budget(&self) -> usize {
+        self.initial_budget
+    }
+}
+
+pub(crate) fn reproject_recent_turns(
+    storage: &AppStorage,
+    reprojection: &RecentTurnsReprojection,
+    budget: usize,
+) -> Option<PromptSection> {
+    render_recent_turns_with_budget(
+        storage,
+        &reprojection.turn_records,
+        &reprojection.messages,
+        &reprojection.briefs,
+        &reprojection.tools,
+        &reprojection.current_message,
+        reprojection.current_work_item.as_ref(),
+        budget,
+    )
+    .map(|content| turn_section("recent_turns", content))
 }
 
 pub fn build_context(
@@ -417,6 +453,16 @@ pub fn build_context_with_default_external_ingress(
         );
     }
 
+    let recent_turns_budget = remaining_budget.min(config.turn_projection_budget());
+    let recent_turns_reprojection = (!turn_records.is_empty()).then(|| RecentTurnsReprojection {
+        turn_records: turn_records.clone(),
+        messages: messages.clone(),
+        briefs: briefs.clone(),
+        tools: tools.clone(),
+        current_message: current_message.clone(),
+        current_work_item: current_work_item.cloned(),
+        initial_budget: recent_turns_budget,
+    });
     if let Some(content) = render_recent_turns_with_budget(
         storage,
         &turn_records,
@@ -425,7 +471,7 @@ pub fn build_context_with_default_external_ingress(
         &tools,
         current_message,
         current_work_item,
-        remaining_budget.min(config.turn_projection_budget()),
+        recent_turns_budget,
     ) {
         push_budgeted_section(
             &mut sections,
@@ -467,7 +513,10 @@ pub fn build_context_with_default_external_ingress(
         ),
     );
 
-    Ok(BuiltContext { sections })
+    Ok(BuiltContext {
+        sections,
+        recent_turns_reprojection,
+    })
 }
 
 fn hydrate_recent_turn_references(

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -16,7 +16,10 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use crate::{
-    context::{build_context_with_default_external_ingress, BuiltContext, ContextConfig},
+    context::{
+        build_context_with_default_external_ingress, reproject_recent_turns, BuiltContext,
+        ContextConfig, RecentTurnsReprojection,
+    },
     storage::AppStorage,
     system::{execution_policy_summary_lines, ExecutionSnapshot},
     tool::{ApplyPatchSurface, ToolSpec},
@@ -78,9 +81,60 @@ pub struct EffectivePrompt {
     pub context_sections: Vec<PromptSection>,
     pub rendered_system_prompt: String,
     pub rendered_context_attachment: String,
+    pub(crate) recent_turns_reprojection: Option<RecentTurnsReprojection>,
 }
 
 impl EffectivePrompt {
+    pub(crate) fn recent_turns_initial_budget(&self) -> Option<usize> {
+        self.recent_turns_reprojection
+            .as_ref()
+            .map(RecentTurnsReprojection::initial_budget)
+    }
+
+    pub(crate) fn reproject_recent_turns(
+        &self,
+        storage: &AppStorage,
+        budget: usize,
+        available_tools: &[ToolSpec],
+    ) -> Option<Self> {
+        let reprojection = self.recent_turns_reprojection.as_ref()?;
+        if budget >= reprojection.initial_budget() {
+            return None;
+        }
+        let replacement = reproject_recent_turns(storage, reprojection, budget);
+        let mut context_sections = self
+            .context_sections
+            .iter()
+            .filter(|section| section.name != "recent_turns")
+            .cloned()
+            .collect::<Vec<_>>();
+        if let Some(replacement) = replacement {
+            let insertion_index = self
+                .context_sections
+                .iter()
+                .position(|section| section.name == "recent_turns")
+                .unwrap_or(context_sections.len())
+                .min(context_sections.len());
+            context_sections.insert(insertion_index, replacement);
+        }
+        let rendered_context_attachment = render_sections(&context_sections);
+        if rendered_context_attachment == self.rendered_context_attachment {
+            return None;
+        }
+        let context_fingerprint = reprojected_context_fingerprint(
+            &self.cache_identity,
+            &self.execution,
+            &self.system_sections,
+            &context_sections,
+            available_tools,
+        );
+        let mut prompt = self.clone();
+        prompt.context_sections = context_sections;
+        prompt.rendered_context_attachment = rendered_context_attachment;
+        prompt.cache_identity.context_fingerprint = context_fingerprint;
+        Some(prompt)
+    }
+
     pub fn cache_scope_diagnostics(&self) -> PromptCacheScopeDiagnostics {
         prompt_cache_scope_diagnostics(&self.system_sections, &self.context_sections)
     }
@@ -469,6 +523,7 @@ fn build_effective_prompt_with_tool_prompt_context_and_default_external_ingress(
         context_sections,
         rendered_system_prompt,
         rendered_context_attachment,
+        recent_turns_reprojection: built_context.recent_turns_reprojection,
     })
 }
 
@@ -521,6 +576,26 @@ fn prompt_context_fingerprint(
     });
     let canonical =
         serde_json::to_vec(&payload).expect("prompt cache fingerprint should serialize");
+    format!("{:x}", Sha256::digest(canonical))
+}
+
+fn reprojected_context_fingerprint(
+    cache_identity: &PromptCacheIdentity,
+    execution: &ExecutionSnapshot,
+    system_sections: &[PromptSection],
+    context_sections: &[PromptSection],
+    available_tools: &[ToolSpec],
+) -> String {
+    let payload = json!({
+        "agent_id": cache_identity.agent_id,
+        "compression_epoch": cache_identity.compression_epoch,
+        "execution_semantics": execution_semantic_cache_payload(execution),
+        "system_sections": system_sections,
+        "context_sections": context_sections,
+        "tools": available_tools,
+    });
+    let canonical =
+        serde_json::to_vec(&payload).expect("reprojected prompt fingerprint should serialize");
     format!("{:x}", Sha256::digest(canonical))
 }
 
@@ -2224,6 +2299,7 @@ mod tests {
             }],
             rendered_system_prompt: "rendered system".to_string(),
             rendered_context_attachment: "rendered context".to_string(),
+            recent_turns_reprojection: None,
         };
 
         let dump = prompt.render_dump();
@@ -2274,6 +2350,7 @@ mod tests {
             }],
             rendered_system_prompt: "rendered turn system".to_string(),
             rendered_context_attachment: "rendered turn context".to_string(),
+            recent_turns_reprojection: None,
         };
 
         let dump = prompt.render_dump();
@@ -2328,6 +2405,7 @@ mod tests {
             context_sections: vec![],
             rendered_system_prompt: "very secret agent guidance".to_string(),
             rendered_context_attachment: String::new(),
+            recent_turns_reprojection: None,
         };
 
         let dump = prompt.render_dump();

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -590,6 +590,7 @@ mod tests {
             }],
             rendered_system_prompt: "system prompt".to_string(),
             rendered_context_attachment: "context attachment".to_string(),
+            recent_turns_reprojection: None,
         }
     }
 
@@ -667,6 +668,7 @@ mod tests {
             ],
             rendered_system_prompt: "system prompt".to_string(),
             rendered_context_attachment: "context attachment".to_string(),
+            recent_turns_reprojection: None,
         };
 
         let request = build_provider_turn_request(&effective_prompt, Vec::new(), None);

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1344,7 +1344,8 @@ fn current_input_summary_extracts_body_from_context_section() {
             stability: PromptStability::AgentScoped
         }],
         rendered_system_prompt: String::new(),
-        rendered_context_attachment: String::new()
+        rendered_context_attachment: String::new(),
+        recent_turns_reprojection: None,
     };
 
     assert_eq!(

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -29,7 +29,7 @@ pub(crate) use crate::{
         LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
         PendingWakeHint, Priority, QueueEntryStatus, TaskKind, TaskOutputRetrievalStatus,
         TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, TodoItem,
-        TodoItemState, TokenUsage, TurnTerminalKind, TurnTerminalRecord, WaitingReason,
+        TodoItemState, TokenUsage, TurnRecord, TurnTerminalKind, TurnTerminalRecord, WaitingReason,
         WorkItemRecord, WorkItemState, WorkReactivationMode, WorkspaceEntry,
     },
 };
@@ -177,6 +177,7 @@ pub(crate) fn test_effective_prompt() -> EffectivePrompt {
         context_sections: vec![],
         rendered_system_prompt: "system".into(),
         rendered_context_attachment: "context".into(),
+        recent_turns_reprojection: None,
     }
 }
 
@@ -377,6 +378,11 @@ impl BaselineOverBudgetProbeProvider {
 
 pub(crate) struct LargeBudgetContinuationProbeProvider {
     pub(crate) calls: Mutex<usize>,
+}
+
+pub(crate) struct RecentTurnsRecoveryProbeProvider {
+    pub(crate) calls: Mutex<usize>,
+    pub(crate) requests: Mutex<Vec<ProviderTurnRequest>>,
 }
 
 pub(crate) struct ContextLengthExceededProvider;
@@ -976,6 +982,47 @@ impl AgentProvider for FailingTimelineProvider {
             },
             anyhow!("bad request"),
         ))
+    }
+}
+
+#[async_trait]
+impl AgentProvider for RecentTurnsRecoveryProbeProvider {
+    async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        self.requests.lock().await.push(request);
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        match *calls {
+            1 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::ToolUse {
+                    id: "exec-recent-turns-recovery".into(),
+                    name: "ExecCommand".into(),
+                    input: serde_json::json!({
+                        "cmd": "printf 'recent-turns-recovery'"
+                    }),
+                    kind: crate::provider::ModelToolCallKind::Function,
+                }],
+                stop_reason: Some("tool_use".into()),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
+                request_diagnostics: None,
+            }),
+            2 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text {
+                    text: "Recovered by shrinking recent turns.".into(),
+                }],
+                stop_reason: Some("end_turn".into()),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
+                request_diagnostics: None,
+            }),
+            _ => panic!("recent-turns recovery should require exactly one continuation"),
+        }
     }
 }
 

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -859,6 +859,11 @@ async fn turn_local_compaction_fails_fast_when_baseline_exceeds_budget() {
         baseline_event.data["reason"].as_str(),
         Some("minimum_exact_round_unfit")
     );
+    assert_eq!(
+        baseline_event.data["recent_turns_retry_attempts"].as_u64(),
+        Some(0)
+    );
+    assert!(baseline_event.data["final_recent_turns_budget"].is_null());
     assert!(
         baseline_event.data["estimated_baseline_tokens"]
             .as_u64()
@@ -871,8 +876,169 @@ async fn turn_local_compaction_fails_fast_when_baseline_exceeds_budget() {
         events
             .iter()
             .all(|event| event.kind != "turn_local_compaction_applied"),
-        "baseline-over-budget should fail fast, not masquerade as compaction"
+        "unrecoverable baseline-over-budget should not masquerade as compaction"
     );
+}
+
+#[tokio::test]
+async fn turn_local_continuation_recovers_by_reprojecting_recent_turns() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(RecentTurnsRecoveryProbeProvider {
+        calls: Mutex::new(0),
+        requests: Mutex::new(Vec::new()),
+    });
+    let available_tools = crate::tool::ToolRegistry::new(workspace.path().to_path_buf())
+        .tool_specs_with_families()
+        .unwrap()
+        .into_iter()
+        .filter(|(family, _)| {
+            AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
+        })
+        .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
+        .map(|(_, tool)| tool)
+        .collect::<Vec<_>>();
+    let continuation_effective_budget = 12_000;
+    let prompt_budget_estimated_tokens = turn::estimate_tool_specs_tokens(&available_tools)
+        + turn::CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS
+        + continuation_effective_budget;
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        ContextConfig {
+            prompt_budget_estimated_tokens,
+            turn_projection_budget_ratio: 1.0,
+            turn_projection_min_budget: 0,
+            turn_projection_max_budget: 10_000,
+            callback_base_url: String::new(),
+            ..context_config()
+        },
+    )
+    .unwrap();
+
+    let mut historical_message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: format!(
+                "historical context {}",
+                "large-history-token ".repeat(12_000)
+            ),
+        },
+    );
+    historical_message.turn_id = Some("turn-large-history".into());
+    runtime
+        .storage()
+        .append_message(&historical_message)
+        .unwrap();
+    let mut historical_turn = TurnRecord::new("default", "turn-large-history", 1);
+    historical_turn.input_message_ids = vec![historical_message.id.clone()];
+    historical_turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(
+        &historical_message,
+    ));
+    runtime.storage().append_turn(&historical_turn).unwrap();
+
+    let current_message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "continue after the large historical turn".into(),
+        },
+    );
+    runtime
+        .process_interactive_message(
+            &current_message,
+            None,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*provider.calls.lock().await, 2);
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state
+            .last_turn_terminal
+            .as_ref()
+            .map(|terminal| terminal.kind),
+        Some(TurnTerminalKind::Completed)
+    );
+
+    let requests = provider.requests.lock().await;
+    assert_eq!(requests.len(), 2);
+    let first_context = requests[0]
+        .conversation
+        .iter()
+        .find_map(|message| match message {
+            ConversationMessage::UserBlocks(blocks) => Some(
+                blocks
+                    .iter()
+                    .map(|block| block.text.as_str())
+                    .collect::<String>(),
+            ),
+            _ => None,
+        })
+        .unwrap_or_default();
+    let continuation_context = requests[1]
+        .conversation
+        .iter()
+        .find_map(|message| match message {
+            ConversationMessage::UserBlocks(blocks) => Some(
+                blocks
+                    .iter()
+                    .map(|block| block.text.as_str())
+                    .collect::<String>(),
+            ),
+            _ => None,
+        })
+        .unwrap_or_default();
+    assert!(first_context.contains("recent_turns"));
+    assert!(
+        continuation_context.len() < first_context.len(),
+        "continuation should carry a smaller recent-turns projection"
+    );
+    assert!(continuation_context.contains("continue after the large historical turn"));
+    assert!(requests[1].conversation.iter().any(|message| {
+        matches!(
+            message,
+            ConversationMessage::AssistantBlocks(blocks)
+                if blocks.iter().any(|block| matches!(
+                    block,
+                    ModelBlock::ToolUse { id, .. } if id == "exec-recent-turns-recovery"
+                ))
+        )
+    }));
+    drop(requests);
+
+    let events = runtime.storage().read_recent_events(40).unwrap();
+    let retry_event = events
+        .iter()
+        .find(|event| event.kind == "turn_local_recent_turns_retry")
+        .expect("missing recent-turns recovery event");
+    assert_eq!(retry_event.data["attempt"].as_u64(), Some(1));
+    assert!(
+        retry_event.data["next_recent_turns_budget"]
+            .as_u64()
+            .unwrap_or_default()
+            < retry_event.data["previous_recent_turns_budget"]
+                .as_u64()
+                .unwrap_or_default()
+    );
+    assert!(events
+        .iter()
+        .all(|event| event.kind != "turn_local_baseline_over_budget"));
 }
 
 #[tokio::test]

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -445,6 +445,8 @@ impl RuntimeHandle {
 pub(super) const TOOL_AUDIT_INPUT_STRING_LIMIT: usize = 4_096;
 pub(super) const TOOL_AUDIT_INPUT_PREVIEW_LIMIT: usize = 240;
 const TOOL_AUDIT_REDACTED: &str = "[REDACTED]";
+const RECENT_TURNS_RETRY_LIMIT: usize = 3;
+const RECENT_TURNS_RETRY_SAFETY_MARGIN_TOKENS: usize = 128;
 
 pub(super) fn tool_audit_input_field(call: &ToolCall) -> Option<Value> {
     if call.name == crate::tool::names::APPLY_PATCH {
@@ -567,7 +569,7 @@ impl TurnExecution<'_> {
             runtime,
             agent_id,
             authority_class,
-            effective_prompt,
+            mut effective_prompt,
             loop_control,
         } = self;
         let mut completed_rounds = Vec::<TurnRoundRecord>::new();
@@ -774,7 +776,7 @@ impl TurnExecution<'_> {
                 };
                 let checkpoint_request_id =
                     Some(format!("turn-{turn_index}-round-{round}-checkpoint"));
-                let prompt_frame = build_provider_prompt_frame(&effective_prompt);
+                let mut prompt_frame = build_provider_prompt_frame(&effective_prompt);
                 let reminder_rounds = work_item_stale_reminder_rounds();
                 let reminder_cooldown_rounds = work_item_stale_reminder_cooldown_rounds();
                 let stale_work_item_reminder = if rounds_since_work_item_update >= reminder_rounds
@@ -880,61 +882,110 @@ impl TurnExecution<'_> {
                     (None, Some(budget)) => Some(budget.to_string()),
                     (None, None) => None,
                 };
-                let projection = match build_turn_local_projection_with_runtime_reminder(
-                    &prompt_frame,
-                    &completed_rounds,
-                    &available_tools,
-                    &checkpoint_state,
-                    checkpoint_request_id,
-                    // Turn-local continuation projection covers the complete provider request.
-                    // The bounded turn projection budget only applies to initial recent_turns.
-                    context_config.prompt_budget_estimated_tokens,
-                    context_config.compaction_keep_recent_estimated_tokens,
-                    runtime_reminder.as_deref(),
-                ) {
-                    TurnLocalProjectionOutcome::Projection(projection) => projection,
-                    TurnLocalProjectionOutcome::BaselineOverBudget(diagnostics) => {
-                        runtime.inner.storage.append_event(&AuditEvent::new(
-                            "turn_local_baseline_over_budget",
-                            serde_json::json!({
-                                "agent_id": agent_id,
-                                "round": round,
-                                "reason": &diagnostics.reason,
-                                "estimated_baseline_tokens": diagnostics.estimated_baseline_tokens,
-                                "minimum_exact_round_estimated_tokens": diagnostics.minimum_exact_round_estimated_tokens,
-                                "minimum_projection_estimated_tokens": diagnostics.minimum_projection_estimated_tokens,
-                                "effective_budget_estimated_tokens": diagnostics.effective_budget_estimated_tokens,
-                                "tool_overhead_estimated_tokens": diagnostics.tool_overhead_estimated_tokens,
-                                "system_prompt_estimated_tokens": diagnostics.system_prompt_estimated_tokens,
-                                "context_attachment_estimated_tokens": diagnostics.context_attachment_estimated_tokens,
-                            }),
-                        ))?;
-                        let final_text = format!(
-                            "Turn stopped because the continuation baseline exceeded the prompt budget (reason={}, estimated_baseline_tokens={}, minimum_projection_estimated_tokens={}, effective_budget_estimated_tokens={}, tool_overhead_estimated_tokens={}).",
-                            diagnostics.reason,
-                            diagnostics.estimated_baseline_tokens,
-                            diagnostics.minimum_projection_estimated_tokens,
-                            diagnostics.effective_budget_estimated_tokens,
-                            diagnostics.tool_overhead_estimated_tokens,
-                        );
-                        let terminal = runtime
-                            .persist_turn_terminal_record(
-                                TurnTerminalKind::BaselineOverBudget,
-                                Some(final_text.clone()),
-                                turn_started_at.elapsed().as_millis() as u64,
-                                None,
-                            )
-                            .await?;
-                        return Ok(AgentLoopOutcome {
-                            final_text,
-                            final_text_source_assistant_round_id: None,
-                            turn_index: terminal.turn_index,
-                            terminal,
-                            should_sleep: false,
-                            sleep_duration_ms: None,
-                            allow_sleep_runnable_work_override: false,
-                            terminal_kind: TurnTerminalKind::BaselineOverBudget,
-                        });
+                let mut recent_turns_budget = effective_prompt.recent_turns_initial_budget();
+                let mut recent_turns_retry_attempts = 0usize;
+                let projection = loop {
+                    match build_turn_local_projection_with_runtime_reminder(
+                        &prompt_frame,
+                        &completed_rounds,
+                        &available_tools,
+                        &checkpoint_state,
+                        checkpoint_request_id.clone(),
+                        // Turn-local continuation projection covers the complete provider request.
+                        // The bounded turn projection budget only applies to initial recent_turns.
+                        context_config.prompt_budget_estimated_tokens,
+                        context_config.compaction_keep_recent_estimated_tokens,
+                        runtime_reminder.as_deref(),
+                    ) {
+                        TurnLocalProjectionOutcome::Projection(projection) => break projection,
+                        TurnLocalProjectionOutcome::BaselineOverBudget(diagnostics)
+                            if diagnostics.reason == "minimum_exact_round_unfit"
+                                && recent_turns_retry_attempts < RECENT_TURNS_RETRY_LIMIT
+                                && recent_turns_budget.is_some() =>
+                        {
+                            let current_budget = recent_turns_budget.unwrap_or_default();
+                            let deficit = diagnostics
+                                .minimum_projection_estimated_tokens
+                                .saturating_sub(diagnostics.effective_budget_estimated_tokens);
+                            let next_budget = current_budget.saturating_sub(
+                                deficit.saturating_add(RECENT_TURNS_RETRY_SAFETY_MARGIN_TOKENS),
+                            );
+                            if next_budget == current_budget {
+                                recent_turns_budget = None;
+                                continue;
+                            }
+                            let Some(reprojected_prompt) = effective_prompt.reproject_recent_turns(
+                                &runtime.inner.storage,
+                                next_budget,
+                                &available_tools,
+                            ) else {
+                                recent_turns_budget = None;
+                                continue;
+                            };
+                            recent_turns_retry_attempts += 1;
+                            runtime.inner.storage.append_event(&AuditEvent::new(
+                                "turn_local_recent_turns_retry",
+                                serde_json::json!({
+                                    "agent_id": agent_id,
+                                    "round": round,
+                                    "attempt": recent_turns_retry_attempts,
+                                    "reason": &diagnostics.reason,
+                                    "previous_recent_turns_budget": current_budget,
+                                    "next_recent_turns_budget": next_budget,
+                                    "deficit_estimated_tokens": deficit,
+                                    "previous_context_attachment_estimated_tokens": diagnostics.context_attachment_estimated_tokens,
+                                }),
+                            ))?;
+                            effective_prompt = reprojected_prompt;
+                            prompt_frame = build_provider_prompt_frame(&effective_prompt);
+                            recent_turns_budget = Some(next_budget);
+                        }
+                        TurnLocalProjectionOutcome::BaselineOverBudget(diagnostics) => {
+                            runtime.inner.storage.append_event(&AuditEvent::new(
+                                "turn_local_baseline_over_budget",
+                                serde_json::json!({
+                                    "agent_id": agent_id,
+                                    "round": round,
+                                    "reason": &diagnostics.reason,
+                                    "estimated_baseline_tokens": diagnostics.estimated_baseline_tokens,
+                                    "minimum_exact_round_estimated_tokens": diagnostics.minimum_exact_round_estimated_tokens,
+                                    "minimum_projection_estimated_tokens": diagnostics.minimum_projection_estimated_tokens,
+                                    "effective_budget_estimated_tokens": diagnostics.effective_budget_estimated_tokens,
+                                    "tool_overhead_estimated_tokens": diagnostics.tool_overhead_estimated_tokens,
+                                    "system_prompt_estimated_tokens": diagnostics.system_prompt_estimated_tokens,
+                                    "context_attachment_estimated_tokens": diagnostics.context_attachment_estimated_tokens,
+                                    "recent_turns_retry_attempts": recent_turns_retry_attempts,
+                                    "final_recent_turns_budget": recent_turns_budget,
+                                }),
+                            ))?;
+                            let final_text = format!(
+                                "Turn stopped because the continuation baseline exceeded the prompt budget after {} recent-turns recovery attempt(s) (reason={}, estimated_baseline_tokens={}, minimum_projection_estimated_tokens={}, effective_budget_estimated_tokens={}, tool_overhead_estimated_tokens={}).",
+                                recent_turns_retry_attempts,
+                                diagnostics.reason,
+                                diagnostics.estimated_baseline_tokens,
+                                diagnostics.minimum_projection_estimated_tokens,
+                                diagnostics.effective_budget_estimated_tokens,
+                                diagnostics.tool_overhead_estimated_tokens,
+                            );
+                            let terminal = runtime
+                                .persist_turn_terminal_record(
+                                    TurnTerminalKind::BaselineOverBudget,
+                                    Some(final_text.clone()),
+                                    turn_started_at.elapsed().as_millis() as u64,
+                                    None,
+                                )
+                                .await?;
+                            return Ok(AgentLoopOutcome {
+                                final_text,
+                                final_text_source_assistant_round_id: None,
+                                turn_index: terminal.turn_index,
+                                terminal,
+                                should_sleep: false,
+                                sleep_duration_ms: None,
+                                allow_sleep_runnable_work_override: false,
+                                terminal_kind: TurnTerminalKind::BaselineOverBudget,
+                            });
+                        }
                     }
                 };
                 if let Some(compaction) = projection.compaction.as_ref() {


### PR DESCRIPTION
## Summary

- preserve structured `recent_turns` inputs so the initial prompt section can be reprojected with a smaller token budget
- recover from `minimum_exact_round_unfit` by adaptively shrinking only `recent_turns` and retrying continuation projection within a bounded loop
- retain the latest exact turn-local round and emit explicit recovery diagnostics, while preserving `BaselineOverBudget` when no safe history reduction remains
- document the recovery contract and add context, prompt, and runtime regression coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo test context::tests -- --nocapture`
- `cargo test prompt::tests -- --nocapture`
- `cargo test runtime::tests::turns -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2291
