### PR TITLE
refactor: retire legacy workspace ID migration

### DIFF
--- a/docs/implementation-decisions/063-workspace-migration-deprecation-plan.md
+++ b/docs/implementation-decisions/063-workspace-migration-deprecation-plan.md
@@ -1,8 +1,8 @@
-# Workspace migration deprecation plan
+# Workspace migration compatibility retirement
 
 ## Context
 
-Two migration functions exist to handle legacy workspace state from before
+Two migration functions handled legacy workspace state from before
 deterministic workspace ID generation was introduced:
 
 1. `canonicalize_agent_home_bindings` (`src/runtime/workspace.rs`) – rewrites
@@ -10,19 +10,24 @@ deterministic workspace ID generation was introduced:
    instead of the canonical agent-specific ID.
 
 2. `migrate_workspace_id` (`src/host_registry.rs` → `src/storage/mod.rs`) –
-   lazily rewrites non-deterministic (random) workspace IDs to deterministic
-   IDs in the shared workspace entry table.
+   lazily rewrote non-deterministic (random) workspace IDs to deterministic
+   IDs in the shared workspace entry table and recorded alias mappings.
 
 ## Decision
 
-Both functions are marked as deprecated migration paths via doc comments and
-emit `tracing::info!` logs with the `workspace migration:` prefix each time
-they execute. This gives operators a concrete signal to determine when all
-agents have migrated and the code can be safely removed.
+The random workspace ID compatibility window has ended. The runtime no longer
+migrates workspace IDs during registry access, stores workspace ID aliases, or
+resolves old IDs through alias fallback. A database that still contains a
+workspace entry whose ID does not match its deterministic ID is unsupported
+and receives an explicit error instead of being modified implicitly.
 
-## Removal criteria
+`canonicalize_agent_home_bindings` remains separate because it canonicalizes
+the reserved AgentHome identity rather than random project workspace IDs.
 
-Remove both migration functions after **3 minor releases** with zero migration
-log entries, or when the next major release occurs, whichever comes first.
-At that point also remove `AGENT_HOME_WORKSPACE_ID` legacy alias resolution
-and the `migrate_workspace_id` storage method.
+## Preserved boundary
+
+- The deterministic workspace ID algorithm is unchanged.
+- No `agent_states.payload_json` backfill is added for the retired migration.
+- Databases from `v0.22` or earlier that never completed workspace ID migration
+  must upgrade through a supported intermediate version or recreate runtime
+  state.

--- a/src/host.rs
+++ b/src/host.rs
@@ -784,13 +784,6 @@ impl RuntimeHost {
         self.inner.registry.workspace_entries()
     }
 
-    pub fn resolve_workspace_aliases(
-        &self,
-        workspace_ids: &[String],
-    ) -> Result<std::collections::HashMap<String, String>> {
-        self.inner.registry.resolve_workspace_aliases(workspace_ids)
-    }
-
     pub fn workspace_occupancies(&self) -> Result<Vec<WorkspaceOccupancyRecord>> {
         self.inner.registry.workspace_occupancies()
     }

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -108,15 +108,6 @@ impl RuntimeRegistry {
         self.inner.host_storage.latest_workspace_entries()
     }
 
-    pub(crate) fn resolve_workspace_aliases(
-        &self,
-        workspace_ids: &[String],
-    ) -> Result<HashMap<String, String>> {
-        self.inner
-            .host_storage
-            .resolve_workspace_aliases(workspace_ids)
-    }
-
     pub(crate) fn workspace_occupancies(&self) -> Result<Vec<WorkspaceOccupancyRecord>> {
         self.inner.host_storage.latest_workspace_occupancies()
     }
