### PR TITLE
refactor: 建立 Runtime Transition Unit of Work

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -46,6 +46,7 @@ implementation and tests.
 - [Runtime ID Generation](./runtime-id-generation.md)
 - [Runtime Ledger Sequences and Object Revisions](./runtime-ledger-sequences-and-revisions.md)
 - [Runtime Ledger Files and Relations](./runtime-ledger-files-and-relations.md)
+- [Runtime Transition Commit Contract](./runtime-transition-commit-contract.md)
 
 ## Provenance, Policy, And Execution
 

--- a/docs/rfcs/runtime-transition-commit-contract.md
+++ b/docs/rfcs/runtime-transition-commit-contract.md
@@ -1,0 +1,295 @@
+---
+title: RFC: Runtime Transition Commit Contract
+date: 2026-07-15
+status: accepted
+handle: rfc-runtime-transition-commit-contract
+---
+
+# RFC: Runtime Transition Commit Contract
+
+## Summary
+
+Holon runtime business transitions must separate durable commit from
+post-commit effects.
+
+The commit phase validates the command's expected state and writes every
+durable fact that belongs to one invariant in one `runtime.sqlite`
+transaction. The post-commit phase updates rebuildable in-memory projections,
+publishes process-local events, and notifies workers only after that
+transaction succeeds.
+
+The first transition families covered by this contract are:
+
+- WorkItem lifecycle updates;
+- wait registration, replacement, cancellation, and resolution;
+- queue claim and terminal settlement;
+- task lifecycle transitions, including terminal wait release.
+
+This contract does not change operator-facing tools or transport payloads.
+
+## Problem
+
+The runtime currently composes business transitions from storage methods that
+each own a separate transaction. A single logical operation can therefore
+write its canonical row and later fail while writing an audit event, related
+wait, agent state, queue settlement, or index outbox row.
+
+Examples include:
+
+- WorkItem updates persist the WorkItem before the lifecycle audit event;
+- wait registration cancels old waits, updates the WorkItem blocker, clears
+  turn binding, inserts the new wait, and appends audit events separately;
+- task terminal state is persisted before matching waits and WorkItem blockers
+  are resolved;
+- queue status changes and their processing or failure facts are persisted
+  independently.
+
+These intermediate states are durable and survive restart. Reordering
+in-memory writes or adding compensating writes does not repair the contract;
+the related durable facts need one transaction boundary.
+
+## Goals
+
+- make each runtime business transition declare its complete durable write set;
+- validate expected revision or state before applying any write;
+- atomically allocate audit sequences and runtime-index outbox rows with the
+  canonical state change;
+- return a typed commit result that distinguishes applied, idempotent, and
+  conflicting commands;
+- run cache, event-bus, indexer, and scheduler effects only after commit;
+- make commit failures and post-commit effect failures independently testable;
+- preserve restart recovery from canonical database facts.
+
+## Non-goals
+
+- do not expose `rusqlite::Transaction` to runtime services;
+- do not make cache, event delivery, or scheduler notification authoritative;
+- do not introduce a general distributed transaction or plugin framework;
+- do not persist every process-local notification in a new generic outbox;
+- do not settle the final canonical WorkItem focus schema, which is handled by
+  the focused follow-up work;
+- do not physically split all large runtime modules in the first change.
+
+## Fact Layers
+
+### Canonical durable facts
+
+These rows participate in transition invariants and must be committed
+atomically when a command changes them:
+
+- `work_items`;
+- `wait_conditions`;
+- `queue_entries`;
+- `tasks`;
+- `agent_states` when the transition changes durable agent or turn binding;
+- `work_item_continuations` when the transition creates, resolves, or cancels a
+  continuation;
+- `audit_events`;
+- `runtime_sequences` used by committed ledgers;
+- `runtime_index_outbox`.
+
+### Durable derived intent
+
+`runtime_index_outbox` is a durable instruction to refresh the rebuildable
+memory index. It belongs in the same transaction as its source row.
+
+Future reliable asynchronous work may add another purpose-specific outbox, but
+process-local event publication and `Notify` calls are not durable facts.
+
+### Rebuildable projections and liveness effects
+
+The following run only after commit:
+
+- `RuntimeProjectionCache` updates;
+- event-bus publication of committed audit events;
+- memory-index worker notification;
+- scheduler/run-loop notification;
+- observational logs and metrics.
+
+Failure of these effects cannot change the committed result. Restart, database
+polling, or idempotent effect retry must restore projection and liveness.
+
+## Command Contract
+
+Runtime services construct domain-specific commands rather than sharing one
+unbounded command enum:
+
+- `WorkItemTransitionCommand`;
+- `WaitTransitionCommand`;
+- `QueueTransitionCommand`;
+- `TaskTransitionCommand`.
+
+Each command contains:
+
+- stable record identifiers;
+- expected revision or expected lifecycle state;
+- the complete replacement record or explicit state delta;
+- audit events that describe the same committed transition;
+- runtime-index changes for affected searchable records;
+- optional related canonical records owned by the same invariant;
+- a stable replay identity when the caller can resubmit the command, or an
+  expected revision/status that makes reapplication an idempotent no-op or a
+  typed conflict.
+
+The database exposes a restricted transition repository. Its implementation
+may compose crate-private `*_tx` helpers, but callers cannot execute arbitrary
+SQL inside the unit of work.
+
+## Commit Result
+
+The commit phase returns `TransitionCommit`:
+
+- whether the command was newly applied or was an idempotent replay;
+- committed canonical records needed by post-commit projections;
+- committed audit events with database-assigned sequences;
+- a typed `PostCommitEffects` description;
+- durable identifiers or sequences required by the caller.
+
+An expected-state mismatch returns the existing typed
+`RuntimeStateTransitionConflict`. Business conflicts are not retried as
+SQLite-busy failures.
+
+The same replay identity with equivalent payload returns an equivalent commit
+without duplicating canonical updates, audit events, result messages, or
+outbox rows. Reuse with a different payload is a conflict. Commands without a
+dedicated replay key use canonical record identity plus expected
+revision/status; exact replays are no-ops and stale or conflicting payloads
+return the existing typed transition conflict.
+
+## Transition Inventory
+
+### WorkItem
+
+| Transition | Expected input | Atomic durable write set | Post-commit effects |
+| --- | --- | --- | --- |
+| create | record absent, revision `1` | WorkItem, lifecycle audit, index outbox | cache WorkItem, publish audit, notify indexer and scheduler |
+| update/block/unblock/recheck | exact prior revision | WorkItem next revision, lifecycle audit, index outbox | cache WorkItem, publish audit, notify indexer and scheduler |
+| complete | exact prior revision and open state | completed WorkItem, related wait cancellation, agent binding release, lifecycle audits, index outbox | cache records, publish audits, notify indexer and scheduler; run the compatibility continuation adapter |
+
+Focus-specific pick/resume and continuation-frame writes will use the same
+transaction primitive, but their final single-source focus schema and atomic
+write set are defined by the focused follow-up. Until that migration, the
+post-commit continuation adapter must not report the already committed
+WorkItem completion as failed; adapter failures are recorded as post-commit
+warnings.
+
+### Wait
+
+| Transition | Expected input | Atomic durable write set | Post-commit effects |
+| --- | --- | --- | --- |
+| register/replace | owned open WorkItem revision when scoped | cancellation of replaced waits, WorkItem blocker revision, optional agent turn binding, new active wait, audits, WorkItem index outbox | cache WorkItem, publish audits, notify indexer and scheduler |
+| cancel | active status | cancelled wait set and cancellation audit | publish audit, notify scheduler |
+| task resolve | active task wait and expected WorkItem blocker | resolved wait, optional cleared WorkItem blocker revision, audits, WorkItem index outbox | cache WorkItem, publish audits, notify indexer and scheduler |
+
+No active wait may reference a WorkItem revision whose blocker update failed,
+and no WorkItem blocker may claim a newly registered wait that is absent.
+
+### Queue
+
+| Transition | Expected input | Atomic durable write set | Post-commit effects |
+| --- | --- | --- | --- |
+| claim | queued or interrupted | dequeued queue row and claim audit | publish audit |
+| processed | dequeued/interjected | processed queue row and processing audit | publish audit, notify scheduler |
+| interrupted/aborted/dropped | allowed non-terminal state | terminal queue row and failure/abort audit | publish audit, notify scheduler |
+
+A queue entry cannot be terminal while its corresponding terminal settlement
+audit is absent because of a later transaction failure.
+
+### Task
+
+| Transition | Expected input | Atomic durable write set | Post-commit effects |
+| --- | --- | --- | --- |
+| create/running/cancelling | monotonic task phase/revision | Task, lifecycle audit, index outbox | cache Task, publish audit, notify indexer and scheduler |
+| terminal without wait | non-terminal task or equivalent replay | terminal Task, lifecycle audit, index outbox | cache Task, publish audit, notify indexer and scheduler |
+| terminal with wait | non-terminal task, active matching wait, expected WorkItem blocker | terminal Task, resolved waits, optional WorkItem blocker revision, lifecycle audits, Task and WorkItem index outbox | cache Task and WorkItem, publish audits, notify indexer and scheduler |
+
+Terminal task persistence and wait release are one transition. A restart cannot
+observe a terminal task with an otherwise matching active task wait solely
+because the runtime crashed between repository calls.
+
+## Commit And Effect Ordering
+
+The required order is:
+
+1. validate command shape;
+2. begin the runtime database transaction;
+3. load and validate expected revisions and statuses;
+4. write canonical rows;
+5. allocate and write audit sequences;
+6. write runtime-index outbox changes;
+7. commit the SQLite transaction;
+8. update in-memory projections;
+9. publish committed audit events;
+10. notify indexer and scheduler;
+11. record any post-commit warning.
+
+Runtime code must not mutate shared projection state before step 7.
+
+## Failure Matrix
+
+| Failure point | Durable result | Returned meaning |
+| --- | --- | --- |
+| validation or expected-state check | no writes | typed conflict or command error |
+| canonical write | full rollback | commit failed |
+| audit or outbox write | full rollback | commit failed |
+| SQLite commit | full rollback or SQLite-defined commit outcome | commit failed unless commit was confirmed |
+| cache update | commit remains authoritative | committed with post-commit warning |
+| event publication | commit remains authoritative | committed with post-commit warning |
+| worker/scheduler notification | commit remains authoritative | committed with post-commit warning |
+
+Callers must not retry the business command merely because a post-commit
+effect failed. They may retry the effect or rebuild the projection.
+
+## Fault Injection Contract
+
+The restricted transition repository exposes a test-only fault seam at:
+
+- after expected-state validation;
+- after canonical rows;
+- after audit events;
+- before transaction commit;
+- before cache update;
+- before event publication;
+- before scheduler notification.
+
+Commit-phase injected failures must leave all participating tables and
+sequences unchanged. Post-commit injected failures must leave every durable
+fact present exactly once.
+
+The seam is intentionally limited to transition tests. General deterministic
+clock and ID injection remains separate work.
+
+## Restart And Replay
+
+Startup recovery reads canonical rows and reconstructs caches, queue replay,
+active waits, and task posture without assuming that the original process
+executed its post-commit effects.
+
+Audit events and index outbox rows are durable consequences of the transition,
+not compensating evidence written during recovery. Recovery may publish or
+refresh projections again, but it does not duplicate the canonical transition.
+
+## Implementation Boundary
+
+- `runtime_db` owns the restricted transaction and crate-private SQL helpers;
+- `storage::AppStorage` constructs index changes and executes storage-local
+  post-commit effects;
+- runtime domain services construct commands, update runtime projection cache
+  from committed records, and notify the scheduler;
+- existing single-record repository methods remain available for imports,
+  tests, and unrelated facts, but migrated business transitions must not split
+  one invariant across those methods.
+
+## Verification
+
+Required tests cover:
+
+- each commit-phase fault point for every transition family;
+- strict WorkItem revision conflict and concurrent winner behavior;
+- idempotent replay without duplicate audit or outbox rows;
+- task terminal plus wait release atomicity;
+- queue terminal settlement atomicity;
+- post-commit failure followed by restart/rebuild;
+- existing runtime restart tests for dequeued messages, active waits, tasks,
+  and WorkItems.
+

--- a/docs/rfcs/runtime-transition-commit-contract.md
+++ b/docs/rfcs/runtime-transition-commit-contract.md
@@ -189,6 +189,7 @@ and no WorkItem blocker may claim a newly registered wait that is absent.
 | Transition | Expected input | Atomic durable write set | Post-commit effects |
 | --- | --- | --- | --- |
 | claim | queued or interrupted | dequeued queue row and claim audit | publish audit |
+| interjected | queued interjection plus expected AgentState snapshot | interjected queue row, decremented AgentState pending count, incoming transcript evidence, and admission audit | remove the committed message from the in-memory queue, publish audit |
 | processed | dequeued/interjected | processed queue row and processing audit | publish audit, notify scheduler |
 | interrupted/aborted/dropped | allowed non-terminal state | terminal queue row and failure/abort audit | publish audit, notify scheduler |
 
@@ -206,6 +207,10 @@ audit is absent because of a later transaction failure.
 Terminal task persistence and wait release are one transition. A restart cannot
 observe a terminal task with an otherwise matching active task wait solely
 because the runtime crashed between repository calls.
+
+An equivalent terminal replay may commit only residual wait and WorkItem
+repairs. It reuses stable lifecycle audit identity and does not rewrite the
+terminal Task or enqueue another Task index change.
 
 ## Commit And Effect Ordering
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -63,6 +63,18 @@ impl RuntimeQueue {
             .or_else(|| pop_matching_from(&mut self.background, &mut predicate))
     }
 
