### PR TITLE
refactor: 将 Context 构建拆为 candidate、priority 与 budget planner

### DIFF
--- a/docs/rfcs/context-candidate-budget-planner.md
+++ b/docs/rfcs/context-candidate-budget-planner.md
@@ -1,0 +1,177 @@
+---
+title: RFC: Context Candidate Budget Planner
+date: 2026-07-17
+status: accepted
+issue:
+  - 2268
+---
+
+# Context Candidate Budget Planner
+
+This RFC defines the selection boundary between runtime context projection and
+final prompt rendering.
+
+It extends:
+
+- [Continuation Anchor](./continuation-anchor.md)
+- [Turn-Based Context Projection](./turn-based-context-projection.md)
+- [Debug Prompt JSON Envelope](./debug-prompt-json-envelope.md)
+
+## 1. Problem
+
+Context assembly previously rendered and appended sections while decrementing a
+shared budget. The append order therefore acted as an implicit priority and
+drop policy. Only `current_input` had a separate reservation, so focused
+WorkItem truth and a trusted continuation anchor could be displaced by sections
+that happened to be rendered first.
+
+The final section list also preserved only the selected result. It did not
+record why a considered section was kept, compacted, truncated, or omitted.
+
+## 2. Goals
+
+- Separate candidate collection, budget selection, and final render order.
+- Make pinned state, retention priority, drop tier, and render order explicit.
+- Produce the same plan for the same candidates regardless of collection order.
+- Keep `current_input`, focused `current_work_item`, and
+  `continuation_anchor` at a defined minimum representation when they exist.
+- Record typed budget decisions for every considered candidate.
+- Preserve the existing total context hard cap and provider wire protocol.
+
+## 3. Non-Goals
+
+- Do not replace all context domain payloads with one large enum.
+- Do not change the recent-turn semantic selector or reduce it to string FIFO.
+- Do not define the complete debug prompt JSON envelope.
+- Do not unify context, system, tool, and turn-local continuation budgets.
+- Do not make every diagnostic section pinned.
+
+## 4. Candidate Contract
+
+A `ContextCandidate` is a section-level typed envelope. It contains:
+
+- a stable candidate id, shared with the final section id
+- the section stability and rendered full representation
+- an optional compact representation
+- a policy containing:
+  - `pinned`
+  - retention priority
+  - drop tier
+  - render order
+
+Candidate ids must be non-empty and unique. A compact representation must keep
+the same id as its full representation.
+
+Pinned candidates must provide a compact representation. The compact form is
+the minimum truthful representation, not an arbitrary substring selected after
+other sections consume the budget.
+
+## 5. Initial Pinned Set
+
+The following candidates are pinned when present:
+
+1. `current_input`
+2. focused `current_work_item`
+3. `continuation_anchor`
+
+Their compact forms preserve:
+
+- the current input provenance/header and a bounded input body
+- the focused WorkItem id and objective
+- the trusted operator relation or bounded continuation anchor
+
+Absence is not synthesized as pinned truth. For example, the explicit
+`current_work_item: none` section remains a normal candidate.
+
+## 6. Deterministic Planning
+
+Planning follows these phases:
+
+1. validate ids, compact ids, and pinned compact availability
+2. calculate the total pinned minimum
+3. reserve every pinned compact representation
+4. allocate remaining budget by explicit selection keys
+5. emit final sections using independent render-order keys
+
+Selection keys are:
+
+1. pinned before non-pinned
+2. higher retention priority first
+3. later-drop tiers before earlier-drop tiers
+4. stable candidate id as the final tie-break
+
+Collection or insertion order is never a tie-break.
+
+Render keys are:
+
+1. explicit render order
+2. stable candidate id
+
+This keeps model-facing section layout independent from retention priority.
+
+## 7. Outcomes And Evidence
+
+Each candidate produces one `ContextPlanDecision` containing:
+
+- candidate id and section name
+- requested estimated tokens
+- minimum estimated tokens
+- allocated estimated tokens
+- outcome
+- typed reason code
+
+Initial outcomes are:
+
+- `full`
+- `compact`
+- `truncated`
+- `omitted`
+
+Initial reason codes include:
+
+- `selected_full`
+- `selected_compact_for_pinned_minimum`
+- `selected_compact_for_budget`
+- `truncated_to_remaining_budget`
+- `omitted_lower_priority`
+- `omitted_drop_tier`
+
+Decision evidence is runtime-internal prompt metadata. The human debug prompt
+dump displays it, but this RFC does not change provider request lowering or
+stabilize the draft JSON debug envelope.
+
+## 8. Over-Budget Failure
+
+If the sum of pinned compact representations exceeds the total context budget,
+planning fails closed with `pinned_minimum_over_budget`.
+
+The diagnostic includes:
+
+- total budget
+- required pinned minimum
+
+The planner must not silently omit a pinned candidate or exceed the hard cap.
+This is the narrow Context build error boundary; it does not introduce a global
+runtime error taxonomy.
+
+## 9. Recent-Turn Boundary
+
+`recent_turns` remains a semantic projection built from turn records and linked
+runtime evidence. Its full and compact candidates are produced by rerunning the
+existing semantic projection with different budgets.
+
+Turn-local recovery may still reproject `recent_turns` with a smaller budget.
+That recovery must rebuild the rendered prompt and update the corresponding
+planning evidence rather than truncating the section as an opaque string.
+
+## 10. Compatibility
+
+- Final context remains within `prompt_budget_estimated_tokens`.
+- `PromptStability` remains attached to the selected representation.
+- Prompt cache fingerprints continue to derive from final selected sections.
+- Provider request wire shapes do not change.
+- Existing section ids remain stable.
+
+Tests must cover pinned minimum boundaries, order independence, selection versus
+render ordering, all outcomes, debug evidence, recent-turn reprojection, and
+the total hard cap.

--- a/src/context/budget.rs
+++ b/src/context/budget.rs
@@ -13,11 +13,6 @@ pub(super) fn estimate_text_tokens(text: &str) -> usize {
     chars.div_ceil(4).max(1)
 }
 
