### PR TITLE
feat: 增加有界的 runtime SQLite retention maintenance

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -47,6 +47,7 @@ implementation and tests.
 - [Runtime Ledger Sequences and Object Revisions](./runtime-ledger-sequences-and-revisions.md)
 - [Runtime Ledger Files and Relations](./runtime-ledger-files-and-relations.md)
 - [Runtime Transition Commit Contract](./runtime-transition-commit-contract.md)
+- [Runtime SQLite Retention And Space Reclamation](./runtime-db-retention.md)
 - [WorkItem Current Focus Canonical Fact](./work-item-current-focus.md)
 
 ## Provenance, Policy, And Execution

--- a/docs/rfcs/runtime-db-retention.md
+++ b/docs/rfcs/runtime-db-retention.md
@@ -1,0 +1,168 @@
+---
+title: RFC: Runtime SQLite Retention And Space Reclamation
+date: 2026-07-18
+status: accepted
+handle: rfc-runtime-db-retention
+---
+
+# RFC: Runtime SQLite Retention And Space Reclamation
+
+## Summary
+
+Holon provides an opt-in, bounded maintenance policy for the largest
+append-oriented tables in `runtime.sqlite`:
+
+- `audit_events`;
+- `transcript_entries`;
+- `tool_executions`.
+
+Retention is disabled unless the operator explicitly sets
+`runtime.retention.enabled = true`. When enabled, a row is eligible only when
+it is older than the table's age window and is outside the configured minimum
+row floor. Active runtime evidence, active WorkItem references, context
+episode references, pending memory-index outbox sources, and a recent completed
+turn tail are protected by typed business logic.
+
+Online maintenance uses bounded transactions and optional incremental vacuum.
+Full `VACUUM` is an explicit offline operation.
+
+## Goals
+
+- stop unbounded growth after an operator enables a retention policy;
+- never prune canonical current state;
+- preserve evidence needed by active lifecycle state;
+- preserve pending memory-index outbox sources;
+- prune audit streams only as continuous sequence prefixes;
+- keep write-lock duration bounded;
+- make candidate, protected, deleted, and reclaimed-space results observable;
+- support existing databases without export, re-import, or payload backfill.
+
+## Non-goals
+
+- no cross-table SQLite foreign keys;
+- no normalization of `payload_json`;
+- no generic plugin-style garbage collector;
+- no automatic full `VACUUM`;
+- no retention for other evidence tables in this change;
+- no filesystem lifecycle cleanup.
+
+## Configuration
+
+The persisted surface is:
+
+```toml
+[runtime.retention]
+enabled = true
+audit_events_days = 30
+transcript_entries_days = 90
+tool_executions_days = 90
+audit_events_min_rows_per_scope = 4096
+transcript_entries_min_rows = 20000
+tool_executions_min_rows = 15000
+interval_hours = 6
+incremental_vacuum_pages = 256
+```
+
+`enabled` defaults to `false`. All other values have validated defaults so an
+operator may enable the policy with only the boolean setting. Age and count
+values are positive. The audit floor cannot be lower than the HTTP event
+replay window.
+
+The age and count conditions are conjunctive. A table or audit scope at or
+below its floor is skipped even when old rows exist. A maintenance pass must
+not delete below the floor.
+
+## Evidence Reference Contract
+
+Retention distinguishes strong roots from soft historical references.
+
+Strong roots are:
+
+- incomplete turns and the most recent 64 completed turns for each agent;
+- open WorkItems;
+- queued, running, or cancelling Tasks;
+- active waits and queued or interrupted messages;
+- `WorkItemRef.status == active` runtime source refs;
+- `ContextEpisodeRecord.source_refs`;
+- every unconsumed `runtime_index_outbox` source;
+- the configured table and audit-scope row floors.
+
+The collector reads typed records and normalized evidence columns. It must not
+use substring matching against JSON.
+
+Old completed `TurnRecord.tool_execution_ids` and resolved, stale, or archived
+WorkItem refs are soft references. After retention, their target may resolve
+as missing. This is an intentional historical-boundary contract, not
+referential corruption.
+
+## Table Rules
+
+### Audit events
+
+Agent scopes and the host scope are planned independently. The first retained
+sequence is the earlier of:
+
+- the first sequence whose timestamp is inside the age window;
+- the first sequence in the configured newest-row floor.
+
+Only rows before that sequence may be deleted. Timestamp disorder therefore
+widens retention rather than creating a sequence hole. `runtime_sequences`
+and `event_log_epoch` are not modified. A cursor older than the retained
+prefix continues to use the existing `cursor_not_found` recovery contract.
+
+### Transcript and tool evidence
+
+Rows must be older than the age cutoff, outside the global table floor, and
+unreferenced by the strong-root set. Candidate discovery is deterministic and
+oldest-first. Each transaction deletes at most a fixed internal batch.
+
+Deleting a tool execution also writes memory-index delete intents in the same
+transaction for every index source derived from that record. A rollback
+therefore preserves both the evidence and its current index state.
+
+## Online Maintenance
+
+The daemon owns at most one maintenance loop. The loop:
+
+1. reads the latest effective config;
+2. does nothing while retention is disabled;
+3. plans and executes one bounded pass;
+4. optionally runs `PRAGMA incremental_vacuum(N)` only when the database is
+   already in incremental auto-vacuum mode;
+5. waits for the configured interval or shutdown.
+
+Failures are logged and retried only on a later scheduled round. They do not
+make the runtime unhealthy and do not trigger a tight retry loop.
+
+New empty runtime databases select incremental auto-vacuum before schema
+creation. Existing databases are not silently rewritten.
+
+## Offline Compaction
+
+`holon debug runtime-db compact` is an explicit offline command. It acquires a
+daemon-held maintenance lock non-blockingly, reports pre-operation page and
+freelist statistics, sets incremental auto-vacuum, and runs full `VACUUM`.
+
+The command fails closed while the daemon holds the maintenance lock. It does
+not delete or replace the original database file itself; SQLite owns the
+atomic rewrite behavior.
+
+## Observability
+
+The dry-run and execution paths share a typed report containing:
+
+- effective policy and cutoffs;
+- observed, candidate, protected, and deleted rows by table;
+- audit-scope skip counts;
+- page size, page count, freelist pages, and estimated reclaimable bytes;
+- incremental-vacuum result;
+- elapsed time.
+
+Structured logs use the same report fields. Maintenance does not add an
+unbounded history table.
+
+## Compatibility
+
+No existing business table is rebuilt or backfilled. Existing JSON, HTTP, and
+tool response schemas are unchanged. Missing historical evidence remains an
+explicit supported result on existing lookup surfaces.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3615,6 +3615,65 @@
                 },
                 "type": "array"
               },
+              "runtime_db_retention": {
+                "properties": {
+                  "audit_events_days": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "audit_events_min_rows_per_scope": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "incremental_vacuum_pages": {
+                    "format": "uint32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "interval_hours": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tool_executions_days": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tool_executions_min_rows": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "transcript_entries_days": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "transcript_entries_min_rows": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "enabled",
+                  "audit_events_days",
+                  "transcript_entries_days",
+                  "tool_executions_days",
+                  "audit_events_min_rows_per_scope",
+                  "transcript_entries_min_rows",
+                  "tool_executions_min_rows",
+                  "interval_hours",
+                  "incremental_vacuum_pages"
+                ],
+                "type": "object"
+              },
               "runtime_max_output_tokens": {
                 "format": "uint32",
                 "minimum": 0,
@@ -3715,6 +3774,7 @@
               "default_tool_output_tokens",
               "max_tool_output_tokens",
               "disable_provider_fallback",
+              "runtime_db_retention",
               "providers",
               "web_search",
               "web_search_providers"
@@ -3988,6 +4048,65 @@
                 },
                 "type": "array"
               },
