### PR TITLE
refactor: 收敛 WorkItem current focus 事务事实

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -47,6 +47,7 @@ implementation and tests.
 - [Runtime Ledger Sequences and Object Revisions](./runtime-ledger-sequences-and-revisions.md)
 - [Runtime Ledger Files and Relations](./runtime-ledger-files-and-relations.md)
 - [Runtime Transition Commit Contract](./runtime-transition-commit-contract.md)
+- [WorkItem Current Focus Canonical Fact](./work-item-current-focus.md)
 
 ## Provenance, Policy, And Execution
 

--- a/docs/rfcs/runtime-transition-commit-contract.md
+++ b/docs/rfcs/runtime-transition-commit-contract.md
@@ -66,8 +66,8 @@ the related durable facts need one transaction boundary.
 - do not make cache, event delivery, or scheduler notification authoritative;
 - do not introduce a general distributed transaction or plugin framework;
 - do not persist every process-local notification in a new generic outbox;
-- do not settle the final canonical WorkItem focus schema, which is handled by
-  the focused follow-up work;
+- do not redefine the canonical WorkItem focus schema, which is specified by
+  [WorkItem Current Focus Canonical Fact](./work-item-current-focus.md);
 - do not physically split all large runtime modules in the first change.
 
 ## Fact Layers
@@ -164,14 +164,12 @@ return the existing typed transition conflict.
 | --- | --- | --- | --- |
 | create | record absent, revision `1` | WorkItem, lifecycle audit, index outbox | cache WorkItem, publish audit, notify indexer and scheduler |
 | update/block/unblock/recheck | exact prior revision | WorkItem next revision, lifecycle audit, index outbox | cache WorkItem, publish audit, notify indexer and scheduler |
-| complete | exact prior revision and open state | completed WorkItem, related wait cancellation, agent binding release, lifecycle audits, index outbox | cache records, publish audits, notify indexer and scheduler; run the compatibility continuation adapter |
+| complete | exact prior revision and open state | completed WorkItem, related wait cancellation, optional continuation resolution and caller focus restore, lifecycle audits, index outbox | cache records, publish audits, notify indexer and scheduler |
 
-Focus-specific pick/resume and continuation-frame writes will use the same
-transaction primitive, but their final single-source focus schema and atomic
-write set are defined by the focused follow-up. Until that migration, the
-post-commit continuation adapter must not report the already committed
-WorkItem completion as failed; adapter failures are recorded as post-commit
-warnings.
+Focus-specific pick/resume and continuation-frame writes use the same
+transaction primitive. Their single-source schema and atomic write sets are
+defined by
+[WorkItem Current Focus Canonical Fact](./work-item-current-focus.md).
 
 ### Wait
 

--- a/docs/rfcs/work-item-continuation-stack.md
+++ b/docs/rfcs/work-item-continuation-stack.md
@@ -190,7 +190,8 @@ fact is still an explicit continuation frame rather than a synthetic blocker.
 
 ### CompleteWorkItem
 
-When `CompleteWorkItem(B)` succeeds:
+When `CompleteWorkItem(B)` succeeds, the following steps are one durable
+transition transaction:
 
 1. Complete `B` using the existing completion rules.
 2. Cancel or resolve active wait conditions owned by `B` as today.

--- a/docs/rfcs/work-item-current-focus.md
+++ b/docs/rfcs/work-item-current-focus.md
@@ -1,0 +1,89 @@
+---
+title: RFC: WorkItem Current Focus Canonical Fact
+date: 2026-07-16
+status: accepted
+handle: rfc-work-item-current-focus
+---
+
+# RFC: WorkItem Current Focus Canonical Fact
+
+## Summary
+
+`agent_states.current_work_item_id` is the only canonical durable WorkItem
+focus fact. It models the single-valued relation `agent -> open WorkItem?`.
+
+`work_items.current_focus` is a deprecated compatibility column. Runtime code
+must neither read nor write it. WorkItem views derive currentness by joining
+the agent state pointer to the owned open WorkItem.
+
+`AgentState.current_turn_work_item_id` is turn attribution, not a fallback
+focus fact. It may retain the WorkItem that owns an already admitted turn even
+after durable focus changes.
+
+## Invariants
+
+For every non-null canonical focus:
+
+1. the target WorkItem exists;
+2. the target belongs to the same agent;
+3. the target is open;
+4. one agent has at most one focus because `agent_states` has one row per
+   `agent_id`.
+
+SQLite triggers enforce target existence, ownership, and open state. Runtime
+transition commands validate the same rules to return useful errors before
+the trigger is the last line of defense.
+
+## Migration
+
+Migration preflight compares `agent_states.current_work_item_id` with legacy
+`work_items.current_focus` rows:
+
+- matching valid facts migrate unchanged;
+- a valid agent-state pointer with no legacy focused row remains canonical;
+- a null agent-state pointer with exactly one valid legacy focused row is
+  backfilled into both the `agent_states` column and JSON payload;
+- conflicting pointers, multiple legacy focused rows, or missing, foreign, or
+  completed targets fail migration with identifying diagnostics.
+
+After preflight, every legacy `current_focus` value is cleared. The column may
+be physically removed in a later table-rebuild migration.
+
+## Atomic Transition Write Sets
+
+Focus transitions use one restricted runtime transition transaction.
+
+| Transition | Atomic durable facts |
+| --- | --- |
+| pick | optional blocker/wait cancellation, continuation create/resolve/cancel, agent focus and turn binding, audits, index outbox |
+| complete without return | completed WorkItem, owned wait cancellation, focus/turn release when matched, audits, index outbox |
+| complete with return | completed WorkItem, owned wait cancellation, continuation resolution, restored caller focus and turn binding, audits, index outbox |
+| explicit yielded return | continuation resolution, restored focus and turn binding, audits |
+| invalid return target | continuation cancellation and deterministic focus fallback in the same transaction |
+
+No committed state may expose a continuation-frame change without its matching
+focus change, or a completed focused WorkItem.
+
+## Operator Input And Sticky Association
+
+Focus, plan status, waits, and turn attribution remain orthogonal:
+
+- ordinary turn completion does not release focus;
+- setting `plan_status=needs_input` alone does not release focus;
+- WorkItem-scoped `WaitFor(operator_input)` atomically records the wait and
+  releases execution focus;
+- a read model may still present that wait-scoped WorkItem as a sticky
+  attention target, but it is not current execution focus.
+
+Automatic rehydration requires an ingress binding issued by the runtime, such
+as a `wait_id` or equivalent continuation token. Current ordinary
+`OperatorPrompt` ingress has no such binding, so the runtime must not guess by
+wait count, recency, text, or transport identity. Without a verified binding,
+the agent or operator explicitly picks the waiting WorkItem.
+
+## Restart And Projections
+
+Restart restores focus only from the canonical agent-state row. In-memory
+`AgentState`, prompt projections, scheduler views, HTTP responses, and TUI
+state are rebuildable projections. Post-commit projection failures do not
+change the committed transition result.

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -430,8 +430,10 @@ The persisted record owns:
 - blocker text;
 - completion summary metadata.
 