@@ -220,25 +211,14 @@ impl RuntimeRegistry {
             .into_iter()
             .find(|entry| entry.workspace_anchor == workspace_anchor)
         {
-            // Lazy migration: migrate non-deterministic workspace IDs in place
-            // and record an alias so old references in agent state still resolve.
-            // Deprecated: planned for removal once migration logs go quiet.
             if existing.workspace_id != det_id {
-                tracing::info!(
-                    old_id = %existing.workspace_id,
-                    new_id = %det_id,
-                    "workspace migration: migrated non-deterministic workspace ID to deterministic ID"
-                );
-                self.inner
-                    .host_storage
-                    .migrate_workspace_id(&existing.workspace_id, &det_id)?;
-                if let Some(entry) = agent_home {
-                    self.inner.host_storage.append_workspace_entry(&entry)?;
-                    return Ok(entry);
-                }
-                let mut migrated = existing;
-                migrated.workspace_id = det_id;
-                return Ok(migrated);
+                return Err(anyhow!(
+                    "unsupported legacy workspace ID '{}' for '{}'; expected deterministic ID '{}'. \
+                     This database predates the supported workspace ID migration window",
+                    existing.workspace_id,
+                    workspace_anchor.display(),
+                    det_id
+                ));
             }
             if let Some(entry) = agent_home {
                 if existing.workspace_alias != entry.workspace_alias
@@ -641,6 +621,41 @@ mod tests {
             .unwrap();
 
         assert_eq!(entry1.workspace_id, entry2.workspace_id);
+    }
+
+    #[test]
+    fn ensure_workspace_entry_rejects_legacy_random_id_without_migrating() {
+        let (_home, registry) = test_registry();
+        let dir = tempdir().unwrap();
+        let legacy = WorkspaceEntry::new(
+            "legacy-random-workspace-id",
+            dir.path().to_path_buf(),
+            Some("legacy-workspace".into()),
+        );
+        registry
+            .inner
+            .host_storage
+            .append_workspace_entry(&legacy)
+            .unwrap();
+
+        let error = registry
+            .ensure_workspace_entry(dir.path().to_path_buf())
+            .unwrap_err();
+        let expected_id = ids::deterministic_workspace_id(dir.path());
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported legacy workspace ID"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains(&expected_id),
+            "error should identify the expected deterministic ID: {error:#}"
+        );
+
+        let entries = registry.workspace_entries().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].workspace_id, legacy.workspace_id);
     }
 
     #[test]

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -420,22 +420,6 @@ fn state_work_item_rank(item: &WorkItemRecord) -> u8 {
 fn state_workspace_snapshot(agent: &AgentSummary, state: &AppState) -> StateWorkspaceSnapshot {
     let all_entries = state.host.workspace_entries().unwrap_or_default();
 
-    // Collect all workspace IDs that might need alias resolution.
-    let mut all_ws_ids: Vec<String> = agent.agent.attached_workspaces.clone();
-    if let Some(active) = &agent.agent.active_workspace_entry {
-        all_ws_ids.push(active.workspace_id.clone());
-    }
-    let alias_map = state
-        .host
-        .resolve_workspace_aliases(&all_ws_ids)
-        .unwrap_or_default();
-    let resolve_id = |ws_id: &str| -> String {
-        alias_map
-            .get(ws_id)
-            .cloned()
-            .unwrap_or_else(|| ws_id.to_string())
-    };
-
     use crate::types::AgentWorkspaceInfo;
     use std::collections::HashSet;
 
@@ -444,11 +428,12 @@ fn state_workspace_snapshot(agent: &AgentSummary, state: &AppState) -> StateWork
 
     // Add active workspace first (with full runtime info).
     if let Some(active_entry) = agent.agent.active_workspace_entry.as_ref() {
-        let resolved_id = resolve_id(&active_entry.workspace_id);
-        seen_ids.insert(resolved_id.clone());
+        seen_ids.insert(active_entry.workspace_id.clone());
 
         // Try to enrich with registry data (alias, repo_name).
-        let registry_entry = all_entries.iter().find(|e| e.workspace_id == resolved_id);
+        let registry_entry = all_entries
+            .iter()
+            .find(|e| e.workspace_id == active_entry.workspace_id);
         let worktree = build_worktree_info(
             active_entry.projection_metadata.as_ref(),
             agent.agent.worktree_session.as_ref(),
@@ -471,13 +456,12 @@ fn state_workspace_snapshot(agent: &AgentSummary, state: &AppState) -> StateWork
 
     // Add remaining attached workspaces (identity-only info from registry).
     for ws_id in &agent.agent.attached_workspaces {
-        let resolved = resolve_id(ws_id);
-        if seen_ids.contains(&resolved) {
+        if seen_ids.contains(ws_id) {
             continue;
         }
-        seen_ids.insert(resolved.clone());
+        seen_ids.insert(ws_id.clone());
 
-        if let Some(entry) = all_entries.iter().find(|e| e.workspace_id == resolved) {
+        if let Some(entry) = all_entries.iter().find(|e| e.workspace_id == *ws_id) {
             workspaces.push(AgentWorkspaceInfo {
                 workspace_id: entry.workspace_id.clone(),
                 workspace_alias: entry.workspace_alias.clone(),

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -878,6 +878,13 @@ CREATE INDEX IF NOT EXISTS idx_execution_root_entries_workspace
   ON execution_root_entries(workspace_id);
 "#,
     },
+    Migration {
+        version: 25,
+        name: "drop_workspace_id_aliases",
+        sql: r#"
+DROP TABLE IF EXISTS workspace_id_aliases;
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1,6 +1,6 @@
 //! Domain repository implementations and their transaction helpers.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
@@ -250,90 +250,6 @@ impl WorkspaceEntryRepository<'_> {
             .collect::<Result<_>>()?;
         records.reverse();
         Ok(records)
-    }
-
-    /// Migrate a workspace entry from a random/old ID to its deterministic ID.
-    /// Updates workspace_entries PK + payload_json, workspace_occupancies, and
-    /// agent_states.active_workspace_id, then records an alias for fallback resolution.
-    pub fn migrate_workspace_id(
-        &self,
-        old_workspace_id: &str,
-        new_workspace_id: &str,
-    ) -> Result<()> {
-        let now = timestamp(Utc::now());
-        self.db.transaction(|tx| {
-            // 1. Record alias for old-ID → new-ID resolution
-            tx.execute(
-                "INSERT OR IGNORE INTO workspace_id_aliases
-                    (old_workspace_id, new_workspace_id, created_at)
-                 VALUES (?1, ?2, ?3)",
-                params![old_workspace_id, new_workspace_id, now],
-            )?;
-
-            // 2. Update workspace_entries: PK column + payload_json
-            let payload_json: Option<String> = tx
-                .query_row(
-                    "SELECT payload_json FROM workspace_entries WHERE workspace_id = ?1",
-                    [old_workspace_id],
-                    |row| row.get(0),
-                )
-                .optional()?;
-
-            if let Some(payload) = payload_json {
-                let mut entry_json: serde_json::Value = serde_json::from_str(&payload)?;
-                if let Some(obj) = entry_json.as_object_mut() {
-                    obj.insert(
-                        "workspace_id".to_string(),
-                        serde_json::Value::String(new_workspace_id.to_string()),
-                    );
-                }
-                let new_payload = serde_json::to_string(&entry_json)?;
-                tx.execute(
-                    "UPDATE workspace_entries SET workspace_id = ?1, payload_json = ?2
-                     WHERE workspace_id = ?3",
-                    params![new_workspace_id, new_payload, old_workspace_id],
-                )?;
-            }
-
-            // 3. Update workspace_occupancies references
-            tx.execute(
-                "UPDATE workspace_occupancies SET workspace_id = ?1 WHERE workspace_id = ?2",
-                params![new_workspace_id, old_workspace_id],
-            )?;
-
-            // 4. Update agent_states.active_workspace_id column
-            tx.execute(
-                "UPDATE agent_states SET active_workspace_id = ?1 WHERE active_workspace_id = ?2",
-                params![new_workspace_id, old_workspace_id],
-            )?;
-
-            Ok(())
-        })
-    }
-
-    /// Resolve old workspace IDs to their current deterministic IDs via the alias table.
-    pub fn resolve_aliases_batch(
-        &self,
-        workspace_ids: &[String],
-    ) -> Result<HashMap<String, String>> {
-        if workspace_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let connection = self.db.connection()?;
-        let mut aliases = HashMap::new();
-        for ws_id in workspace_ids {
-            let resolved = connection
-                .query_row(
-                    "SELECT new_workspace_id FROM workspace_id_aliases WHERE old_workspace_id = ?1",
-                    [ws_id.as_str()],
-                    |row| row.get::<_, String>(0),
-                )
-                .optional()?;
-            if let Some(new_id) = resolved {
-                aliases.insert(ws_id.clone(), new_id);
-            }
-        }
-        Ok(aliases)
     }
 }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -314,6 +314,10 @@ mod tests {
             )?;
             assert_eq!(count, 1, "missing table {table}");
         }
+        assert!(
+            !table_exists(&connection, "workspace_id_aliases")?,
+            "retired workspace ID alias table should be removed"
+        );
 
         Ok(())
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2055,28 +2055,6 @@ impl AppStorage {
         return runtime_db.workspace_entries().latest_all();
     }
 
-    /// Migrate a workspace entry's ID from old (random) to new (deterministic).
-    /// No-ops when the runtime DB is not available (legacy storage).
-    pub fn migrate_workspace_id(&self, old_id: &str, new_id: &str) -> Result<()> {
-        let runtime_db = self.runtime_db.clone();
-        runtime_db
-            .workspace_entries()
-            .migrate_workspace_id(old_id, new_id)?;
-        Ok(())
-    }
-
-    /// Resolve old workspace IDs to current deterministic IDs via the alias table.
-    /// Returns an empty map when the runtime DB is not available.
-    pub fn resolve_workspace_aliases(
-        &self,
-        workspace_ids: &[String],
-    ) -> Result<std::collections::HashMap<String, String>> {
-        let runtime_db = self.runtime_db.clone();
-        return runtime_db
-            .workspace_entries()
-            .resolve_aliases_batch(workspace_ids);
-    }
-
     pub fn latest_workspace_occupancies(&self) -> Result<Vec<WorkspaceOccupancyRecord>> {
         let runtime_db = self.runtime_db.clone();
         return runtime_db.workspace_occupancies().latest_all();


### PR DESCRIPTION
## Summary

- remove HostRegistry lazy migration and workspace alias fallback
- remove `migrate_workspace_id` and alias repository/storage APIs
- drop the obsolete alias table in the next runtime DB migration
- reject legacy random workspace IDs with an explicit unsupported error while preserving the stored data
- update decision 063 and regression coverage for the expired compatibility window

## Verification

- `cargo fmt --all -- --check`
- `cargo test`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2255