+              "runtime_db_retention": {
+                "properties": {
+                  "audit_events_days": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "audit_events_min_rows_per_scope": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "incremental_vacuum_pages": {
+                    "format": "uint32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "interval_hours": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tool_executions_days": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tool_executions_min_rows": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "transcript_entries_days": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "transcript_entries_min_rows": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "enabled",
+                  "audit_events_days",
+                  "transcript_entries_days",
+                  "tool_executions_days",
+                  "audit_events_min_rows_per_scope",
+                  "transcript_entries_min_rows",
+                  "tool_executions_min_rows",
+                  "interval_hours",
+                  "incremental_vacuum_pages"
+                ],
+                "type": "object"
+              },
               "runtime_max_output_tokens": {
                 "format": "uint32",
                 "minimum": 0,
@@ -4088,6 +4207,7 @@
               "default_tool_output_tokens",
               "max_tool_output_tokens",
               "disable_provider_fallback",
+              "runtime_db_retention",
               "providers",
               "web_search",
               "web_search_providers"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -566,11 +566,29 @@ pub enum DebugCommands {
         #[arg(long)]
         json: bool,
     },
+    RuntimeDb {
+        #[command(subcommand)]
+        command: RuntimeDbDebugCommands,
+    },
     SchedulerFixture {
         #[arg(long)]
         agent: Option<String>,
         #[arg(long)]
         output: PathBuf,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RuntimeDbDebugCommands {
+    Retention {
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    Compact {
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -230,6 +230,30 @@ pub struct RuntimeConfigFile {
     pub max_tool_output_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disable_provider_fallback: Option<bool>,
+    #[serde(default, skip_serializing_if = "RuntimeRetentionConfigFile::is_empty")]
+    pub retention: RuntimeRetentionConfigFile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RuntimeRetentionConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_events_days: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_entries_days: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_executions_days: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_events_min_rows_per_scope: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_entries_min_rows: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_executions_min_rows: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval_hours: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incremental_vacuum_pages: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -412,7 +436,25 @@ impl ImageGenerationConfigFile {
 
 impl RuntimeConfigFile {
     pub(crate) fn is_empty(&self) -> bool {
-        self.max_output_tokens.is_none() && self.disable_provider_fallback.is_none()
+        self.max_output_tokens.is_none()
+            && self.default_tool_output_tokens.is_none()
+            && self.max_tool_output_tokens.is_none()
+            && self.disable_provider_fallback.is_none()
+            && self.retention.is_empty()
+    }
+}
+
+impl RuntimeRetentionConfigFile {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.enabled.is_none()
+            && self.audit_events_days.is_none()
+            && self.transcript_entries_days.is_none()
+            && self.tool_executions_days.is_none()
+            && self.audit_events_min_rows_per_scope.is_none()
+            && self.transcript_entries_min_rows.is_none()
+            && self.tool_executions_min_rows.is_none()
+            && self.interval_hours.is_none()
+            && self.incremental_vacuum_pages.is_none()
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -253,6 +253,7 @@ impl AppConfig {
             .max(default_tool_output_tokens);
 
         let disable_provider_fallback = resolve_disable_provider_fallback(&stored_config)?;
+        resolve_runtime_db_retention_policy(&stored_config)?;
         let validated_model_overrides = resolve_model_catalog(&stored_config)?;
         let validated_unknown_model_fallback =
             validate_optional_model_runtime_override(stored_config.model.unknown_fallback.clone())?;
@@ -353,6 +354,16 @@ impl AppConfig {
 
     pub fn runtime_db_lock_path(&self) -> PathBuf {
         self.data_dir.join("state").join("runtime.lock")
+    }
+
+    pub fn runtime_db_maintenance_lock_path(&self) -> PathBuf {
+        self.data_dir.join("state").join("runtime-maintenance.lock")
+    }
+
+    pub fn runtime_db_retention_policy(
+        &self,
+    ) -> Result<crate::runtime_db::RuntimeDbRetentionPolicy> {
+        resolve_runtime_db_retention_policy(&self.stored_config)
     }
 
     pub fn agent_root_dir(&self) -> PathBuf {
@@ -471,6 +482,39 @@ fn resolve_disable_provider_fallback(stored_config: &HolonConfigFile) -> Result<
         env::var("HOLON_DISABLE_PROVIDER_FALLBACK").ok().as_deref(),
         stored_config,
     )
+}
+
+fn resolve_runtime_db_retention_policy(
+    stored_config: &HolonConfigFile,
+) -> Result<crate::runtime_db::RuntimeDbRetentionPolicy> {
+    let configured = &stored_config.runtime.retention;
+    let defaults = crate::runtime_db::RuntimeDbRetentionPolicy::default();
+    crate::runtime_db::RuntimeDbRetentionPolicy {
+        enabled: configured.enabled.unwrap_or(defaults.enabled),
+        audit_events_days: configured
+            .audit_events_days
+            .unwrap_or(defaults.audit_events_days),
+        transcript_entries_days: configured
+            .transcript_entries_days
+            .unwrap_or(defaults.transcript_entries_days),
+        tool_executions_days: configured
+            .tool_executions_days
+            .unwrap_or(defaults.tool_executions_days),
+        audit_events_min_rows_per_scope: configured
+            .audit_events_min_rows_per_scope
+            .unwrap_or(defaults.audit_events_min_rows_per_scope),
+        transcript_entries_min_rows: configured
+            .transcript_entries_min_rows
+            .unwrap_or(defaults.transcript_entries_min_rows),
+        tool_executions_min_rows: configured
+            .tool_executions_min_rows
+            .unwrap_or(defaults.tool_executions_min_rows),
+        interval_hours: configured.interval_hours.unwrap_or(defaults.interval_hours),
+        incremental_vacuum_pages: configured
+            .incremental_vacuum_pages
+            .unwrap_or(defaults.incremental_vacuum_pages),
+    }
+    .validate()
 }
 
 fn resolve_disable_provider_fallback_override(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -348,6 +348,69 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             allowed_values: vec!["true", "false"],
         },
         ConfigSchemaEntry {
+            key: "runtime.retention.enabled",
+            kind: "boolean",
+            description: "Enable bounded runtime SQLite retention. Disabled unless explicitly configured.",
+            default: json!(false),
+            allowed_values: vec!["true", "false"],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.audit_events_days",
+            kind: "positive_integer",
+            description: "Age window in days for audit event retention.",
+            default: json!(crate::runtime_db::retention::DEFAULT_AUDIT_EVENTS_DAYS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.transcript_entries_days",
+            kind: "positive_integer",
+            description: "Age window in days for transcript entry retention.",
+            default: json!(crate::runtime_db::retention::DEFAULT_TRANSCRIPT_ENTRIES_DAYS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.tool_executions_days",
+            kind: "positive_integer",
+            description: "Age window in days for tool execution retention.",
+            default: json!(crate::runtime_db::retention::DEFAULT_TOOL_EXECUTIONS_DAYS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.audit_events_min_rows_per_scope",
+            kind: "positive_integer",
+            description: "Minimum audit event rows retained independently for each agent or host scope.",
+            default: json!(crate::runtime_db::retention::DEFAULT_AUDIT_EVENTS_MIN_ROWS_PER_SCOPE),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.transcript_entries_min_rows",
+            kind: "positive_integer",
+            description: "Minimum transcript rows retained globally.",
+            default: json!(crate::runtime_db::retention::DEFAULT_TRANSCRIPT_ENTRIES_MIN_ROWS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.tool_executions_min_rows",
+            kind: "positive_integer",
+            description: "Minimum tool execution rows retained globally.",
+            default: json!(crate::runtime_db::retention::DEFAULT_TOOL_EXECUTIONS_MIN_ROWS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.interval_hours",
+            kind: "positive_integer",
+            description: "Hours between daemon retention passes while retention is enabled.",
+            default: json!(crate::runtime_db::retention::DEFAULT_RETENTION_INTERVAL_HOURS),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "runtime.retention.incremental_vacuum_pages",
+            kind: "positive_integer",
+            description: "Maximum pages requested from SQLite incremental vacuum after a retention pass.",
+            default: json!(crate::runtime_db::retention::DEFAULT_INCREMENTAL_VACUUM_PAGES),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
             key: "tui.alternate_screen",
             kind: "enum",
             description: "Whether the TUI uses the terminal alternate screen buffer.",
@@ -689,6 +752,60 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .disable_provider_fallback
             .map(Value::Bool)
             .unwrap_or(Value::Null)),
+        "runtime.retention.enabled" => Ok(config
+            .runtime
+            .retention
+            .enabled
+            .map(Value::Bool)
+            .unwrap_or(Value::Null)),
+        "runtime.retention.audit_events_days" => Ok(config
+            .runtime
+            .retention
+            .audit_events_days
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.transcript_entries_days" => Ok(config
+            .runtime
+            .retention
+            .transcript_entries_days
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.tool_executions_days" => Ok(config
+            .runtime
+            .retention
+            .tool_executions_days
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.audit_events_min_rows_per_scope" => Ok(config
+            .runtime
+            .retention
+            .audit_events_min_rows_per_scope
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.transcript_entries_min_rows" => Ok(config
+            .runtime
+            .retention
+            .transcript_entries_min_rows
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.tool_executions_min_rows" => Ok(config
+            .runtime
+            .retention
+            .tool_executions_min_rows
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.interval_hours" => Ok(config
+            .runtime
+            .retention
+            .interval_hours
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "runtime.retention.incremental_vacuum_pages" => Ok(config
+            .runtime
+            .retention
+            .incremental_vacuum_pages
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
         "tui.alternate_screen" => Ok(config
             .tui
             .alternate_screen
@@ -978,6 +1095,42 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
             );
         }
+        "runtime.retention.enabled" => {
+            config.runtime.retention.enabled = Some(
+                parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
+            );
+        }
+        "runtime.retention.audit_events_days" => {
+            config.runtime.retention.audit_events_days =
+                Some(parse_positive_u64_key(key, raw_value)?);
+        }
+        "runtime.retention.transcript_entries_days" => {
+            config.runtime.retention.transcript_entries_days =
+                Some(parse_positive_u64_key(key, raw_value)?);
+        }
+        "runtime.retention.tool_executions_days" => {
+            config.runtime.retention.tool_executions_days =
+                Some(parse_positive_u64_key(key, raw_value)?);
+        }
+        "runtime.retention.audit_events_min_rows_per_scope" => {
+            config.runtime.retention.audit_events_min_rows_per_scope =
+                Some(parse_positive_usize_key(key, raw_value)?);
+        }
+        "runtime.retention.transcript_entries_min_rows" => {
+            config.runtime.retention.transcript_entries_min_rows =
+                Some(parse_positive_usize_key(key, raw_value)?);
+        }
+        "runtime.retention.tool_executions_min_rows" => {
+            config.runtime.retention.tool_executions_min_rows =
+                Some(parse_positive_usize_key(key, raw_value)?);
+        }
+        "runtime.retention.interval_hours" => {
+            config.runtime.retention.interval_hours = Some(parse_positive_u64_key(key, raw_value)?);
+        }
+        "runtime.retention.incremental_vacuum_pages" => {
+            config.runtime.retention.incremental_vacuum_pages =
+                Some(parse_positive_u32_key(key, raw_value)?);
+        }
         "tui.alternate_screen" => {
             config.tui.alternate_screen = Some(AltScreenMode::parse(raw_value)?);
         }
@@ -1187,6 +1340,7 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
         _ => return Err(unknown_config_key(key)),
     }
     validate_api_cors_config(&config.api.cors)?;
+    super::resolve_runtime_db_retention_policy(config)?;
     Ok(())
 }
 
@@ -1241,6 +1395,31 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "runtime.default_tool_output_tokens" => config.runtime.default_tool_output_tokens = None,
         "runtime.max_tool_output_tokens" => config.runtime.max_tool_output_tokens = None,
         "runtime.disable_provider_fallback" => config.runtime.disable_provider_fallback = None,
+        "runtime.retention.enabled" => config.runtime.retention.enabled = None,
+        "runtime.retention.audit_events_days" => {
+            config.runtime.retention.audit_events_days = None;
+        }
+        "runtime.retention.transcript_entries_days" => {
+            config.runtime.retention.transcript_entries_days = None;
+        }
+        "runtime.retention.tool_executions_days" => {
+            config.runtime.retention.tool_executions_days = None;
+        }
+        "runtime.retention.audit_events_min_rows_per_scope" => {
+            config.runtime.retention.audit_events_min_rows_per_scope = None;
+        }
+        "runtime.retention.transcript_entries_min_rows" => {
+            config.runtime.retention.transcript_entries_min_rows = None;
+        }
+        "runtime.retention.tool_executions_min_rows" => {
+            config.runtime.retention.tool_executions_min_rows = None;
+        }
+        "runtime.retention.interval_hours" => {
+            config.runtime.retention.interval_hours = None;
+        }
+        "runtime.retention.incremental_vacuum_pages" => {
+            config.runtime.retention.incremental_vacuum_pages = None;
+        }
         "tui.alternate_screen" => config.tui.alternate_screen = None,
         "web.fetch.enabled" => config.web.fetch.enabled = None,
         "web.fetch.max_chars" => config.web.fetch.max_chars = None,

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -91,6 +91,7 @@ pub struct RuntimeConfigSurface {
     pub default_tool_output_tokens: u32,
     pub max_tool_output_tokens: u32,
     pub disable_provider_fallback: bool,
+    pub runtime_db_retention: crate::runtime_db::RuntimeDbRetentionPolicy,
     pub providers: Vec<RuntimeProviderSummary>,
     pub web_search: RuntimeWebSearchSummary,
     #[serde(default)]
@@ -166,6 +167,9 @@ impl RuntimeConfigSurface {
             default_tool_output_tokens: config.default_tool_output_tokens,
             max_tool_output_tokens: config.max_tool_output_tokens,
             disable_provider_fallback: config.disable_provider_fallback,
+            runtime_db_retention: config
+                .runtime_db_retention_policy()
+                .expect("runtime database retention policy was validated during config load"),
             providers: config
                 .providers
                 .values()

--- a/src/host.rs
+++ b/src/host.rs
@@ -108,6 +108,9 @@ struct HostInner {
     memory_index_notify: Arc<Notify>,
     daemon_indexer_token: CancellationToken,
     daemon_indexer_handle: Mutex<Option<JoinHandle<()>>>,
+    daemon_retention_token: CancellationToken,
+    daemon_retention_handle: Mutex<Option<JoinHandle<()>>>,
+    runtime_db_maintenance_lock: Mutex<Option<crate::runtime_db::RuntimeDbLock>>,
     skills_registry: Arc<RwLock<SkillsRegistry>>,
     static_provider: Option<Arc<dyn AgentProvider>>,
     agents: RwLock<HashMap<String, AgentEntry>>,
@@ -227,6 +230,9 @@ impl RuntimeHost {
                 memory_index_notify: Arc::new(Notify::new()),
                 daemon_indexer_token: CancellationToken::new(),
                 daemon_indexer_handle: Mutex::new(None),
+                daemon_retention_token: CancellationToken::new(),
+                daemon_retention_handle: Mutex::new(None),
+                runtime_db_maintenance_lock: Mutex::new(None),
                 skills_registry: Arc::new(RwLock::new(SkillsRegistry::new())),
                 static_provider,
                 agents: RwLock::new(HashMap::new()),
@@ -313,6 +319,123 @@ impl RuntimeHost {
         let handle = self.inner.daemon_indexer_handle.lock().unwrap().take();
         if let Some(handle) = handle {
             let _ = handle.await;
+        }
+    }
+
+    pub fn spawn_daemon_runtime_db_retention(&self) {
+        if tokio::runtime::Handle::try_current().is_err() {
+            tracing::debug!("daemon runtime db retention not spawned: no Tokio runtime");
+            return;
+        }
+        if self.inner.daemon_retention_handle.lock().unwrap().is_some() {
+            return;
+        }
+        match crate::runtime_db::RuntimeDbLock::try_lock(
+            self.config().runtime_db_maintenance_lock_path(),
+        ) {
+            Ok(lock) => {
+                *self.inner.runtime_db_maintenance_lock.lock().unwrap() = Some(lock);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "daemon runtime db retention disabled: maintenance lock unavailable"
+                );
+                return;
+            }
+        }
+        let host = self.clone();
+        let handle = tokio::spawn(async move {
+            host.run_daemon_runtime_db_retention().await;
+        });
+        *self.inner.daemon_retention_handle.lock().unwrap() = Some(handle);
+    }
+
+    pub async fn shutdown_daemon_runtime_db_retention(&self) {
+        self.inner.daemon_retention_token.cancel();
+        let handle = self.inner.daemon_retention_handle.lock().unwrap().take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
+        self.inner
+            .runtime_db_maintenance_lock
+            .lock()
+            .unwrap()
+            .take();
+    }
+
+    async fn run_daemon_runtime_db_retention(self) {
+        loop {
+            if self.inner.daemon_retention_token.is_cancelled() {
+                break;
+            }
+            let policy = match self.config().runtime_db_retention_policy() {
+                Ok(policy) => policy,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "daemon runtime db retention: invalid reloaded policy"
+                    );
+                    if self
+                        .wait_daemon_retention_round(Duration::from_secs(60))
+                        .await
+                    {
+                        break;
+                    }
+                    continue;
+                }
+            };
+            if policy.enabled {
+                let db = self.inner.runtime_db.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    db.run_retention_pass(policy, chrono::Utc::now())
+                })
+                .await;
+                match result {
+                    Ok(Ok(report)) => {
+                        tracing::info!(
+                            audit_deleted = report.audit_events.deleted_rows,
+                            transcript_deleted = report.transcript_entries.deleted_rows,
+                            tool_deleted = report.tool_executions.deleted_rows,
+                            elapsed_ms = report.elapsed_ms,
+                            freelist_pages = report.freelist_pages_after,
+                            "daemon runtime db retention pass completed"
+                        );
+                    }
+                    Ok(Err(error)) => {
+                        tracing::warn!(
+                            error = %error,
+                            "daemon runtime db retention pass failed"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            "daemon runtime db retention task failed"
+                        );
+                    }
+                }
+            }
+            let interval_hours = self
+                .config()
+                .runtime_db_retention_policy()
+                .map(|policy| policy.interval_hours)
+                .unwrap_or(1);
+            if self
+                .wait_daemon_retention_round(Duration::from_secs(
+                    interval_hours.saturating_mul(60 * 60),
+                ))
+                .await
+            {
+                break;
+            }
+        }
+    }
+
+    async fn wait_daemon_retention_round(&self, duration: Duration) -> bool {
+        tokio::select! {
+            _ = self.inner.daemon_retention_token.cancelled() => true,
+            _ = tokio::time::sleep(duration) => false,
         }
     }
 
@@ -421,6 +544,8 @@ impl RuntimeHost {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
+        self.shutdown_daemon_runtime_db_retention().await;
+        self.shutdown_daemon_memory_indexer().await;
         let entries = {
             let mut agents = self.inner.agents.write().await;
             agents.drain().map(|(_, entry)| entry).collect::<Vec<_>>()

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -300,7 +300,8 @@ fn is_runtime_mutable_config_key(key: &str) -> bool {
             | "runtime.default_tool_output_tokens"
             | "runtime.max_tool_output_tokens"
             | "runtime.disable_provider_fallback"
-    ) || key.starts_with("providers.")
+    ) || key.starts_with("runtime.retention.")
+        || key.starts_with("providers.")
         || key.starts_with("agent_templates.")
         || key.starts_with("web.")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use holon::{
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
     runtime::maybe_enqueue_first_run_intro,
-    runtime_db::RuntimeDb,
+    runtime_db::{RuntimeDb, RuntimeDbLock},
     solve::{run_solve, SolveRequest},
     storage::AppStorage,
     tui::run_tui,
@@ -826,6 +826,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     let host = RuntimeHost::new(config.clone())?;
     let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
+    host.spawn_daemon_runtime_db_retention();
     spawn_stale_agent_template_remote_source_sync(&config, &host);
     emit_first_run_intro(&config, &runtime).await;
     let runtime_service = RuntimeServiceHandle::new(&config)?;
@@ -2188,8 +2189,51 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
             events_limit,
         } => print_latency_diagnostics(&config, agent, limit, events_limit),
         DebugCommands::Performance { json } => print_performance_diagnostics(&config, json).await,
+        DebugCommands::RuntimeDb { command } => handle_runtime_db_debug_command(&config, command),
         DebugCommands::SchedulerFixture { agent, output } => {
             export_scheduler_fixture(&config, agent, &output)
+        }
+    }
+}
+
+fn handle_runtime_db_debug_command(
+    config: &AppConfig,
+    command: holon::cli::RuntimeDbDebugCommands,
+) -> Result<()> {
+    match command {
+        holon::cli::RuntimeDbDebugCommands::Retention { dry_run, json } => {
+            let policy = config.runtime_db_retention_policy()?;
+            let db = RuntimeDb::open_and_migrate(
+                config.runtime_db_path(),
+                config.runtime_db_lock_path(),
+            )?;
+            let report = if dry_run {
+                db.plan_retention(policy, chrono::Utc::now())?
+            } else {
+                let _maintenance_lock =
+                    RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path())
+                        .context("runtime database maintenance is already running")?;
+                db.run_retention_pass(policy, chrono::Utc::now())?
+            };
+            if json {
+                print_json(&serde_json::to_value(report)?)
+            } else {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+                Ok(())
+            }
+        }
+        holon::cli::RuntimeDbDebugCommands::Compact { json } => {
+            let report = RuntimeDb::compact_offline(
+                &config.runtime_db_path(),
+                &config.runtime_db_lock_path(),
+                &config.runtime_db_maintenance_lock_path(),
+            )?;
+            if json {
+                print_json(&serde_json::to_value(report)?)
+            } else {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+                Ok(())
+            }
         }
     }
 }

--- a/src/runtime_db/connection.rs
+++ b/src/runtime_db/connection.rs
@@ -56,6 +56,19 @@ PRAGMA mmap_size = 268435456;
     Ok(())
 }
 
+pub(crate) fn configure_new_database_auto_vacuum(connection: &Connection) -> Result<()> {
+    let application_tables: u64 = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+        [],
+        |row| row.get(0),
+    )?;
+    if application_tables == 0 {
+        connection.execute_batch("PRAGMA auto_vacuum = INCREMENTAL;")?;
+    }
+    Ok(())
+}
+
 pub(crate) fn run_transaction_on_connection<T>(
     connection: &Connection,
     path: &Path,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -1145,6 +1145,11 @@ CREATE TABLE IF NOT EXISTS runtime_metadata (
 );
 "#,
     },
+    Migration {
+        version: 30,
+        name: "runtime_retention_created_at_indexes",
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -1195,6 +1200,9 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     if migration.name == "strict_runtime_sequences" {
         migrate_runtime_sequences(&transaction)?;
     }
+    if migration.name == "runtime_retention_created_at_indexes" {
+        migrate_runtime_retention_created_at_indexes(&transaction)?;
+    }
     transaction.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         (
@@ -1204,6 +1212,22 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
         ),
     )?;
     transaction.commit()?;
+    Ok(())
+}
+
+fn migrate_runtime_retention_created_at_indexes(connection: &Connection) -> Result<()> {
+    if table_exists_internal(connection, "transcript_entries")? {
+        connection.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_transcript_entries_created
+               ON transcript_entries(created_at, evidence_id);",
+        )?;
+    }
+    if table_exists_internal(connection, "tool_executions")? {
+        connection.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_tool_executions_created
+               ON tool_executions(created_at, evidence_id);",
+        )?;
+    }
     Ok(())
 }
 

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -14,6 +14,7 @@ pub mod connection;
 pub mod evidence;
 pub mod migrations;
 pub mod repositories;
+pub mod retention;
 pub mod storage_domain;
 pub(crate) mod transitions;
 pub mod types;
@@ -27,6 +28,10 @@ pub use crate::runtime_db::evidence::{
 };
 pub use crate::runtime_db::index_outbox::{
     RuntimeIndexChange, RuntimeIndexOperation, RuntimeIndexOutboxRepository, RuntimeIndexOutboxRow,
+};
+pub use crate::runtime_db::retention::{
+    RuntimeDbCompactReport, RuntimeDbRetentionPolicy, RuntimeDbRetentionReport,
+    RuntimeDbRetentionTableReport,
 };
 pub use crate::runtime_db::storage_domain::{ExpectedStorageDomain, StorageDomainSnapshot};
 pub use crate::runtime_db::types::{
@@ -53,7 +58,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction};
 
 use crate::runtime_db::connection::{
-    configure_persistent_database, flock, open_connection, unlock, LockMode,
+    configure_new_database_auto_vacuum, configure_persistent_database, flock, open_connection,
+    unlock, LockMode,
 };
 use crate::runtime_db::migrations::{
     apply_migration, backfill_wait_condition_payload_columns, backfill_work_item_recheck_columns,
@@ -623,6 +629,7 @@ impl RuntimeDb {
             .connection
             .lock()
             .map_err(|_| anyhow!("runtime db writer mutex poisoned"))?;
+        configure_new_database_auto_vacuum(&connection)?;
         configure_persistent_database(&connection)?;
         ensure_migration_table(&connection)?;
         let current_version = current_schema_version(&connection)?;

--- a/src/runtime_db/retention.rs
+++ b/src/runtime_db/retention.rs
@@ -227,7 +227,7 @@ impl RuntimeDb {
         let policy = policy.validate()?;
         if !policy.enabled {
             let connection = self.connection()?;
-            return build_retention_report(&connection, &policy, now, false, None);
+            return build_retention_report(&connection, &policy, now, true, None);
         }
         let transaction_policy = policy.clone();
         let mut report = self.transaction_with_context(
@@ -968,6 +968,43 @@ mod tests {
         .validate()
         .expect_err("audit floor below replay window must fail");
         assert!(error.to_string().contains("must be at least"));
+    }
+
+    #[test]
+    fn disabled_retention_reports_candidates_without_deleting() -> Result<()> {
+        let (_directory, db) = runtime_db()?;
+        let now = Utc::now();
+        for id in ["transcript-old-a", "transcript-old-b"] {
+            let mut entry = TranscriptEntry::new(
+                "agent-a",
+                TranscriptEntryKind::IncomingMessage,
+                None,
+                None,
+                serde_json::json!({"text": id}),
+            );
+            entry.id = id.into();
+            entry.created_at = now - Duration::days(60);
+            db.transcript_entries().append(&entry)?;
+        }
+        let mut disabled = policy();
+        disabled.enabled = false;
+
+        let report = db.run_retention_pass(disabled, now)?;
+
+        assert!(report.dry_run);
+        assert!(!report.enabled);
+        assert_eq!(report.transcript_entries.candidate_rows, 2);
+        assert_eq!(report.transcript_entries.planned_delete_rows, 1);
+        assert_eq!(report.transcript_entries.deleted_rows, 0);
+        assert!(db
+            .transcript_entries()
+            .by_id(None, "transcript-old-a")?
+            .is_some());
+        assert!(db
+            .transcript_entries()
+            .by_id(None, "transcript-old-b")?
+            .is_some());
+        Ok(())
     }
 
     #[test]

--- a/src/runtime_db/retention.rs
+++ b/src/runtime_db/retention.rs
@@ -1,0 +1,1099 @@
+//! Bounded runtime database retention and explicit space reclamation.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+    time::Instant,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime_db::{
+        evidence::insert_runtime_index_changes_tx, write_queue::RuntimeDbWriteContext, RuntimeDb,
+        RuntimeDbLock, RuntimeIndexChange, RuntimeIndexOperation,
+    },
+    tool::helpers::{command_output_source_ref, command_receipt_source_ref},
+    types::{
+        BriefRecord, ContextEpisodeRecord, TaskRecord, ToolExecutionRecord, ToolResultData,
+        TranscriptEntry, TurnRecord, WaitConditionRecord, WorkItemRecord, WorkItemRefStatus,
+    },
+};
+
+pub const DEFAULT_AUDIT_EVENTS_DAYS: u64 = 30;
+pub const DEFAULT_TRANSCRIPT_ENTRIES_DAYS: u64 = 90;
+pub const DEFAULT_TOOL_EXECUTIONS_DAYS: u64 = 90;
+pub const DEFAULT_AUDIT_EVENTS_MIN_ROWS_PER_SCOPE: usize = 4096;
+pub const DEFAULT_TRANSCRIPT_ENTRIES_MIN_ROWS: usize = 20_000;
+pub const DEFAULT_TOOL_EXECUTIONS_MIN_ROWS: usize = 15_000;
+pub const DEFAULT_RETENTION_INTERVAL_HOURS: u64 = 6;
+pub const DEFAULT_INCREMENTAL_VACUUM_PAGES: u32 = 256;
+pub const RETENTION_DELETE_BATCH_ROWS: usize = 1000;
+
+const RECENT_COMPLETED_TURNS_PER_AGENT: usize = 64;
+const MAX_RETENTION_DAYS: u64 = 3650;
+const MAX_RETENTION_ROWS: usize = 10_000_000;
+const MAX_RETENTION_INTERVAL_HOURS: u64 = 24 * 30;
+const MAX_INCREMENTAL_VACUUM_PAGES: u32 = 100_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct RuntimeDbRetentionPolicy {
+    pub enabled: bool,
+    pub audit_events_days: u64,
+    pub transcript_entries_days: u64,
+    pub tool_executions_days: u64,
+    pub audit_events_min_rows_per_scope: usize,
+    pub transcript_entries_min_rows: usize,
+    pub tool_executions_min_rows: usize,
+    pub interval_hours: u64,
+    pub incremental_vacuum_pages: u32,
+}
+
+impl Default for RuntimeDbRetentionPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            audit_events_days: DEFAULT_AUDIT_EVENTS_DAYS,
+            transcript_entries_days: DEFAULT_TRANSCRIPT_ENTRIES_DAYS,
+            tool_executions_days: DEFAULT_TOOL_EXECUTIONS_DAYS,
+            audit_events_min_rows_per_scope: DEFAULT_AUDIT_EVENTS_MIN_ROWS_PER_SCOPE,
+            transcript_entries_min_rows: DEFAULT_TRANSCRIPT_ENTRIES_MIN_ROWS,
+            tool_executions_min_rows: DEFAULT_TOOL_EXECUTIONS_MIN_ROWS,
+            interval_hours: DEFAULT_RETENTION_INTERVAL_HOURS,
+            incremental_vacuum_pages: DEFAULT_INCREMENTAL_VACUUM_PAGES,
+        }
+    }
+}
+
+impl RuntimeDbRetentionPolicy {
+    pub fn validate(self) -> Result<Self> {
+        validate_positive_bounded(
+            "runtime.retention.audit_events_days",
+            self.audit_events_days,
+            MAX_RETENTION_DAYS,
+        )?;
+        validate_positive_bounded(
+            "runtime.retention.transcript_entries_days",
+            self.transcript_entries_days,
+            MAX_RETENTION_DAYS,
+        )?;
+        validate_positive_bounded(
+            "runtime.retention.tool_executions_days",
+            self.tool_executions_days,
+            MAX_RETENTION_DAYS,
+        )?;
+        if self.audit_events_min_rows_per_scope < crate::http::MAX_EVENT_STREAM_WINDOW {
+            bail!(
+                "runtime.retention.audit_events_min_rows_per_scope must be at least {}",
+                crate::http::MAX_EVENT_STREAM_WINDOW
+            );
+        }
+        validate_positive_bounded(
+            "runtime.retention.audit_events_min_rows_per_scope",
+            self.audit_events_min_rows_per_scope,
+            MAX_RETENTION_ROWS,
+        )?;
+        validate_positive_bounded(
+            "runtime.retention.transcript_entries_min_rows",
+            self.transcript_entries_min_rows,
+            MAX_RETENTION_ROWS,
+        )?;
+        validate_positive_bounded(
+            "runtime.retention.tool_executions_min_rows",
+            self.tool_executions_min_rows,
+            MAX_RETENTION_ROWS,
+        )?;
+        validate_positive_bounded(
+            "runtime.retention.interval_hours",
+            self.interval_hours,
+            MAX_RETENTION_INTERVAL_HOURS,
+        )?;
+        validate_positive_bounded(
+            "runtime.retention.incremental_vacuum_pages",
+            self.incremental_vacuum_pages,
+            MAX_INCREMENTAL_VACUUM_PAGES,
+        )?;
+        Ok(self)
+    }
+}
+
+fn validate_positive_bounded<T>(key: &str, value: T, max: T) -> Result<()>
+where
+    T: Copy + Ord + Default + std::fmt::Display,
+{
+    if value == T::default() || value > max {
+        bail!("{key} must be between 1 and {max}");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct RuntimeDbRetentionTableReport {
+    pub observed_rows: u64,
+    pub candidate_rows: u64,
+    pub protected_rows: u64,
+    pub planned_delete_rows: u64,
+    pub deleted_rows: u64,
+    pub skipped_below_minimum_rows: bool,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub protection_reasons: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeDbRetentionReport {
+    pub dry_run: bool,
+    pub enabled: bool,
+    pub started_at: DateTime<Utc>,
+    pub elapsed_ms: u64,
+    pub policy: RuntimeDbRetentionPolicy,
+    pub audit_events: RuntimeDbRetentionTableReport,
+    pub transcript_entries: RuntimeDbRetentionTableReport,
+    pub tool_executions: RuntimeDbRetentionTableReport,
+    pub audit_scopes_observed: u64,
+    pub audit_scopes_skipped_below_minimum_rows: u64,
+    pub page_size: u64,
+    pub page_count_before: u64,
+    pub freelist_pages_before: u64,
+    pub page_count_after: u64,
+    pub freelist_pages_after: u64,
+    pub estimated_reclaimable_bytes_before: u64,
+    pub incremental_vacuum_pages_requested: u32,
+    pub incremental_vacuum_ran: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeDbCompactReport {
+    pub started_at: DateTime<Utc>,
+    pub elapsed_ms: u64,
+    pub file_bytes_before: u64,
+    pub file_bytes_after: u64,
+    pub page_size: u64,
+    pub page_count_before: u64,
+    pub page_count_after: u64,
+    pub freelist_pages_before: u64,
+    pub freelist_pages_after: u64,
+    pub estimated_reclaimable_bytes_before: u64,
+    pub auto_vacuum_before: u32,
+    pub auto_vacuum_after: u32,
+}
+
+#[derive(Default)]
+struct StrongRoots {
+    turn_ids: BTreeSet<String>,
+    message_ids: BTreeSet<String>,
+    task_ids: BTreeSet<String>,
+    work_item_ids: BTreeSet<String>,
+    transcript_entry_ids: BTreeSet<String>,
+    tool_execution_ids: BTreeSet<String>,
+}
+
+struct EvidenceCandidate {
+    id: String,
+    turn_id: Option<String>,
+    message_id: Option<String>,
+    task_id: Option<String>,
+    work_item_id: Option<String>,
+    payload_json: Option<String>,
+}
+
+struct DatabasePageStats {
+    page_size: u64,
+    page_count: u64,
+    freelist_pages: u64,
+}
+
+impl RuntimeDb {
+    pub fn plan_retention(
+        &self,
+        policy: RuntimeDbRetentionPolicy,
+        now: DateTime<Utc>,
+    ) -> Result<RuntimeDbRetentionReport> {
+        let policy = policy.validate()?;
+        let connection = self.connection()?;
+        build_retention_report(&connection, &policy, now, true, None)
+    }
+
+    pub fn run_retention_pass(
+        &self,
+        policy: RuntimeDbRetentionPolicy,
+        now: DateTime<Utc>,
+    ) -> Result<RuntimeDbRetentionReport> {
+        let policy = policy.validate()?;
+        if !policy.enabled {
+            let connection = self.connection()?;
+            return build_retention_report(&connection, &policy, now, false, None);
+        }
+        let transaction_policy = policy.clone();
+        let mut report = self.transaction_with_context(
+            RuntimeDbWriteContext::sync("runtime_db.retention", "retained_evidence"),
+            |tx| build_retention_report(tx, &transaction_policy, now, false, Some(tx)),
+        )?;
+        let connection = self.connection()?;
+        if pragma_u64(&connection, "auto_vacuum")? == 2 {
+            connection.execute_batch(&format!(
+                "PRAGMA incremental_vacuum({});",
+                policy.incremental_vacuum_pages
+            ))?;
+            report.incremental_vacuum_ran = true;
+        }
+        let stats = database_page_stats(&connection)?;
+        report.page_count_after = stats.page_count;
+        report.freelist_pages_after = stats.freelist_pages;
+        report.elapsed_ms = elapsed_ms_since(report.started_at);
+        persist_last_report(self, &report)?;
+        Ok(report)
+    }
+
+    pub fn compact_offline(
+        db_path: &Path,
+        migration_lock_path: &Path,
+        maintenance_lock_path: &Path,
+    ) -> Result<RuntimeDbCompactReport> {
+        let started_at = Utc::now();
+        let started = Instant::now();
+        let _maintenance_lock = RuntimeDbLock::try_lock(maintenance_lock_path)
+            .context("runtime database compact requires the daemon to be stopped")?;
+        let db = RuntimeDb::open_and_migrate(db_path, migration_lock_path)?;
+        let connection = db.connection()?;
+        let before = database_page_stats(&connection)?;
+        let file_bytes_before = file_size(db_path)?;
+        let auto_vacuum_before = pragma_u64(&connection, "auto_vacuum")? as u32;
+        connection.execute_batch(
+            "PRAGMA wal_checkpoint(TRUNCATE);
+             PRAGMA auto_vacuum = INCREMENTAL;
+             VACUUM;",
+        )?;
+        let after = database_page_stats(&connection)?;
+        Ok(RuntimeDbCompactReport {
+            started_at,
+            elapsed_ms: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+            file_bytes_before,
+            file_bytes_after: file_size(db_path)?,
+            page_size: before.page_size,
+            page_count_before: before.page_count,
+            page_count_after: after.page_count,
+            freelist_pages_before: before.freelist_pages,
+            freelist_pages_after: after.freelist_pages,
+            estimated_reclaimable_bytes_before: before
+                .page_size
+                .saturating_mul(before.freelist_pages),
+            auto_vacuum_before,
+            auto_vacuum_after: pragma_u64(&connection, "auto_vacuum")? as u32,
+        })
+    }
+}
+
+fn build_retention_report(
+    connection: &Connection,
+    policy: &RuntimeDbRetentionPolicy,
+    now: DateTime<Utc>,
+    dry_run: bool,
+    delete_tx: Option<&Transaction<'_>>,
+) -> Result<RuntimeDbRetentionReport> {
+    let started = Instant::now();
+    let stats = database_page_stats(connection)?;
+    let roots = collect_strong_roots(connection)?;
+    let (audit_events, audit_scopes_observed, audit_scopes_skipped) = plan_audit_events(
+        connection,
+        delete_tx,
+        now - retention_days(policy.audit_events_days)?,
+        policy.audit_events_min_rows_per_scope,
+        dry_run,
+    )?;
+    let transcript_entries = plan_evidence_table(
+        connection,
+        delete_tx,
+        "transcript_entries",
+        now - retention_days(policy.transcript_entries_days)?,
+        policy.transcript_entries_min_rows,
+        &roots,
+        dry_run,
+        false,
+    )?;
+    let tool_executions = plan_evidence_table(
+        connection,
+        delete_tx,
+        "tool_executions",
+        now - retention_days(policy.tool_executions_days)?,
+        policy.tool_executions_min_rows,
+        &roots,
+        dry_run,
+        true,
+    )?;
+    Ok(RuntimeDbRetentionReport {
+        dry_run,
+        enabled: policy.enabled,
+        started_at: now,
+        elapsed_ms: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+        policy: policy.clone(),
+        audit_events,
+        transcript_entries,
+        tool_executions,
+        audit_scopes_observed,
+        audit_scopes_skipped_below_minimum_rows: audit_scopes_skipped,
+        page_size: stats.page_size,
+        page_count_before: stats.page_count,
+        freelist_pages_before: stats.freelist_pages,
+        page_count_after: stats.page_count,
+        freelist_pages_after: stats.freelist_pages,
+        estimated_reclaimable_bytes_before: stats.page_size.saturating_mul(stats.freelist_pages),
+        incremental_vacuum_pages_requested: policy.incremental_vacuum_pages,
+        incremental_vacuum_ran: false,
+    })
+}
+
+fn plan_audit_events(
+    connection: &Connection,
+    delete_tx: Option<&Transaction<'_>>,
+    cutoff: DateTime<Utc>,
+    minimum_rows: usize,
+    dry_run: bool,
+) -> Result<(RuntimeDbRetentionTableReport, u64, u64)> {
+    let mut report = RuntimeDbRetentionTableReport::default();
+    let mut statement = connection.prepare(
+        "SELECT agent_id, COUNT(*) FROM audit_events GROUP BY agent_id ORDER BY agent_id",
+    )?;
+    let scopes = statement.query_map([], |row| {
+        Ok((row.get::<_, Option<String>>(0)?, row.get::<_, u64>(1)?))
+    })?;
+    let mut observed_scopes = 0_u64;
+    let mut skipped_scopes = 0_u64;
+    for scope in scopes {
+        let (agent_id, observed_rows) = scope?;
+        observed_scopes += 1;
+        report.observed_rows = report.observed_rows.saturating_add(observed_rows);
+        if observed_rows <= minimum_rows as u64 {
+            skipped_scopes += 1;
+            continue;
+        }
+        let floor_offset = i64::try_from(minimum_rows - 1).unwrap_or(i64::MAX);
+        let floor_seq = audit_floor_sequence(connection, agent_id.as_deref(), floor_offset)?;
+        let age_seq = audit_age_sequence(connection, agent_id.as_deref(), cutoff)?;
+        let Some(first_retained_seq) = earliest_sequence(floor_seq, age_seq) else {
+            continue;
+        };
+        let candidates =
+            audit_candidate_count(connection, agent_id.as_deref(), first_retained_seq)?;
+        report.candidate_rows = report.candidate_rows.saturating_add(candidates);
+        let planned = candidates.min(RETENTION_DELETE_BATCH_ROWS as u64);
+        report.planned_delete_rows = report.planned_delete_rows.saturating_add(planned);
+        if !dry_run && planned > 0 {
+            let tx =
+                delete_tx.ok_or_else(|| anyhow!("audit retention delete requires transaction"))?;
+            let deleted =
+                delete_audit_prefix(tx, agent_id.as_deref(), first_retained_seq, planned)?;
+            report.deleted_rows = report.deleted_rows.saturating_add(deleted as u64);
+        }
+    }
+    report.skipped_below_minimum_rows = observed_scopes > 0 && observed_scopes == skipped_scopes;
+    Ok((report, observed_scopes, skipped_scopes))
+}
+
+fn audit_floor_sequence(
+    connection: &Connection,
+    agent_id: Option<&str>,
+    floor_offset: i64,
+) -> Result<Option<i64>> {
+    if let Some(agent_id) = agent_id {
+        connection
+            .query_row(
+                "SELECT event_seq FROM audit_events
+                 WHERE agent_id = ?1 ORDER BY event_seq DESC LIMIT 1 OFFSET ?2",
+                params![agent_id, floor_offset],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(Into::into)
+    } else {
+        connection
+            .query_row(
+                "SELECT event_seq FROM audit_events
+                 WHERE agent_id IS NULL ORDER BY event_seq DESC LIMIT 1 OFFSET ?1",
+                [floor_offset],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+}
+
+fn audit_age_sequence(
+    connection: &Connection,
+    agent_id: Option<&str>,
+    cutoff: DateTime<Utc>,
+) -> Result<Option<i64>> {
+    let cutoff = timestamp(cutoff);
+    if let Some(agent_id) = agent_id {
+        connection
+            .query_row(
+                "SELECT MIN(event_seq) FROM audit_events
+                 WHERE agent_id = ?1 AND created_at >= ?2",
+                params![agent_id, cutoff],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    } else {
+        connection
+            .query_row(
+                "SELECT MIN(event_seq) FROM audit_events
+                 WHERE agent_id IS NULL AND created_at >= ?1",
+                [cutoff],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+}
+
+fn audit_candidate_count(
+    connection: &Connection,
+    agent_id: Option<&str>,
+    first_retained_seq: i64,
+) -> Result<u64> {
+    if let Some(agent_id) = agent_id {
+        connection
+            .query_row(
+                "SELECT COUNT(*) FROM audit_events
+                 WHERE agent_id = ?1 AND event_seq < ?2",
+                params![agent_id, first_retained_seq],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    } else {
+        connection
+            .query_row(
+                "SELECT COUNT(*) FROM audit_events
+                 WHERE agent_id IS NULL AND event_seq < ?1",
+                [first_retained_seq],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+}
+
+fn delete_audit_prefix(
+    tx: &Transaction<'_>,
+    agent_id: Option<&str>,
+    first_retained_seq: i64,
+    limit: u64,
+) -> Result<usize> {
+    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+    if let Some(agent_id) = agent_id {
+        tx.execute(
+            "DELETE FROM audit_events WHERE audit_event_id IN (
+               SELECT audit_event_id FROM audit_events
+               WHERE agent_id = ?1 AND event_seq < ?2
+               ORDER BY event_seq ASC LIMIT ?3
+             )",
+            params![agent_id, first_retained_seq, limit],
+        )
+        .map_err(Into::into)
+    } else {
+        tx.execute(
+            "DELETE FROM audit_events WHERE audit_event_id IN (
+               SELECT audit_event_id FROM audit_events
+               WHERE agent_id IS NULL AND event_seq < ?1
+               ORDER BY event_seq ASC LIMIT ?2
+             )",
+            params![first_retained_seq, limit],
+        )
+        .map_err(Into::into)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn plan_evidence_table(
+    connection: &Connection,
+    delete_tx: Option<&Transaction<'_>>,
+    table: &'static str,
+    cutoff: DateTime<Utc>,
+    minimum_rows: usize,
+    roots: &StrongRoots,
+    dry_run: bool,
+    delete_index_sources: bool,
+) -> Result<RuntimeDbRetentionTableReport> {
+    let mut report = RuntimeDbRetentionTableReport::default();
+    report.observed_rows =
+        connection.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })?;
+    if report.observed_rows <= minimum_rows as u64 {
+        report.skipped_below_minimum_rows = true;
+        return Ok(report);
+    }
+    let removable_capacity = report.observed_rows.saturating_sub(minimum_rows as u64);
+    let sql = format!(
+        "SELECT evidence_id, turn_id, message_id, task_id, work_item_id,
+                CASE WHEN ?2 THEN payload_json ELSE NULL END
+         FROM {table}
+         WHERE created_at < ?1
+         ORDER BY created_at ASC, evidence_id ASC"
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(params![timestamp(cutoff), delete_index_sources], |row| {
+        Ok(EvidenceCandidate {
+            id: row.get(0)?,
+            turn_id: row.get(1)?,
+            message_id: row.get(2)?,
+            task_id: row.get(3)?,
+            work_item_id: row.get(4)?,
+            payload_json: row.get(5)?,
+        })
+    })?;
+    let mut deletions = Vec::new();
+    for candidate in rows {
+        let candidate = candidate?;
+        report.candidate_rows = report.candidate_rows.saturating_add(1);
+        if let Some(reason) = candidate_protection_reason(&candidate, roots) {
+            report.protected_rows = report.protected_rows.saturating_add(1);
+            *report.protection_reasons.entry(reason.into()).or_default() += 1;
+        } else if deletions.len() < RETENTION_DELETE_BATCH_ROWS
+            && deletions.len() < removable_capacity as usize
+        {
+            deletions.push(candidate);
+        }
+    }
+    report.planned_delete_rows = deletions.len() as u64;
+    if dry_run || deletions.is_empty() {
+        return Ok(report);
+    }
+    let tx = delete_tx.ok_or_else(|| anyhow!("{table} retention delete requires transaction"))?;
+    for candidate in &deletions {
+        if delete_index_sources {
+            let record: ToolExecutionRecord =
+                serde_json::from_str(candidate.payload_json.as_deref().ok_or_else(|| {
+                    anyhow!("tool execution payload missing for {}", candidate.id)
+                })?)?;
+            insert_runtime_index_changes_tx(tx, &tool_index_delete_changes(&record))?;
+        }
+        tx.execute(
+            &format!("DELETE FROM {table} WHERE evidence_id = ?1"),
+            [&candidate.id],
+        )?;
+    }
+    report.deleted_rows = deletions.len() as u64;
+    Ok(report)
+}
+
+fn candidate_protection_reason(
+    candidate: &EvidenceCandidate,
+    roots: &StrongRoots,
+) -> Option<&'static str> {
+    if candidate
+        .turn_id
+        .as_ref()
+        .is_some_and(|id| roots.turn_ids.contains(id))
+    {
+        Some("turn")
+    } else if candidate
+        .message_id
+        .as_ref()
+        .is_some_and(|id| roots.message_ids.contains(id))
+    {
+        Some("message")
+    } else if candidate
+        .task_id
+        .as_ref()
+        .is_some_and(|id| roots.task_ids.contains(id))
+    {
+        Some("task")
+    } else if candidate
+        .work_item_id
+        .as_ref()
+        .is_some_and(|id| roots.work_item_ids.contains(id))
+    {
+        Some("work_item")
+    } else if roots.tool_execution_ids.contains(&candidate.id) {
+        Some("source_ref")
+    } else if roots.transcript_entry_ids.contains(&candidate.id) {
+        Some("transcript_ref")
+    } else {
+        None
+    }
+}
+
+fn collect_strong_roots(connection: &Connection) -> Result<StrongRoots> {
+    let mut roots = StrongRoots::default();
+    collect_turn_roots(connection, &mut roots)?;
+    collect_work_item_roots(connection, &mut roots)?;
+    collect_task_roots(connection, &mut roots)?;
+    collect_wait_roots(connection, &mut roots)?;
+    collect_queue_roots(connection, &mut roots)?;
+    collect_episode_roots(connection, &mut roots)?;
+    collect_brief_roots(connection, &mut roots)?;
+    collect_transcript_tool_roots(connection, &mut roots)?;
+    collect_outbox_roots(connection, &mut roots)?;
+    Ok(roots)
+}
+
+fn collect_turn_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection.prepare(
+        "SELECT payload_json FROM turn_records
+         ORDER BY agent_id ASC, turn_index DESC, created_at DESC",
+    )?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    let mut completed_per_agent = BTreeMap::<String, usize>::new();
+    for row in rows {
+        let record: TurnRecord = serde_json::from_str(&row?)?;
+        let protect = if record.terminal.is_none() {
+            true
+        } else {
+            let count = completed_per_agent
+                .entry(record.agent_id.clone())
+                .or_default();
+            let protect = *count < RECENT_COMPLETED_TURNS_PER_AGENT;
+            *count += 1;
+            protect
+        };
+        if protect {
+            roots.turn_ids.insert(record.turn_id);
+        }
+    }
+    Ok(())
+}
+
+fn collect_work_item_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection.prepare("SELECT payload_json FROM work_items")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let record: WorkItemRecord = serde_json::from_str(&row?)?;
+        if record.state == crate::types::WorkItemState::Open {
+            roots.work_item_ids.insert(record.id.clone());
+        }
+        for work_ref in record
+            .work_refs
+            .iter()
+            .filter(|work_ref| work_ref.status == WorkItemRefStatus::Active)
+        {
+            if let Some(source_ref) = work_ref.source_ref.as_deref() {
+                collect_source_ref(source_ref, roots);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_task_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection.prepare(
+        "SELECT payload_json FROM tasks
+         WHERE status IN ('queued', 'running', 'cancelling')",
+    )?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let record: TaskRecord = serde_json::from_str(&row?)?;
+        roots.task_ids.insert(record.id);
+        if let Some(message_id) = record.parent_message_id {
+            roots.message_ids.insert(message_id);
+        }
+        if let Some(work_item_id) = record.work_item_id {
+            roots.work_item_ids.insert(work_item_id);
+        }
+    }
+    Ok(())
+}
+
+fn collect_wait_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement =
+        connection.prepare("SELECT payload_json FROM wait_conditions WHERE status = 'active'")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let record: WaitConditionRecord = serde_json::from_str(&row?)?;
+        if let Some(turn_id) = record.turn_id {
+            roots.turn_ids.insert(turn_id);
+        }
+        if let Some(work_item_id) = record.work_item_id {
+            roots.work_item_ids.insert(work_item_id);
+        }
+        if let Some(subject_ref) = record.subject_ref.as_deref() {
+            collect_source_ref(subject_ref, roots);
+        }
+    }
+    Ok(())
+}
+
+fn collect_queue_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection.prepare(
+        "SELECT DISTINCT message_id FROM queue_entries
+         WHERE status IN ('queued', 'interrupted', 'dequeued', 'interjected')",
+    )?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        roots.message_ids.insert(row?);
+    }
+    Ok(())
+}
+
+fn collect_episode_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection.prepare("SELECT payload_json FROM context_episode_anchors")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let record: ContextEpisodeRecord = serde_json::from_str(&row?)?;
+        roots.turn_ids.extend(record.source_turn_ids);
+        for source_ref in record.source_refs {
+            collect_source_ref(&source_ref, roots);
+        }
+    }
+    Ok(())
+}
+
+fn collect_brief_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection.prepare("SELECT payload_json FROM briefs")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let record: BriefRecord = serde_json::from_str(&row?)?;
+        if let Some(entry_id) = record.content_source.transcript_entry_id() {
+            roots.transcript_entry_ids.insert(entry_id.to_string());
+        }
+        if let Some(entry_id) = record.finalizes_assistant_round_id {
+            roots.transcript_entry_ids.insert(entry_id);
+        }
+    }
+    Ok(())
+}
+
+fn collect_transcript_tool_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement = connection
+        .prepare("SELECT payload_json FROM transcript_entries WHERE kind = 'tool_results'")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let record: TranscriptEntry = serde_json::from_str(&row?)?;
+        let Ok(ToolResultData::RefsWithWrapper { refs }) =
+            serde_json::from_value::<ToolResultData>(record.data)
+        else {
+            continue;
+        };
+        for tool_execution_id in refs
+            .into_iter()
+            .filter_map(|reference| reference.tool_execution_id)
+        {
+            roots.tool_execution_ids.insert(tool_execution_id);
+        }
+    }
+    Ok(())
+}
+
+fn collect_outbox_roots(connection: &Connection, roots: &mut StrongRoots) -> Result<()> {
+    let mut statement =
+        connection.prepare("SELECT source_id, source_ref FROM runtime_index_outbox")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (source_id, source_ref) = row?;
+        collect_source_ref(&source_id, roots);
+        collect_source_ref(&source_ref, roots);
+    }
+    Ok(())
+}
+
+fn collect_source_ref(source_ref: &str, roots: &mut StrongRoots) {
+    if let Some(id) = source_ref.strip_prefix("turn:") {
+        roots.turn_ids.insert(id.to_string());
+    } else if let Some(id) = source_ref.strip_prefix("message:") {
+        roots.message_ids.insert(id.to_string());
+    } else if let Some(id) = source_ref.strip_prefix("task:") {
+        roots.task_ids.insert(id.to_string());
+    } else if let Some(id) = source_ref.strip_prefix("work_item:") {
+        roots.work_item_ids.insert(id.to_string());
+    } else if let Some(rest) = source_ref.strip_prefix("tool_execution:") {
+        if let Some(id) = rest.split(':').next().filter(|id| !id.is_empty()) {
+            roots.tool_execution_ids.insert(id.to_string());
+        }
+    }
+}
+
+fn tool_index_delete_changes(record: &ToolExecutionRecord) -> Vec<RuntimeIndexChange> {
+    let mut changes = Vec::new();
+    let mut push = |source_kind: &str, source_ref: String| {
+        changes.push(RuntimeIndexChange {
+            agent_id: record.agent_id.clone(),
+            source_kind: source_kind.into(),
+            source_id: source_ref.clone(),
+            source_ref,
+            operation: RuntimeIndexOperation::Delete,
+            source_updated_at: record.completed_at.or(Some(record.created_at)),
+            reason: "tool_execution_retention_deleted".into(),
+        });
+    };
+    match record.tool_name.as_str() {
+        crate::tool::names::EXEC_COMMAND => {
+            if record.input.get("cmd").and_then(Value::as_str).is_some() {
+                push(
+                    "tool_command_receipt",
+                    command_receipt_source_ref(&record.id, None),
+                );
+            }
+        }
+        crate::tool::names::EXEC_COMMAND_BATCH => {
+            if let Some(items) = record.input.get("items").and_then(Value::as_array) {
+                for (offset, item) in items.iter().enumerate() {
+                    if item.get("cmd").and_then(Value::as_str).is_some() {
+                        push(
+                            "tool_command_receipt",
+                            command_receipt_source_ref(&record.id, Some(offset + 1)),
+                        );
+                    }
+                }
+            }
+        }
+        _ => push(
+            "tool_execution_output_preview",
+            command_output_source_ref(&record.id, None, "output"),
+        ),
+    }
+    changes
+}
+
+fn persist_last_report(db: &RuntimeDb, report: &RuntimeDbRetentionReport) -> Result<()> {
+    let value = serde_json::to_string(report)?;
+    let now = timestamp(Utc::now());
+    db.transaction(|tx| {
+        tx.execute(
+            "INSERT INTO runtime_metadata (key, value, created_at, updated_at)
+             VALUES ('runtime_db_retention_last_report', ?1, ?2, ?2)
+             ON CONFLICT(key) DO UPDATE SET
+               value = excluded.value, updated_at = excluded.updated_at",
+            params![value, now],
+        )?;
+        Ok(())
+    })
+}
+
+fn database_page_stats(connection: &Connection) -> Result<DatabasePageStats> {
+    Ok(DatabasePageStats {
+        page_size: pragma_u64(connection, "page_size")?,
+        page_count: pragma_u64(connection, "page_count")?,
+        freelist_pages: pragma_u64(connection, "freelist_count")?,
+    })
+}
+
+fn pragma_u64(connection: &Connection, name: &str) -> Result<u64> {
+    connection
+        .query_row(&format!("PRAGMA {name}"), [], |row| row.get(0))
+        .with_context(|| format!("reading SQLite PRAGMA {name}"))
+}
+
+fn earliest_sequence(left: Option<i64>, right: Option<i64>) -> Option<i64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn retention_days(value: u64) -> Result<Duration> {
+    Ok(Duration::days(
+        i64::try_from(value).context("retention days exceed chrono range")?,
+    ))
+}
+
+fn timestamp(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+fn elapsed_ms_since(started_at: DateTime<Utc>) -> u64 {
+    Utc::now()
+        .signed_duration_since(started_at)
+        .num_milliseconds()
+        .max(0) as u64
+}
+
+fn file_size(path: &Path) -> Result<u64> {
+    Ok(fs::metadata(path)
+        .with_context(|| format!("reading runtime database metadata {}", path.display()))?
+        .len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AuthorityClass, ToolExecutionStatus, TranscriptEntryKind};
+    use tempfile::TempDir;
+
+    fn runtime_db() -> Result<(TempDir, RuntimeDb)> {
+        let directory = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            directory.path().join("state/runtime.sqlite"),
+            directory.path().join("state/runtime.lock"),
+        )?;
+        Ok((directory, db))
+    }
+
+    fn policy() -> RuntimeDbRetentionPolicy {
+        RuntimeDbRetentionPolicy {
+            enabled: true,
+            audit_events_days: 30,
+            transcript_entries_days: 30,
+            tool_executions_days: 30,
+            audit_events_min_rows_per_scope: crate::http::MAX_EVENT_STREAM_WINDOW,
+            transcript_entries_min_rows: 1,
+            tool_executions_min_rows: 1,
+            interval_hours: 1,
+            incremental_vacuum_pages: 1,
+        }
+    }
+
+    fn tool(id: &str, turn_id: Option<&str>, created_at: DateTime<Utc>) -> ToolExecutionRecord {
+        ToolExecutionRecord {
+            id: id.into(),
+            agent_id: "agent-a".into(),
+            work_item_id: None,
+            turn_index: 1,
+            turn_id: turn_id.map(ToString::to_string),
+            tool_name: "test_tool".into(),
+            created_at,
+            completed_at: Some(created_at),
+            duration_ms: 1,
+            authority_class: AuthorityClass::RuntimeInstruction,
+            status: ToolExecutionStatus::Success,
+            input: serde_json::json!({}),
+            output: serde_json::json!({"ok": true}),
+            summary: id.into(),
+            invocation_surface: None,
+        }
+    }
+
+    #[test]
+    fn policy_defaults_to_disabled_and_rejects_small_audit_floor() {
+        assert!(!RuntimeDbRetentionPolicy::default().enabled);
+        let error = RuntimeDbRetentionPolicy {
+            audit_events_min_rows_per_scope: crate::http::MAX_EVENT_STREAM_WINDOW - 1,
+            ..RuntimeDbRetentionPolicy::default()
+        }
+        .validate()
+        .expect_err("audit floor below replay window must fail");
+        assert!(error.to_string().contains("must be at least"));
+    }
+
+    #[test]
+    fn transcript_retention_requires_age_and_excess_rows() -> Result<()> {
+        let (_directory, db) = runtime_db()?;
+        let now = Utc::now();
+        let mut old = TranscriptEntry::new(
+            "agent-a",
+            TranscriptEntryKind::IncomingMessage,
+            None,
+            None,
+            serde_json::json!({"text": "old"}),
+        );
+        old.id = "transcript-old".into();
+        old.created_at = now - Duration::days(60);
+        let mut recent = TranscriptEntry::new(
+            "agent-a",
+            TranscriptEntryKind::IncomingMessage,
+            None,
+            None,
+            serde_json::json!({"text": "recent"}),
+        );
+        recent.id = "transcript-recent".into();
+        recent.created_at = now;
+        db.transcript_entries().append(&old)?;
+        db.transcript_entries().append(&recent)?;
+
+        let report = db.run_retention_pass(policy(), now)?;
+        assert_eq!(report.transcript_entries.candidate_rows, 1);
+        assert_eq!(report.transcript_entries.deleted_rows, 1);
+        assert!(db
+            .transcript_entries()
+            .by_id(None, "transcript-old")?
+            .is_none());
+        assert!(db
+            .transcript_entries()
+            .by_id(None, "transcript-recent")?
+            .is_some());
+
+        let second = db.run_retention_pass(policy(), now)?;
+        assert!(second.transcript_entries.skipped_below_minimum_rows);
+        Ok(())
+    }
+
+    #[test]
+    fn audit_retention_deletes_only_the_prefix_outside_floor() -> Result<()> {
+        let (_directory, db) = runtime_db()?;
+        let now = Utc::now();
+        let old = timestamp(now - Duration::days(60));
+        db.transaction(|tx| {
+            for sequence in 1..=515_i64 {
+                tx.execute(
+                    "INSERT INTO audit_events (
+                       audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                     ) VALUES (?1, ?2, 'agent-a', 'test', ?3, '{}')",
+                    params![format!("audit-{sequence}"), sequence, old],
+                )?;
+            }
+            Ok(())
+        })?;
+
+        let report = db.run_retention_pass(policy(), now)?;
+        assert_eq!(report.audit_events.candidate_rows, 3);
+        assert_eq!(report.audit_events.deleted_rows, 3);
+        let connection = db.connection()?;
+        let sequences = connection
+            .prepare(
+                "SELECT event_seq FROM audit_events
+                 WHERE agent_id = 'agent-a' ORDER BY event_seq",
+            )?
+            .query_map([], |row| row.get::<_, i64>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        assert_eq!(sequences.len(), crate::http::MAX_EVENT_STREAM_WINDOW);
+        assert_eq!(sequences.first().copied(), Some(4));
+        assert_eq!(sequences.last().copied(), Some(515));
+        Ok(())
+    }
+
+    #[test]
+    fn active_turn_protects_tool_and_delete_writes_index_tombstone() -> Result<()> {
+        let (_directory, db) = runtime_db()?;
+        let now = Utc::now();
+        let old = now - Duration::days(60);
+        let mut active_turn = TurnRecord::new("agent-a", "turn-active", 1);
+        active_turn.created_at = old;
+        db.turn_records().upsert(&active_turn)?;
+        db.evidence()
+            .append_tool_execution(&tool("tool-protected", Some("turn-active"), old))?;
+        db.evidence()
+            .append_tool_execution(&tool("tool-deleted", None, old))?;
+
+        let report = db.run_retention_pass(policy(), now)?;
+        assert_eq!(report.tool_executions.protected_rows, 1);
+        assert_eq!(report.tool_executions.deleted_rows, 1);
+        assert!(db
+            .evidence()
+            .tool_execution_by_id("agent-a", "tool-protected")?
+            .is_some());
+        assert!(db
+            .evidence()
+            .tool_execution_by_id("agent-a", "tool-deleted")?
+            .is_none());
+        let pending = db.runtime_index_outbox().read_after("agent-a", 0, 10)?;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].operation, RuntimeIndexOperation::Delete);
+        assert_eq!(pending[0].source_ref, "tool_execution:tool-deleted:output");
+        Ok(())
+    }
+
+    #[test]
+    fn new_database_uses_incremental_auto_vacuum() -> Result<()> {
+        let (_directory, db) = runtime_db()?;
+        assert_eq!(pragma_u64(&db.connection()?, "auto_vacuum")?, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn offline_compact_fails_while_maintenance_lock_is_held() -> Result<()> {
+        let (directory, _db) = runtime_db()?;
+        let db_path = directory.path().join("state/runtime.sqlite");
+        let migration_lock = directory.path().join("state/runtime.lock");
+        let maintenance_lock = directory.path().join("state/runtime-maintenance.lock");
+        let _held = RuntimeDbLock::lock(&maintenance_lock)?;
+        let error = RuntimeDb::compact_offline(&db_path, &migration_lock, &maintenance_lock)
+            .expect_err("compact must fail while daemon maintenance lock is held");
+        assert!(error.to_string().contains("daemon to be stopped"));
+        Ok(())
+    }
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -3071,6 +3071,7 @@ mod tests {
             default_tool_output_tokens: 4096,
             max_tool_output_tokens: 16384,
             disable_provider_fallback: false,
+            runtime_db_retention: crate::runtime_db::RuntimeDbRetentionPolicy::default(),
             providers: Vec::new(),
             web_search: crate::daemon::RuntimeWebSearchSummary {
                 enabled: false,

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -712,6 +712,56 @@
     "aliases": []
   },
   {
+    "path": "debug.runtime-db",
+    "positionals": [],
+    "flags": [],
+    "aliases": []
+  },
+  {
+    "path": "debug.runtime-db.compact",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "debug.runtime-db.retention",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "dry-run",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "debug.scheduler-fixture",
     "positionals": [],
     "flags": [

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2927,6 +2927,25 @@ export interface components {
                     oauth_supported: boolean;
                     transport: string;
                 }[];
+                runtime_db_retention: {
+                    /** Format: uint64 */
+                    audit_events_days: number;
+                    /** Format: uint */
+                    audit_events_min_rows_per_scope: number;
+                    enabled: boolean;
+                    /** Format: uint32 */
+                    incremental_vacuum_pages: number;
+                    /** Format: uint64 */
+                    interval_hours: number;
+                    /** Format: uint64 */
+                    tool_executions_days: number;
+                    /** Format: uint */
+                    tool_executions_min_rows: number;
+                    /** Format: uint64 */
+                    transcript_entries_days: number;
+                    /** Format: uint */
+                    transcript_entries_min_rows: number;
+                };
                 /** Format: uint32 */
                 runtime_max_output_tokens: number;
                 unknown_model_fallback_configured: boolean;
@@ -3016,6 +3035,25 @@ export interface components {
                     oauth_supported: boolean;
                     transport: string;
                 }[];
+                runtime_db_retention: {
+                    /** Format: uint64 */
+                    audit_events_days: number;
+                    /** Format: uint */
+                    audit_events_min_rows_per_scope: number;
+                    enabled: boolean;
+                    /** Format: uint32 */
+                    incremental_vacuum_pages: number;
+                    /** Format: uint64 */
+                    interval_hours: number;
+                    /** Format: uint64 */
+                    tool_executions_days: number;
+                    /** Format: uint */
+                    tool_executions_min_rows: number;
+                    /** Format: uint64 */
+                    transcript_entries_days: number;
+                    /** Format: uint */
+                    transcript_entries_min_rows: number;
+                };
                 /** Format: uint32 */
                 runtime_max_output_tokens: number;
                 unknown_model_fallback_configured: boolean;


### PR DESCRIPTION
## 概要

- 增加默认关闭、显式启用的 `runtime.retention` 配置，按时间窗口与最低保留条目数联合裁剪 `audit_events`、`transcript_entries` 和 `tool_executions`
- 以 typed strong-root keep set 保护 active lifecycle evidence、active WorkItem refs、context episode refs、近期/未完成 turns 与未消费 `runtime_index_outbox` sources
- audit stream 仅删除连续 sequence 前缀，不重置 sequence/epoch；删除可索引 tool evidence 时在同一 transaction 写入 index delete intent
- daemon 以单实例、小批量 transaction 周期执行 retention，并在数据库已启用 incremental auto-vacuum 时做有界空间回收
- 增加 `holon debug runtime-db retention [--dry-run] [--json]` 可观测入口，以及要求 daemon 停止且持有 maintenance lock 的显式 `compact` 操作
- 增加 accepted RFC，记录引用边界、兼容策略、在线 maintenance 与离线 `VACUUM` contract

## 安全边界

- retention 默认关闭，不会改变现有部署行为
- 不删除 canonical current-state tables
- 不删除未消费 outbox 对应源
- 不增加跨表 foreign key、不展开/backfill JSON payload，也不静默重写已有数据库
- 新建空数据库在 schema 创建前启用 incremental auto-vacuum；已有数据库保持原模式，除非 operator 显式运行离线 compact

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --lib` — 2313 passed
- focused retention、config schema、CLI parser 与 startup regression tests

Closes #1774
