### PR TITLE
fix: model picker provider tab mismatch for non-default endpoints

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -191,7 +191,12 @@ export function AgentPage({
   const activeModelSupportsReasoning = activeModelOption?.supportsReasoningEffort ?? Boolean(activeAgent.modelReasoningEffort);
   const activeReasoningBadge = activeModelSupportsReasoning ? (activeAgent.modelReasoningEffort ?? "auto") : undefined;
   const activeModelTitle = modelButtonTitle(activeAgent.model, activeReasoningBadge, activeAgent.modelSource === "agent_override");
-  const currentProvider = selectedProvider ?? activeModelOption?.provider ?? groupedModelOptions[0]?.provider ?? "runtime";
+  const activeProviderGroup = activeModelOption
+    ? (activeModelOption.endpoint === "default"
+        ? activeModelOption.providerFamily
+        : `${activeModelOption.providerFamily} / ${activeModelOption.endpoint}`)
+    : undefined;
+  const currentProvider = selectedProvider ?? activeProviderGroup ?? groupedModelOptions[0]?.provider ?? "runtime";
   const currentProviderModels = groupedModelOptions.find((group) => group.provider === currentProvider)?.models ?? [];
 
   useEffect(() => {


### PR DESCRIPTION
## 问题

当选择带有非 default endpoint 的模型（如 `dashscope@token-plan/glm5.2`）时，模型选择框的 provider tab 高亮到了 `dashscope`（default），而不是 `dashscope / token-plan`，右侧模型列表也显示的是 default endpoint 的模型。

## 根因

`currentProvider` 使用 `activeModelOption?.provider`（值为 `"dashscope"`），而 `groupModelOptionsByProvider` 的分组 key 使用 `providerFamily / endpoint`（值为 `"dashscope / token-plan"`）。两者在非 default endpoint 时不匹配。

## 修复

使用与 `groupModelOptionsByProvider` 相同的逻辑计算 `activeProviderGroup`：

```typescript
const activeProviderGroup = activeModelOption
  ? (activeModelOption.endpoint === "default"
      ? activeModelOption.providerFamily
      : `${activeModelOption.providerFamily} / ${activeModelOption.endpoint}`)
  : undefined;
const currentProvider = selectedProvider ?? activeProviderGroup ?? groupedModelOptions[0]?.provider ?? "runtime";
```

## 验证

- `tsc --noEmit` ✅ 无错误
- `AgentPage.test.ts` ✅ 6 tests passed