+    pub fn peek_next_matching(
+        &self,
+        mut predicate: impl FnMut(&MessageEnvelope) -> bool,
+    ) -> Option<&MessageEnvelope> {
+        self.interject
+            .iter()
+            .find(|message| predicate(message))
+            .or_else(|| self.next.iter().find(|message| predicate(message)))
+            .or_else(|| self.normal.iter().find(|message| predicate(message)))
+            .or_else(|| self.background.iter().find(|message| predicate(message)))
+    }
+
     pub fn len(&self) -> usize {
         self.interject.len() + self.next.len() + self.normal.len() + self.background.len()
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -75,7 +75,12 @@ use crate::{
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
     },
     queue::RuntimeQueue,
-    runtime_db::RuntimeDb,
+    runtime_db::{
+        transitions::{
+            PostCommitWarning, TransitionApplyResult, TransitionCommit, TransitionFaultPoint,
+        },
+        RuntimeDb,
+    },
     skills::{
         effective_skill_root_registrations, find_skill_by_entrypoint, find_skill_by_script_path,
         skills_runtime_view_from_catalog, SkillVisibility,
@@ -598,34 +603,65 @@ impl CurrentRunAbortSnapshot {
 }
 
 impl RuntimeHandle {
-    pub(crate) async fn record_task_projection(&self, record: &TaskRecord) -> Result<()> {
-        self.inner.storage.append_task(record)?;
-        self.inner
-            .projection_cache
-            .lock()
-            .await
-            .upsert_task(record.clone());
-        Ok(())
-    }
-
-    pub(crate) async fn record_work_item_projection(
+    pub(crate) async fn apply_transition_commit(
         &self,
-        record: &crate::types::WorkItemRecord,
-        expected_revision: Option<u64>,
-    ) -> Result<()> {
-        if let Some(expected_revision) = expected_revision {
-            self.inner
-                .storage
-                .update_work_item_expected(record, expected_revision)?;
-        } else {
-            self.inner.storage.insert_work_item(record)?;
+        commit: TransitionCommit,
+    ) -> TransitionApplyResult {
+        if !commit.applied {
+            return TransitionApplyResult::default();
         }
-        self.inner
-            .projection_cache
-            .lock()
-            .await
-            .upsert_work_item(record.clone());
-        Ok(())
+        let effects = commit.effects;
+        let mut warnings = Vec::new();
+        if effects.fault == Some(TransitionFaultPoint::BeforeCacheUpdate) {
+            warnings.push(PostCommitWarning {
+                effect: "projection_cache_update",
+                message: "injected runtime transition post-commit fault".into(),
+            });
+        } else {
+            let mut cache = self.inner.projection_cache.lock().await;
+            for record in &effects.work_items {
+                cache.upsert_work_item(record.clone());
+            }
+            for record in &effects.tasks {
+                cache.upsert_task(record.clone());
+            }
+        }
+        if let Some(state) = effects.agent_state.as_ref() {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state = state.clone();
+            guard.last_persisted_state = state.clone();
+        }
+        if effects.fault == Some(TransitionFaultPoint::BeforeEventPublication) {
+            warnings.push(PostCommitWarning {
+                effect: "event_publication",
+                message: "injected runtime transition post-commit fault".into(),
+            });
+        } else {
+            warnings.extend(self.inner.storage.publish_transition_events(&effects));
+        }
+        warnings.extend(self.inner.storage.notify_transition_memory_index(&effects));
+        if effects.notify_scheduler {
+            if effects.fault == Some(TransitionFaultPoint::BeforeSchedulerNotification) {
+                warnings.push(PostCommitWarning {
+                    effect: "scheduler_notification",
+                    message: "injected runtime transition post-commit fault".into(),
+                });
+            } else {
+                self.inner.notify.notify_one();
+            }
+        }
+        let result = TransitionApplyResult {
+            applied: true,
+            warnings,
+        };
+        for warning in &result.warnings {
+            tracing::warn!(
+                effect = warning.effect,
+                error = %warning.message,
+                "runtime transition committed with post-commit warning"
+            );
+        }
+        result
     }
 
     pub(crate) async fn record_timer_projection(&self, record: &TimerRecord) -> Result<()> {
@@ -646,12 +682,12 @@ impl RuntimeHandle {
             .upsert_external_trigger(record.clone());
     }
 
-    pub(crate) fn append_work_item_written_event(
+    pub(crate) fn work_item_written_event(
         &self,
         action: &str,
         record: &crate::types::WorkItemRecord,
         extra: Value,
-    ) -> Result<()> {
+    ) -> AuditEvent {
         let mut payload =
             to_json_value(&WorkItemLifecycleAuditEvent::from_work_item(action, record));
         if let (Some(payload), Some(extra)) = (payload.as_object_mut(), extra.as_object()) {
@@ -659,19 +695,17 @@ impl RuntimeHandle {
                 payload.insert(key.clone(), value.clone());
             }
         }
-        self.inner
-            .storage
-            .append_event(&AuditEvent::new("work_item_written", payload))
+        AuditEvent::new("work_item_written", payload)
     }
 
-    pub(crate) fn append_work_item_plan_artifact_refreshed_event(
+    pub(crate) fn work_item_plan_artifact_refreshed_event(
         &self,
         record: &crate::types::WorkItemRecord,
-    ) -> Result<()> {
+    ) -> Option<AuditEvent> {
         let Some(artifact) = record.plan_artifact.as_ref() else {
-            return Ok(());
+            return None;
         };
-        self.inner.storage.append_event(&AuditEvent::new(
+        Some(AuditEvent::new(
             "work_item_plan_artifact_refreshed",
             serde_json::json!({
                 "work_item_id": record.id,
@@ -1469,6 +1503,25 @@ impl RuntimeHandle {
             .append_event(&AuditEvent::new(kind, data))
     }
 
+    pub(crate) async fn commit_queue_settlement(
+        &self,
+        record: QueueEntryRecord,
+        audit_events: Vec<AuditEvent>,
+        notify_scheduler: bool,
+    ) -> Result<bool> {
+        let commit = self.inner.runtime_db.transitions().commit_queue(
+            &crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: record.agent_id.clone(),
+                mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record),
+                agent_state: None,
+                audit_events,
+                notify_scheduler,
+                fault: None,
+            },
+        )?;
+        Ok(self.apply_transition_commit(commit).await.applied)
+    }
+
     pub(crate) fn persist_message_evidence(&self, message: &MessageEnvelope) -> Result<()> {
         self.inner.storage.append_message(message)?;
         self.inner.notify.notify_one();
@@ -1588,23 +1641,27 @@ impl RuntimeHandle {
             {
                 let aborted = err.downcast_ref::<CurrentRunAborted>().cloned();
                 if let Some(aborted) = aborted.as_ref() {
-                    self.inner.storage.append_queue_entry(&QueueEntryRecord {
-                        message_id: message.id.clone(),
-                        agent_id: message.agent_id.clone(),
-                        priority: message.priority.clone(),
-                        status: QueueEntryStatus::Interrupted,
-                        created_at: message.created_at,
-                        updated_at: Utc::now(),
-                    })?;
-                    self.inner.storage.append_event(&AuditEvent::new(
-                        "message_processing_aborted",
-                        serde_json::json!({
-                            "message_id": message.id,
-                            "message_kind": message.kind,
-                            "run_id": aborted.run_id,
-                            "reason": aborted.reason,
-                        }),
-                    ))?;
+                    self.commit_queue_settlement(
+                        QueueEntryRecord {
+                            message_id: message.id.clone(),
+                            agent_id: message.agent_id.clone(),
+                            priority: message.priority.clone(),
+                            status: QueueEntryStatus::Interrupted,
+                            created_at: message.created_at,
+                            updated_at: Utc::now(),
+                        },
+                        vec![AuditEvent::new(
+                            "message_processing_aborted",
+                            serde_json::json!({
+                                "message_id": message.id,
+                                "message_kind": message.kind,
+                                "run_id": aborted.run_id,
+                                "reason": aborted.reason,
+                            }),
+                        )],
+                        true,
+                    )
+                    .await?;
                 } else {
                     error!("failed to process message {}: {err:#}", message.id);
                     self.ensure_runtime_failure_terminal(None, 0).await?;
@@ -1621,14 +1678,27 @@ impl RuntimeHandle {
                     ))?;
                     self.persist_runtime_failure_artifacts(&message, &err)
                         .await?;
-                    self.inner.storage.append_queue_entry(&QueueEntryRecord {
-                        message_id: message.id.clone(),
-                        agent_id: message.agent_id.clone(),
-                        priority: message.priority.clone(),
-                        status: QueueEntryStatus::Aborted,
-                        created_at: message.created_at,
-                        updated_at: Utc::now(),
-                    })?;
+                    self.commit_queue_settlement(
+                        QueueEntryRecord {
+                            message_id: message.id.clone(),
+                            agent_id: message.agent_id.clone(),
+                            priority: message.priority.clone(),
+                            status: QueueEntryStatus::Aborted,
+                            created_at: message.created_at,
+                            updated_at: Utc::now(),
+                        },
+                        vec![AuditEvent::new(
+                            "queue_entry_settled",
+                            serde_json::json!({
+                                "message_id": message.id,
+                                "message_kind": message.kind,
+                                "status": QueueEntryStatus::Aborted,
+                                "reason": "runtime_error",
+                            }),
+                        )],
+                        true,
+                    )
+                    .await?;
                 }
                 let failed_state = {
                     let mut guard = self.inner.agent.lock().await;
@@ -1662,14 +1732,26 @@ impl RuntimeHandle {
                     guard.state.clone()
                 };
                 self.append_state_changed_events(&processed_state)?;
-                self.inner.storage.append_queue_entry(&QueueEntryRecord {
-                    message_id: message.id.clone(),
-                    agent_id: message.agent_id.clone(),
-                    priority: message.priority.clone(),
-                    status: QueueEntryStatus::Processed,
-                    created_at: message.created_at,
-                    updated_at: Utc::now(),
-                })?;
+                self.commit_queue_settlement(
+                    QueueEntryRecord {
+                        message_id: message.id.clone(),
+                        agent_id: message.agent_id.clone(),
+                        priority: message.priority.clone(),
+                        status: QueueEntryStatus::Processed,
+                        created_at: message.created_at,
+                        updated_at: Utc::now(),
+                    },
+                    vec![AuditEvent::new(
+                        "queue_entry_settled",
+                        serde_json::json!({
+                            "message_id": message.id,
+                            "message_kind": message.kind,
+                            "status": QueueEntryStatus::Processed,
+                        }),
+                    )],
+                    true,
+                )
+                .await?;
             }
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -626,10 +626,22 @@ impl RuntimeHandle {
                 cache.upsert_task(record.clone());
             }
         }
-        if let Some(state) = effects.agent_state.as_ref() {
+        if let Some(mutation) = effects.agent_state.as_ref() {
             let mut guard = self.inner.agent.lock().await;
-            guard.state = state.clone();
-            guard.last_persisted_state = state.clone();
+            if mutation
+                .expected
+                .as_ref()
+                .is_none_or(|expected| guard.state == **expected)
+            {
+                guard.state = mutation.record.as_ref().clone();
+                guard.last_persisted_state = mutation.record.as_ref().clone();
+            } else {
+                warnings.push(PostCommitWarning {
+                    effect: "agent_state_projection_update",
+                    message: "agent state changed after transition commit; retained newer in-memory state"
+                        .into(),
+                });
+            }
         }
         if effects.fault == Some(TransitionFaultPoint::BeforeEventPublication) {
             warnings.push(PostCommitWarning {
@@ -1514,6 +1526,7 @@ impl RuntimeHandle {
                 agent_id: record.agent_id.clone(),
                 mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record),
                 agent_state: None,
+                transcript_entries: Vec::new(),
                 audit_events,
                 notify_scheduler,
                 fault: None,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -111,12 +111,36 @@ impl RuntimeHandle {
                 turn_id: current_turn_id,
                 ..refreshed
             };
-            self.record_work_item_projection(&record, Some(latest.revision))
-                .await?;
+            let mut audit_events = Vec::new();
             if plan_artifact_changed {
-                self.append_work_item_plan_artifact_refreshed_event(&record)?;
+                if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
+                    audit_events.push(event);
+                }
             }
-            self.append_work_item_written_event("turn_end_committed", &record, Value::Null)?;
+            audit_events.push(self.work_item_written_event(
+                "turn_end_committed",
+                &record,
+                Value::Null,
+            ));
+            let agent_id = self.agent_id().await?;
+            let state = self.agent_state().await?;
+            let commit = self.inner.runtime_db.transitions().commit_work_item(
+                &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                    agent_id,
+                    mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                        record: record.clone(),
+                        expected_revision: latest.revision,
+                        current_focus: state.current_work_item_id.as_deref()
+                            == Some(record.id.as_str()),
+                    },
+                    agent_state: None,
+                    audit_events,
+                    index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                    notify_scheduler: true,
+                    fault: None,
+                },
+            )?;
+            self.apply_transition_commit(commit).await;
             record
         } else {
             latest

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -245,18 +245,32 @@ impl RuntimeHandle {
         record.work_refs = merged;
         record.revision = record.revision.saturating_add(1);
         record.updated_at = Utc::now();
-        self.record_work_item_projection(&record, Some(record.revision - 1))
-            .await?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_refs_updated",
-            serde_json::json!({
-                "agent_id": agent.id,
-                "work_item_id": record.id,
-                "revision": record.revision,
-                "previous_ref_count": previous_count,
-                "ref_count": record.work_refs.len(),
-            }),
-        ))?;
+        let commit = self.inner.runtime_db.transitions().commit_work_item(
+            &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                agent_id: agent.id.clone(),
+                mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: record.clone(),
+                    expected_revision: record.revision - 1,
+                    current_focus: agent.current_work_item_id.as_deref()
+                        == Some(record.id.as_str()),
+                },
+                agent_state: None,
+                audit_events: vec![AuditEvent::new(
+                    "work_item_refs_updated",
+                    serde_json::json!({
+                        "agent_id": agent.id,
+                        "work_item_id": record.id,
+                        "revision": record.revision,
+                        "previous_ref_count": previous_count,
+                        "ref_count": record.work_refs.len(),
+                    }),
+                )],
+                index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                notify_scheduler: false,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
         Ok(true)
     }
 

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -372,7 +372,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             candidate.queue_len,
         )?;
 
-        let (message, running_state) = {
+        let (message, running_state, transition_commit) = {
             let mut guard = self.runtime.inner.agent.lock().await;
             if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
                 return self.shutdown(guard);
@@ -389,19 +389,41 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
 
             scheduler::append_scheduler_decision(&self.runtime.inner.storage, &decision)?;
-            let claimed =
-                self.runtime
-                    .inner
-                    .storage
-                    .try_claim_queued_message(&QueueEntryRecord {
-                        message_id: candidate.message.id.clone(),
-                        agent_id: candidate.message.agent_id.clone(),
-                        priority: candidate.message.priority.clone(),
-                        status: QueueEntryStatus::Dequeued,
-                        created_at: candidate.message.created_at,
-                        updated_at: Utc::now(),
-                    })?;
-            if !claimed {
+            let queue_record = QueueEntryRecord {
+                message_id: candidate.message.id.clone(),
+                agent_id: candidate.message.agent_id.clone(),
+                priority: candidate.message.priority.clone(),
+                status: QueueEntryStatus::Dequeued,
+                created_at: candidate.message.created_at,
+                updated_at: Utc::now(),
+            };
+            let run_id = crate::ids::run_id();
+            let abort_token = CancellationToken::new();
+            let mut running_state = guard.state.clone();
+            running_state.pending = guard.queue.len().saturating_sub(1);
+            scheduler::apply_running_projection(&mut running_state, run_id.clone());
+            running_state.last_wake_reason = Some(format!("{:?}", candidate.message.kind));
+            let mut commit = self.runtime.inner.runtime_db.transitions().commit_queue(
+                &crate::runtime_db::transitions::QueueTransitionCommand {
+                    agent_id: candidate.message.agent_id.clone(),
+                    mutation: crate::runtime_db::transitions::QueueMutation::Claim(
+                        queue_record.clone(),
+                    ),
+                    agent_state: Some(running_state.clone()),
+                    audit_events: vec![AuditEvent::new(
+                        "queue_entry_claimed",
+                        serde_json::json!({
+                            "message_id": queue_record.message_id,
+                            "agent_id": queue_record.agent_id,
+                            "status": QueueEntryStatus::Dequeued,
+                            "run_id": run_id,
+                        }),
+                    )],
+                    notify_scheduler: false,
+                    fault: None,
+                },
+            )?;
+            if !commit.applied {
                 let _ = guard.queue.pop_if_next(&candidate.message.id);
                 guard.state.pending = guard.queue.len();
                 guard.persist_state(&self.runtime.inner.storage)?;
@@ -411,19 +433,19 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 .queue
                 .pop_if_next(&candidate.message.id)
                 .expect("queue head was just checked");
-            let run_id = crate::ids::run_id();
-            let abort_token = CancellationToken::new();
-            guard.state.pending = guard.queue.len();
-            scheduler::apply_running_projection(&mut guard.state, run_id.clone());
+            guard.state = running_state.clone();
+            guard.last_persisted_state = running_state.clone();
             guard.current_run_abort = Some(CurrentRunAbortHandle {
                 run_id: run_id.clone(),
                 token: abort_token,
                 reason: Arc::new(StdMutex::new("operator_aborted".into())),
             });
-            guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
-            guard.persist_state(&self.runtime.inner.storage)?;
-            (message, guard.state.clone())
+            commit.effects.agent_state = None;
+            (message, running_state, commit)
         };
+        self.runtime
+            .apply_transition_commit(transition_commit)
+            .await;
 
         Ok(RunLoopPoll::Message(ScheduledMessage {
             message,

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -409,7 +409,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     mutation: crate::runtime_db::transitions::QueueMutation::Claim(
                         queue_record.clone(),
                     ),
-                    agent_state: Some(running_state.clone()),
+                    agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(guard.state.clone())),
+                        record: Box::new(running_state.clone()),
+                    }),
+                    transcript_entries: Vec::new(),
                     audit_events: vec![AuditEvent::new(
                         "queue_entry_claimed",
                         serde_json::json!({

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -1,4 +1,7 @@
 use super::{scheduler, *};
+use crate::types::{
+    WaitConditionKind, WaitConditionStatus, WakeSource, WorkItemRecord, WorkItemState,
+};
 
 pub(super) fn is_terminal_task_status(status: &TaskStatus) -> bool {
     scheduler::is_terminal_task_status(status)
@@ -64,23 +67,123 @@ impl RuntimeHandle {
             return Ok(());
         }
 
-        self.inner.runtime_db.tasks().upsert(task)?;
-        self.record_task_projection(task).await?;
-        {
-            let mut guard = self.inner.agent.lock().await;
-            if !matches!(guard.state.status, AgentStatus::Stopped) {
-                if guard.state.current_run_id.is_none() {
-                    scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
-                }
-            }
-            guard.persist_state(&self.inner.storage)?;
+        let agent_id = self.agent_id().await?;
+        let mut state = self.agent_state().await?;
+        if !matches!(state.status, AgentStatus::Stopped) && state.current_run_id.is_none() {
+            scheduler::apply_idle_projection(&mut state, &self.inner.storage)?;
         }
+        let mut wait_conditions = Vec::new();
+        let mut work_items = Vec::new();
+        let mut audit_events = Vec::new();
+        let mut index_changes = self.inner.storage.index_changes_for_task(task)?;
         if emit_event {
-            self.inner.storage.append_event(&AuditEvent::new(
+            audit_events.push(AuditEvent::new(
                 transition.event_kind,
                 to_json_value(&TaskLifecycleAuditEvent::from_task(task)),
-            ))?;
+            ));
         }
+        if is_terminal_task_status(&task.status) {
+            let matching = self
+                .inner
+                .storage
+                .active_wait_conditions_for_agent(&agent_id)?
+                .into_iter()
+                .filter(|condition| {
+                    condition.wake_sources.iter().any(|source| {
+                        matches!(source, WakeSource::TaskResult { task_id } if task_id == &task.id)
+                    })
+                })
+                .collect::<Vec<_>>();
+            let now = Utc::now();
+            let mut resolved_ids = Vec::with_capacity(matching.len());
+            let mut updated_work_item_ids = std::collections::BTreeSet::new();
+            for condition in matching {
+                let mut resolved = condition.clone();
+                resolved.status = WaitConditionStatus::Resolved;
+                resolved.updated_at = now;
+                resolved.resolved_at = Some(now);
+                wait_conditions.push(resolved.clone());
+                resolved_ids.push(condition.id);
+                if resolved.kind == WaitConditionKind::Task {
+                    if let Some(work_item_id) = resolved.work_item_id.as_deref() {
+                        if updated_work_item_ids.insert(work_item_id.to_string()) {
+                            if let Some(existing) =
+                                self.inner.runtime_db.work_items().latest(work_item_id)?
+                            {
+                                if existing.state == WorkItemState::Open
+                                    && existing.blocked_by.as_deref()
+                                        == Some(resolved.waiting_for.as_str())
+                                {
+                                    let mut record = WorkItemRecord {
+                                        revision: existing.revision + 1,
+                                        blocked_by: None,
+                                        recheck_at: None,
+                                        recheck_consumed_at: None,
+                                        updated_at: now,
+                                        ..existing.clone()
+                                    };
+                                    let plan_artifact_changed =
+                                        crate::work_item_plan::refresh_plan_artifact_metadata(
+                                            self.agent_home().as_path(),
+                                            &mut record,
+                                        )?;
+                                    if plan_artifact_changed {
+                                        if let Some(event) =
+                                            self.work_item_plan_artifact_refreshed_event(&record)
+                                        {
+                                            audit_events.push(event);
+                                        }
+                                    }
+                                    audit_events.push(self.work_item_written_event(
+                                        "wait_for_task_resolved",
+                                        &record,
+                                        serde_json::json!({
+                                            "wait_condition_id": resolved.id,
+                                        }),
+                                    ));
+                                    index_changes.extend(
+                                        self.inner.storage.index_changes_for_work_item(&record)?,
+                                    );
+                                    work_items.push(
+                                        crate::runtime_db::transitions::WorkItemMutation::Update {
+                                            record,
+                                            expected_revision: existing.revision,
+                                            current_focus: state.current_work_item_id.as_deref()
+                                                == Some(existing.id.as_str()),
+                                        },
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if !resolved_ids.is_empty() {
+                audit_events.push(AuditEvent::new(
+                    "wait_conditions_resolved",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "task_id": task.id,
+                        "reason": "task_result",
+                        "wait_condition_ids": resolved_ids,
+                    }),
+                ));
+            }
+        }
+        let commit = self.inner.runtime_db.transitions().commit_task(
+            &crate::runtime_db::transitions::TaskTransitionCommand {
+                agent_id,
+                task: task.clone(),
+                work_items,
+                wait_conditions,
+                agent_state: Some(state),
+                audit_events,
+                index_changes,
+                notify_scheduler: false,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
         Ok(())
     }
 
@@ -110,7 +213,6 @@ impl RuntimeHandle {
         }
         self.persist_task_transition(&task, "task_result_received")
             .await?;
-        self.resolve_task_wait_conditions(&task.id).await?;
 
         let task_status_label = match task.status {
             TaskStatus::Completed => "completed",

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -2,6 +2,7 @@ use super::{scheduler, *};
 use crate::types::{
     WaitConditionKind, WaitConditionStatus, WakeSource, WorkItemRecord, WorkItemState,
 };
+use sha2::{Digest, Sha256};
 
 pub(super) fn is_terminal_task_status(status: &TaskStatus) -> bool {
     scheduler::is_terminal_task_status(status)
@@ -63,24 +64,42 @@ impl RuntimeHandle {
         emit_event: bool,
     ) -> Result<()> {
         let task = transition.task;
-        if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, task) {
+        let latest_task = self.inner.runtime_db.tasks().latest(&task.id)?;
+        if should_ignore_task_update(latest_task.clone(), task) {
             return Ok(());
         }
+        let task_will_change = latest_task
+            .as_ref()
+            .map(|latest| {
+                crate::runtime_db::repositories::task_transition(latest, task).map(|outcome| {
+                    outcome == crate::runtime_db::repositories::StateTransitionOutcome::Applied
+                })
+            })
+            .transpose()?
+            .unwrap_or(true);
 
         let agent_id = self.agent_id().await?;
         let mut state = self.agent_state().await?;
+        let expected_state = state.clone();
         if !matches!(state.status, AgentStatus::Stopped) && state.current_run_id.is_none() {
             scheduler::apply_idle_projection(&mut state, &self.inner.storage)?;
         }
         let mut wait_conditions = Vec::new();
         let mut work_items = Vec::new();
         let mut audit_events = Vec::new();
-        let mut index_changes = self.inner.storage.index_changes_for_task(task)?;
+        let mut index_changes = Vec::new();
+        if task_will_change {
+            index_changes.extend(self.inner.storage.index_changes_for_task(task)?);
+        }
         if emit_event {
-            audit_events.push(AuditEvent::new(
+            let mut event = AuditEvent::new(
                 transition.event_kind,
                 to_json_value(&TaskLifecycleAuditEvent::from_task(task)),
-            ));
+            );
+            if is_terminal_task_status(&task.status) {
+                event.id = stable_terminal_task_event_id(transition.event_kind, task);
+            }
+            audit_events.push(event);
         }
         if is_terminal_task_status(&task.status) {
             let matching = self
@@ -176,10 +195,16 @@ impl RuntimeHandle {
                 task: task.clone(),
                 work_items,
                 wait_conditions,
-                agent_state: Some(state),
+                agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(expected_state)),
+                    record: Box::new(state),
+                }),
                 audit_events,
                 index_changes,
                 notify_scheduler: false,
+                commit_on_idempotent: emit_event
+                    && !task_will_change
+                    && is_terminal_task_status(&task.status),
                 fault: None,
             },
         )?;
@@ -265,6 +290,30 @@ impl RuntimeHandle {
         }
         Ok(())
     }
+}
+
+fn stable_terminal_task_event_id(event_kind: &str, task: &TaskRecord) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(event_kind.as_bytes());
+    hasher.update([0]);
+    hasher.update(task.id.as_bytes());
+    hasher.update([0]);
+    if let Some(message_id) = task.parent_message_id.as_deref() {
+        hasher.update(message_id.as_bytes());
+    }
+    hasher.update([0]);
+    let status = match task.status {
+        TaskStatus::Queued => "queued",
+        TaskStatus::Running => "running",
+        TaskStatus::Cancelling => "cancelling",
+        TaskStatus::Completed => "completed",
+        TaskStatus::Failed => "failed",
+        TaskStatus::Cancelled => "cancelled",
+        TaskStatus::Interrupted => "interrupted",
+    };
+    hasher.update(status.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("event_{}", &digest[..15])
 }
 
 fn should_emit_task_result_brief(task: &TaskRecord) -> bool {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2534,6 +2534,7 @@ impl RuntimeHandle {
                 }),
             ));
             let mut state = self.agent_state().await?;
+            let expected_state = state.clone();
             let mut agent_state = None;
             let mut current_focus =
                 state.current_work_item_id.as_deref() == Some(record.id.as_str());
@@ -2560,7 +2561,10 @@ impl RuntimeHandle {
                             "revision": record.revision,
                         }),
                     ));
-                    agent_state = Some(state);
+                    agent_state = Some(crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(expected_state)),
+                        record: Box::new(state),
+                    });
                 }
             }
             let commit = self.inner.runtime_db.transitions().commit_work_item(
@@ -2715,6 +2719,7 @@ impl RuntimeHandle {
             }
         }
         let mut state = self.agent_state().await?;
+        let expected_state = state.clone();
         let release_current = state.current_work_item_id.as_deref() == Some(record.id.as_str());
         let release_turn = state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
         if release_current {
@@ -2763,7 +2768,12 @@ impl RuntimeHandle {
                     current_focus: false,
                 }],
                 wait_conditions,
-                agent_state: (release_current || release_turn).then_some(state),
+                agent_state: (release_current || release_turn).then_some(
+                    crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(expected_state)),
+                        record: Box::new(state),
+                    },
+                ),
                 audit_events,
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -9,7 +9,7 @@ use crate::types::{
     FailureArtifact, FailureArtifactCategory, SpawnAgentModelRequest, SpawnAgentModelResolution,
     SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind,
     TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot,
-    TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemContinuationFrame,
+    TaskStatusSnapshot, TodoItem, ToolArtifactRef, WaitConditionStatus, WorkItemContinuationFrame,
     WorkItemContinuationReturnPolicy, WorkItemDelegationRecord, WorkItemDelegationState,
     WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
 };
@@ -2183,9 +2183,21 @@ impl RuntimeHandle {
             .active_workspace_entry
             .map(|entry| entry.workspace_id)
             .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
-        self.record_work_item_projection(&record, None).await?;
-        self.append_work_item_written_event("created", &record, Value::Null)?;
-        self.inner.notify.notify_one();
+        let commit = self.inner.runtime_db.transitions().commit_work_item(
+            &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                agent_id,
+                mutation: crate::runtime_db::transitions::WorkItemMutation::Insert {
+                    record: record.clone(),
+                    current_focus: false,
+                },
+                agent_state: None,
+                audit_events: vec![self.work_item_written_event("created", &record, Value::Null)],
+                index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                notify_scheduler: true,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
         Ok(record)
     }
 
@@ -2504,12 +2516,13 @@ impl RuntimeHandle {
                 &mut record,
             )?;
             record.revision = existing.revision + 1;
-            self.record_work_item_projection(&record, Some(existing.revision))
-                .await?;
+            let mut audit_events = Vec::new();
             if plan_artifact_changed && record.plan_artifact != existing.plan_artifact {
-                self.append_work_item_plan_artifact_refreshed_event(&record)?;
+                if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
+                    audit_events.push(event);
+                }
             }
-            self.append_work_item_written_event(
+            audit_events.push(self.work_item_written_event(
                 "updated",
                 &record,
                 serde_json::json!({
@@ -2519,14 +2532,53 @@ impl RuntimeHandle {
                     ),
                     "objective_changed": previous_objective != record.objective,
                 }),
-            )?;
+            ));
+            let mut state = self.agent_state().await?;
+            let mut agent_state = None;
+            let mut current_focus =
+                state.current_work_item_id.as_deref() == Some(record.id.as_str());
             if let Some(reason) = focus_release_reason {
-                self.release_current_work_item_if_matches(&agent_id, &record, reason)
-                    .await?;
+                let release_current =
+                    state.current_work_item_id.as_deref() == Some(record.id.as_str());
+                let release_turn =
+                    state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
+                if release_current {
+                    state.current_work_item_id = None;
+                    current_focus = false;
+                }
+                if release_turn {
+                    state.current_turn_work_item_id = None;
+                }
+                if release_current || release_turn {
+                    audit_events.push(AuditEvent::new(
+                        "work_item_focus_released",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "work_item_id": record.id.as_str(),
+                            "reason": reason,
+                            "readiness": record.readiness(),
+                            "revision": record.revision,
+                        }),
+                    ));
+                    agent_state = Some(state);
+                }
             }
-        }
-        if wrote_item {
-            self.inner.notify.notify_one();
+            let commit = self.inner.runtime_db.transitions().commit_work_item(
+                &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                    agent_id,
+                    mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                        record: record.clone(),
+                        expected_revision: existing.revision,
+                        current_focus,
+                    },
+                    agent_state,
+                    audit_events,
+                    index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                    notify_scheduler: true,
+                    fault: None,
+                },
+            )?;
+            self.apply_transition_commit(commit).await;
         }
         Ok(record)
     }
@@ -2563,12 +2615,13 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        self.record_work_item_projection(&record, Some(existing.revision))
-            .await?;
+        let mut audit_events = Vec::new();
         if plan_artifact_changed {
-            self.append_work_item_plan_artifact_refreshed_event(&record)?;
+            if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
+                audit_events.push(event);
+            }
         }
-        self.inner.storage.append_event(&AuditEvent::new(
+        audit_events.push(AuditEvent::new(
             "work_item_recheck_consumed",
             serde_json::json!({
                 "work_item_id": record.id.clone(),
@@ -2576,7 +2629,25 @@ impl RuntimeHandle {
                 "recheck_at": record.recheck_at,
                 "recheck_consumed_at": record.recheck_consumed_at,
             }),
-        ))?;
+        ));
+        let state = self.agent_state().await?;
+        let commit = self.inner.runtime_db.transitions().commit_work_item(
+            &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                agent_id,
+                mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: record.clone(),
+                    expected_revision: existing.revision,
+                    current_focus: state.current_work_item_id.as_deref()
+                        == Some(record.id.as_str()),
+                },
+                agent_state: None,
+                audit_events,
+                index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                notify_scheduler: true,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
         Ok(Some(record))
     }
 
@@ -2619,33 +2690,112 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
-        self.record_work_item_projection(&record, Some(existing.revision))
-            .await?;
+        let now = Utc::now();
+        let active_waits = self
+            .inner
+            .storage
+            .raw_active_wait_conditions_for_agent(&agent_id)?
+            .into_iter()
+            .filter(|condition| condition.work_item_id.as_deref() == Some(record.id.as_str()))
+            .collect::<Vec<_>>();
+        let mut wait_conditions = Vec::with_capacity(active_waits.len());
+        let mut cancelled_wait_condition_ids = Vec::with_capacity(active_waits.len());
+        for condition in active_waits {
+            let mut cancelled = condition.clone();
+            cancelled.status = WaitConditionStatus::Cancelled;
+            cancelled.updated_at = now;
+            cancelled.cancelled_at = Some(now);
+            cancelled_wait_condition_ids.push(condition.id);
+            wait_conditions.push(cancelled);
+        }
+        let mut audit_events = Vec::new();
         if plan_artifact_changed {
-            self.append_work_item_plan_artifact_refreshed_event(&record)?;
+            if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
+                audit_events.push(event);
+            }
         }
-        {
-            self.release_current_work_item_if_matches(&agent_id, &record, "work_item_completed")
-                .await?;
+        let mut state = self.agent_state().await?;
+        let release_current = state.current_work_item_id.as_deref() == Some(record.id.as_str());
+        let release_turn = state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
+        if release_current {
+            state.current_work_item_id = None;
         }
-        self.cancel_active_wait_conditions_for_work_item(
-            &agent_id,
-            &record.id,
-            "work_item_completed",
-        )
-        .await?;
-        let continuation_resumed = self
-            .resume_direct_caller_after_work_item_completed(&agent_id, &record)
-            .await?;
-        self.append_work_item_written_event(
+        if release_turn {
+            state.current_turn_work_item_id = None;
+        }
+        if release_current || release_turn {
+            audit_events.push(AuditEvent::new(
+                "work_item_focus_released",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": record.id.as_str(),
+                    "reason": "work_item_completed",
+                    "readiness": record.readiness(),
+                    "revision": record.revision,
+                }),
+            ));
+        }
+        if !cancelled_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::new(
+                "wait_conditions_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": record.id,
+                    "reason": "work_item_completed",
+                    "wait_condition_ids": &cancelled_wait_condition_ids,
+                }),
+            ));
+        }
+        audit_events.push(self.work_item_written_event(
             "completed",
             &record,
             serde_json::json!({
                 "warning_count": warnings.len(),
-                "continuation_resumed": continuation_resumed.clone(),
+                "continuation_resumed": Value::Null,
             }),
+        ));
+        let commit = self.inner.runtime_db.transitions().commit_wait(
+            &crate::runtime_db::transitions::WaitTransitionCommand {
+                agent_id: agent_id.clone(),
+                work_items: vec![crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: record.clone(),
+                    expected_revision: existing.revision,
+                    current_focus: false,
+                }],
+                wait_conditions,
+                agent_state: (release_current || release_turn).then_some(state),
+                audit_events,
+                index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                notify_scheduler: true,
+                fault: None,
+            },
         )?;
-        self.inner.notify.notify_one();
+        self.apply_transition_commit(commit).await;
+        let continuation_resumed = match self
+            .resume_direct_caller_after_work_item_completed(&agent_id, &record)
+            .await
+        {
+            Ok(continuation) => continuation,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    agent_id = %agent_id,
+                    work_item_id = %record.id,
+                    "work item completion committed but continuation post-commit adapter failed"
+                );
+                let _ = self.inner.storage.append_event(&AuditEvent::new(
+                    "runtime_transition_post_commit_warning",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "transition": "work_item_completed",
+                        "work_item_id": record.id,
+                        "effect": "resume_direct_caller",
+                        "error": error.to_string(),
+                    }),
+                ));
+                None
+            }
+        };
         Ok(CompletedWorkItem {
             work_item: record,
             continuation_resumed,
@@ -2720,22 +2870,37 @@ impl RuntimeHandle {
             updated_at: Utc::now(),
             ..existing
         };
-        self.record_work_item_projection(&record, Some(record.revision - 1))
-            .await?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_completion_report_promoted",
-            serde_json::json!({
-                "agent_id": agent_id,
-                "work_item_id": record.id.clone(),
-                "revision": record.revision,
-                "source_turn_index": source_turn_index,
-                "source_round": source_round,
-                "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
-                "warnings": warnings.clone(),
-                "warning_count": warnings.len(),
-                "brief_id": brief.id.clone(),
-            }),
-        ))?;
+        let state = self.agent_state().await?;
+        let commit = self.inner.runtime_db.transitions().commit_work_item(
+            &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                agent_id: agent_id.clone(),
+                mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: record.clone(),
+                    expected_revision: record.revision - 1,
+                    current_focus: state.current_work_item_id.as_deref()
+                        == Some(record.id.as_str()),
+                },
+                agent_state: None,
+                audit_events: vec![AuditEvent::new(
+                    "work_item_completion_report_promoted",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "work_item_id": record.id.clone(),
+                        "revision": record.revision,
+                        "source_turn_index": source_turn_index,
+                        "source_round": source_round,
+                        "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
+                        "warnings": warnings.clone(),
+                        "warning_count": warnings.len(),
+                        "brief_id": brief.id.clone(),
+                    }),
+                )],
+                index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                notify_scheduler: false,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
         Ok(WorkItemCompletionReportPromotionOutcome::Promoted(
             WorkItemCompletionReportPromotion {
                 record,
@@ -2867,51 +3032,6 @@ impl RuntimeHandle {
             ));
         }
         Ok(record)
-    }
-
-    pub(super) async fn release_current_work_item_if_matches(
-        &self,
-        agent_id: &str,
-        record: &WorkItemRecord,
-        reason: &str,
-    ) -> Result<bool> {
-        let released = {
-            let mut guard = self.inner.agent.lock().await;
-            let release_current =
-                guard.state.current_work_item_id.as_deref() == Some(record.id.as_str());
-            let release_turn =
-                guard.state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
-            if !release_current && !release_turn {
-                return Ok(false);
-            }
-            if release_current {
-                guard.state.current_work_item_id = None;
-            }
-            if release_turn {
-                guard.state.current_turn_work_item_id = None;
-            }
-            guard.persist_state(&self.inner.storage)?;
-            release_current || release_turn
-        };
-        if released {
-            self.inner
-                .runtime_db
-                .work_items()
-                .set_current_focus(agent_id, None)?;
-        }
-        if released {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_focus_released",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "work_item_id": record.id.as_str(),
-                    "reason": reason,
-                    "readiness": record.readiness(),
-                    "revision": record.revision,
-                }),
-            ))?;
-        }
-        Ok(released)
     }
 }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1003,6 +1003,99 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
 }
 
 #[tokio::test]