-/// Reserve a portion of the total budget for the current input section.
-pub(super) fn reserve_current_input_budget(total_budget: usize) -> usize {
-    total_budget.min(256)
-}
-
 /// Truncate text to fit within a token budget, optionally appending a truncation
 /// notice. Uses binary search to find the maximum character count that fits.
 pub(super) fn truncate_section_content(

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,14 +1,21 @@
 //! Context assembly: builds prompt sections from runtime state.
 mod budget;
+mod planner;
 mod render;
+pub(crate) use planner::ContextPlanEvidence;
+#[cfg(test)]
+pub(crate) use planner::{ContextPlanDecision, ContextPlanOutcome, ContextPlanReason};
 // Re-import budget helpers for use within this module.
-use budget::{estimate_text_tokens, reserve_current_input_budget, truncate_section_content};
+use budget::{estimate_text_tokens, truncate_section_content};
+use planner::{
+    plan_context, ContextCandidate, ContextCandidatePolicy, DropTier, RetentionPriority,
+};
 // Re-import render helpers for use within this module.
 #[cfg(test)]
 use render::trust_label;
 use render::{
     body_preview, bounded_inline, enum_label, indent_block, message_body_text, message_header,
-    push_budgeted_section, sanitize_inline, section, turn_section,
+    sanitize_inline, section, turn_section,
 };
 
 use std::cmp::Ordering;
@@ -91,6 +98,7 @@ impl ContextConfig {
 #[derive(Debug, Clone)]
 pub struct BuiltContext {
     pub sections: Vec<PromptSection>,
+    pub(crate) plan_evidence: ContextPlanEvidence,
     pub(crate) recent_turns_reprojection: Option<RecentTurnsReprojection>,
 }
 
@@ -152,6 +160,46 @@ pub fn build_context(
     )
 }
 
+fn context_candidate(
+    full: PromptSection,
+    compact: Option<PromptSection>,
+    pinned: bool,
+) -> ContextCandidate {
+    let policy = context_candidate_policy(&full.id, pinned);
+    ContextCandidate::new(full, compact, policy)
+}
+
+fn context_candidate_policy(id: &str, pinned: bool) -> ContextCandidatePolicy {
+    let (priority, drop_tier, render_order) = match id {
+        "agent" => (RetentionPriority::High, DropTier::Last, 10),
+        "default_external_ingress" => (RetentionPriority::Normal, DropTier::Normal, 20),
+        "execution_environment" => (RetentionPriority::High, DropTier::Last, 30),
+        "active_tasks" => (RetentionPriority::High, DropTier::Late, 40),
+        "current_work_item" => (RetentionPriority::Critical, DropTier::Last, 50),
+        "current_work_refs" => (RetentionPriority::High, DropTier::Late, 60),
+        "relevant_episode_memory" => (RetentionPriority::Normal, DropTier::Normal, 70),
+        "current_work_item_process_trace" => (RetentionPriority::Normal, DropTier::Normal, 80),
+        "queued_blocked_work_items" => (RetentionPriority::Normal, DropTier::Normal, 90),
+        "worktree_session" => (RetentionPriority::Normal, DropTier::Late, 100),
+        "agent_templates_catalog" => (RetentionPriority::Low, DropTier::Early, 110),
+        "skills_catalog" => (RetentionPriority::Low, DropTier::Early, 120),
+        "active_skills" => (RetentionPriority::Normal, DropTier::Normal, 130),
+        "agent_home_notes_catalog" => (RetentionPriority::Low, DropTier::Early, 140),
+        "context_contract" => (RetentionPriority::High, DropTier::Last, 150),
+        "continuation_anchor" => (RetentionPriority::Critical, DropTier::Last, 160),
+        "recent_turns" => (RetentionPriority::High, DropTier::Late, 170),
+        "continuation_context" => (RetentionPriority::High, DropTier::Last, 180),
+        "current_input" => (RetentionPriority::Critical, DropTier::Last, 190),
+        _ => (RetentionPriority::Normal, DropTier::Normal, u16::MAX),
+    };
+    ContextCandidatePolicy {
+        pinned,
+        priority,
+        drop_tier,
+        render_order,
+    }
+}
+
 pub fn build_context_with_default_external_ingress(
     storage: &AppStorage,
     agent: &AgentState,
@@ -185,35 +233,28 @@ pub fn build_context_with_default_external_ingress(
     let work_queue_projection = storage.work_queue_prompt_projection()?;
     let current_work_item = work_queue_projection.current.as_ref();
 
-    let current_input_reserved_budget =
-        reserve_current_input_budget(config.prompt_budget_estimated_tokens);
-    let mut sections = Vec::new();
-    let mut remaining_budget = config
-        .prompt_budget_estimated_tokens
-        .saturating_sub(current_input_reserved_budget);
-    push_budgeted_section(
-        &mut sections,
-        &mut remaining_budget,
+    let mut candidates = Vec::new();
+    candidates.push(context_candidate(
         section("agent", format!("Agent id: {}", agent.id)),
-    );
+        None,
+        false,
+    ));
     let default_ingress = match default_external_ingress_override {
         Some(record) => Some(record.clone()),
         None => default_external_ingress(storage, &agent.id)?,
     };
     if let Some(default_ingress) = default_ingress {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section(
                 "default_external_ingress",
                 render_default_external_ingress(&config.callback_base_url, &default_ingress),
             ),
-        );
+            None,
+            false,
+        ));
     }
     let execution_summary = execution_policy_summary_lines(execution).join("\n");
-    push_budgeted_section(
-        &mut sections,
-        &mut remaining_budget,
+    candidates.push(context_candidate(
         section(
             "execution_environment",
             format!(
@@ -222,43 +263,48 @@ pub fn build_context_with_default_external_ingress(
                 execution_summary,
             ),
         ),
-    );
+        None,
+        false,
+    ));
     let active_task_count = storage.active_task_count_for_agent(&agent.id)?;
     if active_task_count > 0 {
         let active_tasks =
             storage.latest_active_task_records_for_agent(&agent.id, ACTIVE_TASKS_CONTEXT_LIMIT)?;
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section(
                 "active_tasks",
                 render_active_tasks(&active_tasks, active_task_count),
             ),
-        );
+            None,
+            false,
+        ));
     }
 
     if let Some(work_item) = current_work_item {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             turn_section(
                 "current_work_item",
                 render_current_work_item(work_item, storage.data_dir(), &active_wait_conditions),
             ),
-        );
+            Some(turn_section(
+                "current_work_item",
+                render_compact_current_work_item(work_item),
+            )),
+            true,
+        ));
         if let Some(content) = render_current_work_refs(work_item) {
-            push_budgeted_section(
-                &mut sections,
-                &mut remaining_budget,
+            candidates.push(context_candidate(
                 turn_section("current_work_refs", content),
-            );
+                None,
+                false,
+            ));
         }
     } else {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             turn_section("current_work_item", render_empty_current_work_item()),
-        );
+            None,
+            false,
+        ));
     }
 
     let recent_turn_window_start = recent_turn_window_start(&turn_records);
@@ -268,44 +314,42 @@ pub fn build_context_with_default_external_ingress(
         current_work_item,
         current_message,
         config,
-        remaining_budget,
+        config.prompt_budget_estimated_tokens,
         recent_turn_window_start,
     ) {
-        push_budgeted_section(&mut sections, &mut remaining_budget, section);
+        candidates.push(context_candidate(section, None, false));
     }
 
     if let Some(work_item) = current_work_item {
         if let Some(content) =
             render_current_work_item_process_trace(work_item, &briefs, &tools, &transcript)
         {
-            push_budgeted_section(
-                &mut sections,
-                &mut remaining_budget,
+            candidates.push(context_candidate(
                 turn_section("current_work_item_process_trace", content),
-            );
+                None,
+                false,
+            ));
         }
     }
 
     if work_queue_projection.has_non_current_candidates() {
-        let candidates = render_work_item_candidates(
+        let rendered_candidates = render_work_item_candidates(
             &work_queue_projection,
             storage,
             &agent.id,
             storage.data_dir(),
         )?;
-        if let Some(content) = candidates {
-            push_budgeted_section(
-                &mut sections,
-                &mut remaining_budget,
+        if let Some(content) = rendered_candidates {
+            candidates.push(context_candidate(
                 turn_section("queued_blocked_work_items", content),
-            );
+                None,
+                false,
+            ));
         }
     }
 
     if let Some(worktree) = &agent.worktree_session {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section(
                 "worktree_session",
                 format!(
@@ -320,7 +364,9 @@ pub fn build_context_with_default_external_ingress(
                     worktree.worktree_branch
                 ),
             ),
-        );
+            None,
+            false,
+        ));
     }
 
     if !skills.agent_templates_catalog.is_empty() {
@@ -356,14 +402,14 @@ pub fn build_context_with_default_external_ingress(
             })
             .collect::<Vec<_>>()
             .join("\n");
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section(
                 "agent_templates_catalog",
                 format!("Discovered agent templates catalog:\n{rendered}"),
             ),
