### PR TITLE
refactor: generate TypeScript transport DTOs from OpenAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - "tests/**"
       - "agent_templates/**"
       - "builtin_templates/**"
+      - "docs/website/reference/openapi.json"
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
@@ -24,6 +25,7 @@ on:
       - "tests/**"
       - "agent_templates/**"
       - "builtin_templates/**"
+      - "docs/website/reference/openapi.json"
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
@@ -45,7 +47,9 @@ jobs:
         with:
           node-version: '24'
           cache: npm
-          cache-dependency-path: web-gui/app/package-lock.json
+          cache-dependency-path: |
+            web-gui/app/package-lock.json
+            web-gui/openapi-tools/package-lock.json
 
       - name: Test and build web GUI
         run: make web-ci

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: help web web-ci build all test test-concurrent test-concurrent-repeat test-live fmt fmt-check lint check ci run clean
+.PHONY: help web web-ci transport-types transport-types-check build all test test-concurrent test-concurrent-repeat test-live fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
+OPENAPI_TOOLS_DIR := web-gui/openapi-tools
 CONCURRENT_REPEATS ?= 3
 CONCURRENT_LIFECYCLE_TESTS := \
 	runtime_tasks \
@@ -20,7 +21,18 @@ web: ## Build the web GUI (requires Node.js 24). Produces web-gui/app/dist
 
 web-ci: ## Test and build the web GUI with one clean dependency install
 	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
-	cd $(WEB_DIR) && npm ci && npm test && npm run build
+	cd $(OPENAPI_TOOLS_DIR) && npm ci && npm run check && \
+	cd ../../$(WEB_DIR) && npm ci && npm test && npm run build
+
+transport-types: ## Refresh OpenAPI and generated TypeScript transport types
+	cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
+	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
+	cd $(OPENAPI_TOOLS_DIR) && npm ci && npm run generate
+
+transport-types-check: ## Check OpenAPI and generated TypeScript transport type drift
+	cargo test --test openapi_snapshot
+	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
+	cd $(OPENAPI_TOOLS_DIR) && npm ci && npm run check
 
 build: ## Build all Rust targets (cargo build --all-targets)
 	cargo build --all-targets

--- a/docs/release.md
+++ b/docs/release.md
@@ -65,3 +65,11 @@ cargo test --test openapi_snapshot
 The first command regenerates the file; the second verifies it matches. The
 generated output has no trailing newline — adding one manually causes the
 snapshot test to fail.
+
+The Web GUI transport types are generated from the same snapshot. Refresh both
+artifacts together and verify drift with:
+
+```bash
+make transport-types
+make transport-types-check
+```

--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -780,6 +780,14 @@ The server also does not need to claim that every field here belongs to the
 general agent-facing status contract. In phase 1, `/state` is the bootstrap
 aggregate, while `/status` remains the concise agent-facing summary surface.
 
+The bootstrap aggregate is an explicit wire contract rather than a serialized
+domain snapshot. The Rust server and first-party Rust client share
+`AgentStateSnapshotDto`, including dedicated slim task and WorkItem DTOs.
+OpenAPI is generated from those DTOs, and the Web transport layer consumes
+checked-in TypeScript types generated from that OpenAPI schema. UI view models
+remain separate camelCase projections. CI rejects drift in either the OpenAPI
+snapshot or generated TypeScript transport types.
+
 ## Implementation Work Breakdown
 
 The expected rollout should be split into separate work items:

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -97,6 +97,1337 @@
         "title": "AddSkillRequest",
         "type": "object"
       },