+async fn terminal_task_replay_repairs_active_wait_without_rewriting_task_index() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item("repair task wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            Some(work.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-replay".into()),
+            "waiting for task-replay".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let terminal = TaskRecord {
+        id: "task-replay".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: Some("message-replay".into()),
+        work_item_id: Some(work.id.clone()),
+        summary: Some("task-replay".into()),
+        detail: None,
+        recovery: None,
+    };
+    runtime.storage().append_task(&terminal).unwrap();
+    let before = runtime
+        .inner
+        .runtime_db
+        .runtime_index_outbox()
+        .high_watermark_for_agent("default")
+        .unwrap();
+
+    runtime
+        .reduce_task_result_message(
+            &task_result_message("task-replay"),
+            terminal.clone(),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+    runtime
+        .reduce_task_result_message(&task_result_message("task-replay"), terminal, false, None)
+        .await
+        .unwrap();
+
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    assert_eq!(latest.blocked_by, None);
+    assert!(runtime
+        .storage()
+        .active_wait_conditions_for_work_item("default", &work.id)
+        .unwrap()
+        .is_empty());
+    let changes = runtime
+        .inner
+        .runtime_db
+        .runtime_index_outbox()
+        .read_after("default", before, 20)
+        .unwrap();
+    assert!(changes.iter().all(|change| change.source_kind != "task"));
+    assert_eq!(
+        runtime
+            .storage()
+            .read_recent_events(100)
+            .unwrap()
+            .iter()
+            .filter(|event| event.kind == "task_result_received")
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn message_admission_wakes_asleep_and_booting_agents() {
     for status in [AgentStatus::Asleep, AgentStatus::Booting] {
         let dir = tempdir().unwrap();
@@ -3556,4 +3649,77 @@ async fn post_commit_cache_fault_preserves_durable_transition_and_returns_warnin
             fault != crate::runtime_db::transitions::TransitionFaultPoint::BeforeCacheUpdate
         );
     }
+}
+
+#[tokio::test]
+async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let expected = runtime.agent_state().await.unwrap();
+    let mut committed = expected.clone();
+    committed.pending = 1;
+    let commit = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .commit_queue(&crate::runtime_db::transitions::QueueTransitionCommand {
+            agent_id: "default".into(),
+            mutation: crate::runtime_db::transitions::QueueMutation::Upsert(QueueEntryRecord {
+                message_id: "message-agent-state-race".into(),
+                agent_id: "default".into(),
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Queued,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }),
+            agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                expected: Some(Box::new(expected)),
+                record: Box::new(committed),
+            }),
+            transcript_entries: Vec::new(),
+            audit_events: Vec::new(),
+            notify_scheduler: false,
+            fault: None,
+        })
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.last_wake_reason = Some("newer-memory-state".into());
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    let result = runtime.apply_transition_commit(commit).await;
+
+    assert!(result
+        .warnings
+        .iter()
+        .any(|warning| warning.effect == "agent_state_projection_update"));
+    assert_eq!(
+        runtime
+            .agent_state()
+            .await
+            .unwrap()
+            .last_wake_reason
+            .as_deref(),
+        Some("newer-memory-state")
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .agent_states()
+            .latest("default")
+            .unwrap(),
+        Some(runtime.agent_state().await.unwrap())
+    );
 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3,7 +3,8 @@ use super::support::*;
 use crate::types::{
     ActiveSkillRecord, AuthorityClass, QueueEntryStatus, SkillActivationSource,
     SkillActivationState, SkillLoadReason, SkillScope, WaitConditionKind, WaitConditionRecord,
-    WaitConditionStatus, WakeSource, WorkItemPlanStatus, WorkItemSchedulingState,
+    WaitConditionStatus, WakeSource, WorkItemPlanStatus, WorkItemRecord, WorkItemSchedulingState,
+    WorkItemState,
 };
 
 struct BlockingProvider {
@@ -3381,6 +3382,57 @@ async fn register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits() {
 }
 
 #[tokio::test]
+async fn agent_scoped_wait_replacement_preserves_work_item_scoped_waits() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("scoped wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let scoped = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id),
+            WaitForWakeKind::External,
+            Some("github:test/repo#1".into()),
+            "scoped external wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let agent_wait = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "agent operator wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(agent_wait.cancelled_wait_condition_ids.is_empty());
+    let active = runtime
+        .storage()
+        .active_wait_conditions_for_agent("default")
+        .unwrap();
+    assert!(active.iter().any(|wait| wait.id == scoped.condition.id));
+    assert!(active.iter().any(|wait| wait.id == agent_wait.condition.id));
+}
+
+#[tokio::test]
 async fn stop_agent_revokes_active_external_triggers() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -3423,4 +3475,85 @@ async fn stop_agent_revokes_active_external_triggers() {
         .find(|t| t.external_trigger_id == capability.external_trigger_id)
         .expect("trigger should still exist");
     assert_eq!(revoked.status, crate::types::ExternalTriggerStatus::Revoked);
+}
+
+#[tokio::test]
+async fn post_commit_cache_fault_preserves_durable_transition_and_returns_warning() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    for (index, (fault, expected_effect)) in [
+        (
+            crate::runtime_db::transitions::TransitionFaultPoint::BeforeCacheUpdate,
+            "projection_cache_update",
+        ),
+        (
+            crate::runtime_db::transitions::TransitionFaultPoint::BeforeEventPublication,
+            "event_publication",
+        ),
+        (
+            crate::runtime_db::transitions::TransitionFaultPoint::BeforeSchedulerNotification,
+            "scheduler_notification",
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut record = WorkItemRecord::new("default", "post-commit fault", WorkItemState::Open);
+        record.id = format!("work-post-commit-fault-{index}");
+        let commit = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .commit_work_item(&crate::runtime_db::transitions::WorkItemTransitionCommand {
+                agent_id: "default".into(),
+                mutation: crate::runtime_db::transitions::WorkItemMutation::Insert {
+                    record: record.clone(),
+                    current_focus: false,
+                },
+                agent_state: None,
+                audit_events: vec![AuditEvent::new(
+                    "post_commit_fault_test",
+                    serde_json::json!({}),
+                )],
+                index_changes: Vec::new(),
+                notify_scheduler: true,
+                fault: Some(fault),
+            })
+            .unwrap();
+
+        let applied = runtime.apply_transition_commit(commit).await;
+
+        assert!(applied.applied);
+        assert_eq!(applied.warnings.len(), 1);
+        assert_eq!(applied.warnings[0].effect, expected_effect);
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .work_items()
+                .latest(&record.id)
+                .unwrap(),
+            Some(record.clone())
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .projection_cache
+                .lock()
+                .await
+                .work_items
+                .contains_key(&record.id),
+            fault != crate::runtime_db::transitions::TransitionFaultPoint::BeforeCacheUpdate
+        );
+    }
 }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -338,75 +338,96 @@ impl RuntimeHandle {
         round: usize,
         boundary: &str,
     ) -> Result<Vec<String>> {
-        let mut messages = Vec::new();
-        {
-            let mut guard = self.inner.agent.lock().await;
-            while let Some(message) = guard
-                .queue
-                .pop_next_matching(scheduler::is_operator_interjection_message)
-            {
-                guard.state.pending = guard.queue.len();
-                messages.push(message);
-            }
-            if !messages.is_empty() {
-                if let Err(err) = guard.persist_state(&self.inner.storage) {
-                    for message in messages.iter().rev().cloned() {
-                        guard.queue.push_front(message);
-                    }
-                    guard.state.pending = guard.queue.len();
-                    return Err(err);
-                }
-            }
-        }
-
         let mut follow_up_texts = Vec::new();
-        for (index, message) in messages.iter().enumerate() {
-            let persist_result = async {
-                self.record_incoming_transcript_entry(message)?;
-                let text = render_operator_interjection_text(message);
-                self.commit_queue_settlement(
-                    QueueEntryRecord {
+        loop {
+            let committed = {
+                let mut guard = self.inner.agent.lock().await;
+                let Some(message) = guard
+                    .queue
+                    .peek_next_matching(scheduler::is_operator_interjection_message)
+                    .cloned()
+                else {
+                    break;
+                };
+                let expected_state = guard.state.clone();
+                let mut committed_state = expected_state.clone();
+                committed_state.pending = guard.queue.len().saturating_sub(1);
+                let text = render_operator_interjection_text(&message);
+                let transcript = TranscriptEntry::new(
+                    message.agent_id.clone(),
+                    TranscriptEntryKind::IncomingMessage,
+                    None,
+                    Some(message.id.clone()),
+                    serde_json::json!({
+                        "authority_class": message.authority_class,
+                        "delivery_surface": message.delivery_surface,
+                        "admission_context": message.admission_context,
+                        "trigger_kind": message.trigger_kind,
+                        "work_item_id": message.work_item_id.clone(),
+                        "task_id": message.task_id.clone(),
+                        "source_refs": message.source_refs.clone(),
+                        "correlation_id": message.correlation_id.clone(),
+                        "causation_id": message.causation_id.clone(),
+                    }),
+                );
+                let queue_record = QueueEntryRecord {
                     message_id: message.id.clone(),
                     agent_id: message.agent_id.clone(),
                     priority: message.priority.clone(),
                     status: QueueEntryStatus::Interjected,
                     created_at: message.created_at,
                     updated_at: chrono::Utc::now(),
-                    },
-                    vec![AuditEvent::new(
-                        "operator_interjection_admitted",
-                        serde_json::json!({
-                            "agent_id": agent_id,
-                            "round": round,
-                            "boundary": boundary,
-                            "message_id": message.id,
-                            "origin": message.origin,
-                            "authority_class": message.authority_class,
-                            "priority": message.priority,
-                            "delivery_surface": message.delivery_surface,
-                            "admission_context": message.admission_context,
-                            "text_preview": truncate_preview(&message_text(&message.body), ROUND_TEXT_PREVIEW_LIMIT),
+                };
+                let audit_event = AuditEvent::new(
+                    "operator_interjection_admitted",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "round": round,
+                        "boundary": boundary,
+                        "message_id": message.id,
+                        "origin": message.origin,
+                        "authority_class": message.authority_class,
+                        "priority": message.priority,
+                        "delivery_surface": message.delivery_surface,
+                        "admission_context": message.admission_context,
+                        "text_preview": truncate_preview(
+                            &message_text(&message.body),
+                            ROUND_TEXT_PREVIEW_LIMIT
+                        ),
+                    }),
+                );
+                let mut commit = self.inner.runtime_db.transitions().commit_queue(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: message.agent_id.clone(),
+                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
+                            queue_record,
+                        ),
+                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                            expected: Some(Box::new(expected_state)),
+                            record: Box::new(committed_state.clone()),
                         }),
-                    )],
-                    false,
-                )
-                .await?;
-                Ok::<_, anyhow::Error>(text)
-            }
-            .await;
-
-            match persist_result {
-                Ok(text) => follow_up_texts.push(text),
-                Err(err) => {
-                    let mut guard = self.inner.agent.lock().await;
-                    for message in messages[index..].iter().rev().cloned() {
-                        guard.queue.push_front(message);
-                    }
-                    guard.state.pending = guard.queue.len();
-                    let _ = guard.persist_state(&self.inner.storage);
-                    return Err(err);
+                        transcript_entries: vec![transcript],
+                        audit_events: vec![audit_event],
+                        notify_scheduler: false,
+                        fault: None,
+                    },
+                )?;
+                if !commit.applied {
+                    return Err(anyhow::anyhow!(
+                        "interjection settlement made no durable progress"
+                    ));
                 }
-            }
+                guard
+                    .queue
+                    .pop_next_matching(|candidate| candidate.id == message.id)
+                    .expect("peeked interjection remains queued while agent lock is held");
+                guard.state = committed_state.clone();
+                guard.last_persisted_state = committed_state;
+                commit.effects.agent_state = None;
+                (text, commit)
+            };
+            self.apply_transition_commit(committed.1).await;
+            follow_up_texts.push(committed.0);
         }
         Ok(follow_up_texts)
     }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -361,34 +361,39 @@ impl RuntimeHandle {
 
         let mut follow_up_texts = Vec::new();
         for (index, message) in messages.iter().enumerate() {
-            let persist_result = (|| -> Result<String> {
-                self.inner.storage.append_queue_entry(&QueueEntryRecord {
+            let persist_result = async {
+                self.record_incoming_transcript_entry(message)?;
+                let text = render_operator_interjection_text(message);
+                self.commit_queue_settlement(
+                    QueueEntryRecord {
                     message_id: message.id.clone(),
                     agent_id: message.agent_id.clone(),
                     priority: message.priority.clone(),
                     status: QueueEntryStatus::Interjected,
                     created_at: message.created_at,
                     updated_at: chrono::Utc::now(),
-                })?;
-                self.record_incoming_transcript_entry(message)?;
-                let text = render_operator_interjection_text(message);
-                self.inner.storage.append_event(&AuditEvent::new(
-                    "operator_interjection_admitted",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "round": round,
-                        "boundary": boundary,
-                        "message_id": message.id,
-                        "origin": message.origin,
-                        "authority_class": message.authority_class,
-                        "priority": message.priority,
-                        "delivery_surface": message.delivery_surface,
-                        "admission_context": message.admission_context,
-                        "text_preview": truncate_preview(&message_text(&message.body), ROUND_TEXT_PREVIEW_LIMIT),
-                    }),
-                ))?;
-                Ok(text)
-            })();
+                    },
+                    vec![AuditEvent::new(
+                        "operator_interjection_admitted",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "round": round,
+                            "boundary": boundary,
+                            "message_id": message.id,
+                            "origin": message.origin,
+                            "authority_class": message.authority_class,
+                            "priority": message.priority,
+                            "delivery_surface": message.delivery_surface,
+                            "admission_context": message.admission_context,
+                            "text_preview": truncate_preview(&message_text(&message.body), ROUND_TEXT_PREVIEW_LIMIT),
+                        }),
+                    )],
+                    false,
+                )
+                .await?;
+                Ok::<_, anyhow::Error>(text)
+            }
+            .await;
 
             match persist_result {
                 Ok(text) => follow_up_texts.push(text),

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -73,6 +73,7 @@ impl RuntimeHandle {
         let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone())?;
         let recheck_at = recheck_after_ms.map(|delay| recheck_at_from(now, delay));
         let mut state = self.agent_state().await?;
+        let expected_state = state.clone();
         let current_turn_id = state.current_turn_id.clone();
         let mut work_item = None;
         let active_waits = if let Some(work_item_id) = work_item_id.as_deref() {
@@ -229,7 +230,12 @@ impl RuntimeHandle {
                 agent_id: agent_id.to_string(),
                 work_items,
                 wait_conditions,
-                agent_state: committed_agent_state,
+                agent_state: committed_agent_state.map(|record| {
+                    crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(expected_state)),
+                        record: Box::new(record),
+                    }
+                }),
                 audit_events,
                 index_changes,
                 notify_scheduler: true,

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -69,16 +69,52 @@ impl RuntimeHandle {
             return Err(anyhow!("wait_for agent mismatch: {}", agent_id));
         }
 
-        let current_turn_id = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.current_turn_id.clone()
-        };
-
         let now = Utc::now();
         let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone())?;
         let recheck_at = recheck_after_ms.map(|delay| recheck_at_from(now, delay));