-`current_work_item_id` is per-agent focus state. It should not be inferred from
-WorkItem lifecycle state.
+`agent_states.current_work_item_id` is the single canonical per-agent focus
+fact. It is not inferred from WorkItem lifecycle state, and
+`work_items.current_focus` is not an independent source. See
+[WorkItem Current Focus Canonical Fact](./work-item-current-focus.md).
 
 `AgentState` remains the home for:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1473,9 +1473,6 @@ mod tests {
         let agent_id = "default";
         let host = RuntimeHost::new(config.clone()).unwrap();
         let storage = host.agent_storage(agent_id).unwrap();
-        let mut agent = holon::types::AgentState::new("default");
-        agent.current_work_item_id = Some("work-1".into());
-        storage.write_agent(&agent).unwrap();
         let mut work_item = holon::types::WorkItemRecord::new(
             "default",
             "fixture work",
@@ -1483,6 +1480,9 @@ mod tests {
         );
         work_item.id = "work-1".into();
         storage.insert_work_item(&work_item).unwrap();
+        let mut agent = holon::types::AgentState::new("default");
+        agent.current_work_item_id = Some(work_item.id.clone());
+        storage.write_agent(&agent).unwrap();
         work_item.revision = 2;
         storage.update_work_item_expected(&work_item, 1).unwrap();
 
@@ -1511,8 +1511,15 @@ mod tests {
         let runtime_db =
             RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
                 .unwrap();
+        let mut work_item = holon::types::WorkItemRecord::new(
+            "default",
+            "fixture work",
+            holon::types::WorkItemState::Open,
+        );
+        work_item.id = "work-db".into();
+        runtime_db.work_items().insert_new(&work_item).unwrap();
         let mut agent = holon::types::AgentState::new("default");
-        agent.current_work_item_id = Some("work-db".into());
+        agent.current_work_item_id = Some(work_item.id);
         runtime_db.agent_states().upsert(&agent).unwrap();
 
         let output = tempfile::tempdir().unwrap();

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -794,11 +794,6 @@ fn prepare_runtime_storage(
     }
 
     let recovered_agent_for_import = storage.read_legacy_agent_for_import()?;
-    if !storage_domain_complete(&runtime_db, "agent_states")? {
-        runtime_db
-            .agent_states()
-            .import_legacy(recovered_agent_for_import.clone())?;
-    }
     if !workspace_entries_complete {
         runtime_db
             .workspace_entries()
@@ -819,12 +814,12 @@ fn prepare_runtime_storage(
         for record in &mut legacy_work_items {
             crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
         }
-        runtime_db.work_items().import_legacy(
-            legacy_work_items,
-            recovered_agent_for_import
-                .as_ref()
-                .and_then(|agent| agent.current_work_item_id.as_deref()),
-        )?;
+        runtime_db.work_items().import_legacy(legacy_work_items)?;
+    }
+    if !storage_domain_complete(&runtime_db, "agent_states")? {
+        runtime_db
+            .agent_states()
+            .import_legacy(recovered_agent_for_import.clone())?;
     }
     if !storage_domain_complete(&runtime_db, "tasks")? {
         runtime_db

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -123,15 +123,12 @@ impl RuntimeHandle {
                 Value::Null,
             ));
             let agent_id = self.agent_id().await?;
-            let state = self.agent_state().await?;
             let commit = self.inner.runtime_db.transitions().commit_work_item(
                 &crate::runtime_db::transitions::WorkItemTransitionCommand {
                     agent_id,
                     mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
                         record: record.clone(),
                         expected_revision: latest.revision,
-                        current_focus: state.current_work_item_id.as_deref()
-                            == Some(record.id.as_str()),
                     },
                     agent_state: None,
                     audit_events,

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -918,29 +918,25 @@ mod tests {
     fn add_queued_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
         let mut record = WorkItemRecord::new("default", target, WorkItemState::Open);
         record.id = id.to_string();
-        persist_test_work_item(test_runtime, &record, false);
+        persist_test_work_item(test_runtime, &record);
         record
     }
 
-    fn persist_test_work_item(
-        test_runtime: &TestRuntime,
-        record: &WorkItemRecord,
-        current_focus: bool,
-    ) {
+    fn persist_test_work_item(test_runtime: &TestRuntime, record: &WorkItemRecord) {
         let repository = test_runtime.runtime.inner.runtime_db.work_items();
         if let Some(existing) = repository.latest(&record.id).unwrap() {
             repository
-                .update_expected(record, existing.revision, current_focus)
+                .update_expected(record, existing.revision)
                 .unwrap();
         } else {
-            repository.insert_new(record, current_focus).unwrap();
+            repository.insert_new(record).unwrap();
         }
     }
 
     fn add_current_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
         let mut record = WorkItemRecord::new("default", target, WorkItemState::Open);
         record.id = id.to_string();
-        persist_test_work_item(test_runtime, &record, true);
+        persist_test_work_item(test_runtime, &record);
         let mut guard = test_runtime.runtime.inner.agent.blocking_lock();
         guard.state.current_work_item_id = Some(record.id.clone());
         guard
@@ -958,7 +954,7 @@ mod tests {
         updated.revision += 1;
         updated.blocked_by = Some(blocked_by.to_string());
         updated.updated_at = chrono::Utc::now();
-        persist_test_work_item(test_runtime, &updated, false);
+        persist_test_work_item(test_runtime, &updated);
         updated
     }
 
@@ -973,7 +969,7 @@ mod tests {
         updated.recheck_at = Some(chrono::Utc::now() - chrono::Duration::seconds(1));
         updated.recheck_consumed_at = None;
         updated.updated_at = chrono::Utc::now();
-        persist_test_work_item(test_runtime, &updated, false);
+        persist_test_work_item(test_runtime, &updated);
         updated
     }
 

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -251,8 +251,6 @@ impl RuntimeHandle {
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
                     record: record.clone(),
                     expected_revision: record.revision - 1,
-                    current_focus: agent.current_work_item_id.as_deref()
-                        == Some(record.id.as_str()),
                 },
                 agent_state: None,
                 audit_events: vec![AuditEvent::new(

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -167,8 +167,6 @@ impl RuntimeHandle {
                                         crate::runtime_db::transitions::WorkItemMutation::Update {
                                             record,
                                             expected_revision: existing.revision,
-                                            current_focus: state.current_work_item_id.as_deref()
-                                                == Some(existing.id.as_str()),
                                         },
                                     );
                                 }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2759,6 +2759,8 @@ impl RuntimeHandle {
                 }),
             ));
         }
+        // Pick atomically cancels conflicting active frames, so this lookup has
+        // at most one resumable continuation for the completed WorkItem.
         if let Some(frame) = self
             .inner
             .storage

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2188,7 +2188,6 @@ impl RuntimeHandle {
                 agent_id,
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Insert {
                     record: record.clone(),
-                    current_focus: false,
                 },
                 agent_state: None,
                 audit_events: vec![self.work_item_written_event("created", &record, Value::Null)],
@@ -2256,7 +2255,16 @@ impl RuntimeHandle {
         } else {
             WorkItemBlockerClearance::unchanged(record)
         };
-        record = blocker_clearance.work_item;
+        let WorkItemBlockerClearance {
+            work_item,
+            expected_revision,
+            wait_conditions,
+            mut audit_events,
+            index_changes,
+            blocker_cleared,
+            cancelled_wait_condition_ids,
+        } = blocker_clearance;
+        record = work_item;
         let switching = current_id.as_deref().is_some_and(|id| id != record.id);
         let work_queue = self.inner.storage.work_queue_prompt_projection()?;
         let previous_readiness = previous.as_ref().map(|record| {
@@ -2267,15 +2275,20 @@ impl RuntimeHandle {
                 .map(|item| item.readiness)
                 .unwrap_or_else(|| record.readiness())
         });
-        let current_readiness = work_queue
-            .readiness
-            .iter()
-            .find(|item| item.work_item.id == record.id)
-            .map(|item| item.readiness)
-            .unwrap_or_else(|| record.readiness());
+        let current_readiness = if blocker_cleared {
+            record.readiness()
+        } else {
+            work_queue
+                .readiness
+                .iter()
+                .find(|item| item.work_item.id == record.id)
+                .map(|item| item.readiness)
+                .unwrap_or_else(|| record.readiness())
+        };
         let mut warnings = Vec::new();
         let mut continuation_created = None;
         let mut continuation_resolved = None;
+        let mut continuation_records = Vec::new();
         let target_yielded_frame = self
             .inner
             .storage
@@ -2283,17 +2296,15 @@ impl RuntimeHandle {
         let target_was_yielded = target_yielded_frame.is_some();
         if let Some(frame) = target_yielded_frame {
             let resolved = frame.resume("explicit_pick");
-            self.inner
-                .storage
-                .append_work_item_continuation(&resolved)?;
             continuation_resolved = Some(continuation_summary(&resolved, "explicit_pick"));
-            self.inner.storage.append_event(&AuditEvent::new(
+            audit_events.push(AuditEvent::new(
                 "work_item_continuation_resumed",
                 serde_json::json!({
                     "agent_id": agent_id,
                     "continuation": continuation_summary(&resolved, "explicit_pick"),
                 }),
-            ))?;
+            ));
+            continuation_records.push(resolved);
         }
         if let Some(id) = current_id.as_deref() {
             if let Some(frame) = self
@@ -2302,16 +2313,14 @@ impl RuntimeHandle {
                 .latest_active_work_item_continuation_for_suspended(&agent_id, id)?
             {
                 let cancelled = frame.cancel("current_focus_reselected");
-                self.inner
-                    .storage
-                    .append_work_item_continuation(&cancelled)?;
-                self.inner.storage.append_event(&AuditEvent::new(
+                audit_events.push(AuditEvent::new(
                     "work_item_continuation_cancelled",
                     serde_json::json!({
                         "agent_id": agent_id,
                         "continuation": continuation_summary(&cancelled, "current_focus_reselected"),
                     }),
-                ))?;
+                ));
+                continuation_records.push(cancelled);
             }
         }
         let yield_current = switching
@@ -2340,15 +2349,15 @@ impl RuntimeHandle {
                     record.id.clone(),
                     state.current_turn_id.clone(),
                 );
-                self.inner.storage.append_work_item_continuation(&frame)?;
                 continuation_created = Some(continuation_summary(&frame, "pick_work_item"));
-                self.inner.storage.append_event(&AuditEvent::new(
+                audit_events.push(AuditEvent::new(
                     "work_item_continuation_created",
                     serde_json::json!({
                         "agent_id": agent_id,
                         "continuation": continuation_summary(&frame, "pick_work_item"),
                     }),
-                ))?;
+                ));
+                continuation_records.push(frame);
             }
         } else if switching
             && previous_readiness == Some(WorkItemReadiness::Runnable)
@@ -2378,16 +2387,6 @@ impl RuntimeHandle {
             "inspection"
         }
         .to_string();
-        {
-            let mut guard = self.inner.agent.lock().await;
-            guard.state.current_work_item_id = Some(record.id.clone());
-            guard.state.current_turn_work_item_id = Some(record.id.clone());
-            guard.persist_state(&self.inner.storage)?;
-        }
-        self.inner
-            .runtime_db
-            .work_items()
-            .set_current_focus(&agent_id, Some(&record.id))?;
         let transition = WorkItemFocusTransition {
             previous_work_item_id: current_id.clone(),
             current_work_item_id: record.id.clone(),
@@ -2396,11 +2395,11 @@ impl RuntimeHandle {
             current_readiness,
             switch_kind,
             current_focus_mode,
-            blocker_cleared: blocker_clearance.blocker_cleared,
-            cancelled_wait_condition_ids: blocker_clearance.cancelled_wait_condition_ids,
+            blocker_cleared,
+            cancelled_wait_condition_ids,
             warnings,
         };
-        self.inner.storage.append_event(&AuditEvent::new(
+        audit_events.push(AuditEvent::new(
             "work_item_picked",
             serde_json::json!({
                 "agent_id": agent_id,
@@ -2417,7 +2416,35 @@ impl RuntimeHandle {
                 "continuation_created": continuation_created.clone(),
                 "continuation_resolved": continuation_resolved.clone(),
             }),
-        ))?;
+        ));
+        let mut next_state = state.clone();
+        next_state.current_work_item_id = Some(record.id.clone());
+        next_state.current_turn_work_item_id = Some(record.id.clone());
+        let work_items = expected_revision
+            .map(|expected_revision| {
+                vec![crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: record.clone(),
+                    expected_revision,
+                }]
+            })
+            .unwrap_or_default();
+        let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
+            &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
+                agent_id: agent_id.clone(),
+                work_items,
+                wait_conditions,
+                continuations: continuation_records,
+                agent_state: crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(state)),
+                    record: Box::new(next_state),
+                },
+                audit_events,
+                index_changes,
+                notify_scheduler: true,
+                fault: None,
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
         Ok(PickedWorkItem {
             previous_work_item: previous,
             current_work_item: record,
@@ -2469,13 +2496,10 @@ impl RuntimeHandle {
         let mut record = existing.clone();
         let mut wrote_item = false;
         let previous_objective = record.objective.clone();
-        let focus_release_reason = if blocked_by.as_ref().is_some_and(Option::is_some) {
-            Some("work_item_blocked")
-        } else if plan_status == Some(WorkItemPlanStatus::NeedsInput) {
-            Some("work_item_needs_input")
-        } else {
-            None
-        };
+        let focus_release_reason = blocked_by
+            .as_ref()
+            .is_some_and(Option::is_some)
+            .then_some("work_item_blocked");
         if let Some(objective) = objective {
             record.objective = objective;
             record.updated_at = Utc::now();
@@ -2536,8 +2560,6 @@ impl RuntimeHandle {
             let mut state = self.agent_state().await?;
             let expected_state = state.clone();
             let mut agent_state = None;
-            let mut current_focus =
-                state.current_work_item_id.as_deref() == Some(record.id.as_str());
             if let Some(reason) = focus_release_reason {
                 let release_current =
                     state.current_work_item_id.as_deref() == Some(record.id.as_str());
@@ -2545,7 +2567,6 @@ impl RuntimeHandle {
                     state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
                 if release_current {
                     state.current_work_item_id = None;
-                    current_focus = false;
                 }
                 if release_turn {
                     state.current_turn_work_item_id = None;
@@ -2573,7 +2594,6 @@ impl RuntimeHandle {
                     mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
                         record: record.clone(),
                         expected_revision: existing.revision,
-                        current_focus,
                     },
                     agent_state,
                     audit_events,
@@ -2634,15 +2654,12 @@ impl RuntimeHandle {
                 "recheck_consumed_at": record.recheck_consumed_at,
             }),
         ));
-        let state = self.agent_state().await?;
         let commit = self.inner.runtime_db.transitions().commit_work_item(
             &crate::runtime_db::transitions::WorkItemTransitionCommand {
                 agent_id,
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
                     record: record.clone(),
                     expected_revision: existing.revision,
-                    current_focus: state.current_work_item_id.as_deref()
-                        == Some(record.id.as_str()),
                 },
                 agent_state: None,
                 audit_events,
@@ -2722,6 +2739,8 @@ impl RuntimeHandle {
         let expected_state = state.clone();
         let release_current = state.current_work_item_id.as_deref() == Some(record.id.as_str());
         let release_turn = state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
+        let mut continuation_records = Vec::new();
+        let mut continuation_resumed = None;
         if release_current {
             state.current_work_item_id = None;
         }
@@ -2740,6 +2759,65 @@ impl RuntimeHandle {
                 }),
             ));
         }
+        if let Some(frame) = self
+            .inner
+            .storage
+            .latest_active_work_item_continuation_for_active(&agent_id, &record.id)?
+        {
+            let suspended = self
+                .inner
+                .runtime_db
+                .work_items()
+                .latest(&frame.suspended_work_item_id)?;
+            match suspended {
+                Some(suspended)
+                    if suspended.agent_id == agent_id && suspended.state == WorkItemState::Open =>
+                {
+                    let resumed = frame.resume("active_work_item_completed");
+                    let summary = continuation_summary(&resumed, "active_work_item_completed");
+                    state.current_work_item_id = Some(suspended.id.clone());
+                    state.current_turn_work_item_id = Some(suspended.id.clone());
+                    audit_events.push(AuditEvent::new(
+                        "work_item_continuation_resumed",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "continuation": summary,
+                            "completed_work_item_id": record.id,
+                            "resumed_work_item_id": suspended.id,
+                        }),
+                    ));
+                    audit_events.push(AuditEvent::new(
+                        "work_item_continuation_scheduler_evidence",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "reason": "continuation_resumed",
+                            "work_item_id": suspended.id,
+                            "completed_work_item_id": record.id,
+                            "continuation_frame_id": summary.frame_id,
+                        }),
+                    ));
+                    continuation_resumed = Some(summary);
+                    continuation_records.push(resumed);
+                }
+                suspended => {
+                    let reason = if suspended.is_some() {
+                        "suspended_work_item_not_open"
+                    } else {
+                        "suspended_work_item_missing"
+                    };
+                    let cancelled = frame.cancel(reason);
+                    audit_events.push(AuditEvent::new(
+                        "work_item_continuation_cancelled",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "continuation": continuation_summary(&cancelled, reason),
+                            "suspended_work_item_state": suspended.map(|record| record.state),
+                        }),
+                    ));
+                    continuation_records.push(cancelled);
+                }
+            }
+        }
         if !cancelled_wait_condition_ids.is_empty() {
             audit_events.push(AuditEvent::new(
                 "wait_conditions_cancelled",
@@ -2756,24 +2834,22 @@ impl RuntimeHandle {
             &record,
             serde_json::json!({
                 "warning_count": warnings.len(),
-                "continuation_resumed": Value::Null,
+                "continuation_resumed": continuation_resumed,
             }),
         ));
-        let commit = self.inner.runtime_db.transitions().commit_wait(
-            &crate::runtime_db::transitions::WaitTransitionCommand {
+        let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
+            &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
                 agent_id: agent_id.clone(),
                 work_items: vec![crate::runtime_db::transitions::WorkItemMutation::Update {
                     record: record.clone(),
                     expected_revision: existing.revision,
-                    current_focus: false,
                 }],
                 wait_conditions,
-                agent_state: (release_current || release_turn).then_some(
-                    crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(expected_state)),
-                        record: Box::new(state),
-                    },
-                ),
+                continuations: continuation_records,
+                agent_state: crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(expected_state)),
+                    record: Box::new(state),
+                },
                 audit_events,
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,
@@ -2781,31 +2857,6 @@ impl RuntimeHandle {
             },
         )?;
         self.apply_transition_commit(commit).await;
