### PR TITLE
feat: expose web search provider metadata

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1793,6 +1793,96 @@
           },
           "runtime_surface": {
             "properties": {
+              "available_search_provider_kinds": {
+                "default": [],
+                "items": {
+                  "properties": {
+                    "capabilities": {
+                      "properties": {
+                        "auth": {
+                          "enum": [
+                            "none",
+                            "api_key",
+                            "native_provider",
+                            "self_hosted"
+                          ],
+                          "type": "string"
+                        },
+                        "cost_class": {
+                          "enum": [
+                            "free",
+                            "self_hosted",
+                            "paid",
+                            "provider_metered"
+                          ],
+                          "type": "string"
+                        },
+                        "default_priority": {
+                          "format": "uint16",
+                          "maximum": 65535,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "quality_hint": {
+                          "enum": [
+                            "html_fallback",
+                            "keyword",
+                            "semantic",
+                            "research",
+                            "native"
+                          ],
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": [
+                            "supported",
+                            "unsupported",
+                            "native_only"
+                          ],
+                          "type": "string"
+                        },
+                        "supports_domain_filter": {
+                          "type": "boolean"
+                        },
+                        "supports_freshness": {
+                          "type": "boolean"
+                        },
+                        "supports_full_content": {
+                          "type": "boolean"
+                        },
+                        "supports_native_citations": {
+                          "type": "boolean"
+                        },
+                        "supports_region_or_language": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "auth",
+                        "cost_class",
+                        "quality_hint",
+                        "supports_domain_filter",
+                        "supports_freshness",
+                        "supports_region_or_language",
+                        "supports_full_content",
+                        "supports_native_citations",
+                        "default_priority",
+                        "status"
+                      ],
+                      "type": "object"
+                    },
+                    "kind": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "capabilities"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "default_tool_output_tokens": {
                 "format": "uint32",
                 "minimum": 0,
@@ -2076,6 +2166,96 @@
           },
           "runtime_surface": {
             "properties": {
+              "available_search_provider_kinds": {
+                "default": [],
+                "items": {
+                  "properties": {
+                    "capabilities": {
+                      "properties": {
+                        "auth": {
+                          "enum": [
+                            "none",
+                            "api_key",
+                            "native_provider",
+                            "self_hosted"
+                          ],
+                          "type": "string"
+                        },
+                        "cost_class": {
+                          "enum": [
+                            "free",
+                            "self_hosted",
+                            "paid",
+                            "provider_metered"
+                          ],
+                          "type": "string"
+                        },
+                        "default_priority": {
+                          "format": "uint16",
+                          "maximum": 65535,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "quality_hint": {
+                          "enum": [
+                            "html_fallback",
+                            "keyword",
+                            "semantic",
+                            "research",
+                            "native"
+                          ],
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": [
+                            "supported",
+                            "unsupported",
+                            "native_only"
+                          ],
+                          "type": "string"
+                        },
+                        "supports_domain_filter": {
+                          "type": "boolean"
+                        },
+                        "supports_freshness": {
+                          "type": "boolean"
+                        },
+                        "supports_full_content": {
+                          "type": "boolean"
+                        },
+                        "supports_native_citations": {
+                          "type": "boolean"
+                        },
+                        "supports_region_or_language": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "auth",
+                        "cost_class",
+                        "quality_hint",
+                        "supports_domain_filter",
+                        "supports_freshness",
+                        "supports_region_or_language",
+                        "supports_full_content",
+                        "supports_native_citations",
+                        "default_priority",
+                        "status"
+                      ],
+                      "type": "object"
+                    },
+                    "kind": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "capabilities"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "default_tool_output_tokens": {
                 "format": "uint32",
                 "minimum": 0,

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -10,6 +10,7 @@ use crate::{
     config::{AppConfig, ControlAuthMode},
     host::RuntimeHost,
     types::{AgentStatus, RuntimeFailureSummary},
+    web::{WebProviderCapabilityMetadata, WebProviderKind},
 };
 
 use super::daemon_paths;
@@ -92,6 +93,8 @@ pub struct RuntimeConfigSurface {
     pub disable_provider_fallback: bool,
     pub providers: Vec<RuntimeProviderSummary>,
     pub web_search: RuntimeWebSearchSummary,
+    #[serde(default)]
+    pub available_search_provider_kinds: Vec<RuntimeWebSearchProviderKindSummary>,
     pub web_search_providers: Vec<RuntimeWebSearchProviderSummary>,
 }
 
@@ -129,6 +132,12 @@ pub struct RuntimeWebSearchProviderSummary {
     pub base_url: Option<String>,
     pub credential_profile: Option<String>,
     pub credential_configured: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct RuntimeWebSearchProviderKindSummary {
+    pub kind: String,
+    pub capabilities: WebProviderCapabilityMetadata,
 }
 
 impl RuntimeConfigSurface {
@@ -185,6 +194,13 @@ impl RuntimeConfigSurface {
                 max_results: config.web_config.search.max_results,
                 max_provider_attempts: config.web_config.search.max_provider_attempts,
             },
+            available_search_provider_kinds: WebProviderKind::ALL
+                .iter()
+                .map(|kind| RuntimeWebSearchProviderKindSummary {
+                    kind: kind.as_str().to_string(),
+                    capabilities: kind.capabilities(),
+                })
+                .collect(),
             web_search_providers: config
                 .stored_config
                 .web

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -393,6 +393,36 @@ fn effective_config_mismatch_summary_lists_actionable_differences() {
     assert!(!summary.contains("secret"));
 }
 
+#[test]
+fn runtime_config_surface_reports_available_search_provider_capabilities() {
+    let surface = RuntimeConfigSurface::new(&test_config());
+
+    assert_eq!(
+        surface.available_search_provider_kinds.len(),
+        crate::web::WebProviderKind::ALL.len()
+    );
+    let brave = surface
+        .available_search_provider_kinds
+        .iter()
+        .find(|provider| provider.kind == "brave")
+        .expect("brave provider kind should be reported");
+    assert_eq!(
+        brave.capabilities.auth,
+        crate::web::WebProviderAuthClass::ApiKey
+    );
+    assert_eq!(brave.capabilities.default_priority, 80);
+
+    let native = surface
+        .available_search_provider_kinds
+        .iter()
+        .find(|provider| provider.kind == "open_ai_native")
+        .expect("native provider kind should be reported");
+    assert_eq!(
+        native.capabilities.status,
+        crate::web::WebProviderSupportStatus::NativeOnly
+    );
+}
+
 #[tokio::test]
 async fn runtime_activity_summary_reports_idle_runtime() {
     let config = test_config();

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -3081,6 +3081,7 @@ mod tests {
                 max_results: 5,
                 max_provider_attempts: 2,
             },
+            available_search_provider_kinds: Vec::new(),
             web_search_providers: Vec::new(),
         };
         let accepted = crate::http::RuntimeConfigUpdateResponse {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -427,6 +427,10 @@ pub enum WebProviderKind {
 }
 
 impl WebProviderKind {
+    /// Must list every `WebProviderKind` variant exactly once.
+    ///
+    /// Missing entries are not caught at compile time, so keep this in sync
+    /// when adding or removing enum variants.
     pub const ALL: [Self; 13] = [
         Self::DuckDuckGo,
         Self::Searxng,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -7,6 +7,7 @@ pub mod search;
 use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Result};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -177,7 +178,7 @@ impl WebSearchMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WebProviderAuthClass {
     None,
@@ -186,7 +187,7 @@ pub enum WebProviderAuthClass {
     SelfHosted,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WebProviderCostClass {
     Free,
@@ -195,7 +196,7 @@ pub enum WebProviderCostClass {
     ProviderMetered,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WebProviderQualityHint {
     HtmlFallback,
@@ -205,7 +206,7 @@ pub enum WebProviderQualityHint {
     Native,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WebProviderSupportStatus {
     Supported,
@@ -213,7 +214,7 @@ pub enum WebProviderSupportStatus {
     NativeOnly,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct WebProviderCapabilityMetadata {
     pub auth: WebProviderAuthClass,
     pub cost_class: WebProviderCostClass,
@@ -426,6 +427,22 @@ pub enum WebProviderKind {
 }
 
 impl WebProviderKind {
+    pub const ALL: [Self; 13] = [
+        Self::DuckDuckGo,
+        Self::Searxng,
+        Self::Brave,
+        Self::TencentCloudWsa,
+        Self::Bocha,
+        Self::Tavily,
+        Self::Exa,
+        Self::Perplexity,
+        Self::Firecrawl,
+        Self::OpenAiNative,
+        Self::AnthropicNative,
+        Self::GeminiNative,
+        Self::Command,
+    ];
+
     pub fn is_native_search(self) -> bool {
         matches!(
             self,

--- a/web-gui/app/src/features/settings/SettingsPage.test.ts
+++ b/web-gui/app/src/features/settings/SettingsPage.test.ts
@@ -3,11 +3,16 @@ import { describe, expect, it } from "vitest";
 import {
   buildImageGenerationConfigUpdates,
   buildSearchProviderConfigUpdates,
+  buildStandardSearchProviderDefinitions,
   buildVisionConfigUpdates,
   sortProvidersForSettings,
   sortSearchProvidersForSettings,
 } from "./SettingsPage";
-import type { RuntimeProviderSummary, RuntimeWebSearchProviderSummary } from "../../runtime/types";
+import type {
+  RuntimeProviderSummary,
+  RuntimeWebSearchProviderCapabilities,
+  RuntimeWebSearchProviderSummary,
+} from "../../runtime/types";
 
 function provider(id: string, credentialConfigured: boolean): RuntimeProviderSummary {
   return {
@@ -32,6 +37,50 @@ function searchProvider(id: string, credentialConfigured: boolean): RuntimeWebSe
     credentialConfigured,
   };
 }
+
+function searchCapabilities(
+  auth: RuntimeWebSearchProviderCapabilities["auth"],
+  defaultPriority: number,
+): RuntimeWebSearchProviderCapabilities {
+  return {
+    auth,
+    costClass: auth === "self_hosted" ? "self_hosted" : auth === "native_provider" ? "provider_metered" : "paid",
+    qualityHint: auth === "native_provider" ? "native" : "research",
+    supportsDomainFilter: false,
+    supportsFreshness: false,
+    supportsRegionOrLanguage: false,
+    supportsFullContent: false,
+    supportsNativeCitations: false,
+    defaultPriority,
+    status: auth === "native_provider" ? "native_only" : "supported",
+  };
+}
+
+describe("buildStandardSearchProviderDefinitions", () => {
+  it("derives groups and configuration requirements from runtime capabilities", () => {
+    const definitions = buildStandardSearchProviderDefinitions([
+      { kind: "future_api", capabilities: searchCapabilities("api_key", 90) },
+      { kind: "future_self_hosted", capabilities: searchCapabilities("self_hosted", 40) },
+      { kind: "future_native", capabilities: searchCapabilities("native_provider", 60) },
+      { kind: "duck_duck_go", capabilities: searchCapabilities("none", 10) },
+      {
+        kind: "future_unsupported",
+        capabilities: { ...searchCapabilities("api_key", 100), status: "unsupported" },
+      },
+    ]);
+
+    expect(definitions.map(({ id, category, requiresApiKey, requiresBaseUrl }) => ({
+      id,
+      category,
+      requiresApiKey,
+      requiresBaseUrl,
+    }))).toEqual([
+      { id: "future-api", category: "api", requiresApiKey: true, requiresBaseUrl: false },
+      { id: "future-native", category: "native", requiresApiKey: false, requiresBaseUrl: false },
+      { id: "future-self-hosted", category: "selfHosted", requiresApiKey: false, requiresBaseUrl: true },
+    ]);
+  });
+});
 
 describe("sortProvidersForSettings", () => {
   it("places credential-configured providers first without reordering peers", () => {
@@ -113,15 +162,29 @@ describe("buildSearchProviderConfigUpdates", () => {
   });
 
   it("omits base_url for native search providers that do not need one", () => {
+    const capabilities = searchCapabilities("native_provider", 65);
     expect(
       buildSearchProviderConfigUpdates("openai-native", {
         kind: "open_ai_native",
         baseUrl: "",
         credentialProfile: "",
-      }),
+      }, capabilities),
     ).toEqual([
       { key: "web.providers.openai-native.kind", value: "open_ai_native" },
       { key: "web.providers.openai-native.credential_profile", value: "" },
+    ]);
+  });
+
+  it("uses runtime capabilities for future native provider kinds", () => {
+    expect(
+      buildSearchProviderConfigUpdates("future-native", {
+        kind: "future_native",
+        baseUrl: "should-not-be-persisted",
+        credentialProfile: "",
+      }, searchCapabilities("native_provider", 65)),
+    ).toEqual([
+      { key: "web.providers.future-native.kind", value: "future_native" },
+      { key: "web.providers.future-native.credential_profile", value: "" },
     ]);
   });
 });

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import type {
   RuntimeModelCatalog,
   RuntimeModelOption,
   RuntimeProviderSummary,
+  RuntimeWebSearchProviderKindSummary,
   RuntimeWebSearchProviderSummary,
 } from "../../runtime/types";
 
@@ -72,121 +73,32 @@ type SearchProviderDraft = Pick<RuntimeWebSearchProviderSummary, "kind" | "baseU
 type StandardSearchProviderDefinition = {
   id: string;
   kind: string;
-  label: string;
-  description: string;
+  category: "api" | "selfHosted" | "native";
   requiresApiKey: boolean;
-  requiresBaseUrl?: boolean;
+  requiresBaseUrl: boolean;
   defaultCredentialProfile?: string;
-  baseUrlPlaceholder?: string;
+  capabilities: RuntimeWebSearchProviderKindSummary["capabilities"];
 };
 
-const webSearchProviderKinds = [
-  "duck_duck_go",
-  "searxng",
-  "brave",
-  "tencent_cloud_wsa",
-  "bocha",
-  "tavily",
-  "exa",
-  "perplexity",
-  "firecrawl",
-  "open_ai_native",
-  "anthropic_native",
-  "gemini_native",
-  "command",
-];
-
-const standardSearchProviders: StandardSearchProviderDefinition[] = [
-  {
-    id: "brave",
-    kind: "brave",
-    label: "Brave Search",
-    description: "Good general-purpose web results. Requires a Brave Search API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "brave:default",
-  },
-  {
-    id: "tavily",
-    kind: "tavily",
-    label: "Tavily",
-    description: "Search API optimized for agent and RAG workflows. Requires a Tavily API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "tavily:default",
-  },
-  {
-    id: "exa",
-    kind: "exa",
-    label: "Exa",
-    description: "Neural search API for high-relevance web retrieval. Requires an Exa API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "exa:default",
-  },
-  {
-    id: "perplexity",
-    kind: "perplexity",
-    label: "Perplexity",
-    description: "Perplexity search-backed answers. Requires a Perplexity API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "perplexity:default",
-  },
-  {
-    id: "firecrawl",
-    kind: "firecrawl",
-    label: "Firecrawl",
-    description: "Search and crawl provider for page extraction workflows. Requires a Firecrawl API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "firecrawl:default",
-  },
-  {
-    id: "tencent-cloud-wsa",
-    kind: "tencent_cloud_wsa",
-    label: "Tencent Cloud WSA",
-    description: "Tencent Cloud WSA SearchPro — research-quality web search with domain filter and freshness support. Requires a Tencent Cloud API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "tencent_cloud_wsa:default",
-  },
-  {
-    id: "bocha",
-    kind: "bocha",
-    label: "Bocha AI Search",
-    description: "Bocha AI search optimized for Chinese-language queries with freshness support. Requires a Bocha API key.",
-    requiresApiKey: true,
-    defaultCredentialProfile: "bocha:default",
-  },
-  {
-    id: "searxng",
-    kind: "searxng",
-    label: "SearXNG",
-    description: "Use a self-hosted or trusted SearXNG instance. No API key is needed.",
-    requiresApiKey: false,
-    requiresBaseUrl: true,
-    baseUrlPlaceholder: "https://search.example.com",
-  },
-  {
-    id: "openai-native",
-    kind: "open_ai_native",
-    label: "OpenAI Native Search",
-    description: "Use OpenAI's built-in web search (e.g. web_search_preview). No separate API key — uses the OpenAI model provider credentials.",
-    requiresApiKey: false,
-  },
-  {
-    id: "anthropic-native",
-    kind: "anthropic_native",
-    label: "Anthropic Native Search",
-    description: "Use Anthropic's built-in web search tool. No separate API key — uses the Anthropic model provider credentials.",
-    requiresApiKey: false,
-  },
-  {
-    id: "gemini-native",
-    kind: "gemini_native",
-    label: "Gemini Native Search",
-    description: "Use Google Gemini's grounding with Google Search. No separate API key — uses the Gemini model provider credentials.",
-    requiresApiKey: false,
-  },
-];
-
-const standardSearchProviderById = new Map(standardSearchProviders.map((provider) => [provider.id, provider]));
-const standardSearchProviderIds = new Set(standardSearchProviders.map((provider) => provider.id));
+export function buildStandardSearchProviderDefinitions(
+  kinds: RuntimeWebSearchProviderKindSummary[],
+): StandardSearchProviderDefinition[] {
+  return kinds
+    .filter(({ capabilities }) =>
+      capabilities.status !== "unsupported"
+      && (capabilities.auth === "api_key" || capabilities.auth === "self_hosted" || capabilities.auth === "native_provider")
+    )
+    .map(({ kind, capabilities }) => ({
+      id: kind.replaceAll("_", "-"),
+      kind,
+      category: capabilities.auth === "api_key" ? "api" as const : capabilities.auth === "self_hosted" ? "selfHosted" as const : "native" as const,
+      requiresApiKey: capabilities.auth === "api_key",
+      requiresBaseUrl: capabilities.auth === "self_hosted",
+      defaultCredentialProfile: capabilities.auth === "api_key" ? `${kind}:default` : undefined,
+      capabilities,
+    }))
+    .sort((left, right) => right.capabilities.defaultPriority - left.capabilities.defaultPriority);
+}
 
 type SettingsTabKey = "general" | "models" | "vision" | "search" | "advanced";
 
@@ -198,8 +110,7 @@ const settingsTabs: Array<{ key: SettingsTabKey; labelKey: string; descriptionKe
   { key: "advanced", labelKey: "settings.tabAdvanced", descriptionKey: "settings.tabAdvancedDesc" },
 ];
 
-function defaultSearchProviderDraft(providerId: string): SearchProviderDraft {
-  const definition = standardSearchProviderById.get(providerId);
+function defaultSearchProviderDraft(providerId: string, definition?: StandardSearchProviderDefinition): SearchProviderDraft {
   return {
     kind: definition?.kind ?? "brave",
     baseUrl: "",
@@ -207,9 +118,12 @@ function defaultSearchProviderDraft(providerId: string): SearchProviderDraft {
   };
 }
 
-export function buildSearchProviderConfigUpdates(providerId: string, draft: SearchProviderDraft): Array<{ key: string; value?: unknown; unset?: boolean }> {
-  const definition = standardSearchProviderById.get(providerId);
-  const shouldSendBaseUrl = !definition || definition.requiresApiKey || Boolean(definition.requiresBaseUrl);
+export function buildSearchProviderConfigUpdates(
+  providerId: string,
+  draft: SearchProviderDraft,
+  capabilities?: RuntimeWebSearchProviderKindSummary["capabilities"],
+): Array<{ key: string; value?: unknown; unset?: boolean }> {
+  const shouldSendBaseUrl = capabilities?.auth !== "native_provider";
   const updates: Array<{ key: string; value?: unknown; unset?: boolean }> = [
     { key: `web.providers.${providerId}.kind`, value: draft.kind },
     { key: `web.providers.${providerId}.credential_profile`, value: draft.credentialProfile?.trim() ?? "" },
@@ -293,6 +207,30 @@ export function SettingsPage({
   const sortedSearchProviders = useMemo(
     () => sortSearchProvidersForSettings(surface?.webSearchProviders ?? []),
     [surface?.webSearchProviders],
+  );
+  const standardSearchProviders = useMemo(
+    () => buildStandardSearchProviderDefinitions(surface?.availableSearchProviderKinds ?? []),
+    [surface?.availableSearchProviderKinds],
+  );
+  const standardSearchProviderById = useMemo(
+    () => new Map(standardSearchProviders.map((provider) => [provider.id, provider])),
+    [standardSearchProviders],
+  );
+  const standardSearchProviderIds = useMemo(
+    () => new Set(standardSearchProviders.map((provider) => provider.id)),
+    [standardSearchProviders],
+  );
+  const webSearchProviderKinds = useMemo(
+    () => surface?.availableSearchProviderKinds.map(({ kind }) => kind) ?? [],
+    [surface?.availableSearchProviderKinds],
+  );
+  const groupedSearchProviders = useMemo(
+    () => [
+      { category: "api" as const, providers: standardSearchProviders.filter((provider) => provider.category === "api") },
+      { category: "selfHosted" as const, providers: standardSearchProviders.filter((provider) => provider.category === "selfHosted") },
+      { category: "native" as const, providers: standardSearchProviders.filter((provider) => provider.category === "native") },
+    ].filter((group) => group.providers.length > 0),
+    [standardSearchProviders],
   );
 
   useEffect(() => {
@@ -443,10 +381,11 @@ export function SettingsPage({
   }
 
   function updateSearchProviderDraft(providerId: string, patch: Partial<SearchProviderDraft>) {
+    const definition = standardSearchProviderById.get(providerId);
     setSearchProviderDrafts((drafts) => ({
       ...drafts,
       [providerId]: {
-        ...(drafts[providerId] ?? defaultSearchProviderDraft(providerId)),
+        ...(drafts[providerId] ?? defaultSearchProviderDraft(providerId, definition)),
         ...patch,
       },
     }));
@@ -464,9 +403,10 @@ export function SettingsPage({
   }
 
   async function saveSearchProviderConfig(providerId: string) {
-    const draft = searchProviderDrafts[providerId] ?? defaultSearchProviderDraft(providerId);
+    const draft = searchProviderDrafts[providerId] ?? defaultSearchProviderDraft(providerId, standardSearchProviderById.get(providerId));
+    const capabilities = surface?.availableSearchProviderKinds.find(({ kind }) => kind === draft.kind)?.capabilities;
     setSearchProviderSaveMessage(undefined);
-    const result = await onUpdateRuntimeConfig(buildSearchProviderConfigUpdates(providerId, draft));
+    const result = await onUpdateRuntimeConfig(buildSearchProviderConfigUpdates(providerId, draft, capabilities));
     if (!result) return;
     const rejected = result.results?.filter((entry) => entry.effect === "rejected") ?? [];
     setSearchProviderSaveMessage(
@@ -1075,9 +1015,10 @@ export function SettingsPage({
                     {standardSearchProviders.map((provider) => {
                       const configured = surface.webSearchProviders.find((entry) => entry.id === provider.id);
                       const ready = provider.requiresApiKey ? configured?.credentialConfigured : Boolean(configured);
+                      const label = t(`settings.searchProviderKinds.${provider.kind}.label`, { defaultValue: provider.kind });
                       return (
                         <option key={provider.id} value={provider.id}>
-                          {provider.label}{ready ? ` — ${t("settings.readyLabel")}` : provider.requiresApiKey ? ` — ${t("settings.apiKeyNeededLabel")}` : ""}
+                          {label}{ready ? ` — ${t("settings.readyLabel")}` : provider.requiresApiKey ? ` — ${t("settings.apiKeyNeededLabel")}` : ""}
                         </option>
                       );
                     })}
@@ -1092,7 +1033,7 @@ export function SettingsPage({
                   <span>{t("settings.allowModelNativeSearch")}</span>
                 </label>
                 <p className="settings-hint">
-                  DuckDuckGo and native search do not need API keys. Add keys only for API-backed providers below.
+                  {t("settings.searchCredentialHint")}
                 </p>
                 <details className="settings-advanced">
                   <summary>{t("settings.tabAdvanced")}</summary>
@@ -1151,7 +1092,7 @@ export function SettingsPage({
           ) : (
             <div className="settings-provider-list">
               <p className="settings-muted">
-                Standard providers are shown as product choices. The UI creates the matching <code>web.providers.&lt;id&gt;</code> entry and stores API keys in the existing credential store.
+                {t("settings.searchProviderMetadataHint")}
               </p>
               <div className="settings-builtins">
                 <div>
@@ -1165,12 +1106,22 @@ export function SettingsPage({
                 </div>
                 <StatusChip className="settings-status available" tone="success" iconOnly title={t("settings.readyLabel")} />
               </div>
-              {standardSearchProviders.map((definition) => {
+              {groupedSearchProviders.map((group) => (
+                <section className="settings-provider-group" key={group.category}>
+                  <div className="settings-provider-group-head">
+                    <strong>{t(`settings.searchProviderGroups.${group.category}.label`)}</strong>
+                    <span>{t(`settings.searchProviderGroups.${group.category}.description`)}</span>
+                  </div>
+                  {group.providers.map((definition) => {
                 const provider = surface.webSearchProviders.find((entry) => entry.id === definition.id);
-                const draft = searchProviderDrafts[definition.id] ?? defaultSearchProviderDraft(definition.id);
+                const draft = searchProviderDrafts[definition.id] ?? defaultSearchProviderDraft(definition.id, definition);
                 const credentialProfile = draft.credentialProfile?.trim() ?? definition.defaultCredentialProfile ?? "";
                 const credentialReady = credentialProfile ? isCredentialProfileConfigured(credentialProfile) : false;
                 const providerReady = definition.requiresApiKey ? credentialReady : Boolean(provider);
+                const label = t(`settings.searchProviderKinds.${definition.kind}.label`, { defaultValue: definition.kind });
+                const description = t(`settings.searchProviderKinds.${definition.kind}.description`, {
+                  defaultValue: t("settings.searchProviderDefaultDescription"),
+                });
                 return (
                   <form
                     className="settings-provider-editor"
@@ -1182,9 +1133,9 @@ export function SettingsPage({
                   >
                     <header>
                       <div>
-                        <strong>{definition.label}</strong>
+                        <strong>{label}</strong>
                         <small>
-                          {definition.description}
+                          {description}
                         </small>
                       </div>
                       <StatusChip className={`settings-status ${providerReady ? "available" : "unavailable"}`} tone={providerReady ? "success" : "error"} iconOnly title={providerReady ? t("settings.readyLabel") : definition.requiresApiKey ? t("settings.keyNeededLabel") : t("settings.notConfigured")} />
@@ -1196,7 +1147,7 @@ export function SettingsPage({
                           <input
                             value={draft.baseUrl ?? ""}
                             onChange={(event) => updateSearchProviderDraft(definition.id, { baseUrl: event.target.value })}
-                            placeholder={definition.baseUrlPlaceholder ?? t("settings.optionalBaseUrl")}
+                            placeholder={t("settings.selfHostedBaseUrlPlaceholder")}
                           />
                         </label>
                       </div>
@@ -1274,7 +1225,7 @@ export function SettingsPage({
                     </details>
                     <div className="settings-actions">
                       <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>
-                        {runtimeConfigSaving ? t("settings.saving") : provider ? t("settings.saveProvider", { name: definition.label }) : t("settings.enableProvider", { name: definition.label })}
+                        {runtimeConfigSaving ? t("settings.saving") : provider ? t("settings.saveProvider", { name: label }) : t("settings.enableProvider", { name: label })}
                       </Button>
                       {provider ? (
                         <Button
@@ -1289,7 +1240,9 @@ export function SettingsPage({
                     </div>
                   </form>
                 );
-              })}
+                  })}
+                </section>
+              ))}
               {sortedSearchProviders
                 .filter((provider) => !standardSearchProviderIds.has(provider.id))
                 .map((provider) => provider.id)

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -510,6 +510,70 @@ const en = {
     builtinDefaultsValue: "builtin defaults",
     nativeSearchDesc: "Uses model-provider native search when the runtime can route to it. No API key is configured here.",
     duckDuckGoDesc: "Built in and ready by default. No provider id, kind, or API key is required.",
+    searchCredentialHint: "DuckDuckGo and model-native search do not need separate API keys. Add credentials only for API-backed providers.",
+    searchProviderMetadataHint: "Available provider kinds and configuration requirements are reported by the runtime. API keys are stored in the existing credential store.",
+    searchProviderDefaultDescription: "Search provider reported by the runtime.",
+    selfHostedBaseUrlPlaceholder: "https://search.example.com",
+    searchProviderGroups: {
+      api: {
+        label: "API search",
+        description: "Hosted search APIs that require a provider-specific API key.",
+      },
+      selfHosted: {
+        label: "Self-hosted",
+        description: "Search services hosted by you or a trusted operator.",
+      },
+      native: {
+        label: "Model-native",
+        description: "Built-in search through the model API. No separate search credential is required.",
+      },
+    },
+    searchProviderKinds: {
+      brave: {
+        label: "Brave Search",
+        description: "General-purpose web results through the Brave Search API.",
+      },
+      tavily: {
+        label: "Tavily",
+        description: "Search API optimized for agent and RAG workflows.",
+      },
+      exa: {
+        label: "Exa",
+        description: "Neural search API for high-relevance web retrieval.",
+      },
+      perplexity: {
+        label: "Perplexity",
+        description: "Search-backed answers with native citations.",
+      },
+      firecrawl: {
+        label: "Firecrawl",
+        description: "Search and page extraction for crawl-oriented workflows.",
+      },
+      tencent_cloud_wsa: {
+        label: "Tencent Cloud WSA",
+        description: "Tencent Cloud SearchPro with domain filtering and freshness support.",
+      },
+      bocha: {
+        label: "Bocha AI Search",
+        description: "Web search optimized for Chinese-language queries with freshness support.",
+      },
+      searxng: {
+        label: "SearXNG",
+        description: "Use a self-hosted or trusted SearXNG instance.",
+      },
+      open_ai_native: {
+        label: "OpenAI Native Search",
+        description: "Uses OpenAI's built-in web search through the configured model provider.",
+      },
+      anthropic_native: {
+        label: "Anthropic Native Search",
+        description: "Uses Anthropic's built-in web search through the configured model provider.",
+      },
+      gemini_native: {
+        label: "Gemini Native Search",
+        description: "Uses Gemini grounding with Google Search through the configured model provider.",
+      },
+    },
     modelCatalogSummary: "{{models}} models across {{providers}} providers",
     connectLiveRuntime: "Connect to a live runtime and refresh this page to edit model defaults.",
     builtinNoKey: "— builtin, no API key",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -512,6 +512,70 @@ const zh: Record<string, any> = {
     builtinDefaultsValue: "内置默认值",
     nativeSearchDesc: "当运行时可以路由时，使用模型提供商的原生搜索。此处不配置 API 密钥。",
     duckDuckGoDesc: "默认内置且就绪。无需提供商 ID、类型或 API 密钥。",
+    searchCredentialHint: "DuckDuckGo 和模型原生搜索不需要单独的 API 密钥。仅为 API 搜索提供商添加凭证。",
+    searchProviderMetadataHint: "可用的提供商类型和配置要求由运行时报告。API 密钥仍存储在现有凭证存储中。",
+    searchProviderDefaultDescription: "由运行时报告的搜索提供商。",
+    selfHostedBaseUrlPlaceholder: "https://search.example.com",
+    searchProviderGroups: {
+      api: {
+        label: "API 搜索",
+        description: "需要提供商专用 API 密钥的托管搜索服务。",
+      },
+      selfHosted: {
+        label: "自托管",
+        description: "由你或可信运维方托管的搜索服务。",
+      },
+      native: {
+        label: "模型原生",
+        description: "通过模型 API 使用内置搜索，无需单独的搜索凭证。",
+      },
+    },
+    searchProviderKinds: {
+      brave: {
+        label: "Brave Search",
+        description: "通过 Brave Search API 提供通用网页搜索结果。",
+      },
+      tavily: {
+        label: "Tavily",
+        description: "面向智能体和 RAG 工作流优化的搜索 API。",
+      },
+      exa: {
+        label: "Exa",
+        description: "用于高相关性网页检索的神经搜索 API。",
+      },
+      perplexity: {
+        label: "Perplexity",
+        description: "提供原生引用的搜索增强回答。",
+      },
+      firecrawl: {
+        label: "Firecrawl",
+        description: "面向抓取工作流的搜索与页面内容提取服务。",
+      },
+      tencent_cloud_wsa: {
+        label: "腾讯云 WSA",
+        description: "腾讯云 SearchPro 搜索，支持域名过滤与时效性筛选。",
+      },
+      bocha: {
+        label: "博查 AI 搜索",
+        description: "针对中文查询优化并支持时效性筛选的网页搜索。",
+      },
+      searxng: {
+        label: "SearXNG",
+        description: "使用自托管或可信的 SearXNG 实例。",
+      },
+      open_ai_native: {
+        label: "OpenAI 原生搜索",
+        description: "通过已配置的模型提供商使用 OpenAI 内置网页搜索。",
+      },
+      anthropic_native: {
+        label: "Anthropic 原生搜索",
+        description: "通过已配置的模型提供商使用 Anthropic 内置网页搜索。",
+      },
+      gemini_native: {
+        label: "Gemini 原生搜索",
+        description: "通过已配置的模型提供商使用 Gemini 的 Google 搜索 grounding。",
+      },
+    },
     modelCatalogSummary: "{{models}} 个模型，跨 {{providers}} 个提供商",
     connectLiveRuntime: "连接到实时运行时并刷新此页面以编辑模型默认值。",
     builtinNoKey: "— 内置，无需 API 密钥",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -451,6 +451,7 @@ interface RuntimeConfigSurfaceDto {
   disable_provider_fallback?: boolean;
   providers?: RuntimeProviderSummaryDto[];
   web_search?: RuntimeWebSearchSummaryDto;
+  available_search_provider_kinds?: RuntimeWebSearchProviderKindSummaryDto[];
   web_search_providers?: RuntimeWebSearchProviderSummaryDto[];
 }
 
@@ -518,6 +519,24 @@ interface RuntimeWebSearchProviderSummaryDto {
   base_url?: string;
   credential_profile?: string;
   credential_configured?: boolean;
+}
+
+interface RuntimeWebSearchProviderKindSummaryDto {
+  kind?: string;
+  capabilities?: RuntimeWebSearchProviderCapabilitiesDto;
+}
+
+interface RuntimeWebSearchProviderCapabilitiesDto {
+  auth?: "none" | "api_key" | "native_provider" | "self_hosted";
+  cost_class?: "free" | "self_hosted" | "paid" | "provider_metered";
+  quality_hint?: "html_fallback" | "keyword" | "semantic" | "research" | "native";
+  supports_domain_filter?: boolean;
+  supports_freshness?: boolean;
+  supports_region_or_language?: boolean;
+  supports_full_content?: boolean;
+  supports_native_citations?: boolean;
+  default_priority?: number;
+  status?: "supported" | "unsupported" | "native_only";
 }
 
 interface SearchResponseDto {
@@ -1800,6 +1819,21 @@ function projectRuntimeConfigSurface(surface: RuntimeConfigSurfaceDto): RuntimeC
           maxProviderAttempts: surface.web_search.max_provider_attempts ?? 3,
         }
       : undefined,
+    availableSearchProviderKinds: (surface.available_search_provider_kinds ?? []).map((provider) => ({
+      kind: provider.kind ?? "unknown",
+      capabilities: {
+        auth: provider.capabilities?.auth ?? "none",
+        costClass: provider.capabilities?.cost_class ?? "free",
+        qualityHint: provider.capabilities?.quality_hint ?? "keyword",
+        supportsDomainFilter: provider.capabilities?.supports_domain_filter ?? false,
+        supportsFreshness: provider.capabilities?.supports_freshness ?? false,
+        supportsRegionOrLanguage: provider.capabilities?.supports_region_or_language ?? false,
+        supportsFullContent: provider.capabilities?.supports_full_content ?? false,
+        supportsNativeCitations: provider.capabilities?.supports_native_citations ?? false,
+        defaultPriority: provider.capabilities?.default_priority ?? 0,
+        status: provider.capabilities?.status ?? "unsupported",
+      },
+    })),
     webSearchProviders: (surface.web_search_providers ?? []).map((provider) => ({
       id: provider.id ?? "unknown",
       kind: provider.kind ?? "unknown",

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -292,6 +292,7 @@ export interface RuntimeConfigSurface {
   disableProviderFallback: boolean;
   providers: RuntimeProviderSummary[];
   webSearch?: RuntimeWebSearchSummary;
+  availableSearchProviderKinds: RuntimeWebSearchProviderKindSummary[];
   webSearchProviders: RuntimeWebSearchProviderSummary[];
 }
 
@@ -311,6 +312,24 @@ export interface RuntimeWebSearchProviderSummary {
   baseUrl?: string;
   credentialProfile?: string;
   credentialConfigured: boolean;
+}
+
+export interface RuntimeWebSearchProviderKindSummary {
+  kind: string;
+  capabilities: RuntimeWebSearchProviderCapabilities;
+}
+
+export interface RuntimeWebSearchProviderCapabilities {
+  auth: "none" | "api_key" | "native_provider" | "self_hosted";
+  costClass: "free" | "self_hosted" | "paid" | "provider_metered";
+  qualityHint: "html_fallback" | "keyword" | "semantic" | "research" | "native";
+  supportsDomainFilter: boolean;
+  supportsFreshness: boolean;
+  supportsRegionOrLanguage: boolean;
+  supportsFullContent: boolean;
+  supportsNativeCitations: boolean;
+  defaultPriority: number;
+  status: "supported" | "unsupported" | "native_only";
 }
 
 export interface RuntimeConfigUpdateResult {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -4303,6 +4303,23 @@ code {
   line-height: 1.4;
 }
 
+.settings-provider-group {
+  display: grid;
+  gap: 12px;
+}
+
+.settings-provider-group-head {
+  display: grid;
+  gap: 3px;
+  padding: 4px 2px 0;
+}
+
+.settings-provider-group-head span {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
 .settings-provider-editor {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary

- expose every available web search provider kind and its backend-owned capabilities through `RuntimeConfigSurface`
- generate the Web GUI provider definitions and API/self-hosted/native groups from that metadata instead of maintaining a duplicate capability list
- clarify native search behavior and add English/Chinese copy for Tencent Cloud WSA and Bocha
- add backend contract coverage and frontend regressions for metadata-driven rendering, grouping, and future provider kinds

## Verification

- `cargo fmt --all -- --check`
- `cargo test runtime_config_surface_reports_available_search_provider_capabilities -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm --prefix web-gui/app test` (175 tests passed)
- `npm --prefix web-gui/app run build`

Closes #2294
