### PR TITLE
refactor: 统一模型 metadata 解析

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -57,6 +57,7 @@ implementation and tests.
 - [Runtime Configuration Surface](./runtime-configuration-surface.md)
 - [Extensible Model And Provider Configuration](./extensible-model-provider-configuration.md)
 - [Model Capability Resolution](./model-capability-resolution.md)
+- [Model Metadata Precedence](./model-metadata-precedence.md)
 
 ## Workspace And Instruction Surface
 

--- a/docs/rfcs/model-metadata-precedence.md
+++ b/docs/rfcs/model-metadata-precedence.md
@@ -1,0 +1,185 @@
+---
+title: RFC: Model Metadata Precedence
+date: 2026-07-17
+status: accepted
+issue:
+  - 2267
+---
+
+# RFC: Model Metadata Precedence
+
+## Summary
+
+Holon resolves model metadata field by field through one resolver contract.
+Static model metadata, route-specific metadata, remote discovery, runtime
+configuration, derived defaults, and transport constraints are not whole-object
+alternatives.
+
+The resolver produces:
+
+- one runtime policy used by provider construction and runtime context policy;
+- one catalog projection used by model listings;
+- winner evidence for every resolved field;
+- constraint evidence when a model limit or transport capability narrows a
+  selected value.
+
+Transport capabilities are final constraints. They never masquerade as model
+metadata sources.
+
+## Why
+
+The previous implementation selected remote discovery with
+`discovered.or(route_builtin)`. One discovered object could therefore erase
+valid route-specific fields that discovery did not report. Model listings,
+provider construction, diagnostics, and compatibility helpers also performed
+their own partial merges, so the effective precedence depended on the caller.
+
+Route identity makes whole-object replacement especially unsafe. A canonical
+`ModelRef` may have several `ModelRouteRef` values whose endpoint limits or
+accepted parameters differ.
+
+## Sources
+
+Winner evidence uses these source classes:
+
+- `explicit_override`: a field explicitly configured under `models.catalog`;
+- `remote_discovered`: metadata reported by provider discovery;
+- `route_builtin`: built-in metadata for the exact `ModelRouteRef`;
+- `model_builtin`: built-in metadata for the canonical `ModelRef`;
+- `unknown_fallback`: the explicit unknown-model fallback;
+- `runtime_default`: a runtime configuration default;
+- `derived`: a value calculated from other resolved fields or a stable
+  built-in formula.
+
+The existing summary `ModelMetadataSource` remains as a compatibility
+projection. Field evidence is authoritative when fields have different
+sources.
+
+## Precedence Matrix
+
+The first present value wins. Explicit override booleans preserve both `true`
+and `false`. The current discovery cache has legacy non-optional booleans, so a
+discovered `false` is treated as unknown rather than as an explicit denial;
+only a reported `true` overrides built-in capability metadata. Unknown
+discovery data must not implicitly enable or disable a capability.
+
+| Field class | Fields | Precedence |
+| --- | --- | --- |
+| Display | `display_name`, `description` | explicit override, remote discovery, route builtin, model builtin, unknown fallback, derived |
+| Intrinsic/provider-reported fact | `context_window_tokens`, intrinsic capability flags | explicit override, remote discovery, route builtin, model builtin, unknown fallback |
+| Route/endpoint contract | `max_output_tokens_upper_limit`, `reasoning_effort_options` | explicit override where supported, route builtin, remote discovery, model builtin, unknown fallback |
+| Runtime policy | effective context percent, auto-compaction limit, default output size, verbosity, tool-output truncation | explicit override, route builtin, model builtin, remote discovery, unknown fallback, runtime default |
+| Derived runtime policy | prompt budget, compaction trigger, compaction retention | explicit override, unknown fallback override, derived from resolved limits, runtime default |
+
+Non-empty `reasoning_effort_options` from the selected route or discovery are
+authoritative. A discovered model that explicitly reports reasoning support
+with an empty option list is also authoritative: it represents fixed reasoning
+without a configurable effort. Empty legacy route/model built-in lists cannot
+be distinguished from omitted values, so they fall through to deterministic
+route/model derivation. That derivation may itself produce an empty list and
+never borrows options from another route.
+
+## Resolution Stages
+
+### 1. Candidate collection
+
+The resolver receives explicit inputs only:
+
+- canonical model identity and optional exact route;
+- canonical built-in metadata;
+- route-specific built-in metadata;
+- discovered model metadata;
+- model override and unknown-model fallback;
+- runtime context and output defaults;
+- optional selected transport capabilities.
+
+It performs no discovery, configuration I/O, or provider construction.
+
+### 2. Field selection
+
+Each field is selected independently according to the matrix. The selected
+value and its origin are recorded together. Derived fields record `derived`
+rather than borrowing the source of one input.
+
+### 3. Model constraints
+
+Model and endpoint numeric upper limits safely clamp runtime values. Constraint
+evidence records the requested and effective values. Invalid ranges that cannot
+produce a valid policy are errors at configuration validation time.
+
+### 4. Transport constraints
+
+Transport capability is intersected with the resolved model and endpoint
+contract:
+
+- unsupported image input or output resolves to unsupported;
+- the model's intrinsic facts remain visible separately;
+- constraint evidence identifies the transport restriction;
+- an explicitly requested route capability that is unavailable is rejected.
+
+Safe narrowing is allowed. A user intent that cannot be satisfied must fail
+rather than silently select a different semantic behavior.
+
+## Evidence Contract
+
+Evidence is a sidecar, not a wrapper around every value:
+
+```rust
+pub struct ModelMetadataEvidence {
+    pub fields: BTreeMap<ModelMetadataField, ModelMetadataOrigin>,
+    pub constraints: Vec<ModelMetadataConstraint>,
+}
+```
+
+The field map contains the winner for each resolved field. Constraint entries
+exist only for clamping, disabling, or normalization and contain:
+
+- affected field;
+- constraint kind and source;
+- requested value;
+- effective value.
+
+Candidate history is deliberately not retained. Diagnostics need the winning
+decision and final restriction, not every discarded value.
+
+## Consumer Contract
+
+- `RuntimeModelCatalog` is the runtime entry point for route resolution.
+- Provider construction consumes `ResolvedModelRoute`; it does not recalculate
+  model policy or capability intersections.
+- Available-model projection consumes the same field-level resolver output.
+- Diagnostics consume resolved policy and capability evidence; they do not
+  infer source from config presence.
+- Compatibility helpers may remain only as thin delegates to
+  `RuntimeModelCatalog` or the same resolver.
+
+There is one precedence implementation even when compatibility entry points
+remain.
+
+## Compatibility
+
+- persisted provider, model, and override configuration formats do not change;
+- `ResolvedRuntimeModelPolicy.source` remains available as a summary field;
+- existing model and route refs retain their serialization;
+- unknown capability remains conservative and is never default-enabled;
+- behavior changes only where whole-object replacement or caller-specific
+  merging previously discarded a valid field.
+
+## Non-Goals
+
+- provider discovery or capability registry design;
+- context candidate or budget planner redesign;
+- provider transport decomposition;
+- new providers or new public configuration fields;
+- retaining full candidate provenance history.
+
+## Acceptance Criteria
+
+- one production precedence implementation resolves every metadata field;
+- remote discovery cannot erase unrelated route or model fields;
+- transport constraints are applied in one final stage and remain
+  distinguishable from metadata sources;
+- provider construction, model listings, diagnostics, and compatibility paths
+  consume the same resolved contract;
+- matrix tests cover missing fields, conflicts, unknown capabilities, endpoint
+  overrides, clamping, and evidence.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1,5 +1,9 @@
 use super::*;