+      "AgentStateSnapshotDto": {
+        "properties": {
+          "agent": {
+            "properties": {
+              "active_children": {
+                "items": {
+                  "properties": {
+                    "active_task_count": {
+                      "format": "uint",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "current_run_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "identity": {
+                      "properties": {
+                        "agent_id": {
+                          "type": "string"
+                        },
+                        "delegated_from_task_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "is_default_agent": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "enum": [
+                            "default",
+                            "named",
+                            "child"
+                          ],
+                          "type": "string"
+                        },
+                        "lineage_parent_agent_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "ownership": {
+                          "enum": [
+                            "parent_supervised",
+                            "self_owned"
+                          ],
+                          "type": "string"
+                        },
+                        "parent_agent_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "profile_preset": {
+                          "enum": [
+                            "private_child",
+                            "public_named"
+                          ],
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": [
+                            "active",
+                            "archived"
+                          ],
+                          "type": "string"
+                        },
+                        "visibility": {
+                          "enum": [
+                            "public",
+                            "private"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "agent_id",
+                        "kind",
+                        "visibility",
+                        "ownership",
+                        "profile_preset",
+                        "status",
+                        "is_default_agent"
+                      ],
+                      "type": "object"
+                    },
+                    "observability": {
+                      "properties": {
+                        "blocked_reason": {
+                          "enum": [
+                            "managed_task_queued",
+                            "managed_task_running",
+                            "managed_task_cancelling",
+                            "awaiting_managed_task",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "current_work_item_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "last_progress_brief": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "last_result_brief": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "phase": {
+                          "enum": [
+                            "running",
+                            "blocked",
+                            "waiting",
+                            "terminal"
+                          ],
+                          "type": "string"
+                        },
+                        "waiting_reason": {
+                          "enum": [
+                            "awaiting_operator_input",
+                            "awaiting_external_change",
+                            "awaiting_task_result",
+                            "awaiting_timer",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "work_summary": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "phase"
+                      ],
+                      "type": "object"
+                    },
+                    "pending": {
+                      "format": "uint",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "status": {
+                      "enum": [
+                        "booting",
+                        "awake_idle",
+                        "awake_running",
+                        "awaiting_task",
+                        "asleep",
+                        "stopped"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "identity",
+                    "status",
+                    "pending",
+                    "active_task_count",
+                    "observability"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "active_task_count": {
+                "default": 0,
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "agent": {
+                "properties": {
+                  "active_workspace_entry": {
+                    "properties": {
+                      "access_mode": {
+                        "enum": [
+                          "shared_read",
+                          "exclusive_write"
+                        ],
+                        "type": "string"
+                      },
+                      "cwd": {
+                        "type": "string"
+                      },
+                      "execution_root": {
+                        "type": "string"
+                      },
+                      "execution_root_id": {
+                        "type": "string"
+                      },
+                      "projection_kind": {
+                        "enum": [
+                          "canonical_root",
+                          "git_worktree_root"
+                        ],
+                        "type": "string"
+                      },
+                      "workspace_anchor": {
+                        "type": "string"
+                      },
+                      "workspace_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "workspace_id",
+                      "workspace_anchor",
+                      "execution_root_id",
+                      "execution_root",
+                      "projection_kind",
+                      "access_mode",
+                      "cwd"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "attached_workspaces": {
+                    "default": [],
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "current_run_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "current_turn_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "current_turn_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "current_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "last_brief_at": {
+                    "format": "date-time",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "last_turn_terminal": {
+                    "properties": {
+                      "checkpoint": {
+                        "properties": {
+                          "checkpoint_anchor_generation": {
+                            "format": "uint64",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "current_anchor_generation": {
+                            "format": "uint64",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "request_id": {
+                            "type": "string"
+                          },
+                          "requested_at_round": {
+                            "format": "uint",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "response_round": {
+                            "format": "uint",
+                            "minimum": 0,
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "source_turn_index": {
+                            "format": "uint64",
+                            "minimum": 0,
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "text": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "request_id",
+                          "requested_at_round",
+                          "text",
+                          "checkpoint_anchor_generation",
+                          "current_anchor_generation"
+                        ],
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      },
+                      "completed_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "duration_ms": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "kind": {
+                        "enum": [
+                          "completed",
+                          "aborted",
+                          "baseline_over_budget",
+                          "deferred_to_fallback",
+                          "provider_failed_needs_recovery"
+                        ],
+                        "type": "string"
+                      },
+                      "last_assistant_message": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "reason": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "turn_id": {
+                        "type": "string"
+                      },
+                      "turn_index": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "turn_index",
+                      "kind",
+                      "completed_at",
+                      "duration_ms"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "last_wake_reason": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "pending": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "sleeping_until": {
+                    "format": "date-time",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "enum": [
+                      "booting",
+                      "awake_idle",
+                      "awake_running",
+                      "awaiting_task",
+                      "asleep",
+                      "stopped"
+                    ],
+                    "type": "string"
+                  },
+                  "turn_index": {
+                    "default": 0,
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id",
+                  "status",
+                  "pending"
+                ],
+                "type": "object"
+              },
+              "closure": {
+                "properties": {
+                  "outcome": {
+                    "enum": [
+                      "completed",
+                      "continuable",
+                      "failed",
+                      "waiting"
+                    ],
+                    "type": "string"
+                  },
+                  "runtime_posture": {
+                    "enum": [
+                      "awake",
+                      "sleeping"
+                    ],
+                    "type": "string"
+                  },
+                  "waiting_reason": {
+                    "enum": [
+                      "awaiting_operator_input",
+                      "awaiting_external_change",
+                      "awaiting_task_result",
+                      "awaiting_timer",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "outcome",
+                  "runtime_posture"
+                ],
+                "type": "object"
+              },
+              "identity": {
+                "properties": {
+                  "agent_id": {
+                    "type": "string"
+                  },
+                  "delegated_from_task_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "is_default_agent": {
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "enum": [
+                      "default",
+                      "named",
+                      "child"
+                    ],
+                    "type": "string"
+                  },
+                  "lineage_parent_agent_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ownership": {
+                    "enum": [
+                      "parent_supervised",
+                      "self_owned"
+                    ],
+                    "type": "string"
+                  },
+                  "parent_agent_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "profile_preset": {
+                    "enum": [
+                      "private_child",
+                      "public_named"
+                    ],
+                    "type": "string"
+                  },
+                  "status": {
+                    "enum": [
+                      "active",
+                      "archived"
+                    ],
+                    "type": "string"
+                  },
+                  "visibility": {
+                    "enum": [
+                      "public",
+                      "private"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "kind",
+                  "visibility",
+                  "ownership",
+                  "profile_preset",
+                  "status",
+                  "is_default_agent"
+                ],
+                "type": "object"
+              },
+              "lifecycle": {
+                "default": {
+                  "accepts_external_messages": true
+                },
+                "properties": {
+                  "accepts_external_messages": {
+                    "type": "boolean"
+                  },
+                  "operator_hint": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "accepts_external_messages"
+                ],
+                "type": "object"
+              },
+              "model": {
+                "properties": {
+                  "active_model": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "effective_fallback_models": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "effective_model": {
+                    "type": "string"
+                  },
+                  "fallback_active": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "override_model": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "override_reasoning_effort": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "requested_model": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "runtime_default_model": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "enum": [
+                      "runtime_default",
+                      "agent_override"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "runtime_default_model",
+                  "effective_model"
+                ],
+                "type": "object"
+              },
+              "scheduling_posture": {
+                "default": {
+                  "posture": "unknown",
+                  "reason": "posture projection unavailable"
+                },
+                "properties": {
+                  "posture": {
+                    "enum": [
+                      "unknown",
+                      "archived",
+                      "active_turn",
+                      "has_queued_input",
+                      "has_runnable_work",
+                      "waiting_for_task",
+                      "waiting_for_external",
+                      "waiting_for_operator",
+                      "blocked",
+                      "idle"
+                    ],
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "task_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "posture",
+                  "reason"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "identity",
+              "agent",
+              "model",
+              "closure"
+            ],
+            "type": "object"
+          },
+          "external_triggers": {
+            "default": [],
+            "items": {
+              "properties": {
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "delivery_count": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "delivery_mode": {
+                  "enum": [
+                    "enqueue_message",
+                    "wake_hint"
+                  ],
+                  "type": "string"
+                },
+                "external_trigger_id": {
+                  "type": "string"
+                },
+                "last_delivered_at": {
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "revoked_at": {
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "scope": {
+                  "enum": [
+                    "agent"
+                  ],
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "active",
+                    "revoked"
+                  ],
+                  "type": "string"
+                },
+                "target_agent_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "external_trigger_id",
+                "target_agent_id",
+                "scope",
+                "delivery_mode",
+                "status",
+                "delivery_count",
+                "created_at"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "session": {
+            "properties": {
+              "current_run_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "last_turn": {
+                "properties": {
+                  "checkpoint": {
+                    "properties": {
+                      "checkpoint_anchor_generation": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "current_anchor_generation": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "request_id": {
+                        "type": "string"
+                      },
+                      "requested_at_round": {
+                        "format": "uint",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "response_round": {
+                        "format": "uint",
+                        "minimum": 0,
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "source_turn_index": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "text": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "request_id",
+                      "requested_at_round",
+                      "text",
+                      "checkpoint_anchor_generation",
+                      "current_anchor_generation"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "completed_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "duration_ms": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "kind": {
+                    "enum": [
+                      "completed",
+                      "aborted",
+                      "baseline_over_budget",
+                      "deferred_to_fallback",
+                      "provider_failed_needs_recovery"
+                    ],
+                    "type": "string"
+                  },
+                  "last_assistant_message": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reason": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "turn_id": {
+                    "type": "string"
+                  },
+                  "turn_index": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "turn_index",
+                  "kind",
+                  "completed_at",
+                  "duration_ms"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "pending_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "pending_count"
+            ],
+            "type": "object"
+          },
+          "tasks": {
+            "items": {
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "kind": {
+                  "enum": [
+                    "command_task",
+                    "child_agent_task",
+                    "sleep_job",
+                    "subagent_task",
+                    "worktree_subagent_task"
+                  ],
+                  "type": "string"
+                },
+                "parent_message_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "enum": [
+                    "queued",
+                    "running",
+                    "cancelling",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                    "interrupted"
+                  ],
+                  "type": "string"
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "updated_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "work_item_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "agent_id",
+                "kind",
+                "status",
+                "created_at",
+                "updated_at"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "timers": {
+            "default": [],
+            "items": {
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "duration_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "fire_count": {
+                  "default": 0,
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "interval_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "last_fired_at": {
+                  "default": null,
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "next_fire_at": {
+                  "default": null,
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "repeat": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "default": "active",
+                  "enum": [
+                    "active",
+                    "completed",
+                    "cancelled"
+                  ],
+                  "type": "string"
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "agent_id",
+                "created_at",
+                "duration_ms",
+                "repeat"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "work_items": {
+            "default": [],
+            "items": {
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "blocked_by": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "candidate_class": {
+                  "enum": [
+                    "current_runnable",
+                    "triggered_blocked",
+                    "queued_runnable",
+                    "waiting_for_operator",
+                    "yielded",
+                    "blocked",
+                    "completed_recent"
+                  ],
+                  "type": "string"
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "current_todo": {
+                  "properties": {
+                    "state": {
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed"
+                      ],
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "state"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "focus": {
+                  "enum": [
+                    "current",
+                    "queued",
+                    "yielded",
+                    "blocked",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "is_current": {
+                  "type": "boolean"
+                },
+                "is_runnable": {
+                  "type": "boolean"
+                },
+                "objective": {
+                  "type": "string"
+                },
+                "plan_status": {
+                  "enum": [
+                    "draft",
+                    "ready",
+                    "needs_input"
+                  ],
+                  "type": "string"
+                },
+                "readiness": {
+                  "enum": [
+                    "runnable",
+                    "yielded",
+                    "waiting_for_operator",
+                    "blocked",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "reason_code": {
+                  "enum": [
+                    "completed",
+                    "continuation_yielded",
+                    "active_task_wait",
+                    "active_operator_wait",
+                    "active_timer_wait",
+                    "active_external_wait",
+                    "active_system_wait",
+                    "manual_blocker",
+                    "plan_needs_input",
+                    "runnable"
+                  ],
+                  "type": "string"
+                },
+                "recheck_at": {
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "result_brief_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "result_summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "scheduling_state": {
+                  "enum": [
+                    "runnable",
+                    "yielded_to_work_item",
+                    "waiting_operator",
+                    "waiting_task",
+                    "waiting_external",
+                    "waiting_timer",
+                    "waiting_system",
+                    "blocked",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "state": {
+                  "enum": [
+                    "open",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "turn_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "updated_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "agent_id",
+                "workspace_id",
+                "revision",
+                "objective",
+                "state",
+                "plan_status",
+                "created_at",
+                "updated_at",
+                "scheduling_state",
+                "readiness",
+                "candidate_class",
+                "focus",
+                "is_current",
+                "is_runnable",
+                "reason_code"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "workspace": {
+            "default": {
+              "workspaces": []
+            },
+            "properties": {
+              "workspaces": {
+                "default": [],
+                "items": {
+                  "properties": {
+                    "access_mode": {
+                      "enum": [
+                        "shared_read",
+                        "exclusive_write",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cwd": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "execution_root": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "execution_root_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "projection_kind": {
+                      "enum": [
+                        "canonical_root",
+                        "git_worktree_root",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "repo_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "workspace_alias": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "workspace_anchor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "workspace_id": {
+                      "type": "string"
+                    },
+                    "worktree": {
+                      "properties": {
+                        "branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_cwd": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "workspace_id",
+                    "is_active"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "agent",
+          "session",
+          "tasks"
+        ],
+        "title": "AgentStateSnapshotDto",
+        "type": "object"
+      },
       "AttachWorkspaceRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -133,6 +1464,40 @@
         },
         "required": [
           "messages"
+        ],
+        "type": "object"
+      },
+      "BatchGetTranscriptEntriesRequest": {
+        "properties": {
+          "entry_ids": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "title": "BatchGetTranscriptEntriesRequest",
+        "type": "object"
+      },
+      "BatchGetTranscriptEntriesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "type": "array"
+          },
+          "missing_entry_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "entries"
         ],
         "type": "object"
       },
@@ -305,6 +1670,18 @@
           }
         },
         "title": "CancelTimerRequest",
+        "type": "object"
+      },
+      "CheckSkillRequest": {
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "CheckSkillRequest",
         "type": "object"
       },
       "CheckTemplateRequest": {
@@ -1773,6 +3150,22 @@
         "title": "PickWorkItemResponse",
         "type": "object"
       },
+      "ReconcileSkillRequest": {
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "ReconcileSkillRequest",
+        "type": "object"
+      },
+      "RefreshCatalogRequest": {
+        "title": "RefreshCatalogRequest",
+        "type": "object"
+      },
       "RemoveSkillRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -2645,6 +4038,276 @@
       "SetCredentialRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "SlimTaskDto": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "command_task",
+              "child_agent_task",
+              "sleep_job",
+              "subagent_task",
+              "worktree_subagent_task"
+            ],
+            "type": "string"
+          },
+          "parent_message_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "queued",
+              "running",
+              "cancelling",
+              "completed",
+              "failed",
+              "cancelled",
+              "interrupted"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "work_item_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "kind",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "SlimTaskDto",
+        "type": "object"
+      },
+      "SlimWorkItemDto": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "blocked_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "candidate_class": {
+            "enum": [
+              "current_runnable",
+              "triggered_blocked",
+              "queued_runnable",
+              "waiting_for_operator",
+              "yielded",
+              "blocked",
+              "completed_recent"
+            ],
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "current_todo": {
+            "properties": {
+              "state": {
+                "enum": [
+                  "pending",
+                  "in_progress",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "text",
+              "state"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "focus": {
+            "enum": [
+              "current",
+              "queued",
+              "yielded",
+              "blocked",
+              "completed"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_current": {
+            "type": "boolean"
+          },
+          "is_runnable": {
+            "type": "boolean"
+          },
+          "objective": {
+            "type": "string"
+          },
+          "plan_status": {
+            "enum": [
+              "draft",
+              "ready",
+              "needs_input"
+            ],
+            "type": "string"
+          },
+          "readiness": {
+            "enum": [
+              "runnable",
+              "yielded",
+              "waiting_for_operator",
+              "blocked",
+              "completed"
+            ],
+            "type": "string"
+          },
+          "reason_code": {
+            "enum": [
+              "completed",
+              "continuation_yielded",
+              "active_task_wait",
+              "active_operator_wait",
+              "active_timer_wait",
+              "active_external_wait",
+              "active_system_wait",
+              "manual_blocker",
+              "plan_needs_input",
+              "runnable"
+            ],
+            "type": "string"
+          },
+          "recheck_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "result_brief_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "result_summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "revision": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "scheduling_state": {
+            "enum": [
+              "runnable",
+              "yielded_to_work_item",
+              "waiting_operator",
+              "waiting_task",
+              "waiting_external",
+              "waiting_timer",
+              "waiting_system",
+              "blocked",
+              "completed"
+            ],
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "completed"
+            ],
+            "type": "string"
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "workspace_id",
+          "revision",
+          "objective",
+          "state",
+          "plan_status",
+          "created_at",
+          "updated_at",
+          "scheduling_state",
+          "readiness",
+          "candidate_class",
+          "focus",
+          "is_current",
+          "is_runnable",
+          "reason_code"
+        ],
+        "title": "SlimWorkItemDto",
+        "type": "object"
+      },
+      "SyncTemplateRemoteSourcesRequest": {
+        "properties": {
+          "force": {
+            "description": "Force a refresh even if a later TTL policy would consider the cache\n fresh. Currently accepted for forward compatibility.",
+            "type": "boolean"
+          },
+          "source_id": {
+            "description": "Optional configured source id. When omitted, all enabled remote sources\n are synchronized.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "SyncTemplateRemoteSourcesRequest",
         "type": "object"
       },
       "TaskInputRequest": {
@@ -4646,6 +6309,18 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "UpdateSkillRequest": {
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "ReconcileSkillRequest",
+        "type": "object"
+      },
       "UpdateWorkItemRequest": {
         "additionalProperties": false,
         "properties": {
@@ -5580,8 +7255,7 @@
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "style": "simple"
+            }
           }
         ],
         "responses": {
@@ -5589,11 +7263,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/AgentStateSnapshotDto"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -5624,8 +7298,7 @@
         "summary": "Agent state snapshot",
         "tags": [
           "agents"
-        ],
-        "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
+        ]
       }
     },
     "/api/agents/{agent_id}/status": {
@@ -10174,16 +11847,17 @@
       "get": {
         "description": "Compatibility alias for the default agent state route.",
         "operationId": "defaultState",
+        "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/AgentStateSnapshotDto"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -10214,8 +11888,7 @@
         "summary": "Default agent state alias",
         "tags": [
           "compat"
-        ],
-        "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
+        ]
       }
     },
     "/api/status": {

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,7 @@ use crate::{
         RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
         SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
     },
+    http_dto::AgentStateSnapshotDto,
     model_catalog::BuiltInModelMetadata,
     system::ExecutionSnapshot,
     types::{
@@ -445,7 +446,7 @@ impl LocalClient {
         self.get_json(&format!("/agents/{agent_id}/status")).await
     }
 
-    pub async fn agent_state_snapshot(&self, agent_id: &str) -> Result<AgentStateSnapshot> {
+    pub async fn agent_state_snapshot(&self, agent_id: &str) -> Result<AgentStateSnapshotDto> {
         self.get_json(&format!("/agents/{agent_id}/state")).await
     }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -83,8 +83,8 @@ pub(crate) use crate::{
         ExternalTriggerStateSnapshot, MessageBody, MessageDeliverySurface, MessageEnvelope,
         MessageKind, MessageOrigin, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskRecord, TaskStatus, TaskStatusSnapshot,
-        TaskStopResult, TimerRecord, TodoItem, TranscriptEntry, TurnTerminalRecord, WaitingReason,
+        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TaskStatusSnapshot,
+        TaskStopResult, TodoItem, TranscriptEntry, TurnTerminalRecord, WaitingReason,
         WorkItemPlanStatus, WorkItemRecord, WorkItemState,
     },
 };

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -216,14 +216,14 @@ pub async fn agent_state(
         .await
         .map_err(agent_access_error)?;
     runtime.prune_stale_attached_workspaces().await.ok();
-    let mut agent = runtime.agent_summary().await.map_err(error_response)?;
+    let agent = runtime.agent_summary().await.map_err(error_response)?;
     let tasks_started = std::time::Instant::now();
     let tasks = runtime
         .active_tasks(STATE_BOOTSTRAP_TASK_LIMIT)
         .await
         .map_err(error_response)?
         .into_iter()
-        .map(slim_state_task_record)
+        .map(crate::http_dto::SlimTaskDto::from)
         .collect();
     crate::diagnostics::record_projection_state_tasks(tasks_started.elapsed());
     let timers_started = std::time::Instant::now();
@@ -237,7 +237,7 @@ pub async fn agent_state(
         .items
         .into_iter()
         .take(STATE_BOOTSTRAP_WORK_ITEM_LIMIT)
-        .map(slim_state_work_item_projection)
+        .map(slim_state_work_item_dto)
         .collect::<Vec<_>>();
     crate::diagnostics::record_projection_state_work_items(work_items_started.elapsed());
     let triggers_started = std::time::Instant::now();
@@ -250,8 +250,13 @@ pub async fn agent_state(
         .collect();
     crate::diagnostics::record_projection_state_external_triggers(triggers_started.elapsed());
     let workspace = state_workspace_snapshot(&agent, &state);
-    slim_state_agent_summary(&mut agent);
-    let session = StateSessionSnapshot {
+    let mut agent_dto = crate::http_dto::SlimAgentDto::from(&agent);
+    agent_dto.agent.last_turn_terminal = agent
+        .agent
+        .last_turn_terminal
+        .clone()
+        .map(slim_state_turn_terminal_record);
+    let session = crate::http_dto::StateSessionSnapshotDto {
         current_run_id: agent.agent.current_run_id.clone(),
         pending_count: agent.agent.pending,
         last_turn: agent
@@ -263,8 +268,8 @@ pub async fn agent_state(
     traced_json(
         "/agents/{agent_id}/state",
         started_at,
-        AgentStateSnapshot {
-            agent,
+        crate::http_dto::AgentStateSnapshotDto {
+            agent: agent_dto,
             session,
             tasks,
             timers,
@@ -275,58 +280,21 @@ pub async fn agent_state(
     )
 }
 
-fn slim_state_task_record(mut task: TaskRecord) -> TaskRecord {
-    let _ = task.detail.take();
-    let _ = task.recovery.take();
-    task
-}
-
-fn slim_state_work_item_projection(
-    mut projection: crate::work_item_scheduling::WorkItemSchedulingProjection,
-) -> crate::work_item_scheduling::WorkItemSchedulingProjection {
-    projection.work_item.objective = truncate_state_bootstrap_string(
-        &projection.work_item.objective,
-        STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT,
-    );
-    projection.work_item.plan_artifact = None;
-    projection.work_item.todo_list.clear();
-    projection.work_item.work_refs.clear();
-    projection.work_item.blocked_by = projection
-        .work_item
+fn slim_state_work_item_dto(
+    projection: crate::work_item_scheduling::WorkItemSchedulingProjection,
+) -> crate::http_dto::SlimWorkItemDto {
+    let mut dto = crate::http_dto::SlimWorkItemDto::from(projection);
+    dto.objective =
+        truncate_state_bootstrap_string(&dto.objective, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
+    dto.blocked_by = dto
         .blocked_by
         .take()
         .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
-    projection.work_item.result_summary = projection
-        .work_item
+    dto.result_summary = dto
         .result_summary
         .take()
         .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
-    projection
-}
-
-fn slim_state_agent_summary(agent: &mut AgentSummary) {
-    agent.loaded_agents_md = Default::default();
-    agent.skills = Default::default();
-    agent.active_wait_conditions.clear();
-    agent.active_external_triggers.clear();
-    agent.recent_operator_notifications.clear();
-    agent.agent.tool_latency.clear();
-    agent.agent.working_memory.active_episode_builder = None;
-    agent.agent.active_skills.clear();
-    agent.agent.last_continuation = None;
-    agent.agent.last_turn_terminal = agent
-        .agent
-        .last_turn_terminal
-        .take()
-        .map(slim_state_turn_terminal_record);
-    if let Some(failure) = agent.agent.last_runtime_failure.as_mut() {
-        failure.summary =
-            truncate_state_bootstrap_string(&failure.summary, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
-        failure.detail_hint = failure
-            .detail_hint
-            .take()
-            .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
-    }
+    dto
 }
 
 fn slim_state_turn_terminal_record(mut record: TurnTerminalRecord) -> TurnTerminalRecord {
@@ -398,7 +366,10 @@ fn truncate_state_bootstrap_string(text: &str, limit: usize) -> String {
     text.to_string()
 }
 
-fn state_workspace_snapshot(agent: &AgentSummary, state: &AppState) -> StateWorkspaceSnapshot {
+fn state_workspace_snapshot(
+    agent: &AgentSummary,
+    state: &AppState,
+) -> crate::http_dto::StateWorkspaceSnapshotDto {
     let all_entries = state.host.workspace_entries().unwrap_or_default();
 
     use crate::types::AgentWorkspaceInfo;
@@ -474,7 +445,9 @@ fn state_workspace_snapshot(agent: &AgentSummary, state: &AppState) -> StateWork
         }
     }
 
-    StateWorkspaceSnapshot { workspaces }
+    crate::http_dto::StateWorkspaceSnapshotDto {
+        workspaces: workspaces.into_iter().map(Into::into).collect(),
+    }
 }
 
 /// Merge projection_metadata and worktree_session into a unified WorktreeInfo.
@@ -551,9 +524,10 @@ mod tests {
             })),
             recovery: None,
         };
-        let slimmed = super::slim_state_task_record(task);
-        assert!(slimmed.detail.is_none());
-        assert!(slimmed.recovery.is_none());
+        let slimmed = crate::http_dto::SlimTaskDto::from(task);
+        let value = serde_json::to_value(slimmed).expect("serialize slim task");
+        assert!(value.get("detail").is_none());
+        assert!(value.get("recovery").is_none());
 
         let entry = TranscriptEntry {
             id: "entry-1".into(),
@@ -602,12 +576,13 @@ mod tests {
                 trigger_delivery_by_id: &std::collections::BTreeMap::new(),
             },
         );
-        let slimmed = super::slim_state_work_item_projection(projection);
+        let slimmed = super::slim_state_work_item_dto(projection);
 
         assert!(slimmed.objective.chars().count() <= STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
-        assert!(slimmed.todo_list.is_empty());
-        assert!(slimmed.work_refs.is_empty());
-        assert!(slimmed.plan_artifact.is_none());
+        let value = serde_json::to_value(&slimmed).expect("serialize slim work item");
+        assert!(value.get("todo_list").is_none());
+        assert!(value.get("work_refs").is_none());
+        assert!(value.get("plan_artifact").is_none());
         assert!(
             slimmed
                 .blocked_by

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -283,37 +283,6 @@ pub(crate) struct EventReplayProvenance {
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct StateSessionSnapshot {
-    pub(crate) current_run_id: Option<String>,
-    pub(crate) pending_count: usize,
-    pub(crate) last_turn: Option<TurnTerminalRecord>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct StateWorkspaceSnapshot {
-    pub(crate) workspaces: Vec<crate::types::AgentWorkspaceInfo>,
-}
-
-impl Default for StateWorkspaceSnapshot {
-    fn default() -> Self {
-        Self {
-            workspaces: Vec::new(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct AgentStateSnapshot {
-    pub(crate) agent: AgentSummary,
-    pub(crate) session: StateSessionSnapshot,
-    pub(crate) tasks: Vec<TaskRecord>,
-    pub(crate) timers: Vec<TimerRecord>,
-    pub(crate) work_items: Vec<crate::work_item_scheduling::WorkItemSchedulingProjection>,
-    pub(crate) external_triggers: Vec<ExternalTriggerStateSnapshot>,
-    pub(crate) workspace: StateWorkspaceSnapshot,
-}
-
-#[derive(Debug, Serialize)]
 pub(crate) struct StreamEventEnvelope {
     pub(crate) id: String,
     pub(crate) event_seq: u64,

--- a/src/http_dto.rs
+++ b/src/http_dto.rs
@@ -1,0 +1,574 @@
+//! Shared HTTP wire DTOs for first-party state bootstrap clients.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::ModelRouteRef,
+    system::{WorkspaceAccessMode, WorkspaceProjectionKind},
+    types::{
+        ActiveWorkspaceEntry, AgentIdentityView, AgentLifecycleHint, AgentListEntry,
+        AgentListModelSummary, AgentModelSource, AgentPostureProjection, AgentState, AgentStatus,
+        AgentSummary, ChildAgentBlockedReason, ChildAgentObservabilitySnapshot, ChildAgentPhase,
+        ChildAgentSummary, ClosureDecision, ClosureOutcome, ExternalTriggerStateSnapshot,
+        RuntimePosture, TaskKind, TaskRecord, TaskStatus, TimerRecord, TodoItem,
+        TurnTerminalRecord, WaitingReason, WorkItemPlanStatus, WorkItemReadiness,
+        WorkItemSchedulingState, WorkItemState,
+    },
+    work_item_scheduling::{
+        WorkItemCandidateClass, WorkItemFocus, WorkItemSchedulingProjection,
+        WorkItemSchedulingReasonCode,
+    },
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentStateSnapshotDto {
+    pub agent: SlimAgentDto,
+    pub session: StateSessionSnapshotDto,
+    pub tasks: Vec<SlimTaskDto>,
+    #[serde(default)]
+    pub timers: Vec<TimerRecord>,
+    #[serde(default)]
+    pub work_items: Vec<SlimWorkItemDto>,
+    #[serde(default)]
+    pub external_triggers: Vec<ExternalTriggerStateSnapshot>,
+    #[serde(default)]
+    pub workspace: StateWorkspaceSnapshotDto,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct StateSessionSnapshotDto {
+    pub current_run_id: Option<String>,
+    pub pending_count: usize,
+    pub last_turn: Option<TurnTerminalRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+pub struct StateWorkspaceSnapshotDto {
+    #[serde(default)]
+    pub workspaces: Vec<SlimWorkspaceDto>,
+}
+
+impl StateWorkspaceSnapshotDto {
+    pub fn active_workspace(&self) -> Option<&SlimWorkspaceDto> {
+        self.workspaces.iter().find(|workspace| workspace.is_active)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimWorkspaceDto {
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_alias: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_anchor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_name: Option<String>,
+    pub is_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_root_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_kind: Option<WorkspaceProjectionKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_mode: Option<WorkspaceAccessMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<SlimWorktreeDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimWorktreeDto {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct SlimAgentDto {
+    pub identity: AgentIdentityView,
+    pub agent: SlimAgentRuntimeDto,
+    #[serde(default)]
+    pub scheduling_posture: AgentPostureProjection,
+    #[serde(default)]
+    pub active_task_count: usize,
+    #[serde(default)]
+    pub lifecycle: AgentLifecycleHint,
+    pub model: SlimAgentModelDto,
+    pub closure: SlimClosureDto,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_children: Vec<SlimChildAgentDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct SlimAgentRuntimeDto {
+    pub id: String,
+    pub status: AgentStatus,
+    pub sleeping_until: Option<DateTime<Utc>>,
+    pub current_run_id: Option<String>,
+    pub pending: usize,
+    pub last_wake_reason: Option<String>,
+    pub last_brief_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub attached_workspaces: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_workspace_entry: Option<SlimActiveWorkspaceDto>,
+    #[serde(default)]
+    pub turn_index: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_turn_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_turn_terminal: Option<TurnTerminalRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimActiveWorkspaceDto {
+    pub workspace_id: String,
+    pub workspace_anchor: String,
+    pub execution_root_id: String,
+    pub execution_root: String,
+    pub projection_kind: WorkspaceProjectionKind,
+    pub access_mode: WorkspaceAccessMode,
+    pub cwd: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimAgentModelDto {
+    pub source: AgentModelSource,
+    #[schemars(with = "String")]
+    pub runtime_default_model: ModelRouteRef,
+    #[schemars(with = "String")]
+    pub effective_model: ModelRouteRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
+    pub requested_model: Option<ModelRouteRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
+    pub active_model: Option<ModelRouteRef>,
+    #[serde(default)]
+    pub fallback_active: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(with = "Vec<String>")]
+    pub effective_fallback_models: Vec<ModelRouteRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
+    pub override_model: Option<ModelRouteRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_reasoning_effort: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimClosureDto {
+    pub outcome: ClosureOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiting_reason: Option<WaitingReason>,
+    pub runtime_posture: RuntimePosture,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct SlimChildAgentDto {
+    pub identity: AgentIdentityView,
+    pub status: AgentStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_run_id: Option<String>,
+    pub pending: usize,
+    pub active_task_count: usize,
+    pub observability: SlimChildObservabilityDto,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimChildObservabilityDto {
+    pub phase: ChildAgentPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_reason: Option<ChildAgentBlockedReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiting_reason: Option<WaitingReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_progress_brief: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_result_brief: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct SlimTaskDto {
+    pub id: String,
+    pub agent_id: String,
+    pub kind: TaskKind,
+    pub status: TaskStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub parent_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SlimWorkItemDto {
+    pub id: String,
+    pub agent_id: String,
+    pub workspace_id: String,
+    pub revision: u64,
+    pub objective: String,
+    pub state: WorkItemState,
+    pub plan_status: WorkItemPlanStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recheck_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_brief_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_summary: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub scheduling_state: WorkItemSchedulingState,
+    pub readiness: WorkItemReadiness,
+    pub candidate_class: WorkItemCandidateClass,
+    pub focus: WorkItemFocus,
+    pub is_current: bool,
+    pub is_runnable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_todo: Option<TodoItem>,
+    pub reason_code: WorkItemSchedulingReasonCode,
+}
+
+impl From<&AgentSummary> for SlimAgentDto {
+    fn from(summary: &AgentSummary) -> Self {
+        Self {
+            identity: summary.identity.clone(),
+            agent: (&summary.agent).into(),
+            scheduling_posture: summary.scheduling_posture.clone(),
+            active_task_count: summary.active_task_count,
+            lifecycle: summary.lifecycle.clone(),
+            model: (&summary.model).into(),
+            closure: (&summary.closure).into(),
+            active_children: summary.active_children.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&AgentState> for SlimAgentRuntimeDto {
+    fn from(agent: &AgentState) -> Self {
+        Self {
+            id: agent.id.clone(),
+            status: agent.status.clone(),
+            sleeping_until: agent.sleeping_until,
+            current_run_id: agent.current_run_id.clone(),
+            pending: agent.pending,
+            last_wake_reason: agent.last_wake_reason.clone(),
+            last_brief_at: agent.last_brief_at,
+            attached_workspaces: agent.attached_workspaces.clone(),
+            active_workspace_entry: agent.active_workspace_entry.as_ref().map(Into::into),
+            turn_index: agent.turn_index,
+            current_turn_id: agent.current_turn_id.clone(),
+            current_turn_work_item_id: agent.current_turn_work_item_id.clone(),
+            current_work_item_id: agent.current_work_item_id.clone(),
+            last_turn_terminal: None,
+        }
+    }
+}
+
+impl From<&ActiveWorkspaceEntry> for SlimActiveWorkspaceDto {
+    fn from(workspace: &ActiveWorkspaceEntry) -> Self {
+        Self {
+            workspace_id: workspace.workspace_id.clone(),
+            workspace_anchor: workspace.workspace_anchor.display().to_string(),
+            execution_root_id: workspace.execution_root_id.clone(),
+            execution_root: workspace.execution_root.display().to_string(),
+            projection_kind: workspace.projection_kind,
+            access_mode: workspace.access_mode,
+            cwd: workspace.cwd.display().to_string(),
+        }
+    }
+}
+
+impl From<&crate::types::AgentModelState> for SlimAgentModelDto {
+    fn from(model: &crate::types::AgentModelState) -> Self {
+        Self {
+            source: model.source.clone(),
+            runtime_default_model: model.runtime_default_model.clone(),
+            effective_model: model.effective_model.clone(),
+            requested_model: model.requested_model.clone(),
+            active_model: model.active_model.clone(),
+            fallback_active: model.fallback_active,
+            effective_fallback_models: model.effective_fallback_models.clone(),
+            override_model: model.override_model.clone(),
+            override_reasoning_effort: model.override_reasoning_effort.clone(),
+        }
+    }
+}
+
+impl From<&ClosureDecision> for SlimClosureDto {
+    fn from(closure: &ClosureDecision) -> Self {
+        Self {
+            outcome: closure.outcome,
+            waiting_reason: closure.waiting_reason,
+            runtime_posture: closure.runtime_posture,
+        }
+    }
+}
+
+impl From<&ChildAgentSummary> for SlimChildAgentDto {
+    fn from(child: &ChildAgentSummary) -> Self {
+        Self {
+            identity: child.identity.clone(),
+            status: child.status.clone(),
+            current_run_id: child.current_run_id.clone(),
+            pending: child.pending,
+            active_task_count: child.active_task_count,
+            observability: (&child.observability).into(),
+        }
+    }
+}
+
+impl From<&ChildAgentObservabilitySnapshot> for SlimChildObservabilityDto {
+    fn from(observability: &ChildAgentObservabilitySnapshot) -> Self {
+        Self {
+            phase: observability.phase.clone(),
+            blocked_reason: observability.blocked_reason.clone(),
+            waiting_reason: observability.waiting_reason,
+            current_work_item_id: observability.current_work_item_id.clone(),
+            work_summary: observability.work_summary.clone(),
+            last_progress_brief: observability.last_progress_brief.clone(),
+            last_result_brief: observability.last_result_brief.clone(),
+        }
+    }
+}
+
+impl From<TaskRecord> for SlimTaskDto {
+    fn from(task: TaskRecord) -> Self {
+        Self {
+            id: task.id,
+            agent_id: task.agent_id,
+            kind: task.kind,
+            status: task.status,
+            created_at: task.created_at,
+            updated_at: task.updated_at,
+            parent_message_id: task.parent_message_id,
+            work_item_id: task.work_item_id,
+            summary: task.summary,
+        }
+    }
+}
+
+impl From<SlimTaskDto> for TaskRecord {
+    fn from(task: SlimTaskDto) -> Self {
+        Self {
+            id: task.id,
+            agent_id: task.agent_id,
+            kind: task.kind,
+            status: task.status,
+            created_at: task.created_at,
+            updated_at: task.updated_at,
+            parent_message_id: task.parent_message_id,
+            work_item_id: task.work_item_id,
+            summary: task.summary,
+            detail: None,
+            recovery: None,
+        }
+    }
+}
+
+impl From<SlimWorkspaceDto> for crate::types::AgentWorkspaceInfo {
+    fn from(workspace: SlimWorkspaceDto) -> Self {
+        Self {
+            workspace_id: workspace.workspace_id,
+            workspace_alias: workspace.workspace_alias,
+            workspace_anchor: workspace.workspace_anchor,
+            repo_name: workspace.repo_name,
+            is_active: workspace.is_active,
+            execution_root_id: workspace.execution_root_id,
+            execution_root: workspace.execution_root,
+            cwd: workspace.cwd,
+            projection_kind: workspace.projection_kind,
+            access_mode: workspace.access_mode,
+            worktree: workspace.worktree.map(Into::into),
+        }
+    }
+}
+
+impl From<crate::types::AgentWorkspaceInfo> for SlimWorkspaceDto {
+    fn from(workspace: crate::types::AgentWorkspaceInfo) -> Self {
+        Self {
+            workspace_id: workspace.workspace_id,
+            workspace_alias: workspace.workspace_alias,
+            workspace_anchor: workspace.workspace_anchor,
+            repo_name: workspace.repo_name,
+            is_active: workspace.is_active,
+            execution_root_id: workspace.execution_root_id,
+            execution_root: workspace.execution_root,
+            cwd: workspace.cwd,
+            projection_kind: workspace.projection_kind,
+            access_mode: workspace.access_mode,
+            worktree: workspace.worktree.map(Into::into),
+        }
+    }
+}
+
+impl From<SlimWorktreeDto> for crate::types::WorktreeInfo {
+    fn from(worktree: SlimWorktreeDto) -> Self {
+        Self {
+            branch: worktree.branch,
+            path: worktree.path,
+            original_branch: worktree.original_branch,
+            original_cwd: worktree.original_cwd,
+        }
+    }
+}
+
+impl From<crate::types::WorktreeInfo> for SlimWorktreeDto {
+    fn from(worktree: crate::types::WorktreeInfo) -> Self {
+        Self {
+            branch: worktree.branch,
+            path: worktree.path,
+            original_branch: worktree.original_branch,
+            original_cwd: worktree.original_cwd,
+        }
+    }
+}
+
+impl From<WorkItemSchedulingProjection> for SlimWorkItemDto {
+    fn from(projection: WorkItemSchedulingProjection) -> Self {
+        let record = projection.work_item;
+        Self {
+            id: record.id,
+            agent_id: record.agent_id,
+            workspace_id: record.workspace_id,
+            revision: record.revision,
+            objective: record.objective,
+            state: record.state,
+            plan_status: record.plan_status,
+            blocked_by: record.blocked_by,
+            recheck_at: record.recheck_at,
+            result_brief_id: record.result_brief_id,
+            result_summary: record.result_summary,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+            turn_id: record.turn_id,
+            scheduling_state: projection.scheduling_state,
+            readiness: projection.readiness,
+            candidate_class: projection.candidate_class,
+            focus: projection.focus,
+            is_current: projection.is_current,
+            is_runnable: projection.is_runnable,
+            current_todo: projection.current_todo,
+            reason_code: projection.reason_code,
+        }
+    }
+}
+
+impl SlimAgentDto {
+    pub fn into_agent_summary(self) -> AgentSummary {
+        let active_workspace_entry = self.agent.active_workspace_entry.clone().map(Into::into);
+        let model = AgentListModelSummary {
+            source: self.model.source,
+            runtime_default_model: self.model.runtime_default_model,
+            effective_model: self.model.effective_model,
+            requested_model: self.model.requested_model,
+            active_model: self.model.active_model,
+            fallback_active: self.model.fallback_active,
+            effective_fallback_models: self.model.effective_fallback_models,
+            override_model: self.model.override_model,
+            override_reasoning_effort: self.model.override_reasoning_effort,
+        };
+        let mut summary = AgentListEntry {
+            identity: self.identity,
+            status: self.agent.status.clone(),
+            scheduling_posture: self.scheduling_posture,
+            lifecycle: self.lifecycle,
+            pending: self.agent.pending,
+            current_run_id: self.agent.current_run_id.clone(),
+            waiting_reason: self.closure.waiting_reason,
+            model,
+            active_workspace_entry,
+        }
+        .into_agent_summary_placeholder();
+        summary.agent.id = self.agent.id;
+        summary.agent.status = self.agent.status;
+        summary.agent.sleeping_until = self.agent.sleeping_until;
+        summary.agent.current_run_id = self.agent.current_run_id;
+        summary.agent.pending = self.agent.pending;
+        summary.agent.last_wake_reason = self.agent.last_wake_reason;
+        summary.agent.last_brief_at = self.agent.last_brief_at;
+        summary.agent.attached_workspaces = self.agent.attached_workspaces;
+        summary.agent.turn_index = self.agent.turn_index;
+        summary.agent.current_turn_id = self.agent.current_turn_id;
+        summary.agent.current_turn_work_item_id = self.agent.current_turn_work_item_id;
+        summary.agent.current_work_item_id = self.agent.current_work_item_id;
+        summary.agent.last_turn_terminal = self.agent.last_turn_terminal;
+        summary.active_task_count = self.active_task_count;
+        summary.closure = ClosureDecision {
+            outcome: self.closure.outcome,
+            waiting_reason: self.closure.waiting_reason,
+            work_signal: None,
+            runtime_posture: self.closure.runtime_posture,
+            evidence: Vec::new(),
+        };
+        summary.active_children = self.active_children.into_iter().map(Into::into).collect();
+        summary
+    }
+}
+
+impl From<SlimActiveWorkspaceDto> for ActiveWorkspaceEntry {
+    fn from(workspace: SlimActiveWorkspaceDto) -> Self {
+        Self {
+            workspace_id: workspace.workspace_id,
+            workspace_anchor: PathBuf::from(workspace.workspace_anchor),
+            execution_root_id: workspace.execution_root_id,
+            execution_root: PathBuf::from(workspace.execution_root),
+            projection_kind: workspace.projection_kind,
+            access_mode: workspace.access_mode,
+            cwd: PathBuf::from(workspace.cwd),
+            occupancy_id: None,
+            projection_metadata: None,
+        }
+    }
+}
+
+impl From<SlimChildAgentDto> for ChildAgentSummary {
+    fn from(child: SlimChildAgentDto) -> Self {
+        Self {
+            identity: child.identity,
+            status: child.status,
+            current_run_id: child.current_run_id,
+            pending: child.pending,
+            active_task_count: child.active_task_count,
+            observability: child.observability.into(),
+        }
+    }
+}
+
+impl From<SlimChildObservabilityDto> for ChildAgentObservabilitySnapshot {
+    fn from(observability: SlimChildObservabilityDto) -> Self {
+        Self {
+            phase: observability.phase,
+            blocked_reason: observability.blocked_reason,
+            waiting_reason: observability.waiting_reason,
+            current_work_item_id: observability.current_work_item_id,
+            work_summary: observability.work_summary,
+            last_progress_brief: observability.last_progress_brief,
+            last_result_brief: observability.last_result_brief,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod fd_limit;
 pub mod host;
 mod host_registry;
 pub mod http;
+pub mod http_dto;
 pub mod ingress;
 pub mod memory;
 pub mod model_catalog;

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -8,16 +8,19 @@ use serde_json::{json, Value};
 use crate::{
     diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
-        BatchGetMessagesRequest, CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest,
-        MemoryGetRequest, ModelConfigMigrationRequest, PickWorkItemRequest, PickWorkItemResponse,
-        RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
-        SearchRequest, SearchResponse, UpdateWorkItemRequest,
+        BatchGetMessagesRequest, BatchGetTranscriptEntriesRequest, CancelTimerRequest,
+        CompleteWorkItemRequest, CreateTimerRequest, MemoryGetRequest, ModelConfigMigrationRequest,
+        PickWorkItemRequest, PickWorkItemResponse, RuntimeConfigReadResponse,
+        RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse, SearchRequest, SearchResponse,
+        UpdateWorkItemRequest,
     },
+    http_dto::{AgentStateSnapshotDto, SlimTaskDto, SlimWorkItemDto},
     memory::MemoryGetResult,
     model_config_migration::ModelConfigMigrationReport,
     types::{
-        AddSkillRequest, BriefRecord, TaskInputResult, TaskOutputResult, TaskStatusSnapshot,
-        TaskStopResult, TimerRecord, ToolExecutionRecord, WorkItemRecord,
+        AddSkillRequest, BriefRecord, CheckSkillRequest, ReconcileSkillRequest,
+        RefreshCatalogRequest, SyncTemplateRemoteSourcesRequest, TaskInputResult, TaskOutputResult,
+        TaskStatusSnapshot, TaskStopResult, TimerRecord, ToolExecutionRecord, WorkItemRecord,
     },
 };
 
@@ -71,7 +74,7 @@ const ROUTES: &[RouteSpec] = &[
     aide_route("get", "/agents/{agent_id}/status", "agentStatus", "agents", "Agent status", "Return the public AgentSummary read model.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/briefs", "agentBriefs", "agents", "Recent briefs", "Return recent user-facing delivery briefs. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route_with_response("get", "/agents/{agent_id}/briefs/{brief_id}", "agentBrief", "agents", "Brief detail", "Return a persisted user-facing delivery brief by id.", None, "BriefRecord", AuthKind::RemoteAccess),
-    aide_route("get", "/agents/{agent_id}/state", "agentState", "agents", "Agent state snapshot", "Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.", None, AuthKind::RemoteAccess),
+    route_with_response("get", "/agents/{agent_id}/state", "agentState", "agents", "Agent state snapshot", "Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.", None, "AgentStateSnapshotDto", AuthKind::RemoteAccess),
     event_stream_route("get", "/events/stream", "eventsStream", "events", "Global event stream", "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor. If the receiver lags, the server closes the stream; clients must backfill each agent from its last contiguous event_seq before reconnecting.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/events", "agentEvents", "events", "Agent event page", "Return a bounded page of runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Event payloads are included in full; max_level filters event inclusion only. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.", None, AuthKind::RemoteAccess),
     event_stream_route("get", "/agents/{agent_id}/events/stream", "agentEventsStream", "events", "Agent event stream", "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens. If the receiver lags, the server closes the stream so clients can backfill after the last contiguous SSE id before reconnecting. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.", None, AuthKind::RemoteAccess),
@@ -157,7 +160,7 @@ const ROUTES: &[RouteSpec] = &[
     route("post", "/control/agents/{agent_id}/skills/uninstall", "uninstallSkill", "skills", "Uninstall skill compatibility alias", "Compatibility alias for disabling an agent skill.", Some("UninstallSkillRequest"), AuthKind::Control),
     aide_route("get", "/status", "defaultStatus", "compat", "Default agent status alias", "Compatibility alias for the default agent status route.", None, AuthKind::RemoteAccess),
     aide_route("get", "/briefs", "defaultBriefs", "compat", "Default agent briefs alias", "Compatibility alias for the default agent briefs route. Query parameter: limit.", None, AuthKind::RemoteAccess),
-    aide_route("get", "/state", "defaultState", "compat", "Default agent state alias", "Compatibility alias for the default agent state route.", None, AuthKind::RemoteAccess),
+    route_with_response("get", "/state", "defaultState", "compat", "Default agent state alias", "Compatibility alias for the default agent state route.", None, "AgentStateSnapshotDto", AuthKind::RemoteAccess),
     aide_route("get", "/transcript", "defaultTranscript", "compat", "Default agent transcript alias", "Compatibility alias for the default agent transcript route. Query parameter: limit.", None, AuthKind::RemoteAccess),
     aide_route("get", "/worktree-summary", "defaultWorktreeSummary", "compat", "Default agent worktree summary alias", "Compatibility alias for the default agent worktree summary route.", None, AuthKind::RemoteAccess),
 ];
@@ -583,6 +586,15 @@ fn component_schemas() -> Value {
         component_schema::<TaskStatusSnapshot>(),
     );
     schemas.insert(
+        "AgentStateSnapshotDto".into(),
+        component_schema::<AgentStateSnapshotDto>(),
+    );
+    schemas.insert("SlimTaskDto".into(), component_schema::<SlimTaskDto>());
+    schemas.insert(
+        "SlimWorkItemDto".into(),
+        component_schema::<SlimWorkItemDto>(),
+    );
+    schemas.insert(
         "TaskOutputResult".into(),
         component_schema::<TaskOutputResult>(),
     );
@@ -678,6 +690,10 @@ fn component_schemas() -> Value {
         component_schema::<BatchGetMessagesRequest>(),
     );
     schemas.insert(
+        "BatchGetTranscriptEntriesRequest".into(),
+        component_schema::<BatchGetTranscriptEntriesRequest>(),
+    );
+    schemas.insert(
         "BatchGetMessagesResponse".into(),
         json!({
             "type": "object",
@@ -694,6 +710,44 @@ fn component_schemas() -> Value {
             "required": ["messages"],
             "additionalProperties": false
         }),
+    );
+    schemas.insert(
+        "BatchGetTranscriptEntriesResponse".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/JsonValue" }
+                },
+                "missing_entry_ids": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["entries"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "CheckSkillRequest".into(),
+        component_schema::<CheckSkillRequest>(),
+    );
+    schemas.insert(
+        "ReconcileSkillRequest".into(),
+        component_schema::<ReconcileSkillRequest>(),
+    );
+    schemas.insert(
+        "RefreshCatalogRequest".into(),
+        component_schema::<RefreshCatalogRequest>(),
+    );
+    schemas.insert(
+        "UpdateSkillRequest".into(),
+        component_schema::<ReconcileSkillRequest>(),
+    );
+    schemas.insert(
+        "SyncTemplateRemoteSourcesRequest".into(),
+        component_schema::<SyncTemplateRemoteSourcesRequest>(),
     );
     for name in [
         "EnqueueRequest",
@@ -767,6 +821,11 @@ mod tests {
         assert!(
             paths["/api/control/agents/{agent_id}/tasks"]["post"]["x-holon-openapi-source"]
                 .is_null()
+        );
+        assert_eq!(
+            paths["/api/agents/{agent_id}/state"]["get"]["responses"]["200"]["content"]
+                ["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AgentStateSnapshotDto"
         );
     }
 

--- a/src/system/types.rs
+++ b/src/system/types.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use schemars::JsonSchema;
 use std::{ffi::OsString, fmt, path::PathBuf, process::ExitStatus, time::Duration};
 
 use serde::{Deserialize, Deserializer, Serialize};
@@ -113,14 +114,14 @@ pub struct ExecutionPolicySnapshot {
     pub process_execution: ProcessExecutionCapabilitySnapshot,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkspaceProjectionKind {
     CanonicalRoot,
     GitWorktreeRoot,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkspaceAccessMode {
     SharedRead,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -18,6 +18,7 @@ use crate::{
         AgentStateSnapshot, AgentStreamEvent, StateSessionSnapshot, StateWorkspaceSnapshot,
         StreamEventEnvelope,
     },
+    http_dto::{AgentStateSnapshotDto, SlimWorkItemDto},
     operator_event::{
         is_activity_reset_event_kind, is_durable_operator_event_kind,
         is_operator_event_in_display_mode, present_operator_event, OperatorEventCategory,
@@ -104,6 +105,10 @@ pub(crate) struct TuiProjection {
 }
 
 impl TuiProjection {
+    pub(crate) fn from_bootstrap_dto(snapshot: AgentStateSnapshotDto) -> Self {
+        Self::from_snapshot(tui_snapshot_from_dto(snapshot))
+    }
+
     pub(crate) fn from_snapshot(snapshot: AgentStateSnapshot) -> Self {
         let presentation_reducer = crate::presentation::PresentationReducer::new();
         let external_triggers = snapshot.external_triggers;
@@ -136,6 +141,13 @@ impl TuiProjection {
 
     pub(crate) fn reset_from_snapshot(&mut self, snapshot: AgentStateSnapshot) {
         *self = Self::from_snapshot(snapshot);
+    }
+
+    pub(crate) fn reset_from_bootstrap_dto_preserving_event_history(
+        &mut self,
+        snapshot: AgentStateSnapshotDto,
+    ) {
+        self.reset_from_snapshot_preserving_event_history(tui_snapshot_from_dto(snapshot));
     }
 
     pub(crate) fn reset_from_snapshot_preserving_event_history(
@@ -1336,6 +1348,74 @@ impl TuiProjection {
         self.agent.agent.active_workspace_entry = None;
         self.agent.active_workspace_occupancy = None;
         self.agent.agent.worktree_session = None;
+    }
+}
+
+fn tui_snapshot_from_dto(snapshot: AgentStateSnapshotDto) -> AgentStateSnapshot {
+    AgentStateSnapshot {
+        agent: snapshot.agent.into_agent_summary(),
+        session: StateSessionSnapshot {
+            current_run_id: snapshot.session.current_run_id,
+            pending_count: snapshot.session.pending_count,
+            last_turn: snapshot.session.last_turn,
+        },
+        tasks: snapshot.tasks.into_iter().map(Into::into).collect(),
+        timers: snapshot.timers,
+        work_items: snapshot
+            .work_items
+            .into_iter()
+            .map(tui_work_item_from_dto)
+            .collect(),
+        external_triggers: snapshot.external_triggers,
+        operator_notifications: Vec::new(),
+        workspace: StateWorkspaceSnapshot {
+            workspaces: snapshot
+                .workspace
+                .workspaces
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        },
+        execution: None,
+    }
+}
+
+fn tui_work_item_from_dto(item: SlimWorkItemDto) -> WorkItemSchedulingProjection {
+    WorkItemSchedulingProjection {
+        work_item: WorkItemRecord {
+            id: item.id,
+            agent_id: item.agent_id,
+            workspace_id: item.workspace_id,
+            revision: item.revision,
+            objective: item.objective,
+            state: item.state,
+            plan_status: item.plan_status,
+            plan_artifact: None,
+            todo_list: Vec::new(),
+            work_refs: Vec::new(),
+            blocked_by: item.blocked_by,
+            recheck_at: item.recheck_at,
+            recheck_consumed_at: None,
+            result_brief_id: item.result_brief_id,
+            result_summary: item.result_summary,
+            created_at: item.created_at,
+            updated_at: item.updated_at,
+            turn_id: item.turn_id,
+        },
+        scheduling_state: item.scheduling_state,
+        readiness: item.readiness,
+        candidate_class: item.candidate_class,
+        focus: item.focus,
+        is_current: item.is_current,
+        is_runnable: item.is_runnable,
+        has_active_waits: false,
+        has_active_task_waits: false,
+        has_triggered_waits: false,
+        last_triggered_at: None,
+        current_todo: item.current_todo,
+        active_wait_conditions: Vec::new(),
+        reason_code: item.reason_code,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -2,9 +2,10 @@ use super::projection::ProjectionSlice;
 use super::state::TuiClientState;
 use super::*;
 use crate::client::{
-    AgentStateSnapshot, AgentStreamEvent, EventPageRequest, EventPageResponse, EventStreamRequest,
-    LocalEventStream, LocalHttpError, StreamEventEnvelope,
+    AgentStreamEvent, EventPageRequest, EventPageResponse, EventStreamRequest, LocalEventStream,
+    LocalHttpError, StreamEventEnvelope,
 };
+use crate::http_dto::AgentStateSnapshotDto;
 use crate::types::{BriefRecord, MessageEnvelope, TranscriptEntry};
 use tokio::sync::mpsc;
 
@@ -74,7 +75,7 @@ pub(super) enum TuiRuntimeMessage {
 }
 
 type SnapshotBootstrapResult = (
-    AgentStateSnapshot,
+    AgentStateSnapshotDto,
     Vec<StreamEventEnvelope>,
     Option<u64>,
     Option<u64>,
@@ -529,13 +530,13 @@ impl TuiApp {
             self.chat_scroll
                 .preserve_across_refresh(self.chat_max_scroll);
             if let Some(mut projection) = self.projection.take() {
-                projection.reset_from_snapshot_preserving_event_history(snapshot);
+                projection.reset_from_bootstrap_dto_preserving_event_history(snapshot);
                 projection
             } else {
-                TuiProjection::from_snapshot(snapshot)
+                TuiProjection::from_bootstrap_dto(snapshot)
             }
         } else {
-            TuiProjection::from_snapshot(snapshot)
+            TuiProjection::from_bootstrap_dto(snapshot)
         };
         projection.merge_event_tail(events_tail, newest_seq);
         projection.set_event_history_state_from_tail(oldest_seq, has_older);

--- a/src/types.rs
+++ b/src/types.rs
@@ -237,7 +237,7 @@ pub struct ExecutionRootEntry {
     pub removed_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentKind {
     Default,
@@ -245,7 +245,7 @@ pub enum AgentKind {
     Child,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentVisibility {
     Public,
@@ -261,7 +261,7 @@ impl AgentVisibility {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentOwnership {
     ParentSupervised,
@@ -291,7 +291,7 @@ impl AgentOwnership {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentProfilePreset {
     PrivateChild,
@@ -368,7 +368,7 @@ pub enum AgentDurability {
     Ephemeral,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentRegistryStatus {
     Active,
@@ -464,7 +464,7 @@ impl AgentIdentityRecord {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentIdentityView {
     pub agent_id: String,
     pub kind: AgentKind,
@@ -845,7 +845,7 @@ pub enum SkillLoadReason {
     PromptInjection,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ClosureOutcome {
     Completed,
@@ -877,7 +877,7 @@ pub enum WaitingReason {
     AwaitingTimer,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimePosture {
     Awake,
@@ -1084,18 +1084,18 @@ pub struct RemoveSkillRequest {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ReconcileSkillRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RefreshCatalogRequest {}
 
 pub type UpdateSkillRequest = ReconcileSkillRequest;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct CheckSkillRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -1140,7 +1140,7 @@ pub struct RemoveTemplateRequest {
     pub template_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 pub struct SyncTemplateRemoteSourcesRequest {
     /// Optional configured source id. When omitted, all enabled remote sources
     /// are synchronized.
@@ -1454,7 +1454,7 @@ pub enum AdmissionContext {
     RuntimeOwned,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatus {
     Booting,
@@ -1516,7 +1516,7 @@ pub struct RuntimeFailureSummary {
     pub failure_artifact: Option<FailureArtifact>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TurnTerminalKind {
     Completed,
@@ -1532,7 +1532,7 @@ impl TurnTerminalKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct TurnTerminalRecord {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub turn_id: String,
@@ -1645,7 +1645,7 @@ impl TurnRecord {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct TurnTerminalCheckpointRecord {
     pub request_id: String,
     pub requested_at_round: usize,
@@ -2062,7 +2062,7 @@ pub struct PendingWakeHint {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CallbackDeliveryMode {
     EnqueueMessage,
@@ -2070,7 +2070,7 @@ pub enum CallbackDeliveryMode {
     WakeHint,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExternalTriggerScope {
     Agent,
@@ -2253,7 +2253,7 @@ fn json_truthy(value: &Value) -> bool {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExternalTriggerStatus {
     Active,
@@ -2277,7 +2277,7 @@ pub struct ExternalTriggerRecord {
     pub delivery_count: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ExternalTriggerStateSnapshot {
     pub external_trigger_id: String,
     pub target_agent_id: String,
@@ -3605,7 +3605,7 @@ pub enum WorkItemReadiness {
     Completed,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemSchedulingState {
     Runnable,
@@ -3619,7 +3619,7 @@ pub enum WorkItemSchedulingState {
     Completed,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentSchedulingPosture {
     Unknown,
@@ -3634,7 +3634,7 @@ pub enum AgentSchedulingPosture {
     Idle,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentPostureProjection {
     pub posture: AgentSchedulingPosture,
     pub reason: String,
@@ -4715,7 +4715,7 @@ impl ControlAction {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentModelSource {
     RuntimeDefault,
@@ -4835,7 +4835,7 @@ pub struct ProviderModelEntry {
     pub policy_notes: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentLifecycleHint {
     pub accepts_external_messages: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -422,7 +422,6 @@ pub async fn local_client_over_http_can_read_agent_state_snapshot() -> Result<()
     let snapshot = client.agent_state_snapshot("default").await?;
     assert_eq!(snapshot.agent.identity.agent_id, "default");
     assert!(snapshot.session.pending_count <= snapshot.agent.agent.pending);
-    assert!(snapshot.operator_notifications.is_empty());
     let events_page = client
         .agent_events_page(
             "default",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -106,6 +106,38 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
     assert!(state_payload.get("operator_notifications").is_none());
     assert!(state_payload.get("execution").is_none());
     assert!(state_payload.get("cursor").is_none());
+    let agent = state_payload["agent"]
+        .as_object()
+        .expect("state agent should be an object");
+    for heavy_field in [
+        "execution",
+        "loaded_agents_md",
+        "skills",
+        "token_usage",
+        "active_wait_conditions",
+        "active_external_triggers",
+        "recent_operator_notifications",
+    ] {
+        assert!(
+            !agent.contains_key(heavy_field),
+            "/state agent DTO must not expose {heavy_field}"
+        );
+    }
+    let agent_runtime = agent["agent"]
+        .as_object()
+        .expect("state agent runtime should be an object");
+    for domain_field in [
+        "working_memory",
+        "tool_latency",
+        "active_skills",
+        "last_continuation",
+        "execution_profile",
+    ] {
+        assert!(
+            !agent_runtime.contains_key(domain_field),
+            "/state agent runtime DTO must not expose {domain_field}"
+        );
+    }
 
     server.abort();
     Ok(())

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -1,6 +1,61 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createRuntimeClient, projectModelOptions } from "./client";
+import type { components } from "./generated/openapi";
+
+function agentStateFixture(agentId: string): components["schemas"]["AgentStateSnapshotDto"] {
+  return {
+    agent: {
+      identity: {
+        agent_id: agentId,
+        kind: "named",
+        visibility: "public",
+        ownership: "self_owned",
+        profile_preset: "public_named",
+        status: "active",
+        is_default_agent: false,
+      },
+      agent: {
+        id: agentId,
+        status: "awake_idle",
+        current_run_id: null,
+        pending: 0,
+        attached_workspaces: [],
+        turn_index: 0,
+      },
+      scheduling_posture: {
+        posture: "idle",
+        reason: "idle",
+      },
+      active_task_count: 0,
+      lifecycle: {
+        accepts_external_messages: true,
+      },
+      model: {
+        source: "runtime_default",
+        runtime_default_model: "openai-codex@default/gpt-5.6",
+        effective_model: "openai-codex@default/gpt-5.6",
+        fallback_active: false,
+      },
+      closure: {
+        outcome: "completed",
+        runtime_posture: "awake",
+      },
+    },
+    session: {
+      current_run_id: null,
+      pending_count: 0,
+      last_turn: null,
+    },
+    tasks: [],
+    timers: [],
+    work_items: [],
+    external_triggers: [],
+    workspace: {
+      workspaces: [],
+    },
+  };
+}
 
 describe("projectModelOptions", () => {
   it("detects reasoning effort support from runtime available model capabilities", () => {
@@ -690,7 +745,7 @@ describe("createRuntimeClient", () => {
         return Response.json([{ identity: { agent_id: "agent-one" } }]);
       }
       if (url.endsWith("/agents/agent-one/state")) {
-        return Response.json({});
+        return Response.json(agentStateFixture("agent-one"));
       }
       if (url.includes("/agents/agent-one/events?")) {
         return Response.json({

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1,4 +1,5 @@
 import { agentDetailFixtures } from "./fixtures";
+import type { components } from "./generated/openapi";
 import { briefIdForPayload, reduceAgentSessionTimeline, transcriptEntryIdForPayload } from "./session-reducer";
 import type {
   AddSkillInput,
@@ -223,99 +224,10 @@ interface AgentListEntryDto {
   } | null;
 }
 
-interface AgentStateDto {
-  agent?: {
-    identity?: AgentListEntryDto["identity"];
-    agent?: {
-      id?: string;
-      status?: string;
-      pending?: number;
-      last_brief_at?: string | null;
-      current_work_item_id?: string | null;
-    };
-    scheduling_posture?: AgentListEntryDto["scheduling_posture"];
-    active_task_count?: number;
-    lifecycle?: string | Record<string, unknown>;
-    model?: AgentListEntryDto["model"];
-    active_waiting_intents?: unknown[];
-  };
-  session?: {
-    pending_count?: number;
-    current_run_id?: string | null;
-  };
-  tasks?: Array<{
-    id?: string;
-    kind?: string;
-    status?: string;
-    summary?: string;
-    detail?: unknown;
-  }>;
-  work_items?: Array<{
-    id?: string;
-    objective?: string;
-    state?: string;
-    plan_status?: string;
-  }>;
-  waiting_intents?: unknown[];
-  workspace?: AgentWorkspaceDto;
-}
-
-interface WorkItemDto {
-  id?: string;
-  agent_id?: string;
-  revision?: number;
-  objective?: string;
-  state?: string;
-  plan_status?: string;
-  plan_artifact?: {
-    path?: string;
-    relative_path?: string;
-    workspace_id?: string;
-    workspace_alias?: string;
-    preview?: string;
-    preview_complete?: boolean;
-    updated_at?: string;
-  };
-  todo_list?: Array<{
-    text?: string;
-    state?: string;
-  }>;
-  work_refs?: Array<{
-    kind?: string;
-    ref?: string;
-    title?: string;
-    reason?: string;
-    status?: string;
-    last_seen_at?: string;
-  }>;
-  blocked_by?: string;
-  recheck_at?: string;
-  result_brief_id?: string;
-  result_summary?: string;
-  created_at?: string;
-  updated_at?: string;
-}
-
-interface AgentWorkspaceDto {
-    workspaces?: Array<{
-      workspace_id: string;
-      workspace_alias?: string | null;
-      workspace_anchor?: string | null;
-      repo_name?: string | null;
-      is_active?: boolean;
-      execution_root_id?: string | null;
-      execution_root?: string | null;
-      cwd?: string | null;
-      projection_kind?: string | null;
-      access_mode?: string | null;
-      worktree?: {
-        branch?: string | null;
-        path?: string | null;
-        original_branch?: string | null;
-        original_cwd?: string | null;
-      } | null;
-    }>;
-}
+type AgentStateDto = components["schemas"]["AgentStateSnapshotDto"];
+type SlimWorkItemDto = components["schemas"]["SlimWorkItemDto"];
+type WorkItemDto = components["schemas"]["WorkItemRecord"];
+type WorkItemTransportDto = SlimWorkItemDto | WorkItemDto;
 
 type BriefRecordDto = RuntimeBriefRecord;
 
@@ -1906,7 +1818,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   const tasks = projectTasks(state?.tasks ?? []);
   const pending = state?.session?.pending_count ?? entry.pending ?? 0;
   const activeTaskCount = state?.tasks?.length ?? state?.agent?.active_task_count ?? 0;
-  const waitingCount = state?.waiting_intents?.length ?? state?.agent?.active_waiting_intents?.length ?? (entry.waiting_reason ? 1 : 0);
+  const waitingCount = state?.agent.closure.waiting_reason || entry.waiting_reason ? 1 : 0;
   const posture = state?.agent?.scheduling_posture?.posture ?? entry.scheduling_posture?.posture ?? "unknown";
   const postureReason = state?.agent?.scheduling_posture?.reason ?? entry.scheduling_posture?.reason ?? "posture unavailable";
   const focusSummary = currentWork?.objective ?? postureReason;
@@ -1946,7 +1858,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   };
 }
 
-function projectWorkspaceFromInfo(ws: NonNullable<AgentWorkspaceDto["workspaces"]>[number]): WorkspaceSummary {
+function projectWorkspaceFromInfo(ws: AgentStateDto["workspace"]["workspaces"][number]): WorkspaceSummary {
   const anchor = ws.workspace_anchor ?? ws.execution_root ?? ws.cwd ?? "—";
   const name = ws.workspace_alias ?? basename(anchor) ?? ws.workspace_id ?? "not bound";
   const wt = ws.worktree;
@@ -2003,19 +1915,12 @@ function basename(path: string): string | undefined {
 function projectTasks(tasks: NonNullable<AgentStateDto["tasks"]>): TaskSummary[] {
   return tasks
     .filter((task) => task.id)
-    .map((task) => {
-      const detail = asRecord(task.detail);
-      const cmd = stringValue(detail?.cmd);
-      const workdir = stringValue(detail?.workdir);
-      return {
-        id: task.id ?? "unknown-task",
-        kind: task.kind ?? "task",
-        status: task.status ?? "unknown",
-        summary: task.summary ?? cmd ?? task.id ?? "Task",
-        command: cmd,
-        workdir,
-      };
-    });
+    .map((task) => ({
+      id: task.id,
+      kind: task.kind,
+      status: task.status,
+      summary: task.summary ?? task.id,
+    }));
 }
 
 function newestBriefFromEvents(
@@ -2133,30 +2038,34 @@ function compareModelOptions(left: RuntimeModelOption, right: RuntimeModelOption
 }
 
 function selectCurrentWork(
-  workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
+  workItems: readonly WorkItemTransportDto[],
   currentWorkItemId?: string | null,
 ): WorkItemSummary | undefined {
   if (!currentWorkItemId) return undefined;
   const selected = workItems.find((item) => item.id === currentWorkItemId);
-  if (!selected?.id) return undefined;
+  if (!selected) return undefined;
   return {
     id: selected.id,
-    objective: selected.objective ?? selected.id,
-    state: selected.state ?? "unknown",
+    objective: selected.objective,
+    state: selected.state,
     planStatus: selected.plan_status,
     current: true,
   };
 }
 
 function projectWorkItems(
-  workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
+  workItems: readonly WorkItemTransportDto[],
 ): WorkItemSummary[] {
   return selectWorkItems(workItems);
 }
 
-function projectWorkItem(workItem: WorkItemDto | undefined, currentWorkItemId?: string | null): WorkItemSummary | undefined {
+function projectWorkItem(workItem: WorkItemTransportDto | undefined, currentWorkItemId?: string | null): WorkItemSummary | undefined {
   if (!workItem?.id) return undefined;
-  const planArtifact = workItem.plan_artifact;
+  const detail = "plan_artifact" in workItem ? workItem : undefined;
+  const planArtifact = detail?.plan_artifact;
+  const todoList = detail?.todo_list ??
+    ("current_todo" in workItem && workItem.current_todo ? [workItem.current_todo] : []);
+  const workRefs = detail?.work_refs ?? [];
   return {
     id: workItem.id,
     objective: workItem.objective ?? workItem.id,
@@ -2166,33 +2075,33 @@ function projectWorkItem(workItem: WorkItemDto | undefined, currentWorkItemId?: 
     revision: workItem.revision,
     createdAt: workItem.created_at,
     updatedAt: workItem.updated_at,
-    blockedBy: workItem.blocked_by,
-    recheckAt: workItem.recheck_at,
-    resultBriefId: workItem.result_brief_id,
-    resultSummary: workItem.result_summary,
+    blockedBy: workItem.blocked_by ?? undefined,
+    recheckAt: workItem.recheck_at ?? undefined,
+    resultBriefId: workItem.result_brief_id ?? undefined,
+    resultSummary: workItem.result_summary ?? undefined,
     planArtifact: planArtifact
       ? {
           path: planArtifact.path,
           relativePath: planArtifact.relative_path,
-          workspaceAlias: planArtifact.workspace_alias,
+          workspaceAlias: planArtifact.workspace_alias ?? undefined,
           workspaceId: planArtifact.workspace_id,
           preview: planArtifact.preview,
           previewComplete: planArtifact.preview_complete,
           updatedAt: planArtifact.updated_at,
         }
       : undefined,
-    todoList: (workItem.todo_list ?? [])
+    todoList: todoList
       .filter((item) => item.text)
       .map((item) => ({
         text: item.text ?? "",
         state: item.state ?? "unknown",
       })),
-    workRefs: (workItem.work_refs ?? [])
+    workRefs: workRefs
       .filter((item) => item.ref)
       .map((item) => ({
         kind: item.kind ?? "other",
         ref: item.ref ?? "",
-        title: item.title,
+        title: item.title ?? undefined,
         reason: item.reason,
         status: item.status,
         lastSeenAt: item.last_seen_at,
@@ -2201,12 +2110,11 @@ function projectWorkItem(workItem: WorkItemDto | undefined, currentWorkItemId?: 
 }
 
 function selectWorkItems(
-  workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
+  workItems: readonly WorkItemTransportDto[],
   currentWorkItemId?: string | null,
 ): WorkItemSummary[] {
   return workItems
-    .filter((item) => item.id)
-    .map((item) => projectWorkItem(item as WorkItemDto, currentWorkItemId))
+    .map((item) => projectWorkItem(item, currentWorkItemId))
     .filter((item): item is WorkItemSummary => Boolean(item))
     .sort((left, right) => {
       if (left.current !== right.current) return left.current ? -1 : 1;

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -1,0 +1,7676 @@
+// Generated from docs/website/reference/openapi.json by web-gui/openapi-tools.
+// Do not edit by hand. Run `make transport-types` from the repository root.
+export interface paths {
+    "/api/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Root discovery
+         * @description Return the default agent id.
+         */
+        get: operations["root"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List agents
+         * @description Return lightweight public agent entries.
+         */
+        get: operations["listAgents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/briefs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Recent briefs
+         * @description Return recent user-facing delivery briefs. Query parameter: limit.
+         */
+        get: operations["agentBriefs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/briefs/{brief_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Brief detail
+         * @description Return a persisted user-facing delivery brief by id.
+         */
+        get: operations["agentBrief"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/enqueue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enqueue agent message
+         * @description Enqueue a public channel/webhook message for the named agent.
+         */
+        post: operations["enqueueAgent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent event page
+         * @description Return a bounded page of runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Event payloads are included in full; max_level filters event inclusion only. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.
+         */
+        get: operations["agentEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/events/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent event stream
+         * @description Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens. If the receiver lags, the server closes the stream so clients can backfill after the last contiguous SSE id before reconnecting. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.
+         */
+        get: operations["agentEventsStream"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/messages/{message_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Message detail
+         * @description Return a persisted message envelope by id for the selected agent.
+         */
+        get: operations["agentMessage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/messages:batchGet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch get messages
+         * @description Return persisted message envelopes for the selected agent. Missing or cross-agent ids are reported in missing_message_ids.
+         */
+        post: operations["agentMessagesBatchGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/skills": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List agent skills
+         * @description Return skills enabled/effective for an agent.
+         */
+        get: operations["agentSkills"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent state snapshot
+         * @description Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.
+         */
+        get: operations["agentState"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent status
+         * @description Return the public AgentSummary read model.
+         */
+        get: operations["agentStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List active tasks
+         * @description Return active task records. Query parameter: limit.
+         */
+        get: operations["agentTasks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/tasks/{task_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Task status
+         * @description Return a task lifecycle snapshot by id.
+         */
+        get: operations["agentTaskStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/tasks/{task_id}/output": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Task output
+         * @description Return a task output snapshot. Query parameters: block, timeout_ms.
+         */
+        get: operations["agentTaskOutput"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/timers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List timers
+         * @description Return recent timer records. Query parameter: limit.
+         */
+        get: operations["agentTimers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/timers/{timer_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Timer detail
+         * @description Return a timer record by id.
+         */
+        get: operations["agentTimer"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/tool-executions/{tool_execution_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Tool execution detail
+         * @description Return a persisted tool execution record by id.
+         */
+        get: operations["agentToolExecution"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/tool-executions/{tool_execution_id}/artifacts/{artifact_index}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Tool execution artifact
+         * @description Return UTF-8 content for an artifact referenced by the selected tool execution. Artifact paths are resolved server-side and confined to the agent runtime data directory.
+         */
+        get: operations["agentToolExecutionArtifact"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/transcript": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Recent transcript
+         * @description Return recent transcript entries. Query parameter: limit.
+         */
+        get: operations["agentTranscript"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/transcript/{entry_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Transcript entry detail
+         * @description Return a persisted transcript entry by id for the selected agent.
+         */
+        get: operations["agentTranscriptEntry"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/transcript:batchGet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch get transcript entries
+         * @description Return persisted transcript entries for the selected agent. Missing or cross-agent ids are reported in missing_entry_ids.
+         */
+        post: operations["agentTranscriptBatchGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/work-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List work items
+         * @description Return latest work item records for the agent. Query parameter: limit.
+         */
+        get: operations["agentWorkItems"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/work-items/{work_item_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Work item detail
+         * @description Return a work item record by id.
+         */
+        get: operations["agentWorkItem"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/worktree-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Worktree summary
+         * @description Return managed worktree summary for an agent.
+         */
+        get: operations["agentWorktreeSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/codex/device/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start Codex device login
+         * @description Request an OpenAI Codex device code and start a background job that persists the OAuth credential profile after user authorization.
+         */
+        post: operations["startCodexDeviceLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/{provider}/device/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start OAuth device login
+         * @description Request a provider OAuth device code and start a background job that persists the OAuth credential profile after user authorization. Supported providers include openai-codex and xai.
+         */
+        post: operations["startOAuthDeviceLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/briefs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Default agent briefs alias
+         * @description Compatibility alias for the default agent briefs route. Query parameter: limit.
+         */
+        get: operations["defaultBriefs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/callbacks/enqueue/{callback_token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Callback enqueue ingress
+         * @description Capability-token callback ingress for enqueue delivery. The token is a secret path segment and examples intentionally use a placeholder.
+         */
+        post: operations["callbackEnqueue"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/callbacks/wake/{callback_token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Callback wake ingress
+         * @description Capability-token callback ingress for wake delivery. The token is a secret path segment and examples intentionally use a placeholder.
+         */
+        post: operations["callbackWake"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/control": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Control agent lifecycle
+         * @description Submit a lifecycle control action.
+         */
+        post: operations["controlAgent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create named agent
+         * @description Create a public named agent, optionally from a template.
+         */
+        post: operations["createAgent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/current-run/abort": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Abort current run
+         * @description Request abort for the current agent run.
+         */
+        post: operations["abortCurrentRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/debug-prompt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Debug prompt
+         * @description Render a diagnostic prompt preview.
+         */
+        post: operations["debugPrompt"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/model": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set agent model override
+         * @description Set an agent model override and optional reasoning effort.
+         */
+        post: operations["setAgentModel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/model/clear": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clear agent model override
+         * @description Clear an agent model override.
+         */
+        post: operations["clearAgentModel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/operator-bindings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create operator binding
+         * @description Create or update a remote operator transport binding.
+         */
+        post: operations["createOperatorTransportBinding"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/operator-ingress": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Operator ingress
+         * @description Deliver an authenticated remote operator prompt.
+         */
+        post: operations["operatorIngress"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/prompt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit operator prompt
+         * @description Submit a trusted operator prompt through the control plane.
+         */
+        post: operations["controlPrompt"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/reset-callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset external trigger callback
+         * @description Revoke the current external trigger and provision a fresh one with a new token.
+         */
+        post: operations["resetCallback"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/skills/disable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Disable agent skill
+         * @description Disable a skill for an agent.
+         */
+        post: operations["disableSkill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/skills/enable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enable agent skill
+         * @description Enable a locally known skill for an agent.
+         */
+        post: operations["enableSkill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/skills/install": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Install skill compatibility alias
+         * @description Compatibility alias for older agent skill install behavior.
+         */
+        post: operations["installSkill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/skills/uninstall": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Uninstall skill compatibility alias
+         * @description Compatibility alias for disabling an agent skill.
+         */
+        post: operations["uninstallSkill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create command task
+         * @description Schedule a command task for an agent.
+         */
+        post: operations["createCommandTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/tasks/{task_id}/input": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Task input
+         * @description Deliver text input to a managed task.
+         */
+        post: operations["taskInput"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/tasks/{task_id}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Task stop
+         * @description Request cancellation for a managed task.
+         */
+        post: operations["taskStop"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/timers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create timer
+         * @description Schedule a timer for an agent.
+         */
+        post: operations["createTimer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/timers/{timer_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel timer
+         * @description Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.
+         */
+        post: operations["cancelTimer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/wake": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Wake agent
+         * @description Submit a trusted wake hint.
+         */
+        post: operations["controlWake"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/work-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create work item
+         * @description Create or enqueue a public work item objective.
+         */
+        post: operations["createWorkItem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/work-items/{work_item_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update work item
+         * @description Mutate work item objective, plan status, todo list, or blocker fields.
+         */
+        patch: operations["updateWorkItem"];
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/work-items/{work_item_id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete work item
+         * @description Mark an open work item completed.
+         */
+        post: operations["completeWorkItem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/work-items/{work_item_id}/pick": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pick work item
+         * @description Make an existing open work item the current focus for the agent.
+         */
+        post: operations["pickWorkItem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/workspace/attach": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Attach workspace
+         * @description Attach a workspace path to an agent.
+         */
+        post: operations["attachWorkspace"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/workspace/detach": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Detach workspace
+         * @description Detach a workspace binding by workspace id.
+         */
+        post: operations["detachWorkspace"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/agents/{agent_id}/workspace/exit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Exit workspace
+         * @description Return an agent to its default AgentHome workspace.
+         */
+        post: operations["exitWorkspace"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime config
+         * @description Return the daemon effective runtime configuration surface.
+         */
+        get: operations["runtimeConfig"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update runtime config
+         * @description Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.
+         */
+        patch: operations["runtimeConfigUpdate"];
+        trace?: never;
+    };
+    "/api/control/runtime/config/migrate-model-routes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Migrate model config routes
+         * @description Inspect legacy model route references or persist a complete canonical migration across config.json and agent state.
+         */
+        post: operations["migrateModelConfigRoutes"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime credential profiles
+         * @description List credential profiles stored in the runtime credential store.
+         */
+        get: operations["runtimeCredentials"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/credentials/{profile}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set runtime credential
+         * @description Set an API key credential profile in the runtime credential store.
+         */
+        put: operations["setRuntimeCredential"];
+        post?: never;
+        /**
+         * Delete runtime credential
+         * @description Remove a credential profile from the runtime credential store.
+         */
+        delete: operations["deleteRuntimeCredential"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/performance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime performance diagnostics
+         * @description Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.
+         */
+        get: operations["runtimePerformance"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/readiness": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime readiness
+         * @description Return daemon readiness metadata.
+         */
+        get: operations["runtimeReadiness"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/shutdown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Runtime shutdown
+         * @description Request graceful runtime shutdown.
+         */
+        post: operations["runtimeShutdown"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/runtime/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime status
+         * @description Return daemon status and runtime activity metadata.
+         */
+        get: operations["runtimeStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/templates/install": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Install template
+         * @description Install a template package from a GitHub tree URL into the user global library.
+         */
+        post: operations["installTemplate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/control/templates/remove": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Remove template
+         * @description Remove a template from the user global library.
+         */
+        post: operations["removeTemplate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/enqueue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enqueue default agent message
+         * @description Enqueue a public channel/webhook message for the default agent.
+         */
+        post: operations["enqueueDefault"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/events/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global event stream
+         * @description Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor. If the receiver lags, the server closes the stream; clients must backfill each agent from its last contiguous event_seq before reconnecting.
+         */
+        get: operations["eventsStream"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/handshake": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Protocol handshake
+         * @description Return auth mode, protocol version, capabilities, and runtime hints.
+         */
+        get: operations["handshake"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create job
+         * @description Create an asynchronous job. Currently supports kind=skill.install for Global Skill Library installation.
+         */
+        post: operations["createJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Job status
+         * @description Return a generic asynchronous job snapshot by id.
+         */
+        get: operations["jobStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/memory/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fetch runtime memory source
+         * @description Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.
+         */
+        post: operations["runtimeMemoryGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List available models
+         * @description Return model catalog entries and runtime availability.
+         */
+        get: operations["models"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Search runtime memory
+         * @description Search the same memory v2 index used by the agent MemorySearch tool.
+         */
+        post: operations["runtimeSearch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Skills catalog
+         * @description Return the global user Skill Library catalog. Query parameter: scope.
+         */
+        get: operations["skillsCatalog"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/add": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Add skill to library
+         * @description Add or import a skill into the local Skill Library.
+         */
+        post: operations["addSkillToCatalog"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Check skill library
+         * @description Check Skill Library and lock-file consistency.
+         */
+        post: operations["checkSkillCatalog"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/reconcile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reconcile skill library lock
+         * @description Reconcile local Skill Library contents with .skill-lock.json, then check consistency. This does not fetch remote updates.
+         */
+        post: operations["reconcileSkillCatalog"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh runtime catalog
+         * @description Refresh runtime Skill Library catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates.
+         */
+        post: operations["refreshSkillCatalog"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/remove": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Remove skill from library
+         * @description Remove a skill from the local Skill Library.
+         */
+        post: operations["removeSkillFromCatalog"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update skill library
+         * @description Queue an asynchronous update of supported remote Skill Library entries described by .skill-lock.json. Progress and per-skill results are available through the returned job.
+         */
+        post: operations["updateSkillCatalog"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/skills/catalog/{skill_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Skill detail
+         * @description Return catalog metadata and SKILL.md content for a Global Skill Library skill.
+         */
+        get: operations["skillDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Default agent state alias
+         * @description Compatibility alias for the default agent state route.
+         */
+        get: operations["defaultState"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Default agent status alias
+         * @description Compatibility alias for the default agent status route.
+         */
+        get: operations["defaultStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/templates/catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Template catalog
+         * @description Return the global AgentTemplate catalog (user global library + synced remote sources).
+         */
+        get: operations["templatesCatalog"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/templates/catalog/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Check template
+         * @description Validate a local template directory without applying it.
+         */
+        post: operations["checkTemplate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/templates/catalog/{catalog_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Template detail
+         * @description Return template detail with full AGENTS.md content, manifest, and skill dependencies.
+         */
+        get: operations["templateDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/templates/remote-sources/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync remote template sources
+         * @description Queue a daemon job that synchronizes configured AgentTemplate remote sources.
+         */
+        post: operations["syncTemplateRemoteSources"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/transcript": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Default agent transcript alias
+         * @description Compatibility alias for the default agent transcript route. Query parameter: limit.
+         */
+        get: operations["defaultTranscript"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/webhooks/generic/{agent_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generic webhook
+         * @description Convert an arbitrary JSON webhook body into a trusted integration message.
+         */
+        post: operations["genericWebhook"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspace_id}/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Browse workspace root
+         * @description List directory entries at the workspace root. Query parameters: execution_root_id.
+         */
+        get: operations["workspaceFilesRoot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspace_id}/files/{path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Browse workspace files
+         * @description List a directory or read a file by path. Supports content negotiation: Accept: application/json returns structured metadata + content, other Accept values return raw body. Query parameters: execution_root_id, download, meta.
+         */
+        get: operations["workspaceFiles"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/worktree-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Default agent worktree summary alias
+         * @description Compatibility alias for the default agent worktree summary route.
+         */
+        get: operations["defaultWorktreeSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        AbortCurrentRunRequest: {
+            [key: string]: unknown;
+        };
+        /** AddSkillRequest */
+        AddSkillRequest: {
+            kind: {
+                /** @constant */
+                kind: "named";
+                /**
+                 * @default linked
+                 * @enum {string}
+                 */
+                mode: "linked" | "copied";
+                name: string;
+            } | {
+                /** @constant */
+                kind: "local";
+                /**
+                 * @default linked
+                 * @enum {string}
+                 */
+                mode: "linked" | "copied";
+                path: string;
+            } | {
+                /** @constant */
+                kind: "remote";
+                /**
+                 * @default linked
+                 * @enum {string}
+                 */
+                mode: "linked" | "copied";
+                package: string;
+                skill?: string | null;
+            };
+        };
+        /** AgentStateSnapshotDto */
+        AgentStateSnapshotDto: {
+            agent: {
+                active_children?: {
+                    /** Format: uint */
+                    active_task_count: number;
+                    current_run_id?: string | null;
+                    identity: {
+                        agent_id: string;
+                        delegated_from_task_id?: string | null;
+                        is_default_agent: boolean;
+                        /** @enum {string} */
+                        kind: "default" | "named" | "child";
+                        lineage_parent_agent_id?: string | null;
+                        /** @enum {string} */
+                        ownership: "parent_supervised" | "self_owned";
+                        parent_agent_id?: string | null;
+                        /** @enum {string} */
+                        profile_preset: "private_child" | "public_named";
+                        /** @enum {string} */
+                        status: "active" | "archived";
+                        /** @enum {string} */
+                        visibility: "public" | "private";
+                    };
+                    observability: {
+                        /** @enum {string|null} */
+                        blocked_reason?: "managed_task_queued" | "managed_task_running" | "managed_task_cancelling" | "awaiting_managed_task" | null;
+                        current_work_item_id?: string | null;
+                        last_progress_brief?: string | null;
+                        last_result_brief?: string | null;
+                        /** @enum {string} */
+                        phase: "running" | "blocked" | "waiting" | "terminal";
+                        /** @enum {string|null} */
+                        waiting_reason?: "awaiting_operator_input" | "awaiting_external_change" | "awaiting_task_result" | "awaiting_timer" | null;
+                        work_summary?: string | null;
+                    };
+                    /** Format: uint */
+                    pending: number;
+                    /** @enum {string} */
+                    status: "booting" | "awake_idle" | "awake_running" | "awaiting_task" | "asleep" | "stopped";
+                }[];
+                /**
+                 * Format: uint
+                 * @default 0
+                 */
+                active_task_count: number;
+                agent: {
+                    active_workspace_entry?: {
+                        /** @enum {string} */
+                        access_mode: "shared_read" | "exclusive_write";
+                        cwd: string;
+                        execution_root: string;
+                        execution_root_id: string;
+                        /** @enum {string} */
+                        projection_kind: "canonical_root" | "git_worktree_root";
+                        workspace_anchor: string;
+                        workspace_id: string;
+                    } | null;
+                    /** @default [] */
+                    attached_workspaces: string[];
+                    current_run_id?: string | null;
+                    current_turn_id?: string | null;
+                    current_turn_work_item_id?: string | null;
+                    current_work_item_id?: string | null;
+                    id: string;
+                    /** Format: date-time */
+                    last_brief_at?: string | null;
+                    last_turn_terminal?: {
+                        checkpoint?: {
+                            /** Format: uint64 */
+                            checkpoint_anchor_generation: number;
+                            /** Format: uint64 */
+                            current_anchor_generation: number;
+                            request_id: string;
+                            /** Format: uint */
+                            requested_at_round: number;
+                            /** Format: uint */
+                            response_round?: number | null;
+                            /** Format: uint64 */
+                            source_turn_index?: number | null;
+                            text: string;
+                        } | null;
+                        /** Format: date-time */
+                        completed_at: string;
+                        /** Format: uint64 */
+                        duration_ms: number;
+                        /** @enum {string} */
+                        kind: "completed" | "aborted" | "baseline_over_budget" | "deferred_to_fallback" | "provider_failed_needs_recovery";
+                        last_assistant_message?: string | null;
+                        reason?: string | null;
+                        turn_id?: string;
+                        /** Format: uint64 */
+                        turn_index: number;
+                    } | null;
+                    last_wake_reason?: string | null;
+                    /** Format: uint */
+                    pending: number;
+                    /** Format: date-time */
+                    sleeping_until?: string | null;
+                    /** @enum {string} */
+                    status: "booting" | "awake_idle" | "awake_running" | "awaiting_task" | "asleep" | "stopped";
+                    /**
+                     * Format: uint64
+                     * @default 0
+                     */
+                    turn_index: number;
+                };
+                closure: {
+                    /** @enum {string} */
+                    outcome: "completed" | "continuable" | "failed" | "waiting";
+                    /** @enum {string} */
+                    runtime_posture: "awake" | "sleeping";
+                    /** @enum {string|null} */
+                    waiting_reason?: "awaiting_operator_input" | "awaiting_external_change" | "awaiting_task_result" | "awaiting_timer" | null;
+                };
+                identity: {
+                    agent_id: string;
+                    delegated_from_task_id?: string | null;
+                    is_default_agent: boolean;
+                    /** @enum {string} */
+                    kind: "default" | "named" | "child";
+                    lineage_parent_agent_id?: string | null;
+                    /** @enum {string} */
+                    ownership: "parent_supervised" | "self_owned";
+                    parent_agent_id?: string | null;
+                    /** @enum {string} */
+                    profile_preset: "private_child" | "public_named";
+                    /** @enum {string} */
+                    status: "active" | "archived";
+                    /** @enum {string} */
+                    visibility: "public" | "private";
+                };
+                /**
+                 * @default {
+                 *       "accepts_external_messages": true
+                 *     }
+                 */
+                lifecycle: {
+                    accepts_external_messages: boolean;
+                    operator_hint?: string | null;
+                };
+                model: {
+                    active_model?: string | null;
+                    effective_fallback_models?: string[];
+                    effective_model: string;
+                    /** @default false */
+                    fallback_active: boolean;
+                    override_model?: string | null;
+                    override_reasoning_effort?: string | null;
+                    requested_model?: string | null;
+                    runtime_default_model: string;
+                    /** @enum {string} */
+                    source: "runtime_default" | "agent_override";
+                };
+                /**
+                 * @default {
+                 *       "posture": "unknown",
+                 *       "reason": "posture projection unavailable"
+                 *     }
+                 */
+                scheduling_posture: {
+                    /** @enum {string} */
+                    posture: "unknown" | "archived" | "active_turn" | "has_queued_input" | "has_runnable_work" | "waiting_for_task" | "waiting_for_external" | "waiting_for_operator" | "blocked" | "idle";
+                    reason: string;
+                    run_id?: string | null;
+                    task_id?: string | null;
+                    work_item_id?: string | null;
+                };
+            };
+            /** @default [] */
+            external_triggers: {
+                /** Format: date-time */
+                created_at: string;
+                /** Format: uint64 */
+                delivery_count: number;
+                /** @enum {string} */
+                delivery_mode: "enqueue_message" | "wake_hint";
+                external_trigger_id: string;
+                /** Format: date-time */
+                last_delivered_at?: string | null;
+                /** Format: date-time */
+                revoked_at?: string | null;
+                /** @enum {string} */
+                scope: "agent";
+                /** @enum {string} */
+                status: "active" | "revoked";
+                target_agent_id: string;
+            }[];
+            session: {
+                current_run_id?: string | null;
+                last_turn?: {
+                    checkpoint?: {
+                        /** Format: uint64 */
+                        checkpoint_anchor_generation: number;
+                        /** Format: uint64 */
+                        current_anchor_generation: number;
+                        request_id: string;
+                        /** Format: uint */
+                        requested_at_round: number;
+                        /** Format: uint */
+                        response_round?: number | null;
+                        /** Format: uint64 */
+                        source_turn_index?: number | null;
+                        text: string;
+                    } | null;
+                    /** Format: date-time */
+                    completed_at: string;
+                    /** Format: uint64 */
+                    duration_ms: number;
+                    /** @enum {string} */
+                    kind: "completed" | "aborted" | "baseline_over_budget" | "deferred_to_fallback" | "provider_failed_needs_recovery";
+                    last_assistant_message?: string | null;
+                    reason?: string | null;
+                    turn_id?: string;
+                    /** Format: uint64 */
+                    turn_index: number;
+                } | null;
+                /** Format: uint */
+                pending_count: number;
+            };
+            tasks: {
+                agent_id: string;
+                /** Format: date-time */
+                created_at: string;
+                id: string;
+                /** @enum {string} */
+                kind: "command_task" | "child_agent_task" | "sleep_job" | "subagent_task" | "worktree_subagent_task";
+                parent_message_id?: string | null;
+                /** @enum {string} */
+                status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "interrupted";
+                summary?: string | null;
+                /** Format: date-time */
+                updated_at: string;
+                work_item_id?: string | null;
+            }[];
+            /** @default [] */
+            timers: {
+                agent_id: string;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: uint64 */
+                duration_ms: number;
+                /**
+                 * Format: uint64
+                 * @default 0
+                 */
+                fire_count: number;
+                id: string;
+                /** Format: uint64 */
+                interval_ms?: number | null;
+                /**
+                 * Format: date-time
+                 * @default null
+                 */
+                last_fired_at: string | null;
+                /**
+                 * Format: date-time
+                 * @default null
+                 */
+                next_fire_at: string | null;
+                repeat: boolean;
+                /**
+                 * @default active
+                 * @enum {string}
+                 */
+                status: "active" | "completed" | "cancelled";
+                summary?: string | null;
+            }[];
+            /** @default [] */
+            work_items: {
+                agent_id: string;
+                blocked_by?: string | null;
+                /** @enum {string} */
+                candidate_class: "current_runnable" | "triggered_blocked" | "queued_runnable" | "waiting_for_operator" | "yielded" | "blocked" | "completed_recent";
+                /** Format: date-time */
+                created_at: string;
+                current_todo?: {
+                    /** @enum {string} */
+                    state: "pending" | "in_progress" | "completed";
+                    text: string;
+                } | null;
+                /** @enum {string} */
+                focus: "current" | "queued" | "yielded" | "blocked" | "completed";
+                id: string;
+                is_current: boolean;
+                is_runnable: boolean;
+                objective: string;
+                /** @enum {string} */
+                plan_status: "draft" | "ready" | "needs_input";
+                /** @enum {string} */
+                readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed";
+                /** @enum {string} */
+                reason_code: "completed" | "continuation_yielded" | "active_task_wait" | "active_operator_wait" | "active_timer_wait" | "active_external_wait" | "active_system_wait" | "manual_blocker" | "plan_needs_input" | "runnable";
+                /** Format: date-time */
+                recheck_at?: string | null;
+                result_brief_id?: string | null;
+                result_summary?: string | null;
+                /** Format: uint64 */
+                revision: number;
+                /** @enum {string} */
+                scheduling_state: "runnable" | "yielded_to_work_item" | "waiting_operator" | "waiting_task" | "waiting_external" | "waiting_timer" | "waiting_system" | "blocked" | "completed";
+                /** @enum {string} */
+                state: "open" | "completed";
+                turn_id?: string | null;
+                /** Format: date-time */
+                updated_at: string;
+                workspace_id: string;
+            }[];
+            /**
+             * @default {
+             *       "workspaces": []
+             *     }
+             */
+            workspace: {
+                /** @default [] */
+                workspaces: {
+                    /** @enum {string|null} */
+                    access_mode?: "shared_read" | "exclusive_write" | null;
+                    cwd?: string | null;
+                    execution_root?: string | null;
+                    execution_root_id?: string | null;
+                    is_active: boolean;
+                    /** @enum {string|null} */
+                    projection_kind?: "canonical_root" | "git_worktree_root" | null;
+                    repo_name?: string | null;
+                    workspace_alias?: string | null;
+                    workspace_anchor?: string | null;
+                    workspace_id: string;
+                    worktree?: {
+                        branch?: string | null;
+                        original_branch?: string | null;
+                        original_cwd?: string | null;
+                        path?: string | null;
+                    } | null;
+                }[];
+            };
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        AttachWorkspaceRequest: {
+            [key: string]: unknown;
+        };
+        /** BatchGetMessagesRequest */
+        BatchGetMessagesRequest: {
+            /** @default [] */
+            message_ids: string[];
+        };
+        BatchGetMessagesResponse: {
+            messages: components["schemas"]["JsonValue"][];
+            missing_message_ids?: string[];
+        };
+        /** BatchGetTranscriptEntriesRequest */
+        BatchGetTranscriptEntriesRequest: {
+            /** @default [] */
+            entry_ids: string[];
+        };
+        BatchGetTranscriptEntriesResponse: {
+            entries: components["schemas"]["JsonValue"][];
+            missing_entry_ids?: string[];
+        };
+        /** BriefRecord */
+        BriefRecord: {
+            agent_id: string;
+            attachments?: {
+                kind: string;
+                name: string;
+                uri?: string | null;
+                value?: unknown;
+            }[] | null;
+            /**
+             * @default {
+             *       "kind": "inline"
+             *     }
+             */
+            content_source: {
+                entry_id: string;
+                /** @constant */
+                kind: "transcript_entry";
+                /**
+                 * @default derived_from
+                 * @enum {string}
+                 */
+                relation: "derived_from" | "finalizes" | "excerpt";
+            } | {
+                /** @constant */
+                kind: "inline";
+            };
+            /** Format: date-time */
+            created_at: string;
+            finalizes_assistant_round_id?: string | null;
+            id: string;
+            /** @enum {string} */
+            kind: "ack" | "result" | "failure";
+            related_message_id?: string | null;
+            related_task_id?: string | null;
+            text: string;
+            turn_id?: string | null;
+            /** Format: uint64 */
+            turn_index?: number | null;
+            work_item_id?: string | null;
+            /** @default agent_home */
+            workspace_id: string;
+        };
+        /** @description Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON. */
+        CallbackBody: unknown;
+        /** CancelTimerRequest */
+        CancelTimerRequest: {
+            /** @enum {string|null} */
+            authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+        };
+        /** CheckSkillRequest */
+        CheckSkillRequest: {
+            name?: string | null;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        CheckTemplateRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        ClearAgentModelRequest: {
+            [key: string]: unknown;
+        };
+        /** CompleteWorkItemRequest */
+        CompleteWorkItemRequest: {
+            /** @enum {string|null} */
+            authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        ControlPromptRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        ControlRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        ControlWakeRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        CreateAgentRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        CreateCommandTaskRequest: {
+            [key: string]: unknown;
+        };
+        CreateJobRequest: {
+            /** @enum {string} */
+            kind: "skill.install" | "skill.update";
+            params: components["schemas"]["AddSkillRequest"];
+        };
+        /** CreateTimerRequest */
+        CreateTimerRequest: {
+            /** @enum {string|null} */
+            authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+            /** Format: uint64 */
+            duration_ms: number;
+            /** Format: uint64 */
+            interval_ms?: number | null;
+            summary?: string | null;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        CreateWorkItemRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        DebugPromptRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        DetachWorkspaceRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        DisableSkillRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        EnableSkillRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        EnqueueRequest: {
+            [key: string]: unknown;
+        };
+        ErrorResponse: {
+            after_seq?: number;
+            agent_id?: string;
+            code?: string;
+            error: string;
+            event_seq?: number;
+            hint?: string;
+            /** @constant */
+            ok?: false;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        ExitWorkspaceRequest: {
+            [key: string]: unknown;
+        };
+        GenericJsonPayload: components["schemas"]["JsonValue"];
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        IncomingOrigin: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        InstallSkillRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        InstallTemplateRequest: {
+            [key: string]: unknown;
+        };
+        JobResponse: {
+            job: {
+                /** Format: date-time */
+                created_at: string;
+                error?: string;
+                id: string;
+                items: {
+                    [key: string]: unknown;
+                }[];
+                kind: string;
+                phase: string;
+                progress: {
+                    [key: string]: unknown;
+                };
+                result?: {
+                    [key: string]: unknown;
+                };
+                /** @enum {string} */
+                status: "queued" | "running" | "completed" | "failed";
+                summary: string;
+                /** Format: date-time */
+                updated_at: string;
+            } & {
+                [key: string]: unknown;
+            };
+            ok: boolean;
+        };
+        /** @description Arbitrary JSON value. Used as a conservative baseline for routes whose DTO is not yet stabilized. */
+        JsonValue: unknown;
+        /** MemoryGetRequest */
+        MemoryGetRequest: {
+            /** Format: uint */
+            max_chars?: number | null;
+            source_ref: string;
+        };
+        /** MemoryGetResult */
+        MemoryGetResult: {
+            agent_id: string;
+            content: string;
+            kind: string;
+            metadata: unknown;
+            scope_kind: string;
+            source_path?: string | null;
+            source_ref: string;
+            title: string;
+            truncated: boolean;
+            /** Format: date-time */
+            updated_at: string;
+            workspace_id?: string | null;
+        };
+        /** ModelConfigMigrationReport */
+        ModelConfigMigrationReport: {
+            agent_state: {
+                backup_path?: string | null;
+                changed: boolean;
+                fields: {
+                    current: string;
+                    error?: string | null;
+                    location: string;
+                    proposed?: string | null;
+                    /** @enum {string} */
+                    status: "canonical" | "legacy" | "invalid" | "ambiguous";
+                }[];
+            };
+            changed: boolean;
+            config: {
+                backup_path?: string | null;
+                changed: boolean;
+                fields: {
+                    current: string;
+                    error?: string | null;
+                    location: string;
+                    proposed?: string | null;
+                    /** @enum {string} */
+                    status: "canonical" | "legacy" | "invalid" | "ambiguous";
+                }[];
+            };
+            config_file_path: string;
+            ok: boolean;
+            runtime_db_path: string;
+            write: boolean;
+        };
+        /** ModelConfigMigrationRequest */
+        ModelConfigMigrationRequest: {
+            /** @default false */
+            write: boolean;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        OperatorIngressRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        OperatorTransportBindingRequest: {
+            [key: string]: unknown;
+        };
+        /** PerformanceDiagnosticsSnapshot */
+        PerformanceDiagnosticsSnapshot: {
+            captured_at: string;
+            db: {
+                /** Format: double */
+                avg_bytes?: number | null;
+                /** Format: double */
+                avg_ms: number;
+                /** Format: uint64 */
+                count: number;
+                /** Format: uint64 */
+                max_ms: number;
+                name: string;
+                /** Format: uint64 */
+                total_bytes?: number | null;
+                /** Format: uint64 */
+                total_ms: number;
+            }[];
+            http: {
+                /** Format: double */
+                avg_bytes?: number | null;
+                /** Format: double */
+                avg_ms: number;
+                /** Format: uint64 */
+                count: number;
+                /** Format: uint64 */
+                max_ms: number;
+                name: string;
+                /** Format: uint64 */
+                total_bytes?: number | null;
+                /** Format: uint64 */
+                total_ms: number;
+            }[];
+            /** Format: uint64 */
+            process_uptime_ms: number;
+            projections: {
+                /** Format: double */
+                avg_bytes?: number | null;
+                /** Format: double */
+                avg_ms: number;
+                /** Format: uint64 */
+                count: number;
+                /** Format: uint64 */
+                max_ms: number;
+                name: string;
+                /** Format: uint64 */
+                total_bytes?: number | null;
+                /** Format: uint64 */
+                total_ms: number;
+            }[];
+            provider: {
+                /** Format: double */
+                avg_bytes?: number | null;
+                /** Format: double */
+                avg_ms: number;
+                /** Format: uint64 */
+                count: number;
+                /** Format: uint64 */
+                max_ms: number;
+                name: string;
+                /** Format: uint64 */
+                total_bytes?: number | null;
+                /** Format: uint64 */
+                total_ms: number;
+            }[];
+            scheduler: {
+                /** Format: double */
+                avg_bytes?: number | null;
+                /** Format: double */
+                avg_ms: number;
+                /** Format: uint64 */
+                count: number;
+                /** Format: uint64 */
+                max_ms: number;
+                name: string;
+                /** Format: uint64 */
+                total_bytes?: number | null;
+                /** Format: uint64 */
+                total_ms: number;
+            }[];
+            turn: {
+                /** Format: double */
+                avg_bytes?: number | null;
+                /** Format: double */
+                avg_ms: number;
+                /** Format: uint64 */
+                count: number;
+                /** Format: uint64 */
+                max_ms: number;
+                name: string;
+                /** Format: uint64 */
+                total_bytes?: number | null;
+                /** Format: uint64 */
+                total_ms: number;
+            }[];
+        };
+        /** PickWorkItemRequest */
+        PickWorkItemRequest: {
+            /** @enum {string|null} */
+            authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+            /** @default false */
+            clear_blocker: boolean;
+            reason?: string | null;
+        };
+        /** PickWorkItemResponse */
+        PickWorkItemResponse: {
+            current_work_item: {
+                agent_id: string;
+                blocked_by?: string | null;
+                /** Format: date-time */
+                created_at: string;
+                id: string;
+                objective: string;
+                plan_artifact?: {
+                    /** Format: uint64 */
+                    bytes: number;
+                    hash: string;
+                    /** @default  */
+                    owner_agent_id: string;
+                    path: string;
+                    preview: string;
+                    preview_complete: boolean;
+                    /** @default  */
+                    relative_path: string;
+                    /** Format: date-time */
+                    updated_at: string;
+                    workspace_alias?: string | null;
+                    /** @default agent_home */
+                    workspace_id: string;
+                } | null;
+                /** @enum {string} */
+                plan_status: "draft" | "ready" | "needs_input";
+                /** Format: date-time */
+                recheck_at?: string | null;
+                /** Format: date-time */
+                recheck_consumed_at?: string | null;
+                result_brief_id?: string | null;
+                result_summary?: string | null;
+                /**
+                 * Format: uint64
+                 * @default 1
+                 */
+                revision: number;
+                /** @enum {string} */
+                state: "open" | "completed";
+                todo_list?: {
+                    /** @enum {string} */
+                    state: "pending" | "in_progress" | "completed";
+                    text: string;
+                }[];
+                turn_id?: string | null;
+                /** Format: date-time */
+                updated_at: string;
+                work_refs?: {
+                    /** @enum {string} */
+                    kind: "file" | "tool_execution" | "issue" | "pr" | "url" | "memory" | "task" | "wait" | "workspace" | "other";
+                    /** Format: date-time */
+                    last_seen_at: string;
+                    metadata?: {
+                        [key: string]: unknown;
+                    };
+                    reason: string;
+                    ref: string;
+                    source_ref?: string | null;
+                    /** @enum {string} */
+                    status: "active" | "resolved" | "stale" | "archived";
+                    title?: string | null;
+                }[];
+                /** @default agent_home */
+                workspace_id: string;
+            };
+            current_work_item_id: string;
+            previous_work_item?: {
+                agent_id: string;
+                blocked_by?: string | null;
+                /** Format: date-time */
+                created_at: string;
+                id: string;
+                objective: string;
+                plan_artifact?: {
+                    /** Format: uint64 */
+                    bytes: number;
+                    hash: string;
+                    /** @default  */
+                    owner_agent_id: string;
+                    path: string;
+                    preview: string;
+                    preview_complete: boolean;
+                    /** @default  */
+                    relative_path: string;
+                    /** Format: date-time */
+                    updated_at: string;
+                    workspace_alias?: string | null;
+                    /** @default agent_home */
+                    workspace_id: string;
+                } | null;
+                /** @enum {string} */
+                plan_status: "draft" | "ready" | "needs_input";
+                /** Format: date-time */
+                recheck_at?: string | null;
+                /** Format: date-time */
+                recheck_consumed_at?: string | null;
+                result_brief_id?: string | null;
+                result_summary?: string | null;
+                /**
+                 * Format: uint64
+                 * @default 1
+                 */
+                revision: number;
+                /** @enum {string} */
+                state: "open" | "completed";
+                todo_list?: {
+                    /** @enum {string} */
+                    state: "pending" | "in_progress" | "completed";
+                    text: string;
+                }[];
+                turn_id?: string | null;
+                /** Format: date-time */
+                updated_at: string;
+                work_refs?: {
+                    /** @enum {string} */
+                    kind: "file" | "tool_execution" | "issue" | "pr" | "url" | "memory" | "task" | "wait" | "workspace" | "other";
+                    /** Format: date-time */
+                    last_seen_at: string;
+                    metadata?: {
+                        [key: string]: unknown;
+                    };
+                    reason: string;
+                    ref: string;
+                    source_ref?: string | null;
+                    /** @enum {string} */
+                    status: "active" | "resolved" | "stale" | "archived";
+                    title?: string | null;
+                }[];
+                /** @default agent_home */
+                workspace_id: string;
+            } | null;
+            transition: {
+                blocker_cleared: boolean;
+                cancelled_wait_condition_ids?: string[];
+                current_focus_mode: string;
+                /** @enum {string} */
+                current_readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed";
+                current_work_item_id: string;
+                /** @enum {string|null} */
+                previous_readiness?: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed" | null;
+                previous_work_item_id?: string | null;
+                reason?: string | null;
+                switch_kind: string;
+                warnings?: {
+                    code: string;
+                    message: string;
+                }[];
+            };
+        };
+        /** ReconcileSkillRequest */
+        ReconcileSkillRequest: {
+            name?: string | null;
+        };
+        /** RefreshCatalogRequest */
+        RefreshCatalogRequest: Record<string, never>;
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        RemoveSkillRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        RemoveTemplateRequest: {
+            [key: string]: unknown;
+        };
+        /** RuntimeConfigReadResponse */
+        RuntimeConfigReadResponse: {
+            config_file_path: string;
+            ok: boolean;
+            runtime_surface: {
+                /** @default [] */
+                available_search_provider_kinds: {
+                    capabilities: {
+                        /** @enum {string} */
+                        auth: "none" | "api_key" | "native_provider" | "self_hosted";
+                        /** @enum {string} */
+                        cost_class: "free" | "self_hosted" | "paid" | "provider_metered";
+                        /** Format: uint16 */
+                        default_priority: number;
+                        /** @enum {string} */
+                        quality_hint: "html_fallback" | "keyword" | "semantic" | "research" | "native";
+                        /** @enum {string} */
+                        status: "supported" | "unsupported" | "native_only";
+                        supports_domain_filter: boolean;
+                        supports_freshness: boolean;
+                        supports_full_content: boolean;
+                        supports_native_citations: boolean;
+                        supports_region_or_language: boolean;
+                    };
+                    kind: string;
+                }[];
+                /** Format: uint32 */
+                default_tool_output_tokens: number;
+                disable_provider_fallback: boolean;
+                image_generation_default?: string | null;
+                /** Format: uint32 */
+                max_tool_output_tokens: number;
+                model_catalog: string[];
+                model_default: string;
+                model_fallbacks: string[];
+                providers: {
+                    api_key_supported: boolean;
+                    base_url: string;
+                    configured_in_config: boolean;
+                    credential_configured: boolean;
+                    credential_env?: string | null;
+                    credential_external?: string | null;
+                    credential_kind: string;
+                    credential_profile?: string | null;
+                    credential_source: string;
+                    id: string;
+                    oauth_supported: boolean;
+                    transport: string;
+                }[];
+                /** Format: uint32 */
+                runtime_max_output_tokens: number;
+                unknown_model_fallback_configured: boolean;
+                vision_default?: string | null;
+                web_search: {
+                    builtin_provider_enabled: boolean;
+                    enabled: boolean;
+                    /** Format: uint */
+                    max_provider_attempts: number;
+                    /** Format: uint */
+                    max_results: number;
+                    mode: string;
+                    provider: string;
+                    providers: string[];
+                };
+                web_search_providers: {
+                    base_url?: string | null;
+                    credential_configured: boolean;
+                    credential_profile?: string | null;
+                    id: string;
+                    kind: string;
+                }[];
+            };
+        };
+        /** RuntimeConfigUpdateRequest */
+        RuntimeConfigUpdateRequest: {
+            updates: {
+                key: string;
+                /** @default false */
+                unset: boolean;
+                value?: unknown;
+            }[];
+        };
+        /** RuntimeConfigUpdateResponse */
+        RuntimeConfigUpdateResponse: {
+            changed: boolean;
+            config_file_path: string;
+            ok: boolean;
+            results: {
+                /** @enum {string} */
+                effect: "accepted_requires_restart" | "accepted_reloaded" | "rejected";
+                key: string;
+                reason: string;
+            }[];
+            runtime_surface: {
+                /** @default [] */
+                available_search_provider_kinds: {
+                    capabilities: {
+                        /** @enum {string} */
+                        auth: "none" | "api_key" | "native_provider" | "self_hosted";
+                        /** @enum {string} */
+                        cost_class: "free" | "self_hosted" | "paid" | "provider_metered";
+                        /** Format: uint16 */
+                        default_priority: number;
+                        /** @enum {string} */
+                        quality_hint: "html_fallback" | "keyword" | "semantic" | "research" | "native";
+                        /** @enum {string} */
+                        status: "supported" | "unsupported" | "native_only";
+                        supports_domain_filter: boolean;
+                        supports_freshness: boolean;
+                        supports_full_content: boolean;
+                        supports_native_citations: boolean;
+                        supports_region_or_language: boolean;
+                    };
+                    kind: string;
+                }[];
+                /** Format: uint32 */
+                default_tool_output_tokens: number;
+                disable_provider_fallback: boolean;
+                image_generation_default?: string | null;
+                /** Format: uint32 */
+                max_tool_output_tokens: number;
+                model_catalog: string[];
+                model_default: string;
+                model_fallbacks: string[];
+                providers: {
+                    api_key_supported: boolean;
+                    base_url: string;
+                    configured_in_config: boolean;
+                    credential_configured: boolean;
+                    credential_env?: string | null;
+                    credential_external?: string | null;
+                    credential_kind: string;
+                    credential_profile?: string | null;
+                    credential_source: string;
+                    id: string;
+                    oauth_supported: boolean;
+                    transport: string;
+                }[];
+                /** Format: uint32 */
+                runtime_max_output_tokens: number;
+                unknown_model_fallback_configured: boolean;
+                vision_default?: string | null;
+                web_search: {
+                    builtin_provider_enabled: boolean;
+                    enabled: boolean;
+                    /** Format: uint */
+                    max_provider_attempts: number;
+                    /** Format: uint */
+                    max_results: number;
+                    mode: string;
+                    provider: string;
+                    providers: string[];
+                };
+                web_search_providers: {
+                    base_url?: string | null;
+                    credential_configured: boolean;
+                    credential_profile?: string | null;
+                    id: string;
+                    kind: string;
+                }[];
+            };
+        };
+        /** SearchRequest */
+        SearchRequest: {
+            /** @default null */
+            agent_ids: string[] | null;
+            /** @default false */
+            include_all_workspaces: boolean;
+            /** Format: uint */
+            limit?: number | null;
+            query: string;
+            /** @default [] */
+            types: string[];
+        };
+        /** SearchResponse */
+        SearchResponse: {
+            index_status: {
+                consumption_was_limited?: boolean;
+                /** Format: int64 */
+                cursor: number;
+                freshness: string;
+                /** Format: int64 */
+                high_watermark: number;
+                indexing_needed?: boolean;
+                /** Format: int64 */
+                lag: number;
+                /** Format: date-time */
+                last_indexed_at?: string | null;
+                results_may_be_incomplete?: boolean;
+                /** Format: uint */
+                skipped_error_count?: number;
+            };
+            /** Format: uint */
+            limit: number;
+            query: string;
+            results: {
+                agent_id: string;
+                kind: string;
+                metadata: unknown;
+                scope_kind: string;
+                /** Format: double */
+                score: number;
+                snippet: string;
+                source_path?: string | null;
+                source_ref: string;
+                title: string;
+                /** Format: date-time */
+                updated_at: string;
+                workspace_id?: string | null;
+            }[];
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        SetAgentModelRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        SetCredentialRequest: {
+            [key: string]: unknown;
+        };
+        /** SlimTaskDto */
+        SlimTaskDto: {
+            agent_id: string;
+            /** Format: date-time */
+            created_at: string;
+            id: string;
+            /** @enum {string} */
+            kind: "command_task" | "child_agent_task" | "sleep_job" | "subagent_task" | "worktree_subagent_task";
+            parent_message_id?: string | null;
+            /** @enum {string} */
+            status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "interrupted";
+            summary?: string | null;
+            /** Format: date-time */
+            updated_at: string;
+            work_item_id?: string | null;
+        };
+        /** SlimWorkItemDto */
+        SlimWorkItemDto: {
+            agent_id: string;
+            blocked_by?: string | null;
+            /** @enum {string} */
+            candidate_class: "current_runnable" | "triggered_blocked" | "queued_runnable" | "waiting_for_operator" | "yielded" | "blocked" | "completed_recent";
+            /** Format: date-time */
+            created_at: string;
+            current_todo?: {
+                /** @enum {string} */
+                state: "pending" | "in_progress" | "completed";
+                text: string;
+            } | null;
+            /** @enum {string} */
+            focus: "current" | "queued" | "yielded" | "blocked" | "completed";
+            id: string;
+            is_current: boolean;
+            is_runnable: boolean;
+            objective: string;
+            /** @enum {string} */
+            plan_status: "draft" | "ready" | "needs_input";
+            /** @enum {string} */
+            readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed";
+            /** @enum {string} */
+            reason_code: "completed" | "continuation_yielded" | "active_task_wait" | "active_operator_wait" | "active_timer_wait" | "active_external_wait" | "active_system_wait" | "manual_blocker" | "plan_needs_input" | "runnable";
+            /** Format: date-time */
+            recheck_at?: string | null;
+            result_brief_id?: string | null;
+            result_summary?: string | null;
+            /** Format: uint64 */
+            revision: number;
+            /** @enum {string} */
+            scheduling_state: "runnable" | "yielded_to_work_item" | "waiting_operator" | "waiting_task" | "waiting_external" | "waiting_timer" | "waiting_system" | "blocked" | "completed";
+            /** @enum {string} */
+            state: "open" | "completed";
+            turn_id?: string | null;
+            /** Format: date-time */
+            updated_at: string;
+            workspace_id: string;
+        };
+        /** SyncTemplateRemoteSourcesRequest */
+        SyncTemplateRemoteSourcesRequest: {
+            /**
+             * @description Force a refresh even if a later TTL policy would consider the cache
+             *      fresh. Currently accepted for forward compatibility.
+             */
+            force?: boolean;
+            /**
+             * @description Optional configured source id. When omitted, all enabled remote sources
+             *      are synchronized.
+             */
+            source_id?: string | null;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        TaskInputRequest: {
+            [key: string]: unknown;
+        };
+        /** TaskInputResult */
+        TaskInputResult: {
+            accepted_input: boolean;
+            /** Format: uint64 */
+            bytes_written?: number | null;
+            input_target?: string | null;
+            summary_text?: string | null;
+            task: {
+                child_agent_id?: string | null;
+                child_observability?: {
+                    /** @enum {string|null} */
+                    blocked_reason?: "managed_task_queued" | "managed_task_running" | "managed_task_cancelling" | "awaiting_managed_task" | null;
+                    current_work_item_id?: string | null;
+                    last_progress_brief?: string | null;
+                    last_result_brief?: string | null;
+                    /** @enum {string} */
+                    phase: "running" | "blocked" | "waiting" | "terminal";
+                    /** @enum {string|null} */
+                    waiting_reason?: "awaiting_operator_input" | "awaiting_external_change" | "awaiting_task_result" | "awaiting_timer" | null;
+                    work_summary?: string | null;
+                } | null;
+                child_supervision?: {
+                    child_agent_id: string;
+                    child_work_item_id?: string | null;
+                    cleanup_owner: string;
+                    cleanup_status?: string | null;
+                    delegation_id?: string | null;
+                    followup_target: string;
+                    parent_agent_id: string;
+                    parent_work_item_id?: string | null;
+                    supervision_task_id: string;
+                    /** @enum {string|null} */
+                    workspace_mode?: "inherit" | "worktree" | null;
+                    worktree?: {
+                        actual_branch?: string | null;
+                        auto_cleaned_up?: boolean | null;
+                        branch_cleanup_error?: string | null;
+                        branch_cleanup_status?: string | null;
+                        changed_files?: string[];
+                        cleanup_error?: string | null;
+                        cleanup_reason?: string | null;
+                        cleanup_status?: string | null;
+                        original_branch?: string | null;
+                        original_cwd?: string | null;
+                        projection_kind?: string | null;
+                        retained_for_review?: boolean | null;
+                        worktree_branch?: string | null;
+                        worktree_path?: string | null;
+                    } | null;
+                } | null;
+                command?: {
+                    accepts_input?: boolean | null;
+                    cmd?: string | null;
+                    cmd_digest?: string | null;
+                    /** Format: int32 */
+                    exit_status?: number | null;
+                    input_target?: string | null;
+                    login?: boolean | null;
+                    output_path?: string | null;
+                    promoted_from_exec_command?: boolean | null;
+                    result_summary?: string | null;
+                    shell?: string | null;
+                    terminal_reentry?: boolean | null;
+                    tty?: boolean | null;
+                    workdir?: string | null;
+                } | null;
+                /** Format: date-time */
+                created_at: string;
+                kind: string;
+                parent_message_id?: string | null;
+                /** @enum {string} */
+                status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "interrupted";
+                summary?: string | null;
+                task_id: string;
+                token_usage?: {
+                    last_turn?: {
+                        /** Format: uint64 */
+                        input_tokens: number;
+                        /** Format: uint64 */
+                        output_tokens: number;
+                        /** Format: uint64 */
+                        total_tokens: number;
+                    } | null;
+                    total: {
+                        /** Format: uint64 */
+                        input_tokens: number;
+                        /** Format: uint64 */
+                        output_tokens: number;
+                        /** Format: uint64 */
+                        total_tokens: number;
+                    };
+                    /** Format: uint64 */
+                    total_model_rounds: number;
+                } | null;
+                /** Format: date-time */
+                updated_at: string;
+                /** @enum {string} */
+                wait_policy: "background";
+            };
+        };
+        /** TaskOutputResult */
+        TaskOutputResult: {
+            /** @enum {string} */
+            retrieval_status: "success" | "timeout" | "not_ready";
+            task: {
+                artifacts?: {
+                    path: string;
+                }[];
+                child_supervision?: {
+                    child_agent_id: string;
+                    child_work_item_id?: string | null;
+                    cleanup_owner: string;
+                    cleanup_status?: string | null;
+                    delegation_id?: string | null;
+                    followup_target: string;
+                    parent_agent_id: string;
+                    parent_work_item_id?: string | null;
+                    supervision_task_id: string;
+                    /** @enum {string|null} */
+                    workspace_mode?: "inherit" | "worktree" | null;
+                    worktree?: {
+                        actual_branch?: string | null;
+                        auto_cleaned_up?: boolean | null;
+                        branch_cleanup_error?: string | null;
+                        branch_cleanup_status?: string | null;
+                        changed_files?: string[];
+                        cleanup_error?: string | null;
+                        cleanup_reason?: string | null;
+                        cleanup_status?: string | null;
+                        original_branch?: string | null;
+                        original_cwd?: string | null;
+                        projection_kind?: string | null;
+                        retained_for_review?: boolean | null;
+                        worktree_branch?: string | null;
+                        worktree_path?: string | null;
+                    } | null;
+                } | null;
+                /** Format: int32 */
+                exit_status?: number | null;
+                failure_artifact?: {
+                    /** @enum {string} */
+                    category: "transport" | "protocol" | "runtime" | "task" | "unknown";
+                    /** Format: int32 */
+                    exit_status?: number | null;
+                    kind: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                    model_ref?: string | null;
+                    provider?: string | null;
+                    source_chain?: string[];
+                    /** Format: uint16 */
+                    status?: number | null;
+                    summary: string;
+                    task_id?: string | null;
+                } | null;
+                kind: string;
+                /** Format: uint */
+                output_artifact?: number | null;
+                output_preview: string;
+                output_truncated: boolean;
+                result_summary?: string | null;
+                /** @enum {string} */
+                status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "interrupted";
+                summary?: string | null;
+                task_id: string;
+                token_usage?: {
+                    last_turn?: {
+                        /** Format: uint64 */
+                        input_tokens: number;
+                        /** Format: uint64 */
+                        output_tokens: number;
+                        /** Format: uint64 */
+                        total_tokens: number;
+                    } | null;
+                    total: {
+                        /** Format: uint64 */
+                        input_tokens: number;
+                        /** Format: uint64 */
+                        output_tokens: number;
+                        /** Format: uint64 */
+                        total_tokens: number;
+                    };
+                    /** Format: uint64 */
+                    total_model_rounds: number;
+                } | null;
+            };
+        };
+        /** TaskStatusSnapshot */
+        TaskStatusSnapshot: {
+            child_agent_id?: string | null;
+            child_observability?: {
+                /** @enum {string|null} */
+                blocked_reason?: "managed_task_queued" | "managed_task_running" | "managed_task_cancelling" | "awaiting_managed_task" | null;
+                current_work_item_id?: string | null;
+                last_progress_brief?: string | null;
+                last_result_brief?: string | null;
+                /** @enum {string} */
+                phase: "running" | "blocked" | "waiting" | "terminal";
+                /** @enum {string|null} */
+                waiting_reason?: "awaiting_operator_input" | "awaiting_external_change" | "awaiting_task_result" | "awaiting_timer" | null;
+                work_summary?: string | null;
+            } | null;
+            child_supervision?: {
+                child_agent_id: string;
+                child_work_item_id?: string | null;
+                cleanup_owner: string;
+                cleanup_status?: string | null;
+                delegation_id?: string | null;
+                followup_target: string;
+                parent_agent_id: string;
+                parent_work_item_id?: string | null;
+                supervision_task_id: string;
+                /** @enum {string|null} */
+                workspace_mode?: "inherit" | "worktree" | null;
+                worktree?: {
+                    actual_branch?: string | null;
+                    auto_cleaned_up?: boolean | null;
+                    branch_cleanup_error?: string | null;
+                    branch_cleanup_status?: string | null;
+                    changed_files?: string[];
+                    cleanup_error?: string | null;
+                    cleanup_reason?: string | null;
+                    cleanup_status?: string | null;
+                    original_branch?: string | null;
+                    original_cwd?: string | null;
+                    projection_kind?: string | null;
+                    retained_for_review?: boolean | null;
+                    worktree_branch?: string | null;
+                    worktree_path?: string | null;
+                } | null;
+            } | null;
+            command?: {
+                accepts_input?: boolean | null;
+                cmd?: string | null;
+                cmd_digest?: string | null;
+                /** Format: int32 */
+                exit_status?: number | null;
+                input_target?: string | null;
+                login?: boolean | null;
+                output_path?: string | null;
+                promoted_from_exec_command?: boolean | null;
+                result_summary?: string | null;
+                shell?: string | null;
+                terminal_reentry?: boolean | null;
+                tty?: boolean | null;
+                workdir?: string | null;
+            } | null;
+            /** Format: date-time */
+            created_at: string;
+            kind: string;
+            parent_message_id?: string | null;
+            /** @enum {string} */
+            status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "interrupted";
+            summary?: string | null;
+            task_id: string;
+            token_usage?: {
+                last_turn?: {
+                    /** Format: uint64 */
+                    input_tokens: number;
+                    /** Format: uint64 */
+                    output_tokens: number;
+                    /** Format: uint64 */
+                    total_tokens: number;
+                } | null;
+                total: {
+                    /** Format: uint64 */
+                    input_tokens: number;
+                    /** Format: uint64 */
+                    output_tokens: number;
+                    /** Format: uint64 */
+                    total_tokens: number;
+                };
+                /** Format: uint64 */
+                total_model_rounds: number;
+            } | null;
+            /** Format: date-time */
+            updated_at: string;
+            /** @enum {string} */
+            wait_policy: "background";
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        TaskStopRequest: {
+            [key: string]: unknown;
+        };
+        /** TaskStopResult */
+        TaskStopResult: {
+            force_stop_requested: boolean;
+            stop_requested: boolean;
+            summary_text?: string | null;
+            task: {
+                child_agent_id?: string | null;
+                child_observability?: {
+                    /** @enum {string|null} */
+                    blocked_reason?: "managed_task_queued" | "managed_task_running" | "managed_task_cancelling" | "awaiting_managed_task" | null;
+                    current_work_item_id?: string | null;
+                    last_progress_brief?: string | null;
+                    last_result_brief?: string | null;
+                    /** @enum {string} */
+                    phase: "running" | "blocked" | "waiting" | "terminal";
+                    /** @enum {string|null} */
+                    waiting_reason?: "awaiting_operator_input" | "awaiting_external_change" | "awaiting_task_result" | "awaiting_timer" | null;
+                    work_summary?: string | null;
+                } | null;
+                child_supervision?: {
+                    child_agent_id: string;
+                    child_work_item_id?: string | null;
+                    cleanup_owner: string;
+                    cleanup_status?: string | null;
+                    delegation_id?: string | null;
+                    followup_target: string;
+                    parent_agent_id: string;
+                    parent_work_item_id?: string | null;
+                    supervision_task_id: string;
+                    /** @enum {string|null} */
+                    workspace_mode?: "inherit" | "worktree" | null;
+                    worktree?: {
+                        actual_branch?: string | null;
+                        auto_cleaned_up?: boolean | null;
+                        branch_cleanup_error?: string | null;
+                        branch_cleanup_status?: string | null;
+                        changed_files?: string[];
+                        cleanup_error?: string | null;
+                        cleanup_reason?: string | null;
+                        cleanup_status?: string | null;
+                        original_branch?: string | null;
+                        original_cwd?: string | null;
+                        projection_kind?: string | null;
+                        retained_for_review?: boolean | null;
+                        worktree_branch?: string | null;
+                        worktree_path?: string | null;
+                    } | null;
+                } | null;
+                command?: {
+                    accepts_input?: boolean | null;
+                    cmd?: string | null;
+                    cmd_digest?: string | null;
+                    /** Format: int32 */
+                    exit_status?: number | null;
+                    input_target?: string | null;
+                    login?: boolean | null;
+                    output_path?: string | null;
+                    promoted_from_exec_command?: boolean | null;
+                    result_summary?: string | null;
+                    shell?: string | null;
+                    terminal_reentry?: boolean | null;
+                    tty?: boolean | null;
+                    workdir?: string | null;
+                } | null;
+                /** Format: date-time */
+                created_at: string;
+                kind: string;
+                parent_message_id?: string | null;
+                /** @enum {string} */
+                status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "interrupted";
+                summary?: string | null;
+                task_id: string;
+                token_usage?: {
+                    last_turn?: {
+                        /** Format: uint64 */
+                        input_tokens: number;
+                        /** Format: uint64 */
+                        output_tokens: number;
+                        /** Format: uint64 */
+                        total_tokens: number;
+                    } | null;
+                    total: {
+                        /** Format: uint64 */
+                        input_tokens: number;
+                        /** Format: uint64 */
+                        output_tokens: number;
+                        /** Format: uint64 */
+                        total_tokens: number;
+                    };
+                    /** Format: uint64 */
+                    total_model_rounds: number;
+                } | null;
+                /** Format: date-time */
+                updated_at: string;
+                /** @enum {string} */
+                wait_policy: "background";
+            };
+        };
+        /** TimerRecord */
+        TimerRecord: {
+            agent_id: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: uint64 */
+            duration_ms: number;
+            /**
+             * Format: uint64
+             * @default 0
+             */
+            fire_count: number;
+            id: string;
+            /** Format: uint64 */
+            interval_ms?: number | null;
+            /**
+             * Format: date-time
+             * @default null
+             */
+            last_fired_at: string | null;
+            /**
+             * Format: date-time
+             * @default null
+             */
+            next_fire_at: string | null;
+            repeat: boolean;
+            /**
+             * @default active
+             * @enum {string}
+             */
+            status: "active" | "completed" | "cancelled";
+            summary?: string | null;
+        };
+        /** ToolExecutionArtifactContent */
+        ToolExecutionArtifactContent: {
+            /** Format: uint */
+            artifact_index: number;
+            content: string;
+            /** Format: uint64 */
+            size: number;
+        };
+        /** ToolExecutionRecord */
+        ToolExecutionRecord: {
+            agent_id: string;
+            /** @enum {string} */
+            authority_class: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence";
+            /**
+             * Format: date-time
+             * @default null
+             */
+            completed_at: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /**
+             * Format: uint64
+             * @default 0
+             */
+            duration_ms: number;
+            id: string;
+            input: unknown;
+            invocation_surface?: string | null;
+            output: unknown;
+            /** @enum {string} */
+            status: "success" | "error";
+            summary: string;
+            tool_name: string;
+            turn_id?: string | null;
+            /**
+             * Format: uint64
+             * @default 0
+             */
+            turn_index: number;
+            work_item_id?: string | null;
+        };
+        /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
+        UninstallSkillRequest: {
+            [key: string]: unknown;
+        };
+        /** ReconcileSkillRequest */
+        UpdateSkillRequest: {
+            name?: string | null;
+        };
+        /** UpdateWorkItemRequest */
+        UpdateWorkItemRequest: {
+            /** @enum {string|null} */
+            authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+            blocked_by?: unknown;
+            objective?: string | null;
+            /** @enum {string|null} */
+            plan_status?: "draft" | "ready" | "needs_input" | null;
+            /** Format: uint64 */
+            recheck_after?: number | null;
+            todo_list?: {
+                /** @enum {string} */
+                state: "pending" | "in_progress" | "completed";
+                text: string;
+            }[] | null;
+        };
+        /** WorkItemRecord */
+        WorkItemRecord: {
+            agent_id: string;
+            blocked_by?: string | null;
+            /** Format: date-time */
+            created_at: string;
+            id: string;
+            objective: string;
+            plan_artifact?: {
+                /** Format: uint64 */
+                bytes: number;
+                hash: string;
+                /** @default  */
+                owner_agent_id: string;
+                path: string;
+                preview: string;
+                preview_complete: boolean;
+                /** @default  */
+                relative_path: string;
+                /** Format: date-time */
+                updated_at: string;
+                workspace_alias?: string | null;
+                /** @default agent_home */
+                workspace_id: string;
+            } | null;
+            /** @enum {string} */
+            plan_status: "draft" | "ready" | "needs_input";
+            /** Format: date-time */
+            recheck_at?: string | null;
+            /** Format: date-time */
+            recheck_consumed_at?: string | null;
+            result_brief_id?: string | null;
+            result_summary?: string | null;
+            /**
+             * Format: uint64
+             * @default 1
+             */
+            revision: number;
+            /** @enum {string} */
+            state: "open" | "completed";
+            todo_list?: {
+                /** @enum {string} */
+                state: "pending" | "in_progress" | "completed";
+                text: string;
+            }[];
+            turn_id?: string | null;
+            /** Format: date-time */
+            updated_at: string;
+            work_refs?: {
+                /** @enum {string} */
+                kind: "file" | "tool_execution" | "issue" | "pr" | "url" | "memory" | "task" | "wait" | "workspace" | "other";
+                /** Format: date-time */
+                last_seen_at: string;
+                metadata?: {
+                    [key: string]: unknown;
+                };
+                reason: string;
+                ref: string;
+                source_ref?: string | null;
+                /** @enum {string} */
+                status: "active" | "resolved" | "stale" | "archived";
+                title?: string | null;
+            }[];
+            /** @default agent_home */
+            workspace_id: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    root: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listAgents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentBriefs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentBrief: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Brief id. */
+                brief_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BriefRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    enqueueAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnqueueRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentEventsStream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            /** @description Client error before stream establishment. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentMessage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Message id. */
+                message_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentMessagesBatchGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchGetMessagesRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchGetMessagesResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentSkills: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentState: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentStateSnapshotDto"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTasks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTaskStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Task id. */
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskStatusSnapshot"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTaskOutput: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Task id. */
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskOutputResult"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTimers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTimer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Timer id. */
+                timer_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentToolExecution: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Tool execution id. */
+                tool_execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolExecutionRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentToolExecutionArtifact: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Tool execution id. */
+                tool_execution_id: string;
+                /** @description Zero-based artifact index within the tool execution result. */
+                artifact_index: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolExecutionArtifactContent"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTranscript: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTranscriptEntry: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentTranscriptBatchGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchGetTranscriptEntriesRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchGetTranscriptEntriesResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentWorkItems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentWorkItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Work item id. */
+                work_item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentWorktreeSummary: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    startCodexDeviceLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    startOAuthDeviceLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    defaultBriefs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    callbackEnqueue: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque callback capability token. This is a secret and must not be exposed in examples. */
+                callback_token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CallbackBody"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    callbackWake: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque callback capability token. This is a secret and must not be exposed in examples. */
+                callback_token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CallbackBody"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    controlAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControlRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAgentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    abortCurrentRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AbortCurrentRunRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    debugPrompt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DebugPromptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    setAgentModel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetAgentModelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    clearAgentModel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClearAgentModelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createOperatorTransportBinding: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OperatorTransportBindingRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    operatorIngress: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OperatorIngressRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    controlPrompt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControlPromptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    resetCallback: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    disableSkill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DisableSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    enableSkill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnableSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    installSkill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InstallSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    uninstallSkill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UninstallSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createCommandTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateCommandTaskRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    taskInput: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Task id. */
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TaskInputRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskInputResult"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    taskStop: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Task id. */
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TaskStopRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskStopResult"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createTimer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTimerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TimerRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    cancelTimer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Timer id. */
+                timer_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CancelTimerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TimerRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    controlWake: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControlWakeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createWorkItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateWorkItemRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkItemRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateWorkItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Work item id. */
+                work_item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateWorkItemRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkItemRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    completeWorkItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Work item id. */
+                work_item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CompleteWorkItemRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkItemRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    pickWorkItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Work item id. */
+                work_item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PickWorkItemRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PickWorkItemResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    attachWorkspace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AttachWorkspaceRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    detachWorkspace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DetachWorkspaceRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    exitWorkspace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExitWorkspaceRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeConfigReadResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeConfigUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeConfigUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeConfigUpdateResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    migrateModelConfigRoutes: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ModelConfigMigrationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModelConfigMigrationReport"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeCredentials: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    setRuntimeCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetCredentialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteRuntimeCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimePerformance: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerformanceDiagnosticsSnapshot"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeReadiness: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeShutdown: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    installTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InstallTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    removeTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RemoveTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    enqueueDefault: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnqueueRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    eventsStream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            /** @description Client error before stream establishment. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    handshake: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateJobRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    jobStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeMemoryGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MemoryGetRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MemoryGetResult"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    models: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runtimeSearch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SearchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    skillsCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    addSkillToCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    checkSkillCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CheckSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    reconcileSkillCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReconcileSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    refreshSkillCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefreshCatalogRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    removeSkillFromCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RemoveSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateSkillCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSkillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    skillDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Root-qualified skill id. */
+                skill_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    defaultState: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentStateSnapshotDto"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    defaultStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    templatesCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    checkTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CheckTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    templateDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    syncTemplateRemoteSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncTemplateRemoteSourcesRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    defaultTranscript: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    genericWebhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GenericJsonPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    workspaceFilesRoot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    workspaceFiles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    defaultWorktreeSummary: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+}

--- a/web-gui/openapi-tools/generate-openapi-types.mjs
+++ b/web-gui/openapi-tools/generate-openapi-types.mjs
@@ -1,0 +1,30 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import openapiTS, { astToString } from "openapi-typescript";
+
+const schemaUrl = new URL("../../docs/website/reference/openapi.json", import.meta.url);
+const outputUrl = new URL("../app/src/runtime/generated/openapi.ts", import.meta.url);
+const check = process.argv.includes("--check");
+const header = [
+  "// Generated from docs/website/reference/openapi.json by web-gui/openapi-tools.",
+  "// Do not edit by hand. Run `make transport-types` from the repository root.",
+  "",
+].join("\n");
+
+const ast = await openapiTS(schemaUrl);
+const generated = `${header}${astToString(ast)}`;
+
+if (check) {
+  const current = await readFile(outputUrl, "utf8").catch(() => "");
+  if (current !== generated) {
+    console.error(
+      "Generated TypeScript transport types are stale. Run `make transport-types` and commit the result.",
+    );
+    process.exitCode = 1;
+  }
+} else {
+  await mkdir(dirname(fileURLToPath(outputUrl)), { recursive: true });
+  await writeFile(outputUrl, generated);
+}

--- a/web-gui/openapi-tools/package-lock.json
+++ b/web-gui/openapi-tools/package-lock.json
@@ -1,0 +1,394 @@
+{
+  "name": "@holon/openapi-tools",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@holon/openapi-tools",
+      "version": "0.1.0",
+      "devDependencies": {
+        "openapi-typescript": "7.13.0",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.17",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
+      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.2.0",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/web-gui/openapi-tools/package.json
+++ b/web-gui/openapi-tools/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@holon/openapi-tools",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "generate": "node generate-openapi-types.mjs",
+    "check": "node generate-openapi-types.mjs --check"
+  },
+  "devDependencies": {
+    "openapi-typescript": "7.13.0",
+    "typescript": "5.9.3"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2266.

- introduce explicit Rust HTTP wire DTOs for `/agents/{agent_id}/state` and `/state`, including named slim task/work-item/bootstrap agent projections
- make the Rust public client deserialize and expose the shared slim DTO contract, while keeping full TUI aggregation behind an internal projection boundary
- register typed OpenAPI responses/components and generate checked-in TypeScript transport types with `openapi-typescript`
- derive the Web transport adapter from generated types and add OpenAPI/TypeScript drift checks to the normal CI path
- document the generated-contract release workflow and runtime event-stream contract boundary

## Verification

- `make web-ci`
- `make fmt-check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' make build test`
- `make lint`
- OpenAPI snapshot tests
- generated transport type drift check
- Web TypeScript typecheck
- 20 Web test files / 175 tests
- independent read-only contract review
