### PR TITLE
fix: handle empty operator prompt responses

### DIFF
--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -416,6 +416,20 @@ describe("createRuntimeClient", () => {
     });
   });
 
+  it("reports a missing message_id for an empty operator prompt response", async () => {
+    const fetchImpl = async () => new Response(null, { status: 204 });
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      token: "secret-token",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.sendOperatorPrompt("agent-one", "hello")).rejects.toThrow(
+      "Operator prompt response did not include message_id.",
+    );
+  });
+
   it("fetches full tool execution detail for inspector hydration", async () => {
     const seen: string[] = [];
     const fetchImpl = async (input: RequestInfo | URL) => {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1050,7 +1050,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         },
         requestHeaders,
       );
-      if (!response.message_id) {
+      if (!response?.message_id) {
         throw new Error("Operator prompt response did not include message_id.");
       }
       return { messageId: response.message_id };


### PR DESCRIPTION
## Summary
- guard `sendOperatorPrompt` response access when `postJson` returns no body
- keep the existing message reference fallback behavior for non-empty responses
- add a regression test covering a successful `204 No Content` operator prompt response

## Background
Follow-up to #2325. Review identified that the web client could dereference `undefined` when the operator prompt endpoint succeeds with a 204 or otherwise empty response body.

## Verification
- `npm test -- --run src/runtime/client.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