-use crate::model_catalog::ReasoningEffortValidationError;
+use crate::model_catalog::{
+    ModelMetadataConstraint, ModelMetadataConstraintKind, ModelMetadataConstraintSource,
+    ModelMetadataField, ReasoningEffortValidationError,
+};
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModelRef {
@@ -221,15 +225,27 @@ pub struct ResolvedModelCapabilities {
 }
 
 impl ResolvedModelCapabilities {
-    fn resolve(policy: &ResolvedRuntimeModelPolicy, transport: ProviderTransportKind) -> Self {
+    fn resolve(policy: &mut ResolvedRuntimeModelPolicy, transport: ProviderTransportKind) -> Self {
         let intrinsic = policy.capabilities.intrinsic();
         let endpoint = crate::model_catalog::EndpointModelPolicy {
             accepted_parameters: resolved_parameter_contracts(policy),
         };
         let transport = transport.capabilities();
+        let image_input = constrain_transport_capability(
+            policy,
+            ModelMetadataField::ImageInput,
+            policy.capabilities.image_input,
+            transport.image_input,
+        );
+        let image_output = constrain_transport_capability(
+            policy,
+            ModelMetadataField::ImageGeneration,
+            policy.capabilities.image_generation,
+            transport.image_output,
+        );
         Self {
-            image_input: policy.capabilities.image_input && transport.image_input,
-            image_output: policy.capabilities.image_generation && transport.image_output,
+            image_input,
+            image_output,
             intrinsic,
             endpoint,
             transport,
@@ -243,6 +259,28 @@ impl ResolvedModelCapabilities {
             ModelRouteCapability::ImageGeneration => self.image_output,
         }
     }
+}
+
+fn constrain_transport_capability(
+    policy: &mut ResolvedRuntimeModelPolicy,
+    field: ModelMetadataField,
+    model_supports: bool,
+    transport_supports: bool,
+) -> bool {
+    let effective = model_supports && transport_supports;
+    if model_supports && !transport_supports {
+        let constraint = ModelMetadataConstraint {
+            field,
+            kind: ModelMetadataConstraintKind::Disabled,
+            source: ModelMetadataConstraintSource::TransportCapability,
+            requested: "true".to_string(),
+            effective: "false".to_string(),
+        };
+        if !policy.evidence.constraints.contains(&constraint) {
+            policy.evidence.constraints.push(constraint);
+        }
+    }
+    effective
 }
 
 fn resolved_parameter_contracts(
@@ -289,6 +327,15 @@ pub struct ResolvedModelRoute {
     pub policy: ResolvedRuntimeModelPolicy,
     pub capabilities: ResolvedModelCapabilities,
     pub requested_capability: ModelRouteCapability,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedModelRouteMetadata {
+    pub route_ref: ModelRouteRef,
+    pub model_ref: ModelRef,
+    pub endpoint: ResolvedProviderEndpointConfig,
+    pub policy: ResolvedRuntimeModelPolicy,
+    pub capabilities: ResolvedModelCapabilities,
 }
 
 impl ResolvedModelRoute {
@@ -398,26 +445,16 @@ impl RuntimeModelCatalog {
             endpoint.endpoint.clone(),
             model_ref.model.clone(),
         );
-
-        let policy = self.built_in_catalog.resolve_route_policy(
-            &route_ref,
-            &self.model_overrides,
-            &self.discovered_models,
-            self.unknown_model_fallback.as_ref(),
-            base_context_config,
-            self.configured_runtime_max_output_tokens,
-        );
-        let capabilities =
-            ResolvedModelCapabilities::resolve(&policy, endpoint.runtime_config.transport);
-        if !capabilities.supports(requested_capability) {
+        let metadata = self.resolve_explicit_model_metadata(base_context_config, &route_ref)?;
+        if !metadata.capabilities.supports(requested_capability) {
             return None;
         }
         Some(ResolvedModelRoute {
-            route_ref,
-            model_ref: model_ref.clone(),
-            endpoint: endpoint.clone(),
-            policy,
-            capabilities,
+            route_ref: metadata.route_ref,
+            model_ref: metadata.model_ref,
+            endpoint: metadata.endpoint,
+            policy: metadata.policy,
+            capabilities: metadata.capabilities,
             requested_capability,
         })
     }
@@ -428,6 +465,25 @@ impl RuntimeModelCatalog {
         route_ref: &ModelRouteRef,
         requested_capability: ModelRouteCapability,
     ) -> Option<ResolvedModelRoute> {
+        let metadata = self.resolve_explicit_model_metadata(base_context_config, route_ref)?;
+        if !metadata.capabilities.supports(requested_capability) {
+            return None;
+        }
+        Some(ResolvedModelRoute {
+            route_ref: metadata.route_ref,
+            model_ref: metadata.model_ref,
+            endpoint: metadata.endpoint,
+            policy: metadata.policy,
+            capabilities: metadata.capabilities,
+            requested_capability,
+        })
+    }
+
+    pub(crate) fn resolve_explicit_model_metadata(
+        &self,
+        base_context_config: &ContextConfig,
+        route_ref: &ModelRouteRef,
+    ) -> Option<ResolvedModelRouteMetadata> {
         let canonical_model_ref = self
             .built_in_catalog
             .canonicalize_model_ref(&route_ref.model_ref());
@@ -440,26 +496,16 @@ impl RuntimeModelCatalog {
             endpoint.provider == canonical_route_ref.provider
                 && endpoint.endpoint == canonical_route_ref.endpoint
         })?;
-        let policy = self.built_in_catalog.resolve_route_policy(
-            &canonical_route_ref,
-            &self.model_overrides,
-            &self.discovered_models,
-            self.unknown_model_fallback.as_ref(),
-            base_context_config,
-            self.configured_runtime_max_output_tokens,
-        );
+        let mut policy =
+            self.resolved_model_policy_for_route(base_context_config, &canonical_route_ref);
         let capabilities =
-            ResolvedModelCapabilities::resolve(&policy, endpoint.runtime_config.transport);
-        if !capabilities.supports(requested_capability) {
-            return None;
-        }
-        Some(ResolvedModelRoute {
+            ResolvedModelCapabilities::resolve(&mut policy, endpoint.runtime_config.transport);
+        Some(ResolvedModelRouteMetadata {
             route_ref: canonical_route_ref,
             model_ref: canonical_model_ref,
             endpoint: endpoint.clone(),
             policy,
             capabilities,
-            requested_capability,
         })
     }
 
@@ -530,8 +576,28 @@ impl RuntimeModelCatalog {
         model_override: Option<&ModelRouteRef>,
     ) -> ResolvedRuntimeModelPolicy {
         let route_ref = self.effective_model(model_override);
+        self.resolve_explicit_model_metadata(base_context_config, &route_ref)
+            .map(|route| route.policy)
+            .unwrap_or_else(|| {
+                self.resolved_model_policy_for_route(base_context_config, &route_ref)
+            })
+    }
+
+    fn resolved_model_policy_for_route(
+        &self,
+        base_context_config: &ContextConfig,
+        route_ref: &ModelRouteRef,
+    ) -> ResolvedRuntimeModelPolicy {
+        let canonical_model_ref = self
+            .built_in_catalog
+            .canonicalize_model_ref(&route_ref.model_ref());
+        let canonical_route_ref = ModelRouteRef::new(
+            route_ref.provider.clone(),
+            route_ref.endpoint.clone(),
+            canonical_model_ref.model,
+        );
         self.built_in_catalog.resolve_route_policy(
-            &route_ref,
+            &canonical_route_ref,
             &self.model_overrides,
             &self.discovered_models,
             self.unknown_model_fallback.as_ref(),
@@ -545,87 +611,51 @@ impl RuntimeModelCatalog {
         base_context_config: &ContextConfig,
         model_override: Option<&ModelRouteRef>,
     ) -> ContextConfig {
-        let model_ref = self.effective_model(model_override).model_ref();
-        self.built_in_catalog
-            .apply_policy(
-                &model_ref,
-                &self.model_overrides,
-                &self.discovered_models,
-                self.unknown_model_fallback.as_ref(),
-                base_context_config,
-                self.configured_runtime_max_output_tokens,
-            )
-            .0
+        let policy = self.resolved_model_policy(base_context_config, model_override);
+        let mut resolved = base_context_config.clone();
+        resolved.prompt_budget_estimated_tokens = policy.prompt_budget_estimated_tokens;
+        resolved.compaction_trigger_estimated_tokens = policy.compaction_trigger_estimated_tokens;
+        resolved.compaction_keep_recent_estimated_tokens =
+            policy.compaction_keep_recent_estimated_tokens;
+        resolved
     }
 
     pub fn available_models(&self) -> Vec<BuiltInModelMetadata> {
-        let mut models = self.built_in_catalog.list();
-        for discovered in self.discovered_models.values() {
-            if !self.model_overrides.contains_key(&discovered.model_ref) {
-                models.retain(|model| model.model_ref != discovered.model_ref);
-                models.push(discovered.clone());
-            }
-        }
-        for (model_ref, override_config) in &self.model_overrides {
-            let base = self
-                .discovered_models
-                .get(model_ref)
-                .or_else(|| self.built_in_catalog.get(model_ref));
-            models.retain(|model| &model.model_ref != model_ref);
-            models.push(BuiltInModelMetadata {
-                model_ref: model_ref.clone(),
-                display_name: override_config
-                    .display_name
-                    .clone()
-                    .or_else(|| base.map(|model| model.display_name.clone()))
-                    .unwrap_or_else(|| model_ref.as_string()),
-                description: override_config
-                    .description
-                    .clone()
-                    .or_else(|| base.map(|model| model.description.clone()))
-                    .unwrap_or_else(|| "User-configured model metadata override.".to_string()),
-                context_window_tokens: override_config
-                    .context_window_tokens
-                    .or_else(|| base.and_then(|model| model.context_window_tokens)),
-                effective_context_window_percent: override_config
-                    .effective_context_window_percent
-                    .unwrap_or_else(|| {
-                        base.map(|model| model.effective_context_window_percent)
-                            .unwrap_or(95)
-                    }),
-                auto_compact_token_limit: override_config
-                    .auto_compact_token_limit
-                    .or_else(|| base.and_then(|model| model.auto_compact_token_limit)),
-                default_max_output_tokens: override_config
-                    .runtime_max_output_tokens
-                    .or_else(|| base.and_then(|model| model.default_max_output_tokens)),
-                max_output_tokens_upper_limit: base
-                    .and_then(|model| model.max_output_tokens_upper_limit),
-                default_verbosity: override_config
-                    .verbosity
-                    .or_else(|| base.and_then(|model| model.default_verbosity)),
-                tool_output_truncation_estimated_tokens: override_config
-                    .tool_output_truncation_estimated_tokens
-                    .or_else(|| {
-                        base.and_then(|model| model.tool_output_truncation_estimated_tokens)
-                    }),
-                capabilities: merged_model_capabilities(
-                    base.map(|model| &model.capabilities),
-                    override_config.capabilities.as_ref(),
-                ),
-                reasoning_effort_options: base
-                    .map(|model| model.reasoning_effort_options.clone())
-                    .unwrap_or_default(),
-                source: crate::model_catalog::ModelMetadataSource::ConfigOverride,
-                endpoint: None,
-            });
-        }
+        let mut model_refs = self
+            .built_in_catalog
+            .list()
+            .into_iter()
+            .map(|model| model.model_ref)
+            .collect::<HashSet<_>>();
+        model_refs.extend(self.discovered_models.keys().cloned());
+        model_refs.extend(self.model_overrides.keys().cloned());
+        let base_context_config = ContextConfig::default();
+        let mut models = model_refs
+            .into_iter()
+            .map(|model_ref| self.resolved_catalog_entry(&base_context_config, &model_ref))
+            .collect::<Vec<_>>();
         models.sort_by(|left, right| {
             left.display_name
                 .cmp(&right.display_name)
                 .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
         });
         models
+    }
+
+    fn resolved_catalog_entry(
+        &self,
+        base_context_config: &ContextConfig,
+        model_ref: &ModelRef,
+    ) -> BuiltInModelMetadata {
+        let canonical_model_ref = self.built_in_catalog.canonicalize_model_ref(model_ref);
+        self.built_in_catalog.resolve_catalog_entry(
+            &canonical_model_ref,
+            &self.model_overrides,
+            &self.discovered_models,
+            self.unknown_model_fallback.as_ref(),
+            base_context_config,
+            self.configured_runtime_max_output_tokens,
+        )
     }
 
     pub fn available_model_routes(&self) -> Vec<ModelRouteRef> {
@@ -698,27 +728,18 @@ impl RuntimeModelCatalog {
         let mut selected = None;
 
         for route_ref in &model_refs {
-            let model_ref = route_ref.model_ref();
-            let policy = self.built_in_catalog.resolve_policy(
-                &model_ref,
-                &self.model_overrides,
-                &self.discovered_models,
-                self.unknown_model_fallback.as_ref(),
-                base_context_config,
-                self.configured_runtime_max_output_tokens,
-            );
-            let image_input = policy.capabilities.image_input;
-            let supported_transport = self
-                .provider_endpoints
-                .values()
-                .find(|endpoint| {
-                    endpoint.provider == route_ref.provider
-                        && endpoint.endpoint == route_ref.endpoint
-                })
-                .is_some_and(|endpoint| {
-                    ModelRouteCapability::VisionObservation
-                        .transport_supports(endpoint.runtime_config.transport)
+            let resolved = self.resolve_explicit_model_metadata(base_context_config, route_ref);
+            let policy = resolved
+                .as_ref()
+                .map(|route| route.policy.clone())
+                .unwrap_or_else(|| {
+                    self.resolved_model_policy(base_context_config, Some(route_ref))
                 });
+            let image_input = policy.capabilities.image_input;
+            let supported_transport = resolved.as_ref().is_some_and(|route| {
+                ModelRouteCapability::VisionObservation
+                    .transport_supports(route.endpoint.runtime_config.transport)
+            });
             let reason = if !image_input {
                 "model_lacks_image_input"
             } else if supported_transport {
@@ -733,15 +754,7 @@ impl RuntimeModelCatalog {
                 image_input,
                 reason: reason.to_string(),
             });
-            if self
-                .resolve_explicit_model_route(
-                    base_context_config,
-                    route_ref,
-                    ModelRouteCapability::VisionObservation,
-                )
-                .is_some()
-                && selected.is_none()
-            {
+            if resolved.is_some_and(|route| route.capabilities.image_input) && selected.is_none() {
                 selected = Some(route_ref.clone());
             }
         }
@@ -834,31 +847,6 @@ impl Default for RuntimeModelCatalog {
             configured_runtime_max_output_tokens: 8192,
         }
     }
-}
-
-pub(crate) fn merged_model_capabilities(
-    base: Option<&crate::model_catalog::ModelCapabilityFlags>,
-    override_config: Option<&crate::model_catalog::ModelCapabilityOverride>,
-) -> crate::model_catalog::ModelCapabilityFlags {
-    let mut capabilities = base.cloned().unwrap_or_default();
-    if let Some(override_config) = override_config {
-        if let Some(value) = override_config.parallel_tool_calls {
-            capabilities.parallel_tool_calls = value;
-        }
-        if let Some(value) = override_config.supports_reasoning {
-            capabilities.supports_reasoning = value;
-        }
-        if let Some(value) = override_config.image_input {
-            capabilities.image_input = value;
-        }
-        if let Some(value) = override_config.image_generation {
-            capabilities.image_generation = value;
-        }
-        if let Some(value) = override_config.interactive_exec {
-            capabilities.interactive_exec = value;
-        }
-    }
-    capabilities
 }
 
 impl ModelRef {
@@ -1160,8 +1148,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn model_policy_preserves_exact_route_metadata_without_a_configured_endpoint() {
+        let catalog = RuntimeModelCatalog::default();
+        let route_ref = ModelRouteRef::parse("volcengine@plan/glm-5.2").unwrap();
+
+        let policy = catalog.resolved_model_policy(&ContextConfig::default(), Some(&route_ref));
+
+        assert_eq!(policy.reasoning_effort_options, ["low", "medium", "high"]);
+        assert_eq!(
+            policy
+                .evidence
+                .source_for(ModelMetadataField::ReasoningEffortOptions),
+            Some(crate::model_catalog::ModelMetadataOrigin::RouteBuiltin)
+        );
+    }
+
+    #[test]
     fn resolved_capabilities_intersect_model_and_transport_image_output() {
-        let policy = ResolvedRuntimeModelPolicy {
+        let mut policy = ResolvedRuntimeModelPolicy {
             capabilities: crate::model_catalog::ModelCapabilityFlags {
                 image_generation: true,
                 ..Default::default()
@@ -1169,8 +1173,10 @@ mod tests {
             ..Default::default()
         };
 
-        let capabilities =
-            ResolvedModelCapabilities::resolve(&policy, ProviderTransportKind::AnthropicMessages);
+        let capabilities = ResolvedModelCapabilities::resolve(
+            &mut policy,
+            ProviderTransportKind::AnthropicMessages,
+        );
 
         assert!(capabilities
             .intrinsic
@@ -1179,12 +1185,77 @@ mod tests {
         assert!(!capabilities.transport.image_output);
         assert!(!capabilities.image_output);
         assert!(!capabilities.supports(ModelRouteCapability::ImageGeneration));
+        assert_eq!(
+            policy.evidence.constraints,
+            [ModelMetadataConstraint {
+                field: ModelMetadataField::ImageGeneration,
+                kind: ModelMetadataConstraintKind::Disabled,
+                source: ModelMetadataConstraintSource::TransportCapability,
+                requested: "true".into(),
+                effective: "false".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn resolved_capabilities_record_each_transport_image_constraint_once() {
+        let mut policy = ResolvedRuntimeModelPolicy {
+            capabilities: crate::model_catalog::ModelCapabilityFlags {
+                image_input: true,
+                image_generation: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        for _ in 0..2 {
+            let capabilities = ResolvedModelCapabilities::resolve(
+                &mut policy,
+                ProviderTransportKind::GeminiGenerateContent,
+            );
+            assert!(!capabilities.image_input);
+            assert!(!capabilities.image_output);
+        }
+
+        assert_eq!(
+            policy.evidence.constraints,
+            [
+                ModelMetadataConstraint {
+                    field: ModelMetadataField::ImageInput,
+                    kind: ModelMetadataConstraintKind::Disabled,
+                    source: ModelMetadataConstraintSource::TransportCapability,
+                    requested: "true".into(),
+                    effective: "false".into(),
+                },
+                ModelMetadataConstraint {
+                    field: ModelMetadataField::ImageGeneration,
+                    kind: ModelMetadataConstraintKind::Disabled,
+                    source: ModelMetadataConstraintSource::TransportCapability,
+                    requested: "true".into(),
+                    effective: "false".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn resolved_capabilities_do_not_record_inactive_transport_constraints() {
+        let mut policy = ResolvedRuntimeModelPolicy::default();
+
+        let capabilities = ResolvedModelCapabilities::resolve(
+            &mut policy,
+            ProviderTransportKind::GeminiGenerateContent,
+        );
+
+        assert!(!capabilities.image_input);
+        assert!(!capabilities.image_output);
+        assert!(policy.evidence.constraints.is_empty());
     }
 
     #[test]
     fn gemini_transport_does_not_advertise_unimplemented_vision_or_reasoning_controls() {
         let catalog = crate::model_catalog::BuiltInModelCatalog::new();
-        let policy = catalog.resolve_policy(
+        let mut policy = catalog.resolve_policy(
             &ModelRef::parse("gemini/gemini-3.5-flash").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
@@ -1198,7 +1269,7 @@ mod tests {
         assert!(policy.reasoning_effort_options.is_empty());
 
         let capabilities = ResolvedModelCapabilities::resolve(
-            &policy,
+            &mut policy,
             ProviderTransportKind::GeminiGenerateContent,
         );
         assert!(!capabilities.transport.image_input);
@@ -1213,13 +1284,13 @@ mod tests {
 
     #[test]
     fn resolved_capabilities_preserve_reasoning_effort_allowed_values() {
-        let policy = ResolvedRuntimeModelPolicy {
+        let mut policy = ResolvedRuntimeModelPolicy {
             reasoning_effort_options: vec!["low".into(), "high".into()],
             ..Default::default()
         };
 
         let capabilities =
-            ResolvedModelCapabilities::resolve(&policy, ProviderTransportKind::OpenAiResponses);
+            ResolvedModelCapabilities::resolve(&mut policy, ProviderTransportKind::OpenAiResponses);
 
         assert_eq!(
             capabilities.endpoint.accepted_parameters,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2487,12 +2487,19 @@ fn runtime_model_catalog_resolves_config_override_and_unknown_fallback() {
             .compaction_keep_recent_estimated_tokens,
         recent_episode_candidates: fixture.config.recent_episode_candidates,
         max_relevant_episodes: fixture.config.max_relevant_episodes,
+        callback_base_url: "https://callback.example".into(),
         ..ContextConfig::default()
     };
 
     let known = catalog.resolved_model_policy(&base_context, None);
     assert_eq!(known.prompt_budget_estimated_tokens, 24_000);
     assert_eq!(known.runtime_max_output_tokens, 4_096);
+    let resolved_context = catalog.resolved_context_config(&base_context, None);
+    assert_eq!(resolved_context.prompt_budget_estimated_tokens, 24_000);
+    assert_eq!(
+        resolved_context.callback_base_url,
+        "https://callback.example"
+    );
 
     let unknown =
         catalog.resolved_model_policy(&base_context, Some(&route_ref("openai/custom-model")));
@@ -3059,11 +3066,17 @@ fn runtime_model_catalog_resolves_canonical_seedream_route_endpoint() {
 #[test]
 fn runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins() {
     let mut fixture = test_app_config("openrouter/anthropic/claude-3.5-sonnet", &[]);
+    let openrouter = ProviderId::parse("openrouter").unwrap();
+    let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+    fixture.config.providers.insert(
+        openrouter.clone(),
+        built_ins.get(&openrouter).unwrap().clone(),
+    );
     let remote_model_ref = ModelRef::parse("openrouter/anthropic/claude-3.5-sonnet").unwrap();
     fixture.config.model_discovery_cache.providers.insert(
-        ProviderId::parse("openrouter").unwrap(),
+        openrouter.clone(),
         ProviderModelDiscoveryCache {
-            provider: ProviderId::parse("openrouter").unwrap(),
+            provider: openrouter,
             fetched_at: chrono::Utc::now(),
             source_url: Some("https://openrouter.ai/api/v1/models".into()),
             response_hash: Some("sha256:test".into()),
@@ -3119,6 +3132,19 @@ fn runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins() {
         .find(|model| model.model_ref == remote_model_ref)
         .expect("remote model should be listed");
     assert_eq!(listed.source, ModelMetadataSource::RemoteDiscovered);
+    assert_eq!(listed.display_name, remote.display_name);
+    assert_eq!(listed.context_window_tokens, remote.context_window_tokens);
+    assert_eq!(
+        listed.default_max_output_tokens,
+        Some(remote.runtime_max_output_tokens)
+    );
+    let route = catalog
+        .resolve_explicit_model_metadata(
+            &base_context,
+            &route_ref("openrouter/anthropic/claude-3.5-sonnet"),
+        )
+        .expect("configured OpenRouter route should resolve");
+    assert_eq!(route.policy, remote);
 
     let override_config = ModelRuntimeOverride {
         display_name: Some("Configured Claude".into()),
@@ -3140,6 +3166,16 @@ fn runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins() {
     assert_eq!(overridden.source, ModelMetadataSource::ConfigOverride);
     assert_eq!(overridden.display_name, "Configured Claude");
     assert_eq!(overridden.prompt_budget_estimated_tokens, 42_000);
+    let listed = catalog
+        .available_models()
+        .into_iter()
+        .find(|model| model.model_ref == remote_model_ref)
+        .expect("overridden model should remain listed");
+    assert_eq!(listed.display_name, overridden.display_name);
+    assert_eq!(
+        listed.context_window_tokens,
+        overridden.context_window_tokens
+    );
 }
 
 #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -26,6 +26,78 @@ pub enum ModelMetadataSource {
 impl Default for ModelMetadataSource {
     fn default() -> Self {
         Self::UnknownFallback
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelMetadataOrigin {
+    ExplicitOverride,
+    RemoteDiscovered,
+    RouteBuiltin,
+    ModelBuiltin,
+    UnknownFallback,
+    RuntimeDefault,
+    Derived,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelMetadataField {
+    DisplayName,
+    Description,
+    ContextWindowTokens,
+    EffectiveContextWindowPercent,
+    AutoCompactTokenLimit,
+    PromptBudgetEstimatedTokens,
+    CompactionTriggerEstimatedTokens,
+    CompactionKeepRecentEstimatedTokens,
+    RuntimeMaxOutputTokens,
+    Verbosity,
+    ToolOutputTruncationEstimatedTokens,
+    MaxOutputTokensUpperLimit,
+    ParallelToolCalls,
+    ImageInput,
+    ImageGeneration,
+    SupportsReasoning,
+    InteractiveExec,
+    ReasoningEffortOptions,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelMetadataConstraintKind {
+    Clamped,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelMetadataConstraintSource {
+    ModelUpperLimit,
+    TransportCapability,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelMetadataConstraint {
+    pub field: ModelMetadataField,
+    pub kind: ModelMetadataConstraintKind,
+    pub source: ModelMetadataConstraintSource,
+    pub requested: String,
+    pub effective: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ModelMetadataEvidence {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<ModelMetadataField, ModelMetadataOrigin>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<ModelMetadataConstraint>,
+}
+
+impl ModelMetadataEvidence {
+    pub fn source_for(&self, field: ModelMetadataField) -> Option<ModelMetadataOrigin> {
+        self.fields.get(&field).copied()
     }
 }
 
@@ -126,24 +198,6 @@ impl ModelCapabilityOverride {
             && self.image_generation.is_none()
             && self.supports_reasoning.is_none()
             && self.interactive_exec.is_none()
-    }
-
-    fn apply_to(&self, base: &mut ModelCapabilityFlags) {
-        if let Some(value) = self.parallel_tool_calls {
-            base.parallel_tool_calls = value;
-        }
-        if let Some(value) = self.image_input {
-            base.image_input = value;
-        }
-        if let Some(value) = self.image_generation {
-            base.image_generation = value;
-        }
-        if let Some(value) = self.supports_reasoning {
-            base.supports_reasoning = value;
-        }
-        if let Some(value) = self.interactive_exec {
-            base.interactive_exec = value;
-        }
     }
 }
 
@@ -266,6 +320,8 @@ pub struct ResolvedRuntimeModelPolicy {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reasoning_effort_options: Vec<String>,
     pub source: ModelMetadataSource,
+    #[serde(default)]
+    pub evidence: ModelMetadataEvidence,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -317,6 +373,7 @@ impl Default for ResolvedRuntimeModelPolicy {
             capabilities: ModelCapabilityFlags::default(),
             reasoning_effort_options: Vec::new(),
             source: ModelMetadataSource::UnknownFallback,
+            evidence: ModelMetadataEvidence::default(),
         }
     }
 }
@@ -351,6 +408,12 @@ impl ResolvedRuntimeModelPolicy {
             self.reasoning_effort_options.join(", ")
         )))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedModelMetadata {
+    policy: ResolvedRuntimeModelPolicy,
+    catalog_entry: BuiltInModelMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -517,9 +580,10 @@ impl BuiltInModelCatalog {
         configured_runtime_max_output_tokens: u32,
     ) -> ResolvedRuntimeModelPolicy {
         let model_ref = route_ref.model_ref();
-        self.resolve_policy_with_builtin(
+        self.resolve_metadata(
             &model_ref,
             self.route_entries.get(route_ref),
+            self.get(&model_ref),
             overrides,
             discovered_models,
             unknown_fallback,
@@ -527,6 +591,7 @@ impl BuiltInModelCatalog {
             configured_runtime_max_output_tokens,
             Some(&route_ref.endpoint),
         )
+        .policy
     }
 
     pub fn resolve_policy(
@@ -538,8 +603,9 @@ impl BuiltInModelCatalog {
         base_context_config: &ContextConfig,
         configured_runtime_max_output_tokens: u32,
     ) -> ResolvedRuntimeModelPolicy {
-        self.resolve_policy_with_builtin(
+        self.resolve_metadata(
             model_ref,
+            None,
             self.get(model_ref),
             overrides,
             discovered_models,
@@ -548,153 +614,588 @@ impl BuiltInModelCatalog {
             configured_runtime_max_output_tokens,
             None,
         )
+        .policy
+    }
+
+    pub(crate) fn resolve_catalog_entry(
+        &self,
+        model_ref: &ModelRef,
+        overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+        discovered_models: &HashMap<ModelRef, BuiltInModelMetadata>,
+        unknown_fallback: Option<&ModelRuntimeOverride>,
+        base_context_config: &ContextConfig,
+        configured_runtime_max_output_tokens: u32,
+    ) -> BuiltInModelMetadata {
+        self.resolve_metadata(
+            model_ref,
+            None,
+            self.get(model_ref),
+            overrides,
+            discovered_models,
+            unknown_fallback,
+            base_context_config,
+            configured_runtime_max_output_tokens,
+            None,
+        )
+        .catalog_entry
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn resolve_policy_with_builtin(
+    fn resolve_metadata(
         &self,
         model_ref: &ModelRef,
         route_builtin: Option<&BuiltInModelMetadata>,
+        model_builtin: Option<&BuiltInModelMetadata>,
         overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
         discovered_models: &HashMap<ModelRef, BuiltInModelMetadata>,
         unknown_fallback: Option<&ModelRuntimeOverride>,
         base_context_config: &ContextConfig,
         configured_runtime_max_output_tokens: u32,
         endpoint: Option<&ProviderEndpointId>,
-    ) -> ResolvedRuntimeModelPolicy {
+    ) -> ResolvedModelMetadata {
         let discovered = discovered_models.get(model_ref);
-        let built_in = discovered.or(route_builtin);
         let override_config = overrides.get(model_ref);
-        let fallback_override = if built_in.is_none() {
+        let has_metadata =
+            route_builtin.is_some() || model_builtin.is_some() || discovered.is_some();
+        let fallback_override = if !has_metadata {
             unknown_fallback
         } else {
             None
         };
-        let source = if override_config.is_some() || fallback_override.is_some() {
-            if built_in.is_some() {
-                ModelMetadataSource::ConfigOverride
-            } else {
-                ModelMetadataSource::UnknownFallback
-            }
+        let mut evidence = ModelMetadataEvidence::default();
+        let source = if override_config.is_some() {
+            ModelMetadataSource::ConfigOverride
+        } else if fallback_override.is_some() {
+            ModelMetadataSource::UnknownFallback
+        } else if discovered.is_some() {
+            ModelMetadataSource::RemoteDiscovered
         } else {
-            built_in
+            route_builtin
+                .or(model_builtin)
                 .map(|entry| entry.source)
                 .unwrap_or(ModelMetadataSource::UnknownFallback)
         };
-        let display_name = override_config
-            .and_then(|value| value.display_name.clone())
-            .or_else(|| built_in.map(|entry| entry.display_name.clone()))
-            .or_else(|| fallback_override.and_then(|value| value.display_name.clone()))
-            .unwrap_or_else(|| model_ref.as_string());
-        let description = override_config
-            .and_then(|value| value.description.clone())
-            .or_else(|| built_in.map(|entry| entry.description.clone()))
-            .or_else(|| fallback_override.and_then(|value| value.description.clone()))
-            .unwrap_or_else(|| "Explicit unknown-model fallback policy".to_string());
-        let context_window_tokens = override_config
-            .and_then(|value| value.context_window_tokens)
-            .or_else(|| built_in.and_then(|entry| entry.context_window_tokens))
-            .or_else(|| fallback_override.and_then(|value| value.context_window_tokens));
-        let effective_context_window_percent = validated_percent(
-            override_config
-                .and_then(|value| value.effective_context_window_percent)
-                .or_else(|| built_in.map(|entry| entry.effective_context_window_percent))
-                .or_else(|| {
-                    fallback_override.and_then(|value| value.effective_context_window_percent)
-                })
-                .unwrap_or(DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT),
+        let display_name = select_field(
+            &mut evidence,
+            ModelMetadataField::DisplayName,
+            [
+                (
+                    override_config.and_then(|value| value.display_name.clone()),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    discovered.map(|entry| entry.display_name.clone()),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    route_builtin.map(|entry| entry.display_name.clone()),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.map(|entry| entry.display_name.clone()),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    fallback_override.and_then(|value| value.display_name.clone()),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        )
+        .unwrap_or_else(|| {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::DisplayName,
+                ModelMetadataOrigin::Derived,
+            );
+            model_ref.as_string()
+        });
+        let description = select_field(
+            &mut evidence,
+            ModelMetadataField::Description,
+            [
+                (
+                    override_config.and_then(|value| value.description.clone()),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    discovered.map(|entry| entry.description.clone()),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    route_builtin.map(|entry| entry.description.clone()),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.map(|entry| entry.description.clone()),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    fallback_override.and_then(|value| value.description.clone()),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        )
+        .unwrap_or_else(|| {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::Description,
+                ModelMetadataOrigin::Derived,
+            );
+            "Explicit unknown-model fallback policy".to_string()
+        });
+        let context_window_tokens = select_field(
+            &mut evidence,
+            ModelMetadataField::ContextWindowTokens,
+            [
+                (
+                    override_config.and_then(|value| value.context_window_tokens),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    discovered.and_then(|entry| entry.context_window_tokens),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    route_builtin.and_then(|entry| entry.context_window_tokens),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.and_then(|entry| entry.context_window_tokens),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    fallback_override.and_then(|value| value.context_window_tokens),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
         );
-        let prompt_budget_estimated_tokens = override_config
-            .and_then(|value| value.prompt_budget_estimated_tokens)
-            .or_else(|| {
-                context_window_tokens
-                    .map(|window| percent_of(window, usize::from(effective_context_window_percent)))
-            })
-            .or_else(|| fallback_override.and_then(|value| value.prompt_budget_estimated_tokens))
+        if context_window_tokens.is_none() {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::ContextWindowTokens,
+                ModelMetadataOrigin::Derived,
+            );
+        }
+        let effective_context_window_percent = validated_percent(
+            select_field(
+                &mut evidence,
+                ModelMetadataField::EffectiveContextWindowPercent,
+                [
+                    (
+                        override_config.and_then(|value| value.effective_context_window_percent),
+                        ModelMetadataOrigin::ExplicitOverride,
+                    ),
+                    (
+                        route_builtin.map(|entry| entry.effective_context_window_percent),
+                        ModelMetadataOrigin::RouteBuiltin,
+                    ),
+                    (
+                        model_builtin.map(|entry| entry.effective_context_window_percent),
+                        ModelMetadataOrigin::ModelBuiltin,
+                    ),
+                    (
+                        discovered.map(|entry| entry.effective_context_window_percent),
+                        ModelMetadataOrigin::RemoteDiscovered,
+                    ),
+                    (
+                        fallback_override.and_then(|value| value.effective_context_window_percent),
+                        ModelMetadataOrigin::UnknownFallback,
+                    ),
+                ],
+            )
             .unwrap_or_else(|| {
-                if built_in.is_none() {
-                    DEFAULT_UNKNOWN_FALLBACK_PROMPT_BUDGET_ESTIMATED_TOKENS
-                } else {
-                    base_context_config.prompt_budget_estimated_tokens
-                }
-            });
-        let auto_compact_token_limit = override_config
-            .and_then(|value| value.auto_compact_token_limit)
-            .or_else(|| built_in.and_then(|entry| entry.auto_compact_token_limit))
-            .or_else(|| fallback_override.and_then(|value| value.auto_compact_token_limit));
-        let compaction_trigger_estimated_tokens = override_config
-            .and_then(|value| value.compaction_trigger_estimated_tokens)
-            .or_else(|| {
-                fallback_override.and_then(|value| value.compaction_trigger_estimated_tokens)
-            })
-            .or(auto_compact_token_limit)
-            .or_else(|| {
-                Some(percent_of(
-                    prompt_budget_estimated_tokens,
-                    usize::from(DEFAULT_COMPACTION_TRIGGER_PERCENT),
-                ))
-            })
-            .unwrap_or(base_context_config.compaction_trigger_estimated_tokens);
-        let compaction_keep_recent_estimated_tokens = override_config
-            .and_then(|value| value.compaction_keep_recent_estimated_tokens)
-            .or_else(|| {
-                fallback_override.and_then(|value| value.compaction_keep_recent_estimated_tokens)
-            })
-            .or_else(|| {
-                Some(percent_of(
-                    compaction_trigger_estimated_tokens,
-                    usize::from(DEFAULT_KEEP_RECENT_PERCENT),
-                ))
-            })
-            .unwrap_or(base_context_config.compaction_keep_recent_estimated_tokens);
-        let runtime_max_output_tokens = override_config
-            .and_then(|value| value.runtime_max_output_tokens)
-            .or_else(|| built_in.and_then(|entry| entry.default_max_output_tokens))
-            .or_else(|| fallback_override.and_then(|value| value.runtime_max_output_tokens))
-            .unwrap_or(configured_runtime_max_output_tokens);
-        let max_output_tokens_upper_limit =
-            built_in.and_then(|entry| entry.max_output_tokens_upper_limit);
-        // Clamp runtime_max_output_tokens to the model's declared upper limit so
-        // wire-level requests (e.g. Anthropic max_tokens) never exceed what the
-        // provider accepts.
+                record_origin(
+                    &mut evidence,
+                    ModelMetadataField::EffectiveContextWindowPercent,
+                    ModelMetadataOrigin::Derived,
+                );
+                DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT
+            }),
+        );
+        let prompt_budget_estimated_tokens = select_field(
+            &mut evidence,
+            ModelMetadataField::PromptBudgetEstimatedTokens,
+            [
+                (
+                    override_config.and_then(|value| value.prompt_budget_estimated_tokens),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    fallback_override.and_then(|value| value.prompt_budget_estimated_tokens),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        )
+        .unwrap_or_else(|| {
+            if let Some(window) = context_window_tokens {
+                record_origin(
+                    &mut evidence,
+                    ModelMetadataField::PromptBudgetEstimatedTokens,
+                    ModelMetadataOrigin::Derived,
+                );
+                percent_of(window, usize::from(effective_context_window_percent))
+            } else if has_metadata {
+                record_origin(
+                    &mut evidence,
+                    ModelMetadataField::PromptBudgetEstimatedTokens,
+                    ModelMetadataOrigin::RuntimeDefault,
+                );
+                base_context_config.prompt_budget_estimated_tokens
+            } else {
+                record_origin(
+                    &mut evidence,
+                    ModelMetadataField::PromptBudgetEstimatedTokens,
+                    ModelMetadataOrigin::Derived,
+                );
+                DEFAULT_UNKNOWN_FALLBACK_PROMPT_BUDGET_ESTIMATED_TOKENS
+            }
+        });
+        let auto_compact_token_limit = select_field(
+            &mut evidence,
+            ModelMetadataField::AutoCompactTokenLimit,
+            [
+                (
+                    override_config.and_then(|value| value.auto_compact_token_limit),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    route_builtin.and_then(|entry| entry.auto_compact_token_limit),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.and_then(|entry| entry.auto_compact_token_limit),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    discovered.and_then(|entry| entry.auto_compact_token_limit),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    fallback_override.and_then(|value| value.auto_compact_token_limit),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        );
+        if auto_compact_token_limit.is_none() {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::AutoCompactTokenLimit,
+                ModelMetadataOrigin::Derived,
+            );
+        }
+        let compaction_trigger_estimated_tokens = select_field(
+            &mut evidence,
+            ModelMetadataField::CompactionTriggerEstimatedTokens,
+            [
+                (
+                    override_config.and_then(|value| value.compaction_trigger_estimated_tokens),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    fallback_override.and_then(|value| value.compaction_trigger_estimated_tokens),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+                (auto_compact_token_limit, ModelMetadataOrigin::Derived),
+            ],
+        )
+        .unwrap_or_else(|| {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::CompactionTriggerEstimatedTokens,
+                ModelMetadataOrigin::Derived,
+            );
+            percent_of(
+                prompt_budget_estimated_tokens,
+                usize::from(DEFAULT_COMPACTION_TRIGGER_PERCENT),
+            )
+        });
+        let compaction_keep_recent_estimated_tokens = select_field(
+            &mut evidence,
+            ModelMetadataField::CompactionKeepRecentEstimatedTokens,
+            [
+                (
+                    override_config.and_then(|value| value.compaction_keep_recent_estimated_tokens),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    fallback_override
+                        .and_then(|value| value.compaction_keep_recent_estimated_tokens),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        )
+        .unwrap_or_else(|| {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::CompactionKeepRecentEstimatedTokens,
+                ModelMetadataOrigin::Derived,
+            );
+            percent_of(
+                compaction_trigger_estimated_tokens,
+                usize::from(DEFAULT_KEEP_RECENT_PERCENT),
+            )
+        });
+        let default_max_output_tokens = select_field(
+            &mut evidence,
+            ModelMetadataField::RuntimeMaxOutputTokens,
+            [
+                (
+                    override_config.and_then(|value| value.runtime_max_output_tokens),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    route_builtin.and_then(|entry| entry.default_max_output_tokens),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.and_then(|entry| entry.default_max_output_tokens),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    discovered.and_then(|entry| entry.default_max_output_tokens),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    fallback_override.and_then(|value| value.runtime_max_output_tokens),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        );
+        let requested_runtime_max_output_tokens = default_max_output_tokens.unwrap_or_else(|| {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::RuntimeMaxOutputTokens,
+                ModelMetadataOrigin::RuntimeDefault,
+            );
+            configured_runtime_max_output_tokens
+        });
+        let max_output_tokens_upper_limit = select_field(
+            &mut evidence,
+            ModelMetadataField::MaxOutputTokensUpperLimit,
+            [
+                (
+                    route_builtin.and_then(|entry| entry.max_output_tokens_upper_limit),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    discovered.and_then(|entry| entry.max_output_tokens_upper_limit),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    model_builtin.and_then(|entry| entry.max_output_tokens_upper_limit),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+            ],
+        );
+        if max_output_tokens_upper_limit.is_none() {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::MaxOutputTokensUpperLimit,
+                ModelMetadataOrigin::Derived,
+            );
+        }
         let runtime_max_output_tokens = match max_output_tokens_upper_limit {
-            Some(upper) => runtime_max_output_tokens.min(upper),
-            None => runtime_max_output_tokens,
+            Some(upper) if requested_runtime_max_output_tokens > upper => {
+                evidence.constraints.push(ModelMetadataConstraint {
+                    field: ModelMetadataField::RuntimeMaxOutputTokens,
+                    kind: ModelMetadataConstraintKind::Clamped,
+                    source: ModelMetadataConstraintSource::ModelUpperLimit,
+                    requested: requested_runtime_max_output_tokens.to_string(),
+                    effective: upper.to_string(),
+                });
+                upper
+            }
+            _ => requested_runtime_max_output_tokens,
         };
-        let verbosity = override_config
-            .and_then(|value| value.verbosity)
-            .or_else(|| built_in.and_then(|entry| entry.default_verbosity))
-            .or_else(|| fallback_override.and_then(|value| value.verbosity))
-            .or_else(|| default_verbosity_for_model(model_ref));
-        let tool_output_truncation_estimated_tokens = override_config
-            .and_then(|value| value.tool_output_truncation_estimated_tokens)
-            .or_else(|| built_in.and_then(|entry| entry.tool_output_truncation_estimated_tokens))
-            .or_else(|| {
-                fallback_override.and_then(|value| value.tool_output_truncation_estimated_tokens)
-            })
-            .unwrap_or(DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS);
-        let mut capabilities = built_in
-            .map(|entry| entry.capabilities.clone())
-            .unwrap_or_default();
-        if let Some(fallback_capabilities) =
-            fallback_override.and_then(|value| value.capabilities.as_ref())
-        {
-            fallback_capabilities.apply_to(&mut capabilities);
+        let effective_default_max_output_tokens =
+            default_max_output_tokens.map(|_| runtime_max_output_tokens);
+        let verbosity = select_field(
+            &mut evidence,
+            ModelMetadataField::Verbosity,
+            [
+                (
+                    override_config.and_then(|value| value.verbosity),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    route_builtin.and_then(|entry| entry.default_verbosity),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.and_then(|entry| entry.default_verbosity),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    discovered.and_then(|entry| entry.default_verbosity),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    fallback_override.and_then(|value| value.verbosity),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+                (
+                    default_verbosity_for_model(model_ref),
+                    ModelMetadataOrigin::Derived,
+                ),
+            ],
+        );
+        if verbosity.is_none() {
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::Verbosity,
+                ModelMetadataOrigin::Derived,
+            );
         }
-        if let Some(override_capabilities) =
-            override_config.and_then(|value| value.capabilities.as_ref())
-        {
-            override_capabilities.apply_to(&mut capabilities);
-        }
-        let reasoning_effort_options = built_in
-            .map(|entry| entry.reasoning_effort_options.clone())
-            .filter(|options| !options.is_empty())
-            .unwrap_or_else(|| reasoning_effort_options(model_ref, endpoint, &capabilities));
+        let configured_tool_output_truncation_estimated_tokens = select_field(
+            &mut evidence,
+            ModelMetadataField::ToolOutputTruncationEstimatedTokens,
+            [
+                (
+                    override_config.and_then(|value| value.tool_output_truncation_estimated_tokens),
+                    ModelMetadataOrigin::ExplicitOverride,
+                ),
+                (
+                    route_builtin.and_then(|entry| entry.tool_output_truncation_estimated_tokens),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    model_builtin.and_then(|entry| entry.tool_output_truncation_estimated_tokens),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+                (
+                    discovered.and_then(|entry| entry.tool_output_truncation_estimated_tokens),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    fallback_override
+                        .and_then(|value| value.tool_output_truncation_estimated_tokens),
+                    ModelMetadataOrigin::UnknownFallback,
+                ),
+            ],
+        );
+        let tool_output_truncation_estimated_tokens =
+            configured_tool_output_truncation_estimated_tokens.unwrap_or_else(|| {
+                record_origin(
+                    &mut evidence,
+                    ModelMetadataField::ToolOutputTruncationEstimatedTokens,
+                    ModelMetadataOrigin::Derived,
+                );
+                DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS
+            });
+        let capabilities = ModelCapabilityFlags {
+            parallel_tool_calls: resolve_capability_field(
+                &mut evidence,
+                ModelMetadataField::ParallelToolCalls,
+                override_config
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.parallel_tool_calls),
+                discovered.map(|entry| entry.capabilities.parallel_tool_calls),
+                route_builtin.map(|entry| entry.capabilities.parallel_tool_calls),
+                model_builtin.map(|entry| entry.capabilities.parallel_tool_calls),
+                fallback_override
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.parallel_tool_calls),
+            ),
+            image_input: resolve_capability_field(
+                &mut evidence,
+                ModelMetadataField::ImageInput,
+                override_config
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.image_input),
+                discovered.map(|entry| entry.capabilities.image_input),
+                route_builtin.map(|entry| entry.capabilities.image_input),
+                model_builtin.map(|entry| entry.capabilities.image_input),
+                fallback_override
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.image_input),
+            ),
+            image_generation: resolve_capability_field(
+                &mut evidence,
+                ModelMetadataField::ImageGeneration,
+                override_config
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.image_generation),
+                discovered.map(|entry| entry.capabilities.image_generation),
+                route_builtin.map(|entry| entry.capabilities.image_generation),
+                model_builtin.map(|entry| entry.capabilities.image_generation),
+                fallback_override
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.image_generation),
+            ),
+            supports_reasoning: resolve_capability_field(
+                &mut evidence,
+                ModelMetadataField::SupportsReasoning,
+                override_config
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.supports_reasoning),
+                discovered.map(|entry| entry.capabilities.supports_reasoning),
+                route_builtin.map(|entry| entry.capabilities.supports_reasoning),
+                model_builtin.map(|entry| entry.capabilities.supports_reasoning),
+                fallback_override
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.supports_reasoning),
+            ),
+            interactive_exec: resolve_capability_field(
+                &mut evidence,
+                ModelMetadataField::InteractiveExec,
+                override_config
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.interactive_exec),
+                discovered.map(|entry| entry.capabilities.interactive_exec),
+                route_builtin.map(|entry| entry.capabilities.interactive_exec),
+                model_builtin.map(|entry| entry.capabilities.interactive_exec),
+                fallback_override
+                    .and_then(|value| value.capabilities.as_ref())
+                    .and_then(|value| value.interactive_exec),
+            ),
+        };
+        let reasoning_effort_options = select_field(
+            &mut evidence,
+            ModelMetadataField::ReasoningEffortOptions,
+            [
+                (
+                    route_builtin
+                        .map(|entry| entry.reasoning_effort_options.clone())
+                        .filter(|options| !options.is_empty()),
+                    ModelMetadataOrigin::RouteBuiltin,
+                ),
+                (
+                    discovered.and_then(|entry| {
+                        (!entry.reasoning_effort_options.is_empty()
+                            || entry.capabilities.supports_reasoning)
+                            .then(|| entry.reasoning_effort_options.clone())
+                    }),
+                    ModelMetadataOrigin::RemoteDiscovered,
+                ),
+                (
+                    model_builtin
+                        .map(|entry| entry.reasoning_effort_options.clone())
+                        .filter(|options| !options.is_empty()),
+                    ModelMetadataOrigin::ModelBuiltin,
+                ),
+            ],
+        )
+        .unwrap_or_else(|| {
+            let options = reasoning_effort_options(model_ref, endpoint, &capabilities);
+            let origin = if !options.is_empty() && route_builtin.is_some() {
+                ModelMetadataOrigin::RouteBuiltin
+            } else if !options.is_empty() && model_builtin.is_some() {
+                ModelMetadataOrigin::ModelBuiltin
+            } else {
+                ModelMetadataOrigin::Derived
+            };
+            record_origin(
+                &mut evidence,
+                ModelMetadataField::ReasoningEffortOptions,
+                origin,
+            );
+            options
+        });
 
-        ResolvedRuntimeModelPolicy {
+        let policy = ResolvedRuntimeModelPolicy {
             model_ref: model_ref.clone(),
-            display_name,
-            description,
+            display_name: display_name.clone(),
+            description: description.clone(),
             context_window_tokens,
             effective_context_window_percent,
             prompt_budget_estimated_tokens,
@@ -704,9 +1205,31 @@ impl BuiltInModelCatalog {
             verbosity,
             tool_output_truncation_estimated_tokens,
             max_output_tokens_upper_limit,
+            capabilities: capabilities.clone(),
+            reasoning_effort_options: reasoning_effort_options.clone(),
+            source,
+            evidence,
+        };
+        let catalog_entry = BuiltInModelMetadata {
+            model_ref: model_ref.clone(),
+            display_name,
+            description,
+            context_window_tokens,
+            effective_context_window_percent,
+            auto_compact_token_limit,
+            default_max_output_tokens: effective_default_max_output_tokens,
+            max_output_tokens_upper_limit,
+            default_verbosity: verbosity,
+            tool_output_truncation_estimated_tokens:
+                configured_tool_output_truncation_estimated_tokens,
             capabilities,
             reasoning_effort_options,
             source,
+            endpoint: endpoint.cloned(),
+        };
+        ResolvedModelMetadata {
+            policy,
+            catalog_entry,
         }
     }
 
@@ -750,6 +1273,57 @@ impl Default for BuiltInModelCatalog {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn record_origin(
+    evidence: &mut ModelMetadataEvidence,
+    field: ModelMetadataField,
+    origin: ModelMetadataOrigin,
+) {
+    evidence.fields.entry(field).or_insert(origin);
+}
+
+fn select_field<T, const N: usize>(
+    evidence: &mut ModelMetadataEvidence,
+    field: ModelMetadataField,
+    candidates: [(Option<T>, ModelMetadataOrigin); N],
+) -> Option<T> {
+    for (value, origin) in candidates {
+        if value.is_some() {
+            record_origin(evidence, field, origin);
+            return value;
+        }
+    }
+    None
+}
+
+fn resolve_capability_field(
+    evidence: &mut ModelMetadataEvidence,
+    field: ModelMetadataField,
+    explicit_override: Option<bool>,
+    discovered: Option<bool>,
+    route_builtin: Option<bool>,
+    model_builtin: Option<bool>,
+    unknown_fallback: Option<bool>,
+) -> bool {
+    select_field(
+        evidence,
+        field,
+        [
+            (explicit_override, ModelMetadataOrigin::ExplicitOverride),
+            (
+                discovered.filter(|value| *value),
+                ModelMetadataOrigin::RemoteDiscovered,
+            ),
+            (route_builtin, ModelMetadataOrigin::RouteBuiltin),
+            (model_builtin, ModelMetadataOrigin::ModelBuiltin),
+            (unknown_fallback, ModelMetadataOrigin::UnknownFallback),
+        ],
+    )
+    .unwrap_or_else(|| {
+        record_origin(evidence, field, ModelMetadataOrigin::Derived);
+        false
+    })
 }
 
 fn default_effective_context_window_percent() -> u8 {
@@ -4944,6 +5518,222 @@ mod tests {
     }
 
     #[test]
+    fn metadata_precedence_matrix_resolves_fields_independently_with_evidence() {
+        let catalog = BuiltInModelCatalog::new();
+        let model_ref = ModelRef::new(ProviderId::openai(), "matrix-model");
+        let mut model_builtin = catalog_model(
+            "openai",
+            "matrix-model",
+            "Model Builtin",
+            100_000,
+            6_000,
+            true,
+            false,
+        );
+        model_builtin.default_verbosity = Some(ModelVerbosity::High);
+        let mut route_builtin = model_builtin.clone();
+        route_builtin.display_name = "Route Builtin".into();
+        route_builtin.context_window_tokens = Some(120_000);
+        route_builtin.default_max_output_tokens = Some(4_000);
+        route_builtin.max_output_tokens_upper_limit = Some(8_000);
+        route_builtin.capabilities.image_input = true;
+        route_builtin.reasoning_effort_options = vec!["route".into()];
+        let mut discovered = model_builtin.clone();
+        discovered.display_name = "Remote Discovered".into();
+        discovered.description = "Remote description".into();
+        discovered.context_window_tokens = Some(200_000);
+        discovered.default_max_output_tokens = Some(16_000);
+        discovered.max_output_tokens_upper_limit = Some(16_000);
+        discovered.default_verbosity = Some(ModelVerbosity::Low);
+        discovered.capabilities.image_input = false;
+        discovered.reasoning_effort_options = vec!["remote".into()];
+        discovered.source = ModelMetadataSource::RemoteDiscovered;
+        let discovered_models = HashMap::from([(model_ref.clone(), discovered)]);
+        let overrides = HashMap::from([(
+            model_ref.clone(),
+            ModelRuntimeOverride {
+                display_name: Some("Explicit Override".into()),
+                runtime_max_output_tokens: Some(12_000),
+                verbosity: Some(ModelVerbosity::Medium),
+                capabilities: Some(ModelCapabilityOverride {
+                    image_input: Some(false),
+                    ..ModelCapabilityOverride::default()
+                }),
+                ..ModelRuntimeOverride::default()
+            },
+        )]);
+
+        let resolved = catalog.resolve_metadata(
+            &model_ref,
+            Some(&route_builtin),
+            Some(&model_builtin),
+            &overrides,
+            &discovered_models,
+            None,
+            &base_context(),
+            8_192,
+            Some(&ProviderEndpointId::default_endpoint()),
+        );
+        assert_eq!(
+            resolved.catalog_entry.default_max_output_tokens,
+            Some(8_000)
+        );
+        let policy = resolved.policy;
+
+        assert_eq!(policy.display_name, "Explicit Override");
+        assert_eq!(policy.description, "Remote description");
+        assert_eq!(policy.context_window_tokens, Some(200_000));
+        assert_eq!(policy.runtime_max_output_tokens, 8_000);
+        assert_eq!(policy.max_output_tokens_upper_limit, Some(8_000));
+        assert_eq!(policy.verbosity, Some(ModelVerbosity::Medium));
+        assert!(!policy.capabilities.image_input);
+        assert_eq!(policy.reasoning_effort_options, ["route"]);
+        assert_eq!(
+            policy.evidence.source_for(ModelMetadataField::DisplayName),
+            Some(ModelMetadataOrigin::ExplicitOverride)
+        );
+        assert_eq!(
+            policy.evidence.source_for(ModelMetadataField::Description),
+            Some(ModelMetadataOrigin::RemoteDiscovered)
+        );
+        assert_eq!(
+            policy
+                .evidence
+                .source_for(ModelMetadataField::ContextWindowTokens),
+            Some(ModelMetadataOrigin::RemoteDiscovered)
+        );
+        assert_eq!(
+            policy
+                .evidence
+                .source_for(ModelMetadataField::MaxOutputTokensUpperLimit),
+            Some(ModelMetadataOrigin::RouteBuiltin)
+        );
+        assert_eq!(
+            policy
+                .evidence
+                .source_for(ModelMetadataField::ReasoningEffortOptions),
+            Some(ModelMetadataOrigin::RouteBuiltin)
+        );
+        assert_eq!(
+            policy.evidence.constraints,
+            [ModelMetadataConstraint {
+                field: ModelMetadataField::RuntimeMaxOutputTokens,
+                kind: ModelMetadataConstraintKind::Clamped,
+                source: ModelMetadataConstraintSource::ModelUpperLimit,
+                requested: "12000".into(),
+                effective: "8000".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn capability_precedence_treats_discovered_false_as_unknown_but_preserves_explicit_false() {
+        let catalog = BuiltInModelCatalog::new();
+        let model_ref = ModelRef::new(ProviderId::openai(), "capability-matrix");
+        let mut route_builtin = catalog_model(
+            "openai",
+            "capability-matrix",
+            "Route",
+            100_000,
+            8_192,
+            true,
+            true,
+        );
+        route_builtin.capabilities.image_input = true;
+        let mut discovered = route_builtin.clone();
+        discovered.capabilities.image_input = false;
+        discovered.source = ModelMetadataSource::RemoteDiscovered;
+        let discovered_models = HashMap::from([(model_ref.clone(), discovered)]);
+
+        let route_selected = catalog.resolve_metadata(
+            &model_ref,
+            Some(&route_builtin),
+            None,
+            &HashMap::new(),
+            &discovered_models,
+            None,
+            &base_context(),
+            8_192,
+            Some(&ProviderEndpointId::default_endpoint()),
+        );
+        assert!(route_selected.policy.capabilities.image_input);
+        assert_eq!(
+            route_selected
+                .policy
+                .evidence
+                .source_for(ModelMetadataField::ImageInput),
+            Some(ModelMetadataOrigin::RouteBuiltin)
+        );
+
+        let overrides = HashMap::from([(
+            model_ref.clone(),
+            ModelRuntimeOverride {
+                capabilities: Some(ModelCapabilityOverride {
+                    image_input: Some(false),
+                    ..ModelCapabilityOverride::default()
+                }),
+                ..ModelRuntimeOverride::default()
+            },
+        )]);
+        let explicit_false = catalog.resolve_metadata(
+            &model_ref,
+            Some(&route_builtin),
+            None,
+            &overrides,
+            &discovered_models,
+            None,
+            &base_context(),
+            8_192,
+            Some(&ProviderEndpointId::default_endpoint()),
+        );
+        assert!(!explicit_false.policy.capabilities.image_input);
+        assert_eq!(
+            explicit_false
+                .policy
+                .evidence
+                .source_for(ModelMetadataField::ImageInput),
+            Some(ModelMetadataOrigin::ExplicitOverride)
+        );
+    }
+
+    #[test]
+    fn discovered_fixed_reasoning_preserves_an_explicit_empty_effort_contract() {
+        let catalog = BuiltInModelCatalog::new();
+        let model_ref = ModelRef::new(ProviderId::openai(), "fixed-reasoning");
+        let mut model_builtin = catalog_model(
+            "openai",
+            "fixed-reasoning",
+            "Fixed Reasoning",
+            100_000,
+            8_192,
+            true,
+            false,
+        );
+        model_builtin.reasoning_effort_options = vec!["low".into(), "high".into()];
+        let mut discovered = model_builtin.clone();
+        discovered.reasoning_effort_options.clear();
+        discovered.source = ModelMetadataSource::RemoteDiscovered;
+        let discovered_models = HashMap::from([(model_ref.clone(), discovered)]);
+
+        let policy = catalog.resolve_policy(
+            &model_ref,
+            &HashMap::new(),
+            &discovered_models,
+            None,
+            &base_context(),
+            8_192,
+        );
+
+        assert!(policy.reasoning_effort_options.is_empty());
+        assert_eq!(
+            policy
+                .evidence
+                .source_for(ModelMetadataField::ReasoningEffortOptions),
+            Some(ModelMetadataOrigin::RemoteDiscovered)
+        );
+    }
+
+    #[test]
     fn resolves_unknown_model_from_explicit_fallback() {
         let catalog = BuiltInModelCatalog::new();
         let policy = catalog.resolve_policy(
@@ -4963,6 +5753,12 @@ mod tests {
         assert_eq!(policy.compaction_trigger_estimated_tokens, 48_000);
         assert_eq!(policy.compaction_keep_recent_estimated_tokens, 24_000);
         assert_eq!(policy.source, ModelMetadataSource::UnknownFallback);
+        assert_eq!(
+            policy
+                .evidence
+                .source_for(ModelMetadataField::PromptBudgetEstimatedTokens),
+            Some(ModelMetadataOrigin::UnknownFallback)
+        );
     }
 
     #[test]
@@ -5015,7 +5811,7 @@ mod tests {
         );
 
         assert!(policy.capabilities.image_input);
-        assert_eq!(policy.source, ModelMetadataSource::UnknownFallback);
+        assert_eq!(policy.source, ModelMetadataSource::ConfigOverride);
     }
 
     #[test]
@@ -5062,6 +5858,7 @@ mod tests {
         );
         assert_eq!(policy.runtime_max_output_tokens, 131_072);
         assert_eq!(policy.max_output_tokens_upper_limit, Some(131_072));
+        assert!(policy.evidence.constraints.is_empty());
 
         // Override that exceeds the limit should also be clamped.
         let mut overrides = HashMap::new();
@@ -5081,6 +5878,16 @@ mod tests {
             8192,
         );
         assert_eq!(policy.runtime_max_output_tokens, 131_072);
+        assert_eq!(
+            policy.evidence.constraints,
+            [ModelMetadataConstraint {
+                field: ModelMetadataField::RuntimeMaxOutputTokens,
+                kind: ModelMetadataConstraintKind::Clamped,
+                source: ModelMetadataConstraintSource::ModelUpperLimit,
+                requested: "200000".into(),
+                effective: "131072".into(),
+            }]
+        );
     }
 
     #[test]

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -121,7 +121,7 @@ pub(crate) fn build_candidate_from_model_route(
             )?)
         }
         ProviderTransportKind::OpenAiChatCompletions => {
-            Arc::new(OpenAiChatCompletionsProvider::from_runtime_config(
+            Arc::new(OpenAiChatCompletionsProvider::from_resolved_runtime_config(
                 provider_config,
                 &model_ref.model,
                 max_output_tokens,

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -4,10 +4,7 @@ use serde_json::{json, Value};
 
 use crate::{
     auth::{load_codex_cli_credential, load_codex_oauth_profile_credential},
-    config::{
-        AppConfig, CredentialSource, ModelRouteCapability, ModelRouteRef, ProviderId,
-        RuntimeModelCatalog,
-    },
+    config::{AppConfig, CredentialSource, ModelRouteRef, ProviderId, RuntimeModelCatalog},
     context::ContextConfig,
     onboarding::{onboarding_report, search_diagnostics},
     types::{
@@ -327,16 +324,15 @@ fn resolved_model_availability_entry(
 ) -> ResolvedModelAvailability {
     let base_context = base_context_config(config);
     let model_ref = route_ref.model_ref();
-    let policy = catalog.resolved_model_policy(&base_context, Some(route_ref));
     let route = resolve_route_for_diagnostics(catalog, &base_context, route_ref);
-    let metadata_source = if config.validated_model_overrides.contains_key(&model_ref) {
-        "config_override".to_string()
-    } else {
-        serde_json::to_value(policy.source)
-            .ok()
-            .and_then(|value| value.as_str().map(ToString::to_string))
-            .unwrap_or_else(|| "unknown_fallback".to_string())
-    };
+    let policy = route
+        .as_ref()
+        .map(|route| route.policy.clone())
+        .unwrap_or_else(|| catalog.resolved_model_policy(&base_context, Some(route_ref)));
+    let metadata_source = serde_json::to_value(policy.source)
+        .ok()
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| "unknown_fallback".to_string());
     let route_provider = route
         .as_ref()
         .map(|route| route.endpoint.runtime_config.id.clone())
@@ -400,16 +396,8 @@ fn resolve_route_for_diagnostics(
     catalog: &RuntimeModelCatalog,
     base_context: &ContextConfig,
     route_ref: &ModelRouteRef,
-) -> Option<crate::config::ResolvedModelRoute> {
-    [
-        ModelRouteCapability::Turn,
-        ModelRouteCapability::ImageGeneration,
-        ModelRouteCapability::VisionObservation,
-    ]
-    .into_iter()
-    .find_map(|capability| {
-        catalog.resolve_explicit_model_route(base_context, route_ref, capability)
-    })
+) -> Option<crate::config::ResolvedModelRouteMetadata> {
+    catalog.resolve_explicit_model_metadata(base_context, route_ref)
 }
 
 fn provider_source_for_config(config: &AppConfig, provider_id: &ProviderId) -> String {
@@ -537,8 +525,9 @@ mod tests {
     };
 
     use super::{
-        provider_doctor, resolved_model_availability, resolved_model_providers,
-        resolved_model_providers_from_availability_for_runtime, resolved_provider_models,
+        base_context_config, provider_doctor, resolved_model_availability,
+        resolved_model_providers, resolved_model_providers_from_availability_for_runtime,
+        resolved_provider_models, RuntimeModelCatalog,
     };
 
     struct TestConfigFixture {
@@ -622,6 +611,18 @@ mod tests {
         assert_eq!(
             openai.policy.source,
             ModelMetadataSource::ConservativeBuiltin
+        );
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+        let route = catalog
+            .resolve_explicit_model_metadata(
+                &base_context_config(&fixture.config),
+                &fixture.config.default_model,
+            )
+            .expect("default OpenAI route should resolve");
+        assert_eq!(openai.policy, route.policy);
+        assert_eq!(
+            openai.resolved_capabilities.as_ref(),
+            Some(&route.capabilities)
         );
     }
 

--- a/src/provider/tests/openai_chat_completions.rs
+++ b/src/provider/tests/openai_chat_completions.rs
@@ -2,12 +2,15 @@
 
 use super::support::*;
 use super::*;
-use crate::config::{ModelRouteRef, ProviderId, ProviderTransportKind};
+use crate::config::{ModelRef, ModelRouteRef, ProviderId, ProviderTransportKind};
+use crate::model_catalog::{ModelRuntimeOverride, ModelVerbosity};
 use crate::provider::provider_transport_diagnostics;
 use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
-use crate::provider::transports::build_chat_completion_messages;
+use crate::provider::transports::{build_chat_completion_messages, OpenAiChatCompletionsProvider};
 use crate::tool::ToolSpec;
+use axum::{routing::post, Json, Router};
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn build_candidate_creates_chat_completions_provider() {
@@ -27,6 +30,59 @@ fn build_candidate_creates_chat_completions_provider() {
 
     assert_eq!(candidate.model_ref, "openai@default/gpt-5.4");
     assert_eq!(candidate.provider_name, "openai");
+}
+
+#[tokio::test]
+async fn chat_completions_from_config_uses_resolved_max_output_override_on_the_wire() {
+    let request_bodies = Arc::new(Mutex::new(Vec::new()));
+    let request_bodies_for_server = request_bodies.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/v1/chat/completions",
+        post(move |Json(body): Json<serde_json::Value>| {
+            let captured = request_bodies_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                Json(json!({
+                    "id": "chatcmpl-test",
+                    "choices": [{
+                        "message": { "role": "assistant", "content": "done" },
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2
+                    }
+                }))
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    let provider_config = fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap();
+    provider_config.base_url = base_url;
+    provider_config.transport = ProviderTransportKind::OpenAiChatCompletions;
+    fixture.config.validated_model_overrides.insert(
+        ModelRef::parse("openai/gpt-5.4").unwrap(),
+        ModelRuntimeOverride {
+            runtime_max_output_tokens: Some(1_234),
+            verbosity: Some(ModelVerbosity::Low),
+            ..ModelRuntimeOverride::default()
+        },
+    );
+    let provider = OpenAiChatCompletionsProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(ProviderTurnRequest::plain("hello", Vec::new(), Vec::new()))
+        .await
+        .unwrap();
+
+    let request_bodies = request_bodies.lock().unwrap();
+    assert_eq!(request_bodies[0]["max_tokens"], json!(1_234));
 }
 
 #[test]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -162,6 +162,46 @@ fn provider_large_window_request_with_prompt_frame() -> ProviderTurnRequest {
 }
 
 #[tokio::test]
+async fn openai_from_config_uses_resolved_max_output_override_on_the_wire() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = response_bodies_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                Json(openai_text_response("resp_1", "done"))
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    fixture.config.validated_model_overrides.insert(
+        ModelRef::parse("openai/gpt-5.4").unwrap(),
+        ModelRuntimeOverride {
+            runtime_max_output_tokens: Some(1_234),
+            ..ModelRuntimeOverride::default()
+        },
+    );
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let response_bodies = response_bodies.lock().unwrap();
+    assert_eq!(response_bodies[0]["max_output_tokens"], json!(1_234));
+}
+
+#[tokio::test]
 async fn openai_responses_lowers_user_image_to_input_image() {
     let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
     let response_bodies_for_server = response_bodies.clone();

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -21,11 +21,11 @@ use crate::{
     },
     config::{
         load_credential_store_at, save_credential_store_at, AppConfig, CredentialKind,
-        CredentialProfileFile, CredentialSource, ModelRef, ProviderBuiltinWebSearchConfig,
-        ProviderId, ProviderRuntimeConfig,
+        CredentialProfileFile, CredentialSource, ModelRef, ModelRouteRef,
+        ProviderBuiltinWebSearchConfig, ProviderId, ProviderRuntimeConfig, RuntimeModelCatalog,
     },
     context::ContextConfig,
-    model_catalog::{BuiltInModelCatalog, ModelVerbosity},
+    model_catalog::{ModelRuntimeOverride, ModelVerbosity},
     provider::{
         builtin_web_search_probe_turn_request, emitted_tool_json_schema,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
@@ -267,12 +267,15 @@ impl OpenAiProvider {
             .providers
             .get(&ProviderId::openai())
             .ok_or_else(|| anyhow::anyhow!("missing openai provider config"))?;
+        let policy = openai_model_policy_from_config(config, ProviderId::openai(), model);
         Self::from_runtime_config_with_compaction_policy(
             provider_config,
             model,
-            config.runtime_max_output_tokens,
+            policy.runtime_max_output_tokens,
             &config.home_dir,
-            openai_compaction_policy_from_config(config, ProviderId::openai(), model),
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+            },
         )
     }
 
@@ -282,12 +285,16 @@ impl OpenAiProvider {
         max_output_tokens: u32,
         trace_home_dir: &Path,
     ) -> Result<Self> {
+        let policy =
+            openai_model_policy_for_runtime_config(provider_config, model, max_output_tokens);
         Self::from_runtime_config_with_compaction_policy(
             provider_config,
             model,
-            max_output_tokens,
+            policy.runtime_max_output_tokens,
             trace_home_dir,
-            openai_compaction_policy_for_model(ProviderId::openai(), model, max_output_tokens),
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+            },
         )
     }
 
@@ -491,14 +498,17 @@ impl OpenAiCodexProvider {
             .providers
             .get(&ProviderId::openai_codex())
             .ok_or_else(|| anyhow::anyhow!("missing openai-codex provider config"))?;
+        let policy = openai_model_policy_from_config(config, ProviderId::openai_codex(), model);
         Self::from_runtime_config_with_compaction_policy(
             provider_config,
             model,
-            config.runtime_max_output_tokens,
+            policy.runtime_max_output_tokens,
             &config.home_dir,
-            openai_compaction_policy_from_config(config, ProviderId::openai_codex(), model),
-            openai_verbosity_from_config(config, ProviderId::openai_codex(), model),
-            false,
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+            },
+            policy.verbosity,
+            policy.capabilities.supports_reasoning,
         )
     }
 
@@ -509,17 +519,17 @@ impl OpenAiCodexProvider {
         trace_home_dir: &Path,
         supports_reasoning: bool,
     ) -> Result<Self> {
+        let policy =
+            openai_model_policy_for_runtime_config(provider_config, model, max_output_tokens);
         Self::from_runtime_config_with_compaction_policy(
             provider_config,
             model,
-            max_output_tokens,
+            policy.runtime_max_output_tokens,
             trace_home_dir,
-            openai_compaction_policy_for_model(
-                ProviderId::openai_codex(),
-                model,
-                max_output_tokens,
-            ),
-            openai_verbosity_for_model(ProviderId::openai_codex(), model, max_output_tokens),
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+            },
+            policy.verbosity,
             supports_reasoning,
         )
     }
@@ -828,25 +838,6 @@ fn resolve_openai_codex_credential(
     })
 }
 
-fn openai_compaction_policy_from_config(
-    config: &AppConfig,
-    provider: ProviderId,
-    model: &str,
-) -> OpenAiCompactionPolicy {
-    let policy = openai_model_policy_from_config(config, provider, model);
-    OpenAiCompactionPolicy {
-        trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
-    }
-}
-
-fn openai_verbosity_from_config(
-    config: &AppConfig,
-    provider: ProviderId,
-    model: &str,
-) -> Option<ModelVerbosity> {
-    openai_model_policy_from_config(config, provider, model).verbosity
-}
-
 fn openai_model_policy_from_config(
     config: &AppConfig,
     provider: ProviderId,
@@ -864,49 +855,46 @@ fn openai_model_policy_from_config(
         max_relevant_episodes: config.max_relevant_episodes,
         ..ContextConfig::default()
     };
-    BuiltInModelCatalog::default().resolve_policy(
-        &ModelRef::new(provider, model),
-        &config.validated_model_overrides,
-        &config.model_discovery_cache.models(),
-        config.validated_unknown_model_fallback.as_ref(),
-        &base_context_config,
-        config.runtime_max_output_tokens,
-    )
+    let route_ref = config
+        .providers
+        .get(&provider)
+        .map(|provider_config| {
+            ModelRouteRef::new(
+                provider_config.route_provider.clone(),
+                provider_config.route_endpoint.clone(),
+                model,
+            )
+        })
+        .unwrap_or_else(|| ModelRouteRef::from_legacy_model_ref(&ModelRef::new(provider, model)));
+    RuntimeModelCatalog::from_config(config)
+        .resolved_model_policy(&base_context_config, Some(&route_ref))
 }
 
-fn openai_compaction_policy_for_model(
-    provider: ProviderId,
+fn openai_model_policy_for_runtime_config(
+    provider_config: &ProviderRuntimeConfig,
     model: &str,
     max_output_tokens: u32,
-) -> OpenAiCompactionPolicy {
-    let policy = BuiltInModelCatalog::default().resolve_policy(
-        &ModelRef::new(provider, model),
-        &Default::default(),
-        &Default::default(),
-        None,
-        &ContextConfig::default(),
-        max_output_tokens,
+) -> crate::model_catalog::ResolvedRuntimeModelPolicy {
+    let model_ref = ModelRef::new(provider_config.route_provider.clone(), model);
+    let route_ref = ModelRouteRef::new(
+        provider_config.route_provider.clone(),
+        provider_config.route_endpoint.clone(),
+        model,
     );
-    OpenAiCompactionPolicy {
-        trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+    let mut model_overrides = HashMap::new();
+    model_overrides.insert(
+        model_ref,
+        ModelRuntimeOverride {
+            runtime_max_output_tokens: Some(max_output_tokens),
+            ..ModelRuntimeOverride::default()
+        },
+    );
+    RuntimeModelCatalog {
+        model_overrides,
+        configured_runtime_max_output_tokens: max_output_tokens,
+        ..RuntimeModelCatalog::default()
     }
-}
-
-fn openai_verbosity_for_model(
-    provider: ProviderId,
-    model: &str,
-    max_output_tokens: u32,
-) -> Option<ModelVerbosity> {
-    BuiltInModelCatalog::default()
-        .resolve_policy(
-            &ModelRef::new(provider, model),
-            &Default::default(),
-            &Default::default(),
-            None,
-            &ContextConfig::default(),
-            max_output_tokens,
-        )
-        .verbosity
+    .resolved_model_policy(&ContextConfig::default(), Some(&route_ref))
 }
 
 impl OpenAiChatCompletionsProvider {
@@ -915,10 +903,11 @@ impl OpenAiChatCompletionsProvider {
             .providers
             .get(&ProviderId::openai())
             .ok_or_else(|| anyhow::anyhow!("missing openai provider config"))?;
-        Self::from_runtime_config(
+        let policy = openai_model_policy_from_config(config, ProviderId::openai(), model);
+        Self::from_resolved_runtime_config(
             provider_config,
             model,
-            config.runtime_max_output_tokens,
+            policy.runtime_max_output_tokens,
             &config.home_dir,
         )
     }
@@ -927,6 +916,22 @@ impl OpenAiChatCompletionsProvider {
         provider_config: &ProviderRuntimeConfig,
         model: &str,
         max_output_tokens: u32,
+        trace_home_dir: &Path,
+    ) -> Result<Self> {
+        let policy =
+            openai_model_policy_for_runtime_config(provider_config, model, max_output_tokens);
+        Self::from_resolved_runtime_config(
+            provider_config,
+            model,
+            policy.runtime_max_output_tokens,
+            trace_home_dir,
+        )
+    }
+
+    pub(crate) fn from_resolved_runtime_config(
+        provider_config: &ProviderRuntimeConfig,
+        model: &str,
+        resolved_max_output_tokens: u32,
         trace_home_dir: &Path,
     ) -> Result<Self> {
         let client = build_http_client()?;
@@ -955,7 +960,7 @@ impl OpenAiChatCompletionsProvider {
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             api_key,
             model: model.to_string(),
-            max_output_tokens,
+            max_output_tokens: resolved_max_output_tokens,
             trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
@@ -5744,12 +5749,12 @@ mod tests {
         chat_completions_url, choose_openai_codex_credential, consume_openai_sse_event,
         incremental_diagnostics, latest_openai_compaction_index, native_web_search_diagnostics,
         openai_compaction_trigger_for_request_plan, openai_compaction_trigger_for_window,
-        openai_provider_window_compaction_candidate,
+        openai_model_policy_for_runtime_config, openai_provider_window_compaction_candidate,
         parse_openai_codex_image_generation_response_items, plan_openai_responses_request,
-        resolve_openai_codex_credential, CredentialStoreRefreshLock, OpenAiCodexProvider,
-        OpenAiCompactionPolicy, OpenAiContinuationState, OpenAiProvider, OpenAiProviderWindow,
-        OpenAiRequestPlan, OpenAiRequestShape, OpenAiResponsesContinuationContract,
-        OpenAiResponsesTransportContract, ToolSchemaContract,
+        resolve_openai_codex_credential, CredentialStoreRefreshLock, OpenAiChatCompletionsProvider,
+        OpenAiCodexProvider, OpenAiCompactionPolicy, OpenAiContinuationState, OpenAiProvider,
+        OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
+        OpenAiResponsesContinuationContract, OpenAiResponsesTransportContract, ToolSchemaContract,
     };
     use crate::auth::CodexCliCredential;
     use crate::config::{
@@ -5857,6 +5862,38 @@ mod tests {
             context_management: Default::default(),
             builtin_web_search: None,
         }
+    }
+
+    #[test]
+    fn runtime_config_policy_preserves_exact_route_and_explicit_output_limit() {
+        let mut config = test_openai_codex_config(Some("credential".into()));
+        config.route_provider = ProviderId::parse("volcengine").unwrap();
+        config.route_endpoint = ProviderEndpointId::parse("plan").unwrap();
+
+        let clamped = openai_model_policy_for_runtime_config(&config, "glm-5.2", 200_000);
+        assert_eq!(clamped.runtime_max_output_tokens, 128_000);
+        assert_eq!(clamped.reasoning_effort_options, ["low", "medium", "high"]);
+
+        let explicit = openai_model_policy_for_runtime_config(&config, "glm-5.2", 1_024);
+        assert_eq!(explicit.runtime_max_output_tokens, 1_024);
+    }
+
+    #[test]
+    fn chat_completions_resolved_runtime_config_does_not_resolve_metadata_again() {
+        let mut config = test_openai_codex_config(Some("credential".into()));
+        config.route_provider = ProviderId::parse("volcengine").unwrap();
+        config.route_endpoint = ProviderEndpointId::parse("plan").unwrap();
+        let home = tempfile::tempdir().unwrap();
+
+        let provider = OpenAiChatCompletionsProvider::from_resolved_runtime_config(
+            &config,
+            "glm-5.2",
+            200_000,
+            home.path(),
+        )
+        .unwrap();
+
+        assert_eq!(provider.max_output_tokens, 200_000);
     }
 
     #[test]

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -259,6 +259,7 @@ mod tests {
                 .then(|| vec!["low".into(), "medium".into(), "high".into()])
                 .unwrap_or_default(),
             source: ModelMetadataSource::BuiltInCatalog,
+            evidence: Default::default(),
         }
     }
 

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -3820,6 +3820,7 @@ mod tests {
                     },
                     reasoning_effort_options: Vec::new(),
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
+                    evidence: Default::default(),
                 },
             },
             token_usage: AgentTokenUsageSummary {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1120,6 +1120,7 @@ mod tests {
                     },
                     reasoning_effort_options: Vec::new(),
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
+                    evidence: Default::default(),
                 },
             },
             token_usage: AgentTokenUsageSummary {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -244,6 +244,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
                 },
                 reasoning_effort_options: Vec::new(),
                 source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
+                evidence: Default::default(),
             },
         },
         token_usage: AgentTokenUsageSummary {
@@ -332,6 +333,7 @@ fn sample_model_availability(
                 .then(|| vec!["low".into(), "medium".into(), "high".into()])
                 .unwrap_or_default(),
             source: crate::model_catalog::ModelMetadataSource::RemoteDiscovered,
+            evidence: Default::default(),
         },
         resolved_capabilities: None,
     }


### PR DESCRIPTION
## 变更摘要

- 增加 focused RFC，定义字段分类 precedence matrix、解析阶段、transport constraint 与 evidence contract
- 建立唯一字段级 Model metadata resolver，统一 override、discovery、route/model builtin 与 fallback 的来源竞争
- 将 transport capability 作为最终约束，记录 clamp/disable evidence，并迁移 diagnostics、available-model projection、provider catalog、TUI 与 OpenAI 兼容入口
- 增加矩阵测试与回归测试，确保 Chat Completions 不再重复解析 metadata

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --lib`（2293 passed，1 ignored）
- `git diff --check`

Closes #2267