+        let mut state = self.agent_state().await?;
+        let current_turn_id = state.current_turn_id.clone();
         let mut work_item = None;
-        let cancelled_wait_condition_ids;
+        let active_waits = if let Some(work_item_id) = work_item_id.as_deref() {
+            self.inner
+                .storage
+                .raw_active_wait_conditions_for_agent(agent_id)?
+                .into_iter()
+                .filter(|record| record.work_item_id.as_deref() == Some(work_item_id))
+                .collect::<Vec<_>>()
+        } else {
+            self.inner
+                .storage
+                .active_wait_conditions_for_agent(agent_id)?
+                .into_iter()
+                .filter(|record| record.work_item_id.is_none())
+                .collect()
+        };
+        let mut wait_conditions = Vec::with_capacity(active_waits.len() + 1);
+        let mut cancelled_wait_condition_ids = Vec::with_capacity(active_waits.len());
+        for existing in active_waits {
+            let mut cancelled = existing.clone();
+            cancelled.status = WaitConditionStatus::Cancelled;
+            cancelled.updated_at = now;
+            cancelled.cancelled_at = Some(now);
+            cancelled_wait_condition_ids.push(existing.id);
+            wait_conditions.push(cancelled);
+        }
+        let mut work_items = Vec::new();
+        let mut audit_events = Vec::new();
+        let mut index_changes = Vec::new();
+        let mut committed_agent_state = None;
+        if !cancelled_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::new(
+                "wait_conditions_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": work_item_id,
+                    "reason": "wait_for_replaced",
+                    "wait_condition_ids": &cancelled_wait_condition_ids,
+                }),
+            ));
+        }
         if let Some(work_item_id) = work_item_id.as_deref() {
             let existing = self.validate_owned_work_item(agent_id, work_item_id)?;
             if existing.state != WorkItemState::Open {
@@ -87,25 +123,56 @@ impl RuntimeHandle {
                     work_item_id
                 ));
             }
