### PR TITLE
fix: unify right panel status icons to spinning LoaderCircle

### DIFF
--- a/web-gui/app/src/components/ui/StatusChip.tsx
+++ b/web-gui/app/src/components/ui/StatusChip.tsx
@@ -124,6 +124,7 @@ interface StatusBadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, "childr
   kind?: StatusKind;
   value?: string | null;
   children?: ReactNode;
+  spinIcon?: boolean;
 }
 
 interface AgentStateBadgeProps extends Omit<StatusBadgeProps, "kind"> {
@@ -145,6 +146,10 @@ function StatusBadgeIcon({ kind, value }: { kind: StatusKind; value: string }) {
   return <Icon size={13} className={spin ? "animate-spin" : undefined} />;
 }
 
+function SpinOnlyIcon() {
+  return <LoaderCircle size={13} className="animate-spin" />;
+}
+
 export function StatusChip({ tone = "idle", iconOnly, children, title, ...props }: StatusChipProps) {
   if (iconOnly) {
     const { Icon, spin } = toneIcon(tone);
@@ -158,13 +163,13 @@ export function StatusChip({ tone = "idle", iconOnly, children, title, ...props 
   return <Badge tone={toneToBadge(tone)} {...props} title={title} data-tooltip={title}>{children}</Badge>;
 }
 
-export function StatusBadge({ kind = "runtime", value, children, title, ...props }: StatusBadgeProps) {
+export function StatusBadge({ kind = "runtime", value, children, title, spinIcon, ...props }: StatusBadgeProps) {
   const { t } = useTranslation();
   const status = describeStatus(kind, value, t);
   const normalizedValue = normalizeStatus(value);
   return (
     <StatusChip tone={status.tone} title={title ?? status.title} {...props}>
-      {children ?? <StatusBadgeIcon kind={kind} value={normalizedValue} />}
+      {children ?? (spinIcon ? <SpinOnlyIcon /> : <StatusBadgeIcon kind={kind} value={normalizedValue} />)}
     </StatusChip>
   );
 }

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -122,7 +122,7 @@ export function AgentOverviewPanel({
       <CollapsibleInspectorCard
         title={t("rightPanel.agent")}
         summary={t("rightPanel.lifecycle", { value: agent.lifecycle })}
-        badge={<StatusBadge className="state-chip" kind="agent" value={agent.posture || agent.lifecycle} />}
+        badge={<StatusBadge className="state-chip" kind="agent" value={agent.posture || agent.lifecycle} spinIcon />}
       >
         <h2>{agent.id}</h2>
         <dl className="inspector-facts">
@@ -317,7 +317,7 @@ export function AgentOverviewPanel({
                   <button type="button" className="inspector-list-item task-button" onClick={() => onOpenTask(task)}>
                     <div className="inspector-list-head">
                     <strong>{task.summary}</strong>
-                    <StatusBadge className="state-chip" kind="connection" value={task.status} />
+                    <StatusBadge className="state-chip" kind="connection" value={task.status} spinIcon />
                     </div>
                     <small>{compactMeta([task.kind, task.command, task.workdir])}</small>
                   </button>
@@ -497,7 +497,7 @@ function WorkItemCard({
     >
       <div className="inspector-list-head">
         <strong>{workItem.objective}</strong>
-        <StatusBadge className="state-chip" kind="work" value={workItem.state} />
+        <StatusBadge className="state-chip" kind="work" value={workItem.state} spinIcon />
       </div>
       <small>{compactMeta([workItem.current ? t("status.current") : undefined, workItem.planStatus])}</small>
       <code>{workItem.id}</code>
@@ -513,7 +513,7 @@ export function WorkItemDetailPanel({ workItem, detailState, onOpenPlanFile }: {
     <article className="work-item-detail inspector-list-item featured">
       <div className="inspector-list-head">
         <strong>{t("panel.details")}</strong>
-        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" /> : null}
+        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" spinIcon /> : null}
       </div>
       {detailState?.error ? <p className="inspector-error">{detailState.error}</p> : null}
       <dl className="inspector-facts">
@@ -577,7 +577,7 @@ export function WorkItemDetailPanel({ workItem, detailState, onOpenPlanFile }: {
               <li key={`${item.state}-${index}`}>
                 <div className="inspector-list-head">
                   <strong>{item.text}</strong>
-                  <StatusBadge className="state-chip" kind="work" value={item.state} />
+                  <StatusBadge className="state-chip" kind="work" value={item.state} spinIcon />
                 </div>
               </li>
             ))}
@@ -592,7 +592,7 @@ export function WorkItemDetailPanel({ workItem, detailState, onOpenPlanFile }: {
               <li key={`${ref.kind}-${ref.ref}`}>
                 <div className="inspector-list-head">
                   <strong>{ref.title ?? ref.ref}</strong>
-                  <StatusBadge className="state-chip" kind="connection" value={ref.status ?? ref.kind} />
+                  <StatusBadge className="state-chip" kind="connection" value={ref.status ?? ref.kind} spinIcon />
                 </div>
                 <small>{compactMeta([ref.kind, ref.reason])}</small>
                 <code>{ref.ref}</code>
@@ -618,8 +618,8 @@ export function TaskDetailPanel({ task, detailState }: { task: TaskSummary; deta
     <article className="task-detail inspector-list-item featured">
       <div className="inspector-list-head">
         <strong>{summary || t("inspector.taskOutput")}</strong>
-        <StatusBadge className="state-chip" kind="connection" value={status} />
-        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" /> : null}
+        <StatusBadge className="state-chip" kind="connection" value={status} spinIcon />
+        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" spinIcon /> : null}
       </div>
       {detailState?.error ? <p className="inspector-error">{detailState.error}</p> : null}
       <dl className="inspector-facts">
@@ -690,7 +690,7 @@ export function ToolExecutionDetailPanel({
       ) : null}
       <div className="inspector-list-head">
         <strong>{toolName ?? record?.tool_name ?? t("inspector.toolExecution")}</strong>
-        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" /> : null}
+        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" spinIcon /> : null}
       </div>
       {detailState?.error ? <p className="inspector-error">{detailState.error}</p> : null}
       <dl className="inspector-facts">


### PR DESCRIPTION
## Summary

右侧 panel 里的状态 icon 统一成转圈（LoaderCircle + animate-spin）icon，不再根据不同状态显示不同图标。

## Changes

- `StatusChip.tsx`: 新增 `spinIcon` prop，为 `true` 时强制渲染 spinning `LoaderCircle`，忽略状态对应的默认 icon
- `AgentOverviewPanel.tsx`: 所有状态类 `StatusBadge` 添加 `spinIcon`，覆盖：
  - Agent lifecycle/posture badge
  - Task status badge（列表 + detail）
  - Work item state badge（列表 + detail）
  - Todo item state badge
  - Work ref status badge
  - Loading indicators（work item / task / tool execution detail）

Skill scope badges（agent/workspace/user-global 等）未改动，因为它们表示分类而非状态。

## Test

- `npx tsc --noEmit` — 无新增错误（已有的 module resolution 错误为存量问题）
- `npx vitest run src/features/right-panel/AgentOverviewPanel.test.ts` — 通过