### PR TITLE
fix: complete failed tool audit projections

### DIFF
--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -329,6 +329,13 @@ async fn disallowed_tool_call_is_auditable_and_continuation_stays_valid() {
         failure_event.data["error_kind"].as_str(),
         Some("tool_not_exposed_for_round")
     );
+    assert_eq!(failure_event.data["agent_id"].as_str(), Some("default"));
+    assert_eq!(failure_event.data["status"].as_str(), Some("error"));
+    assert_eq!(failure_event.data["duration_ms"].as_u64(), Some(0));
+    assert_eq!(
+        failure_event.data["summary"].as_str(),
+        Some("Failed: CreateTask not exposed for round")
+    );
 
     let transcript = runtime.storage().read_recent_transcript(10).unwrap();
     assert_eq!(

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1700,18 +1700,23 @@ impl TurnExecution<'_> {
                     tool_execution_refs.push((tool_call_id.clone(), failed_id.clone()));
                     runtime.inner.storage.append_event(&AuditEvent::new(
                         "tool_execution_failed",
-                        serde_json::json!({
-                            "tool_call_id": tool_call_id,
-                            "tool_execution_id": failed_id,
-                            "tool_name": tool_name,
-                            "turn_index": turn_index,
-                            "run_id": run_id,
-                            "work_item_id": work_item_id,
-                            "input": tool_audit_input_field(&call),
-                            "exec_command_cmd": command_preview_field(&call),
-                            "exec_command_display": command_display_field(&call),
-                            "exec_command_batch_items": command_batch_preview_field(&call),
-                            "exec_command_cost": command_cost_field(
+                        to_json_value(&ToolExecutionAuditEvent {
+                            tool_call_id: tool_call_id.clone(),
+                            tool_execution_id: failed_id,
+                            agent_id: failed_record.agent_id.clone(),
+                            tool_name: tool_name.clone(),
+                            turn_index,
+                            turn_id,
+                            run_id,
+                            work_item_id,
+                            status: failed_record.status.clone(),
+                            duration_ms: failed_record.duration_ms,
+                            summary: failed_record.summary.clone(),
+                            input: tool_audit_input_field(&call),
+                            exec_command_cmd: command_preview_field(&call),
+                            exec_command_display: command_display_field(&call),
+                            exec_command_batch_items: command_batch_preview_field(&call),
+                            exec_command_cost: command_cost_field(
                                 &call,
                                 {
                                     let snap = runtime.inner.config_snapshot.load();
@@ -1722,10 +1727,13 @@ impl TurnExecution<'_> {
                                     snap.max_tool_output_tokens
                                 },
                             ),
-                            "error": audit_error,
-                            "error_kind": error.kind.clone(),
-                            "tool_error": error.clone(),
-                            "reason": "tool_not_exposed_for_round",
+                            exec_command_disposition: None,
+                            exit_status: None,
+                            task_handle: None,
+                            error: Some(audit_error),
+                            error_kind: Some(error.kind.clone()),
+                            tool_error: Some(error.clone()),
+                            reason: Some("tool_not_exposed_for_round".into()),
                         }),
                     ))?;
                     tool_results.push(ToolResultBlock {
@@ -1889,6 +1897,8 @@ impl TurnExecution<'_> {
                                 ),
                                 error: result.tool_error().map(|error| error.render()),
                                 error_kind: result.tool_error().map(|error| error.kind.clone()),
+                                tool_error: result.tool_error().cloned(),
+                                reason: None,
                             }),
                         ))?;
                         tool_result_envelopes.push(result.envelope.clone());
@@ -1953,24 +1963,38 @@ impl TurnExecution<'_> {
                         tool_execution_refs.push((tool_call_id.clone(), failed_id.clone()));
                         runtime.inner.storage.append_event(&AuditEvent::new(
                             "tool_execution_failed",
-                            serde_json::json!({
-                                "tool_call_id": tool_call_id,
-                                "tool_execution_id": failed_id,
-                                "tool_name": tool_name,
-                                "turn_index": turn_index,
-                                "run_id": run_id,
-                                "work_item_id": work_item_id,
-                                "exec_command_cmd": command_preview_field(&call),
-                                "exec_command_display": command_display_field(&call),
-                                "exec_command_batch_items": command_batch_preview_field(&call),
-                                "exec_command_cost": command_cost_field(
+                            to_json_value(&ToolExecutionAuditEvent {
+                                tool_call_id: tool_call_id.clone(),
+                                tool_execution_id: failed_id,
+                                agent_id: failed_record.agent_id.clone(),
+                                tool_name: tool_name.clone(),
+                                turn_index,
+                                turn_id,
+                                run_id,
+                                work_item_id,
+                                status: failed_record.status.clone(),
+                                duration_ms: failed_record.duration_ms,
+                                summary: failed_record.summary.clone(),
+                                input: tool_audit_input_field(&call),
+                                exec_command_cmd: command_preview_field(&call),
+                                exec_command_display: command_display_field(&call),
+                                exec_command_batch_items: command_batch_preview_field(&call),
+                                exec_command_cost: command_cost_field(
                                     &call,
-                                    runtime.inner.config_snapshot.load().default_tool_output_tokens,
-                                    runtime.inner.config_snapshot.load().max_tool_output_tokens
+                                    runtime
+                                        .inner
+                                        .config_snapshot
+                                        .load()
+                                        .default_tool_output_tokens,
+                                    runtime.inner.config_snapshot.load().max_tool_output_tokens,
                                 ),
-                                "error": audit_error,
-                                "error_kind": error.kind.clone(),
-                                "tool_error": error.clone(),
+                                exec_command_disposition: None,
+                                exit_status: None,
+                                task_handle: None,
+                                error: Some(audit_error),
+                                error_kind: Some(error.kind.clone()),
+                                tool_error: Some(error.clone()),
+                                reason: None,
                             }),
                         ))?;
                         tool_results.push(ToolResultBlock {

--- a/src/types.rs
+++ b/src/types.rs
@@ -4380,6 +4380,10 @@ pub struct ToolExecutionAuditEvent {
     pub error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_error: Option<ToolError>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -5983,6 +5987,8 @@ mod tests {
             task_handle: None,
             error: None,
             error_kind: None,
+            tool_error: None,
+            reason: None,
         })
         .unwrap();
 

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -916,6 +916,16 @@ pub async fn tool_schema_and_dispatch_errors_are_recorded_without_corrupting_run
         .filter(|event| event.kind == "tool_execution_failed")
         .collect::<Vec<_>>();
     assert_eq!(failed_events.len(), 3);
+    assert!(failed_events.iter().all(|event| {
+        event.data["agent_id"].as_str() == Some("default")
+            && event.data["status"].as_str() == Some("error")
+            && event.data["duration_ms"].as_u64().is_some()
+            && event
+                .data
+                .get("summary")
+                .and_then(|value| value.as_str())
+                .is_some_and(|summary| summary.starts_with("Failed: "))
+    }));
     assert!(failed_events.iter().any(|event| {
         event.data.get("tool_name").and_then(|value| value.as_str()) == Some("ExecCommand")
             && event.data["tool_error"]["kind"].as_str() == Some("invalid_tool_input")

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -714,9 +714,6 @@ function genericToolDescription(toolName: string, payload: Record<string, unknow
   const objective = stringField(payload, "objective");
   if (objective) return objective;
 
-  const workItemId = stringField(payload, "work_item_id");
-  if (workItemId) return workItemId;
-
   const resource = stringField(payload, "resource");
   if (resource) return resource;
 

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -463,6 +463,7 @@ describe("reduceAgentSessionTimeline", () => {
             type: "tool_execution_failed",
             payload: {
               tool_name: "ApplyPatch",
+              work_item_id: "work_665c0e258dd0de0",
               error: JSON.stringify({
                 kind: "ambiguous_context",
                 message: "hunk context matches 8 locations in web-gui/app/src/runtime/session-reducer.ts",


### PR DESCRIPTION
Closes #2303

## Summary
- populate failed tool audit events with the same user-facing summary and timing projections as successful executions
- prevent the Web timeline fallback from exposing internal work item IDs as failure descriptions
- add Rust audit-contract and Web reducer regression coverage

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- targeted Rust tool execution audit tests
- Web reducer tests and TypeScript type checking