-            cancelled_wait_condition_ids = self
-                .cancel_active_wait_conditions_for_work_item(
-                    agent_id,
-                    work_item_id,
-                    "wait_for_replaced",
-                )
-                .await?;
-            let updated = self
-                .write_wait_for_work_item_blocker(existing, &reason, recheck_at)
-                .await?;
-            self.clear_current_turn_work_item_if_matches(agent_id, &updated, "work_item_waiting")
-                .await?;
+            let mut updated = existing.clone();
+            if existing.blocked_by.as_deref() != Some(reason.as_str())
+                || existing.recheck_at != recheck_at
+                || existing.recheck_consumed_at.is_some()
+            {
+                updated = WorkItemRecord {
+                    revision: existing.revision + 1,
+                    blocked_by: Some(reason.clone()),
+                    recheck_at,
+                    recheck_consumed_at: None,
+                    updated_at: now,
+                    ..existing.clone()
+                };
+                let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+                    self.agent_home().as_path(),
+                    &mut updated,
+                )?;
+                if plan_artifact_changed {
+                    if let Some(event) = self.work_item_plan_artifact_refreshed_event(&updated) {
+                        audit_events.push(event);
+                    }
+                }
+                audit_events.push(self.work_item_written_event(
+                    "wait_for_blocked",
+                    &updated,
+                    Value::Null,
+                ));
+                index_changes.extend(self.inner.storage.index_changes_for_work_item(&updated)?);
+                work_items.push(crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: updated.clone(),
+                    expected_revision: existing.revision,
+                    current_focus: state.current_work_item_id.as_deref()
+                        == Some(updated.id.as_str()),
+                });
+            }
+            if state.current_turn_work_item_id.as_deref() == Some(updated.id.as_str()) {
+                state.current_turn_work_item_id = None;
+                audit_events.push(AuditEvent::new(
+                    "work_item_turn_binding_released",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "work_item_id": updated.id.as_str(),
+                        "reason": "work_item_waiting",
+                        "readiness": updated.readiness(),
+                        "revision": updated.revision,
+                    }),
+                ));
+                committed_agent_state = Some(state.clone());
+            }
             work_item = Some(updated);
-        } else {
-            // Agent-scoped wait: cancel prior active agent-scoped waits,
-            // symmetric with the work-item-scoped branch above.
-            cancelled_wait_condition_ids = self
-                .cancel_active_wait_conditions_for_agent(agent_id, "wait_for_replaced")
-                .await?;
         }
 
         let condition = WaitConditionRecord {
@@ -137,8 +204,13 @@ impl RuntimeHandle {
             cancelled_at: None,
             turn_id: current_turn_id,
         };
-        self.inner.storage.append_wait_condition(&condition)?;
-        self.inner.storage.append_event(&AuditEvent::new(
+        wait_conditions.push(condition.clone());
+        audit_events.extend(
+            self.inner
+                .storage
+                .wait_condition_auxiliary_events(&condition),
+        );
+        audit_events.push(AuditEvent::new(
             "wait_condition_registered",
             serde_json::json!({
                 "agent_id": agent_id,
@@ -151,8 +223,20 @@ impl RuntimeHandle {
                 "wake_sources": &condition.wake_sources,
                 "cancelled_wait_condition_ids": &cancelled_wait_condition_ids,
             }),
-        ))?;
-        self.inner.notify.notify_one();
+        ));
+        let commit = self.inner.runtime_db.transitions().commit_wait(
+            &crate::runtime_db::transitions::WaitTransitionCommand {
+                agent_id: agent_id.to_string(),
+                work_items,
+                wait_conditions,
+                agent_state: committed_agent_state,
+                audit_events,
+                index_changes,
+                notify_scheduler: true,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
 
         Ok(WaitForRegistration {
             scope: if condition.work_item_id.is_some() {
@@ -168,284 +252,99 @@ impl RuntimeHandle {
         })
     }
 
-    pub(super) async fn cancel_active_wait_conditions_for_work_item(
-        &self,
-        agent_id: &str,
-        work_item_id: &str,
-        reason: &str,
-    ) -> Result<Vec<String>> {
-        let now = Utc::now();
-        // Use raw (unfiltered) active waits: filter_active_wait_conditions_for_live_scope
-        // hides waits whose WorkItem is Completed, but this cancel path is called
-        // AFTER the WorkItem is already marked Completed during completion. Using
-        // the filtered path would find nothing to cancel, leaving orphaned waits.
-        let active = self
-            .inner
-            .storage
-            .raw_active_wait_conditions_for_agent(agent_id)?
-            .into_iter()
-            .filter(|record| record.work_item_id.as_deref() == Some(work_item_id))
-            .collect::<Vec<_>>();
-        let mut cancelled = Vec::new();
-        for condition in active {
-            let mut cancelled_condition = condition.clone();
-            cancelled_condition.status = WaitConditionStatus::Cancelled;
-            cancelled_condition.updated_at = now;
-            cancelled_condition.cancelled_at = Some(now);
-            self.inner
-                .storage
-                .append_wait_condition(&cancelled_condition)?;
-            cancelled.push(condition.id);
-        }
-        if !cancelled.is_empty() {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "wait_conditions_cancelled",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "work_item_id": work_item_id,
-                    "reason": reason,
-                    "wait_condition_ids": cancelled,
-                }),
-            ))?;
-        }
-        Ok(cancelled)
-    }
-
-    pub(super) async fn cancel_active_wait_conditions_for_agent(
-        &self,
-        agent_id: &str,
-        reason: &str,
-    ) -> Result<Vec<String>> {
-        let now = Utc::now();
-        let active = self
-            .inner
-            .storage
-            .active_wait_conditions_for_agent(agent_id)?;
-        let mut cancelled = Vec::new();
-        for condition in active {
-            let mut cancelled_condition = condition.clone();
-            cancelled_condition.status = WaitConditionStatus::Cancelled;
-            cancelled_condition.updated_at = now;
-            cancelled_condition.cancelled_at = Some(now);
-            self.inner
-                .storage
-                .append_wait_condition(&cancelled_condition)?;
-            cancelled.push(condition.id);
-        }
-        if !cancelled.is_empty() {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "wait_conditions_cancelled",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "reason": reason,
-                    "wait_condition_ids": cancelled,
-                }),
-            ))?;
-        }
-        Ok(cancelled)
-    }
-
-    pub(super) async fn resolve_task_wait_conditions(&self, task_id: &str) -> Result<Vec<String>> {
-        let agent_id = self.agent_id().await?;
-        let active_conditions = self
-            .inner
-            .storage
-            .active_wait_conditions_for_agent(&agent_id)?;
-        let matching = active_conditions
-            .into_iter()
-            .filter(|condition| {
-                condition.wake_sources.iter().any(|source| {
-                    matches!(source, WakeSource::TaskResult { task_id: id } if id == task_id)
-                })
-            })
-            .collect::<Vec<_>>();
-        if matching.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let now = Utc::now();
-        let mut resolved_ids = Vec::new();
-        for condition in matching {
-            let mut resolved = condition.clone();
-            resolved.status = WaitConditionStatus::Resolved;
-            resolved.updated_at = now;
-            resolved.resolved_at = Some(now);
-            self.inner.storage.append_wait_condition(&resolved)?;
-            if resolved.kind == WaitConditionKind::Task {
-                self.clear_wait_for_blocker_after_task_result(&resolved)
-                    .await?;
-            }
-            resolved_ids.push(condition.id);
-        }
-        self.inner.storage.append_event(&AuditEvent::new(
-            "wait_conditions_resolved",
-            serde_json::json!({
-                "agent_id": agent_id,
-                "task_id": task_id,
-                "reason": "task_result",
-                "wait_condition_ids": &resolved_ids,
-            }),
-        ))?;
-        self.inner.notify.notify_one();
-        Ok(resolved_ids)
-    }
-
-    async fn write_wait_for_work_item_blocker(
-        &self,
-        existing: WorkItemRecord,
-        reason: &str,
-        recheck_at: Option<DateTime<Utc>>,
-    ) -> Result<WorkItemRecord> {
-        if existing.blocked_by.as_deref() == Some(reason)
-            && existing.recheck_at == recheck_at
-            && existing.recheck_consumed_at.is_none()
-        {
-            return Ok(existing);
-        }
-        let mut record = WorkItemRecord {
-            revision: existing.revision + 1,
-            blocked_by: Some(reason.to_string()),
-            recheck_at,
-            recheck_consumed_at: None,
-            updated_at: Utc::now(),
-            ..existing
-        };
-        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
-            self.agent_home().as_path(),
-            &mut record,
-        )?;
-        self.record_work_item_projection(&record, Some(record.revision - 1))
-            .await?;
-        if plan_artifact_changed {
-            self.append_work_item_plan_artifact_refreshed_event(&record)?;
-        }
-        self.append_work_item_written_event("wait_for_blocked", &record, Value::Null)?;
-        Ok(record)
-    }
-
-    async fn clear_current_turn_work_item_if_matches(
-        &self,
-        agent_id: &str,
-        record: &WorkItemRecord,
-        reason: &str,
-    ) -> Result<bool> {
-        let released = {
-            let mut guard = self.inner.agent.lock().await;
-            if guard.state.current_turn_work_item_id.as_deref() != Some(record.id.as_str()) {
-                return Ok(false);
-            }
-            guard.state.current_turn_work_item_id = None;
-            guard.persist_state(&self.inner.storage)?;
-            true
-        };
-        if released {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_turn_binding_released",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "work_item_id": record.id.as_str(),
-                    "reason": reason,
-                    "readiness": record.readiness(),
-                    "revision": record.revision,
-                }),
-            ))?;
-        }
-        Ok(released)
-    }
-
-    async fn clear_wait_for_blocker_after_task_result(
-        &self,
-        condition: &WaitConditionRecord,
-    ) -> Result<()> {
-        let Some(work_item_id) = condition.work_item_id.as_deref() else {
-            return Ok(());
-        };
-        let Some(existing) = self.inner.runtime_db.work_items().latest(work_item_id)? else {
-            return Ok(());
-        };
-        if existing.state != WorkItemState::Open {
-            return Ok(());
-        }
-        if existing.blocked_by.as_deref() != Some(condition.waiting_for.as_str()) {
-            return Ok(());
-        }
-        let mut record = WorkItemRecord {
-            revision: existing.revision + 1,
-            blocked_by: None,
-            recheck_at: None,
-            recheck_consumed_at: None,
-            updated_at: Utc::now(),
-            ..existing
-        };
-        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
-            self.agent_home().as_path(),
-            &mut record,
-        )?;
-        self.record_work_item_projection(&record, Some(record.revision - 1))
-            .await?;
-        if plan_artifact_changed {
-            self.append_work_item_plan_artifact_refreshed_event(&record)?;
-        }
-        self.append_work_item_written_event(
-            "wait_for_task_resolved",
-            &record,
-            serde_json::json!({
-                "wait_condition_id": condition.id,
-            }),
-        )?;
-        Ok(())
-    }
-
     pub(super) async fn clear_work_item_blocker_for_pick(
         &self,
         agent_id: &str,
         existing: WorkItemRecord,
         reason: &str,
     ) -> Result<WorkItemBlockerClearance> {
-        let cancelled_wait_condition_ids = self
-            .cancel_active_wait_conditions_for_work_item(
-                agent_id,
-                &existing.id,
-                "pick_work_item_clear_blocker",
-            )
-            .await?;
+        let now = Utc::now();
+        let active_waits = self
+            .inner
+            .storage
+            .raw_active_wait_conditions_for_agent(agent_id)?
+            .into_iter()
+            .filter(|condition| condition.work_item_id.as_deref() == Some(existing.id.as_str()))
+            .collect::<Vec<_>>();
+        let mut wait_conditions = Vec::with_capacity(active_waits.len());
+        let mut cancelled_wait_condition_ids = Vec::with_capacity(active_waits.len());
+        for condition in active_waits {
+            let mut cancelled = condition.clone();
+            cancelled.status = WaitConditionStatus::Cancelled;
+            cancelled.updated_at = now;
+            cancelled.cancelled_at = Some(now);
+            cancelled_wait_condition_ids.push(condition.id);
+            wait_conditions.push(cancelled);
+        }
         let needs_record_write = existing.blocked_by.is_some()
             || existing.recheck_at.is_some()
             || existing.recheck_consumed_at.is_some();
-        if !needs_record_write {
-            return Ok(WorkItemBlockerClearance {
-                work_item: existing,
-                blocker_cleared: !cancelled_wait_condition_ids.is_empty(),
-                cancelled_wait_condition_ids,
-            });
+        if !needs_record_write && wait_conditions.is_empty() {
+            return Ok(WorkItemBlockerClearance::unchanged(existing));
         }
 
-        let mut record = WorkItemRecord {
-            revision: existing.revision + 1,
-            blocked_by: None,
-            recheck_at: None,
-            recheck_consumed_at: None,
-            updated_at: Utc::now(),
-            ..existing
-        };
-        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
-            self.agent_home().as_path(),
-            &mut record,
-        )?;
-        self.record_work_item_projection(&record, Some(record.revision - 1))
-            .await?;
-        if plan_artifact_changed {
-            self.append_work_item_plan_artifact_refreshed_event(&record)?;
+        let mut audit_events = Vec::new();
+        if !cancelled_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::new(
+                "wait_conditions_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": existing.id,
+                    "reason": "pick_work_item_clear_blocker",
+                    "wait_condition_ids": &cancelled_wait_condition_ids,
+                }),
+            ));
         }
-        self.append_work_item_written_event(
-            "pick_blocker_cleared",
-            &record,
-            serde_json::json!({
-                "reason": reason,
-                "cancelled_wait_condition_ids": cancelled_wait_condition_ids.clone(),
-            }),
+        let mut record = existing.clone();
+        let mut work_items = Vec::new();
+        let mut index_changes = Vec::new();
+        if needs_record_write {
+            record = WorkItemRecord {
+                revision: existing.revision + 1,
+                blocked_by: None,
+                recheck_at: None,
+                recheck_consumed_at: None,
+                updated_at: now,
+                ..existing.clone()
+            };
+            let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+                self.agent_home().as_path(),
+                &mut record,
+            )?;
+            if plan_artifact_changed {
+                if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
+                    audit_events.push(event);
+                }
+            }
+            audit_events.push(self.work_item_written_event(
+                "pick_blocker_cleared",
+                &record,
+                serde_json::json!({
+                    "reason": reason,
+                    "cancelled_wait_condition_ids": cancelled_wait_condition_ids.clone(),
+                }),
+            ));
+            let state = self.agent_state().await?;
+            work_items.push(crate::runtime_db::transitions::WorkItemMutation::Update {
+                record: record.clone(),
+                expected_revision: existing.revision,
+                current_focus: state.current_work_item_id.as_deref() == Some(existing.id.as_str()),
+            });
+            index_changes = self.inner.storage.index_changes_for_work_item(&record)?;
+        }
+        let commit = self.inner.runtime_db.transitions().commit_wait(
+            &crate::runtime_db::transitions::WaitTransitionCommand {
+                agent_id: agent_id.to_string(),
+                work_items,
+                wait_conditions,
+                agent_state: None,
+                audit_events,
+                index_changes,
+                notify_scheduler: true,
+                fault: None,
+            },
         )?;
