### PR TITLE
fix: preserve runtime failure in slim state DTO

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -379,6 +379,115 @@
                       "null"
                     ]
                   },
+                  "last_runtime_failure": {
+                    "properties": {
+                      "detail_hint": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "failure_artifact": {
+                        "properties": {
+                          "category": {
+                            "enum": [
+                              "transport",
+                              "protocol",
+                              "runtime",
+                              "task",
+                              "unknown"
+                            ],
+                            "type": "string"
+                          },
+                          "exit_status": {
+                            "format": "int32",
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "model_ref": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "provider": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "source_chain": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "status": {
+                            "format": "uint16",
+                            "maximum": 65535,
+                            "minimum": 0,
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "summary": {
+                            "type": "string"
+                          },
+                          "task_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "category",
+                          "kind",
+                          "summary"
+                        ],
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      },
+                      "occurred_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "phase": {
+                        "enum": [
+                          "startup",
+                          "shutdown",
+                          "runtime_turn"
+                        ],
+                        "type": "string"
+                      },
+                      "summary": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "occurred_at",
+                      "summary",
+                      "phase"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
                   "last_turn_terminal": {
                     "properties": {
                       "checkpoint": {

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -256,6 +256,11 @@ pub async fn agent_state(
         .last_turn_terminal
         .clone()
         .map(slim_state_turn_terminal_record);
+    agent_dto.agent.last_runtime_failure = agent
+        .agent
+        .last_runtime_failure
+        .clone()
+        .map(slim_state_runtime_failure);
     let session = crate::http_dto::StateSessionSnapshotDto {
         current_run_id: agent.agent.current_run_id.clone(),
         pending_count: agent.agent.pending,
@@ -310,6 +315,17 @@ fn slim_state_turn_terminal_record(mut record: TurnTerminalRecord) -> TurnTermin
         checkpoint
     });
     record
+}
+
+fn slim_state_runtime_failure(
+    mut failure: crate::types::RuntimeFailureSummary,
+) -> crate::types::RuntimeFailureSummary {
+    failure.summary =
+        truncate_state_bootstrap_string(&failure.summary, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
+    failure.detail_hint = failure
+        .detail_hint
+        .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
+    failure
 }
 
 #[cfg(test)]
@@ -498,8 +514,8 @@ mod tests {
         STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT,
     };
     use crate::types::{
-        TaskKind, TaskRecord, TaskStatus, TodoItem, TodoItemState, TranscriptEntry,
-        TranscriptEntryKind, WorkItemRecord, WorkItemState,
+        RuntimeFailurePhase, RuntimeFailureSummary, TaskKind, TaskRecord, TaskStatus, TodoItem,
+        TodoItemState, TranscriptEntry, TranscriptEntryKind, WorkItemRecord, WorkItemState,
     };
     use serde_json::json;
 
@@ -597,6 +613,30 @@ mod tests {
                 .result_summary
                 .as_deref()
                 .expect("result")
+                .chars()
+                .count()
+                <= STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT
+        );
+    }
+
+    #[test]
+    fn state_bootstrap_preserves_and_slims_last_runtime_failure() {
+        let failure = RuntimeFailureSummary {
+            occurred_at: chrono::Utc::now(),
+            summary: "s".repeat(STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT + 64),
+            phase: RuntimeFailurePhase::RuntimeTurn,
+            detail_hint: Some("d".repeat(STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT + 64)),
+            failure_artifact: None,
+        };
+
+        let slimmed = super::slim_state_runtime_failure(failure);
+
+        assert!(slimmed.summary.chars().count() <= STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
+        assert!(
+            slimmed
+                .detail_hint
+                .as_deref()
+                .expect("detail hint")
                 .chars()
                 .count()
                 <= STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT

--- a/src/http_dto.rs
+++ b/src/http_dto.rs
@@ -14,8 +14,8 @@ use crate::{
         AgentListModelSummary, AgentModelSource, AgentPostureProjection, AgentState, AgentStatus,
         AgentSummary, ChildAgentBlockedReason, ChildAgentObservabilitySnapshot, ChildAgentPhase,
         ChildAgentSummary, ClosureDecision, ClosureOutcome, ExternalTriggerStateSnapshot,
-        RuntimePosture, TaskKind, TaskRecord, TaskStatus, TimerRecord, TodoItem,
-        TurnTerminalRecord, WaitingReason, WorkItemPlanStatus, WorkItemReadiness,
+        RuntimeFailureSummary, RuntimePosture, TaskKind, TaskRecord, TaskStatus, TimerRecord,
+        TodoItem, TurnTerminalRecord, WaitingReason, WorkItemPlanStatus, WorkItemReadiness,
         WorkItemSchedulingState, WorkItemState,
     },
     work_item_scheduling::{
@@ -133,6 +133,8 @@ pub struct SlimAgentRuntimeDto {
     pub current_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_turn_terminal: Option<TurnTerminalRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_runtime_failure: Option<RuntimeFailureSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -285,6 +287,7 @@ impl From<&AgentState> for SlimAgentRuntimeDto {
             current_turn_work_item_id: agent.current_turn_work_item_id.clone(),
             current_work_item_id: agent.current_work_item_id.clone(),
             last_turn_terminal: None,
+            last_runtime_failure: None,
         }
     }
 }
@@ -504,6 +507,9 @@ impl SlimAgentDto {
             active_workspace_entry,
         }
         .into_agent_summary_placeholder();
+        // This is an internal TUI projection, not a full domain roundtrip. Fields omitted from
+        // SlimAgentRuntimeDto intentionally retain placeholder defaults; transported fields must
+        // be assigned explicitly here.
         summary.agent.id = self.agent.id;
         summary.agent.status = self.agent.status;
         summary.agent.sleeping_until = self.agent.sleeping_until;
@@ -517,6 +523,7 @@ impl SlimAgentDto {
         summary.agent.current_turn_work_item_id = self.agent.current_turn_work_item_id;
         summary.agent.current_work_item_id = self.agent.current_work_item_id;
         summary.agent.last_turn_terminal = self.agent.last_turn_terminal;
+        summary.agent.last_runtime_failure = self.agent.last_runtime_failure;
         summary.active_task_count = self.active_task_count;
         summary.closure = ClosureDecision {
             outcome: self.closure.outcome,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1466,7 +1466,7 @@ pub enum AgentStatus {
     Stopped,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeFailurePhase {
     Startup,
@@ -1505,7 +1505,7 @@ pub struct FailureArtifact {
     pub metadata: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeFailureSummary {
     pub occurred_at: DateTime<Utc>,
     pub summary: String,

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -1996,6 +1996,31 @@ export interface components {
                     id: string;
                     /** Format: date-time */
                     last_brief_at?: string | null;
+                    last_runtime_failure?: {
+                        detail_hint?: string | null;
+                        failure_artifact?: {
+                            /** @enum {string} */
+                            category: "transport" | "protocol" | "runtime" | "task" | "unknown";
+                            /** Format: int32 */
+                            exit_status?: number | null;
+                            kind: string;
+                            metadata?: {
+                                [key: string]: string;
+                            };
+                            model_ref?: string | null;
+                            provider?: string | null;
+                            source_chain?: string[];
+                            /** Format: uint16 */
+                            status?: number | null;
+                            summary: string;
+                            task_id?: string | null;
+                        } | null;
+                        /** Format: date-time */
+                        occurred_at: string;
+                        /** @enum {string} */
+                        phase: "startup" | "shutdown" | "runtime_turn";
+                        summary: string;
+                    } | null;
                     last_turn_terminal?: {
                         checkpoint?: {
                             /** Format: uint64 */


### PR DESCRIPTION
## 摘要

- 在 slim agent/workspace state DTO 中保留 `last_runtime_failure`，避免 bootstrap transport 丢失最近一次运行失败
- 补充回归测试，验证错误详情经过预算裁剪后仍被保留
- 重新生成并提交 OpenAPI snapshot 与 TypeScript transport types

这是 #2312（#2266）的最小 follow-up，处理合并前 review 指出的运行失败信息丢失问题。

## 验证

- `cargo test state_bootstrap_preserves_and_slims_last_runtime_failure`
- `make transport-types-check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo fmt --all -- --check`
