### PR TITLE
refactor: Web 使用唯一 SessionProjectionState 并保证批次无关归约

### DIFF
--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createRuntimeClient, projectModelOptions } from "./client";
 import type { components } from "./generated/openapi";
+import {
+  createSessionProjectionState,
+  deriveSessionTimeline,
+  reduceSessionProjection,
+} from "./session-projection";
 
 function agentStateFixture(agentId: string): components["schemas"]["AgentStateSnapshotDto"] {
   return {
@@ -820,9 +825,25 @@ describe("createRuntimeClient", () => {
     });
 
     const detail = await client.getAgentDetail("agent-one");
+    let projection = reduceSessionProjection(createSessionProjectionState(), {
+      type: "events_received",
+      events: detail.events ?? [],
+      eventLogEpoch: detail.eventLogEpoch,
+    });
+    projection = reduceSessionProjection(projection, {
+      type: "transcripts_hydrated",
+      entries: Object.values(detail.transcriptEntriesById ?? {}),
+      missingIds: [],
+    });
+    projection = reduceSessionProjection(projection, {
+      type: "briefs_hydrated",
+      recordsById: detail.briefRecordsById ?? {},
+      missingIds: [],
+    });
 
     expect(detail.agent.lastBrief).toBe("Canonical persisted brief.");
-    expect(detail.timeline[0]).toEqual(
+    expect(detail.timeline).toEqual([]);
+    expect(deriveSessionTimeline(projection)[0]).toEqual(
       expect.objectContaining({
         id: "brief-event",
         body: "Canonical persisted brief.",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1,6 +1,6 @@
 import { agentDetailFixtures } from "./fixtures";
 import type { components } from "./generated/openapi";
-import { briefIdForPayload, reduceAgentSessionTimeline, transcriptEntryIdForPayload } from "./session-reducer";
+import { briefIdForPayload, transcriptEntryIdForPayload } from "./session-reducer";
 import type {
   AddSkillInput,
   AgentDetail,
@@ -131,13 +131,12 @@ async function fetchAgentDetail(
   displayLevel: DisplayLevel,
 ): Promise<AgentDetail> {
   const encodedAgentId = encodeURIComponent(agentId);
-  const eventDisplayLevel = displayLevel;
   const [entry, state, events, workItems] = await Promise.all([
     getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers })
       .then((agents) => agents.find((agent) => agent.identity?.agent_id === agentId))
       .catch(() => undefined),
     getJson<AgentStateDto>(fetchImpl, baseUrl, `/agents/${encodedAgentId}/state`, { headers }),
-    fetchAgentEvents(baseUrl, fetchImpl, headers, agentId, { limit: 80, order: "desc", displayLevel: eventDisplayLevel }).catch(emptyEventPage),
+    fetchAgentEvents(baseUrl, fetchImpl, headers, agentId, { limit: 80, order: "desc", displayLevel }).catch(emptyEventPage),
     // Return undefined on failure so projectAgent falls back to state.work_items.
     // Returning [] would shadow the state endpoint's work_items (empty array is not nullish).
     fetchAgentWorkItems(baseUrl, fetchImpl, headers, agentId, { limit: 50 }).catch(() => undefined),
@@ -151,15 +150,14 @@ async function fetchAgentDetail(
     newestBriefFromEvents(events.events ?? [], briefRecordsById),
     workItems,
   );
-  const timeline = reduceAgentSessionTimeline({ events, eventDisplayLevel, transcriptEntriesById, briefRecordsById });
-
   return {
     agent,
     source: "http",
-    timeline,
+    timeline: [],
     eventLogEpoch: events.event_log_epoch,
     events: events.events ?? [],
     briefRecordsById,
+    transcriptEntriesById,
     eventCursorSeq: events.cursor_seq ?? undefined,
     newestEventSeq: events.newest_seq ?? undefined,
     oldestEventSeq: events.oldest_seq ?? undefined,

--- a/web-gui/app/src/runtime/idb-cache.ts
+++ b/web-gui/app/src/runtime/idb-cache.ts
@@ -8,7 +8,7 @@
 
 const DB_NAME = "holon-webgui-cache";
 const DB_VERSION = 1;
-export const CACHE_SCHEMA_VERSION = 2;
+export const CACHE_SCHEMA_VERSION = 3;
 const SESSIONS_STORE = "sessions";
 const META_STORE = "meta";
 
@@ -16,6 +16,7 @@ export interface CachedAgentSession {
   remoteKey: string;
   agentId: string;
   schemaVersion: number;
+  projectionGeneration?: number;
   eventLogEpoch?: string;
   eventsBySeq: Record<number, unknown>;
   eventSeqs: number[];

--- a/web-gui/app/src/runtime/object-renderers.ts
+++ b/web-gui/app/src/runtime/object-renderers.ts
@@ -11,7 +11,7 @@
 import type { AgentTimelineActivity, AgentTimelineItem, TimelineStateObjectRef } from "./types";
 import type { DomainObject, RuntimeActivityObject, TaskObject, ToolExecutionObject, WorkItemObject } from "./session-object-types";
 import type { RenderContext } from "./timeline-view-model";
-import { projectRuntimeEvent, projectToolExecution } from "./session-reducer-core";
+import { eventMeta, projectRuntimeEvent, projectToolExecution } from "./session-reducer-core";
 
 /**
  * Render any domain object into a display-ready timeline item.
@@ -26,6 +26,11 @@ export function renderDomainObject(
   obj: DomainObject,
   ctx: RenderContext,
 ): AgentTimelineItem | undefined {
+  const event = ctx.eventsById[obj.primaryEventId];
+  if (!event) return undefined;
+  const eventType = event.type ?? "runtime_event";
+  const payload = asRecord(event.payload);
+
   // Specialized renderers: objects with stable identity that aggregate
   // multiple events render from their own fields, producing one stable card
   // with lifecycle events shown as activities underneath.
@@ -36,12 +41,12 @@ export function renderDomainObject(
     return renderTaskObject(obj, ctx);
   }
   if (isToolExecutionObject(obj)) {
-    return renderToolExecutionObject(obj);
+    return renderToolExecutionObject(obj, ctx);
   }
 
   const projection = projectRuntimeEvent(
-    obj.render.eventType,
-    obj.render.payload,
+    eventType,
+    payload,
     ctx.messagesById,
     ctx.transcriptEntriesById,
     ctx.briefRecordsById,
@@ -53,27 +58,30 @@ export function renderDomainObject(
     kind: projection.kind,
     label: projection.label,
     body: projection.body,
-    timestamp: projection.timestamp || obj.render.timestamp,
-    meta: obj.render.meta,
+    timestamp: projection.timestamp || event.ts || obj.updatedAt,
+    meta: eventMeta(eventType, payload, event.event_seq),
     minDisplayLevel: projection.minDisplayLevel,
-    sourceIds: obj.sourceEventIds,
+    sourceIds: orderedSourceEventIds(obj, ctx),
     relatedStateObjectRef: relatedStateObjectRefFor(obj),
     detail: projection.detail,
-    rawEvent: obj.render.rawEvent,
-    debug: obj.render.debug,
+    rawEvent: event,
+    debug: ctx.includeDebug ? JSON.stringify(event, null, 2) : undefined,
   };
 }
 
 function renderWorkItemObject(obj: WorkItemObject, ctx: RenderContext): AgentTimelineItem {
+  const event = ctx.eventsById[obj.primaryEventId];
+  const eventType = event?.type ?? "runtime_event";
+  const payload = asRecord(event?.payload);
   return {
     id: obj.id,
     kind: "system" as const,
     label: "Work item",
     body: obj.objective || "Work item",
-    timestamp: obj.render.timestamp,
-    meta: obj.render.meta,
+    timestamp: event?.ts ?? obj.updatedAt,
+    meta: eventMeta(eventType, payload, event?.event_seq),
     minDisplayLevel: "verbose" as const,
-    sourceIds: obj.sourceEventIds,
+    sourceIds: orderedSourceEventIds(obj, ctx),
     stateObjectRef: {
       kind: "work_item",
       id: obj.id,
@@ -81,15 +89,19 @@ function renderWorkItemObject(obj: WorkItemObject, ctx: RenderContext): AgentTim
       state: obj.state,
     },
     activities: renderWorkItemActivities(obj, ctx),
-    rawEvent: obj.render.rawEvent,
-    debug: obj.render.debug,
+    rawEvent: event,
+    debug: ctx.includeDebug && event ? JSON.stringify(event, null, 2) : undefined,
   };
 }
 
-function renderToolExecutionObject(obj: ToolExecutionObject): AgentTimelineItem | undefined {
+function renderToolExecutionObject(obj: ToolExecutionObject, ctx: RenderContext): AgentTimelineItem | undefined {
+  const event = ctx.eventsById[obj.primaryEventId];
+  if (!event) return undefined;
+  const eventType = event.type ?? "runtime_event";
+  const payload = asRecord(event.payload);
   const projection = projectToolExecution(
-    obj.render.eventType,
-    obj.render.payload,
+    eventType,
+    payload,
   );
   if (!projection) return undefined;
 
@@ -98,10 +110,10 @@ function renderToolExecutionObject(obj: ToolExecutionObject): AgentTimelineItem 
     kind: projection.kind,
     label: projection.label,
     body: projection.body,
-    timestamp: obj.render.timestamp,
-    meta: obj.render.meta,
+    timestamp: event.ts ?? obj.updatedAt,
+    meta: eventMeta(eventType, payload, event.event_seq),
     minDisplayLevel: projection.minDisplayLevel,
-    sourceIds: obj.sourceEventIds,
+    sourceIds: orderedSourceEventIds(obj, ctx),
     stateObjectRef: {
       kind: "tool_execution",
       id: obj.id,
@@ -110,22 +122,25 @@ function renderToolExecutionObject(obj: ToolExecutionObject): AgentTimelineItem 
     },
     relatedStateObjectRef: obj.relatedStateObjectRef,
     detail: projection.detail,
-    rawEvent: obj.render.rawEvent,
-    debug: obj.render.debug,
+    rawEvent: event,
+    debug: ctx.includeDebug ? JSON.stringify(event, null, 2) : undefined,
   };
 }
 
 function renderTaskObject(obj: TaskObject, ctx: RenderContext): AgentTimelineItem {
+  const event = ctx.eventsById[obj.primaryEventId];
+  const eventType = event?.type ?? "runtime_event";
+  const payload = asRecord(event?.payload);
   const summary = obj.summary || "Task";
   return {
     id: obj.id,
     kind: "tool" as const,
     label: taskStatusLabel(obj.initialStatus ?? obj.status),
     body: summary,
-    timestamp: obj.render.timestamp,
-    meta: obj.render.meta,
+    timestamp: event?.ts ?? obj.updatedAt,
+    meta: eventMeta(eventType, payload, event?.event_seq),
     minDisplayLevel: isFailedTaskStatus(obj.status) ? ("info" as const) : ("verbose" as const),
-    sourceIds: obj.sourceEventIds,
+    sourceIds: orderedSourceEventIds(obj, ctx),
     stateObjectRef: {
       kind: "task",
       id: obj.id,
@@ -133,8 +148,8 @@ function renderTaskObject(obj: TaskObject, ctx: RenderContext): AgentTimelineIte
       summary: obj.summary,
     },
     activities: renderTaskActivities(obj, ctx),
-    rawEvent: obj.render.rawEvent,
-    debug: obj.render.debug,
+    rawEvent: event,
+    debug: ctx.includeDebug && event ? JSON.stringify(event, null, 2) : undefined,
   };
 }
 
@@ -168,17 +183,15 @@ function renderTaskActivities(obj: TaskObject, ctx: RenderContext): AgentTimelin
 }
 
 function isWorkItemObject(obj: DomainObject): obj is WorkItemObject {
-  // RuntimeActivityObject also carries work_item_ event types but has its own
-  // `eventType` field; exclude it so only true WorkItemObjects match.
-  return obj.render.eventType.startsWith("work_item_") && !("eventType" in obj);
+  return "objective" in obj && !("eventType" in obj);
 }
 
 function isTaskObject(obj: DomainObject): obj is TaskObject {
-  return obj.render.eventType === "task_created" || obj.render.eventType === "task_status_updated" || obj.render.eventType === "task_result_received";
+  return "initialStatus" in obj;
 }
 
 function isToolExecutionObject(obj: DomainObject): obj is ToolExecutionObject {
-  return obj.render.eventType === "tool_executed" || obj.render.eventType === "tool_execution_failed";
+  return "toolName" in obj;
 }
 
 function relatedStateObjectRefFor(obj: DomainObject): TimelineStateObjectRef | undefined {
@@ -198,9 +211,12 @@ function renderWorkItemActivities(obj: WorkItemObject, ctx: RenderContext): Agen
 }
 
 function renderRuntimeActivity(activity: RuntimeActivityObject, ctx: RenderContext): AgentTimelineActivity | undefined {
+  const event = ctx.eventsById[activity.primaryEventId];
+  if (!event) return undefined;
+  const payload = asRecord(event.payload);
   const projection = projectRuntimeEvent(
-    activity.render.eventType,
-    activity.render.payload,
+    activity.eventType,
+    payload,
     ctx.messagesById,
     ctx.transcriptEntriesById,
     ctx.briefRecordsById,
@@ -212,17 +228,34 @@ function renderRuntimeActivity(activity: RuntimeActivityObject, ctx: RenderConte
     kind: projection.kind,
     label: projection.label,
     body: projection.body,
-    timestamp: projection.timestamp || activity.render.timestamp,
-    meta: activity.render.meta,
+    timestamp: projection.timestamp || event.ts || activity.updatedAt,
+    meta: eventMeta(activity.eventType, payload, event.event_seq),
     minDisplayLevel: projection.minDisplayLevel,
-    sourceIds: activity.sourceEventIds,
+    sourceIds: orderedSourceEventIds(activity, ctx),
     relatedStateObjectRef: activity.relatedStateObjectRef,
     detail: projection.detail,
-    rawEvent: activity.render.rawEvent,
-    debug: activity.render.debug,
+    rawEvent: event,
+    debug: ctx.includeDebug ? JSON.stringify(event, null, 2) : undefined,
   };
 }
 
 function isRuntimeActivityObject(obj: DomainObject): obj is RuntimeActivityObject {
   return "eventType" in obj;
+}
+
+function orderedSourceEventIds(obj: DomainObject, ctx: RenderContext): string[] {
+  return [...obj.sourceEventIds].sort((leftId, rightId) => {
+    const left = ctx.eventsById[leftId];
+    const right = ctx.eventsById[rightId];
+    const leftSeq = left?.event_seq;
+    const rightSeq = right?.event_seq;
+    if (leftSeq != null && rightSeq != null && leftSeq !== rightSeq) return leftSeq - rightSeq;
+    return leftId.localeCompare(rightId);
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }

--- a/web-gui/app/src/runtime/runtime-store-helpers.ts
+++ b/web-gui/app/src/runtime/runtime-store-helpers.ts
@@ -13,28 +13,18 @@ import type {
   TaskDetailState,
   ToolExecutionDetailState,
 } from "./types";
+import type { SessionProjectionState } from "./session-projection";
 
 export type { WorkItemDetailState, TaskDetailState, ToolExecutionDetailState };
 
 export type AgentLiveStatus = "idle" | "connecting" | "streaming" | "reconnecting" | "recovering" | "stale" | "error";
 
-export interface AgentSessionState {
+export interface AgentSessionState extends SessionProjectionState {
   loading: boolean;
   loadingOlder: boolean;
   liveStatus: AgentLiveStatus;
   sendingPrompt: boolean;
   detail: AgentDetail | null;
-  eventLogEpoch?: string;
-  eventsBySeq: Record<number, unknown>;
-  eventSeqs: number[];
-  messagesById: Record<string, RuntimeMessageEnvelope>;
-  missingMessageIds: Record<string, true>;
-  transcriptEntriesById: Record<string, RuntimeTranscriptEntry>;
-  missingTranscriptEntryIds: Record<string, true>;
-  briefRecordsById: Record<string, RuntimeBriefRecord>;
-  missingBriefIds: Record<string, true>;
-  newestSeq?: number;
-  oldestSeq?: number;
   hasOlder?: boolean;
   targetEventSeq?: number;
   lastStreamActivityAt?: string;

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -5,6 +5,7 @@ import {
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
   isLoopbackWebHostname,
+  mergeCachedSessionIntoCurrent,
   missingBriefIdsForHydration,
   readStoredRemoteConnectionProfiles,
   readStoredRuntimeConnectionConfig,
@@ -14,6 +15,7 @@ import {
 } from "./runtime-store";
 import type { StreamEventEnvelopeDto } from "./client";
 import type { AgentSessionState } from "./runtime-store";
+import { createSessionProjectionState } from "./session-projection";
 
 class MemoryStorage implements Storage {
   private readonly items = new Map<string, string>();
@@ -45,19 +47,12 @@ class MemoryStorage implements Storage {
 
 function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionState {
   return {
+    ...createSessionProjectionState(),
     loading: false,
     loadingOlder: false,
     liveStatus: "idle",
     sendingPrompt: false,
     detail: null,
-    eventsBySeq: {},
-    eventSeqs: [],
-    messagesById: {},
-    missingMessageIds: {},
-    transcriptEntriesById: {},
-    missingTranscriptEntryIds: {},
-    briefRecordsById: {},
-    missingBriefIds: {},
     workItemDetailsById: {},
     taskDetailsById: {},
     toolExecutionDetailsById: {},
@@ -74,6 +69,15 @@ describe("runtime event epoch", () => {
       messagesById: { msg: { id: "msg" } },
       newestSeq: 7,
       oldestSeq: 7,
+      hasOlder: true,
+      detail: {
+        agent: { id: "agent-1" } as NonNullable<AgentSessionState["detail"]>["agent"],
+        source: "http",
+        timeline: [],
+        events: [],
+        eventCursorSeq: 7,
+        hasOlderEvents: true,
+      },
     });
 
     const reset = sessionForEventLogEpoch(current, "epoch-new");
@@ -84,6 +88,9 @@ describe("runtime event epoch", () => {
     expect(reset.messagesById).toEqual({});
     expect(reset.newestSeq).toBeUndefined();
     expect(reset.oldestSeq).toBeUndefined();
+    expect(reset.hasOlder).toBeUndefined();
+    expect(reset.detail?.eventCursorSeq).toBeUndefined();
+    expect(reset.detail?.hasOlderEvents).toBeUndefined();
   });
 
   it("detects conflicting immutable content for the same epoch and sequence", () => {
@@ -145,6 +152,45 @@ describe("runtime event epoch", () => {
       payload_schema_version: 1,
       provenance,
     });
+  });
+});
+
+describe("session cache restoration", () => {
+  it("does not overwrite HTTP or SSE state that arrived while cache was loading", () => {
+    const current = sessionState({
+      eventLogEpoch: "epoch-live",
+      eventsBySeq: { 9: { id: "live-event", event_seq: 9 } },
+      eventSeqs: [9],
+      newestSeq: 9,
+      oldestSeq: 9,
+      liveStatus: "streaming",
+    });
+    const cached = {
+      ...createSessionProjectionState("epoch-cache"),
+      eventsBySeq: { 1: { id: "cached-event", event_seq: 1 } },
+      eventSeqs: [1],
+      newestSeq: 1,
+      oldestSeq: 1,
+    };
+
+    expect(mergeCachedSessionIntoCurrent(current, cached)).toBe(current);
+  });
+
+  it("restores cached projection into an empty session without changing UI state", () => {
+    const current = sessionState({ loading: true, liveStatus: "connecting" });
+    const cached = {
+      ...createSessionProjectionState("epoch-cache"),
+      eventsBySeq: { 1: { id: "cached-event", event_seq: 1 } },
+      eventSeqs: [1],
+      newestSeq: 1,
+      oldestSeq: 1,
+    };
+
+    const restored = mergeCachedSessionIntoCurrent(current, cached);
+
+    expect(restored.eventSeqs).toEqual([1]);
+    expect(restored.loading).toBe(true);
+    expect(restored.liveStatus).toBe("connecting");
   });
 });
 
@@ -371,6 +417,7 @@ describe("brief projection and hydration", () => {
 
   it("hydrates a missing brief even when its associated transcript is loaded", () => {
     const session: AgentSessionState = {
+      ...createSessionProjectionState(),
       loading: false,
       loadingOlder: false,
       liveStatus: "idle",
@@ -389,8 +436,7 @@ describe("brief projection and hydration", () => {
         },
       },
       eventSeqs: [23],
-      messagesById: {},
-      missingMessageIds: {},
+      referencedBriefIds: { "brief-123": true },
       transcriptEntriesById: {
         "round-123": {
           id: "round-123",
@@ -402,9 +448,6 @@ describe("brief projection and hydration", () => {
           },
         },
       },
-      missingTranscriptEntryIds: {},
-      briefRecordsById: {},
-      missingBriefIds: {},
       workItemDetailsById: {},
       taskDetailsById: {},
       toolExecutionDetailsById: {},

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -17,11 +17,20 @@ import {
 import type { AgentSessionState as AgentSessionStateBase } from "./runtime-store-helpers";
 import {
   compactAgentTimelineItems,
-  mergeAgentTimelineItems,
-  reduceAgentSessionTimeline,
   briefIdForPayload,
-  transcriptEntryIdForPayload,
 } from "./session-reducer";
+import {
+  briefIdsForProjectionHydration,
+  createSessionProjectionState,
+  deriveSessionTimeline,
+  eventIdentityConflicts,
+  messageIdsForProjectionHydration,
+  projectionEvents,
+  reduceSessionProjection,
+  transcriptEntryIdsForProjectionHydration,
+  type SessionProjectionAction,
+  type SessionProjectionState,
+} from "./session-projection";
 import { canApplySessionEvent } from "./session-events";
 import type {
   AddSkillInput,
@@ -146,18 +155,11 @@ function rebuildProvisionalDetailsWithAgents(
       .map((seq) => session.eventsBySeq[seq])
       .filter(isStreamEventEnvelope);
     if (events.length === 0) continue;
-    const timeline = reduceAgentSessionTimeline({
-      events: { events },
-      eventDisplayLevel: "debug",
-      messagesById: session.messagesById,
-      transcriptEntriesById: session.transcriptEntriesById,
-      briefRecordsById: session.briefRecordsById,
-    });
     updated[agentId] = {
       ...session,
       detail: {
         agent,
-        timeline,
+        timeline: deriveSessionTimeline(session, "debug"),
         source: "http",
         events,
         newestEventSeq: highestSeq(session.eventSeqs),
@@ -770,13 +772,15 @@ function initSessionCacheForRemote(set: StoreSet, get?: () => RuntimeStoreState)
     const cached = await hydrateAllSessions(remoteKey);
     if (Object.keys(cached).length === 0) return;
 
+    const restoredAgentIds: string[] = [];
     set((state) => {
       const sessionsByAgentId = { ...state.sessionsByAgentId };
       for (const [agentId, partial] of Object.entries(cached)) {
-        sessionsByAgentId[agentId] = {
-          ...emptyAgentSession(),
-          ...partial,
-        };
+        const current = sessionsByAgentId[agentId] ?? emptyAgentSession();
+        const restored = mergeCachedSessionIntoCurrent(current, partial);
+        if (restored === current) continue;
+        sessionsByAgentId[agentId] = restored;
+        restoredAgentIds.push(agentId);
       }
       const withProvisional = rebuildProvisionalDetailsWithAgents(
         state.bootstrap.agents,
@@ -787,13 +791,36 @@ function initSessionCacheForRemote(set: StoreSet, get?: () => RuntimeStoreState)
 
     if (get) {
       const displayLevel = get().displayLevel;
-      for (const agentId of Object.keys(cached)) {
+      for (const agentId of restoredAgentIds) {
         scheduleMessageHydration(get, set, agentId, displayLevel);
         scheduleTranscriptHydration(get, set, agentId, displayLevel);
         scheduleBriefHydration(get, set, agentId, displayLevel);
       }
     }
   })();
+}
+
+export function mergeCachedSessionIntoCurrent(
+  current: AgentSessionState,
+  cached: Partial<AgentSessionState>,
+): AgentSessionState {
+  if (
+    current.detail ||
+    current.eventSeqs.length > 0 ||
+    Object.keys(current.messagesById).length > 0 ||
+    Object.keys(current.transcriptEntriesById).length > 0 ||
+    Object.keys(current.briefRecordsById).length > 0
+  ) {
+    return current;
+  }
+  return {
+    ...current,
+    ...cached,
+    loading: current.loading,
+    loadingOlder: current.loadingOlder,
+    liveStatus: current.liveStatus,
+    sendingPrompt: current.sendingPrompt,
+  };
 }
 
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
@@ -2208,22 +2235,51 @@ if (typeof window !== "undefined") {
 
 function emptyAgentSession(): AgentSessionState {
   return {
+    ...createSessionProjectionState(),
     loading: false,
     loadingOlder: false,
     liveStatus: "idle",
     sendingPrompt: false,
     detail: null,
-    eventsBySeq: {},
-    eventSeqs: [],
-    messagesById: {},
-    missingMessageIds: {},
-    transcriptEntriesById: {},
-    missingTranscriptEntryIds: {},
-    briefRecordsById: {},
-    missingBriefIds: {},
     workItemDetailsById: {},
     taskDetailsById: {},
     toolExecutionDetailsById: {},
+  };
+}
+
+function applyProjectionAction(
+  current: AgentSessionState,
+  action: SessionProjectionAction,
+  displayLevel: DisplayLevel = "debug",
+  detailBase: AgentDetail | null = current.detail,
+): AgentSessionState {
+  const projection = reduceSessionProjection(current, action);
+  return {
+    ...current,
+    ...projection,
+    detail: materializeProjectionDetail(detailBase, projection, displayLevel),
+  };
+}
+
+function materializeProjectionDetail(
+  detail: AgentDetail | null,
+  projection: SessionProjectionState,
+  displayLevel: DisplayLevel,
+): AgentDetail | null {
+  if (!detail) return null;
+  const optimisticItems = detail.timeline.filter((item) => item.sourceIds.includes("pending-operator-prompt"));
+  const timeline = compactAgentTimelineItems([
+    ...deriveSessionTimeline(projection, displayLevel),
+    ...optimisticItems,
+  ]).sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
+  return {
+    ...detail,
+    timeline,
+    events: projectionEvents(projection),
+    eventLogEpoch: projection.eventLogEpoch,
+    newestEventSeq: projection.newestSeq,
+    oldestEventSeq: projection.oldestSeq,
+    briefRecordsById: projection.briefRecordsById,
   };
 }
 
@@ -2256,53 +2312,25 @@ export function sessionForEventLogEpoch(
       ? current
       : { ...current, eventLogEpoch: incomingEpoch };
   }
+  const reset = applyProjectionAction(current, { type: "reset", eventLogEpoch: incomingEpoch });
   return {
-    ...emptyAgentSession(),
-    loading: current.loading,
-    loadingOlder: current.loadingOlder,
-    liveStatus: current.liveStatus,
-    sendingPrompt: current.sendingPrompt,
-    detail: current.detail
+    ...reset,
+    hasOlder: undefined,
+    detail: reset.detail
       ? {
-          ...current.detail,
-          timeline: [],
-          events: [],
-          eventLogEpoch: incomingEpoch,
+          ...reset.detail,
           eventCursorSeq: undefined,
-          newestEventSeq: undefined,
-          oldestEventSeq: undefined,
           hasOlderEvents: undefined,
         }
       : null,
-    eventLogEpoch: incomingEpoch,
   };
-}
-
-function eventIdentityFingerprint(event: StreamEventEnvelopeDto): string {
-  return JSON.stringify({
-    id: event.id,
-    ts: event.ts,
-    type: event.type,
-    contract_version: event.contract_version,
-    payload_schema: event.payload_schema,
-    payload_schema_version: event.payload_schema_version,
-    provenance: event.provenance,
-    payload: event.payload,
-  });
 }
 
 export function hasEventIdentityConflict(
   current: AgentSessionState,
   incomingEvents: StreamEventEnvelopeDto[],
 ): boolean {
-  return incomingEvents.some((event) => {
-    if (event.event_seq == null) return false;
-    const existing = current.eventsBySeq[event.event_seq];
-    return (
-      isStreamEventEnvelope(existing) &&
-      eventIdentityFingerprint(existing) !== eventIdentityFingerprint(event)
-    );
-  });
+  return eventIdentityConflicts(current, incomingEvents);
 }
 
 function resetSessionForEventConflict(
@@ -2310,12 +2338,13 @@ function resetSessionForEventConflict(
   eventLogEpoch?: string,
 ): AgentSessionState {
   return {
-    ...emptyAgentSession(),
-    loading: current.loading,
-    loadingOlder: current.loadingOlder,
+    ...applyProjectionAction(current, {
+      type: "reset",
+      eventLogEpoch: eventLogEpoch ?? current.eventLogEpoch,
+      reason: "event_identity_conflict",
+    }),
     liveStatus: "stale",
-    sendingPrompt: current.sendingPrompt,
-    eventLogEpoch: eventLogEpoch ?? current.eventLogEpoch,
+    hasOlder: undefined,
     error: "runtime event identity conflict; refreshing projection",
   };
 }
@@ -3162,10 +3191,6 @@ function messageOrigin(payload: unknown): string | undefined {
   return stringField(origin, "kind") ?? stringField(origin, "role") ?? stringField(asRecord(payload), "origin");
 }
 
-function messageIdFromEventPayload(payload: unknown): string | undefined {
-  return stringField(asRecord(payload), "message_id");
-}
-
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
 }
@@ -3233,40 +3258,34 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
   const current = hasEventIdentityConflict(epochSession, pageEvents)
     ? resetSessionForEventConflict(epochSession, detail.eventLogEpoch)
     : epochSession;
-  const projectionEvents = pageEvents.filter(canApplySessionEvent);
-  const eventsBySeq = {
-    ...current.eventsBySeq,
-    ...eventsBySeqFromPage(pageEvents),
-  };
-  const briefRecordsById = {
-    ...current.briefRecordsById,
-    ...(detail.briefRecordsById ?? {}),
-  };
-  const missingBriefIds = { ...current.missingBriefIds };
-  for (const briefId of Object.keys(briefRecordsById)) {
-    delete missingBriefIds[briefId];
-  }
-  const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(pageEvents)])).sort((left, right) => left - right);
-  const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
-  const pageTimeline = reduceAgentSessionTimeline({
-    events: { events: projectionEvents },
-    eventDisplayLevel: "debug",
-    messagesById: current.messagesById,
-    transcriptEntriesById: current.transcriptEntriesById,
-    briefRecordsById,
-  });
   const liveDetailIsNewer = (current.newestSeq ?? 0) > Math.max(detail.eventCursorSeq ?? 0, detail.newestEventSeq ?? 0);
   const agent = liveDetailIsNewer && current.detail ? mergeCachedAgentState(detail.agent, current.detail.agent) : detail.agent;
-  const mergedDetail: AgentDetail = {
+  const detailBase: AgentDetail = {
     ...detail,
     agent,
-    timeline: mergeTimeline(pageTimeline, current.detail?.timeline ?? []),
-    events,
-    newestEventSeq: Math.max(detail.newestEventSeq ?? 0, current.detail?.newestEventSeq ?? 0, highestSeq(eventSeqs) ?? 0),
-    oldestEventSeq: detail.oldestEventSeq ?? current.detail?.oldestEventSeq ?? eventSeqs[0],
+    timeline: current.detail?.timeline ?? detail.timeline,
     hasOlderEvents: detail.hasOlderEvents,
   };
-  const newestSeq = Math.max(detail.newestEventSeq ?? 0, current.newestSeq ?? 0, highestSeq(eventSeqs) ?? 0);
+  let projected = applyProjectionAction(current, {
+    type: "events_received",
+    events: pageEvents,
+    eventLogEpoch: detail.eventLogEpoch,
+  }, "debug", detailBase);
+  if (detail.transcriptEntriesById) {
+    projected = applyProjectionAction(projected, {
+      type: "transcripts_hydrated",
+      entries: Object.values(detail.transcriptEntriesById),
+      missingIds: [],
+    }, "debug", projected.detail);
+  }
+  if (detail.briefRecordsById) {
+    projected = applyProjectionAction(projected, {
+      type: "briefs_hydrated",
+      recordsById: detail.briefRecordsById,
+      missingIds: [],
+    }, "debug", projected.detail);
+  }
+  const newestSeq = Math.max(detail.newestEventSeq ?? 0, projected.newestSeq ?? 0);
 
   return {
     bootstrap:
@@ -3276,17 +3295,11 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
       [agentId]: {
-        ...emptyAgentSession(),
-        ...current,
-        detail: mergedDetail,
+        ...projected,
         loading: false,
         liveStatus: detail.error ? "error" : current.liveStatus,
-        eventsBySeq,
-        eventSeqs,
-        briefRecordsById,
-        missingBriefIds,
         newestSeq: newestSeq || undefined,
-        oldestSeq: detail.oldestEventSeq ?? current.oldestSeq ?? eventSeqs[0],
+        oldestSeq: detail.oldestEventSeq ?? projected.oldestSeq,
         hasOlder: detail.hasOlderEvents,
         error: detail.error,
       },
@@ -3377,33 +3390,15 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
     if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
       writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
     }
-    const eventsBySeq = {
-      ...current.eventsBySeq,
-      ...eventsBySeqFromPage(uniqueEvents),
-    };
-    const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(uniqueEvents)])).sort((left, right) => left - right);
-    const liveTimelineDelta = reduceAgentSessionTimeline({
-      events: { events: projectionEvents },
-      eventDisplayLevel: "debug",
-      messagesById: current.messagesById,
-      transcriptEntriesById: current.transcriptEntriesById,
-      briefRecordsById: current.briefRecordsById,
-    });
-    const detailEvents = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
     const baseDetail = current.detail ?? createLiveAgentDetail(state.bootstrap.agents.find((agent) => agent.id === agentId));
-    const highestIncomingSeq = highestSeq(eventSeqs) ?? 0;
     const runPatch = agentRunPatchFromEvents(projectionEvents);
     const briefPatch = agentBriefPatchFromEvents(projectionEvents, current.briefRecordsById);
     const patchedBaseDetail = patchAgentDetail(baseDetail, runPatch, briefPatch);
-    const detail = patchedBaseDetail
-      ? {
-          ...patchedBaseDetail,
-          timeline: mergeTimeline(patchedBaseDetail.timeline, liveTimelineDelta),
-          events: detailEvents,
-          newestEventSeq: Math.max(highestIncomingSeq, patchedBaseDetail.newestEventSeq ?? 0),
-          oldestEventSeq: patchedBaseDetail.oldestEventSeq ?? eventSeqs[0],
-        }
-      : patchedBaseDetail;
+    const projected = applyProjectionAction(current, {
+      type: "events_received",
+      events: uniqueEvents,
+      eventLogEpoch: incomingEpoch,
+    }, "debug", patchedBaseDetail);
 
     return {
       bootstrap: sortBootstrapAgents(
@@ -3414,13 +3409,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
       sessionsByAgentId: {
         ...state.sessionsByAgentId,
         [agentId]: {
-          ...current,
-          detail,
-          eventsBySeq,
-          eventSeqs,
-          eventLogEpoch: incomingEpoch ?? current.eventLogEpoch,
-          newestSeq: Math.max(highestIncomingSeq, current.newestSeq ?? 0),
-          oldestSeq: current.oldestSeq ?? eventSeqs[0],
+          ...projected,
           liveStatus,
           error: undefined,
         },
@@ -3623,67 +3612,15 @@ export function agentBriefPatchFromEvents(
 }
 
 function missingMessageIdsForHydration(session: AgentSessionState | undefined): string[] {
-  if (!session) return [];
-  const seen = new Set<string>();
-  const missing: string[] = [];
-  for (const eventSeq of session.eventSeqs) {
-    const event = session.eventsBySeq[eventSeq];
-    if (
-      !isStreamEventEnvelope(event) ||
-      !canApplySessionEvent(event) ||
-      event.type !== "message_enqueued"
-    ) continue;
-    const messageId = messageIdFromEventPayload(event.payload);
-    if (!messageId || seen.has(messageId) || session.messagesById[messageId] || session.missingMessageIds[messageId]) continue;
-    seen.add(messageId);
-    missing.push(messageId);
-  }
-  return missing;
+  return session ? messageIdsForProjectionHydration(session) : [];
 }
 
 function missingTranscriptEntryIdsForHydration(session: AgentSessionState | undefined): string[] {
-  if (!session) return [];
-  const seen = new Set<string>();
-  const missing: string[] = [];
-  for (const eventSeq of session.eventSeqs) {
-    const event = session.eventsBySeq[eventSeq];
-    if (!isStreamEventEnvelope(event) || !canApplySessionEvent(event)) continue;
-    const entryId = transcriptEntryIdForPayload(asRecord(event.payload));
-    if (
-      !entryId ||
-      seen.has(entryId) ||
-      session.transcriptEntriesById[entryId] ||
-      session.missingTranscriptEntryIds[entryId]
-    ) {
-      continue;
-    }
-    seen.add(entryId);
-    missing.push(entryId);
-  }
-  return missing;
+  return session ? transcriptEntryIdsForProjectionHydration(session) : [];
 }
 
 export function missingBriefIdsForHydration(session: AgentSessionState | undefined): string[] {
-  if (!session) return [];
-  const seen = new Set<string>();
-  const missing: string[] = [];
-  for (const eventSeq of session.eventSeqs) {
-    const event = session.eventsBySeq[eventSeq];
-    if (
-      !isStreamEventEnvelope(event) ||
-      !canApplySessionEvent(event) ||
-      event.type !== "brief_created"
-    ) continue;
-    const payload = asRecord(event.payload);
-    const briefId = briefIdForPayload(payload);
-    if (!briefId || seen.has(briefId) || session.briefRecordsById[briefId] || session.missingBriefIds[briefId]) {
-      continue;
-    }
-    if (stringField(payload, "text")) continue;
-    seen.add(briefId);
-    missing.push(briefId);
-  }
-  return missing;
+  return session ? briefIdsForProjectionHydration(session) : [];
 }
 
 function mergeHydratedMessagesIntoSession(
@@ -3694,47 +3631,17 @@ function mergeHydratedMessagesIntoSession(
   displayLevel: DisplayLevel,
 ): Partial<RuntimeStoreState> {
   const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
-  const messagesById = { ...current.messagesById };
-  let changed = false;
-  for (const message of messages) {
-    const messageId = typeof message.id === "string" && message.id.trim() ? message.id : undefined;
-    if (!messageId) continue;
-    messagesById[messageId] = message;
-    changed = true;
-  }
-
-  const missingById = { ...current.missingMessageIds };
-  for (const messageId of missingMessageIds) {
-    if (!messageId) continue;
-    missingById[messageId] = true;
-    changed = true;
-  }
-  if (!changed) return {};
-
-  const events = current.eventSeqs.map((eventSeq) => current.eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
-  const timeline = reduceAgentSessionTimeline({
-    events: { events },
-    eventDisplayLevel: displayLevel,
-    messagesById,
-    transcriptEntriesById: current.transcriptEntriesById,
-    briefRecordsById: current.briefRecordsById,
-  });
-  const detail = current.detail
-    ? {
-        ...current.detail,
-        timeline,
-      }
-    : current.detail;
+  if (!messages.length && !missingMessageIds.length) return {};
+  const projected = applyProjectionAction(current, {
+    type: "messages_hydrated",
+    messages,
+    missingIds: missingMessageIds,
+  }, displayLevel);
 
   return {
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
-      [agentId]: {
-        ...current,
-        detail,
-        messagesById,
-        missingMessageIds: missingById,
-      },
+      [agentId]: projected,
     },
   };
 }
@@ -3747,53 +3654,20 @@ function mergeHydratedTranscriptEntriesIntoSession(
   displayLevel: DisplayLevel,
 ): Partial<RuntimeStoreState> {
   const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
-  const transcriptEntriesById = { ...current.transcriptEntriesById };
-  let changed = false;
-  for (const entry of entries) {
-    const entryId = typeof entry.id === "string" && entry.id.trim() ? entry.id : undefined;
-    if (!entryId) continue;
-    transcriptEntriesById[entryId] = entry;
-    changed = true;
-  }
-
-  const missingById = { ...current.missingTranscriptEntryIds };
-  for (const entryId of missingEntryIds) {
-    if (!entryId) continue;
-    missingById[entryId] = true;
-    changed = true;
-  }
-  if (!changed) return {};
-
-  const events = current.eventSeqs.map((eventSeq) => current.eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
-  const timeline = reduceAgentSessionTimeline({
-    events: { events },
-    eventDisplayLevel: displayLevel,
-    messagesById: current.messagesById,
-    transcriptEntriesById,
-    briefRecordsById: current.briefRecordsById,
-  });
-  const briefPatch = agentBriefPatchFromEvents(events, current.briefRecordsById);
-  const detail = current.detail
-    ? patchAgentDetail(
-        {
-          ...current.detail,
-          timeline,
-        },
-        undefined,
-        briefPatch,
-      )
-    : current.detail;
+  if (!entries.length && !missingEntryIds.length) return {};
+  let projected = applyProjectionAction(current, {
+    type: "transcripts_hydrated",
+    entries,
+    missingIds: missingEntryIds,
+  }, displayLevel);
+  const briefPatch = agentBriefPatchFromEvents(projectionEvents(projected), projected.briefRecordsById);
+  projected = { ...projected, detail: patchAgentDetail(projected.detail, undefined, briefPatch) };
 
   return {
     bootstrap: patchBootstrapAgent(state.bootstrap, agentId, undefined, briefPatch),
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
-      [agentId]: {
-        ...current,
-        detail,
-        transcriptEntriesById,
-        missingTranscriptEntryIds: missingById,
-      },
+      [agentId]: projected,
     },
   };
 }
@@ -3806,59 +3680,20 @@ function mergeHydratedBriefRecordsIntoSession(
   displayLevel: DisplayLevel,
 ): Partial<RuntimeStoreState> {
   const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
-  const briefRecordsById = { ...current.briefRecordsById };
-  let changed = false;
-  for (const [briefId, record] of Object.entries(recordsById)) {
-    if (!briefId || !record?.text) continue;
-    briefRecordsById[briefId] = record;
-    changed = true;
-  }
-
-  const missingById = { ...current.missingBriefIds };
-  for (const briefId of Object.keys(recordsById)) {
-    if (missingById[briefId]) {
-      delete missingById[briefId];
-      changed = true;
-    }
-  }
-  for (const briefId of notFoundBriefIds) {
-    if (!briefId || recordsById[briefId]) continue;
-    missingById[briefId] = true;
-    changed = true;
-  }
-  if (!changed) return {};
-
-  const events = current.eventSeqs.map((eventSeq) => current.eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
-  const timeline = reduceAgentSessionTimeline({
-    events: { events },
-    eventDisplayLevel: displayLevel,
-    messagesById: current.messagesById,
-    transcriptEntriesById: current.transcriptEntriesById,
-    briefRecordsById,
-  });
-  const briefPatch = agentBriefPatchFromEvents(events, briefRecordsById);
-  const detail = current.detail
-    ? patchAgentDetail(
-        {
-          ...current.detail,
-          timeline,
-          briefRecordsById,
-        },
-        undefined,
-        briefPatch,
-      )
-    : current.detail;
+  if (!Object.keys(recordsById).length && !notFoundBriefIds.length) return {};
+  let projected = applyProjectionAction(current, {
+    type: "briefs_hydrated",
+    recordsById,
+    missingIds: notFoundBriefIds,
+  }, displayLevel);
+  const briefPatch = agentBriefPatchFromEvents(projectionEvents(projected), projected.briefRecordsById);
+  projected = { ...projected, detail: patchAgentDetail(projected.detail, undefined, briefPatch) };
 
   return {
     bootstrap: patchBootstrapAgent(state.bootstrap, agentId, undefined, briefPatch),
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
-      [agentId]: {
-        ...current,
-        detail,
-        briefRecordsById,
-        missingBriefIds: missingById,
-      },
+      [agentId]: projected,
     },
   };
 }
@@ -3939,42 +3774,25 @@ function mergeEventPageIntoSession(
   const current = hasEventIdentityConflict(epochSession, pageEvents)
     ? resetSessionForEventConflict(epochSession, options.eventLogEpoch)
     : epochSession;
-  const projectionEvents = pageEvents.filter(canApplySessionEvent);
-  const eventsBySeq = {
-    ...current.eventsBySeq,
-    ...eventsBySeqFromPage(pageEvents),
-  };
-  const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(pageEvents)])).sort((left, right) => left - right);
-  const pageTimeline = reduceAgentSessionTimeline({
-    events: { events: projectionEvents },
-    eventDisplayLevel: displayLevel,
-    messagesById: current.messagesById,
-    transcriptEntriesById: current.transcriptEntriesById,
-    briefRecordsById: current.briefRecordsById,
-  });
-  const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
-  const detail = current.detail
+  const detailBase = current.detail
     ? {
         ...current.detail,
-        timeline: options.append ? mergeTimeline(current.detail.timeline, pageTimeline) : mergeTimeline(pageTimeline, current.detail.timeline),
-        events,
-        newestEventSeq: Math.max(options.newestSeq ?? 0, current.detail.newestEventSeq ?? 0, highestSeq(eventSeqs) ?? 0),
-        oldestEventSeq: pageOldestSeq ?? eventSeqs[0] ?? current.detail.oldestEventSeq,
         hasOlderEvents: pageHasOlder,
       }
     : current.detail;
+  const projected = applyProjectionAction(current, {
+    type: "events_received",
+    events: pageEvents,
+    eventLogEpoch: options.eventLogEpoch,
+  }, displayLevel, detailBase);
 
   return {
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
       [agentId]: {
-        ...current,
-        detail,
-        eventsBySeq,
-        eventSeqs,
-        eventLogEpoch: options.eventLogEpoch || current.eventLogEpoch,
-        newestSeq: Math.max(options.newestSeq ?? 0, current.newestSeq ?? 0, highestSeq(eventSeqs) ?? 0) || undefined,
-        oldestSeq: pageOldestSeq ?? eventSeqs[0] ?? current.oldestSeq,
+        ...projected,
+        newestSeq: Math.max(options.newestSeq ?? 0, projected.newestSeq ?? 0) || undefined,
+        oldestSeq: pageOldestSeq ?? projected.oldestSeq,
         hasOlder: pageHasOlder,
         loadingOlder: false,
         historyError: undefined,
@@ -4067,13 +3885,6 @@ function highestSeq(eventSeqs: number[]): number | undefined {
 
 function isStreamEventEnvelope(event: unknown): event is StreamEventEnvelopeDto {
   return typeof event === "object" && event !== null;
-}
-
-function mergeTimeline(existing: AgentTimelineItem[], incoming: AgentTimelineItem[]): AgentTimelineItem[] {
-  const sorted = mergeAgentTimelineItems(existing, incoming).sort(
-    (left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp),
-  );
-  return compactAgentTimelineItems(sorted);
 }
 
 function sortableTime(value: string): number {

--- a/web-gui/app/src/runtime/session-cache.test.ts
+++ b/web-gui/app/src/runtime/session-cache.test.ts
@@ -9,22 +9,20 @@ import {
 } from "./session-cache";
 import type { AgentSessionState } from "./runtime-store-helpers";
 import { CACHE_SCHEMA_VERSION } from "./idb-cache";
+import {
+  SESSION_PROJECTION_GENERATION,
+  createSessionProjectionState,
+  type ProjectionEvent,
+} from "./session-projection";
 
 function makeSession(overrides: Partial<AgentSessionState> = {}): AgentSessionState {
   return {
+    ...createSessionProjectionState(),
     loading: false,
     loadingOlder: false,
     liveStatus: "idle",
     sendingPrompt: false,
     detail: null,
-    eventsBySeq: {},
-    eventSeqs: [],
-    messagesById: {},
-    missingMessageIds: {},
-    transcriptEntriesById: {},
-    missingTranscriptEntryIds: {},
-    briefRecordsById: {},
-    missingBriefIds: {},
     workItemDetailsById: {},
     taskDetailsById: {},
     toolExecutionDetailsById: {},
@@ -92,7 +90,7 @@ describe("extractCacheableSession", () => {
   it("trims events exceeding MAX_EVENTS_PER_AGENT", () => {
     const MAX = 5000;
     const eventSeqs = Array.from({ length: MAX + 100 }, (_, i) => i + 1);
-    const eventsBySeq: Record<number, unknown> = {};
+    const eventsBySeq: Record<number, ProjectionEvent> = {};
     for (const seq of eventSeqs) eventsBySeq[seq] = { id: `e${seq}` };
 
     const session = makeSession({ eventsBySeq, eventSeqs });
@@ -102,6 +100,8 @@ describe("extractCacheableSession", () => {
     expect(result.eventSeqs.length).toBe(MAX);
     expect(result.eventSeqs[0]).toBe(101); // First 100 trimmed
     expect(result.eventSeqs[MAX - 1]).toBe(MAX + 100);
+    expect(result.oldestSeq).toBe(101);
+    expect(result.newestSeq).toBe(MAX + 100);
   });
 });
 
@@ -111,6 +111,7 @@ describe("hydrateSessionFromCache", () => {
       remoteKey: "local",
       agentId: "agent-1",
       schemaVersion: CACHE_SCHEMA_VERSION,
+      projectionGeneration: SESSION_PROJECTION_GENERATION,
       eventLogEpoch: "epoch-1",
       eventsBySeq: { 1: { id: "e1" } },
       eventSeqs: [1],
@@ -124,7 +125,7 @@ describe("hydrateSessionFromCache", () => {
 
     const result = hydrateSessionFromCache(cached);
 
-    expect(result.eventsBySeq).toEqual({ 1: { id: "e1" } });
+    expect(result.eventsBySeq).toEqual({ 1: { id: "e1", event_seq: 1 } });
     expect(result.eventLogEpoch).toBe("epoch-1");
     expect(result.eventSeqs).toEqual([1]);
     expect(result.newestSeq).toBe(1);

--- a/web-gui/app/src/runtime/session-cache.ts
+++ b/web-gui/app/src/runtime/session-cache.ts
@@ -14,6 +14,12 @@ import {
   type CachedAgentSession,
 } from "./idb-cache";
 import type { AgentSessionState } from "./runtime-store-helpers";
+import {
+  SESSION_PROJECTION_GENERATION,
+  createSessionProjectionState,
+  reduceSessionProjection,
+  type ProjectionEvent,
+} from "./session-projection";
 import type {
   RuntimeBriefRecord,
   RuntimeMessageEnvelope,
@@ -65,14 +71,15 @@ export function extractCacheableSession(
     remoteKey,
     agentId,
     schemaVersion: CACHE_SCHEMA_VERSION,
+    projectionGeneration: session.generation,
     eventLogEpoch: session.eventLogEpoch,
     eventsBySeq,
     eventSeqs,
     messagesById: session.messagesById as Record<string, unknown>,
     transcriptEntriesById: session.transcriptEntriesById as Record<string, unknown>,
     briefRecordsById: session.briefRecordsById as Record<string, unknown>,
-    newestSeq: session.newestSeq,
-    oldestSeq: session.oldestSeq,
+    newestSeq: eventSeqs.at(-1) ?? session.newestSeq,
+    oldestSeq: eventSeqs[0] ?? session.oldestSeq,
     cachedAt: Date.now(),
   };
 }
@@ -82,16 +89,18 @@ export function extractCacheableSession(
  * The caller merges this into an emptyAgentSession() base.
  */
 export function hydrateSessionFromCache(cached: CachedAgentSession): Partial<AgentSessionState> {
-  return {
+  return reduceSessionProjection(createSessionProjectionState(), {
+    type: "cache_restored",
+    generation: cached.projectionGeneration ?? SESSION_PROJECTION_GENERATION - 1,
     eventLogEpoch: cached.eventLogEpoch,
-    eventsBySeq: cached.eventsBySeq,
+    eventsBySeq: cached.eventsBySeq as Record<number, ProjectionEvent>,
     eventSeqs: cached.eventSeqs,
     messagesById: cached.messagesById as Record<string, RuntimeMessageEnvelope>,
     transcriptEntriesById: cached.transcriptEntriesById as Record<string, RuntimeTranscriptEntry>,
     briefRecordsById: cached.briefRecordsById as Record<string, RuntimeBriefRecord>,
     newestSeq: cached.newestSeq,
     oldestSeq: cached.oldestSeq,
-  };
+  });
 }
 
 /**

--- a/web-gui/app/src/runtime/session-object-types.ts
+++ b/web-gui/app/src/runtime/session-object-types.ts
@@ -5,9 +5,9 @@
  * execution, task, work item, assistant round, or runtime activity) with an
  * explicit status field and lifecycle semantics.
  *
- * Each object also carries render data from the winning event. The renderer
- * layer (`deriveTimelineView`) uses this to produce display-ready items,
- * keeping domain state separate from display formatting.
+ * Domain objects retain only event references and lifecycle fields. The
+ * renderer resolves the referenced canonical event from SessionProjectionState
+ * when deriving display-ready items.
  */
 
 import type { TimelineStateObjectRef } from "./types";
@@ -20,28 +20,14 @@ export type SessionObjectType =
   | "assistant_round"
   | "activity";
 
-/**
- * Rendering data carried by each domain object from the winning event.
- * The renderer reads these fields to produce display output.
- */
-export interface RenderData {
-  eventType: string;
-  payload: Record<string, unknown> | undefined;
-  timestamp: string;
-  eventId: string;
-  eventSeq: number | undefined;
-  meta: string;
-  debug?: string;
-  rawEvent?: unknown;
-}
-
 interface BaseObject {
   id: string;
   status: string;
   sourceEventIds: string[];
+  primaryEventId: string;
+  primaryEventSeq?: number;
   createdAt: string;
   updatedAt: string;
-  render: RenderData;
 }
 
 export type MessageStatus = "enqueued" | "processing" | "delivered";

--- a/web-gui/app/src/runtime/session-projection.test.ts
+++ b/web-gui/app/src/runtime/session-projection.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SESSION_PROJECTION_GENERATION,
+  createSessionProjectionState,
+  deriveSessionTimeline,
+  reduceSessionProjection,
+  type ProjectionEvent,
+  type SessionProjectionState,
+} from "./session-projection";
+
+function event(
+  eventSeq: number,
+  type: string,
+  payload: Record<string, unknown>,
+): ProjectionEvent {
+  return {
+    id: `event-${eventSeq}`,
+    event_seq: eventSeq,
+    event_log_epoch: "epoch-1",
+    ts: `2026-07-16T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    type,
+    payload,
+  };
+}
+
+function receive(
+  projection: SessionProjectionState,
+  events: ProjectionEvent[],
+): SessionProjectionState {
+  return reduceSessionProjection(projection, {
+    type: "events_received",
+    eventLogEpoch: "epoch-1",
+    events,
+  });
+}
+
+function projectionSnapshot(projection: SessionProjectionState) {
+  return {
+    eventSeqs: projection.eventSeqs,
+    gaps: projection.gaps,
+    messages: Array.from(projection.domain.messages.values()),
+    tasks: Array.from(projection.domain.tasks.values()),
+    workItems: Array.from(projection.domain.workItems.values()),
+    timeline: deriveSessionTimeline(projection),
+  };
+}
+
+describe("SessionProjectionState", () => {
+  const events = [
+    event(1, "message_enqueued", {
+      message_id: "message-1",
+      origin: { kind: "operator" },
+      body: "Ship the projection",
+    }),
+    event(2, "message_processing_started", {
+      message_id: "message-1",
+      origin: { kind: "operator" },
+    }),
+    event(3, "task_created", {
+      task_id: "task-1",
+      status: "created",
+      summary: "Run checks",
+    }),
+    event(4, "task_status_updated", {
+      task_id: "task-1",
+      status: "running",
+    }),
+    event(5, "task_result_received", {
+      task_id: "task-1",
+      status: "completed",
+      exit_status: 0,
+    }),
+  ];
+
+  it("converges across single-batch, split, and older-page-later ingestion", () => {
+    const single = receive(createSessionProjectionState(), events);
+    const split = receive(
+      receive(createSessionProjectionState(), events.slice(0, 2)),
+      events.slice(2),
+    );
+    const olderPageLater = receive(
+      receive(createSessionProjectionState(), events.slice(2)),
+      events.slice(0, 2),
+    );
+
+    expect(projectionSnapshot(split)).toEqual(projectionSnapshot(single));
+    expect(projectionSnapshot(olderPageLater)).toEqual(projectionSnapshot(single));
+    expect(single.domain.messages.get("message:message-1")).toEqual(
+      expect.objectContaining({
+        status: "processing",
+        primaryEventId: "event-1",
+        sourceEventIds: ["event-1", "event-2"],
+      }),
+    );
+    expect(single.domain.tasks.get("task:task-1")).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        initialStatus: "created",
+        summary: "Run checks",
+        sourceEventIds: ["event-3", "event-4", "event-5"],
+      }),
+    );
+  });
+
+  it("is idempotent for duplicate epoch/sequence events", () => {
+    const once = receive(createSessionProjectionState(), events);
+    const twice = receive(once, events);
+
+    expect(twice).toBeDefined();
+    expect(projectionSnapshot(twice)).toEqual(projectionSnapshot(once));
+  });
+
+  it("records and closes gaps when backfill arrives", () => {
+    const withGap = receive(createSessionProjectionState(), [events[0], events[2]]);
+    expect(withGap.gaps).toEqual([{ afterSeq: 1, beforeSeq: 3 }]);
+
+    const recovered = receive(withGap, [events[1]]);
+    expect(recovered.gaps).toEqual([]);
+    expect(recovered.eventSeqs).toEqual([1, 2, 3]);
+  });
+
+  it("hydrates references without rebuilding normalized domain state", () => {
+    const projected = receive(createSessionProjectionState(), [events[0]]);
+    const domain = projected.domain;
+    const hydrated = reduceSessionProjection(projected, {
+      type: "messages_hydrated",
+      messages: [{
+        id: "message-1",
+        origin: { kind: "operator" },
+        body: { text: "Canonical operator input" },
+      }],
+      missingIds: [],
+    });
+
+    expect(hydrated.domain).toBe(domain);
+    expect(deriveSessionTimeline(hydrated)[0]?.body).toBe("Canonical operator input");
+  });
+
+  it("rebuilds once from canonical cache input and rejects stale generations", () => {
+    const restored = reduceSessionProjection(createSessionProjectionState(), {
+      type: "cache_restored",
+      generation: SESSION_PROJECTION_GENERATION,
+      eventLogEpoch: "epoch-1",
+      eventsBySeq: Object.fromEntries(events.map((item) => [item.event_seq!, item])),
+      eventSeqs: events.map((item) => item.event_seq!),
+      messagesById: {},
+      transcriptEntriesById: {},
+      briefRecordsById: {},
+    });
+    const stale = reduceSessionProjection(restored, {
+      type: "cache_restored",
+      generation: SESSION_PROJECTION_GENERATION - 1,
+      eventLogEpoch: "epoch-1",
+      eventsBySeq: {},
+      eventSeqs: [],
+      messagesById: {},
+      transcriptEntriesById: {},
+      briefRecordsById: {},
+    });
+
+    expect(projectionSnapshot(restored)).toEqual(
+      projectionSnapshot(receive(createSessionProjectionState(), events)),
+    );
+    expect(stale.eventSeqs).toEqual([]);
+    expect(stale.invalidatedReason).toBe("cache_generation_mismatch");
+  });
+});

--- a/web-gui/app/src/runtime/session-projection.ts
+++ b/web-gui/app/src/runtime/session-projection.ts
@@ -1,0 +1,466 @@
+import {
+  applySessionEvent,
+  briefIdForPayload,
+  buildSessionState,
+  transcriptEntryIdForPayload,
+} from "./session-reducer-core";
+import { canApplySessionEvent, type SessionEventEnvelope } from "./session-events";
+import { cloneSessionState, createSessionState, type SessionState } from "./session-state-reducer";
+import { deriveTimelineView } from "./timeline-view-model";
+import type {
+  AgentTimelineItem,
+  DisplayLevel,
+  RuntimeBriefRecord,
+  RuntimeMessageEnvelope,
+  RuntimeTranscriptEntry,
+} from "./types";
+
+export type ProjectionEvent = SessionEventEnvelope;
+
+export const SESSION_PROJECTION_GENERATION = 1;
+
+export interface EventGap {
+  afterSeq: number;
+  beforeSeq: number;
+}
+
+export interface SessionProjectionState {
+  generation: number;
+  eventLogEpoch?: string;
+  eventsBySeq: Record<number, ProjectionEvent>;
+  eventSeqs: number[];
+  eventsById: Record<string, ProjectionEvent>;
+  domain: SessionState;
+  unknownEventIds: string[];
+  gaps: EventGap[];
+  messagesById: Record<string, RuntimeMessageEnvelope>;
+  missingMessageIds: Record<string, true>;
+  transcriptEntriesById: Record<string, RuntimeTranscriptEntry>;
+  missingTranscriptEntryIds: Record<string, true>;
+  briefRecordsById: Record<string, RuntimeBriefRecord>;
+  missingBriefIds: Record<string, true>;
+  referencedMessageIds: Record<string, true>;
+  referencedTranscriptEntryIds: Record<string, true>;
+  referencedBriefIds: Record<string, true>;
+  newestSeq?: number;
+  oldestSeq?: number;
+  invalidatedReason?: "event_identity_conflict" | "cache_generation_mismatch";
+}
+
+export type SessionProjectionAction =
+  | {
+      type: "events_received";
+      events: ProjectionEvent[];
+      eventLogEpoch?: string;
+    }
+  | {
+      type: "cache_restored";
+      generation: number;
+      eventLogEpoch?: string;
+      eventsBySeq: Record<number, ProjectionEvent>;
+      eventSeqs: number[];
+      messagesById: Record<string, RuntimeMessageEnvelope>;
+      transcriptEntriesById: Record<string, RuntimeTranscriptEntry>;
+      briefRecordsById: Record<string, RuntimeBriefRecord>;
+      newestSeq?: number;
+      oldestSeq?: number;
+    }
+  | {
+      type: "messages_hydrated";
+      messages: RuntimeMessageEnvelope[];
+      missingIds: string[];
+    }
+  | {
+      type: "transcripts_hydrated";
+      entries: RuntimeTranscriptEntry[];
+      missingIds: string[];
+    }
+  | {
+      type: "briefs_hydrated";
+      recordsById: Record<string, RuntimeBriefRecord>;
+      missingIds: string[];
+    }
+  | {
+      type: "reset";
+      eventLogEpoch?: string;
+      reason?: SessionProjectionState["invalidatedReason"];
+    };
+
+export function createSessionProjectionState(eventLogEpoch?: string): SessionProjectionState {
+  return {
+    generation: SESSION_PROJECTION_GENERATION,
+    eventLogEpoch,
+    eventsBySeq: {},
+    eventSeqs: [],
+    eventsById: {},
+    domain: createSessionState(),
+    unknownEventIds: [],
+    gaps: [],
+    messagesById: {},
+    missingMessageIds: {},
+    transcriptEntriesById: {},
+    missingTranscriptEntryIds: {},
+    briefRecordsById: {},
+    missingBriefIds: {},
+    referencedMessageIds: {},
+    referencedTranscriptEntryIds: {},
+    referencedBriefIds: {},
+    newestSeq: undefined,
+    oldestSeq: undefined,
+    invalidatedReason: undefined,
+  };
+}
+
+export function reduceSessionProjection(
+  current: SessionProjectionState,
+  action: SessionProjectionAction,
+): SessionProjectionState {
+  switch (action.type) {
+    case "reset":
+      return {
+        ...createSessionProjectionState(action.eventLogEpoch),
+        invalidatedReason: action.reason,
+      };
+    case "cache_restored": {
+      if (action.generation !== SESSION_PROJECTION_GENERATION) {
+        return reduceSessionProjection(current, {
+          type: "reset",
+          eventLogEpoch: action.eventLogEpoch,
+          reason: "cache_generation_mismatch",
+        });
+      }
+      const eventsBySeq = normalizeEventsBySeq(action.eventsBySeq);
+      return rebuildProjection({
+        ...createSessionProjectionState(action.eventLogEpoch),
+        eventsBySeq,
+        eventSeqs: action.eventSeqs,
+        messagesById: action.messagesById,
+        transcriptEntriesById: action.transcriptEntriesById,
+        briefRecordsById: action.briefRecordsById,
+        newestSeq: action.newestSeq,
+        oldestSeq: action.oldestSeq,
+      });
+    }
+    case "events_received":
+      return reduceEvents(current, action.events, action.eventLogEpoch);
+    case "messages_hydrated": {
+      const messagesById = { ...current.messagesById };
+      for (const message of action.messages) {
+        if (message.id) messagesById[message.id] = message;
+      }
+      return {
+        ...current,
+        messagesById,
+        missingMessageIds: mergeMissingIds(current.missingMessageIds, action.missingIds, Object.keys(messagesById)),
+      };
+    }
+    case "transcripts_hydrated": {
+      const transcriptEntriesById = { ...current.transcriptEntriesById };
+      for (const entry of action.entries) {
+        if (entry.id) transcriptEntriesById[entry.id] = entry;
+      }
+      return {
+        ...current,
+        transcriptEntriesById,
+        missingTranscriptEntryIds: mergeMissingIds(
+          current.missingTranscriptEntryIds,
+          action.missingIds,
+          Object.keys(transcriptEntriesById),
+        ),
+      };
+    }
+    case "briefs_hydrated": {
+      const briefRecordsById = { ...current.briefRecordsById, ...action.recordsById };
+      return {
+        ...current,
+        briefRecordsById,
+        missingBriefIds: mergeMissingIds(current.missingBriefIds, action.missingIds, Object.keys(briefRecordsById)),
+      };
+    }
+  }
+}
+
+export function deriveSessionTimeline(
+  projection: SessionProjectionState,
+  eventDisplayLevel: DisplayLevel = "debug",
+  includeDebug = false,
+): AgentTimelineItem[] {
+  return deriveTimelineView(projection.domain, {
+    eventDisplayLevel,
+    includeDebug,
+    activitiesById: projection.domain.activitiesById,
+    eventsById: projection.eventsById,
+    messagesById: projection.messagesById,
+    transcriptEntriesById: projection.transcriptEntriesById,
+    briefRecordsById: projection.briefRecordsById,
+  });
+}
+
+export function projectionEvents(projection: SessionProjectionState): ProjectionEvent[] {
+  return projection.eventSeqs
+    .map((eventSeq) => projection.eventsBySeq[eventSeq])
+    .filter((event): event is ProjectionEvent => Boolean(event));
+}
+
+export function messageIdsForProjectionHydration(
+  projection: SessionProjectionState,
+): string[] {
+  return unresolvedReferenceIds(
+    projection.referencedMessageIds,
+    projection.messagesById,
+    projection.missingMessageIds,
+  );
+}
+
+export function transcriptEntryIdsForProjectionHydration(
+  projection: SessionProjectionState,
+): string[] {
+  return unresolvedReferenceIds(
+    projection.referencedTranscriptEntryIds,
+    projection.transcriptEntriesById,
+    projection.missingTranscriptEntryIds,
+  );
+}
+
+export function briefIdsForProjectionHydration(
+  projection: SessionProjectionState,
+): string[] {
+  return unresolvedReferenceIds(
+    projection.referencedBriefIds,
+    projection.briefRecordsById,
+    projection.missingBriefIds,
+  );
+}
+
+export function eventIdentityConflicts(
+  projection: SessionProjectionState,
+  incomingEvents: ProjectionEvent[],
+): boolean {
+  return incomingEvents.some((event) => {
+    if (event.event_seq == null) return false;
+    const existing = projection.eventsBySeq[event.event_seq];
+    return existing != null && eventIdentityFingerprint(existing) !== eventIdentityFingerprint(event);
+  });
+}
+
+function reduceEvents(
+  current: SessionProjectionState,
+  incomingEvents: ProjectionEvent[],
+  eventLogEpoch?: string,
+): SessionProjectionState {
+  const incomingEpoch = eventLogEpoch ?? lastEventEpoch(incomingEvents);
+  const base =
+    incomingEpoch &&
+    (current.eventLogEpoch != null || current.eventSeqs.length > 0) &&
+    current.eventLogEpoch !== incomingEpoch
+      ? createSessionProjectionState(incomingEpoch)
+      : current.eventLogEpoch || !incomingEpoch
+        ? current
+        : { ...current, eventLogEpoch: incomingEpoch };
+
+  if (eventIdentityConflicts(base, incomingEvents)) {
+    return reduceSessionProjection(base, {
+      type: "reset",
+      eventLogEpoch: incomingEpoch ?? base.eventLogEpoch,
+      reason: "event_identity_conflict",
+    });
+  }
+
+  const eventsBySeq = { ...base.eventsBySeq };
+  const eventsById = { ...base.eventsById };
+  const domain = cloneSessionState(base.domain);
+  const references = {
+    messageIds: { ...base.referencedMessageIds },
+    transcriptEntryIds: { ...base.referencedTranscriptEntryIds },
+    briefIds: { ...base.referencedBriefIds },
+  };
+  for (const event of [...incomingEvents].sort(compareEvents)) {
+    if (event.event_seq == null) continue;
+    if (incomingEpoch && event.event_log_epoch && event.event_log_epoch !== incomingEpoch) continue;
+    const existing = eventsBySeq[event.event_seq];
+    if (existing) {
+      if (eventIdentityFingerprint(existing) !== eventIdentityFingerprint(event)) {
+        return reduceSessionProjection(base, {
+          type: "reset",
+          eventLogEpoch: incomingEpoch ?? base.eventLogEpoch,
+          reason: "event_identity_conflict",
+        });
+      }
+      continue;
+    }
+    eventsBySeq[event.event_seq] = event;
+    const eventId = event.id ?? `event-${event.event_seq}`;
+    eventsById[eventId] = event;
+    if (canApplySessionEvent(event)) {
+      applySessionEvent(domain, event);
+      indexEventReferences(references, event);
+    }
+  }
+  const eventSeqs = Object.keys(eventsBySeq).map(Number).sort((left, right) => left - right);
+  const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]);
+  return {
+    ...base,
+    eventLogEpoch: incomingEpoch ?? base.eventLogEpoch,
+    eventsBySeq,
+    eventSeqs,
+    eventsById,
+    domain,
+    referencedMessageIds: references.messageIds,
+    referencedTranscriptEntryIds: references.transcriptEntryIds,
+    referencedBriefIds: references.briefIds,
+    unknownEventIds: events
+      .filter((event) => !canApplySessionEvent(event))
+      .map((event) => event.id ?? `event-${event.event_seq}`),
+    gaps: eventGaps(events),
+    newestSeq: eventSeqs[eventSeqs.length - 1],
+    oldestSeq: eventSeqs[0],
+    invalidatedReason: undefined,
+  };
+}
+
+function rebuildProjection(projection: SessionProjectionState): SessionProjectionState {
+  const events = projectionEvents(projection);
+  const eventsById: Record<string, ProjectionEvent> = {};
+  const applicableEvents: ProjectionEvent[] = [];
+  const unknownEventIds: string[] = [];
+  const references = {
+    messageIds: {} as Record<string, true>,
+    transcriptEntryIds: {} as Record<string, true>,
+    briefIds: {} as Record<string, true>,
+  };
+  for (const event of events) {
+    const eventId = event.id ?? `event-${event.event_seq}`;
+    eventsById[eventId] = event;
+    if (canApplySessionEvent(event)) {
+      applicableEvents.push(event);
+      indexEventReferences(references, event);
+    } else {
+      unknownEventIds.push(eventId);
+    }
+  }
+  return {
+    ...projection,
+    eventSeqs: events.flatMap((event) => event.event_seq == null ? [] : [event.event_seq]),
+    eventsById,
+    domain: buildSessionState(applicableEvents),
+    unknownEventIds,
+    referencedMessageIds: references.messageIds,
+    referencedTranscriptEntryIds: references.transcriptEntryIds,
+    referencedBriefIds: references.briefIds,
+    gaps: eventGaps(events),
+    newestSeq: projection.newestSeq ?? events.at(-1)?.event_seq,
+    oldestSeq: projection.oldestSeq ?? events[0]?.event_seq,
+  };
+}
+
+function eventGaps(events: ProjectionEvent[]): EventGap[] {
+  const gaps: EventGap[] = [];
+  for (let index = 1; index < events.length; index += 1) {
+    const previous = events[index - 1].event_seq;
+    const current = events[index].event_seq;
+    if (previous == null || current == null) continue;
+    if (current > previous + 1) gaps.push({ afterSeq: previous, beforeSeq: current });
+  }
+  return gaps;
+}
+
+function mergeMissingIds(
+  current: Record<string, true>,
+  missingIds: string[],
+  hydratedIds: string[],
+): Record<string, true> {
+  const next = { ...current };
+  for (const id of missingIds) {
+    if (id) next[id] = true;
+  }
+  for (const id of hydratedIds) delete next[id];
+  return next;
+}
+
+function lastEventEpoch(events: ProjectionEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index].event_log_epoch) return events[index].event_log_epoch;
+  }
+  return undefined;
+}
+
+function eventIdentityFingerprint(event: ProjectionEvent): string {
+  return JSON.stringify({
+    id: event.id,
+    ts: event.ts,
+    type: event.type,
+    contract_version: event.contract_version,
+    payload_schema: event.payload_schema,
+    payload_schema_version: event.payload_schema_version,
+    provenance: event.provenance,
+    payload: event.payload,
+  });
+}
+
+function compareEvents(left: ProjectionEvent, right: ProjectionEvent): number {
+  const leftSeq = left.event_seq;
+  const rightSeq = right.event_seq;
+  if (leftSeq != null && rightSeq != null && leftSeq !== rightSeq) return leftSeq - rightSeq;
+  const leftTime = Date.parse(left.ts ?? "");
+  const rightTime = Date.parse(right.ts ?? "");
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+    return leftTime - rightTime;
+  }
+  return 0;
+}
+
+function normalizeEventsBySeq(
+  eventsBySeq: Record<number, ProjectionEvent>,
+): Record<number, ProjectionEvent> {
+  return Object.fromEntries(
+    Object.entries(eventsBySeq).map(([seq, event]) => [
+      Number(seq),
+      event.event_seq == null ? { ...event, event_seq: Number(seq) } : event,
+    ]),
+  );
+}
+
+function indexEventReferences(
+  references: {
+    messageIds: Record<string, true>;
+    transcriptEntryIds: Record<string, true>;
+    briefIds: Record<string, true>;
+  },
+  event: ProjectionEvent,
+): void {
+  const payload = asRecord(event.payload);
+  if (event.type === "message_enqueued") {
+    const messageId = stringField(payload, "message_id");
+    if (messageId) references.messageIds[messageId] = true;
+  }
+  const transcriptEntryId = transcriptEntryIdForPayload(payload);
+  if (transcriptEntryId) references.transcriptEntryIds[transcriptEntryId] = true;
+  if (event.type === "brief_created" && !stringField(payload, "text")) {
+    const briefId = briefIdForPayload(payload);
+    if (briefId) references.briefIds[briefId] = true;
+  }
+}
+
+function unresolvedReferenceIds(
+  referencedIds: Record<string, true>,
+  hydratedById: Record<string, unknown>,
+  missingIds: Record<string, true>,
+): string[] {
+  return Object.keys(referencedIds).filter(
+    (id) => !hydratedById[id] && !missingIds[id],
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringField(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -38,7 +38,7 @@ import type {
   RuntimeTranscriptEntry,
 } from "./types";
 import { canApplySessionEvent, type SessionEventEnvelope } from "./session-events";
-import { createSessionState, getObject, upsertObject } from "./session-state-reducer";
+import { createSessionState, upsertObject } from "./session-state-reducer";
 import type { SessionState } from "./session-state-reducer";
 import type {
   DomainObject,
@@ -47,7 +47,6 @@ import type {
   SessionObjectType,
   TaskObject,
   WorkItemObject,
-  RenderData,
 } from "./session-object-types";
 import { deriveTimelineView } from "./timeline-view-model";
 import type { RenderContext } from "./timeline-view-model";
@@ -112,34 +111,32 @@ const debugOnlyToolNames = new Set(["WaitFor"]);
 
 export function reduceAgentSessionTimeline(input: ReduceAgentSessionInput): AgentTimelineItem[] {
   const state = createSessionState();
-  const applyCtx: ApplyContext = {
-    eventDisplayLevel: input.eventDisplayLevel ?? "debug",
-    includeDebug: input.includeDebug ?? false,
-    messagesById: input.messagesById,
-    transcriptEntriesById: input.transcriptEntriesById,
-    briefRecordsById: input.briefRecordsById,
-  };
+  const events = canonicalSessionEvents(input.events.events ?? []);
+  const eventsById: Record<string, SessionEventEnvelope> = {};
 
-  for (const event of input.events.events ?? []) {
-    applyEvent(state, event, applyCtx);
+  for (const event of events) {
+    const eventId = event.id ?? `event-${event.event_seq}`;
+    eventsById[eventId] = event;
+    applySessionEvent(state, event);
   }
 
   return deriveTimelineView(state, {
-    eventDisplayLevel: applyCtx.eventDisplayLevel,
-    includeDebug: applyCtx.includeDebug,
+    eventDisplayLevel: input.eventDisplayLevel ?? "debug",
+    includeDebug: input.includeDebug ?? false,
     activitiesById: state.activitiesById,
-    messagesById: applyCtx.messagesById,
-    transcriptEntriesById: applyCtx.transcriptEntriesById,
-    briefRecordsById: applyCtx.briefRecordsById,
+    eventsById,
+    messagesById: input.messagesById,
+    transcriptEntriesById: input.transcriptEntriesById,
+    briefRecordsById: input.briefRecordsById,
   });
 }
 
-interface ApplyContext {
-  eventDisplayLevel: DisplayLevel;
-  includeDebug: boolean;
-  messagesById?: Record<string, RuntimeMessageEnvelope>;
-  transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>;
-  briefRecordsById?: Record<string, RuntimeBriefRecord>;
+export function buildSessionState(events: SessionEventEnvelope[]): SessionState {
+  const state = createSessionState();
+  for (const event of canonicalSessionEvents(events)) {
+    applySessionEvent(state, event);
+  }
+  return state;
 }
 
 /**
@@ -150,7 +147,7 @@ interface ApplyContext {
  * (`deriveTimelineView`). This function only handles object routing,
  * identity, and render-data storage.
  */
-function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: ApplyContext): void {
+export function applySessionEvent(state: SessionState, event: SessionEventEnvelope): void {
   if (!event.id && event.event_seq == null) return;
   if (!canApplySessionEvent(event)) return;
 
@@ -158,24 +155,12 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
   const eventType = event.type ?? "runtime_event";
   const payload = asRecord(event.payload);
   const ts = event.ts ?? "";
-  const meta = eventMeta(eventType, payload, event.event_seq);
-
-  const render: RenderData = {
-    eventType,
-    payload,
-    timestamp: ts,
-    eventId,
-    eventSeq: event.event_seq,
-    meta,
-    debug: ctx.includeDebug ? debugJson(event) : undefined,
-    rawEvent: event,
-  };
-
   const baseFields = {
     sourceEventIds: [eventId],
+    primaryEventId: eventId,
+    primaryEventSeq: event.event_seq,
     createdAt: ts,
     updatedAt: ts,
-    render,
   };
 
   // Route by event type to determine object type, identity key, and status
@@ -184,22 +169,6 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
     const originKind = stringField(origin, "kind")?.toLowerCase();
     const messageId = stringField(payload, "message_id");
     const objId = messageId ? `message:${messageId}` : eventId;
-
-    // For message_processing_started, if the message object already exists (from
-    // message_enqueued with the same message_id), only update the status and
-    // accumulate sourceEventIds without overwriting render data (which carries
-    // the message body text).
-    if (eventType === "message_processing_started") {
-      const existing = getObject(state, "message", objId);
-      if (existing) {
-        existing.status = "processing";
-        existing.updatedAt = ts;
-        if (!existing.sourceEventIds.includes(eventId)) {
-          existing.sourceEventIds.push(eventId);
-        }
-        return;
-      }
-    }
 
     upsertObject(state, "message", objId, {
       ...baseFields,
@@ -226,16 +195,15 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
   } else if (eventType === "task_created" || eventType === "task_status_updated" || eventType === "task_result_received") {
     const taskId = stringField(payload, "task_id");
     const taskObjId = taskId ? `task:${taskId}` : eventId;
-    const existingTask = state.tasks.get(taskObjId);
     const taskStatus = firstStringField(payload, ["task_status", "status"]) as TaskObject["status"];
-    const summary = stringField(payload, "summary") ?? state.tasks.get(taskObjId)?.summary;
+    const summary = stringField(payload, "summary");
     const isActivity = eventType !== "task_created";
     const activityIds = isActivity ? [eventId] : undefined;
     upsertObject(state, "task", taskId ? `task:${taskId}` : eventId, {
       ...baseFields,
       id: taskObjId,
       status: taskStatus ?? (eventType === "task_created" ? "created" : "running"),
-      initialStatus: existingTask?.initialStatus ?? (taskStatus ?? "created"),
+      initialStatus: taskStatus ?? (eventType === "task_created" ? "created" : "running"),
       summary,
       activityIds,
     } as DomainObject);
@@ -262,14 +230,13 @@ function applyEvent(state: SessionState, event: SessionEventEnvelope, ctx: Apply
     } as DomainObject);
   } else if (eventType.startsWith("work_item_")) {
     const workItemId = workItemObjectId(payload) ?? eventId;
-    const previousWorkItem = state.workItems.get(workItemId);
-    const objective = workItemObjective(payload) ?? previousWorkItem?.objective;
-    const stateName = workItemState(payload) ?? previousWorkItem?.state;
+    const objective = workItemObjective(payload);
+    const stateName = workItemState(payload);
     const activityIds = isWorkItemActivityEvent(eventType) ? [eventId] : undefined;
     upsertObject(state, "work_item", workItemId, {
       ...baseFields,
       id: workItemId,
-      status: workItemStatus(eventType, stateName, previousWorkItem?.status),
+      status: workItemStatus(eventType, stateName),
       objective,
       state: stateName,
       activityIds,
@@ -356,7 +323,7 @@ function debugEventDetail(
   return undefined;
 }
 
-function eventMeta(eventType: string, payload: Record<string, unknown> | undefined, eventSeq: number | undefined): string {
+export function eventMeta(eventType: string, payload: Record<string, unknown> | undefined, eventSeq: number | undefined): string {
   const eventRef = eventSeq == null ? undefined : `event #${eventSeq}`;
   if (eventType === "message_enqueued" && messageEnvelopeProjection(payload)?.origin === "operator") {
     return compactJoin(["Sent", eventRef]);
@@ -758,13 +725,12 @@ function isDebugOnlyWorkItemEvent(eventType: string): boolean {
 function workItemStatus(
   eventType: string,
   stateName: string | undefined,
-  previousStatus: WorkItemObject["status"] | undefined,
 ): WorkItemObject["status"] {
   if (isKnownWorkItemStatus(stateName)) return stateName;
   if (eventType === "work_item_completed" || eventType === "work_item_completion_report_promoted") return "completed";
   if (eventType === "work_item_blocked") return "blocked";
-  if (eventType === "work_item_focus_released") return previousStatus ?? "yielded";
-  return previousStatus ?? "unknown";
+  if (eventType === "work_item_focus_released") return "yielded";
+  return "unknown";
 }
 
 function isKnownWorkItemStatus(value: string | undefined): value is WorkItemObject["status"] {
@@ -1817,6 +1783,19 @@ function normalizeTextKey(text: string): string {
 function sortableTime(value: string): number {
   const parsed = Date.parse(value);
   return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function canonicalSessionEvents(events: SessionEventEnvelope[]): SessionEventEnvelope[] {
+  return [...events].sort((left, right) => {
+    const leftSeq = left.event_seq;
+    const rightSeq = right.event_seq;
+    if (leftSeq != null && rightSeq != null && leftSeq !== rightSeq) return leftSeq - rightSeq;
+    if (leftSeq != null && rightSeq == null) return -1;
+    if (leftSeq == null && rightSeq != null) return 1;
+    const timeOrder = sortableTime(left.ts ?? "") - sortableTime(right.ts ?? "");
+    if (timeOrder !== 0) return timeOrder;
+    return 0;
+  });
 }
 
 function debugJson(value: unknown): string {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -1,6 +1,7 @@
 export * from "./session-events";
 export * from "./session-object-types";
 export * from "./session-reducer-core";
+export * from "./session-projection";
 export * from "./session-state-reducer";
 export * from "./timeline-display";
 export * from "./timeline-view-model";

--- a/web-gui/app/src/runtime/session-state-reducer.ts
+++ b/web-gui/app/src/runtime/session-state-reducer.ts
@@ -9,8 +9,6 @@ import type {
   ToolExecutionObject,
   WorkItemObject,
 } from "./session-object-types";
-import { mergeSourceIds } from "./timeline-display";
-
 /**
  * Normalized session state built by applying events incrementally.
  *
@@ -43,12 +41,23 @@ export function createSessionState(): SessionState {
   };
 }
 
+export function cloneSessionState(state: SessionState): SessionState {
+  return {
+    messages: cloneObjectMap(state.messages),
+    toolExecutions: cloneObjectMap(state.toolExecutions),
+    tasks: cloneObjectMap(state.tasks),
+    workItems: cloneObjectMap(state.workItems),
+    rounds: cloneObjectMap(state.rounds),
+    activitiesById: cloneObjectMap(state.activitiesById),
+    insertionOrder: state.insertionOrder.map((entry) => ({ ...entry })),
+  };
+}
+
 /**
  * Insert or update a domain object in the state.
  *
  * If an object with the same key already exists in its typed map, the two
- * are merged using priority logic: the winning event's render data and
- * domain fields are kept; sourceEventIds are accumulated.
+ * are merged by canonical event order and sourceEventIds are accumulated.
  */
 export function upsertObject(
   state: SessionState,
@@ -85,31 +94,88 @@ function objectMap(state: SessionState, objectType: SessionObjectType): Map<stri
 }
 
 /**
- * Merge a new object into an existing one. The higher-priority event's render
- * data and domain fields win; sourceEventIds are accumulated in insertion order.
- *
- * Priority mirrors the original `timelineItemPriority` logic:
- * - `operator-prompt:pending:*` ids or `pending-operator-prompt` sourceIds → 0
- * - fallback `event-*` ids or meta containing `event #` → 1
- * - everything else → 2
+ * Merge a new object into an existing one. The latest semantic event owns
+ * lifecycle fields, while older events can still fill missing context.
  */
 function mergeObjectFields(existing: DomainObject, incoming: DomainObject): void {
-  const existingPriority = objectPriority(existing);
-  const incomingPriority = objectPriority(incoming);
-
-  const winner = incomingPriority >= existingPriority ? incoming : existing;
-  const loser = incomingPriority >= existingPriority ? existing : incoming;
+  const incomingIsNewer = compareObjectOrder(incoming, existing) >= 0;
+  const newer = incomingIsNewer ? incoming : existing;
+  const older = incomingIsNewer ? existing : incoming;
+  const olderInitialStatus = "initialStatus" in older ? older.initialStatus : undefined;
+  const olderRole = "role" in older ? older.role : undefined;
+  const olderStatus = older.status;
+  const olderPrimaryEventId = older.primaryEventId;
+  const olderPrimaryEventSeq = older.primaryEventSeq;
   const activityIds = mergeActivityIds(existing, incoming);
-
-  // Copy all render and domain fields from the winner, preserving
-  // earliest createdAt and accumulating sourceEventIds.
-  const { id: _id, createdAt: _createdAt, sourceEventIds: _sourceIds, ...winnerFields } = winner;
-  Object.assign(existing, winnerFields, {
-    sourceEventIds: mergeSourceIds([...loser.sourceEventIds, ...winner.sourceEventIds]),
+  const sourceEventIds = Array.from(new Set([...existing.sourceEventIds, ...incoming.sourceEventIds]));
+  const merged = mergeDefinedFields(older, newer);
+  Object.assign(existing, merged, {
+    id: existing.id,
+    sourceEventIds,
+    primaryEventId: newer.primaryEventId,
+    primaryEventSeq: newer.primaryEventSeq,
+    createdAt: compareObjectOrder(existing, incoming) <= 0 ? existing.createdAt : incoming.createdAt,
+    updatedAt: newer.updatedAt,
   });
+  if ("initialStatus" in existing && olderInitialStatus) {
+    existing.initialStatus = olderInitialStatus;
+  }
+  if ("role" in existing && existing.role === "unknown" && olderRole && olderRole !== "unknown") {
+    existing.role = olderRole;
+  }
+  if ("role" in existing && olderStatus === "enqueued") {
+    existing.primaryEventId = olderPrimaryEventId;
+    existing.primaryEventSeq = olderPrimaryEventSeq;
+  }
+  if ("objective" in existing && existing.status === "unknown" && olderStatus !== "unknown") {
+    existing.status = olderStatus as WorkItemObject["status"];
+  }
   if (activityIds.length) {
     (existing as { activityIds?: string[] }).activityIds = activityIds;
   }
+}
+
+function cloneObjectMap<T extends DomainObject>(map: Map<string, T>): Map<string, T> {
+  return new Map(
+    Array.from(map, ([id, object]) => [
+      id,
+      {
+        ...object,
+        sourceEventIds: [...object.sourceEventIds],
+        ...("activityIds" in object && object.activityIds
+          ? { activityIds: [...object.activityIds] }
+          : {}),
+      } as T,
+    ]),
+  );
+}
+
+function mergeDefinedFields(older: DomainObject, newer: DomainObject): DomainObject {
+  const merged = { ...older } as Record<string, unknown>;
+  for (const [key, value] of Object.entries(newer)) {
+    if (value !== undefined) merged[key] = value;
+  }
+  return merged as unknown as DomainObject;
+}
+
+function compareObjectOrder(left: DomainObject, right: DomainObject): number {
+  if (left.primaryEventSeq != null && right.primaryEventSeq != null) {
+    if (left.primaryEventSeq !== right.primaryEventSeq) {
+      return left.primaryEventSeq - right.primaryEventSeq;
+    }
+  } else if (left.primaryEventSeq != null) {
+    return 1;
+  } else if (right.primaryEventSeq != null) {
+    return -1;
+  }
+  const timeOrder = sortableTime(left.updatedAt) - sortableTime(right.updatedAt);
+  if (timeOrder !== 0) return timeOrder;
+  return left.primaryEventId.localeCompare(right.primaryEventId);
+}
+
+function sortableTime(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
 function mergeActivityIds(existing: DomainObject, incoming: DomainObject): string[] {
@@ -118,12 +184,4 @@ function mergeActivityIds(existing: DomainObject, incoming: DomainObject): strin
     ...("activityIds" in incoming ? (incoming.activityIds ?? []) : []),
   ];
   return Array.from(new Set(ids));
-}
-
-function objectPriority(obj: DomainObject): number {
-  const eventId = obj.render.eventId;
-  if (eventId.startsWith("operator-prompt:pending:")) return 0;
-  if (obj.sourceEventIds.includes("pending-operator-prompt")) return 0;
-  if (eventId.startsWith("event-") || obj.render.meta.includes("event #")) return 1;
-  return 2;
 }

--- a/web-gui/app/src/runtime/timeline-view-model.ts
+++ b/web-gui/app/src/runtime/timeline-view-model.ts
@@ -1,4 +1,5 @@
 import type { AgentTimelineItem, DisplayLevel, RuntimeMessageEnvelope, RuntimeBriefRecord, RuntimeTranscriptEntry } from "./types";
+import type { SessionEventEnvelope } from "./session-events";
 import type { SessionState } from "./session-state-reducer";
 import type { DomainObject, InsertionEntry } from "./session-object-types";
 import { compactAgentTimelineItems } from "./timeline-display";
@@ -13,6 +14,7 @@ export interface RenderContext {
   eventDisplayLevel: DisplayLevel;
   includeDebug: boolean;
   activitiesById?: SessionState["activitiesById"];
+  eventsById: Record<string, SessionEventEnvelope>;
   messagesById?: Record<string, RuntimeMessageEnvelope>;
   transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>;
   briefRecordsById?: Record<string, RuntimeBriefRecord>;
@@ -35,9 +37,13 @@ export function deriveTimelineView(state: SessionState, ctx: RenderContext): Age
     const item = renderObject(obj, ctx);
     if (item) items.push(item);
   }
-  const sorted = items.sort(
-    (left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp),
-  );
+  const sorted = items.sort((left, right) => {
+    const timeOrder = sortableTime(left.timestamp) - sortableTime(right.timestamp);
+    if (timeOrder !== 0) return timeOrder;
+    const leftSeq = rawEventSeq(left.rawEvent);
+    const rightSeq = rawEventSeq(right.rawEvent);
+    return leftSeq != null && rightSeq != null ? leftSeq - rightSeq : 0;
+  });
   return compactAgentTimelineItems(sorted);
 }
 
@@ -73,12 +79,17 @@ function renderObject(obj: DomainObject, ctx: RenderContext): AgentTimelineItem 
     // source event id for objects without a stable identity.
     id: item.stateObjectRef || obj.id.startsWith("message:")
       ? obj.id
-      : (obj.sourceEventIds[obj.sourceEventIds.length - 1] ?? obj.render.eventId),
-    timestamp: item.timestamp || obj.render.timestamp,
+      : obj.primaryEventId,
   };
 }
 
 function sortableTime(value: string): number {
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function rawEventSeq(rawEvent: unknown): number | undefined {
+  if (!rawEvent || typeof rawEvent !== "object" || Array.isArray(rawEvent)) return undefined;
+  const value = (rawEvent as Record<string, unknown>).event_seq;
+  return typeof value === "number" ? value : undefined;
 }

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -656,6 +656,7 @@ export interface AgentDetail {
   oldestEventSeq?: number;
   hasOlderEvents?: boolean;
   briefRecordsById?: Record<string, RuntimeBriefRecord>;
+  transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>;
 }
 
 export interface RuntimeBootstrap {


### PR DESCRIPTION
## 概要

- 为每个 agent 引入唯一 normalized `SessionProjectionState`
- 统一 bootstrap、分页 replay、gap backfill、SSE live event、hydration 与 cache restore 的 projection action/reducer 路径
- 将 timeline、agent detail 与 hydration selectors 改为从 projection 纯派生，移除 `runtime-store` 中重复的 batch timeline merge/reduce
- 显式处理 event identity conflict、epoch reset、重复/乱序事件、gap 恢复与 cache generation
- 修复异步 IndexedDB restore 覆盖期间 HTTP/SSE/live UI 状态，以及裁剪 cache 后分页边界不一致的问题

## 验证

- `make web-ci`
  - OpenAPI generated types check
  - Vitest 全量测试
  - TypeScript typecheck
  - production build
- 最终只读复审：cache hydrate、分页游标与 projection correctness 无阻塞问题

Closes #2265