-        );
+            None,
+            false,
+        ));
     }
 
     if !skills.discoverable_skills.is_empty() {
@@ -381,16 +427,16 @@ pub fn build_context_with_default_external_ingress(
             })
             .collect::<Vec<_>>()
             .join("\n");
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section(
                 "skills_catalog",
                 format!(
                     "Discovered skills catalog (same-name precedence: agent > workspace > user; lower-precedence duplicates are omitted):\n{rendered}"
                 ),
             ),
-        );
+            None,
+            false,
+        ));
     }
 
     if !skills.active_skills.is_empty() {
@@ -409,60 +455,72 @@ pub fn build_context_with_default_external_ingress(
             })
             .collect::<Vec<_>>()
             .join("\n");
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section(
                 "active_skills",
                 format!("Active skills (same-name precedence follows skills_catalog):\n{rendered}"),
             ),
-        );
+            None,
+            false,
+        ));
     }
 
     if let Some(notes_content) =
         crate::notes_catalog::render_agent_home_notes_catalog_section(agent_home)
     {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        candidates.push(context_candidate(
             section("agent_home_notes_catalog", notes_content),
-        );
+            None,
+            false,
+        ));
     }
 
-    push_budgeted_section(
-        &mut sections,
-        &mut remaining_budget,
+    candidates.push(context_candidate(
         section(
             "context_contract",
             "Interpret the memory block with this priority: current work item objective first, durable plan artifact second, todo_list third, and current work refs after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and plan artifact as the ground truth unless the current input explicitly changes it."
                 .to_string(),
         ),
-    );
+        None,
+        false,
+    ));
 
     if let Some(anchor) = render_continuation_anchor(
         &continuation_anchor_messages,
         current_message,
         continuation,
         current_work_item,
-        remaining_budget,
+        config.prompt_budget_estimated_tokens,
     ) {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        let compact_anchor = render_continuation_anchor(
+            &continuation_anchor_messages,
+            current_message,
+            continuation,
+            current_work_item,
+            48,
+        )
+        .expect("full continuation anchor implies compact continuation anchor");
+        candidates.push(context_candidate(
             turn_section("continuation_anchor", anchor),
-        );
+            Some(turn_section("continuation_anchor", compact_anchor)),
+            true,
+        ));
     }
 
-    let recent_turns_budget = remaining_budget.min(config.turn_projection_budget());
-    let recent_turns_reprojection = (!turn_records.is_empty()).then(|| RecentTurnsReprojection {
-        turn_records: turn_records.clone(),
-        messages: messages.clone(),
-        briefs: briefs.clone(),
-        tools: tools.clone(),
-        current_message: current_message.clone(),
-        current_work_item: current_work_item.cloned(),
-        initial_budget: recent_turns_budget,
-    });
+    let recent_turns_budget = config
+        .prompt_budget_estimated_tokens
+        .min(config.turn_projection_budget());
+    let recent_turns_compact_budget = recent_turns_budget.min(128);
+    let mut recent_turns_reprojection =
+        (!turn_records.is_empty()).then(|| RecentTurnsReprojection {
+            turn_records: turn_records.clone(),
+            messages: messages.clone(),
+            briefs: briefs.clone(),
+            tools: tools.clone(),
+            current_message: current_message.clone(),
+            current_work_item: current_work_item.cloned(),
+            initial_budget: recent_turns_budget,
+        });
     if let Some(content) = render_recent_turns_with_budget(
         storage,
         &turn_records,
@@ -473,48 +531,82 @@ pub fn build_context_with_default_external_ingress(
         current_work_item,
         recent_turns_budget,
     ) {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
+        let compact = render_recent_turns_with_budget(
+            storage,
+            &turn_records,
+            &messages,
+            &briefs,
+            &tools,
+            current_message,
+            current_work_item,
+            recent_turns_compact_budget,
+        )
+        .map(|content| turn_section("recent_turns", content));
+        candidates.push(context_candidate(
             turn_section("recent_turns", content),
-        );
+            compact,
+            false,
+        ));
     }
 
-    let continuation_pushed =
+    let continuation_present =
         if let Some(content) = continuation_context(current_message, continuation) {
-            push_budgeted_section(
-                &mut sections,
-                &mut remaining_budget,
+            candidates.push(context_candidate(
                 turn_section("continuation_context", content),
-            )
+                None,
+                false,
+            ));
+            true
         } else {
             false
         };
 
-    let mut current_input_budget = current_input_reserved_budget.saturating_add(remaining_budget);
-    let current_input_body = render_current_input_body_with_budget(
-        &current_message.body,
-        current_input_budget,
-        (!continuation_pushed)
-            .then(|| render_wake_hint_context(current_message))
-            .flatten()
-            .as_deref(),
+    let wake_hint_fallback = (!continuation_present)
+        .then(|| render_wake_hint_context(current_message))
+        .flatten();
+    let current_input_full = render_current_input_section(
+        current_message,
+        config.prompt_budget_estimated_tokens,
+        wake_hint_fallback.as_deref(),
     );
-    push_budgeted_section(
-        &mut sections,
-        &mut current_input_budget,
-        turn_section(
-            "current_input",
-            format!(
-                "Current input:\n- {}\n{}",
-                message_header(current_message),
-                indent_block(&current_input_body, 2),
-            ),
-        ),
-    );
+    let current_input_compact =
+        render_current_input_section(current_message, 48, wake_hint_fallback.as_deref());
+    candidates.push(context_candidate(
+        current_input_full,
+        Some(current_input_compact),
+        true,
+    ));
+
+    let plan = plan_context(candidates, config.prompt_budget_estimated_tokens)?;
+    let drop_recent_turns_reprojection =
+        if let Some(reprojection) = recent_turns_reprojection.as_mut() {
+            match plan
+                .evidence
+                .decisions
+                .iter()
+                .find(|decision| decision.candidate_id == "recent_turns")
+            {
+                Some(decision) if decision.outcome == planner::ContextPlanOutcome::Full => false,
+                Some(decision) if decision.outcome == planner::ContextPlanOutcome::Compact => {
+                    reprojection.initial_budget = recent_turns_compact_budget;
+                    false
+                }
+                Some(decision) if decision.outcome == planner::ContextPlanOutcome::Truncated => {
+                    reprojection.initial_budget = decision.allocated_estimated_tokens;
+                    false
+                }
+                _ => true,
+            }
+        } else {
+            false
+        };
+    if drop_recent_turns_reprojection {
+        recent_turns_reprojection = None;
+    }
 
     Ok(BuiltContext {
-        sections,
+        sections: plan.sections,
+        plan_evidence: plan.evidence,
         recent_turns_reprojection,
     })
 }
