### PR TITLE
refactor: 强制严格 revision CAS 与数据库 sequence 分配

### DIFF
--- a/docs/rfcs/runtime-ledger-sequences-and-revisions.md
+++ b/docs/rfcs/runtime-ledger-sequences-and-revisions.md
@@ -1,7 +1,7 @@
 ---
 title: RFC: Runtime Ledger Sequences and Object Revisions
 date: 2026-05-29
-status: draft
+status: accepted
 Handle: rfc-runtime-ledger-sequences-and-revisions
 ---
 
@@ -373,14 +373,19 @@ Each ledger append path should own sequence assignment for its ledger.
 
 Preferred rule:
 
-1. read the last known sequence for the ledger;
-2. assign `last_seq + 1`;
-3. append the record with the assigned sequence;
-4. expose cursor APIs using `after_seq` only when the sequence field exists.
+1. identify the ledger domain and its explicit scope key;
+2. atomically increment `runtime_sequences(domain, scope_key, last_value)`;
+3. insert the target record with the returned value in the same transaction;
+4. commit or roll back the head update and target insert together;
+5. expose cursor APIs using `after_seq` only when the sequence field exists.
 
-If the storage backend can make sequence assignment atomic, it should. For the
-current local JSONL storage model, the append path should keep the logic narrow
-and covered by tests. Do not spread "find max seq" logic across call sites.
+`audit_event`, `message`, and `transcript` sequences are per-agent. Host audit
+events without an agent use a distinct host scope key. Target tables enforce
+non-null sequence uniqueness within that scope. Process-local counters may be
+used for observation, but they are not allocation authority.
+
+Committed records are monotonic and unique within their scope. The contract does
+not promise an absolutely gap-free sequence after explicit deletion or repair.
 
 ### Backward compatibility
 
@@ -399,14 +404,36 @@ handled before exposing the cursor as stable.
 Adoption should be incremental:
 
 1. document the policy in this RFC;
-2. implement `message_seq` only when a message-ledger cursor or queue replay
-   path needs it;
-3. implement `transcript_seq` when transcript replay, UI paging, or context
-   assembly needs a durable transcript cursor;
-4. defer `tool_seq`, `brief_seq`, and additional revisions until their owning
+2. reject existing duplicate non-null sequences before adding unique indexes;
+3. initialize each database sequence head from the existing scoped maximum;
+4. preserve legacy null sequences rather than inventing historical order;
+5. defer `tool_seq`, `brief_seq`, and additional revisions until their owning
    surfaces need them.
 
 Historical records do not need to be rewritten merely because the RFC exists.
+Legacy import selects canonical records before updating sequence heads. A
+migration must not silently renumber an externally visible event cursor.
+
+### WorkItem revision CAS
+
+WorkItem persistence exposes separate create and semantic-update operations:
+
+- `insert_new(record)` accepts only `revision = 1` and an absent ID.
+- `update_expected(next, expected_revision)` accepts only
+  `next.revision = expected_revision + 1`.
+
+The repository is the final CAS authority. If the stored revision already equals
+`expected_revision + 1`, an exact canonical persisted-payload match is an
+idempotent replay; a different payload is a
+`same_revision_payload_conflict`. Other stale writes return a typed
+`revision_conflict`. Invalid initial or next revisions are rejected rather than
+normalized.
+
+Semantic conflicts are returned to the caller with stable `domain`,
+`record_id`, `code`, expected/actual revision, and retryability metadata. The
+repository does not silently retry them. SQLite `BUSY`/`LOCKED` retry remains an
+infrastructure concern; a higher transition layer may later retry only an
+explicitly merge-safe operation after rereading current state.
 
 ### Tests
 
@@ -423,17 +450,20 @@ Tests for revisions should assert:
 - created records start at revision 1
 - semantic updates increment revision by one
 - no-op reads or projections do not increment revision
-- stale or repeated updates behave according to the owning object contract
+- one of two concurrent updates from the same expected revision wins
+- exact replay is idempotent and different same-revision payload conflicts
+- stale, skipped, or reversed revisions return typed conflicts
 
 ## Proposed First Decision
 
 Holon should adopt the terminology and naming policy now, but should not add new
 runtime fields as part of the runtime ID generation work.
 
-The first implementation batch should be limited to:
+The implemented ledger sequence batch is limited to:
 
-1. `MessageEnvelope.message_seq`
-2. `TranscriptEntry.transcript_seq`
+1. `AuditEvent.event_seq`
+2. `MessageEnvelope.message_seq`
+3. `TranscriptEntry.transcript_seq`
 
 Everything else should wait for a concrete surface:
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -6217,7 +6217,6 @@ mod tests {
                 }
             }
         }));
-        storage.append_message(&system_tick).unwrap();
         append_turn_for_message(&storage, &system_tick, "turn-wake-summary", 1);
 
         let current_message = MessageEnvelope::new(
@@ -6360,7 +6359,6 @@ mod tests {
                 "runtime_switched_current_item": false
             }
         }));
-        storage.append_message(&system_tick).unwrap();
         append_turn_for_message(&storage, &system_tick, "turn-queue-summary", 1);
 
         let current_message = MessageEnvelope::new(
@@ -6429,7 +6427,6 @@ mod tests {
             },
         );
         system_tick.trigger_kind = Some(ContinuationTriggerKind::SystemTick);
-        storage.append_message(&system_tick).unwrap();
         append_turn_for_message(&storage, &system_tick, "turn-generic-system-summary", 1);
 
         let current_message = MessageEnvelope::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1482,8 +1482,9 @@ mod tests {
             holon::types::WorkItemState::Open,
         );
         work_item.id = "work-1".into();
+        storage.insert_work_item(&work_item).unwrap();
         work_item.revision = 2;