-        let continuation_resumed = match self
-            .resume_direct_caller_after_work_item_completed(&agent_id, &record)
-            .await
-        {
-            Ok(continuation) => continuation,
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    agent_id = %agent_id,
-                    work_item_id = %record.id,
-                    "work item completion committed but continuation post-commit adapter failed"
-                );
-                let _ = self.inner.storage.append_event(&AuditEvent::new(
-                    "runtime_transition_post_commit_warning",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "transition": "work_item_completed",
-                        "work_item_id": record.id,
-                        "effect": "resume_direct_caller",
-                        "error": error.to_string(),
-                    }),
-                ));
-                None
-            }
-        };
         Ok(CompletedWorkItem {
             work_item: record,
             continuation_resumed,
@@ -2880,15 +2931,12 @@ impl RuntimeHandle {
             updated_at: Utc::now(),
             ..existing
         };
-        let state = self.agent_state().await?;
         let commit = self.inner.runtime_db.transitions().commit_work_item(
             &crate::runtime_db::transitions::WorkItemTransitionCommand {
                 agent_id: agent_id.clone(),
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
                     record: record.clone(),
                     expected_revision: record.revision - 1,
-                    current_focus: state.current_work_item_id.as_deref()
-                        == Some(record.id.as_str()),
                 },
                 agent_state: None,
                 audit_events: vec![AuditEvent::new(
@@ -2940,88 +2988,6 @@ impl RuntimeHandle {
             }),
         ))?;
         Ok(())
-    }
-
-    async fn resume_direct_caller_after_work_item_completed(
-        &self,
-        agent_id: &str,
-        completed: &WorkItemRecord,
-    ) -> Result<Option<WorkItemContinuationSummary>> {
-        let Some(frame) = self
-            .inner
-            .storage
-            .latest_active_work_item_continuation_for_active(agent_id, &completed.id)?
-        else {
-            return Ok(None);
-        };
-        let Some(suspended) = self
-            .inner
-            .runtime_db
-            .work_items()
-            .latest(&frame.suspended_work_item_id)?
-        else {
-            let cancelled = frame.cancel("suspended_work_item_missing");
-            self.inner
-                .storage
-                .append_work_item_continuation(&cancelled)?;
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_continuation_cancelled",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "continuation": continuation_summary(&cancelled, "suspended_work_item_missing"),
-                }),
-            ))?;
-            return Ok(None);
-        };
-        if suspended.agent_id != agent_id || suspended.state != WorkItemState::Open {
-            let cancelled = frame.cancel("suspended_work_item_not_open");
-            self.inner
-                .storage
-                .append_work_item_continuation(&cancelled)?;
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_continuation_cancelled",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "continuation": continuation_summary(&cancelled, "suspended_work_item_not_open"),
-                    "suspended_work_item_state": suspended.state,
-                }),
-            ))?;
-            return Ok(None);
-        }
-
-        let resumed = frame.resume("active_work_item_completed");
-        self.inner.storage.append_work_item_continuation(&resumed)?;
-        {
-            let mut guard = self.inner.agent.lock().await;
-            guard.state.current_work_item_id = Some(suspended.id.clone());
-            guard.state.current_turn_work_item_id = Some(suspended.id.clone());
-            guard.persist_state(&self.inner.storage)?;
-        }
-        self.inner
-            .runtime_db
-            .work_items()
-            .set_current_focus(agent_id, Some(&suspended.id))?;
-        let summary = continuation_summary(&resumed, "active_work_item_completed");
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_continuation_resumed",
-            serde_json::json!({
-                "agent_id": agent_id,
-                "continuation": summary,
-                "completed_work_item_id": completed.id,
-                "resumed_work_item_id": suspended.id,
-            }),
-        ))?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_continuation_scheduler_evidence",
-            serde_json::json!({
-                "agent_id": agent_id,
-                "reason": "continuation_resumed",
-                "work_item_id": suspended.id,
-                "completed_work_item_id": completed.id,
-                "continuation_frame_id": summary.frame_id,
-            }),
-        ))?;
-        Ok(Some(summary))
     }
 
     pub(super) fn validate_owned_work_item(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3611,7 +3611,6 @@ async fn post_commit_cache_fault_preserves_durable_transition_and_returns_warnin
                 agent_id: "default".into(),
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Insert {
                     record: record.clone(),
-                    current_focus: false,
                 },
                 agent_state: None,
                 audit_events: vec![AuditEvent::new(

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -295,8 +295,6 @@ fn build_scheduler_fixture(name: &str) -> (tempfile::TempDir, AppStorage, AgentS
             created_at: Utc::now(),
         });
     }
-    storage.write_agent(&agent).unwrap();
-
     for item in work_items {
         let mut record = WorkItemRecord::new("default", item.objective, item.state);
         record.id = item.id;
@@ -306,6 +304,7 @@ fn build_scheduler_fixture(name: &str) -> (tempfile::TempDir, AppStorage, AgentS
         record.revision = item.revision;
         append_work_item_at_revision(&storage, &record);
     }
+    storage.write_agent(&agent).unwrap();
     for task in tasks {
         storage
             .append_task(&TaskRecord {
@@ -552,12 +551,12 @@ fn compaction_events_and_briefs_do_not_change_scheduler_projection() {
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-active".into());
-    storage.write_agent(&agent).unwrap();
 
     let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
     work_item.id = "work-active".into();
     work_item.revision = 3;
     append_work_item_at_revision(&storage, &work_item);
+    storage.write_agent(&agent).unwrap();
     storage
         .append_task(&TaskRecord {
             id: "task-active".into(),
@@ -783,11 +782,11 @@ fn idle_boundary_decision_reactivates_runnable_work_while_asleep() {
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     agent.current_work_item_id = Some("work-current".into());
-    storage.write_agent(&agent).unwrap();
     let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
     work_item.id = "work-current".into();
     work_item.plan_status = WorkItemPlanStatus::Ready;
     storage.append_work_item(&work_item).unwrap();
+    storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     let decision = scheduler::idle_boundary_decision(&projection, "fixture");
@@ -904,14 +903,13 @@ fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
 fn background_work_item_task_does_not_block_runnable_work() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
-    let mut agent = AgentState::new("default");
-    agent.current_work_item_id = Some("work-background".into());
-    storage.write_agent(&agent).unwrap();
     let now = Utc::now();
-
     let mut work_item = WorkItemRecord::new("default", "runnable work", WorkItemState::Open);
     work_item.id = "work-background".into();
     storage.append_work_item(&work_item).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = Some("work-background".into());
+    storage.write_agent(&agent).unwrap();
     storage
         .append_task(&TaskRecord {
             id: "background-task".into(),
@@ -944,8 +942,8 @@ fn scheduling_diagnostics_detect_idle_posture_with_runnable_work() {
     let mut agent = AgentState::new("default");
     let work_item = WorkItemRecord::new("default", "runnable work", WorkItemState::Open);
     agent.current_work_item_id = Some(work_item.id.clone());
-    storage.write_agent(&agent).unwrap();
     storage.append_work_item(&work_item).unwrap();
+    storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     let work_queue = storage.work_queue_prompt_projection().unwrap();
@@ -1395,7 +1393,6 @@ fn waiting_operator_with_expired_unconsumed_recheck_lets_agent_wake() {
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-recheck-expired".into());
-    storage.write_agent(&agent).unwrap();
 
     setup_waiting_operator_work_item(
         &storage,
@@ -1406,6 +1403,7 @@ fn waiting_operator_with_expired_unconsumed_recheck_lets_agent_wake() {
         // not consumed
         None,
     );
+    storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
 
@@ -1426,7 +1424,6 @@ fn waiting_operator_with_expired_but_consumed_recheck_still_waits() {
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-recheck-consumed".into());
-    storage.write_agent(&agent).unwrap();
 
     let recheck_at = Utc::now() - chrono::Duration::seconds(30);
     setup_waiting_operator_work_item(
@@ -1437,6 +1434,7 @@ fn waiting_operator_with_expired_but_consumed_recheck_still_waits() {
         // consumed after recheck_at → no re-pending
         Some(recheck_at + chrono::Duration::seconds(5)),
     );
+    storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     assert_eq!(
@@ -1457,7 +1455,6 @@ fn waiting_operator_with_future_recheck_still_waits() {
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-recheck-future".into());
-    storage.write_agent(&agent).unwrap();
 
     setup_waiting_operator_work_item(
         &storage,
@@ -1467,6 +1464,7 @@ fn waiting_operator_with_future_recheck_still_waits() {
         Some(Utc::now() + chrono::Duration::hours(1)),
         None,
     );
+    storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     assert_eq!(

--- a/src/runtime/tests/tasks.rs
+++ b/src/runtime/tests/tasks.rs
@@ -503,6 +503,7 @@ async fn fresh_start_initializes_agent_state_with_default_status() {
 async fn restart_preserves_persisted_agent_state() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
+    let picked_work_item_id;
 
     // First start: create a work item and pick it
     {
@@ -520,6 +521,7 @@ async fn restart_preserves_persisted_agent_state() {
             .create_work_item("persistent work".into(), None, None, Vec::new())
             .await
             .unwrap();
+        picked_work_item_id = item.id.clone();
         runtime.pick_work_item(item.id.clone()).await.unwrap();
     }
 
@@ -536,9 +538,18 @@ async fn restart_preserves_persisted_agent_state() {
         )
         .unwrap();
         let state = runtime.inner.agent.lock().await.state.clone();
-        assert!(
-            state.current_work_item_id.is_some(),
-            "current_work_item_id should be recovered from storage across restart"
+        assert_eq!(
+            state.current_work_item_id.as_deref(),
+            Some(picked_work_item_id.as_str()),
+            "current_work_item_id should recover exactly from the canonical agent-state fact"
+        );
+        assert_eq!(
+            runtime
+                .storage()
+                .read_agent()
+                .unwrap()
+                .and_then(|agent| agent.current_work_item_id),
+            Some(picked_work_item_id.clone())
         );
     }
 }

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -4178,7 +4178,7 @@ async fn wait_for_tool_result_keeps_blocked_focus_current() {
 }
 
 #[tokio::test]
-async fn needs_input_current_work_item_releases_focus() {
+async fn needs_input_current_work_item_keeps_focus_until_operator_wait() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -4212,12 +4212,66 @@ async fn needs_input_current_work_item_releases_focus() {
 
     assert_eq!(waiting.readiness(), WorkItemReadiness::WaitingForOperator);
     let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(work.id.as_str())
+    );
+    assert_eq!(
+        state.current_turn_work_item_id.as_deref(),
+        Some(work.id.as_str())
+    );
+    let events = runtime.storage().read_recent_events(10).unwrap();
+    assert!(!events.iter().any(|event| {
+        event.kind == "work_item_focus_released"
+            && event.data["work_item_id"].as_str() == Some(work.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn operator_input_wait_releases_execution_focus() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("wait for operator".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            Some(work.id.clone()),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "operator decision".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
     assert!(state.current_work_item_id.is_none());
     assert!(state.current_turn_work_item_id.is_none());
+    let projection = runtime.storage().work_queue_prompt_projection().unwrap();
+    assert!(projection.current.is_none());
+    assert!(projection
+        .waiting_for_operator
+        .iter()
+        .any(|item| item.work_item.id == work.id));
     let events = runtime.storage().read_recent_events(10).unwrap();
     assert!(events.iter().any(|event| {
         event.kind == "work_item_focus_released"
-            && event.data["reason"] == "work_item_needs_input"
+            && event.data["reason"] == "operator_input_wait"
             && event.data["work_item_id"].as_str() == Some(work.id.as_str())
     }));
 }

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -40,6 +40,10 @@ pub(crate) struct WaitForRegistration {
 #[derive(Debug, Clone)]
 pub(super) struct WorkItemBlockerClearance {
     pub(super) work_item: WorkItemRecord,
+    pub(super) expected_revision: Option<u64>,
+    pub(super) wait_conditions: Vec<WaitConditionRecord>,
+    pub(super) audit_events: Vec<AuditEvent>,
+    pub(super) index_changes: Vec<crate::runtime_db::RuntimeIndexChange>,
     pub(super) blocker_cleared: bool,
     pub(super) cancelled_wait_condition_ids: Vec<String>,
 }
@@ -48,6 +52,10 @@ impl WorkItemBlockerClearance {
     pub(super) fn unchanged(work_item: WorkItemRecord) -> Self {
         Self {
             work_item,
+            expected_revision: None,
+            wait_conditions: Vec::new(),
+            audit_events: Vec::new(),
+            index_changes: Vec::new(),
             blocker_cleared: false,
             cancelled_wait_condition_ids: Vec::new(),
         }
@@ -155,8 +163,6 @@ impl RuntimeHandle {
                 work_items.push(crate::runtime_db::transitions::WorkItemMutation::Update {
                     record: updated.clone(),
                     expected_revision: existing.revision,
-                    current_focus: state.current_work_item_id.as_deref()
-                        == Some(updated.id.as_str()),
                 });
             }
             if state.current_turn_work_item_id.as_deref() == Some(updated.id.as_str()) {
@@ -167,6 +173,22 @@ impl RuntimeHandle {
                         "agent_id": agent_id,
                         "work_item_id": updated.id.as_str(),
                         "reason": "work_item_waiting",
+                        "readiness": updated.readiness(),
+                        "revision": updated.revision,
+                    }),
+                ));
+                committed_agent_state = Some(state.clone());
+            }
+            if wake == WaitForWakeKind::OperatorInput
+                && state.current_work_item_id.as_deref() == Some(updated.id.as_str())
+            {
+                state.current_work_item_id = None;
+                audit_events.push(AuditEvent::new(
+                    "work_item_focus_released",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "work_item_id": updated.id.as_str(),
+                        "reason": "operator_input_wait",
                         "readiness": updated.readiness(),
                         "revision": updated.revision,
                     }),
@@ -302,7 +324,6 @@ impl RuntimeHandle {
             ));
         }
         let mut record = existing.clone();
-        let mut work_items = Vec::new();
         let mut index_changes = Vec::new();
         if needs_record_write {
             record = WorkItemRecord {
@@ -330,29 +351,14 @@ impl RuntimeHandle {
                     "cancelled_wait_condition_ids": cancelled_wait_condition_ids.clone(),
                 }),
             ));
-            let state = self.agent_state().await?;
-            work_items.push(crate::runtime_db::transitions::WorkItemMutation::Update {
-                record: record.clone(),
-                expected_revision: existing.revision,
-                current_focus: state.current_work_item_id.as_deref() == Some(existing.id.as_str()),
-            });
             index_changes = self.inner.storage.index_changes_for_work_item(&record)?;
         }
-        let commit = self.inner.runtime_db.transitions().commit_wait(
-            &crate::runtime_db::transitions::WaitTransitionCommand {
-                agent_id: agent_id.to_string(),
-                work_items,
-                wait_conditions,
-                agent_state: None,
-                audit_events,
-                index_changes,
-                notify_scheduler: true,
-                fault: None,
-            },
-        )?;
-        self.apply_transition_commit(commit).await;
         Ok(WorkItemBlockerClearance {
             work_item: record,
+            expected_revision: needs_record_write.then_some(existing.revision),
+            wait_conditions,
+            audit_events,
+            index_changes,
             blocker_cleared: true,
             cancelled_wait_condition_ids,
         })

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -4,12 +4,181 @@ use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::types::{WaitConditionRecord, WorkItemRecord};
+use crate::types::{AgentState, WaitConditionRecord, WorkItemRecord};
 
 pub struct Migration {
     pub version: i64,
     pub(crate) name: &'static str,
     pub(crate) sql: &'static str,
+}
+
+fn preflight_work_item_focus(connection: &Connection) -> Result<()> {
+    let invalid_agent_focus = connection
+        .query_row(
+            "SELECT a.agent_id, a.current_work_item_id,
+                    COALESCE(w.agent_id, '<missing>'), COALESCE(w.state, '<missing>')
+             FROM agent_states a
+             LEFT JOIN work_items w ON w.work_item_id = a.current_work_item_id
+             WHERE a.current_work_item_id IS NOT NULL
+               AND (
+                 w.work_item_id IS NULL
+                 OR w.agent_id != a.agent_id
+                 OR w.state != 'open'
+               )
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            },
+        )
+        .optional()?;
+    if let Some((agent_id, work_item_id, owner_agent_id, state)) = invalid_agent_focus {
+        bail!(
+            "work item focus migration found invalid canonical focus: agent_id={agent_id}, work_item_id={work_item_id}, owner_agent_id={owner_agent_id}, state={state}"
+        );
+    }
+
+    let invalid_legacy_focus = connection
+        .query_row(
+            "SELECT work_item_id, agent_id, state
+             FROM work_items
+             WHERE current_focus != 0 AND state != 'open'
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    if let Some((work_item_id, agent_id, state)) = invalid_legacy_focus {
+        bail!(
+            "work item focus migration found invalid legacy focus: agent_id={agent_id}, work_item_id={work_item_id}, state={state}"
+        );
+    }
+
+    let duplicate_legacy_focus = connection
+        .query_row(
+            "SELECT agent_id, COUNT(*), GROUP_CONCAT(work_item_id, ',')
+             FROM work_items
+             WHERE current_focus != 0
+             GROUP BY agent_id
+             HAVING COUNT(*) > 1
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    if let Some((agent_id, count, work_item_ids)) = duplicate_legacy_focus {
+        bail!(
+            "work item focus migration found multiple legacy focuses: agent_id={agent_id}, count={count}, work_item_ids={work_item_ids}"
+        );
+    }
+
+    let conflicting_focus = connection
+        .query_row(
+            "SELECT a.agent_id, a.current_work_item_id, w.work_item_id
+             FROM agent_states a
+             JOIN work_items w
+               ON w.agent_id = a.agent_id
+              AND w.current_focus != 0
+             WHERE a.current_work_item_id IS NOT NULL
+               AND a.current_work_item_id != w.work_item_id
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    if let Some((agent_id, canonical_id, legacy_id)) = conflicting_focus {
+        bail!(
+            "work item focus migration found conflicting focus facts: agent_id={agent_id}, canonical_work_item_id={canonical_id}, legacy_work_item_id={legacy_id}"
+        );
+    }
+
+    let orphaned_legacy_focus = connection
+        .query_row(
+            "SELECT w.agent_id, w.work_item_id
+             FROM work_items w
+             LEFT JOIN agent_states a ON a.agent_id = w.agent_id
+             WHERE w.current_focus != 0 AND a.agent_id IS NULL
+             LIMIT 1",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    if let Some((agent_id, work_item_id)) = orphaned_legacy_focus {
+        bail!(
+            "work item focus migration cannot backfill legacy focus without agent state: agent_id={agent_id}, work_item_id={work_item_id}"
+        );
+    }
+    Ok(())
+}
+
+fn migrate_work_item_focus(connection: &Connection) -> Result<()> {
+    let mut statement = connection.prepare(
+        "SELECT a.agent_id, a.current_work_item_id, a.payload_json,
+                (
+                  SELECT w.work_item_id
+                  FROM work_items w
+                  WHERE w.agent_id = a.agent_id AND w.current_focus != 0
+                  LIMIT 1
+                )
+         FROM agent_states a",
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(statement);
+
+    for (agent_id, canonical_id, payload_json, legacy_id) in rows {
+        let selected_id = canonical_id.or(legacy_id);
+        let mut state: AgentState = serde_json::from_str(&payload_json)
+            .with_context(|| format!("decoding agent state {agent_id} for focus migration"))?;
+        if state.id != agent_id {
+            bail!(
+                "work item focus migration found agent payload identity mismatch: row_agent_id={agent_id}, payload_agent_id={}",
+                state.id
+            );
+        }
+        if state.current_work_item_id != selected_id {
+            state.current_work_item_id = selected_id.clone();
+            connection.execute(
+                "UPDATE agent_states
+                 SET current_work_item_id = ?1, payload_json = ?2
+                 WHERE agent_id = ?3",
+                params![selected_id, serde_json::to_string(&state)?, agent_id],
+            )?;
+        }
+    }
+    connection.execute("UPDATE work_items SET current_focus = 0", [])?;
+    Ok(())
 }
 
 pub(crate) const MIGRATIONS: &[Migration] = &[
@@ -897,6 +1066,65 @@ CREATE TABLE IF NOT EXISTS runtime_sequences (
 );
 "#,
     },
+    Migration {
+        version: 27,
+        name: "canonical_work_item_focus",
+        sql: r#"
+CREATE INDEX IF NOT EXISTS idx_agent_states_current_work_item
+  ON agent_states(current_work_item_id);
+
+DROP INDEX IF EXISTS idx_work_items_current_focus;
+
+CREATE TRIGGER IF NOT EXISTS trg_agent_states_focus_insert
+BEFORE INSERT ON agent_states
+WHEN NEW.current_work_item_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM work_items
+    WHERE work_item_id = NEW.current_work_item_id
+      AND agent_id = NEW.agent_id
+      AND state = 'open'
+  ) THEN RAISE(ABORT, 'current WorkItem focus must reference an owned open WorkItem') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_agent_states_focus_update
+BEFORE UPDATE OF current_work_item_id ON agent_states
+WHEN NEW.current_work_item_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM work_items
+    WHERE work_item_id = NEW.current_work_item_id
+      AND agent_id = NEW.agent_id
+      AND state = 'open'
+  ) THEN RAISE(ABORT, 'current WorkItem focus must reference an owned open WorkItem') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_work_items_preserve_focused_target
+BEFORE UPDATE OF agent_id, state ON work_items
+WHEN EXISTS (
+  SELECT 1
+  FROM agent_states
+  WHERE current_work_item_id = OLD.work_item_id
+    AND (agent_id != NEW.agent_id OR NEW.state != 'open')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'focused WorkItem must remain owned and open');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_work_items_preserve_focused_delete
+BEFORE DELETE ON work_items
+WHEN EXISTS (
+  SELECT 1
+  FROM agent_states
+  WHERE current_work_item_id = OLD.work_item_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'focused WorkItem cannot be deleted');
+END;
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -935,6 +1163,10 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     let transaction = connection.transaction()?;
     if migration.name == "strict_runtime_sequences" {
         preflight_runtime_sequence_uniqueness(&transaction)?;
+    }
+    if migration.name == "canonical_work_item_focus" {
+        preflight_work_item_focus(&transaction)?;
+        migrate_work_item_focus(&transaction)?;
     }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "strict_runtime_sequences" {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -18,11 +18,7 @@ use crate::runtime_db::{
 use crate::types::*;
 
 impl WorkItemRepository<'_> {
-    pub fn import_legacy(
-        &self,
-        records: Vec<WorkItemRecord>,
-        current_work_item_id: Option<&str>,
-    ) -> Result<()> {
+    pub fn import_legacy(&self, records: Vec<WorkItemRecord>) -> Result<()> {
         if self.db.storage_domain_is_complete("work_items", "db")? {
             return Ok(());
         }
@@ -38,29 +34,24 @@ impl WorkItemRepository<'_> {
                     }
                 }
                 for record in latest.values() {
-                    import_work_item_tx(
-                        tx,
-                        record,
-                        current_work_item_id == Some(record.id.as_str()),
-                    )?;
+                    import_work_item_tx(tx, record)?;
                 }
                 Ok(serde_json::json!({ "imported_records": latest.len() }))
             })
     }
 
-    pub fn insert_new(&self, record: &WorkItemRecord, current_focus: bool) -> Result<bool> {
+    pub fn insert_new(&self, record: &WorkItemRecord) -> Result<bool> {
         self.db
-            .transaction(|tx| insert_new_work_item_tx(tx, record, current_focus))
+            .transaction(|tx| insert_new_work_item_tx(tx, record))
     }
 
     pub fn insert_new_with_index_changes(
         &self,
         record: &WorkItemRecord,
-        current_focus: bool,
         changes: &[RuntimeIndexChange],
     ) -> Result<bool> {
         self.db.transaction(|tx| {
-            let inserted = insert_new_work_item_tx(tx, record, current_focus)?;
+            let inserted = insert_new_work_item_tx(tx, record)?;
             if inserted {
                 insert_runtime_index_changes_tx(tx, changes)?;
             }
@@ -68,47 +59,23 @@ impl WorkItemRepository<'_> {
         })
     }
 
-    pub fn update_expected(
-        &self,
-        record: &WorkItemRecord,
-        expected_revision: u64,
-        current_focus: bool,
-    ) -> Result<bool> {
-        self.db.transaction(|tx| {
-            update_expected_work_item_tx(tx, record, expected_revision, current_focus)
-        })
+    pub fn update_expected(&self, record: &WorkItemRecord, expected_revision: u64) -> Result<bool> {
+        self.db
+            .transaction(|tx| update_expected_work_item_tx(tx, record, expected_revision))
     }
 
     pub fn update_expected_with_index_changes(
         &self,
         record: &WorkItemRecord,
         expected_revision: u64,
-        current_focus: bool,
         changes: &[RuntimeIndexChange],
     ) -> Result<bool> {
         self.db.transaction(|tx| {
-            let updated =
-                update_expected_work_item_tx(tx, record, expected_revision, current_focus)?;
+            let updated = update_expected_work_item_tx(tx, record, expected_revision)?;
             if updated {
                 insert_runtime_index_changes_tx(tx, changes)?;
             }
             Ok(updated)
-        })
-    }
-
-    pub fn set_current_focus(&self, agent_id: &str, work_item_id: Option<&str>) -> Result<()> {
-        self.db.transaction(|tx| {
-            tx.execute(
-                "UPDATE work_items SET current_focus = 0 WHERE agent_id = ?1 AND current_focus != 0",
-                [agent_id],
-            )?;
-            if let Some(work_item_id) = work_item_id {
-                tx.execute(
-                    "UPDATE work_items SET current_focus = 1 WHERE agent_id = ?1 AND work_item_id = ?2",
-                    params![agent_id, work_item_id],
-                )?;
-            }
-            Ok(())
         })
     }
 
@@ -560,8 +527,10 @@ impl WorkItemContinuationRepository<'_> {
     }
 
     pub fn upsert(&self, record: &WorkItemContinuationFrame) -> Result<()> {
-        self.db
-            .transaction(|tx| upsert_work_item_continuation_tx(tx, record))
+        self.db.transaction(|tx| {
+            upsert_work_item_continuation_tx(tx, record)?;
+            Ok(())
+        })
     }
 
     pub fn recent(&self, limit: usize) -> Result<Vec<WorkItemContinuationFrame>> {
@@ -2543,14 +2512,24 @@ fn upsert_work_item_delegation_tx(
     Ok(())
 }
 
-fn upsert_work_item_continuation_tx(
+pub(crate) fn upsert_work_item_continuation_tx(
     tx: &Transaction<'_>,
     record: &WorkItemContinuationFrame,
-) -> Result<()> {
+) -> Result<bool> {
     let payload_json = serde_json::to_string(record)?;
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM work_item_continuations WHERE continuation_id = ?1",
+            [&record.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    if existing.as_deref() == Some(payload_json.as_str()) {
+        return Ok(false);
+    }
     let return_policy = enum_string(&record.return_policy)?;
     let state = enum_string(&record.state)?;
-    tx.execute(
+    let changed = tx.execute(
         "INSERT INTO work_item_continuations (
             continuation_id, agent_id, suspended_work_item_id, active_work_item_id,
             return_policy, state, created_at, updated_at, resolved_at, cancelled_at,
@@ -2586,7 +2565,7 @@ fn upsert_work_item_continuation_tx(
             payload_json,
         ],
     )?;
-    Ok(())
+    Ok(changed != 0)
 }
 
 fn upsert_context_episode_tx(tx: &Transaction<'_>, record: &ContextEpisodeRecord) -> Result<()> {
@@ -2791,7 +2770,6 @@ fn upsert_operator_delivery_record_tx(
 pub(crate) fn insert_new_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
-    current_focus: bool,
 ) -> Result<bool> {
     if record.revision != 1 {
         return Err(RuntimeStateTransitionConflict::revision(
@@ -2822,7 +2800,7 @@ pub(crate) fn insert_new_work_item_tx(
         )
         .into());
     }
-    import_work_item_tx(tx, record, current_focus)?;
+    import_work_item_tx(tx, record)?;
     Ok(true)
 }
 
@@ -2830,7 +2808,6 @@ pub(crate) fn update_expected_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
     expected_revision: u64,
-    current_focus: bool,
 ) -> Result<bool> {
     let next_revision = expected_revision.checked_add(1).ok_or_else(|| {
         RuntimeStateTransitionConflict::revision(
@@ -2896,14 +2873,13 @@ pub(crate) fn update_expected_work_item_tx(
         .into());
     }
 
-    update_work_item_row_tx(tx, record, current_focus, &payload_json, expected_revision)?;
+    update_work_item_row_tx(tx, record, &payload_json, expected_revision)?;
     Ok(true)
 }
 
 fn update_work_item_row_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
-    current_focus: bool,
     payload_json: &str,
     expected_revision: u64,
 ) -> Result<()> {
@@ -2924,17 +2900,16 @@ fn update_work_item_row_tx(
             plan_status = ?4,
             readiness = ?5,
             revision = ?6,
-            current_focus = ?7,
-            created_at = ?8,
-            updated_at = ?9,
-            completed_at = ?10,
-            plan_artifact_path = ?11,
-            last_turn_id = ?12,
-            payload_json = ?13,
-            blocked_by = ?14,
-            recheck_at = ?15,
-            recheck_consumed_at = ?16
-         WHERE work_item_id = ?17 AND revision = ?18",
+            created_at = ?7,
+            updated_at = ?8,
+            completed_at = ?9,
+            plan_artifact_path = ?10,
+            last_turn_id = ?11,
+            payload_json = ?12,
+            blocked_by = ?13,
+            recheck_at = ?14,
+            recheck_consumed_at = ?15
+         WHERE work_item_id = ?16 AND revision = ?17",
         params![
             record.agent_id,
             state,
@@ -2942,7 +2917,6 @@ fn update_work_item_row_tx(
             plan_status,
             readiness,
             record.revision as i64,
-            i64::from(current_focus),
             timestamp(record.created_at),
             timestamp(record.updated_at),
             completed_at,
@@ -2969,11 +2943,7 @@ fn update_work_item_row_tx(
     Ok(())
 }
 
-fn import_work_item_tx(
-    tx: &Transaction<'_>,
-    record: &WorkItemRecord,
-    current_focus: bool,
-) -> Result<()> {
+fn import_work_item_tx(tx: &Transaction<'_>, record: &WorkItemRecord) -> Result<()> {
     let payload_json = serde_json::to_string(record)?;
     let state = enum_string(&record.state)?;
     let plan_status = enum_string(&record.plan_status)?;
@@ -3001,7 +2971,6 @@ fn import_work_item_tx(
             plan_status = excluded.plan_status,
             readiness = excluded.readiness,
             revision = excluded.revision,
-            current_focus = excluded.current_focus,
             created_at = excluded.created_at,
             updated_at = excluded.updated_at,
             completed_at = excluded.completed_at,
@@ -3020,7 +2989,7 @@ fn import_work_item_tx(
             plan_status,
             readiness,
             record.revision as i64,
-            i64::from(current_focus),
+            0_i64,
             timestamp(record.created_at),
             timestamp(record.updated_at),
             completed_at,

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -102,6 +102,22 @@ mod tests {
         }
     }
 
+    fn mark_migration_applied(connection: &rusqlite::Connection, name: &str) -> Result<()> {
+        let migration = MIGRATIONS
+            .iter()
+            .find(|migration| migration.name == name)
+            .ok_or_else(|| anyhow!("missing migration {name}"))?;
+        connection.execute(
+            "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+            (
+                migration.version,
+                migration.name,
+                Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            ),
+        )?;
+        Ok(())
+    }
+
     #[test]
     fn runtime_db_retryable_error_classification_survives_context() -> Result<()> {
         let (_temp_dir, db_path, _lock_path) = temp_paths()?;
@@ -403,6 +419,7 @@ INSERT INTO storage_domains (
                     ),
                 )?;
             }
+            mark_migration_applied(&connection, "canonical_work_item_focus")?;
         }
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -543,6 +560,115 @@ INSERT INTO storage_domains (
     }
 
     #[test]
+    fn work_item_focus_migration_backfills_single_legacy_focus() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut work = WorkItemRecord::new("agent-a", "legacy focus", WorkItemState::Open);
+        work.id = "work-legacy-focus".into();
+        db.work_items().insert_new(&work)?;
+        db.agent_states().upsert(&AgentState::new("agent-a"))?;
+        {
+            let connection = open_connection(&db_path)?;
+            connection.execute_batch(
+                "DELETE FROM schema_migrations WHERE version = 27;
+                 DROP INDEX idx_agent_states_current_work_item;
+                 DROP TRIGGER trg_agent_states_focus_insert;
+                 DROP TRIGGER trg_agent_states_focus_update;
+                 DROP TRIGGER trg_work_items_preserve_focused_target;
+                 DROP TRIGGER trg_work_items_preserve_focused_delete;",
+            )?;
+            connection.execute(
+                "UPDATE work_items SET current_focus = 1 WHERE work_item_id = ?1",
+                [&work.id],
+            )?;
+        }
+
+        let migrated = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let state = migrated
+            .agent_states()
+            .latest("agent-a")?
+            .expect("agent state");
+        assert_eq!(
+            state.current_work_item_id.as_deref(),
+            Some(work.id.as_str())
+        );
+        let connection = migrated.connection()?;
+        let legacy_focus: i64 = connection.query_row(
+            "SELECT current_focus FROM work_items WHERE work_item_id = ?1",
+            [&work.id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(legacy_focus, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_focus_migration_rejects_conflicting_facts() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut canonical = WorkItemRecord::new("agent-a", "canonical", WorkItemState::Open);
+        canonical.id = "work-canonical".into();
+        let mut legacy = WorkItemRecord::new("agent-a", "legacy", WorkItemState::Open);
+        legacy.id = "work-legacy".into();
+        db.work_items().insert_new(&canonical)?;
+        db.work_items().insert_new(&legacy)?;
+        let mut state = AgentState::new("agent-a");
+        state.current_work_item_id = Some(canonical.id.clone());
+        db.agent_states().upsert(&state)?;
+        {
+            let connection = open_connection(&db_path)?;
+            connection.execute_batch(
+                "DELETE FROM schema_migrations WHERE version = 27;
+                 DROP INDEX idx_agent_states_current_work_item;
+                 DROP TRIGGER trg_agent_states_focus_insert;
+                 DROP TRIGGER trg_agent_states_focus_update;
+                 DROP TRIGGER trg_work_items_preserve_focused_target;
+                 DROP TRIGGER trg_work_items_preserve_focused_delete;",
+            )?;
+            connection.execute(
+                "UPDATE work_items SET current_focus = 1 WHERE work_item_id = ?1",
+                [&legacy.id],
+            )?;
+        }
+
+        let error = RuntimeDb::open_and_migrate(&db_path, &lock_path).unwrap_err();
+        let text = error.to_string();
+        assert!(text.contains("conflicting focus facts"), "{text}");
+        assert!(text.contains(&canonical.id), "{text}");
+        assert!(text.contains(&legacy.id), "{text}");
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_focus_constraints_reject_invalid_targets_and_completion() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut own = WorkItemRecord::new("agent-a", "own", WorkItemState::Open);
+        own.id = "work-own".into();
+        let mut foreign = WorkItemRecord::new("agent-b", "foreign", WorkItemState::Open);
+        foreign.id = "work-foreign".into();
+        db.work_items().insert_new(&own)?;
+        db.work_items().insert_new(&foreign)?;
+        let mut state = AgentState::new("agent-a");
+        state.current_work_item_id = Some(foreign.id.clone());
+        assert!(db.agent_states().upsert(&state).is_err());
+        state.current_work_item_id = Some("work-missing".into());
+        assert!(db.agent_states().upsert(&state).is_err());
+        state.current_work_item_id = Some(own.id.clone());
+        db.agent_states().upsert(&state)?;
+
+        let mut completed = own.clone();
+        completed.revision = 2;
+        completed.state = WorkItemState::Completed;
+        completed.updated_at = Utc::now();
+        assert!(db
+            .work_items()
+            .update_expected(&completed, own.revision)
+            .is_err());
+        Ok(())
+    }
+
+    #[test]
     fn runtime_db_migration_compacts_queue_entries_to_current_view() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         {
@@ -594,6 +720,7 @@ INSERT INTO queue_entries (
                     ),
                 )?;
             }
+            mark_migration_applied(&connection, "canonical_work_item_focus")?;
         }
 
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -1053,6 +1180,7 @@ CREATE TABLE working_memory_deltas (
                 "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
                 (15_i64, "message_search_index", Utc::now().to_rfc3339()),
             )?;
+            mark_migration_applied(&connection, "canonical_work_item_focus")?;
         }
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -1650,6 +1778,12 @@ CREATE TABLE working_memory_deltas (
     fn agent_state_repository_upserts_latest_turn_state() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut current_work = WorkItemRecord::new("agent-a", "current focus", WorkItemState::Open);
+        current_work.id = "work-current".into();
+        let mut stale_work = WorkItemRecord::new("agent-a", "stale focus", WorkItemState::Open);
+        stale_work.id = "work-stale".into();
+        db.work_items().insert_new(&current_work)?;
+        db.work_items().insert_new(&stale_work)?;
         let mut current = AgentState::new("agent-a");
         current.status = AgentStatus::AwakeIdle;
         current.turn_index = 3;
@@ -2146,9 +2280,9 @@ CREATE TABLE working_memory_deltas (
         newer.updated_at = older.updated_at + chrono::Duration::seconds(10);
 
         db.work_items()
-            .import_legacy(vec![older.clone(), newer.clone()], Some("work-test"))?;
+            .import_legacy(vec![older.clone(), newer.clone()])?;
         db.work_items()
-            .import_legacy(vec![older.clone(), newer.clone()], Some("work-test"))?;
+            .import_legacy(vec![older.clone(), newer.clone()])?;
 
         let imported = db
             .work_items()
@@ -2165,7 +2299,7 @@ CREATE TABLE working_memory_deltas (
             [],
             |row| row.get(0),
         )?;
-        assert_eq!(current_focus, 1);
+        assert_eq!(current_focus, 0);
         Ok(())
     }
 
@@ -2173,22 +2307,19 @@ CREATE TABLE working_memory_deltas (
     fn work_item_upsert_rejects_revision_rollback() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        db.work_items().import_legacy(Vec::new(), None)?;
+        db.work_items().import_legacy(Vec::new())?;
         let mut current = WorkItemRecord::new("agent-a", "current", WorkItemState::Open);
         current.id = "work-revision".into();
-        db.work_items().insert_new(&current, false)?;
+        db.work_items().insert_new(&current)?;
         current.revision = 2;
         current.updated_at += chrono::Duration::seconds(1);
-        db.work_items().update_expected(&current, 1, false)?;
+        db.work_items().update_expected(&current, 1)?;
 
         let mut stale = current.clone();
         stale.objective = "stale".into();
         stale.revision = 1;
         stale.updated_at = current.updated_at + chrono::Duration::seconds(10);
-        let error = db
-            .work_items()
-            .update_expected(&stale, 0, false)
-            .unwrap_err();
+        let error = db.work_items().update_expected(&stale, 0).unwrap_err();
         let conflict = error
             .downcast_ref::<RuntimeStateTransitionConflict>()
             .expect("stale update should return typed conflict");
@@ -2213,20 +2344,20 @@ CREATE TABLE working_memory_deltas (
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let mut initial = WorkItemRecord::new("agent-a", "initial", WorkItemState::Open);
         initial.id = "work-cas".into();
-        db.work_items().insert_new(&initial, false)?;
+        db.work_items().insert_new(&initial)?;
 
         let mut updated = initial.clone();
         updated.revision = 2;
         updated.objective = "updated".into();
         updated.updated_at += chrono::Duration::seconds(1);
-        assert!(db.work_items().update_expected(&updated, 1, false)?);
-        assert!(!db.work_items().update_expected(&updated, 1, false)?);
+        assert!(db.work_items().update_expected(&updated, 1)?);
+        assert!(!db.work_items().update_expected(&updated, 1)?);
 
         let mut conflicting = updated.clone();
         conflicting.objective = "conflicting".into();
         let error = db
             .work_items()
-            .update_expected(&conflicting, 1, false)
+            .update_expected(&conflicting, 1)
             .unwrap_err();
         let conflict = error
             .downcast_ref::<RuntimeStateTransitionConflict>()
@@ -2246,7 +2377,7 @@ CREATE TABLE working_memory_deltas (
         let second = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let mut initial = WorkItemRecord::new("agent-a", "initial", WorkItemState::Open);
         initial.id = "work-concurrent-cas".into();
-        first.work_items().insert_new(&initial, false)?;
+        first.work_items().insert_new(&initial)?;
 
         let mut left = initial.clone();
         left.revision = 2;
@@ -2255,11 +2386,8 @@ CREATE TABLE working_memory_deltas (
         right.revision = 2;
         right.objective = "right".into();
 
-        assert!(first.work_items().update_expected(&left, 1, false)?);
-        let error = second
-            .work_items()
-            .update_expected(&right, 1, false)
-            .unwrap_err();
+        assert!(first.work_items().update_expected(&left, 1)?);
+        let error = second.work_items().update_expected(&right, 1).unwrap_err();
         let conflict = error
             .downcast_ref::<RuntimeStateTransitionConflict>()
             .expect("second writer should return typed conflict");
@@ -2279,13 +2407,13 @@ CREATE TABLE working_memory_deltas (
     fn work_item_listing_is_partitioned_by_agent() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        db.work_items().import_legacy(Vec::new(), None)?;
+        db.work_items().import_legacy(Vec::new())?;
         let mut first = WorkItemRecord::new("agent-a", "first", WorkItemState::Open);
         first.id = "work-first".into();
         let mut second = WorkItemRecord::new("agent-b", "second", WorkItemState::Open);
         second.id = "work-second".into();
-        db.work_items().insert_new(&first, false)?;
-        db.work_items().insert_new(&second, false)?;
+        db.work_items().insert_new(&first)?;
+        db.work_items().insert_new(&second)?;
 
         let agent_items = db.work_items().latest_for_agent("agent-a", 20)?;
         assert_eq!(agent_items.len(), 1);

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -12,13 +12,14 @@ use crate::{
         repositories::{
             insert_new_work_item_tx, queue_entry_transition, task_transition,
             try_claim_queued_message_tx, update_expected_work_item_tx, upsert_queue_entry_tx,
-            upsert_task_tx, upsert_wait_condition_tx, wait_condition_transition,
+            upsert_task_tx, upsert_wait_condition_tx, upsert_work_item_continuation_tx,
+            wait_condition_transition,
         },
         RuntimeDb, RuntimeIndexChange,
     },
     types::{
         AgentState, AuditEvent, QueueEntryRecord, TaskRecord, TranscriptEntry, WaitConditionRecord,
-        WorkItemRecord,
+        WorkItemContinuationFrame, WorkItemRecord, WorkItemState,
     },
 };
 
@@ -54,12 +55,10 @@ pub(crate) struct PostCommitWarning {
 pub(crate) enum WorkItemMutation {
     Insert {
         record: WorkItemRecord,
-        current_focus: bool,
     },
     Update {
         record: WorkItemRecord,
         expected_revision: u64,
-        current_focus: bool,
     },
 }
 
@@ -130,6 +129,19 @@ pub(crate) struct WaitTransitionCommand {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct WorkItemFocusTransitionCommand {
+    pub agent_id: String,
+    pub work_items: Vec<WorkItemMutation>,
+    pub wait_conditions: Vec<WaitConditionRecord>,
+    pub continuations: Vec<WorkItemContinuationFrame>,
+    pub agent_state: AgentStateMutation,
+    pub audit_events: Vec<AuditEvent>,
+    pub index_changes: Vec<RuntimeIndexChange>,
+    pub notify_scheduler: bool,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct QueueTransitionCommand {
     pub agent_id: String,
     pub mutation: QueueMutation,
@@ -165,6 +177,63 @@ impl RuntimeDb {
 }
 
 impl RuntimeTransitionRepository<'_> {
+    pub fn commit_work_item_focus(
+        &self,
+        command: &WorkItemFocusTransitionCommand,
+    ) -> Result<TransitionCommit> {
+        self.db.transaction(|tx| {
+            for work_item in &command.work_items {
+                validate_work_item_mutation_tx(tx, work_item)?;
+            }
+            for condition in &command.wait_conditions {
+                validate_wait_condition_tx(tx, condition)?;
+            }
+            for continuation in &command.continuations {
+                validate_work_item_continuation_tx(tx, continuation)?;
+            }
+            validate_agent_state_mutation_tx(tx, Some(&command.agent_state))?;
+            validate_focus_target_tx(tx, &command.agent_state.record)?;
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+
+            let agent_state_applied =
+                apply_agent_state_mutation_tx(tx, Some(&command.agent_state))?;
+            let mut applied = agent_state_applied;
+            let mut work_items = Vec::new();
+            for work_item in &command.work_items {
+                let work_item_applied = apply_work_item_mutation_tx(tx, work_item)?;
+                applied |= work_item_applied;
+                if work_item_applied {
+                    work_items.push(work_item.record().clone());
+                }
+            }
+            for condition in &command.wait_conditions {
+                applied |= upsert_wait_condition_tx(tx, condition)?;
+            }
+            for continuation in &command.continuations {
+                applied |= upsert_work_item_continuation_tx(tx, continuation)?;
+            }
+            if !applied {
+                return Ok(TransitionCommit::default());
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+
+            finish_transition_tx(
+                tx,
+                applied,
+                &command.agent_id,
+                &command.audit_events,
+                &command.index_changes,
+                command.fault,
+                PostCommitEffects {
+                    agent_state: agent_state_applied.then(|| command.agent_state.clone()),
+                    work_items,
+                    notify_scheduler: command.notify_scheduler,
+                    ..PostCommitEffects::default()
+                },
+            )
+        })
+    }
+
     pub fn commit_work_item(
         &self,
         command: &WorkItemTransitionCommand,
@@ -409,6 +478,64 @@ fn validate_agent_state_mutation_tx(
     Ok(())
 }
 
+fn validate_focus_target_tx(tx: &Transaction<'_>, state: &AgentState) -> Result<()> {
+    let Some(work_item_id) = state.current_work_item_id.as_deref() else {
+        return Ok(());
+    };
+    let target = tx
+        .query_row(
+            "SELECT agent_id, payload_json FROM work_items WHERE work_item_id = ?1",
+            [work_item_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    let Some((owner_agent_id, payload_json)) = target else {
+        return Err(anyhow!(
+            "cannot focus missing work item {work_item_id} for agent {}",
+            state.id
+        ));
+    };
+    let record: WorkItemRecord = serde_json::from_str(&payload_json)?;
+    if owner_agent_id != state.id || record.agent_id != state.id {
+        return Err(anyhow!(
+            "cannot focus work item {work_item_id} owned by another agent"
+        ));
+    }
+    if record.state != WorkItemState::Open {
+        return Err(anyhow!("cannot focus completed work item {work_item_id}"));
+    }
+    Ok(())
+}
+
+fn validate_work_item_continuation_tx(
+    tx: &Transaction<'_>,
+    incoming: &WorkItemContinuationFrame,
+) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM work_item_continuations WHERE continuation_id = ?1",
+            [&incoming.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<WorkItemContinuationFrame>(&payload))
+        .transpose()?;
+    if let Some(existing) = existing {
+        if existing.agent_id != incoming.agent_id
+            || existing.suspended_work_item_id != incoming.suspended_work_item_id
+            || existing.active_work_item_id != incoming.active_work_item_id
+            || existing.return_policy != incoming.return_policy
+            || incoming.updated_at < existing.updated_at
+        {
+            return Err(anyhow!(
+                "work item continuation {} changed before runtime transition commit",
+                incoming.id
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn apply_agent_state_mutation_tx(
     tx: &Transaction<'_>,
     mutation: Option<&AgentStateMutation>,
@@ -425,7 +552,7 @@ fn apply_agent_state_mutation_tx(
 
 fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<()> {
     match mutation {
-        WorkItemMutation::Insert { record, .. } => {
+        WorkItemMutation::Insert { record } => {
             if record.revision != 1 {
                 return Err(anyhow!(
                     "work item {} insert requires revision 1",
@@ -441,14 +568,13 @@ fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutat
                 .optional()?;
             if let Some(payload) = existing {
                 if payload != serde_json::to_string(record)? {
-                    insert_new_work_item_tx(tx, record, false)?;
+                    insert_new_work_item_tx(tx, record)?;
                 }
             }
         }
         WorkItemMutation::Update {
             record,
             expected_revision,
-            ..
         } => {
             let existing = tx
                 .query_row(
@@ -458,7 +584,7 @@ fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutat
                 )
                 .optional()?;
             let Some((actual_revision, payload)) = existing else {
-                update_expected_work_item_tx(tx, record, *expected_revision, false)?;
+                update_expected_work_item_tx(tx, record, *expected_revision)?;
                 return Ok(());
             };
             let actual_revision = u64::try_from(actual_revision)?;
@@ -466,7 +592,7 @@ fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutat
                 && !(actual_revision == record.revision
                     && payload == serde_json::to_string(record)?)
             {
-                update_expected_work_item_tx(tx, record, *expected_revision, false)?;
+                update_expected_work_item_tx(tx, record, *expected_revision)?;
             }
         }
     }
@@ -475,10 +601,7 @@ fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutat
 
 fn apply_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<bool> {
     match mutation {
-        WorkItemMutation::Insert {
-            record,
-            current_focus,
-        } => {
+        WorkItemMutation::Insert { record } => {
             let existing = tx
                 .query_row(
                     "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
@@ -489,14 +612,13 @@ fn apply_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation
             if existing.as_deref() == Some(serde_json::to_string(record)?.as_str()) {
                 Ok(false)
             } else {
-                insert_new_work_item_tx(tx, record, *current_focus)
+                insert_new_work_item_tx(tx, record)
             }
         }
         WorkItemMutation::Update {
             record,
             expected_revision,
-            current_focus,
-        } => update_expected_work_item_tx(tx, record, *expected_revision, *current_focus),
+        } => update_expected_work_item_tx(tx, record, *expected_revision),
     }
 }
 
@@ -568,7 +690,7 @@ mod tests {
         runtime_db::{RuntimeIndexChange, RuntimeIndexOperation},
         types::{
             Priority, QueueEntryStatus, TaskKind, TaskStatus, WaitConditionKind,
-            WaitConditionStatus, WakeSource, WorkItemState,
+            WaitConditionStatus, WakeSource, WorkItemContinuationState, WorkItemState,
         },
     };
     use chrono::Utc;
@@ -658,7 +780,6 @@ mod tests {
                     agent_id: "agent-a".into(),
                     mutation: WorkItemMutation::Insert {
                         record: record.clone(),
-                        current_focus: false,
                     },
                     agent_state: None,
                     audit_events: vec![AuditEvent::new("work_item_test", serde_json::json!({}))],
@@ -689,7 +810,6 @@ mod tests {
             agent_id: "agent-a".into(),
             mutation: WorkItemMutation::Insert {
                 record: record.clone(),
-                current_focus: false,
             },
             agent_state: None,
             audit_events: vec![AuditEvent::new("work_item_test", serde_json::json!({}))],
@@ -710,10 +830,164 @@ mod tests {
     }
 
     #[test]
+    fn work_item_focus_transition_faults_roll_back_focus_and_continuation() -> Result<()> {
+        for fault in [
+            TransitionFaultPoint::AfterValidation,
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let first = work_item("work-first");
+            let second = work_item("work-second");
+            db.work_items().insert_new(&first)?;
+            db.work_items().insert_new(&second)?;
+            let mut initial_state = AgentState::new("agent-a");
+            initial_state.current_work_item_id = Some(first.id.clone());
+            db.agent_states().upsert(&initial_state)?;
+            let mut next_state = initial_state.clone();
+            next_state.current_work_item_id = Some(second.id.clone());
+            let continuation = WorkItemContinuationFrame::new_on_completed(
+                "agent-a",
+                first.id.clone(),
+                second.id.clone(),
+                None,
+            );
+
+            db.transitions()
+                .commit_work_item_focus(&WorkItemFocusTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    work_items: Vec::new(),
+                    wait_conditions: Vec::new(),
+                    continuations: vec![continuation],
+                    agent_state: AgentStateMutation {
+                        expected: Some(Box::new(initial_state.clone())),
+                        record: Box::new(next_state),
+                    },
+                    audit_events: vec![AuditEvent::new("work_item_picked", serde_json::json!({}))],
+                    index_changes: Vec::new(),
+                    notify_scheduler: true,
+                    fault: Some(fault),
+                })
+                .unwrap_err();
+
+            assert_eq!(db.agent_states().latest("agent-a")?, Some(initial_state));
+            assert!(db.work_item_continuations().latest_all()?.is_empty());
+            assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_focus_transition_restores_caller_atomically_with_completion() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let caller = work_item("work-caller");
+        let active = work_item("work-active");
+        db.work_items().insert_new(&caller)?;
+        db.work_items().insert_new(&active)?;
+        let frame = WorkItemContinuationFrame::new_on_completed(
+            "agent-a",
+            caller.id.clone(),
+            active.id.clone(),
+            None,
+        );
+        db.work_item_continuations().upsert(&frame)?;
+        let mut initial_state = AgentState::new("agent-a");
+        initial_state.current_work_item_id = Some(active.id.clone());
+        db.agent_states().upsert(&initial_state)?;
+        let mut next_state = initial_state.clone();
+        next_state.current_work_item_id = Some(caller.id.clone());
+        let mut completed = active.clone();
+        completed.revision = 2;
+        completed.state = WorkItemState::Completed;
+        completed.updated_at = Utc::now();
+        let resumed = frame.resume("active_work_item_completed");
+
+        db.transitions()
+            .commit_work_item_focus(&WorkItemFocusTransitionCommand {
+                agent_id: "agent-a".into(),
+                work_items: vec![WorkItemMutation::Update {
+                    record: completed.clone(),
+                    expected_revision: active.revision,
+                }],
+                wait_conditions: Vec::new(),
+                continuations: vec![resumed],
+                agent_state: AgentStateMutation {
+                    expected: Some(Box::new(initial_state)),
+                    record: Box::new(next_state.clone()),
+                },
+                audit_events: Vec::new(),
+                index_changes: Vec::new(),
+                notify_scheduler: true,
+                fault: None,
+            })?;
+
+        assert_eq!(db.agent_states().latest("agent-a")?, Some(next_state));
+        assert_eq!(
+            db.work_items().latest(&active.id)?.unwrap().state,
+            WorkItemState::Completed
+        );
+        assert_eq!(
+            db.work_item_continuations().latest_all()?[0].state,
+            WorkItemContinuationState::Resumed
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_focus_commands_require_the_same_expected_agent_state() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let first = work_item("work-first");
+        let second = work_item("work-second");
+        db.work_items().insert_new(&first)?;
+        db.work_items().insert_new(&second)?;
+        let initial_state = AgentState::new("agent-a");
+        db.agent_states().upsert(&initial_state)?;
+        let command = |target: &WorkItemRecord| {
+            let mut next_state = initial_state.clone();
+            next_state.current_work_item_id = Some(target.id.clone());
+            WorkItemFocusTransitionCommand {
+                agent_id: "agent-a".into(),
+                work_items: Vec::new(),
+                wait_conditions: Vec::new(),
+                continuations: Vec::new(),
+                agent_state: AgentStateMutation {
+                    expected: Some(Box::new(initial_state.clone())),
+                    record: Box::new(next_state),
+                },
+                audit_events: Vec::new(),
+                index_changes: Vec::new(),
+                notify_scheduler: true,
+                fault: None,
+            }
+        };
+
+        assert!(
+            db.transitions()
+                .commit_work_item_focus(&command(&first))?
+                .applied
+        );
+        let error = db
+            .transitions()
+            .commit_work_item_focus(&command(&second))
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("changed before runtime transition commit"));
+        assert_eq!(
+            db.agent_states()
+                .latest("agent-a")?
+                .and_then(|state| state.current_work_item_id),
+            Some(first.id)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn wait_transition_rolls_back_work_item_wait_audit_and_outbox_together() -> Result<()> {
         let (_dir, db) = runtime_db()?;
         let initial = work_item("work-wait");
-        db.work_items().insert_new(&initial, false)?;
+        db.work_items().insert_new(&initial)?;
         let mut blocked = initial.clone();
         blocked.revision = 2;
         blocked.blocked_by = Some("waiting for task".into());
@@ -726,7 +1000,6 @@ mod tests {
                 work_items: vec![WorkItemMutation::Update {
                     record: blocked,
                     expected_revision: 1,
-                    current_focus: false,
                 }],
                 wait_conditions: vec![wait],
                 agent_state: None,
@@ -812,7 +1085,7 @@ mod tests {
         let (_dir, db) = runtime_db()?;
         let mut initial_work = work_item("work-task");
         initial_work.blocked_by = Some("waiting for task".into());
-        db.work_items().insert_new(&initial_work, false)?;
+        db.work_items().insert_new(&initial_work)?;
         let active_wait = wait_condition("wait-task", &initial_work.id, "task-1");
         db.wait_conditions().upsert(&active_wait)?;
         let running = task("task-1", TaskStatus::Running);
@@ -835,7 +1108,6 @@ mod tests {
             work_items: vec![WorkItemMutation::Update {
                 record: cleared.clone(),
                 expected_revision: 1,
-                current_focus: false,
             }],
             wait_conditions: vec![resolved],
             agent_state: None,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -546,15 +546,10 @@ impl AppStorage {
     pub fn insert_work_item(&self, record: &WorkItemRecord) -> Result<()> {
         self.ensure_writable()?;
         let runtime_db = self.runtime_db.clone();
-        let current_focus = self
-            .read_agent()?
-            .and_then(|agent| agent.current_work_item_id)
-            .as_deref()
-            == Some(record.id.as_str());
         let changes = self.index_changes_for_work_item(record)?;
         runtime_db
             .work_items()
-            .insert_new_with_index_changes(record, current_focus, &changes)?;
+            .insert_new_with_index_changes(record, &changes)?;
         self.enqueue_memory_index_work_item_best_effort(record)
     }
 
@@ -565,16 +560,10 @@ impl AppStorage {
     ) -> Result<()> {
         self.ensure_writable()?;
         let runtime_db = self.runtime_db.clone();
-        let current_focus = self
-            .read_agent()?
-            .and_then(|agent| agent.current_work_item_id)
-            .as_deref()
-            == Some(record.id.as_str());
         let changes = self.index_changes_for_work_item(record)?;
         runtime_db.work_items().update_expected_with_index_changes(
             record,
             expected_revision,
-            current_focus,
             &changes,
         )?;
         self.enqueue_memory_index_work_item_best_effort(record)
@@ -2651,10 +2640,7 @@ mod tests {
         )
         .unwrap();
         runtime_db.tasks().import_legacy(Vec::new()).unwrap();
-        runtime_db
-            .work_items()
-            .import_legacy(Vec::new(), None)
-            .unwrap();
+        runtime_db.work_items().import_legacy(Vec::new()).unwrap();
         runtime_db
             .wait_conditions()
             .import_legacy(Vec::new())
@@ -4727,8 +4713,8 @@ mod tests {
         agent.status = AgentStatus::Asleep;
         let runnable = WorkItemRecord::new("default", "current runnable", WorkItemState::Open);
         agent.current_work_item_id = Some(runnable.id.clone());
-        storage.write_agent(&agent).unwrap();
         storage.append_work_item(&runnable).unwrap();
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::HasRunnableWork
@@ -5218,10 +5204,7 @@ mod tests {
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        runtime_db
-            .work_items()
-            .import_legacy(Vec::new(), None)
-            .unwrap();
+        runtime_db.work_items().import_legacy(Vec::new()).unwrap();
         let mut current = WorkItemRecord::new("default", "current agent item", WorkItemState::Open);
         current.updated_at = Utc::now();
         let mut other_agent =


### PR DESCRIPTION
## 关联 Issue

Closes #2261

## 需求解释

将 WorkItem current focus 收敛为每个 agent 唯一的 durable canonical fact，并保证 pick、complete、yield、resume、recovery 在 Transition UoW 内一致更新与恢复。

## 主要变更

- 新增 current focus RFC，冻结 canonical fact、transition 与 operator wait rehydrate 合约。
- 以 `agent_states.current_work_item_id` 作为唯一持久事实，并在数据库 migration 中增加引用完整性与迁移 preflight。
- 将 pick、release、complete、continuation yield/resume 等路径迁移到原子 focus transition command。
- 移除 `work_items.current_focus` 双写，以及 durable focus 对 `current_turn_work_item_id` fallback 的依赖。
- 更新 repository/runtime 测试，覆盖约束、迁移、原子 transition 与重启恢复语义。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`

以上门禁均通过。

## 阻塞与后续

- 无已知阻塞。
- #2263 可在本 PR 确立的 canonical focus fact 上统一 scheduling read-model。