@@ -888,6 +980,14 @@ fn render_current_work_item(
         }));
     }
     lines.join("\n")
+}
+
+fn render_compact_current_work_item(work_item: &WorkItemRecord) -> String {
+    format!(
+        "Current work item:\n- Id: {}\n- Objective: {}",
+        work_item.id,
+        bounded_inline(&work_item.objective, 96)
+    )
 }
 
 fn render_empty_current_work_item() -> String {
@@ -1487,8 +1587,28 @@ fn render_current_input_body_with_budget(
     truncate_section_content(
         "",
         &rendered,
-        budget.max(64),
+        budget.max(16),
         Some("\n[truncated current input body]"),
+    )
+}
+
+fn render_current_input_section(
+    current_message: &MessageEnvelope,
+    body_budget: usize,
+    wake_hint_fallback: Option<&str>,
+) -> PromptSection {
+    let current_input_body = render_current_input_body_with_budget(
+        &current_message.body,
+        body_budget,
+        wake_hint_fallback,
+    );
+    turn_section(
+        "current_input",
+        format!(
+            "Current input:\n- {}\n{}",
+            message_header(current_message),
+            indent_block(&current_input_body, 2),
+        ),
     )
 }
 
@@ -6840,6 +6960,241 @@ mod tests {
             .content
             .contains("Implement continuation anchor runtime behavior"));
         assert!(!anchor.content.contains("Current WorkItem"));
+    }
+
+    #[test]
+    fn build_context_preserves_pinned_truth_at_exact_minimum_and_fails_below_it() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+
+        let operator_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Preserve this trusted operator intent for the active implementation."
+                    .repeat(8),
+            },
+        );
+        storage.append_message(&operator_message).unwrap();
+
+        let active = crate::types::WorkItemRecord::new(
+            "default",
+            "Implement the deterministic context budget planner without losing durable truth."
+                .repeat(6),
+            crate::types::WorkItemState::Open,
+        );
+        storage.append_work_item(&active).unwrap();
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some(active.id.clone());
+        storage.write_agent(&agent).unwrap();
+
+        let mut system_tick = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_queue".to_string(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue the focused work item after a runtime scheduling wake.".repeat(8),
+            },
+        );
+        system_tick.trigger_kind = Some(ContinuationTriggerKind::SystemTick);
+        let continuation = ContinuationResolution {
+            trigger_kind: ContinuationTriggerKind::SystemTick,
+            class: ContinuationClass::LocalContinuation,
+            model_reentry: true,
+            prior_closure_outcome: crate::types::ClosureOutcome::Continuable,
+            prior_waiting_reason: None,
+            matched_waiting_reason: false,
+            evidence: vec![],
+        };
+
+        let build = |budget| {
+            build_context(
+                &storage,
+                &agent,
+                &execution_snapshot_for(&agent),
+                &crate::types::SkillsRuntimeView::default(),
+                &system_tick,
+                Some(&continuation),
+                &ContextConfig {
+                    recent_messages: 4,
+                    recent_briefs: 4,
+                    prompt_budget_estimated_tokens: budget,
+                    ..ContextConfig::default()
+                },
+                dir.path(),
+            )
+        };
+
+        let initial = build(4096).unwrap();
+        let pinned_ids = ["current_input", "current_work_item", "continuation_anchor"];
+        let pinned_minimum = initial
+            .plan_evidence
+            .decisions
+            .iter()
+            .filter(|decision| pinned_ids.contains(&decision.candidate_id.as_str()))
+            .map(|decision| decision.minimum_estimated_tokens)
+            .sum::<usize>();
+        assert!(pinned_minimum > 0);
+
+        let exact = build(pinned_minimum).unwrap();
+        for candidate_id in pinned_ids {
+            assert!(
+                exact
+                    .sections
+                    .iter()
+                    .any(|section| section.id == candidate_id),
+                "missing pinned candidate {candidate_id}"
+            );
+            let decision = exact
+                .plan_evidence
+                .decisions
+                .iter()
+                .find(|decision| decision.candidate_id == candidate_id)
+                .expect("pinned decision should be present");
+            assert_ne!(
+                decision.outcome,
+                super::planner::ContextPlanOutcome::Omitted
+            );
+            assert!(decision.allocated_estimated_tokens >= decision.minimum_estimated_tokens);
+        }
+        assert!(exact.plan_evidence.allocated_estimated_tokens <= pinned_minimum);
+
+        let error = build(pinned_minimum - 1).unwrap_err();
+        assert!(error.to_string().contains("pinned_minimum_over_budget"));
+        assert!(error
+            .to_string()
+            .contains(&format!("pinned_minimum={pinned_minimum}")));
+    }
+
+    #[test]
+    fn build_context_bounds_recent_turn_reprojection_to_planned_compact_budget() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let mut historical_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "large historical context ".repeat(4_000),
+            },
+        );
+        historical_message.turn_id = Some("turn-large-history".to_string());
+        storage.append_message(&historical_message).unwrap();
+        let mut historical_turn = crate::types::TurnRecord::new("default", "turn-large-history", 1);
+        historical_turn.input_message_ids = vec![historical_message.id.clone()];
+        historical_turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(
+            &historical_message,
+        ));
+        storage.append_turn(&historical_turn).unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue with the current task.".to_string(),
+            },
+        );
+        let agent = AgentState::new("default");
+        let config_for_budget = |budget| ContextConfig {
+            prompt_budget_estimated_tokens: budget,
+            turn_projection_budget_ratio: 1.0,
+            turn_projection_min_budget: 0,
+            turn_projection_max_budget: budget,
+            ..ContextConfig::default()
+        };
+        let initial = build_context(
+            &storage,
+            &agent,
+            &execution_snapshot_for(&agent),
+            &crate::types::SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &config_for_budget(20_000),
+            dir.path(),
+        )
+        .unwrap();
+        let requested = |candidate_id: &str| {
+            initial
+                .plan_evidence
+                .decisions
+                .iter()
+                .find(|decision| decision.candidate_id == candidate_id)
+                .expect("candidate decision")
+                .requested_estimated_tokens
+        };
+        let recent_turns_minimum = initial
+            .plan_evidence
+            .decisions
+            .iter()
+            .find(|decision| decision.candidate_id == "recent_turns")
+            .expect("recent_turns decision")
+            .minimum_estimated_tokens;
+        let compact_plan_budget = [
+            "current_input",
+            "current_work_item",
+            "agent",
+            "execution_environment",
+            "context_contract",
+        ]
+        .into_iter()
+        .map(requested)
+        .sum::<usize>()
+            + recent_turns_minimum;
+
+        let (compact_plan_budget, compact) = (compact_plan_budget..compact_plan_budget + 512)
+            .find_map(|budget| {
+                let built = build_context(
+                    &storage,
+                    &agent,
+                    &execution_snapshot_for(&agent),
+                    &crate::types::SkillsRuntimeView::default(),
+                    &current_message,
+                    None,
+                    &config_for_budget(budget),
+                    dir.path(),
+                )
+                .unwrap();
+                built
+                    .plan_evidence
+                    .decisions
+                    .iter()
+                    .any(|decision| {
+                        decision.candidate_id == "recent_turns"
+                            && decision.outcome == super::planner::ContextPlanOutcome::Compact
+                    })
+                    .then_some((budget, built))
+            })
+            .expect("a nearby budget should select compact recent_turns");
+        let decision = compact
+            .plan_evidence
+            .decisions
+            .iter()
+            .find(|decision| decision.candidate_id == "recent_turns")
+            .expect("recent_turns decision");
+        assert_eq!(
+            decision.outcome,
+            super::planner::ContextPlanOutcome::Compact
+        );
+        assert_eq!(
+            compact
+                .recent_turns_reprojection
+                .as_ref()
+                .expect("selected recent_turns remains reprojectable")
+                .initial_budget(),
+            compact_plan_budget.min(128)
+        );
     }
 
     #[test]

