### PR TITLE
chore: prepare v0.30.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,18 +114,20 @@ jobs:
 
           Holon ${GITHUB_REF_NAME} is part of the Rust runtime line. The Rust runtime is now the main \`holon\` binary.
 
-          This patch release makes workspace file references durable across managed worktrees and improves runtime and Web GUI state consistency. It also fixes empty result briefs during tool-only waits, stale agent details after workspace changes, incomplete failed-tool details, and truncated ExecCommand output rendering.
+          This minor release expands web search provider metadata and configuration, fixes Gemini prompt projection and model capability routing, and strengthens runtime lifecycle consistency, continuation recovery, and Web GUI event handling. It also retires the legacy random workspace ID compatibility path after its migration window.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
 
           ## Changes
 
-          - Preserve durable \`workspace://\` file links across managed worktrees by carrying an execution-root identifier through the runtime and resolver ([#2241](https://github.com/holon-run/holon/pull/2241)).
-          - Avoid publishing empty result briefs when a turn only waits for tool completion ([#2240](https://github.com/holon-run/holon/pull/2240)).
-          - Refresh agent state after workspace change events so detail views do not remain stale ([#2243](https://github.com/holon-run/holon/pull/2243)).
-          - Show tool input parameters and errors for failed calls in the Web GUI detail panel ([#2244](https://github.com/holon-run/holon/pull/2244)).
-          - Lazily load and display complete ExecCommand stdout and stderr artifacts when timeline previews are truncated ([#2246](https://github.com/holon-run/holon/pull/2246)).
-          - Refresh documentation for image generation, Web GUI workflows, and WebFetch/WebSearch providers ([#2239](https://github.com/holon-run/holon/pull/2239)).
+          - Expose web search provider metadata, complete built-in search provider coverage, and align provider selection and settings behavior for non-default endpoints ([#2292](https://github.com/holon-run/holon/pull/2292), [#2297](https://github.com/holon-run/holon/pull/2297), [#2300](https://github.com/holon-run/holon/pull/2300)).
+          - Deduplicate Gemini system and context prompt sections while preserving the structured GenerateContent request contract ([#2296](https://github.com/holon-run/holon/pull/2296)).
+          - Validate reasoning effort against the resolved model route and capability metadata, including fallback diagnostics ([#2281](https://github.com/holon-run/holon/pull/2281), [#2283](https://github.com/holon-run/holon/pull/2283), [#2285](https://github.com/holon-run/holon/pull/2285)).
+          - Strengthen persisted runtime lifecycle transitions by publishing audit events after persistence, requiring turn ownership, preserving queue/wait terminal states, and enforcing first-writer-wins task completion ([#2276](https://github.com/holon-run/holon/pull/2276), [#2289](https://github.com/holon-run/holon/pull/2289), [#2290](https://github.com/holon-run/holon/pull/2290), [#2293](https://github.com/holon-run/holon/pull/2293)).
+          - Recover oversized continuations by shrinking projected recent turns instead of abandoning resumable work ([#2295](https://github.com/holon-run/holon/pull/2295)).
+          - Close lagged SSE streams, recover Web GUI event gaps from a contiguous cursor, and keep WorkItem detail state visible during refreshes ([#2247](https://github.com/holon-run/holon/pull/2247), [#2287](https://github.com/holon-run/holon/pull/2287), [#2288](https://github.com/holon-run/holon/pull/2288)).
+          - Retire lazy migration and alias resolution for unsupported legacy random workspace IDs while preserving canonical workspace behavior ([#2298](https://github.com/holon-run/holon/pull/2298)).
+          - Expand mainline CI coverage for runtime lifecycle concurrency and the Web GUI test suite, and refresh onboarding-focused project documentation ([#2242](https://github.com/holon-run/holon/pull/2242), [#2277](https://github.com/holon-run/holon/pull/2277), [#2280](https://github.com/holon-run/holon/pull/2280)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.29.1"
+version = "0.30.0"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Status and compatibility
 
 Holon is under active development. The current recommended release is
-[`v0.29.1`](https://github.com/holon-run/holon/releases/tag/v0.29.1).
+[`v0.30.0`](https://github.com/holon-run/holon/releases/tag/v0.30.0).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -105,7 +105,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.29.1`](https://github.com/holon-run/holon/releases/tag/v0.29.1).
+[`v0.30.0`](https://github.com/holon-run/holon/releases/tag/v0.30.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,9 +1,9 @@
 ---
 title: CLI reference
-summary: Holon's command-line interface — verified against holon --help (v0.29.1).
+summary: Holon's command-line interface — verified against holon --help (v0.30.0).
 order: 10
 ---
-<!-- maintenance: regenerate from `holon --help` output when commands change. Last regenerated against v0.29.1. -->
+<!-- maintenance: regenerate from `holon --help` output when commands change. Last regenerated against v0.30.0. -->
 
 # CLI Reference
 
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.29.1)
+holon (v0.30.0)
 ├── serve        Start HTTP control plane server
 ├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4974,7 +4974,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.29.1"
+    "version": "0.30.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary

Prepare Holon v0.30.0 for release.

- bump the crate and lockfile version to `0.30.0`
- update README and CLI reference install examples
- refresh the generated OpenAPI snapshot
- update the release workflow notes for changes since v0.29.1

## Verification

- `cargo fmt --all -- --check`
- `cargo test`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored`
- `cargo test --test openapi_snapshot`
- `git diff --check`
- `cargo test --test live_llm_baseline -- --ignored --nocapture`: 2/3 passed; the Anthropic prompt-cache case was blocked by an external provider `429` reporting that the configured GLM Coding Plan subscription has expired. The configured-chain smoke and tool roundtrip passed.