-        self.inner.notify.notify_one();
+        self.apply_transition_commit(commit).await;
         Ok(WorkItemBlockerClearance {
             work_item: record,
             blocker_cleared: true,

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -15,6 +15,7 @@ pub mod evidence;
 pub mod migrations;
 pub mod repositories;
 pub mod storage_domain;
+pub(crate) mod transitions;
 pub mod types;
 pub mod write_queue;
 

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1072,7 +1072,7 @@ impl TaskRepository<'_> {
             .run_storage_domain_import("tasks", "jsonl", "db", |tx| {
                 let latest = reduce_task_records(records);
                 for record in latest.values() {
-                    upsert_task_tx(tx, record)?;
+                    let _ = upsert_task_tx(tx, record)?;
                 }
                 let active_records = latest
                     .values()
@@ -1086,7 +1086,8 @@ impl TaskRepository<'_> {
     }
 
     pub fn upsert(&self, record: &TaskRecord) -> Result<()> {
-        self.db.transaction(|tx| upsert_task_tx(tx, record))
+        self.db
+            .transaction(|tx| upsert_task_tx(tx, record).map(|_| ()))
     }
 
     pub fn upsert_with_index_changes(
@@ -1095,7 +1096,7 @@ impl TaskRepository<'_> {
         changes: &[RuntimeIndexChange],
     ) -> Result<()> {
         self.db.transaction(|tx| {
-            upsert_task_tx(tx, record)?;
+            let _ = upsert_task_tx(tx, record)?;
             insert_runtime_index_changes_tx(tx, changes)
         })
     }
@@ -1218,7 +1219,7 @@ impl WaitConditionRepository<'_> {
                 let mut imported_ids = BTreeMap::<String, ()>::new();
                 for record in records {
                     imported_ids.insert(record.id.clone(), ());
-                    upsert_wait_condition_tx(tx, &record)?;
+                    let _ = upsert_wait_condition_tx(tx, &record)?;
                 }
                 Ok(serde_json::json!({ "imported_records": imported_ids.len() }))
             })
@@ -1226,7 +1227,7 @@ impl WaitConditionRepository<'_> {
 
     pub fn upsert(&self, record: &WaitConditionRecord) -> Result<()> {
         self.db
-            .transaction(|tx| upsert_wait_condition_tx(tx, record))
+            .transaction(|tx| upsert_wait_condition_tx(tx, record).map(|_| ()))
     }
 
     pub fn latest_all(&self) -> Result<Vec<WaitConditionRecord>> {
@@ -1348,14 +1349,15 @@ impl QueueEntryRepository<'_> {
                 let mut imported_ids = BTreeMap::<String, ()>::new();
                 for record in records {
                     imported_ids.insert(record.message_id.clone(), ());
-                    upsert_queue_entry_tx(tx, &record)?;
+                    let _ = upsert_queue_entry_tx(tx, &record)?;
                 }
                 Ok(serde_json::json!({ "imported_records": imported_ids.len() }))
             })
     }
 
     pub fn upsert(&self, record: &QueueEntryRecord) -> Result<()> {
-        self.db.transaction(|tx| upsert_queue_entry_tx(tx, record))
+        self.db
+            .transaction(|tx| upsert_queue_entry_tx(tx, record).map(|_| ()))
     }
 
     pub fn try_claim_queued_message(&self, record: &QueueEntryRecord) -> Result<bool> {
@@ -2786,7 +2788,7 @@ fn upsert_operator_delivery_record_tx(
     Ok(())
 }
 
-fn insert_new_work_item_tx(
+pub(crate) fn insert_new_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
     current_focus: bool,
@@ -2824,7 +2826,7 @@ fn insert_new_work_item_tx(
     Ok(true)
 }
 
-fn update_expected_work_item_tx(
+pub(crate) fn update_expected_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
     expected_revision: u64,
@@ -3033,7 +3035,7 @@ fn import_work_item_tx(
     Ok(())
 }
 
-fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
+pub(crate) fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<bool> {
     let existing = tx
         .query_row(
             "SELECT payload_json FROM tasks WHERE task_id = ?1",
@@ -3046,7 +3048,7 @@ fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
     if let Some(existing) = existing.as_ref() {
         match task_transition(existing, record)? {
             StateTransitionOutcome::Applied => {}
-            StateTransitionOutcome::Idempotent => return Ok(()),
+            StateTransitionOutcome::Idempotent => return Ok(false),
         }
     }
 
@@ -3121,7 +3123,7 @@ fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
             status_phase,
         ],
     )?;
-    Ok(())
+    Ok(true)
 }
 
 pub(crate) fn task_status_phase(status: &TaskStatus) -> u8 {
@@ -3136,7 +3138,10 @@ pub(crate) fn task_status_phase(status: &TaskStatus) -> u8 {
     }
 }
 
-fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) -> Result<()> {
+pub(crate) fn upsert_wait_condition_tx(
+    tx: &Transaction<'_>,
+    record: &WaitConditionRecord,
+) -> Result<bool> {
     let existing = tx
         .query_row(
             "SELECT payload_json FROM wait_conditions WHERE wait_condition_id = ?1",
@@ -3149,7 +3154,7 @@ fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) 
     if let Some(existing) = existing.as_ref() {
         match wait_condition_transition(existing, record)? {
             StateTransitionOutcome::Applied => {}
-            StateTransitionOutcome::Idempotent => return Ok(()),
+            StateTransitionOutcome::Idempotent => return Ok(false),
         }
     }
 
@@ -3207,10 +3212,13 @@ fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) 
             payload_json,
         ],
     )?;
-    Ok(())
+    Ok(true)
 }
 
-fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<()> {
+pub(crate) fn upsert_queue_entry_tx(
+    tx: &Transaction<'_>,
+    record: &QueueEntryRecord,
+) -> Result<bool> {
     let existing = tx
         .query_row(
             "SELECT payload_json FROM queue_entries WHERE message_id = ?1",
@@ -3223,7 +3231,7 @@ fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Res
     if let Some(existing) = existing.as_ref() {
         match queue_entry_transition(existing, record)? {
             StateTransitionOutcome::Applied => {}
-            StateTransitionOutcome::Idempotent => return Ok(()),
+            StateTransitionOutcome::Idempotent => return Ok(false),
         }
     }
 
@@ -3252,16 +3260,22 @@ fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Res
             payload_json,
         ],
     )?;
-    Ok(())
+    Ok(true)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StateTransitionOutcome {
+pub(crate) enum StateTransitionOutcome {
     Applied,
     Idempotent,
 }
 
-fn task_transition(existing: &TaskRecord, incoming: &TaskRecord) -> Result<StateTransitionOutcome> {
+pub(crate) fn task_transition(
+    existing: &TaskRecord,
+    incoming: &TaskRecord,
+) -> Result<StateTransitionOutcome> {
+    if existing == incoming {
+        return Ok(StateTransitionOutcome::Idempotent);
+    }
     if is_terminal_task_status(&existing.status) {
         if is_terminal_task_status(&incoming.status) && task_terminal_payload_eq(existing, incoming)
         {
@@ -3284,10 +3298,13 @@ fn task_transition(existing: &TaskRecord, incoming: &TaskRecord) -> Result<State
     Ok(StateTransitionOutcome::Applied)
 }
 
-fn queue_entry_transition(
+pub(crate) fn queue_entry_transition(
     existing: &QueueEntryRecord,
     incoming: &QueueEntryRecord,
 ) -> Result<StateTransitionOutcome> {
+    if existing == incoming {
+        return Ok(StateTransitionOutcome::Idempotent);
+    }
     if is_terminal_queue_entry_status(&existing.status) {
         if is_terminal_queue_entry_status(&incoming.status)
             && queue_entry_terminal_payload_eq(existing, incoming)
@@ -3308,10 +3325,13 @@ fn queue_entry_transition(
     Ok(StateTransitionOutcome::Applied)
 }
 
-fn wait_condition_transition(
+pub(crate) fn wait_condition_transition(
     existing: &WaitConditionRecord,
     incoming: &WaitConditionRecord,
 ) -> Result<StateTransitionOutcome> {
+    if existing == incoming {
+        return Ok(StateTransitionOutcome::Idempotent);
+    }
     if is_terminal_wait_condition_status(&existing.status) {
         if is_terminal_wait_condition_status(&incoming.status)
             && wait_condition_terminal_payload_eq(existing, incoming)
@@ -3415,7 +3435,10 @@ fn canonical_task_terminal_detail(value: &serde_json::Value) -> serde_json::Valu
     }
 }
 
-fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<bool> {
+pub(crate) fn try_claim_queued_message_tx(
+    tx: &Transaction<'_>,
+    record: &QueueEntryRecord,
+) -> Result<bool> {
     let queued_status = enum_string(&QueueEntryStatus::Queued)?;
     let interrupted_status = enum_string(&QueueEntryStatus::Interrupted)?;
     let mut claimed = record.clone();

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -1,0 +1,798 @@
+//! Restricted runtime business-transition unit of work.
+
+use anyhow::{anyhow, Result};
+use rusqlite::{OptionalExtension, Transaction};
+
+use crate::{
+    runtime_db::{
+        evidence::{append_audit_event_tx, insert_runtime_index_changes_tx, upsert_agent_state_tx},
+        repositories::{
+            insert_new_work_item_tx, queue_entry_transition, task_transition,
+            try_claim_queued_message_tx, update_expected_work_item_tx, upsert_queue_entry_tx,
+            upsert_task_tx, upsert_wait_condition_tx, wait_condition_transition,
+        },
+        RuntimeDb, RuntimeIndexChange,
+    },
+    types::{
+        AgentState, AuditEvent, QueueEntryRecord, TaskRecord, WaitConditionRecord, WorkItemRecord,
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransitionFaultPoint {
+    AfterValidation,
+    AfterCanonicalWrites,
+    AfterAuditWrites,
+    BeforeCommit,
+    BeforeCacheUpdate,
+    BeforeEventPublication,
+    BeforeSchedulerNotification,
+}
+
+impl TransitionFaultPoint {
+    fn is_post_commit(self) -> bool {
+        matches!(
+            self,
+            Self::BeforeCacheUpdate
+                | Self::BeforeEventPublication
+                | Self::BeforeSchedulerNotification
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PostCommitWarning {
+    pub effect: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum WorkItemMutation {
+    Insert {
+        record: WorkItemRecord,
+        current_focus: bool,
+    },
+    Update {
+        record: WorkItemRecord,
+        expected_revision: u64,
+        current_focus: bool,
+    },
+}
+
+impl WorkItemMutation {
+    fn record(&self) -> &WorkItemRecord {
+        match self {
+            Self::Insert { record, .. } | Self::Update { record, .. } => record,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum QueueMutation {
+    Claim(QueueEntryRecord),
+    Upsert(QueueEntryRecord),
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PostCommitEffects {
+    pub agent_state: Option<AgentState>,
+    pub work_items: Vec<WorkItemRecord>,
+    pub tasks: Vec<TaskRecord>,
+    pub audit_events: Vec<AuditEvent>,
+    pub notify_memory_index: bool,
+    pub notify_scheduler: bool,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TransitionCommit {
+    pub applied: bool,
+    pub effects: PostCommitEffects,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TransitionApplyResult {
+    pub applied: bool,
+    pub warnings: Vec<PostCommitWarning>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkItemTransitionCommand {
+    pub agent_id: String,
+    pub mutation: WorkItemMutation,
+    pub agent_state: Option<AgentState>,
+    pub audit_events: Vec<AuditEvent>,
+    pub index_changes: Vec<RuntimeIndexChange>,
+    pub notify_scheduler: bool,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WaitTransitionCommand {
+    pub agent_id: String,
+    pub work_items: Vec<WorkItemMutation>,
+    pub wait_conditions: Vec<WaitConditionRecord>,
+    pub agent_state: Option<AgentState>,
+    pub audit_events: Vec<AuditEvent>,
+    pub index_changes: Vec<RuntimeIndexChange>,
+    pub notify_scheduler: bool,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueueTransitionCommand {
+    pub agent_id: String,
+    pub mutation: QueueMutation,
+    pub agent_state: Option<AgentState>,
+    pub audit_events: Vec<AuditEvent>,
+    pub notify_scheduler: bool,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskTransitionCommand {
+    pub agent_id: String,
+    pub task: TaskRecord,
+    pub work_items: Vec<WorkItemMutation>,
+    pub wait_conditions: Vec<WaitConditionRecord>,
+    pub agent_state: Option<AgentState>,
+    pub audit_events: Vec<AuditEvent>,
+    pub index_changes: Vec<RuntimeIndexChange>,
+    pub notify_scheduler: bool,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+pub(crate) struct RuntimeTransitionRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+impl RuntimeDb {
+    pub(crate) fn transitions(&self) -> RuntimeTransitionRepository<'_> {
+        RuntimeTransitionRepository { db: self }
+    }
+}
+
+impl RuntimeTransitionRepository<'_> {
+    pub fn commit_work_item(
+        &self,
+        command: &WorkItemTransitionCommand,
+    ) -> Result<TransitionCommit> {
+        let record = command.mutation.record().clone();
+        self.db.transaction(|tx| {
+            validate_work_item_mutation_tx(tx, &command.mutation)?;
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+            let applied = apply_work_item_mutation_tx(tx, &command.mutation)?;
+            if !applied {
+                return Ok(TransitionCommit::default());
+            }
+            if let Some(agent_state) = command.agent_state.as_ref() {
+                upsert_agent_state_tx(tx, agent_state)?;
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+            finish_transition_tx(
+                tx,
+                applied,
+                &command.agent_id,
+                &command.audit_events,
+                &command.index_changes,
+                command.fault,
+                PostCommitEffects {
+                    agent_state: command.agent_state.clone(),
+                    work_items: applied.then_some(record.clone()).into_iter().collect(),
+                    notify_scheduler: command.notify_scheduler,
+                    ..PostCommitEffects::default()
+                },
+            )
+        })
+    }
+
+    pub fn commit_wait(&self, command: &WaitTransitionCommand) -> Result<TransitionCommit> {
+        self.db.transaction(|tx| {
+            for work_item in &command.work_items {
+                validate_work_item_mutation_tx(tx, work_item)?;
+            }
+            for condition in &command.wait_conditions {
+                validate_wait_condition_tx(tx, condition)?;
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+
+            let mut applied = false;
+            let mut work_items = Vec::new();
+            for work_item in &command.work_items {
+                let work_item_applied = apply_work_item_mutation_tx(tx, work_item)?;
+                applied |= work_item_applied;
+                if work_item_applied {
+                    work_items.push(work_item.record().clone());
+                }
+            }
+            for condition in &command.wait_conditions {
+                applied |= upsert_wait_condition_tx(tx, condition)?;
+            }
+            if !applied {
+                return Ok(TransitionCommit::default());
+            }
+            if let Some(agent_state) = command.agent_state.as_ref() {
+                upsert_agent_state_tx(tx, agent_state)?;
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+
+            finish_transition_tx(
+                tx,
+                applied,
+                &command.agent_id,
+                &command.audit_events,
+                &command.index_changes,
+                command.fault,
+                PostCommitEffects {
+                    agent_state: command.agent_state.clone(),
+                    work_items,
+                    notify_scheduler: command.notify_scheduler,
+                    ..PostCommitEffects::default()
+                },
+            )
+        })
+    }
+
+    pub fn commit_queue(&self, command: &QueueTransitionCommand) -> Result<TransitionCommit> {
+        self.db.transaction(|tx| {
+            validate_queue_mutation_tx(tx, &command.mutation)?;
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+            let applied = match &command.mutation {
+                QueueMutation::Claim(record) => try_claim_queued_message_tx(tx, record)?,
+                QueueMutation::Upsert(record) => upsert_queue_entry_tx(tx, record)?,
+            };
+            if !applied {
+                return Ok(TransitionCommit::default());
+            }
+            if let Some(agent_state) = command.agent_state.as_ref() {
+                upsert_agent_state_tx(tx, agent_state)?;
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+            finish_transition_tx(
+                tx,
+                applied,
+                &command.agent_id,
+                &command.audit_events,
+                &[],
+                command.fault,
+                PostCommitEffects {
+                    agent_state: command.agent_state.clone(),
+                    notify_scheduler: command.notify_scheduler,
+                    ..PostCommitEffects::default()
+                },
+            )
+        })
+    }
+
+    pub fn commit_task(&self, command: &TaskTransitionCommand) -> Result<TransitionCommit> {
+        self.db.transaction(|tx| {
+            validate_task_tx(tx, &command.task)?;
+            for work_item in &command.work_items {
+                validate_work_item_mutation_tx(tx, work_item)?;
+            }
+            for condition in &command.wait_conditions {
+                validate_wait_condition_tx(tx, condition)?;
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+
+            let task_applied = upsert_task_tx(tx, &command.task)?;
+            let mut applied = task_applied;
+            let mut work_items = Vec::new();
+            for work_item in &command.work_items {
+                let work_item_applied = apply_work_item_mutation_tx(tx, work_item)?;
+                applied |= work_item_applied;
+                if work_item_applied {
+                    work_items.push(work_item.record().clone());
+                }
+            }
+            for condition in &command.wait_conditions {
+                applied |= upsert_wait_condition_tx(tx, condition)?;
+            }
+            if !applied {
+                return Ok(TransitionCommit::default());
+            }
+            if let Some(agent_state) = command.agent_state.as_ref() {
+                upsert_agent_state_tx(tx, agent_state)?;
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+
+            finish_transition_tx(
+                tx,
+                applied,
+                &command.agent_id,
+                &command.audit_events,
+                &command.index_changes,
+                command.fault,
+                PostCommitEffects {
+                    agent_state: command.agent_state.clone(),
+                    work_items,
+                    tasks: task_applied
+                        .then_some(command.task.clone())
+                        .into_iter()
+                        .collect(),
+                    notify_scheduler: command.notify_scheduler,
+                    ..PostCommitEffects::default()
+                },
+            )
+        })
+    }
+}
+
+fn finish_transition_tx(
+    tx: &Transaction<'_>,
+    applied: bool,
+    agent_id: &str,
+    audit_events: &[AuditEvent],
+    index_changes: &[RuntimeIndexChange],
+    fault: Option<TransitionFaultPoint>,
+    mut effects: PostCommitEffects,
+) -> Result<TransitionCommit> {
+    if !applied {
+        return Ok(TransitionCommit::default());
+    }
+
+    let mut committed_events = Vec::with_capacity(audit_events.len());
+    for event in audit_events {
+        committed_events.push(append_audit_event_tx(tx, Some(agent_id), event)?.0);
+    }
+    inject_fault(fault, TransitionFaultPoint::AfterAuditWrites)?;
+    insert_runtime_index_changes_tx(tx, index_changes)?;
+    inject_fault(fault, TransitionFaultPoint::BeforeCommit)?;
+
+    effects.audit_events = committed_events;
+    effects.notify_memory_index = !index_changes.is_empty();
+    effects.fault = fault.filter(|point| point.is_post_commit());
+    Ok(TransitionCommit {
+        applied: true,
+        effects,
+    })
+}
+
+fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<()> {
+    match mutation {
+        WorkItemMutation::Insert { record, .. } => {
+            if record.revision != 1 {
+                return Err(anyhow!(
+                    "work item {} insert requires revision 1",
+                    record.id
+                ));
+            }
+            let existing = tx
+                .query_row(
+                    "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+                    [&record.id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            if let Some(payload) = existing {
+                if payload != serde_json::to_string(record)? {
+                    insert_new_work_item_tx(tx, record, false)?;
+                }
+            }
+        }
+        WorkItemMutation::Update {
+            record,
+            expected_revision,
+            ..
+        } => {
+            let existing = tx
+                .query_row(
+                    "SELECT revision, payload_json FROM work_items WHERE work_item_id = ?1",
+                    [&record.id],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            let Some((actual_revision, payload)) = existing else {
+                update_expected_work_item_tx(tx, record, *expected_revision, false)?;
+                return Ok(());
+            };
+            let actual_revision = u64::try_from(actual_revision)?;
+            if actual_revision != *expected_revision
+                && !(actual_revision == record.revision
+                    && payload == serde_json::to_string(record)?)
+            {
+                update_expected_work_item_tx(tx, record, *expected_revision, false)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<bool> {
+    match mutation {
+        WorkItemMutation::Insert {
+            record,
+            current_focus,
+        } => {
+            let existing = tx
+                .query_row(
+                    "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+                    [&record.id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            if existing.as_deref() == Some(serde_json::to_string(record)?.as_str()) {
+                Ok(false)
+            } else {
+                insert_new_work_item_tx(tx, record, *current_focus)
+            }
+        }
+        WorkItemMutation::Update {
+            record,
+            expected_revision,
+            current_focus,
+        } => update_expected_work_item_tx(tx, record, *expected_revision, *current_focus),
+    }
+}
+
+fn validate_task_tx(tx: &Transaction<'_>, incoming: &TaskRecord) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM tasks WHERE task_id = ?1",
+            [&incoming.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<TaskRecord>(&payload))
+        .transpose()?;
+    if let Some(existing) = existing.as_ref() {
+        task_transition(existing, incoming)?;
+    }
+    Ok(())
+}
+
+fn validate_wait_condition_tx(tx: &Transaction<'_>, incoming: &WaitConditionRecord) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM wait_conditions WHERE wait_condition_id = ?1",
+            [&incoming.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<WaitConditionRecord>(&payload))
+        .transpose()?;
+    if let Some(existing) = existing.as_ref() {
+        wait_condition_transition(existing, incoming)?;
+    }
+    Ok(())
+}
+
+fn validate_queue_mutation_tx(tx: &Transaction<'_>, mutation: &QueueMutation) -> Result<()> {
+    let incoming = match mutation {
+        QueueMutation::Claim(record) | QueueMutation::Upsert(record) => record,
+    };
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM queue_entries WHERE message_id = ?1",
+            [&incoming.message_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<QueueEntryRecord>(&payload))
+        .transpose()?;
+    if let (QueueMutation::Upsert(_), Some(existing)) = (mutation, existing.as_ref()) {
+        queue_entry_transition(existing, incoming)?;
+    }
+    Ok(())
+}
+
+fn inject_fault(
+    configured: Option<TransitionFaultPoint>,
+    current: TransitionFaultPoint,
+) -> Result<()> {
+    if configured == Some(current) {
+        return Err(anyhow!("injected runtime transition fault at {current:?}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        runtime_db::{RuntimeIndexChange, RuntimeIndexOperation},
+        types::{
+            Priority, QueueEntryStatus, TaskKind, TaskStatus, WaitConditionKind,
+            WaitConditionStatus, WakeSource, WorkItemState,
+        },
+    };
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn runtime_db() -> Result<(TempDir, RuntimeDb)> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )?;
+        Ok((dir, db))
+    }
+
+    fn index_change(kind: &str, id: &str) -> RuntimeIndexChange {
+        RuntimeIndexChange {
+            agent_id: "agent-a".into(),
+            source_kind: kind.into(),
+            source_id: id.into(),
+            source_ref: format!("{kind}:{id}"),
+            operation: RuntimeIndexOperation::Upsert,
+            source_updated_at: Some(Utc::now()),
+            reason: "transition_test".into(),
+        }
+    }
+
+    fn work_item(id: &str) -> WorkItemRecord {
+        let mut record = WorkItemRecord::new("agent-a", "transition test", WorkItemState::Open);
+        record.id = id.into();
+        record
+    }
+
+    fn wait_condition(id: &str, work_item_id: &str, task_id: &str) -> WaitConditionRecord {
+        let now = Utc::now();
+        WaitConditionRecord {
+            id: id.into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some(work_item_id.into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Task,
+            source: Some("test".into()),
+            subject_ref: Some(task_id.into()),
+            waiting_for: "waiting for task".into(),
+            wake_sources: vec![WakeSource::TaskResult {
+                task_id: task_id.into(),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        }
+    }
+
+    fn task(id: &str, status: TaskStatus) -> TaskRecord {
+        let now = Utc::now();
+        TaskRecord {
+            id: id.into(),
+            agent_id: "agent-a".into(),
+            kind: TaskKind::CommandTask,
+            status,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: Some("work-task".into()),
+            summary: Some("transition task".into()),
+            detail: None,
+            recovery: None,
+        }
+    }
+
+    #[test]
+    fn work_item_transition_faults_roll_back_all_durable_facts() -> Result<()> {
+        for fault in [
+            TransitionFaultPoint::AfterValidation,
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let record = work_item("work-fault");
+            let error = db
+                .transitions()
+                .commit_work_item(&WorkItemTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    mutation: WorkItemMutation::Insert {
+                        record: record.clone(),
+                        current_focus: false,
+                    },
+                    agent_state: None,
+                    audit_events: vec![AuditEvent::new("work_item_test", serde_json::json!({}))],
+                    index_changes: vec![index_change("work_item", &record.id)],
+                    notify_scheduler: true,
+                    fault: Some(fault),
+                })
+                .unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("injected runtime transition fault"));
+            assert!(db.work_items().latest(&record.id)?.is_none());
+            assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+            assert_eq!(
+                db.runtime_index_outbox()
+                    .high_watermark_for_agent("agent-a")?,
+                0
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_transition_replay_does_not_duplicate_audit_or_outbox() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let record = work_item("work-replay");
+        let command = WorkItemTransitionCommand {
+            agent_id: "agent-a".into(),
+            mutation: WorkItemMutation::Insert {
+                record: record.clone(),
+                current_focus: false,
+            },
+            agent_state: None,
+            audit_events: vec![AuditEvent::new("work_item_test", serde_json::json!({}))],
+            index_changes: vec![index_change("work_item", &record.id)],
+            notify_scheduler: true,
+            fault: None,
+        };
+        assert!(db.transitions().commit_work_item(&command)?.applied);
+        assert!(!db.transitions().commit_work_item(&command)?.applied);
+        assert_eq!(db.audit_events().recent(Some("agent-a"), 10)?.len(), 1);
+        assert_eq!(
+            db.runtime_index_outbox()
+                .read_after("agent-a", 0, 10)?
+                .len(),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wait_transition_rolls_back_work_item_wait_audit_and_outbox_together() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let initial = work_item("work-wait");
+        db.work_items().insert_new(&initial, false)?;
+        let mut blocked = initial.clone();
+        blocked.revision = 2;
+        blocked.blocked_by = Some("waiting for task".into());
+        blocked.updated_at = Utc::now();
+        let wait = wait_condition("wait-1", &initial.id, "task-1");
+
+        db.transitions()
+            .commit_wait(&WaitTransitionCommand {
+                agent_id: "agent-a".into(),
+                work_items: vec![WorkItemMutation::Update {
+                    record: blocked,
+                    expected_revision: 1,
+                    current_focus: false,
+                }],
+                wait_conditions: vec![wait],
+                agent_state: None,
+                audit_events: vec![AuditEvent::new("wait_registered", serde_json::json!({}))],
+                index_changes: vec![index_change("work_item", &initial.id)],
+                notify_scheduler: true,
+                fault: Some(TransitionFaultPoint::AfterAuditWrites),
+            })
+            .unwrap_err();
+
+        assert_eq!(db.work_items().latest(&initial.id)?.unwrap(), initial);
+        assert!(db.wait_conditions().latest_all()?.is_empty());
+        assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+        assert_eq!(
+            db.runtime_index_outbox()
+                .high_watermark_for_agent("agent-a")?,
+            0
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn queue_settlement_fault_preserves_claimable_queue_entry() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-1".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&queued)?;
+        let mut processed = queued.clone();
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at = now + chrono::Duration::seconds(1);
+
+        db.transitions()
+            .commit_queue(&QueueTransitionCommand {
+                agent_id: "agent-a".into(),
+                mutation: QueueMutation::Upsert(processed),
+                agent_state: None,
+                audit_events: vec![AuditEvent::new("queue_settled", serde_json::json!({}))],
+                notify_scheduler: true,
+                fault: Some(TransitionFaultPoint::BeforeCommit),
+            })
+            .unwrap_err();
+
+        let latest = db.queue_entries().latest_all()?;
+        assert_eq!(latest.len(), 1);
+        assert_eq!(latest[0].status, QueueEntryStatus::Queued);
+        assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_task_wait_release_is_atomic_and_idempotent() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let mut initial_work = work_item("work-task");
+        initial_work.blocked_by = Some("waiting for task".into());
+        db.work_items().insert_new(&initial_work, false)?;
+        let active_wait = wait_condition("wait-task", &initial_work.id, "task-1");
+        db.wait_conditions().upsert(&active_wait)?;
+        let running = task("task-1", TaskStatus::Running);
+        db.tasks().upsert(&running)?;
+
+        let mut terminal = running.clone();
+        terminal.status = TaskStatus::Completed;
+        terminal.updated_at += chrono::Duration::seconds(1);
+        let mut resolved = active_wait.clone();
+        resolved.status = WaitConditionStatus::Resolved;
+        resolved.updated_at = terminal.updated_at;
+        resolved.resolved_at = Some(terminal.updated_at);
+        let mut cleared = initial_work.clone();
+        cleared.revision = 2;
+        cleared.blocked_by = None;
+        cleared.updated_at = terminal.updated_at;
+        let command = TaskTransitionCommand {
+            agent_id: "agent-a".into(),
+            task: terminal.clone(),
+            work_items: vec![WorkItemMutation::Update {
+                record: cleared.clone(),
+                expected_revision: 1,
+                current_focus: false,
+            }],
+            wait_conditions: vec![resolved],
+            agent_state: None,
+            audit_events: vec![
+                AuditEvent::new("task_terminal", serde_json::json!({})),
+                AuditEvent::new("wait_resolved", serde_json::json!({})),
+            ],
+            index_changes: vec![
+                index_change("task", &terminal.id),
+                index_change("work_item", &cleared.id),
+            ],
+            notify_scheduler: true,
+            fault: Some(TransitionFaultPoint::AfterCanonicalWrites),
+        };
+        db.transitions().commit_task(&command).unwrap_err();
+        assert_eq!(
+            db.tasks().latest(&running.id)?.unwrap().status,
+            TaskStatus::Running
+        );
+        assert_eq!(
+            db.work_items().latest(&initial_work.id)?.unwrap(),
+            initial_work
+        );
+        assert_eq!(
+            db.wait_conditions().latest_all()?[0].status,
+            WaitConditionStatus::Active
+        );
+        assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+        assert_eq!(
+            db.runtime_index_outbox()
+                .high_watermark_for_agent("agent-a")?,
+            0
+        );
+
+        let command = TaskTransitionCommand {
+            fault: None,
+            ..command
+        };
+        assert!(db.transitions().commit_task(&command)?.applied);
+        assert!(!db.transitions().commit_task(&command)?.applied);
+        assert_eq!(
+            db.tasks().latest(&terminal.id)?.unwrap().status,
+            TaskStatus::Completed
+        );
+        assert_eq!(db.work_items().latest(&cleared.id)?.unwrap(), cleared);
+        assert_eq!(
+            db.wait_conditions().latest_all()?[0].status,
+            WaitConditionStatus::Resolved
+        );
+        assert_eq!(db.audit_events().recent(Some("agent-a"), 10)?.len(), 2);
+        assert_eq!(
+            db.runtime_index_outbox()
+                .read_after("agent-a", 0, 10)?
+                .len(),
+            2
+        );
+        Ok(())
+    }
+}

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -5,7 +5,10 @@ use rusqlite::{OptionalExtension, Transaction};
 
 use crate::{
     runtime_db::{
-        evidence::{append_audit_event_tx, insert_runtime_index_changes_tx, upsert_agent_state_tx},
+        evidence::{
+            append_audit_event_tx, append_transcript_entry_tx, insert_runtime_index_changes_tx,
+            upsert_agent_state_tx,
+        },
         repositories::{
             insert_new_work_item_tx, queue_entry_transition, task_transition,
             try_claim_queued_message_tx, update_expected_work_item_tx, upsert_queue_entry_tx,
@@ -14,7 +17,8 @@ use crate::{
         RuntimeDb, RuntimeIndexChange,
     },
     types::{
-        AgentState, AuditEvent, QueueEntryRecord, TaskRecord, WaitConditionRecord, WorkItemRecord,
+        AgentState, AuditEvent, QueueEntryRecord, TaskRecord, TranscriptEntry, WaitConditionRecord,
+        WorkItemRecord,
     },
 };
 
@@ -75,13 +79,19 @@ pub(crate) enum QueueMutation {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PostCommitEffects {
-    pub agent_state: Option<AgentState>,
+    pub agent_state: Option<AgentStateMutation>,
     pub work_items: Vec<WorkItemRecord>,
     pub tasks: Vec<TaskRecord>,
     pub audit_events: Vec<AuditEvent>,
     pub notify_memory_index: bool,
     pub notify_scheduler: bool,
     pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AgentStateMutation {
+    pub expected: Option<Box<AgentState>>,
+    pub record: Box<AgentState>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -100,7 +110,7 @@ pub(crate) struct TransitionApplyResult {
 pub(crate) struct WorkItemTransitionCommand {
     pub agent_id: String,
     pub mutation: WorkItemMutation,
-    pub agent_state: Option<AgentState>,
+    pub agent_state: Option<AgentStateMutation>,
     pub audit_events: Vec<AuditEvent>,
     pub index_changes: Vec<RuntimeIndexChange>,
     pub notify_scheduler: bool,
@@ -112,7 +122,7 @@ pub(crate) struct WaitTransitionCommand {
     pub agent_id: String,
     pub work_items: Vec<WorkItemMutation>,
     pub wait_conditions: Vec<WaitConditionRecord>,
-    pub agent_state: Option<AgentState>,
+    pub agent_state: Option<AgentStateMutation>,
     pub audit_events: Vec<AuditEvent>,
     pub index_changes: Vec<RuntimeIndexChange>,
     pub notify_scheduler: bool,
@@ -123,7 +133,8 @@ pub(crate) struct WaitTransitionCommand {
 pub(crate) struct QueueTransitionCommand {
     pub agent_id: String,
     pub mutation: QueueMutation,
-    pub agent_state: Option<AgentState>,
+    pub agent_state: Option<AgentStateMutation>,
+    pub transcript_entries: Vec<TranscriptEntry>,
     pub audit_events: Vec<AuditEvent>,
     pub notify_scheduler: bool,
     pub fault: Option<TransitionFaultPoint>,
@@ -135,10 +146,11 @@ pub(crate) struct TaskTransitionCommand {
     pub task: TaskRecord,
     pub work_items: Vec<WorkItemMutation>,
     pub wait_conditions: Vec<WaitConditionRecord>,
-    pub agent_state: Option<AgentState>,
+    pub agent_state: Option<AgentStateMutation>,
     pub audit_events: Vec<AuditEvent>,
     pub index_changes: Vec<RuntimeIndexChange>,
     pub notify_scheduler: bool,
+    pub commit_on_idempotent: bool,
     pub fault: Option<TransitionFaultPoint>,
 }
 
@@ -160,13 +172,14 @@ impl RuntimeTransitionRepository<'_> {
         let record = command.mutation.record().clone();
         self.db.transaction(|tx| {
             validate_work_item_mutation_tx(tx, &command.mutation)?;
+            validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
-            let applied = apply_work_item_mutation_tx(tx, &command.mutation)?;
+            let mut applied = apply_work_item_mutation_tx(tx, &command.mutation)?;
+            let agent_state_applied =
+                apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            applied |= agent_state_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
-            }
-            if let Some(agent_state) = command.agent_state.as_ref() {
-                upsert_agent_state_tx(tx, agent_state)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
             finish_transition_tx(
@@ -177,7 +190,9 @@ impl RuntimeTransitionRepository<'_> {
                 &command.index_changes,
                 command.fault,
                 PostCommitEffects {
-                    agent_state: command.agent_state.clone(),
+                    agent_state: agent_state_applied
+                        .then(|| command.agent_state.clone())
+                        .flatten(),
                     work_items: applied.then_some(record.clone()).into_iter().collect(),
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
@@ -194,6 +209,7 @@ impl RuntimeTransitionRepository<'_> {
             for condition in &command.wait_conditions {
                 validate_wait_condition_tx(tx, condition)?;
             }
+            validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
             let mut applied = false;
@@ -208,11 +224,11 @@ impl RuntimeTransitionRepository<'_> {
             for condition in &command.wait_conditions {
                 applied |= upsert_wait_condition_tx(tx, condition)?;
             }
+            let agent_state_applied =
+                apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            applied |= agent_state_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
-            }
-            if let Some(agent_state) = command.agent_state.as_ref() {
-                upsert_agent_state_tx(tx, agent_state)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
 
@@ -224,7 +240,9 @@ impl RuntimeTransitionRepository<'_> {
                 &command.index_changes,
                 command.fault,
                 PostCommitEffects {
-                    agent_state: command.agent_state.clone(),
+                    agent_state: agent_state_applied
+                        .then(|| command.agent_state.clone())
+                        .flatten(),
                     work_items,
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
@@ -236,16 +254,20 @@ impl RuntimeTransitionRepository<'_> {
     pub fn commit_queue(&self, command: &QueueTransitionCommand) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_queue_mutation_tx(tx, &command.mutation)?;
+            validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
-            let applied = match &command.mutation {
+            let mut applied = match &command.mutation {
                 QueueMutation::Claim(record) => try_claim_queued_message_tx(tx, record)?,
                 QueueMutation::Upsert(record) => upsert_queue_entry_tx(tx, record)?,
             };
+            let agent_state_applied =
+                apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            applied |= agent_state_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
-            if let Some(agent_state) = command.agent_state.as_ref() {
-                upsert_agent_state_tx(tx, agent_state)?;
+            for entry in &command.transcript_entries {
+                append_transcript_entry_tx(tx, entry)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
             finish_transition_tx(
@@ -256,7 +278,9 @@ impl RuntimeTransitionRepository<'_> {
                 &[],
                 command.fault,
                 PostCommitEffects {
-                    agent_state: command.agent_state.clone(),
+                    agent_state: agent_state_applied
+                        .then(|| command.agent_state.clone())
+                        .flatten(),
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
                 },
@@ -273,6 +297,7 @@ impl RuntimeTransitionRepository<'_> {
             for condition in &command.wait_conditions {
                 validate_wait_condition_tx(tx, condition)?;
             }
+            validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
             let task_applied = upsert_task_tx(tx, &command.task)?;
@@ -288,11 +313,12 @@ impl RuntimeTransitionRepository<'_> {
             for condition in &command.wait_conditions {
                 applied |= upsert_wait_condition_tx(tx, condition)?;
             }
+            let agent_state_applied =
+                apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            applied |= agent_state_applied;
+            applied |= command.commit_on_idempotent;
             if !applied {
                 return Ok(TransitionCommit::default());
-            }
-            if let Some(agent_state) = command.agent_state.as_ref() {
-                upsert_agent_state_tx(tx, agent_state)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
 
@@ -304,7 +330,9 @@ impl RuntimeTransitionRepository<'_> {
                 &command.index_changes,
                 command.fault,
                 PostCommitEffects {
-                    agent_state: command.agent_state.clone(),
+                    agent_state: agent_state_applied
+                        .then(|| command.agent_state.clone())
+                        .flatten(),
                     work_items,
                     tasks: task_applied
                         .then_some(command.task.clone())
@@ -333,7 +361,10 @@ fn finish_transition_tx(
 
     let mut committed_events = Vec::with_capacity(audit_events.len());
     for event in audit_events {
-        committed_events.push(append_audit_event_tx(tx, Some(agent_id), event)?.0);
+        let (event, inserted) = append_audit_event_tx(tx, Some(agent_id), event)?;
+        if inserted {
+            committed_events.push(event);
+        }
     }
     inject_fault(fault, TransitionFaultPoint::AfterAuditWrites)?;
     insert_runtime_index_changes_tx(tx, index_changes)?;
@@ -346,6 +377,50 @@ fn finish_transition_tx(
         applied: true,
         effects,
     })
+}
+
+fn agent_state_tx(tx: &Transaction<'_>, agent_id: &str) -> Result<Option<AgentState>> {
+    tx.query_row(
+        "SELECT payload_json FROM agent_states WHERE agent_id = ?1",
+        [agent_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|payload| serde_json::from_str(&payload).map_err(Into::into))
+    .transpose()
+}
+
+fn validate_agent_state_mutation_tx(
+    tx: &Transaction<'_>,
+    mutation: Option<&AgentStateMutation>,
+) -> Result<()> {
+    let Some(mutation) = mutation else {
+        return Ok(());
+    };
+    if let Some(expected) = mutation.expected.as_ref() {
+        let actual = agent_state_tx(tx, &mutation.record.id)?;
+        if actual.as_ref() != Some(expected.as_ref()) {
+            return Err(anyhow!(
+                "agent state {} changed before runtime transition commit",
+                mutation.record.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn apply_agent_state_mutation_tx(
+    tx: &Transaction<'_>,
+    mutation: Option<&AgentStateMutation>,
+) -> Result<bool> {
+    let Some(mutation) = mutation else {
+        return Ok(false);
+    };
+    if agent_state_tx(tx, &mutation.record.id)?.as_ref() == Some(mutation.record.as_ref()) {
+        return Ok(false);
+    }
+    upsert_agent_state_tx(tx, mutation.record.as_ref())?;
+    Ok(true)
 }
 
 fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<()> {
@@ -675,36 +750,60 @@ mod tests {
 
     #[test]
     fn queue_settlement_fault_preserves_claimable_queue_entry() -> Result<()> {
-        let (_dir, db) = runtime_db()?;
-        let now = Utc::now();
-        let queued = QueueEntryRecord {
-            message_id: "message-1".into(),
-            agent_id: "agent-a".into(),
-            priority: Priority::Normal,
-            status: QueueEntryStatus::Queued,
-            created_at: now,
-            updated_at: now,
-        };
-        db.queue_entries().upsert(&queued)?;
-        let mut processed = queued.clone();
-        processed.status = QueueEntryStatus::Processed;
-        processed.updated_at = now + chrono::Duration::seconds(1);
-
-        db.transitions()
-            .commit_queue(&QueueTransitionCommand {
+        for fault in [
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let now = Utc::now();
+            let queued = QueueEntryRecord {
+                message_id: "message-1".into(),
                 agent_id: "agent-a".into(),
-                mutation: QueueMutation::Upsert(processed),
-                agent_state: None,
-                audit_events: vec![AuditEvent::new("queue_settled", serde_json::json!({}))],
-                notify_scheduler: true,
-                fault: Some(TransitionFaultPoint::BeforeCommit),
-            })
-            .unwrap_err();
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Queued,
+                created_at: now,
+                updated_at: now,
+            };
+            db.queue_entries().upsert(&queued)?;
+            let mut initial_state = AgentState::new("agent-a");
+            initial_state.pending = 1;
+            db.agent_states().upsert(&initial_state)?;
+            let mut settled_state = initial_state.clone();
+            settled_state.pending = 0;
+            let transcript = TranscriptEntry::new(
+                "agent-a",
+                crate::types::TranscriptEntryKind::IncomingMessage,
+                None,
+                Some(queued.message_id.clone()),
+                serde_json::json!({}),
+            );
+            let mut processed = queued.clone();
+            processed.status = QueueEntryStatus::Processed;
+            processed.updated_at = now + chrono::Duration::seconds(1);
 
-        let latest = db.queue_entries().latest_all()?;
-        assert_eq!(latest.len(), 1);
-        assert_eq!(latest[0].status, QueueEntryStatus::Queued);
-        assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+            db.transitions()
+                .commit_queue(&QueueTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    mutation: QueueMutation::Upsert(processed),
+                    agent_state: Some(AgentStateMutation {
+                        expected: Some(Box::new(initial_state.clone())),
+                        record: Box::new(settled_state),
+                    }),
+                    transcript_entries: vec![transcript],
+                    audit_events: vec![AuditEvent::new("queue_settled", serde_json::json!({}))],
+                    notify_scheduler: true,
+                    fault: Some(fault),
+                })
+                .unwrap_err();
+
+            let latest = db.queue_entries().latest_all()?;
+            assert_eq!(latest.len(), 1);
+            assert_eq!(latest[0].status, QueueEntryStatus::Queued);
+            assert_eq!(db.agent_states().latest("agent-a")?, Some(initial_state));
+            assert!(db.transcript_entries().all(Some("agent-a"))?.is_empty());
+            assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+        }
         Ok(())
     }
 
@@ -749,6 +848,7 @@ mod tests {
                 index_change("work_item", &cleared.id),
             ],
             notify_scheduler: true,
+            commit_on_idempotent: false,
             fault: Some(TransitionFaultPoint::AfterCanonicalWrites),
         };
         db.transitions().commit_task(&command).unwrap_err();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,7 +12,10 @@ use tokio::sync::{broadcast, Notify};
 
 use crate::{
     memory::index::enqueue_memory_index_upsert,
-    runtime_db::{RuntimeDb, RuntimeIndexChange, RuntimeIndexOperation},
+    runtime_db::{
+        transitions::{PostCommitEffects, PostCommitWarning},
+        RuntimeDb, RuntimeIndexChange, RuntimeIndexOperation,
+    },
     tool::helpers::{command_output_source_ref, command_receipt_source_ref},
     types::{
         AgentIdentityRecord, AgentPostureProjection, AgentSchedulingPosture, AgentState,
@@ -300,6 +303,58 @@ impl AppStorage {
             });
         }
         Ok(())
+    }
+
+    pub(crate) fn publish_transition_events(
+        &self,
+        effects: &PostCommitEffects,
+    ) -> Vec<PostCommitWarning> {
+        let agent_id = self.agent_id.clone();
+        let mut warnings = Vec::new();
+        for event in &effects.audit_events {
+            if let Err(error) = self.publish_event(agent_id.clone(), event) {
+                tracing::warn!(
+                    error = %error,
+                    event_id = %event.id,
+                    event_kind = %event.kind,
+                    event_seq = event.event_seq,
+                    "failed to publish committed transition audit event"
+                );
+                warnings.push(PostCommitWarning {
+                    effect: "event_publication",
+                    message: error.to_string(),
+                });
+            }
+        }
+        warnings
+    }
+
+    pub(crate) fn notify_transition_memory_index(
+        &self,
+        effects: &PostCommitEffects,
+    ) -> Vec<PostCommitWarning> {
+        let mut warnings = Vec::new();
+        if effects.notify_memory_index {
+            match self.memory_index_notify.lock() {
+                Ok(guard) => {
+                    if let Some(notify) = guard.as_ref() {
+                        notify.notify_one();
+                    }
+                }
+                Err(_) => {
+                    let message = "memory index notify mutex poisoned after transition commit";
+                    tracing::warn!(
+                        agent_id = self.agent_id.as_deref().unwrap_or("<global>"),
+                        message
+                    );
+                    warnings.push(PostCommitWarning {
+                        effect: "memory_index_notification",
+                        message: message.into(),
+                    });
+                }
+            }
+        }
+        warnings
     }
 
     #[cfg(test)]
@@ -727,7 +782,10 @@ impl AppStorage {
         )?])
     }
 
-    fn index_changes_for_task(&self, task: &TaskRecord) -> Result<Vec<RuntimeIndexChange>> {
+    pub(crate) fn index_changes_for_task(
+        &self,
+        task: &TaskRecord,
+    ) -> Result<Vec<RuntimeIndexChange>> {
         Ok(vec![self.runtime_index_upsert(
             task.agent_id.clone(),
             "task",
@@ -738,7 +796,7 @@ impl AppStorage {
         )?])
     }
 
-    fn index_changes_for_work_item(
+    pub(crate) fn index_changes_for_work_item(
         &self,
         record: &WorkItemRecord,
     ) -> Result<Vec<RuntimeIndexChange>> {
@@ -750,6 +808,15 @@ impl AppStorage {
             Some(record.updated_at),
             "work_item_written",
         )?])
+    }
+
+    pub(crate) fn wait_condition_auxiliary_events(
+        &self,
+        record: &WaitConditionRecord,
+    ) -> Vec<AuditEvent> {
+        external_wait_recoverability_event(record)
+            .into_iter()
+            .collect()
     }
 
     fn index_changes_for_context_episode(

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1558,10 +1558,9 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
     assert_eq!(first.agent_id, "bench-15");
 
     let first_state = first_host
-        .get_public_agent("bench-15")
-        .await?
-        .agent_state()
-        .await?;
+        .agent_storage("bench-15")?
+        .read_agent()?
+        .expect("persistent agent state should be stored after the first run");
     assert!(first_state.total_message_count > 0);
 
     let second_host =


### PR DESCRIPTION
## 目标

Closes #2260。

建立受限的 Runtime Transition Unit of Work，将 WorkItem、Wait、Queue settlement 与 Task transition 的 canonical rows、expected revision/status、audit sequence 和 runtime-index outbox 收敛到单一 SQLite transaction；仅在 commit 成功后更新内存 projection、发布 event 并通知 scheduler/indexer。

## 主要改动

- 新增 accepted RFC：`docs/rfcs/runtime-transition-commit-contract.md`，冻结 authoritative facts、commit/effect 顺序、failure matrix 与首批 transition write set。
- 新增 `runtime_db::transitions`：domain-specific commands、`TransitionCommit`、`PostCommitEffects`、typed post-commit warnings，以及 commit/post-commit fault seam。
- 迁移 WorkItem create/update/recheck/complete/turn-end/ref refresh 与 Wait register/replace/cancel/resolve，使 WorkItem revision、wait rows、agent binding、audit 和 index outbox 原子提交。
- 迁移 Queue claim、processed/interrupted/aborted settlement 和 operator interjection admission；claim 与 running `AgentState` 同事务提交。
- 迁移 Task lifecycle；terminal Task 与 matching wait resolution、WorkItem blocker clearing、audit/index 同事务提交。
- exact replay 变为 no-op，不重复 audit/outbox；stale/conflicting payload 继续返回 typed transition conflict。
- post-commit cache/event/scheduler fault 保留 durable commit 并返回/记录 warning，不诱导调用方重做业务 transition。

## 边界

- 本 PR 不改变 operator-facing tool surface。
- WorkItem pick/yield/resume 与 continuation-frame 的最终 canonical focus write set 仍由 #2261 收敛；本 PR 已确保 complete 的 durable facts 提交后，compatibility continuation adapter 失败只记录 post-commit warning，不会把已提交 completion 报告为业务失败。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib`：2261 passed，1 ignored
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- transition contract fault/replay tests：5 passed
- WorkItem targeted suite：68 passed
- Task reducer、runtime state 与 interjection targeted tests 通过