--- a/src/context/planner.rs
+++ b/src/context/planner.rs
@@ -1,0 +1,639 @@
+//! Deterministic context candidate selection and budget planning.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::prompt::PromptSection;
+
+use super::budget::{estimate_section_tokens, fit_section_to_budget};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum RetentionPriority {
+    Low,
+    Normal,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum DropTier {
+    Last,
+    Late,
+    Normal,
+    Early,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ContextCandidatePolicy {
+    pub pinned: bool,
+    pub priority: RetentionPriority,
+    pub drop_tier: DropTier,
+    pub render_order: u16,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextCandidate {
+    pub full: PromptSection,
+    pub compact: Option<PromptSection>,
+    pub policy: ContextCandidatePolicy,
+}
+
+impl ContextCandidate {
+    pub(super) fn new(
+        full: PromptSection,
+        compact: Option<PromptSection>,
+        policy: ContextCandidatePolicy,
+    ) -> Self {
+        Self {
+            full,
+            compact,
+            policy,
+        }
+    }
+
+    fn id(&self) -> &str {
+        &self.full.id
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextPlanOutcome {
+    Full,
+    Compact,
+    Truncated,
+    Omitted,
+}
+
+impl ContextPlanOutcome {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Compact => "compact",
+            Self::Truncated => "truncated",
+            Self::Omitted => "omitted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextPlanReason {
+    SelectedFull,
+    SelectedCompactForPinnedMinimum,
+    SelectedCompactForBudget,
+    TruncatedToRemainingBudget,
+    OmittedLowerPriority,
+    OmittedDropTier,
+}
+
+impl ContextPlanReason {
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::SelectedFull => "selected_full",
+            Self::SelectedCompactForPinnedMinimum => "selected_compact_for_pinned_minimum",
+            Self::SelectedCompactForBudget => "selected_compact_for_budget",
+            Self::TruncatedToRemainingBudget => "truncated_to_remaining_budget",
+            Self::OmittedLowerPriority => "omitted_lower_priority",
+            Self::OmittedDropTier => "omitted_drop_tier",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ContextPlanDecision {
+    pub candidate_id: String,
+    pub section_name: String,
+    pub requested_estimated_tokens: usize,
+    pub minimum_estimated_tokens: usize,
+    pub allocated_estimated_tokens: usize,
+    pub outcome: ContextPlanOutcome,
+    pub reason: ContextPlanReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ContextPlanEvidence {
+    pub total_budget_estimated_tokens: usize,
+    pub allocated_estimated_tokens: usize,
+    pub decisions: Vec<ContextPlanDecision>,
+}
+
+impl ContextPlanEvidence {
+    pub(crate) fn record_reprojection(
+        &mut self,
+        candidate_id: &str,
+        replacement: Option<&PromptSection>,
+    ) {
+        let Some(decision) = self
+            .decisions
+            .iter_mut()
+            .find(|decision| decision.candidate_id == candidate_id)
+        else {
+            return;
+        };
+        match replacement {
+            Some(section) => {
+                decision.allocated_estimated_tokens = estimate_section_tokens(section);
+                decision.outcome = ContextPlanOutcome::Truncated;
+                decision.reason = ContextPlanReason::TruncatedToRemainingBudget;
+            }
+            None => {
+                decision.allocated_estimated_tokens = 0;
+                decision.outcome = ContextPlanOutcome::Omitted;
+                decision.reason = ContextPlanReason::OmittedLowerPriority;
+            }
+        }
+        self.allocated_estimated_tokens = self
+            .decisions
+            .iter()
+            .map(|decision| decision.allocated_estimated_tokens)
+            .sum();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextPlan {
+    pub sections: Vec<PromptSection>,
+    pub evidence: ContextPlanEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ContextPlanningError {
+    #[error("context candidate id must not be empty")]
+    EmptyCandidateId,
+    #[error("duplicate context candidate id: {0}")]
+    DuplicateCandidateId(String),
+    #[error("context candidate {candidate_id} compact representation id does not match")]
+    CompactCandidateIdMismatch { candidate_id: String },
+    #[error("pinned context candidate {candidate_id} has no compact representation")]
+    MissingPinnedCompact { candidate_id: String },
+    #[error(
+        "pinned_minimum_over_budget: budget={budget_estimated_tokens}, pinned_minimum={pinned_minimum_estimated_tokens}"
+    )]
+    PinnedMinimumOverBudget {
+        budget_estimated_tokens: usize,
+        pinned_minimum_estimated_tokens: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct Selection {
+    section: Option<PromptSection>,
+    decision: ContextPlanDecision,
+    render_order: u16,
+}
+
+pub(super) fn plan_context(
+    mut candidates: Vec<ContextCandidate>,
+    total_budget: usize,
+) -> Result<ContextPlan, ContextPlanningError> {
+    validate_candidates(&candidates)?;
+    candidates.sort_by(selection_order);
+
+    let pinned_minimum = candidates
+        .iter()
+        .filter(|candidate| candidate.policy.pinned)
+        .map(|candidate| {
+            estimate_section_tokens(
+                candidate
+                    .compact
+                    .as_ref()
+                    .expect("validated pinned compact representation"),
+            )
+        })
+        .sum::<usize>();
+    if pinned_minimum > total_budget {
+        return Err(ContextPlanningError::PinnedMinimumOverBudget {
+            budget_estimated_tokens: total_budget,
+            pinned_minimum_estimated_tokens: pinned_minimum,
+        });
+    }
+
+    let mut remaining_budget = total_budget.saturating_sub(pinned_minimum);
+    let mut selections = BTreeMap::new();
+
+    for candidate in &candidates {
+        let requested = estimate_section_tokens(&candidate.full);
+        let minimum = candidate
+            .compact
+            .as_ref()
+            .map(estimate_section_tokens)
+            .unwrap_or(0);
+        if candidate.policy.pinned {
+            let compact = candidate
+                .compact
+                .clone()
+                .expect("validated pinned compact representation");
+            selections.insert(
+                candidate.id().to_string(),
+                Selection {
+                    section: Some(compact),
+                    decision: ContextPlanDecision {
+                        candidate_id: candidate.id().to_string(),
+                        section_name: candidate.full.name.clone(),
+                        requested_estimated_tokens: requested,
+                        minimum_estimated_tokens: minimum,
+                        allocated_estimated_tokens: minimum,
+                        outcome: ContextPlanOutcome::Compact,
+                        reason: ContextPlanReason::SelectedCompactForPinnedMinimum,
+                    },
+                    render_order: candidate.policy.render_order,
+                },
+            );
+        }
+    }
+
+    for candidate in candidates {
+        let requested = estimate_section_tokens(&candidate.full);
+        let minimum = candidate
+            .compact
+            .as_ref()
+            .map(estimate_section_tokens)
+            .unwrap_or(0);
+
+        if candidate.policy.pinned {
+            let additional = requested.saturating_sub(minimum);
+            if additional <= remaining_budget {
+                remaining_budget = remaining_budget.saturating_sub(additional);
+                let selection = selections
+                    .get_mut(candidate.id())
+                    .expect("pinned selection initialized");
+                selection.section = Some(candidate.full);
+                selection.decision.allocated_estimated_tokens = requested;
+                selection.decision.outcome = ContextPlanOutcome::Full;
+                selection.decision.reason = ContextPlanReason::SelectedFull;
+            }
+            continue;
+        }
+
+        let (section, allocated, outcome, reason) = if requested <= remaining_budget {
+            (
+                Some(candidate.full.clone()),
+                requested,
+                ContextPlanOutcome::Full,
+                ContextPlanReason::SelectedFull,
+            )
+        } else if let Some(compact) = candidate
+            .compact
+            .clone()
+            .filter(|compact| estimate_section_tokens(compact) <= remaining_budget)
+        {
+            let allocated = estimate_section_tokens(&compact);
+            (
+                Some(compact),
+                allocated,
+                ContextPlanOutcome::Compact,
+                ContextPlanReason::SelectedCompactForBudget,
+            )
+        } else {
+            let truncated = candidate
+                .compact
+                .is_none()
+                .then(|| fit_section_to_budget(candidate.full.clone(), remaining_budget))
+                .flatten();
+            if let Some(truncated) = truncated {
+                let allocated = estimate_section_tokens(&truncated);
+                (
+                    Some(truncated),
+                    allocated,
+                    ContextPlanOutcome::Truncated,
+                    ContextPlanReason::TruncatedToRemainingBudget,
+                )
+            } else {
+                let reason = if candidate.policy.drop_tier == DropTier::Early {
+                    ContextPlanReason::OmittedDropTier
+                } else {
+                    ContextPlanReason::OmittedLowerPriority
+                };
+                (None, 0, ContextPlanOutcome::Omitted, reason)
+            }
+        };
+        remaining_budget = remaining_budget.saturating_sub(allocated);
+        selections.insert(
+            candidate.id().to_string(),
+            Selection {
+                section,
+                decision: ContextPlanDecision {
+                    candidate_id: candidate.id().to_string(),
+                    section_name: candidate.full.name,
+                    requested_estimated_tokens: requested,
+                    minimum_estimated_tokens: minimum,
+                    allocated_estimated_tokens: allocated,
+                    outcome,
+                    reason,
+                },
+                render_order: candidate.policy.render_order,
+            },
+        );
+    }
+
+    let mut selections = selections.into_values().collect::<Vec<_>>();
+    let mut decisions = selections
+        .iter()
+        .map(|selection| selection.decision.clone())
+        .collect::<Vec<_>>();
+    decisions.sort_by(|left, right| left.candidate_id.cmp(&right.candidate_id));
+    selections.sort_by(|left, right| {
+        left.render_order
+            .cmp(&right.render_order)
+            .then_with(|| left.decision.candidate_id.cmp(&right.decision.candidate_id))
+    });
+    let sections = selections
+        .into_iter()
+        .filter_map(|selection| selection.section)
+        .collect::<Vec<_>>();
+    let allocated_estimated_tokens = decisions
+        .iter()
+        .map(|decision| decision.allocated_estimated_tokens)
+        .sum();
+
+    Ok(ContextPlan {
+        sections,
+        evidence: ContextPlanEvidence {
+            total_budget_estimated_tokens: total_budget,
+            allocated_estimated_tokens,
+            decisions,
+        },
+    })
+}
+
+fn validate_candidates(candidates: &[ContextCandidate]) -> Result<(), ContextPlanningError> {
+    let mut ids = BTreeSet::new();
+    for candidate in candidates {
+        let id = candidate.id();
+        if id.trim().is_empty() {
+            return Err(ContextPlanningError::EmptyCandidateId);
+        }
+        if !ids.insert(id) {
+            return Err(ContextPlanningError::DuplicateCandidateId(id.to_string()));
+        }
+        if let Some(compact) = candidate.compact.as_ref() {
+            if compact.id != id {
+                return Err(ContextPlanningError::CompactCandidateIdMismatch {
+                    candidate_id: id.to_string(),
+                });
+            }
+        } else if candidate.policy.pinned {
+            return Err(ContextPlanningError::MissingPinnedCompact {
+                candidate_id: id.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn selection_order(left: &ContextCandidate, right: &ContextCandidate) -> std::cmp::Ordering {
+    right
+        .policy
+        .pinned
+        .cmp(&left.policy.pinned)
+        .then_with(|| right.policy.priority.cmp(&left.policy.priority))
+        .then_with(|| left.policy.drop_tier.cmp(&right.policy.drop_tier))
+        .then_with(|| left.id().cmp(right.id()))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prompt::{PromptSection, PromptStability};
+
+    use super::*;
+
+    fn prompt_section(id: &str, body: &str) -> PromptSection {
+        PromptSection {
+            name: id.to_string(),
+            id: id.to_string(),
+            content: body.to_string(),
+            stability: PromptStability::TurnScoped,
+        }
+    }
+
+    fn policy(
+        pinned: bool,
+        priority: RetentionPriority,
+        drop_tier: DropTier,
+        render_order: u16,
+    ) -> ContextCandidatePolicy {
+        ContextCandidatePolicy {
+            pinned,
+            priority,
+            drop_tier,
+            render_order,
+        }
+    }
+
+    #[test]
+    fn preserves_all_pinned_compact_representations_at_minimum_budget() {
+        let candidates = ["current_input", "current_work_item", "continuation_anchor"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, id)| {
+                ContextCandidate::new(
+                    prompt_section(id, &"full ".repeat(80)),
+                    Some(prompt_section(id, "compact truth")),
+                    policy(
+                        true,
+                        RetentionPriority::Critical,
+                        DropTier::Last,
+                        index as u16,
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        let minimum = candidates
+            .iter()
+            .map(|candidate| estimate_section_tokens(candidate.compact.as_ref().unwrap()))
+            .sum();
+
+        let plan = plan_context(candidates, minimum).unwrap();
+
+        assert_eq!(plan.sections.len(), 3);
+        assert!(plan
+            .evidence
+            .decisions
+            .iter()
+            .all(|decision| decision.outcome == ContextPlanOutcome::Compact));
+        assert_eq!(plan.evidence.allocated_estimated_tokens, minimum);
+    }
+
+    #[test]
+    fn fails_closed_when_pinned_minimum_exceeds_budget() {
+        let candidate = ContextCandidate::new(
+            prompt_section("current_input", "full input"),
+            Some(prompt_section("current_input", "minimum input")),
+            policy(true, RetentionPriority::Critical, DropTier::Last, 0),
+        );
+        let minimum = estimate_section_tokens(candidate.compact.as_ref().unwrap());
+
+        let error = plan_context(vec![candidate], minimum - 1).unwrap_err();
+
+        assert_eq!(
+            error,
+            ContextPlanningError::PinnedMinimumOverBudget {
+                budget_estimated_tokens: minimum - 1,
+                pinned_minimum_estimated_tokens: minimum,
+            }
+        );
+    }
+
+    #[test]
+    fn candidate_input_order_does_not_change_plan_or_render_order() {
+        let candidates = vec![
+            ContextCandidate::new(
+                prompt_section("beta", "beta"),
+                None,
+                policy(false, RetentionPriority::Normal, DropTier::Normal, 20),
+            ),
+            ContextCandidate::new(
+                prompt_section("alpha", "alpha"),
+                None,
+                policy(false, RetentionPriority::Normal, DropTier::Normal, 10),
+            ),
+        ];
+        let budget = candidates
+            .iter()
+            .map(|candidate| estimate_section_tokens(&candidate.full))
+            .sum();
+
+        let forward = plan_context(candidates.clone(), budget).unwrap();
+        let reverse = plan_context(candidates.into_iter().rev().collect(), budget).unwrap();
+
+        assert_eq!(forward.evidence, reverse.evidence);
+        assert_eq!(
+            forward
+                .sections
+                .iter()
+                .map(|section| section.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+        assert_eq!(
+            forward
+                .sections
+                .iter()
+                .map(|section| section.id.as_str())
+                .collect::<Vec<_>>(),
+            reverse
+                .sections
+                .iter()
+                .map(|section| section.id.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn priority_drop_tier_and_stable_id_drive_selection_not_render_order() {
+        let candidates = vec![
+            ContextCandidate::new(
+                prompt_section("zeta", "selected by stable id"),
+                None,
+                policy(false, RetentionPriority::High, DropTier::Last, 10),
+            ),
+            ContextCandidate::new(
+                prompt_section("alpha", "selected by drop tier"),
+                None,
+                policy(false, RetentionPriority::High, DropTier::Late, 30),
+            ),
+            ContextCandidate::new(
+                prompt_section("beta", "omitted"),
+                None,
+                policy(false, RetentionPriority::High, DropTier::Late, 20),
+            ),
+        ];
+        let budget = estimate_section_tokens(&candidates[0].full)
+            + estimate_section_tokens(&candidates[1].full);
+
+        let plan = plan_context(candidates, budget).unwrap();
+        let included = plan
+            .sections
+            .iter()
+            .map(|section| section.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(included, vec!["zeta", "alpha"]);
+        assert_eq!(
+            plan.evidence
+                .decisions
+                .iter()
+                .find(|decision| decision.candidate_id == "beta")
+                .unwrap()
+                .outcome,
+            ContextPlanOutcome::Omitted
+        );
+    }
+
+    #[test]
+    fn records_full_compact_truncated_and_omitted_outcomes() {
+        let full = ContextCandidate::new(
+            prompt_section("full", "fits"),
+            None,
+            policy(false, RetentionPriority::Critical, DropTier::Last, 0),
+        );
+        let compact = ContextCandidate::new(
+            prompt_section("compact", &"large ".repeat(80)),
+            Some(prompt_section("compact", "small")),
+            policy(false, RetentionPriority::High, DropTier::Last, 1),
+        );
+        let truncated = ContextCandidate::new(
+            prompt_section("truncated", &"truncate ".repeat(80)),
+            None,
+            policy(false, RetentionPriority::Normal, DropTier::Normal, 2),
+        );
+        let omitted = ContextCandidate::new(
+            prompt_section("omitted", "cannot fit"),
+            None,
+            policy(false, RetentionPriority::Low, DropTier::Early, 3),
+        );
+        let budget = estimate_section_tokens(&full.full)
+            + estimate_section_tokens(compact.compact.as_ref().unwrap())
+            + 24;
+
+        let plan = plan_context(vec![omitted, truncated, compact, full], budget).unwrap();
+        let outcomes = plan
+            .evidence
+            .decisions
+            .iter()
+            .map(|decision| (decision.candidate_id.as_str(), decision.outcome))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(outcomes["full"], ContextPlanOutcome::Full);
+        assert_eq!(outcomes["compact"], ContextPlanOutcome::Compact);
+        assert_eq!(outcomes["truncated"], ContextPlanOutcome::Truncated);
+        assert_eq!(outcomes["omitted"], ContextPlanOutcome::Omitted);
+        assert_eq!(
+            plan.evidence
+                .decisions
+                .iter()
+                .find(|decision| decision.candidate_id == "omitted")
+                .unwrap()
+                .reason,
+            ContextPlanReason::OmittedDropTier
+        );
+    }
+
+    #[test]
+    fn reprojection_updates_recent_turn_allocation_evidence() {
+        let candidate = ContextCandidate::new(
+            prompt_section("recent_turns", &"turn ".repeat(80)),
+            None,
+            policy(false, RetentionPriority::High, DropTier::Late, 0),
+        );
+        let full_budget = estimate_section_tokens(&candidate.full);
+        let mut plan = plan_context(vec![candidate], full_budget).unwrap();
+        let replacement = prompt_section("recent_turns", "one compact projected turn");
+
+        plan.evidence
+            .record_reprojection("recent_turns", Some(&replacement));
+
+        let decision = &plan.evidence.decisions[0];
+        assert_eq!(decision.outcome, ContextPlanOutcome::Truncated);
+        assert_eq!(
+            decision.reason,
+            ContextPlanReason::TruncatedToRemainingBudget
+        );
+        assert_eq!(
+            decision.allocated_estimated_tokens,
+            estimate_section_tokens(&replacement)
+        );
+        assert_eq!(
+            plan.evidence.allocated_estimated_tokens,
+            decision.allocated_estimated_tokens
+        );
+    }
+}

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -7,8 +7,6 @@ use crate::types::{
     MessageOrigin,
 };
 
-use super::budget::estimate_section_tokens;
-
 /// Create a section with `AgentScoped` stability.
 pub(super) fn section(name: &'static str, content: String) -> PromptSection {
     PromptSection {
@@ -27,21 +25,6 @@ pub(super) fn turn_section(name: &'static str, content: String) -> PromptSection
         content,
         stability: PromptStability::TurnScoped,
     }
-}
-
-/// Push a section into the sections list if it fits within the remaining budget.
-/// Returns `true` if the section was pushed.
-pub(super) fn push_budgeted_section(
-    sections: &mut Vec<PromptSection>,
-    remaining_budget: &mut usize,
-    section: PromptSection,
-) -> bool {
-    let Some(section) = super::budget::fit_section_to_budget(section, *remaining_budget) else {
-        return false;
-    };
-    *remaining_budget = remaining_budget.saturating_sub(estimate_section_tokens(&section));
-    sections.push(section);
-    true
 }
 
 /// Sanitize a string for inline display: collapse whitespace, no newlines.

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -18,7 +18,7 @@ use sha2::{Digest, Sha256};
 use crate::{
     context::{
         build_context_with_default_external_ingress, reproject_recent_turns, BuiltContext,
-        ContextConfig, RecentTurnsReprojection,
+        ContextConfig, ContextPlanEvidence, RecentTurnsReprojection,
     },
     storage::AppStorage,
     system::{execution_policy_summary_lines, ExecutionSnapshot},
@@ -81,6 +81,7 @@ pub struct EffectivePrompt {
     pub context_sections: Vec<PromptSection>,
     pub rendered_system_prompt: String,
     pub rendered_context_attachment: String,
+    pub(crate) context_plan_evidence: ContextPlanEvidence,
     pub(crate) recent_turns_reprojection: Option<RecentTurnsReprojection>,
 }
 
@@ -102,6 +103,7 @@ impl EffectivePrompt {
             return None;
         }
         let replacement = reproject_recent_turns(storage, reprojection, budget);
+        let replacement_for_evidence = replacement.clone();
         let mut context_sections = self
             .context_sections
             .iter()
@@ -132,6 +134,9 @@ impl EffectivePrompt {
         prompt.context_sections = context_sections;
         prompt.rendered_context_attachment = rendered_context_attachment;
         prompt.cache_identity.context_fingerprint = context_fingerprint;
+        prompt
+            .context_plan_evidence
+            .record_reprojection("recent_turns", replacement_for_evidence.as_ref());
         Some(prompt)
     }
 
@@ -257,6 +262,28 @@ impl EffectivePrompt {
                 section.stability,
                 prompt_cache_scope_label(section.stability),
                 section.content.chars().count()
+            ));
+        }
+        output.push("".to_string());
+        output.push("Context budget plan:".to_string());
+        output.push(format!(
+            "  - total estimated tokens: {}",
+            self.context_plan_evidence.total_budget_estimated_tokens
+        ));
+        output.push(format!(
+            "  - allocated estimated tokens: {}",
+            self.context_plan_evidence.allocated_estimated_tokens
+        ));
+        for decision in &self.context_plan_evidence.decisions {
+            output.push(format!(
+                "  - [{}] section={} outcome={} reason={} requested={} minimum={} allocated={}",
+                decision.candidate_id,
+                decision.section_name,
+                decision.outcome.label(),
+                decision.reason.code(),
+                decision.requested_estimated_tokens,
+                decision.minimum_estimated_tokens,
+                decision.allocated_estimated_tokens,
             ));
         }
         output.push("".to_string());
@@ -523,6 +550,7 @@ fn build_effective_prompt_with_tool_prompt_context_and_default_external_ingress(
         context_sections,
         rendered_system_prompt,
         rendered_context_attachment,
+        context_plan_evidence: built_context.plan_evidence,
         recent_turns_reprojection: built_context.recent_turns_reprojection,
     })
 }
@@ -2299,6 +2327,19 @@ mod tests {
             }],
             rendered_system_prompt: "rendered system".to_string(),
             rendered_context_attachment: "rendered context".to_string(),
+            context_plan_evidence: ContextPlanEvidence {
+                total_budget_estimated_tokens: 100,
+                allocated_estimated_tokens: 20,
+                decisions: vec![crate::context::ContextPlanDecision {
+                    candidate_id: "context_section".to_string(),
+                    section_name: "context_section".to_string(),
+                    requested_estimated_tokens: 40,
+                    minimum_estimated_tokens: 10,
+                    allocated_estimated_tokens: 20,
+                    outcome: crate::context::ContextPlanOutcome::Truncated,
+                    reason: crate::context::ContextPlanReason::TruncatedToRemainingBudget,
+                }],
+            },
             recent_turns_reprojection: None,
         };
 
@@ -2322,6 +2363,11 @@ mod tests {
         ));
         assert!(dump.contains(
             "#1 [context_section] (id: ctx-id-456, stability: AgentScoped, cache scope: included"
+        ));
+        assert!(dump.contains("Context budget plan:"));
+        assert!(dump.contains("total estimated tokens: 100"));
+        assert!(dump.contains(
+            "[context_section] section=context_section outcome=truncated reason=truncated_to_remaining_budget requested=40 minimum=10 allocated=20"
         ));
         assert!(dump.contains("[test_section][id: test-stable-id-123][Stable]"));
         assert!(dump.contains("[context_section][id: ctx-id-456][AgentScoped]"));
@@ -2350,6 +2396,7 @@ mod tests {
             }],
             rendered_system_prompt: "rendered turn system".to_string(),
             rendered_context_attachment: "rendered turn context".to_string(),
+            context_plan_evidence: ContextPlanEvidence::default(),
             recent_turns_reprojection: None,
         };
 
@@ -2405,6 +2452,7 @@ mod tests {
             context_sections: vec![],
             rendered_system_prompt: "very secret agent guidance".to_string(),
             rendered_context_attachment: String::new(),
+            context_plan_evidence: ContextPlanEvidence::default(),
             recent_turns_reprojection: None,
         };
 

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -590,6 +590,7 @@ mod tests {
             }],
             rendered_system_prompt: "system prompt".to_string(),
             rendered_context_attachment: "context attachment".to_string(),
+            context_plan_evidence: Default::default(),
             recent_turns_reprojection: None,
         }
     }
@@ -668,6 +669,7 @@ mod tests {
             ],
             rendered_system_prompt: "system prompt".to_string(),
             rendered_context_attachment: "context attachment".to_string(),
+            context_plan_evidence: Default::default(),
             recent_turns_reprojection: None,
         };
 

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1345,6 +1345,7 @@ fn current_input_summary_extracts_body_from_context_section() {
         }],
         rendered_system_prompt: String::new(),
         rendered_context_attachment: String::new(),
+        context_plan_evidence: Default::default(),
         recent_turns_reprojection: None,
     };
 

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -177,6 +177,7 @@ pub(crate) fn test_effective_prompt() -> EffectivePrompt {
         context_sections: vec![],
         rendered_system_prompt: "system".into(),
         rendered_context_attachment: "context".into(),
+        context_plan_evidence: Default::default(),
         recent_turns_reprojection: None,
     }
 }


### PR DESCRIPTION
## 概要

- 将 Context 构建拆分为 typed `ContextCandidate` 收集、deterministic budget planning 与最终渲染三个阶段
- 为候选显式建模 pinned、priority、drop tier、render order，以及 full/compact 最小预算
- 固定保护 `current_input`、focused `current_work_item` truth 与 trusted `continuation_anchor`，pinned minimum 超预算时 fail closed
- 在 `BuiltContext` / `EffectivePrompt` 和 human debug dump 中保留逐候选 decision evidence，包括 requested/minimum/allocated budget、outcome 与 reason code
- 保留 recent-turn semantic projection，并确保 planner 省略的 section 不会被重投影重新加入或突破 hard cap
- 新增 RFC，记录候选、选择、排序和审计证据边界

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --lib`（2301 passed, 1 ignored）
- `cargo test --test prompt_context_snapshots`（17 passed）
- `git diff --check`

Closes #2268
