### PR TITLE
fix(web): 对账 timeline assistant round 与 optimistic prompt

### DIFF
--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -383,7 +383,7 @@ describe("createRuntimeClient", () => {
     let requestBody: unknown;
     const fetchImpl = async (_input: RequestInfo | URL, init?: RequestInit) => {
       requestBody = init?.body ? JSON.parse(String(init.body)) : undefined;
-      return new Response(null, { status: 204 });
+      return Response.json({ message_id: "message-123" });
     };
 
     const client = createRuntimeClient({
@@ -393,7 +393,7 @@ describe("createRuntimeClient", () => {
       fetchImpl: fetchImpl as typeof fetch,
     });
 
-    await client.sendOperatorPrompt("agent-one", "see attached", [
+    const response = await client.sendOperatorPrompt("agent-one", "see attached", [
       {
         kind: "file",
         name: "report.pdf",
@@ -402,6 +402,7 @@ describe("createRuntimeClient", () => {
       },
     ]);
 
+    expect(response).toEqual({ messageId: "message-123" });
     expect(requestBody).toEqual({
       text: "see attached",
       attachments: [
@@ -845,7 +846,7 @@ describe("createRuntimeClient", () => {
     expect(detail.timeline).toEqual([]);
     expect(deriveSessionTimeline(projection)[0]).toEqual(
       expect.objectContaining({
-        id: "brief-event",
+        id: "assistant_round:round-123",
         body: "Canonical persisted brief.",
       }),
     );

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -57,6 +57,14 @@ export interface OperatorPromptAttachment {
   dataBase64: string;
 }
 
+export interface OperatorPromptResponse {
+  messageId: string;
+}
+
+interface OperatorPromptResponseDto {
+  message_id?: string;
+}
+
 const DEFAULT_DEV_API_BASE = "/api";
 const DEFAULT_REQUEST_TIMEOUT_MS = 8000;
 const OPTIONAL_DETAIL_TIMEOUT_MS = 4000;
@@ -1019,19 +1027,33 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       if (!baseUrl) return undefined;
       return streamGlobalEvents(baseUrl, fetchImpl, requestHeaders, options);
     },
-    async sendOperatorPrompt(agentId: string, text: string, attachments: OperatorPromptAttachment[] = []): Promise<void> {
+    async sendOperatorPrompt(
+      agentId: string,
+      text: string,
+      attachments: OperatorPromptAttachment[] = [],
+    ): Promise<OperatorPromptResponse> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
-      await postJson<unknown>(fetchImpl, baseUrl, `/control/agents/${encodeURIComponent(agentId)}/prompt`, {
-        text,
-        attachments: attachments.map((attachment) => ({
-          kind: attachment.kind,
-          name: attachment.name,
-          media_type: attachment.mediaType,
-          data_base64: attachment.dataBase64,
-        })),
-      }, requestHeaders);
+      const response = await postJson<OperatorPromptResponseDto>(
+        fetchImpl,
+        baseUrl,
+        `/control/agents/${encodeURIComponent(agentId)}/prompt`,
+        {
+          text,
+          attachments: attachments.map((attachment) => ({
+            kind: attachment.kind,
+            name: attachment.name,
+            media_type: attachment.mediaType,
+            data_base64: attachment.dataBase64,
+          })),
+        },
+        requestHeaders,
+      );
+      if (!response.message_id) {
+        throw new Error("Operator prompt response did not include message_id.");
+      }
+      return { messageId: response.message_id };
     },
     async setAgentModel(agentId: string, model: string, reasoningEffort?: string): Promise<AgentModelStateDto | undefined> {
       if (!baseUrl) {

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -5,6 +5,7 @@ import {
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
   isLoopbackWebHostname,
+  materializeProjectionDetail,
   mergeCachedSessionIntoCurrent,
   missingBriefIdsForHydration,
   readStoredRemoteConnectionProfiles,
@@ -15,7 +16,7 @@ import {
 } from "./runtime-store";
 import type { StreamEventEnvelopeDto } from "./client";
 import type { AgentSessionState } from "./runtime-store";
-import { createSessionProjectionState } from "./session-projection";
+import { createSessionProjectionState, reduceSessionProjection } from "./session-projection";
 
 class MemoryStorage implements Storage {
   private readonly items = new Map<string, string>();
@@ -454,5 +455,73 @@ describe("brief projection and hydration", () => {
     };
 
     expect(missingBriefIdsForHydration(session)).toEqual(["brief-123"]);
+  });
+});
+
+describe("optimistic operator prompt reconciliation", () => {
+  it("removes a confirmed optimistic item when its canonical message is projected", () => {
+    const projection = reduceSessionProjection(createSessionProjectionState(), {
+      type: "events_received",
+      eventLogEpoch: "epoch-1",
+      events: [{
+        id: "message-event",
+        event_seq: 1,
+        event_log_epoch: "epoch-1",
+        ts: "2026-07-17T00:00:01Z",
+        type: "message_enqueued",
+        payload: {
+          message_id: "message-123",
+          origin: { kind: "operator" },
+          body: "Run the checks",
+        },
+      }],
+    });
+    const detail = materializeProjectionDetail({
+      agent: { id: "agent-1" } as NonNullable<AgentSessionState["detail"]>["agent"],
+      source: "http",
+      timeline: [{
+        id: "operator-prompt:pending:client-123",
+        kind: "operator",
+        label: "Operator input",
+        body: "Run the checks",
+        timestamp: "2026-07-17T00:00:00Z",
+        meta: "Sent",
+        minDisplayLevel: "info",
+        sourceIds: [
+          "pending-operator-prompt",
+          "operator-prompt-client:client-123",
+          "operator-prompt-message:message-123",
+        ],
+      }, {
+        id: "operator-prompt:pending:client-456",
+        kind: "operator",
+        label: "Operator input",
+        body: "Run different checks",
+        timestamp: "2026-07-17T00:00:00Z",
+        meta: "Sent",
+        minDisplayLevel: "info",
+        sourceIds: [
+          "pending-operator-prompt",
+          "operator-prompt-client:client-456",
+          "operator-prompt-message:message-456",
+        ],
+      }],
+    }, projection, "info");
+
+    expect(detail?.timeline).toHaveLength(2);
+    expect(detail?.timeline).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "message:message-123",
+      }),
+      expect.objectContaining({
+      id: "operator-prompt:pending:client-456",
+      body: "Run different checks",
+      }),
+    ]));
+    expect(detail?.timeline).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "operator-prompt:pending:client-123",
+      }),
+    ]));
   });
 });

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -179,7 +179,16 @@ export interface AgentRosterActivity {
   lastReadSeq?: number;
 }
 
-function appendOptimisticOperatorPrompt(detail: AgentDetail | null, agent: AgentSummary | undefined, prompt: string): AgentDetail | null {
+const OPTIMISTIC_OPERATOR_PROMPT_SOURCE = "pending-operator-prompt";
+const OPTIMISTIC_OPERATOR_CLIENT_PREFIX = "operator-prompt-client:";
+const OPTIMISTIC_OPERATOR_MESSAGE_PREFIX = "operator-prompt-message:";
+
+function appendOptimisticOperatorPrompt(
+  detail: AgentDetail | null,
+  agent: AgentSummary | undefined,
+  prompt: string,
+  clientId: string,
+): AgentDetail | null {
   const baseDetail = detail ?? createLiveAgentDetail(agent);
   if (!baseDetail) return null;
   const timestamp = new Date().toISOString();
@@ -188,30 +197,38 @@ function appendOptimisticOperatorPrompt(detail: AgentDetail | null, agent: Agent
     timeline: [
       ...baseDetail.timeline,
       {
-        id: `operator-prompt:pending:${timestamp}`,
+        id: `operator-prompt:pending:${clientId}`,
         kind: "operator",
         label: "Operator input",
         body: prompt,
         timestamp,
         meta: "sending",
         minDisplayLevel: "info",
-        sourceIds: ["pending-operator-prompt"],
+        sourceIds: [OPTIMISTIC_OPERATOR_PROMPT_SOURCE, `${OPTIMISTIC_OPERATOR_CLIENT_PREFIX}${clientId}`],
       },
     ],
   };
 }
 
-function markOptimisticOperatorPromptsSent(detail: AgentDetail | null): AgentDetail | null {
+function confirmOptimisticOperatorPrompt(
+  detail: AgentDetail | null,
+  clientId: string,
+  messageId: string,
+): AgentDetail | null {
   if (!detail) return detail;
   let changed = false;
   const timeline = detail.timeline.map((item) => {
-    if (item.kind !== "operator" || item.meta !== "sending" || !item.sourceIds.includes("pending-operator-prompt")) {
+    if (
+      item.kind !== "operator" ||
+      !item.sourceIds.includes(`${OPTIMISTIC_OPERATOR_CLIENT_PREFIX}${clientId}`)
+    ) {
       return item;
     }
     changed = true;
     return {
       ...item,
       meta: "Sent",
+      sourceIds: [...item.sourceIds, `${OPTIMISTIC_OPERATOR_MESSAGE_PREFIX}${messageId}`],
     };
   });
   return changed ? { ...detail, timeline } : detail;
@@ -2049,6 +2066,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       return;
     }
 
+    const clientId = crypto.randomUUID();
     set((state) => {
       const rosterActivityByAgentId = touchRosterActivity(state.rosterActivityByAgentId, agentId, "operator", new Date().toISOString());
       if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
@@ -2068,6 +2086,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
               state.sessionsByAgentId[agentId]?.detail ?? null,
               state.bootstrap.agents.find((agent) => agent.id === agentId),
               prompt,
+              clientId,
             ),
           },
         },
@@ -2075,7 +2094,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     });
 
     try {
-      await runtimeClient.sendOperatorPrompt(agentId, prompt, attachments);
+      const { messageId } = await runtimeClient.sendOperatorPrompt(agentId, prompt, attachments);
       scheduleBootstrapRefresh(get, 250);
       set((state) => ({
         sessionsByAgentId: {
@@ -2085,7 +2104,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
             ...state.sessionsByAgentId[agentId],
             sendingPrompt: false,
             promptError: undefined,
-            detail: markOptimisticOperatorPromptsSent(state.sessionsByAgentId[agentId]?.detail ?? null),
+            detail: confirmOptimisticOperatorPrompt(
+              state.sessionsByAgentId[agentId]?.detail ?? null,
+              clientId,
+              messageId,
+            ),
           },
         },
       }));
@@ -2261,15 +2284,29 @@ function applyProjectionAction(
   };
 }
 
-function materializeProjectionDetail(
+export function materializeProjectionDetail(
   detail: AgentDetail | null,
   projection: SessionProjectionState,
   displayLevel: DisplayLevel,
 ): AgentDetail | null {
   if (!detail) return null;
-  const optimisticItems = detail.timeline.filter((item) => item.sourceIds.includes("pending-operator-prompt"));
+  const projectedTimeline = deriveSessionTimeline(projection, displayLevel);
+  const projectedMessageIds = new Set(
+    projectedTimeline.flatMap((item) =>
+      item.kind === "operator" && item.id.startsWith("message:")
+        ? [item.id.slice("message:".length)]
+        : [],
+    ),
+  );
+  const optimisticItems = detail.timeline.filter((item) => {
+    if (!item.sourceIds.includes(OPTIMISTIC_OPERATOR_PROMPT_SOURCE)) return false;
+    const canonicalMessageId = item.sourceIds
+      .find((sourceId) => sourceId.startsWith(OPTIMISTIC_OPERATOR_MESSAGE_PREFIX))
+      ?.slice(OPTIMISTIC_OPERATOR_MESSAGE_PREFIX.length);
+    return !canonicalMessageId || !projectedMessageIds.has(canonicalMessageId);
+  });
   const timeline = compactAgentTimelineItems([
-    ...deriveSessionTimeline(projection, displayLevel),
+    ...projectedTimeline,
     ...optimisticItems,
   ]).sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
   return {

--- a/web-gui/app/src/runtime/session-projection.test.ts
+++ b/web-gui/app/src/runtime/session-projection.test.ts
@@ -111,6 +111,110 @@ describe("SessionProjectionState", () => {
     expect(projectionSnapshot(twice)).toEqual(projectionSnapshot(once));
   });
 
+  it("promotes an assistant round across event batches using semantic identity", () => {
+    const recorded = receive(createSessionProjectionState(), [
+      event(6, "assistant_round_recorded", {
+        assistant_round_id: "round-1",
+        text_preview: "Partial result...",
+      }),
+    ]);
+    const promoted = receive(recorded, [
+      event(7, "brief_created", {
+        brief_id: "brief-1",
+        finalizes_assistant_round_id: "round-1",
+        kind: "result",
+        text: "Complete result.",
+      }),
+    ]);
+
+    expect(promoted.domain.rounds).toHaveLength(1);
+    expect(promoted.domain.rounds.get("assistant_round:round-1")).toEqual(
+      expect.objectContaining({
+        status: "brief_promoted",
+        sourceEventIds: ["event-6", "event-7"],
+      }),
+    );
+    expect(deriveSessionTimeline(promoted)).toEqual([
+      expect.objectContaining({
+        id: "assistant_round:round-1",
+        body: "Complete result.",
+      }),
+    ]);
+  });
+
+  it("promotes a cached assistant round when its live brief arrives", () => {
+    const recordedEvent = event(6, "assistant_round_recorded", {
+      assistant_round_id: "round-1",
+      text_preview: "Partial result...",
+    });
+    const restored = reduceSessionProjection(createSessionProjectionState(), {
+      type: "cache_restored",
+      generation: SESSION_PROJECTION_GENERATION,
+      eventLogEpoch: "epoch-1",
+      eventsBySeq: { 6: recordedEvent },
+      eventSeqs: [6],
+      messagesById: {},
+      transcriptEntriesById: {},
+      briefRecordsById: {},
+      newestSeq: 6,
+      oldestSeq: 6,
+    });
+    const promoted = receive(restored, [
+      event(7, "brief_created", {
+        brief_id: "brief-1",
+        finalizes_assistant_round_id: "round-1",
+        kind: "result",
+        text: "Complete result.",
+      }),
+    ]);
+
+    expect(promoted.domain.rounds).toHaveLength(1);
+    expect(deriveSessionTimeline(promoted)).toEqual([
+      expect.objectContaining({
+        id: "assistant_round:round-1",
+        body: "Complete result.",
+        sourceIds: ["event-6", "event-7"],
+      }),
+    ]);
+  });
+
+  it("only uses transcript entry identity when the brief relation is finalizes", () => {
+    const projection = receive(createSessionProjectionState(), [
+      event(8, "assistant_round_recorded", {
+        assistant_round_id: "round-1",
+        text_preview: "First round",
+      }),
+      event(9, "brief_created", {
+        brief_id: "brief-final",
+        content_source: {
+          kind: "transcript_entry",
+          relation: "finalizes",
+          entry_id: "round-1",
+        },
+        text: "Promoted first round",
+      }),
+      event(10, "brief_created", {
+        brief_id: "brief-independent",
+        content_source: {
+          kind: "transcript_entry",
+          relation: "references",
+          entry_id: "round-1",
+        },
+        text: "Independent result",
+      }),
+      event(11, "assistant_round_recorded", {
+        assistant_round_id: "round-2",
+        text_preview: "Second round",
+      }),
+    ]);
+
+    expect(Array.from(projection.domain.rounds.keys())).toEqual([
+      "assistant_round:round-1",
+      "brief:brief-independent",
+      "assistant_round:round-2",
+    ]);
+  });
+
   it("records and closes gaps when backfill arrives", () => {
     const withGap = receive(createSessionProjectionState(), [events[0], events[2]]);
     expect(withGap.gaps).toEqual([{ afterSeq: 1, beforeSeq: 3 }]);

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -260,10 +260,11 @@ export function applySessionEvent(state: SessionState, event: SessionEventEnvelo
       } as DomainObject);
     }
   } else if (eventType === "brief_created" || eventType === "assistant_round_recorded") {
-    upsertObject(state, "assistant_round", eventId, {
+    const roundIdentity = assistantRoundIdentity(eventType, payload, eventId);
+    upsertObject(state, "assistant_round", roundIdentity.id, {
       ...baseFields,
-      id: eventId,
-      status: "recorded",
+      id: roundIdentity.id,
+      status: roundIdentity.promoted ? "brief_promoted" : "recorded",
     } as DomainObject);
   } else {
     upsertObject(state, "activity", eventId, {
@@ -273,6 +274,45 @@ export function applySessionEvent(state: SessionState, event: SessionEventEnvelo
       eventType,
     } as DomainObject);
   }
+}
+
+function assistantRoundIdentity(
+  eventType: string,
+  payload: Record<string, unknown> | undefined,
+  eventId: string,
+): { id: string; promoted: boolean } {
+  if (eventType === "assistant_round_recorded") {
+    const assistantRoundId = stringField(payload, "assistant_round_id");
+    return {
+      id: assistantRoundId ? `assistant_round:${assistantRoundId}` : eventId,
+      promoted: false,
+    };
+  }
+
+  const finalizedRoundId =
+    stringField(payload, "finalizes_assistant_round_id") ??
+    finalizedTranscriptEntryId(payload);
+  if (finalizedRoundId) {
+    return { id: `assistant_round:${finalizedRoundId}`, promoted: true };
+  }
+  const briefId = firstStringField(payload, ["brief_id", "id"]);
+  return {
+    id: briefId ? `brief:${briefId}` : eventId,
+    promoted: false,
+  };
+}
+
+function finalizedTranscriptEntryId(
+  payload: Record<string, unknown> | undefined,
+): string | undefined {
+  const contentSource = asRecord(payload?.content_source);
+  if (
+    stringField(contentSource, "kind") !== "transcript_entry" ||
+    stringField(contentSource, "relation") !== "finalizes"
+  ) {
+    return undefined;
+  }
+  return stringField(contentSource, "entry_id");
 }
 
 export function debugAgentSessionEvents(events: SessionEventEnvelope[], options: { itemLimit?: number } = {}): AgentTimelineItem[] {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1201,7 +1201,7 @@ describe("reduceAgentSessionTimeline", () => {
 
     expect(timeline[0]).toEqual(
       expect.objectContaining({
-        id: "brief-event",
+        id: "brief:brief_123",
         label: "Result",
         body: "Full persisted brief text.",
       }),
@@ -1246,7 +1246,7 @@ describe("reduceAgentSessionTimeline", () => {
 
     expect(timeline[0]).toEqual(
       expect.objectContaining({
-        id: "brief-event",
+        id: "assistant_round:round_123",
         body: "Canonical persisted brief.",
       }),
     );
@@ -1282,7 +1282,7 @@ describe("reduceAgentSessionTimeline", () => {
 
     expect(timeline[0]).toEqual(
       expect.objectContaining({
-        id: "assistant-round",
+        id: "assistant_round:round_123",
         body: "Operator-visible response.",
         minDisplayLevel: "verbose",
       }),

--- a/web-gui/app/src/runtime/timeline-view-model.ts
+++ b/web-gui/app/src/runtime/timeline-view-model.ts
@@ -1,7 +1,7 @@
 import type { AgentTimelineItem, DisplayLevel, RuntimeMessageEnvelope, RuntimeBriefRecord, RuntimeTranscriptEntry } from "./types";
 import type { SessionEventEnvelope } from "./session-events";
 import type { SessionState } from "./session-state-reducer";
-import type { DomainObject, InsertionEntry } from "./session-object-types";
+import type { DomainObject, InsertionEntry, SessionObjectType } from "./session-object-types";
 import { compactAgentTimelineItems } from "./timeline-display";
 import { renderDomainObject } from "./object-renderers";
 
@@ -34,7 +34,7 @@ export function deriveTimelineView(state: SessionState, ctx: RenderContext): Age
   for (const entry of state.insertionOrder) {
     const obj = lookupObject(state, entry);
     if (!obj) continue;
-    const item = renderObject(obj, ctx);
+    const item = renderObject(obj, entry.objectType, ctx);
     if (item) items.push(item);
   }
   const sorted = items.sort((left, right) => {
@@ -64,7 +64,11 @@ function lookupObject(state: SessionState, entry: InsertionEntry): DomainObject 
  * Calls {@link renderDomainObject} to produce the display-ready item.
  * Returns `undefined` when the object produces no visible projection.
  */
-function renderObject(obj: DomainObject, ctx: RenderContext): AgentTimelineItem | undefined {
+function renderObject(
+  obj: DomainObject,
+  objectType: SessionObjectType,
+  ctx: RenderContext,
+): AgentTimelineItem | undefined {
   // Skip activity objects that are children of a parent StateObject.
   // Tool execution objects may carry relatedStateObjectRef for breadcrumb
   // navigation but should still render as standalone timeline items.
@@ -77,7 +81,7 @@ function renderObject(obj: DomainObject, ctx: RenderContext): AgentTimelineItem 
     // Use the stable object id when available (stateObjectRef-bearing objects
     // and messages with message_id-based identity). Fall back to the last
     // source event id for objects without a stable identity.
-    id: item.stateObjectRef || obj.id.startsWith("message:")
+    id: item.stateObjectRef || obj.id.startsWith("message:") || objectType === "assistant_round"
       ? obj.id
       : obj.primaryEventId,
   };


### PR DESCRIPTION
## 概要

- 按 assistant round 的语义身份合并 progress/brief，避免同一轮输出重复展示
- 使用控制接口返回的 canonical `message_id` 精确确认并清理对应 optimistic operator prompt
- 补充同批、跨批、bootstrap + live，以及并发 optimistic prompt 回归测试

## 验证

- `cd web-gui/app && npm test -- --run`（195 项通过）
- `cd web-gui/app && npm run build`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2310
Closes #2324