-        storage.append_work_item(&work_item).unwrap();
+        storage.update_work_item_expected(&work_item, 1).unwrap();
 
         let output = tempfile::tempdir().unwrap();
         export_scheduler_fixture(&config, None, output.path()).unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -611,8 +611,15 @@ impl RuntimeHandle {
     pub(crate) async fn record_work_item_projection(
         &self,
         record: &crate::types::WorkItemRecord,
+        expected_revision: Option<u64>,
     ) -> Result<()> {
-        self.inner.storage.append_work_item(record)?;
+        if let Some(expected_revision) = expected_revision {
+            self.inner
+                .storage
+                .update_work_item_expected(record, expected_revision)?;
+        } else {
+            self.inner.storage.insert_work_item(record)?;
+        }
         self.inner
             .projection_cache
             .lock()

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -111,13 +111,8 @@ impl RuntimeHandle {
                 turn_id: current_turn_id,
                 ..refreshed
             };
-            let current_focus = self.agent_state().await?.current_work_item_id.as_deref()
-                == Some(record.id.as_str());
-            self.inner
-                .runtime_db
-                .work_items()
-                .upsert(&record, current_focus)?;
-            self.record_work_item_projection(&record).await?;
+            self.record_work_item_projection(&record, Some(latest.revision))
+                .await?;
             if plan_artifact_changed {
                 self.append_work_item_plan_artifact_refreshed_event(&record)?;
             }

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -927,19 +927,14 @@ mod tests {
         record: &WorkItemRecord,
         current_focus: bool,
     ) {
-        test_runtime
-            .runtime
-            .inner
-            .runtime_db
-            .work_items()
-            .upsert(record, current_focus)
-            .unwrap();
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .append_work_item(record)
-            .unwrap();
+        let repository = test_runtime.runtime.inner.runtime_db.work_items();
+        if let Some(existing) = repository.latest(&record.id).unwrap() {
+            repository
+                .update_expected(record, existing.revision, current_focus)
+                .unwrap();
+        } else {
+            repository.insert_new(record, current_focus).unwrap();
+        }
     }
 
     fn add_current_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
@@ -960,6 +955,7 @@ mod tests {
         blocked_by: &str,
     ) -> WorkItemRecord {
         let mut updated = record.clone();
+        updated.revision += 1;
         updated.blocked_by = Some(blocked_by.to_string());
         updated.updated_at = chrono::Utc::now();
         persist_test_work_item(test_runtime, &updated, false);
@@ -972,6 +968,7 @@ mod tests {
         blocked_by: &str,
     ) -> WorkItemRecord {
         let mut updated = record.clone();
+        updated.revision += 1;
         updated.blocked_by = Some(blocked_by.to_string());
         updated.recheck_at = Some(chrono::Utc::now() - chrono::Duration::seconds(1));
         updated.recheck_consumed_at = None;
@@ -1899,6 +1896,7 @@ mod tests {
         set_agent_idle(&test_runtime);
 
         let mut active = add_current_work_item(&test_runtime, "wi-active", "active-target");
+        active.revision += 1;
         active.todo_list = vec![TodoItem {
             text: "finish remaining implementation".to_string(),
             state: TodoItemState::InProgress,

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -245,7 +245,8 @@ impl RuntimeHandle {
         record.work_refs = merged;
         record.revision = record.revision.saturating_add(1);
         record.updated_at = Utc::now();
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(record.revision - 1))
+            .await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_refs_updated",
             serde_json::json!({

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2183,8 +2183,7 @@ impl RuntimeHandle {
             .active_workspace_entry
             .map(|entry| entry.workspace_id)
             .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
-        self.inner.runtime_db.work_items().upsert(&record, false)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, None).await?;
         self.append_work_item_written_event("created", &record, Value::Null)?;
         self.inner.notify.notify_one();
         Ok(record)
@@ -2505,13 +2504,8 @@ impl RuntimeHandle {
                 &mut record,
             )?;
             record.revision = existing.revision + 1;
-            let current_focus = self.agent_state().await?.current_work_item_id.as_deref()
-                == Some(record.id.as_str());
-            self.inner
-                .runtime_db
-                .work_items()
-                .upsert(&record, current_focus)?;
-            self.record_work_item_projection(&record).await?;
+            self.record_work_item_projection(&record, Some(existing.revision))
+                .await?;
             if plan_artifact_changed && record.plan_artifact != existing.plan_artifact {
                 self.append_work_item_plan_artifact_refreshed_event(&record)?;
             }
@@ -2569,13 +2563,8 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        let current_focus =
-            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
-        self.inner
-            .runtime_db
-            .work_items()
-            .upsert(&record, current_focus)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(existing.revision))
+            .await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -2630,8 +2619,8 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        self.inner.runtime_db.work_items().upsert(&record, false)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(existing.revision))
+            .await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -2731,8 +2720,8 @@ impl RuntimeHandle {
             updated_at: Utc::now(),
             ..existing
         };
-        self.inner.runtime_db.work_items().upsert(&record, false)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(record.revision - 1))
+            .await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_completion_report_promoted",
             serde_json::json!({

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -232,6 +232,17 @@ fn read_optional_scheduler_jsonl_fixture<T: DeserializeOwned>(name: &str, path: 
     Vec::new()
 }
 
+fn append_work_item_at_revision(storage: &AppStorage, record: &WorkItemRecord) {
+    let target_revision = record.revision;
+    let mut version = record.clone();
+    version.revision = 1;
+    storage.append_work_item(&version).unwrap();
+    for revision in 2..=target_revision {
+        version.revision = revision;
+        storage.append_work_item(&version).unwrap();
+    }
+}
+
 fn build_scheduler_fixture(name: &str) -> (tempfile::TempDir, AppStorage, AgentState) {
     let agent_fixture: AgentFixture = read_scheduler_fixture(name, "agent.json");
     let work_items: Vec<WorkItemFixture> =
@@ -293,7 +304,7 @@ fn build_scheduler_fixture(name: &str) -> (tempfile::TempDir, AppStorage, AgentS
             record.plan_status = plan_status;
         }
         record.revision = item.revision;
-        storage.append_work_item(&record).unwrap();
+        append_work_item_at_revision(&storage, &record);
     }
     for task in tasks {
         storage
@@ -546,7 +557,7 @@ fn compaction_events_and_briefs_do_not_change_scheduler_projection() {
     let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
     work_item.id = "work-active".into();
     work_item.revision = 3;
-    storage.append_work_item(&work_item).unwrap();
+    append_work_item_at_revision(&storage, &work_item);
     storage
         .append_task(&TaskRecord {
             id: "task-active".into(),
@@ -798,7 +809,7 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
     let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
     work_item.id = "work-1".into();
     work_item.revision = 7;
-    storage.append_work_item(&work_item).unwrap();
+    append_work_item_at_revision(&storage, &work_item);
 
     let pending = PendingWakeHint {
         reason: "external update".into(),
@@ -860,7 +871,7 @@ fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
     let mut work_item = WorkItemRecord::new("default", "queued work", WorkItemState::Open);
     work_item.id = "work-queued".into();
     work_item.revision = 4;
-    storage.append_work_item(&work_item).unwrap();
+    append_work_item_at_revision(&storage, &work_item);
     append_active_external_wait_condition(&storage, "agent-wait", "default", None);
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -314,13 +314,8 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        let current_focus =
-            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
-        self.inner
-            .runtime_db
-            .work_items()
-            .upsert(&record, current_focus)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(record.revision - 1))
+            .await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -386,13 +381,8 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        let current_focus =
-            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
-        self.inner
-            .runtime_db
-            .work_items()
-            .upsert(&record, current_focus)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(record.revision - 1))
+            .await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -442,13 +432,8 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        let current_focus =
-            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
-        self.inner
-            .runtime_db
-            .work_items()
-            .upsert(&record, current_focus)?;
-        self.record_work_item_projection(&record).await?;
+        self.record_work_item_projection(&record, Some(record.revision - 1))
+            .await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Transaction};
+use rusqlite::{params, OptionalExtension, Transaction};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
@@ -14,6 +14,52 @@ use crate::types::{
     ExecutionRootEntry, MessageEnvelope, ToolExecutionRecord, TranscriptEntry, WorkspaceEntry,
     WorkspaceOccupancyRecord,
 };
+
+pub(crate) const AUDIT_EVENT_SEQUENCE_DOMAIN: &str = "audit_event";
+pub(crate) const MESSAGE_SEQUENCE_DOMAIN: &str = "message";
+pub(crate) const TRANSCRIPT_SEQUENCE_DOMAIN: &str = "transcript";
+
+pub(crate) fn agent_sequence_scope(agent_id: &str) -> String {
+    format!("agent:{agent_id}")
+}
+
+pub(crate) fn audit_event_sequence_scope(agent_id: Option<&str>) -> String {
+    agent_id.map_or_else(|| "host".to_string(), agent_sequence_scope)
+}
+
+pub(crate) fn allocate_runtime_sequence_tx(
+    tx: &Transaction<'_>,
+    domain: &str,
+    scope_key: &str,
+) -> Result<u64> {
+    let value = tx.query_row(
+        "INSERT INTO runtime_sequences(domain, scope_key, last_value)
+         VALUES (?1, ?2, 1)
+         ON CONFLICT(domain, scope_key) DO UPDATE SET
+           last_value = runtime_sequences.last_value + 1
+         RETURNING last_value",
+        params![domain, scope_key],
+        |row| row.get::<_, i64>(0),
+    )?;
+    u64::try_from(value).context("runtime sequence is negative")
+}
+
+pub(crate) fn observe_runtime_sequence_tx(
+    tx: &Transaction<'_>,
+    domain: &str,
+    scope_key: &str,
+    value: u64,
+) -> Result<()> {
+    let value = i64::try_from(value).context("runtime sequence exceeds SQLite integer range")?;
+    tx.execute(
+        "INSERT INTO runtime_sequences(domain, scope_key, last_value)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(domain, scope_key) DO UPDATE SET
+           last_value = MAX(runtime_sequences.last_value, excluded.last_value)",
+        params![domain, scope_key, value],
+    )?;
+    Ok(())
+}
 
 /// Evidence kind for table routing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -131,11 +177,59 @@ pub(crate) fn insert_message_evidence_tx(
     upsert_message_tx(tx, message)
 }
 
+pub(crate) fn append_message_tx(
+    tx: &Transaction<'_>,
+    message: &MessageEnvelope,
+) -> Result<(MessageEnvelope, bool)> {
+    if let Some(payload) = tx
+        .query_row(
+            "SELECT payload_json FROM messages WHERE evidence_id = ?1",
+            [&message.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        return Ok((serde_json::from_str(&payload)?, false));
+    }
+    let mut message = message.clone();
+    message.message_seq = Some(allocate_runtime_sequence_tx(
+        tx,
+        MESSAGE_SEQUENCE_DOMAIN,
+        &agent_sequence_scope(&message.agent_id),
+    )?);
+    upsert_message_tx(tx, &message)?;
+    Ok((message, true))
+}
+
 pub(crate) fn insert_transcript_evidence_tx(
     tx: &Transaction<'_>,
     entry: &TranscriptEntry,
 ) -> Result<()> {
     upsert_transcript_entry_tx(tx, entry)
+}
+
+pub(crate) fn append_transcript_entry_tx(
+    tx: &Transaction<'_>,
+    entry: &TranscriptEntry,
+) -> Result<(TranscriptEntry, bool)> {
+    if let Some(payload) = tx
+        .query_row(
+            "SELECT payload_json FROM transcript_entries WHERE evidence_id = ?1",
+            [&entry.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        return Ok((serde_json::from_str(&payload)?, false));
+    }
+    let mut entry = entry.clone();
+    entry.transcript_seq = Some(allocate_runtime_sequence_tx(
+        tx,
+        TRANSCRIPT_SEQUENCE_DOMAIN,
+        &agent_sequence_scope(&entry.agent_id),
+    )?);
+    upsert_transcript_entry_tx(tx, &entry)?;
+    Ok((entry, true))
 }
 
 pub(crate) fn upsert_agent_state_tx(tx: &Transaction<'_>, record: &AgentState) -> Result<()> {
@@ -327,6 +421,14 @@ pub(crate) fn upsert_agent_identity_tx(
 }
 
 pub(crate) fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<()> {
+    if let Some(message_seq) = message.message_seq {
+        observe_runtime_sequence_tx(
+            tx,
+            MESSAGE_SEQUENCE_DOMAIN,
+            &agent_sequence_scope(&message.agent_id),
+            message_seq,
+        )?;
+    }
     let payload_json = serde_json::to_string(message)?;
     let content_hash = content_hash(&payload_json);
     let kind = enum_string(&message.kind)?;
@@ -372,6 +474,14 @@ pub(crate) fn upsert_transcript_entry_tx(
     tx: &Transaction<'_>,
     entry: &TranscriptEntry,
 ) -> Result<()> {
+    if let Some(transcript_seq) = entry.transcript_seq {
+        observe_runtime_sequence_tx(
+            tx,
+            TRANSCRIPT_SEQUENCE_DOMAIN,
+            &agent_sequence_scope(&entry.agent_id),
+            transcript_seq,
+        )?;
+    }
     let turn_id = entry
         .data
         .get("turn_id")
@@ -512,7 +622,59 @@ pub(crate) fn insert_delivery_summary_evidence_tx(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn insert_audit_event_tx(
+    tx: &Transaction<'_>,
+    agent_id: Option<&str>,
+    event: &AuditEvent,
+) -> Result<()> {
+    append_audit_event_tx(tx, agent_id, event).map(|_| ())
+}
+
+pub(crate) fn append_audit_event_tx(
+    tx: &Transaction<'_>,
+    agent_id: Option<&str>,
+    event: &AuditEvent,
+) -> Result<(AuditEvent, bool)> {
+    if let Some(payload) = tx
+        .query_row(
+            "SELECT data_json FROM audit_events WHERE audit_event_id = ?1",
+            [&event.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        return Ok((serde_json::from_str(&payload)?, false));
+    }
+    let mut event = event.clone();
+    event.event_seq = allocate_runtime_sequence_tx(
+        tx,
+        AUDIT_EVENT_SEQUENCE_DOMAIN,
+        &audit_event_sequence_scope(agent_id),
+    )?;
+    insert_audit_event_with_sequence_tx(tx, agent_id, &event)?;
+    Ok((event, true))
+}
+
+pub(crate) fn import_audit_event_tx(
+    tx: &Transaction<'_>,
+    agent_id: Option<&str>,
+    event: &AuditEvent,
+) -> Result<()> {
+    if event.event_seq == 0 {
+        append_audit_event_tx(tx, agent_id, event)?;
+        return Ok(());
+    }
+    insert_audit_event_with_sequence_tx(tx, agent_id, event)?;
+    observe_runtime_sequence_tx(
+        tx,
+        AUDIT_EVENT_SEQUENCE_DOMAIN,
+        &audit_event_sequence_scope(agent_id),
+        event.event_seq,
+    )
+}
+
+fn insert_audit_event_with_sequence_tx(
     tx: &Transaction<'_>,
     agent_id: Option<&str>,
     event: &AuditEvent,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -885,6 +885,18 @@ CREATE INDEX IF NOT EXISTS idx_execution_root_entries_workspace
 DROP TABLE IF EXISTS workspace_id_aliases;
 "#,
     },
+    Migration {
+        version: 26,
+        name: "strict_runtime_sequences",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS runtime_sequences (
+  domain TEXT NOT NULL,
+  scope_key TEXT NOT NULL,
+  last_value INTEGER NOT NULL,
+  PRIMARY KEY (domain, scope_key)
+);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -921,7 +933,13 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     }
 
     let transaction = connection.transaction()?;
+    if migration.name == "strict_runtime_sequences" {
+        preflight_runtime_sequence_uniqueness(&transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
+    if migration.name == "strict_runtime_sequences" {
+        migrate_runtime_sequences(&transaction)?;
+    }
     transaction.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         (
@@ -931,6 +949,137 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
         ),
     )?;
     transaction.commit()?;
+    Ok(())
+}
+
+fn preflight_runtime_sequence_uniqueness(connection: &Connection) -> Result<()> {
+    if table_exists_internal(connection, "audit_events")? {
+        preflight_sequence_domain(
+            connection,
+            "audit_event",
+            "audit_events",
+            "CASE WHEN agent_id IS NULL THEN 'host' ELSE 'agent:' || agent_id END",
+            "event_seq",
+            "audit_event_id",
+        )?;
+    }
+    if table_exists_internal(connection, "messages")? {
+        preflight_sequence_domain(
+            connection,
+            "message",
+            "messages",
+            "'agent:' || agent_id",
+            "message_seq",
+            "evidence_id",
+        )?;
+    }
+    if table_exists_internal(connection, "transcript_entries")? {
+        preflight_sequence_domain(
+            connection,
+            "transcript",
+            "transcript_entries",
+            "'agent:' || agent_id",
+            "transcript_seq",
+            "evidence_id",
+        )?;
+    }
+    Ok(())
+}
+
+fn migrate_runtime_sequences(connection: &Connection) -> Result<()> {
+    if table_exists_internal(connection, "audit_events")? {
+        connection.execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_events_agent_event_seq_unique
+               ON audit_events(agent_id, event_seq)
+               WHERE agent_id IS NOT NULL AND event_seq IS NOT NULL;
+             CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_events_host_event_seq_unique
+               ON audit_events(event_seq)
+               WHERE agent_id IS NULL AND event_seq IS NOT NULL;
+             INSERT INTO runtime_sequences(domain, scope_key, last_value)
+             SELECT
+               'audit_event',
+               CASE WHEN agent_id IS NULL THEN 'host' ELSE 'agent:' || agent_id END,
+               MAX(event_seq)
+             FROM audit_events
+             WHERE event_seq IS NOT NULL
+             GROUP BY agent_id
+             ON CONFLICT(domain, scope_key) DO UPDATE SET
+               last_value = MAX(runtime_sequences.last_value, excluded.last_value);",
+        )?;
+    }
+    if table_exists_internal(connection, "messages")? {
+        connection.execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_agent_message_seq_unique
+               ON messages(agent_id, message_seq)
+               WHERE message_seq IS NOT NULL;
+             INSERT INTO runtime_sequences(domain, scope_key, last_value)
+             SELECT 'message', 'agent:' || agent_id, MAX(message_seq)
+             FROM messages
+             WHERE message_seq IS NOT NULL
+             GROUP BY agent_id
+             ON CONFLICT(domain, scope_key) DO UPDATE SET
+               last_value = MAX(runtime_sequences.last_value, excluded.last_value);",
+        )?;
+    }
+    if table_exists_internal(connection, "transcript_entries")? {
+        connection.execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_transcript_entries_agent_transcript_seq_unique
+               ON transcript_entries(agent_id, transcript_seq)
+               WHERE transcript_seq IS NOT NULL;
+             INSERT INTO runtime_sequences(domain, scope_key, last_value)
+             SELECT 'transcript', 'agent:' || agent_id, MAX(transcript_seq)
+             FROM transcript_entries
+             WHERE transcript_seq IS NOT NULL
+             GROUP BY agent_id
+             ON CONFLICT(domain, scope_key) DO UPDATE SET
+               last_value = MAX(runtime_sequences.last_value, excluded.last_value);",
+        )?;
+    }
+    Ok(())
+}
+
+fn table_exists_internal(connection: &Connection, table_name: &str) -> Result<bool> {
+    connection
+        .query_row(
+            "SELECT EXISTS(
+               SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1
+             )",
+            [table_name],
+            |row| row.get(0),
+        )
+        .map_err(Into::into)
+}
+
+fn preflight_sequence_domain(
+    connection: &Connection,
+    domain: &str,
+    table: &str,
+    scope_expression: &str,
+    sequence_column: &str,
+    id_column: &str,
+) -> Result<()> {
+    let sql = format!(
+        "SELECT {scope_expression}, {sequence_column}, GROUP_CONCAT({id_column}, ',')
+         FROM {table}
+         WHERE {sequence_column} IS NOT NULL
+         GROUP BY {scope_expression}, {sequence_column}
+         HAVING COUNT(*) > 1
+         LIMIT 1"
+    );
+    let duplicate = connection
+        .query_row(&sql, [], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .optional()?;
+    if let Some((scope, sequence, record_ids)) = duplicate {
+        bail!(
+            "runtime sequence migration found duplicate sequence: domain={domain}, scope={scope}, sequence={sequence}, record_ids={record_ids}"
+        );
+    }
     Ok(())
 }
 

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -110,8 +110,12 @@ impl StdError for RuntimeDbRetryableError {}
 pub struct RuntimeStateTransitionConflict {
     domain: &'static str,
     record_id: String,
+    code: &'static str,
     existing_status: String,
     incoming_status: String,
+    expected_revision: Option<u64>,
+    actual_revision: Option<u64>,
+    retryable: bool,
 }
 
 impl RuntimeStateTransitionConflict {
@@ -124,8 +128,33 @@ impl RuntimeStateTransitionConflict {
         Self {
             domain,
             record_id: record_id.into(),
+            code: "state_transition_conflict",
             existing_status: existing_status.into(),
             incoming_status: incoming_status.into(),
+            expected_revision: None,
+            actual_revision: None,
+            retryable: false,
+        }
+    }
+
+    pub(crate) fn revision(
+        record_id: impl Into<String>,
+        code: &'static str,
+        expected_revision: Option<u64>,
+        actual_revision: Option<u64>,
+        retryable: bool,
+    ) -> Self {
+        Self {
+            domain: "work_item",
+            record_id: record_id.into(),
+            code,
+            existing_status: actual_revision
+                .map_or_else(|| "missing".to_string(), |revision| revision.to_string()),
+            incoming_status: expected_revision
+                .map_or_else(|| "none".to_string(), |revision| revision.to_string()),
+            expected_revision,
+            actual_revision,
+            retryable,
         }
     }
 
@@ -137,6 +166,10 @@ impl RuntimeStateTransitionConflict {
         &self.record_id
     }
 
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
     pub fn existing_status(&self) -> &str {
         &self.existing_status
     }
@@ -144,15 +177,39 @@ impl RuntimeStateTransitionConflict {
     pub fn incoming_status(&self) -> &str {
         &self.incoming_status
     }
+
+    pub fn expected_revision(&self) -> Option<u64> {
+        self.expected_revision
+    }
+
+    pub fn actual_revision(&self) -> Option<u64> {
+        self.actual_revision
+    }
+
+    pub fn retryable(&self) -> bool {
+        self.retryable
+    }
 }
 
 impl fmt::Display for RuntimeStateTransitionConflict {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "conflicting {} transition for {}: {} -> {}",
-            self.domain, self.record_id, self.existing_status, self.incoming_status
-        )
+        if self.expected_revision.is_some() || self.actual_revision.is_some() {
+            write!(
+                formatter,
+                "{} for {} {}: expected revision {:?}, actual revision {:?}",
+                self.code,
+                self.domain,
+                self.record_id,
+                self.expected_revision,
+                self.actual_revision
+            )
+        } else {
+            write!(
+                formatter,
+                "conflicting {} transition for {}: {} -> {}",
+                self.domain, self.record_id, self.existing_status, self.incoming_status
+            )
+        }
     }
 }
 

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -38,7 +38,7 @@ impl WorkItemRepository<'_> {
                     }
                 }
                 for record in latest.values() {
-                    upsert_work_item_tx(
+                    import_work_item_tx(
                         tx,
                         record,
                         current_work_item_id == Some(record.id.as_str()),
@@ -48,20 +48,51 @@ impl WorkItemRepository<'_> {
             })
     }
 
-    pub fn upsert(&self, record: &WorkItemRecord, current_focus: bool) -> Result<()> {
+    pub fn insert_new(&self, record: &WorkItemRecord, current_focus: bool) -> Result<bool> {
         self.db
-            .transaction(|tx| upsert_work_item_tx(tx, record, current_focus))
+            .transaction(|tx| insert_new_work_item_tx(tx, record, current_focus))
     }
 
-    pub fn upsert_with_index_changes(
+    pub fn insert_new_with_index_changes(
         &self,
         record: &WorkItemRecord,
         current_focus: bool,
         changes: &[RuntimeIndexChange],
-    ) -> Result<()> {
+    ) -> Result<bool> {
         self.db.transaction(|tx| {
-            upsert_work_item_tx(tx, record, current_focus)?;
-            insert_runtime_index_changes_tx(tx, changes)
+            let inserted = insert_new_work_item_tx(tx, record, current_focus)?;
+            if inserted {
+                insert_runtime_index_changes_tx(tx, changes)?;
+            }
+            Ok(inserted)
+        })
+    }
+
+    pub fn update_expected(
+        &self,
+        record: &WorkItemRecord,
+        expected_revision: u64,
+        current_focus: bool,
+    ) -> Result<bool> {
+        self.db.transaction(|tx| {
+            update_expected_work_item_tx(tx, record, expected_revision, current_focus)
+        })
+    }
+
+    pub fn update_expected_with_index_changes(
+        &self,
+        record: &WorkItemRecord,
+        expected_revision: u64,
+        current_focus: bool,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<bool> {
+        self.db.transaction(|tx| {
+            let updated =
+                update_expected_work_item_tx(tx, record, expected_revision, current_focus)?;
+            if updated {
+                insert_runtime_index_changes_tx(tx, changes)?;
+            }
+            Ok(updated)
         })
     }
 
@@ -1621,6 +1652,20 @@ impl MessageRepository<'_> {
         self.db.transaction(|tx| upsert_message_tx(tx, message))
     }
 
+    pub fn append_with_index_changes(
+        &self,
+        message: &MessageEnvelope,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<MessageEnvelope> {
+        self.db.transaction(|tx| {
+            let (appended, inserted) = append_message_tx(tx, message)?;
+            if inserted {
+                insert_runtime_index_changes_tx(tx, changes)?;
+            }
+            Ok(appended)
+        })
+    }
+
     pub fn upsert_with_index_changes(
         &self,
         message: &MessageEnvelope,
@@ -1830,6 +1875,11 @@ impl TranscriptRepository<'_> {
     pub fn upsert(&self, entry: &TranscriptEntry) -> Result<()> {
         self.db
             .transaction(|tx| upsert_transcript_entry_tx(tx, entry))
+    }
+
+    pub fn append(&self, entry: &TranscriptEntry) -> Result<TranscriptEntry> {
+        self.db
+            .transaction(|tx| append_transcript_entry_tx(tx, entry).map(|(entry, _)| entry))
     }
 
     pub fn upsert_many(&self, entries: &[TranscriptEntry]) -> Result<()> {
@@ -2261,21 +2311,26 @@ impl EvidenceRepository<'_> {
 }
 
 impl AuditEventSink<'_> {
-    pub fn append(&self, agent_id: Option<&str>, event: &AuditEvent) -> Result<()> {
+    pub fn append(&self, agent_id: Option<&str>, event: &AuditEvent) -> Result<AuditEvent> {
         self.db.transaction_with_context(
             RuntimeDbWriteContext::sync("audit_events.append", "audit_events"),
-            |tx| insert_audit_event_tx(tx, agent_id, event),
+            |tx| append_audit_event_tx(tx, agent_id, event).map(|(event, _)| event),
         )
     }
 
-    pub fn append_many(&self, agent_id: Option<&str>, events: &[AuditEvent]) -> Result<()> {
+    pub fn append_many(
+        &self,
+        agent_id: Option<&str>,
+        events: &[AuditEvent],
+    ) -> Result<Vec<AuditEvent>> {
         self.db.transaction_with_context(
             RuntimeDbWriteContext::sync("audit_events.append_many", "audit_events"),
             |tx| {
+                let mut appended = Vec::with_capacity(events.len());
                 for event in events {
-                    insert_audit_event_tx(tx, agent_id, event)?;
+                    appended.push(append_audit_event_tx(tx, agent_id, event)?.0);
                 }
-                Ok(())
+                Ok(appended)
             },
         )
     }
@@ -2287,7 +2342,7 @@ impl AuditEventSink<'_> {
         self.db
             .run_storage_domain_import("audit_events", "jsonl", "db", |tx| {
                 for event in &events {
-                    insert_audit_event_tx(tx, agent_id, event)?;
+                    import_audit_event_tx(tx, agent_id, event)?;
                 }
                 Ok(serde_json::json!({ "imported_records": events.len() }))
             })
@@ -2731,7 +2786,188 @@ fn upsert_operator_delivery_record_tx(
     Ok(())
 }
 
-fn upsert_work_item_tx(
+fn insert_new_work_item_tx(
+    tx: &Transaction<'_>,
+    record: &WorkItemRecord,
+    current_focus: bool,
+) -> Result<bool> {
+    if record.revision != 1 {
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "invalid_initial_revision",
+            Some(1),
+            Some(record.revision),
+            false,
+        )
+        .into());
+    }
+    let actual_revision = tx
+        .query_row(
+            "SELECT revision FROM work_items WHERE work_item_id = ?1",
+            [&record.id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .map(|revision| u64::try_from(revision).context("stored work item revision is negative"))
+        .transpose()?;
+    if let Some(actual_revision) = actual_revision {
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "record_exists",
+            None,
+            Some(actual_revision),
+            false,
+        )
+        .into());
+    }
+    import_work_item_tx(tx, record, current_focus)?;
+    Ok(true)
+}
+
+fn update_expected_work_item_tx(
+    tx: &Transaction<'_>,
+    record: &WorkItemRecord,
+    expected_revision: u64,
+    current_focus: bool,
+) -> Result<bool> {
+    let next_revision = expected_revision.checked_add(1).ok_or_else(|| {
+        RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "invalid_revision_transition",
+            Some(expected_revision),
+            Some(record.revision),
+            false,
+        )
+    })?;
+    if record.revision != next_revision {
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "invalid_revision_transition",
+            Some(expected_revision),
+            Some(record.revision),
+            false,
+        )
+        .into());
+    }
+
+    let existing = tx
+        .query_row(
+            "SELECT revision, payload_json FROM work_items WHERE work_item_id = ?1",
+            [&record.id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    let Some((actual_revision, existing_payload)) = existing else {
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "not_found",
+            Some(expected_revision),
+            None,
+            false,
+        )
+        .into());
+    };
+    let actual_revision =
+        u64::try_from(actual_revision).context("stored work item revision is negative")?;
+    let payload_json = serde_json::to_string(record)?;
+    if actual_revision == next_revision {
+        if existing_payload == payload_json {
+            return Ok(false);
+        }
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "same_revision_payload_conflict",
+            Some(expected_revision),
+            Some(actual_revision),
+            false,
+        )
+        .into());
+    }
+    if actual_revision != expected_revision {
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "revision_conflict",
+            Some(expected_revision),
+            Some(actual_revision),
+            true,
+        )
+        .into());
+    }
+
+    update_work_item_row_tx(tx, record, current_focus, &payload_json, expected_revision)?;
+    Ok(true)
+}
+
+fn update_work_item_row_tx(
+    tx: &Transaction<'_>,
+    record: &WorkItemRecord,
+    current_focus: bool,
+    payload_json: &str,
+    expected_revision: u64,
+) -> Result<()> {
+    let state = enum_string(&record.state)?;
+    let plan_status = enum_string(&record.plan_status)?;
+    let readiness = enum_string(&record.readiness())?;
+    let completed_at =
+        (record.state == WorkItemState::Completed).then(|| timestamp(record.updated_at));
+    let plan_artifact_path = record
+        .plan_artifact
+        .as_ref()
+        .map(|artifact| artifact.path.display().to_string());
+    let changed = tx.execute(
+        "UPDATE work_items SET
+            agent_id = ?1,
+            state = ?2,
+            objective = ?3,
+            plan_status = ?4,
+            readiness = ?5,
+            revision = ?6,
+            current_focus = ?7,
+            created_at = ?8,
+            updated_at = ?9,
+            completed_at = ?10,
+            plan_artifact_path = ?11,
+            last_turn_id = ?12,
+            payload_json = ?13,
+            blocked_by = ?14,
+            recheck_at = ?15,
+            recheck_consumed_at = ?16
+         WHERE work_item_id = ?17 AND revision = ?18",
+        params![
+            record.agent_id,
+            state,
+            record.objective,
+            plan_status,
+            readiness,
+            record.revision as i64,
+            i64::from(current_focus),
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            completed_at,
+            plan_artifact_path,
+            record.turn_id,
+            payload_json,
+            record.blocked_by,
+            record.recheck_at.map(timestamp),
+            record.recheck_consumed_at.map(timestamp),
+            record.id,
+            expected_revision as i64,
+        ],
+    )?;
+    if changed != 1 {
+        return Err(RuntimeStateTransitionConflict::revision(
+            &record.id,
+            "revision_conflict",
+            Some(expected_revision),
+            None,
+            true,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn import_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
     current_focus: bool,

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -21,8 +21,9 @@ use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, CallbackDeliveryMode,
     ExecutionRootEntry, ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus,
     MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus,
-    ToolExecutionRecord, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
-    WorkItemRecord, WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
+    ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, WaitConditionKind,
+    WaitConditionRecord, WaitConditionStatus, WorkItemRecord, WorkItemState, WorkspaceEntry,
+    WorkspaceOccupancyRecord,
 };
 #[cfg(test)]
 use anyhow::{anyhow, bail, Context, Result};
@@ -286,6 +287,7 @@ mod tests {
             "storage_domains",
             "agents",
             "audit_events",
+            "runtime_sequences",
             "work_items",
             "tasks",
             "external_triggers",
@@ -433,6 +435,110 @@ INSERT INTO storage_domains (
             current_schema_version(&connection)?,
             max_known_migration_version()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_sequence_migration_rejects_duplicate_historical_values() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        {
+            let connection = open_connection(&db_path)?;
+            connection.execute_batch(
+                "DELETE FROM schema_migrations WHERE version = 26;
+                 DROP INDEX idx_messages_agent_message_seq_unique;
+                 DROP TABLE runtime_sequences;",
+            )?;
+            for (id, text) in [("duplicate-a", "a"), ("duplicate-b", "b")] {
+                let mut message = MessageEnvelope::new(
+                    "agent-a",
+                    crate::types::MessageKind::OperatorPrompt,
+                    crate::types::MessageOrigin::Operator { actor_id: None },
+                    crate::types::AuthorityClass::OperatorInstruction,
+                    crate::types::Priority::Normal,
+                    crate::types::MessageBody::Text { text: text.into() },
+                );
+                message.id = id.into();
+                message.message_seq = Some(7);
+                connection.execute(
+                    "INSERT INTO messages (
+                        evidence_id, agent_id, message_id, message_seq, created_at,
+                        kind, payload_json
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    params![
+                        message.id,
+                        message.agent_id,
+                        message.id,
+                        7_i64,
+                        timestamp(message.created_at),
+                        "operator_prompt",
+                        serde_json::to_string(&message)?,
+                    ],
+                )?;
+            }
+        }
+
+        let error = RuntimeDb::open_and_migrate(&db_path, &lock_path).unwrap_err();
+        let text = error.to_string();
+        assert!(text.contains("domain=message"), "{text}");
+        assert!(text.contains("scope=agent:agent-a"), "{text}");
+        assert!(text.contains("sequence=7"), "{text}");
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_sequence_migration_initializes_head_from_historical_max() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        {
+            let connection = open_connection(&db_path)?;
+            connection.execute_batch(
+                "DELETE FROM schema_migrations WHERE version = 26;
+                 DROP INDEX idx_messages_agent_message_seq_unique;
+                 DROP TABLE runtime_sequences;",
+            )?;
+            let mut historical = MessageEnvelope::new(
+                "agent-a",
+                crate::types::MessageKind::OperatorPrompt,
+                crate::types::MessageOrigin::Operator { actor_id: None },
+                crate::types::AuthorityClass::OperatorInstruction,
+                crate::types::Priority::Normal,
+                crate::types::MessageBody::Text {
+                    text: "historical".into(),
+                },
+            );
+            historical.id = "historical-message".into();
+            historical.message_seq = Some(7);
+            connection.execute(
+                "INSERT INTO messages (
+                    evidence_id, agent_id, message_id, message_seq, created_at,
+                    kind, payload_json
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    historical.id,
+                    historical.agent_id,
+                    historical.id,
+                    7_i64,
+                    timestamp(historical.created_at),
+                    "operator_prompt",
+                    serde_json::to_string(&historical)?,
+                ],
+            )?;
+        }
+
+        let migrated = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let next = MessageEnvelope::new(
+            "agent-a",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text {
+                text: "next".into(),
+            },
+        );
+        let next = migrated.messages().append_with_index_changes(&next, &[])?;
+        assert_eq!(next.message_seq, Some(8));
         Ok(())
     }
 
@@ -587,7 +693,8 @@ INSERT INTO queue_entries (
                         format!("runtime_db_concurrent_write_{index}"),
                         serde_json::json!({ "index": index }),
                     ),
-                )
+                )?;
+                Ok(())
             }));
         }
 
@@ -680,6 +787,82 @@ INSERT INTO queue_entries (
         assert_eq!(
             kinds,
             vec!["runtime_db_queue_first", "runtime_db_queue_second"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_sequences_are_atomic_across_db_instances_and_scopes() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let first = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let second = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+
+        let event_a = first.audit_events().append(
+            Some("agent-a"),
+            &AuditEvent::new("event-a", serde_json::json!({})),
+        )?;
+        let event_b = second.audit_events().append(
+            Some("agent-a"),
+            &AuditEvent::new("event-b", serde_json::json!({})),
+        )?;
+        let host_event = second
+            .audit_events()
+            .append(None, &AuditEvent::new("host-event", serde_json::json!({})))?;
+        assert_eq!((event_a.event_seq, event_b.event_seq), (1, 2));
+        assert_eq!(host_event.event_seq, 1);
+
+        let message_a = MessageEnvelope::new(
+            "agent-a",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text { text: "a".into() },
+        );
+        let message_b = MessageEnvelope::new(
+            "agent-a",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text { text: "b".into() },
+        );
+        let appended_a = first
+            .messages()
+            .append_with_index_changes(&message_a, &[])?;
+        let appended_b = second
+            .messages()
+            .append_with_index_changes(&message_b, &[])?;
+        assert_eq!(appended_a.message_seq, Some(1));
+        assert_eq!(appended_b.message_seq, Some(2));
+
+        let transcript_a = TranscriptEntry::new(
+            "agent-a",
+            TranscriptEntryKind::AssistantRound,
+            Some(1),
+            None,
+            serde_json::json!({ "text": "a" }),
+        );
+        let transcript_b = TranscriptEntry::new(
+            "agent-a",
+            TranscriptEntryKind::AssistantRound,
+            Some(2),
+            None,
+            serde_json::json!({ "text": "b" }),
+        );
+        assert_eq!(
+            first
+                .transcript_entries()
+                .append(&transcript_a)?
+                .transcript_seq,
+            Some(1)
+        );
+        assert_eq!(
+            second
+                .transcript_entries()
+                .append(&transcript_b)?
+                .transcript_seq,
+            Some(2)
         );
         Ok(())
     }
@@ -1993,21 +2176,102 @@ CREATE TABLE working_memory_deltas (
         db.work_items().import_legacy(Vec::new(), None)?;
         let mut current = WorkItemRecord::new("agent-a", "current", WorkItemState::Open);
         current.id = "work-revision".into();
-        current.revision = 5;
-        db.work_items().upsert(&current, false)?;
+        db.work_items().insert_new(&current, false)?;
+        current.revision = 2;
+        current.updated_at += chrono::Duration::seconds(1);
+        db.work_items().update_expected(&current, 1, false)?;
 
         let mut stale = current.clone();
         stale.objective = "stale".into();
-        stale.revision = 4;
+        stale.revision = 1;
         stale.updated_at = current.updated_at + chrono::Duration::seconds(10);
-        db.work_items().upsert(&stale, false)?;
+        let error = db
+            .work_items()
+            .update_expected(&stale, 0, false)
+            .unwrap_err();
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("stale update should return typed conflict");
+        assert_eq!(conflict.code(), "revision_conflict");
+        assert_eq!(conflict.expected_revision(), Some(0));
+        assert_eq!(conflict.actual_revision(), Some(2));
+        assert!(conflict.retryable());
 
         let persisted = db
             .work_items()
             .latest("work-revision")?
             .expect("work item persisted");
-        assert_eq!(persisted.revision, 5);
+        assert_eq!(persisted.revision, 2);
         assert_eq!(persisted.objective, "current");
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_expected_update_is_idempotent_and_rejects_same_revision_payload_change(
+    ) -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut initial = WorkItemRecord::new("agent-a", "initial", WorkItemState::Open);
+        initial.id = "work-cas".into();
+        db.work_items().insert_new(&initial, false)?;
+
+        let mut updated = initial.clone();
+        updated.revision = 2;
+        updated.objective = "updated".into();
+        updated.updated_at += chrono::Duration::seconds(1);
+        assert!(db.work_items().update_expected(&updated, 1, false)?);
+        assert!(!db.work_items().update_expected(&updated, 1, false)?);
+
+        let mut conflicting = updated.clone();
+        conflicting.objective = "conflicting".into();
+        let error = db
+            .work_items()
+            .update_expected(&conflicting, 1, false)
+            .unwrap_err();
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("same revision payload change should return typed conflict");
+        assert_eq!(conflict.domain(), "work_item");
+        assert_eq!(conflict.code(), "same_revision_payload_conflict");
+        assert_eq!(conflict.expected_revision(), Some(1));
+        assert_eq!(conflict.actual_revision(), Some(2));
+        assert!(!conflict.retryable());
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_expected_update_allows_only_one_writer_across_db_instances() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let first = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let second = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut initial = WorkItemRecord::new("agent-a", "initial", WorkItemState::Open);
+        initial.id = "work-concurrent-cas".into();
+        first.work_items().insert_new(&initial, false)?;
+
+        let mut left = initial.clone();
+        left.revision = 2;
+        left.objective = "left".into();
+        let mut right = initial.clone();
+        right.revision = 2;
+        right.objective = "right".into();
+
+        assert!(first.work_items().update_expected(&left, 1, false)?);
+        let error = second
+            .work_items()
+            .update_expected(&right, 1, false)
+            .unwrap_err();
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("second writer should return typed conflict");
+        assert_eq!(conflict.code(), "same_revision_payload_conflict");
+        assert_eq!(
+            second
+                .work_items()
+                .latest("work-concurrent-cas")?
+                .expect("persisted work item")
+                .objective,
+            "left"
+        );
         Ok(())
     }
 
@@ -2020,8 +2284,8 @@ CREATE TABLE working_memory_deltas (
         first.id = "work-first".into();
         let mut second = WorkItemRecord::new("agent-b", "second", WorkItemState::Open);
         second.id = "work-second".into();
-        db.work_items().upsert(&first, false)?;
-        db.work_items().upsert(&second, false)?;
+        db.work_items().insert_new(&first, false)?;
+        db.work_items().insert_new(&second, false)?;
 
         let agent_items = db.work_items().latest_for_agent("agent-a", 20)?;
         assert_eq!(agent_items.len(), 1);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -75,9 +75,6 @@ pub struct AppStorage {
     read_only: bool,
     agent_path: PathBuf,
     append_mutex: Arc<Mutex<()>>,
-    event_seq_counter: Arc<Mutex<u64>>,
-    message_seq_counter: Arc<Mutex<u64>>,
-    transcript_seq_counter: Arc<Mutex<u64>>,
     audit_event_index: Arc<Mutex<Option<AuditEventIndexSink>>>,
     runtime_db: RuntimeDb,
     event_bus: Arc<Mutex<Option<EventBus>>>,
@@ -221,22 +218,11 @@ impl AppStorage {
             }
         }
 
-        let event_seq_counter = runtime_db
-            .audit_events()
-            .max_event_seq(agent_id.as_deref())?;
-        let message_seq_counter = runtime_db.messages().max_message_seq(agent_id.as_deref())?;
-        let transcript_seq_counter = runtime_db
-            .transcript_entries()
-            .max_transcript_seq(agent_id.as_deref())?;
-
         Ok(Self {
             agent_id,
             read_only: mode == StorageOpenMode::ReadOnly,
             agent_path: state_dir.join("agent.json"),
             append_mutex: Arc::new(Mutex::new(())),
-            event_seq_counter: Arc::new(Mutex::new(event_seq_counter)),
-            message_seq_counter: Arc::new(Mutex::new(message_seq_counter)),
-            transcript_seq_counter: Arc::new(Mutex::new(transcript_seq_counter)),
             audit_event_index: Arc::new(Mutex::new(None)),
             runtime_db,
             event_bus: Arc::new(Mutex::new(None)),
@@ -423,14 +409,6 @@ impl AppStorage {
 
     fn append_event_with_append_mutex_held(&self, event: &AuditEvent) -> Result<()> {
         self.ensure_writable()?;
-        let mut event = event.clone();
-        let mut counter = self
-            .event_seq_counter
-            .lock()
-            .map_err(|_| anyhow::anyhow!("event sequence counter mutex poisoned"))?;
-        event.event_seq = counter
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("event sequence counter overflow"))?;
         let sink = self
             .audit_event_index
             .lock()
@@ -438,18 +416,20 @@ impl AppStorage {
             .clone();
         let agent_id = if let Some(sink) = sink {
             let agent_id = sink.agent_id.clone();
-            sink.runtime_db
+            let event = sink
+                .runtime_db
                 .audit_events()
                 .append(agent_id.as_deref(), &event)?;
-            agent_id
+            (agent_id, event)
         } else {
             let agent_id = self.current_agent_id()?;
-            self.runtime_db
+            let event = self
+                .runtime_db
                 .audit_events()
                 .append(agent_id.as_deref(), &event)?;
-            agent_id
+            (agent_id, event)
         };
-        *counter = event.event_seq;
+        let (agent_id, event) = agent_id;
         if let Err(error) = self.publish_event(agent_id.clone(), &event) {
             tracing::warn!(
                 error = %error,
@@ -473,25 +453,12 @@ impl AppStorage {
     }
 
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
-        let mut message = message.clone();
-        {
-            let _guard = self
-                .append_mutex
-                .lock()
-                .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
-            let mut counter = self
-                .message_seq_counter
-                .lock()
-                .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
-            *counter += 1;
-            message.message_seq = Some(*counter);
-            drop(counter);
-            let runtime_db = self.runtime_db.clone();
-            let changes = self.index_changes_for_message(&message)?;
-            runtime_db
-                .messages()
-                .upsert_with_index_changes(&message, &changes)?;
-        }
+        self.ensure_writable()?;
+        let runtime_db = self.runtime_db.clone();
+        let changes = self.index_changes_for_message(message)?;
+        let message = runtime_db
+            .messages()
+            .append_with_index_changes(message, &changes)?;
         self.enqueue_memory_index_message_best_effort(&message)
     }
 
@@ -505,6 +472,24 @@ impl AppStorage {
     }
 
     pub fn append_work_item(&self, record: &WorkItemRecord) -> Result<()> {
+        self.ensure_writable()?;
+        if self.runtime_db.work_items().latest(&record.id)?.is_some() {
+            let expected_revision = record.revision.checked_sub(1).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "work item {} update has invalid revision {}",
+                    record.id,
+                    record.revision
+                )
+            })?;
+            self.update_work_item_expected(record, expected_revision)?;
+        } else {
+            self.insert_work_item(record)?;
+        }
+        Ok(())
+    }
+
+    pub fn insert_work_item(&self, record: &WorkItemRecord) -> Result<()> {
+        self.ensure_writable()?;
         let runtime_db = self.runtime_db.clone();
         let current_focus = self
             .read_agent()?
@@ -514,7 +499,29 @@ impl AppStorage {
         let changes = self.index_changes_for_work_item(record)?;
         runtime_db
             .work_items()
-            .upsert_with_index_changes(record, current_focus, &changes)?;
+            .insert_new_with_index_changes(record, current_focus, &changes)?;
+        self.enqueue_memory_index_work_item_best_effort(record)
+    }
+
+    pub fn update_work_item_expected(
+        &self,
+        record: &WorkItemRecord,
+        expected_revision: u64,
+    ) -> Result<()> {
+        self.ensure_writable()?;
+        let runtime_db = self.runtime_db.clone();
+        let current_focus = self
+            .read_agent()?
+            .and_then(|agent| agent.current_work_item_id)
+            .as_deref()
+            == Some(record.id.as_str());
+        let changes = self.index_changes_for_work_item(record)?;
+        runtime_db.work_items().update_expected_with_index_changes(
+            record,
+            expected_revision,
+            current_focus,
+            &changes,
+        )?;
         self.enqueue_memory_index_work_item_best_effort(record)
     }
 
@@ -558,19 +565,9 @@ impl AppStorage {
     }
 
     pub fn append_transcript_entry(&self, entry: &TranscriptEntry) -> Result<()> {
-        let _guard = self
-            .append_mutex
-            .lock()
-            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
-        let mut entry = entry.clone();
-        let mut counter = self
-            .transcript_seq_counter
-            .lock()
-            .map_err(|_| anyhow::anyhow!("transcript sequence counter mutex poisoned"))?;
-        *counter += 1;
-        entry.transcript_seq = Some(*counter);
+        self.ensure_writable()?;
         let runtime_db = self.runtime_db.clone();
-        runtime_db.transcript_entries().upsert(&entry)?;
+        runtime_db.transcript_entries().append(entry)?;
         return Ok(());
     }
 
@@ -3389,7 +3386,7 @@ mod tests {
     }
 
     #[test]
-    fn message_seq_counter_resumes_from_existing_ledger() {
+    fn message_sequence_resumes_from_existing_ledger() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
@@ -3842,6 +3839,90 @@ mod tests {
         assert_eq!(
             entries
                 .iter()
+                .map(|entry| entry.transcript_seq)
+                .collect::<Vec<_>>(),
+            vec![Some(1), Some(2)]
+        );
+    }
+
+    #[test]
+    fn independent_storage_handles_allocate_unique_sequences() {
+        let dir = tempdir().unwrap();
+        let first = AppStorage::new_for_test(dir.path()).unwrap();
+        let second = AppStorage::new_for_test(dir.path()).unwrap();
+
+        first
+            .append_event(&AuditEvent::new("first", serde_json::json!({})))
+            .unwrap();
+        second
+            .append_event(&AuditEvent::new("second", serde_json::json!({})))
+            .unwrap();
+        first
+            .append_message(&MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "first".into(),
+                },
+            ))
+            .unwrap();
+        second
+            .append_message(&MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "second".into(),
+                },
+            ))
+            .unwrap();
+        first
+            .append_transcript_entry(&TranscriptEntry::new(
+                "default",
+                TranscriptEntryKind::IncomingMessage,
+                None,
+                Some("message-1".into()),
+                serde_json::json!({}),
+            ))
+            .unwrap();
+        second
+            .append_transcript_entry(&TranscriptEntry::new(
+                "default",
+                TranscriptEntryKind::IncomingMessage,
+                None,
+                Some("message-2".into()),
+                serde_json::json!({}),
+            ))
+            .unwrap();
+
+        assert_eq!(
+            second
+                .read_recent_events(10)
+                .unwrap()
+                .into_iter()
+                .map(|event| event.event_seq)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            second
+                .read_recent_messages(10)
+                .unwrap()
+                .into_iter()
+                .map(|message| message.message_seq)
+                .collect::<Vec<_>>(),
+            vec![Some(1), Some(2)]
+        );
+        assert_eq!(
+            second
+                .read_recent_transcript(10)
+                .unwrap()
+                .into_iter()
                 .map(|entry| entry.transcript_seq)
                 .collect::<Vec<_>>(),
             vec![Some(1), Some(2)]
@@ -4893,6 +4974,7 @@ mod tests {
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
         let mut updated = item.clone();
+        updated.revision += 1;
         updated.blocked_by = Some("working".into());
         updated.updated_at = Utc::now();
 
@@ -4912,6 +4994,7 @@ mod tests {
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let older = WorkItemRecord::new("default", "older", WorkItemState::Open);
         let mut updated = older.clone();
+        updated.revision += 1;
         updated.objective = "updated".into();
         updated.updated_at = older.created_at + chrono::Duration::milliseconds(100);
         let other_agent = WorkItemRecord::new("other", "other agent", WorkItemState::Open);

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -385,9 +385,13 @@ fn append_work_item_todo(
     let Some(mut work_item) = storage.latest_work_item(&work_item_id)? else {
         anyhow::bail!("missing work item {work_item_id}");
     };
+    let expected_revision = work_item.revision;
+    work_item.revision = expected_revision
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("work item revision overflow"))?;
     work_item.todo_list = todo_list;
     work_item.updated_at = Utc::now();
-    storage.append_work_item(&work_item)?;
+    storage.update_work_item_expected(&work_item, expected_revision)?;
     Ok(())
 }
 
@@ -429,7 +433,6 @@ fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
         AdmissionContext::LocalProcess,
     );
     previous_operator.id = "msg_focused_prompt_projection".into();
-    storage.append_message(&previous_operator)?;
     let mut result_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
@@ -530,7 +533,6 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
     operator_message.id = "msg_runtime_flow_operator".into();
     let mut operator_message_with_turn = operator_message.clone();
     operator_message_with_turn.turn_id = Some("turn_op_test".into());
-    storage.append_message(&operator_message_with_turn)?;
     let mut turn_index_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
@@ -630,7 +632,7 @@ runtime flow
 
 ## continuation_anchor
 Continuation anchor:
-Latest trusted operator input: message_seq 2.
+Latest trusted operator input: message_seq 1.
 Current input relation: current_input is a task-result continuation, not a new operator request. Continue the latest trusted operator input above unless the current WorkItem projection is more specific.
 
 ## recent_turns
@@ -638,7 +640,7 @@ Recent turns:
 - Turn turn_index 1:
   - turn_id: turn_op_test
   - trigger: trusted operator input
-  - continues input: message_seq 2
+  - continues input: message_seq 1
   - continuation trigger: a task-result continuation
   - operator input full: Run cargo test runtime_flow and report back. message_ref=message:msg_runtime_flow_operator
   - produced briefs:
@@ -1766,7 +1768,6 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         MessageDeliverySurface::CliPrompt,
         AdmissionContext::LocalProcess,
     );
-    storage.append_message(&first_operator)?;
     let mut first_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
@@ -1816,7 +1817,6 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
     );
-    storage.append_message(&task_result)?;
     let mut task_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
@@ -1978,7 +1978,6 @@ fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_disc
         MessageDeliverySurface::CliPrompt,
         AdmissionContext::LocalProcess,
     );
-    storage.append_message(&first_operator)?;
     storage.append_tool_execution(&ToolExecutionRecord {
         id: "tool_issue_list_analysis".into(),
         agent_id: "default".into(),
@@ -2184,7 +2183,6 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
         MessageDeliverySurface::CliPrompt,
         AdmissionContext::LocalProcess,
     );
-    storage.append_message(&recent_operator)?;
     let mut recent_brief = BriefRecord::new(
         "default",
         BriefKind::Result,

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -126,9 +126,15 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
         None,
     )
     .await?;
+    let expected_revision = completed.revision;
+    completed.revision = expected_revision
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("work item revision overflow"))?;
     completed.result_summary = Some("Promoted cleanup completion report.".into());
     completed.updated_at = Utc::now();
-    runtime.storage().append_work_item(&completed)?;
+    runtime
+        .storage()
+        .update_work_item_expected(&completed, expected_revision)?;
 
     for idx in 0..4 {
         runtime.storage().append_message(&MessageEnvelope::new(


### PR DESCRIPTION
## 概要

- 将 WorkItem 写入拆分为严格 create/import/update 语义，业务更新要求 `expected_revision` 且仅允许 `N -> N + 1`
- 对同 revision 的相同 canonical payload 保留幂等重放，对不同 payload 返回包含 domain/code/revision/retryability 的 typed conflict
- 将 audit event、message、transcript sequence 改为在数据库 append transaction 内分配，并增加既有 scope 下的唯一约束与历史数据迁移
- 移除 `AppStorage` 进程内 sequence counter 的权威分配职责，并迁移 runtime/storage 调用点
- 补充多 handle 并发、迁移恢复、严格 CAS、幂等与冲突传播测试，并更新持久化一致性 RFC

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --lib`（2254 passed，0 failed，1 ignored）

Fixes #2262
