### PR TITLE
refactor: 统一 Runtime error taxonomy、source chain 与 correlation contract

### DIFF
--- a/docs/rfcs/runtime-error-taxonomy.md
+++ b/docs/rfcs/runtime-error-taxonomy.md
@@ -1,0 +1,188 @@
+# Runtime Error Taxonomy
+
+## Status
+
+Accepted for incremental implementation by GitHub issue #2269.
+
+## Problem
+
+Holon already has typed provider failures and selected typed runtime database
+conflicts, but many runtime, tool, and HTTP boundaries still collapse errors
+into free-form strings. That loses stable codes, retryability, safe source
+context, and the IDs needed to follow a failure from an input message through a
+turn, provider/tool/task work, and the final brief or failure artifact.
+
+The runtime continues to use `anyhow::Error` as an internal propagation
+container. This RFC defines one typed description extracted at boundaries; it
+does not require replacing every internal result type.
+
+## Contract
+
+`RuntimeErrorDescriptor` contains:
+
+- `domain`: a small stable classification, not a module name.
+- `code`: the existing stable string code when one exists.
+- `retryable`: whether repeating the same operation may succeed without a
+  semantic input change.
+- `operator_message`: a bounded, redacted summary safe for operator surfaces.
+- `recovery_hint`: an optional bounded corrective action.
+- `safe_context`: allowlisted scalar identifiers and status fields.
+- `source_chain`: a bounded, deduplicated, redacted display chain.
+
+Initial domains are:
+
+`runtime`, `storage`, `policy`, `io`, `conflict`, `not_found`, `validation`,
+`provider`, `tool`, `task`, `http`, and `unknown`.
+
+Unknown errors are fail-closed: code `runtime_error`, domain `unknown`, and
+`retryable=false`.
+
+`RuntimeErrorContext` contains correlation references:
+
+- `message_id`
+- `turn_id`
+- `run_id`
+- `work_item_id`
+- `tool_execution_id`
+- `task_id`
+- `correlation_id`
+- `causation_id`
+- `provider`
+- `model_ref`
+
+These values identify existing records. They do not copy record payloads and do
+not create a second tracing identity system.
+
+## Classification order
+
+The descriptor extractor walks the `anyhow` source chain and selects the most
+specific supported typed source:
+
+1. `RuntimeError`
+2. `ToolError`
+3. `ProviderTransportError`
+4. `RuntimeStateTransitionConflict`
+5. `RuntimeDbRetryableError`
+6. `std::io::Error`
+7. conservative unknown fallback
+
+Provider attempt timelines may enrich context, but free-form timeline messages
+do not create a stable code. Upstream provider codes such as
+`context_length_exceeded` are stored on the typed transport error and queried
+directly.
+
+## Boundary projections
+
+### Tool
+
+`ToolError` retains `kind`, `message`, `details`, `recovery_hint`, and
+`retryable`. Additive `domain` and `source_chain` fields carry taxonomy data.
+`ToolError::from_anyhow` preserves an existing nested `ToolError`; otherwise it
+projects the shared descriptor.
+
+Canonical tool failure output and audit events retain the structured
+`ToolError`. Existing model-visible receipt fields remain compatible.
+
+### HTTP and local client
+
+The HTTP error envelope retains required `ok`, `error`, and optional `code` and
+`hint`. It additively exposes:
+
+- `domain`
+- `retryable`
+- `context`
+- `correlation`
+
+Typed status mapping is:
+
+| Domain | HTTP status |
+| --- | --- |
+| `validation` | 400 |
+| `not_found` | 404 |
+| `conflict` | 409 |
+| `policy` | 403 |
+| retryable `storage` / `io` | 503 |
+| retryable `provider` | 503 |
+| non-retryable `provider` | 502 |
+| other / unknown | 500 |
+
+Endpoint-specific existing statuses and codes remain valid. The generic
+boundary mapping is used where an `anyhow::Error` reaches `error_response`.
+The local client reads all new fields but continues to accept old envelopes.
+
+Task and work-item lifecycle handlers must produce typed domain errors before
+the HTTP boundary. HTTP code must not depend on `starts_with`, `ends_with`, or
+`contains` over an error message.
+
+### Failure artifacts
+
+`FailureArtifact` retains its existing category, kind, summary, provider,
+model, status, task, exit status, source chain, and metadata fields. It
+additively exposes:
+
+- `domain`
+- `retryable`
+- `recovery_hint`
+- `context`
+
+Provider, runtime, and task failure artifacts project the same taxonomy and
+reuse the existing message, turn, run, work-item, tool, task, provider, and
+model identifiers. Additive serde defaults keep old persisted JSON readable.
+State bootstrap projections must bound all added strings.
+
+## Redaction and bounds
+
+No public descriptor may serialize raw `Debug` output, request/response bodies,
+SQL, environment variables, authorization headers, bearer tokens, capability
+URLs, URL credentials or queries, or arbitrary absolute paths.
+
+The implementation:
+
+- allowlists `safe_context` keys;
+- removes URL credentials, query, and fragment;
+- replaces absolute path prefixes with a redacted marker and basename;
+- redacts messages containing known authorization or token markers;
+- bounds each public string and the number of source-chain entries;
+- deduplicates source-chain entries after redaction.
+
+High-cardinality correlation values may appear in records, artifacts, audit
+payloads, and structured logs. They must not become metric labels.
+
+## Persistence
+
+This contract uses additive serde fields in existing JSON records and evidence.
+No SQLite schema migration is required. Existing `MessageEnvelope`,
+`TurnRecord`, `ToolExecutionRecord`, `TaskRecord`, audit events, and brief
+records already contain the required identifiers or adjacency.
+
+## Compatibility
+
+- Existing string codes remain unchanged.
+- Existing required JSON fields remain unchanged.
+- New fields use serde defaults and omission when empty.
+- Provider retry count, fallback order, and wire behavior are unchanged.
+- Old clients can ignore new fields; new clients accept old envelopes.
+- Existing metadata remains readable, but taxonomy facts should not only exist
+  in metadata.
+
+## Non-goals
+
+- Replacing all `anyhow` usage.
+- Defining a plugin or registry system for errors.
+- Rewriting provider retry policy.
+- Adding distributed tracing or a vendor observability backend.
+- Adding high-cardinality metric labels.
+- Performing the `types.rs` or storage facade refactors tracked separately.
+
+## Verification
+
+Tests must cover:
+
+- typed classification through multiple `anyhow::Context` layers;
+- conservative unknown retryability;
+- source-chain bounds, deduplication, URL/path/secret redaction;
+- ToolError compatibility and typed runtime/provider projections;
+- typed task/work-item HTTP status and local client decoding;
+- provider upstream code detection without message substring matching;
+- runtime, provider, and task failure artifact taxonomy and correlation fields;
+- state bootstrap bounds for added artifact fields.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -399,6 +399,92 @@
                             ],
                             "type": "string"
                           },
+                          "context": {
+                            "properties": {
+                              "causation_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "correlation_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "message_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "model_ref": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "provider": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "run_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "task_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "tool_execution_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "turn_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "work_item_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "domain": {
+                            "enum": [
+                              "runtime",
+                              "storage",
+                              "policy",
+                              "io",
+                              "conflict",
+                              "not_found",
+                              "validation",
+                              "provider",
+                              "tool",
+                              "task",
+                              "http",
+                              "unknown",
+                              null
+                            ],
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "exit_status": {
                             "format": "int32",
                             "type": [
@@ -424,6 +510,18 @@
                           "provider": {
                             "type": [
                               "string",
+                              "null"
+                            ]
+                          },
+                          "recovery_hint": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "retryable": {
+                            "type": [
+                              "boolean",
                               "null"
                             ]
                           },
@@ -5429,6 +5527,92 @@
                     ],
                     "type": "string"
                   },
+                  "context": {
+                    "properties": {
+                      "causation_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "correlation_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "message_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "model_ref": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "provider": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "run_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "task_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tool_execution_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "turn_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "work_item_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "domain": {
+                    "enum": [
+                      "runtime",
+                      "storage",
+                      "policy",
+                      "io",
+                      "conflict",
+                      "not_found",
+                      "validation",
+                      "provider",
+                      "tool",
+                      "task",
+                      "http",
+                      "unknown",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "exit_status": {
                     "format": "int32",
                     "type": [
@@ -5454,6 +5638,18 @@
                   "provider": {
                     "type": [
                       "string",
+                      "null"
+                    ]
+                  },
+                  "recovery_hint": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "retryable": {
+                    "type": [
+                      "boolean",
                       "null"
                     ]
                   },

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     http_dto::AgentStateSnapshotDto,
     model_catalog::BuiltInModelMetadata,
+    runtime_error::{RuntimeErrorContext, RuntimeErrorDomain},
     system::ExecutionSnapshot,
     types::{
         AgentListEntry, AgentSummary, AuthorityClass, BriefRecord, ExternalTriggerStateSnapshot,
@@ -220,6 +221,10 @@ pub struct LocalHttpError {
     pub message: String,
     pub code: Option<String>,
     pub hint: Option<String>,
+    pub domain: Option<RuntimeErrorDomain>,
+    pub retryable: Option<bool>,
+    pub context: std::collections::BTreeMap<String, String>,
+    pub correlation: RuntimeErrorContext,
 }
 
 impl LocalHttpError {
@@ -1393,6 +1398,14 @@ struct ErrorPayload {
     code: Option<String>,
     #[serde(default)]
     hint: Option<String>,
+    #[serde(default)]
+    domain: Option<RuntimeErrorDomain>,
+    #[serde(default)]
+    retryable: Option<bool>,
+    #[serde(default)]
+    context: std::collections::BTreeMap<String, String>,
+    #[serde(default)]
+    correlation: RuntimeErrorContext,
 }
 
 fn event_stream_path(agent_id: &str, request: &EventStreamRequest) -> Result<String> {
@@ -1600,12 +1613,26 @@ fn decode_or_error(status_code: u16, body: Vec<u8>, path: &str) -> Result<Vec<u8
         .unwrap_or_else(|| String::from_utf8_lossy(&body).trim().to_string());
     let code = payload.as_ref().and_then(|value| value.code.clone());
     let hint = payload.as_ref().and_then(|value| value.hint.clone());
+    let domain = payload.as_ref().and_then(|value| value.domain);
+    let retryable = payload.as_ref().and_then(|value| value.retryable);
+    let context = payload
+        .as_ref()
+        .map(|value| value.context.clone())
+        .unwrap_or_default();
+    let correlation = payload
+        .as_ref()
+        .map(|value| value.correlation.clone())
+        .unwrap_or_default();
     Err(LocalHttpError {
         path: path.to_string(),
         status_code,
         message,
         code,
         hint,
+        domain,
+        retryable,
+        context,
+        correlation,
     }
     .into())
 }
@@ -1690,6 +1717,7 @@ mod tests {
         EventStreamRequest, EventStreamTransport, LocalEventStream, LocalHttpError,
         StreamEventEnvelope, TuiNetworkPolicy, TUI_LOCAL_NETWORK_POLICY, TUI_REMOTE_NETWORK_POLICY,
     };
+    use crate::runtime_error::RuntimeErrorDomain;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
@@ -1753,6 +1781,23 @@ mod tests {
         assert!(rendered.contains("agent default is stopped; start first"));
         assert!(rendered.contains("[agent_stopped]"));
         assert!(rendered.contains("Hint: start with `holon agent start default`"));
+    }
+
+    #[test]
+    fn decode_or_error_reads_runtime_taxonomy_and_correlation() {
+        let err = decode_or_error(
+            404,
+            br#"{"ok":false,"error":"task task_123 not found","code":"task_not_found","domain":"not_found","retryable":false,"context":{"task_id":"task_123"},"correlation":{"message_id":"msg_123","turn_id":"turn_123"}}"#.to_vec(),
+            "/agents/default/tasks/task_123",
+        )
+        .unwrap_err();
+        let typed = err.downcast_ref::<LocalHttpError>().unwrap();
+
+        assert_eq!(typed.domain, Some(RuntimeErrorDomain::NotFound));
+        assert_eq!(typed.retryable, Some(false));
+        assert_eq!(typed.context["task_id"], "task_123");
+        assert_eq!(typed.correlation.message_id.as_deref(), Some("msg_123"));
+        assert_eq!(typed.correlation.turn_id.as_deref(), Some("turn_123"));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -224,7 +224,7 @@ pub struct LocalHttpError {
     pub domain: Option<RuntimeErrorDomain>,
     pub retryable: Option<bool>,
     pub context: std::collections::BTreeMap<String, String>,
-    pub correlation: RuntimeErrorContext,
+    pub correlation: Box<RuntimeErrorContext>,
 }
 
 impl LocalHttpError {
@@ -1405,7 +1405,7 @@ struct ErrorPayload {
     #[serde(default)]
     context: std::collections::BTreeMap<String, String>,
     #[serde(default)]
-    correlation: RuntimeErrorContext,
+    correlation: Box<RuntimeErrorContext>,
 }
 
 fn event_stream_path(agent_id: &str, request: &EventStreamRequest) -> Result<String> {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -198,7 +198,7 @@ pub(crate) struct HttpErrorEnvelope {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     context: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "RuntimeErrorContext::is_empty")]
-    correlation: RuntimeErrorContext,
+    correlation: Box<RuntimeErrorContext>,
     #[serde(flatten)]
     extensions: Map<String, Value>,
 }
@@ -213,7 +213,7 @@ impl HttpErrorEnvelope {
             domain: None,
             retryable: None,
             context: BTreeMap::new(),
-            correlation: RuntimeErrorContext::default(),
+            correlation: Box::default(),
             extensions: Map::new(),
         }
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     path::{Component, PathBuf},
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -74,6 +74,9 @@ pub(crate) use crate::{
     },
     policy::{default_authority_for_origin, validate_message_kind_for_origin},
     runtime::{CurrentRunAbortError, CurrentRunAbortMode, CurrentRunAbortRequest},
+    runtime_error::{
+        describe_runtime_error, RuntimeErrorContext, RuntimeErrorDescriptor, RuntimeErrorDomain,
+    },
     skills::registry::SkillsRegistry,
     storage::EventLogPageOrder,
     system::{ExecutionScopeKind, HostLocalBoundary},
@@ -188,6 +191,14 @@ pub(crate) struct HttpErrorEnvelope {
     code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    domain: Option<RuntimeErrorDomain>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retryable: Option<bool>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    context: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "RuntimeErrorContext::is_empty")]
+    correlation: RuntimeErrorContext,
     #[serde(flatten)]
     extensions: Map<String, Value>,
 }
@@ -199,6 +210,10 @@ impl HttpErrorEnvelope {
             error: error.into(),
             code: None,
             hint: None,
+            domain: None,
+            retryable: None,
+            context: BTreeMap::new(),
+            correlation: RuntimeErrorContext::default(),
             extensions: Map::new(),
         }
     }
@@ -215,6 +230,25 @@ impl HttpErrorEnvelope {
 
     fn extension(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
         self.extensions.insert(key.into(), value.into());
+        self
+    }
+
+    fn descriptor(mut self, descriptor: RuntimeErrorDescriptor) -> Self {
+        self.error = descriptor.operator_message;
+        self.code = Some(descriptor.code);
+        self.hint = descriptor.recovery_hint;
+        self.domain = Some(descriptor.domain);
+        self.retryable = Some(descriptor.retryable);
+        self.correlation.message_id = descriptor.safe_context.get("message_id").cloned();
+        self.correlation.turn_id = descriptor.safe_context.get("turn_id").cloned();
+        self.correlation.run_id = descriptor.safe_context.get("run_id").cloned();
+        self.correlation.work_item_id = descriptor.safe_context.get("work_item_id").cloned();
+        self.correlation.tool_execution_id =
+            descriptor.safe_context.get("tool_execution_id").cloned();
+        self.correlation.task_id = descriptor.safe_context.get("task_id").cloned();
+        self.correlation.provider = descriptor.safe_context.get("provider").cloned();
+        self.correlation.model_ref = descriptor.safe_context.get("model_ref").cloned();
+        self.context = descriptor.safe_context;
         self
     }
 }
@@ -873,26 +907,11 @@ pub(crate) fn not_found(reason: impl Into<String>) -> (StatusCode, Json<Value>) 
 }
 
 pub(crate) fn task_lifecycle_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
-    let message = error.to_string();
-    if message.starts_with("task ") && message.ends_with(" not found") {
-        not_found(message)
-    } else {
-        error_response(error)
-    }
+    error_response(error)
 }
 
 pub(crate) fn work_item_lifecycle_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
-    let message = error.to_string();
-    let lower = message.to_ascii_lowercase();
-    if (lower.contains("work item") && lower.ends_with("not found"))
-        || lower.starts_with("unknown work item ")
-    {
-        not_found(message)
-    } else if message.starts_with("cannot ") {
-        bad_request(message)
-    } else {
-        error_response(error)
-    }
+    error_response(error)
 }
 
 pub(crate) fn agent_model_override_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
@@ -1044,10 +1063,32 @@ fn remote_skill_install_failed_envelope(
 }
 
 pub(crate) fn error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    let descriptor = describe_runtime_error(&error);
+    let status = runtime_error_status(&descriptor);
     http_error(
-        StatusCode::INTERNAL_SERVER_ERROR,
-        HttpErrorEnvelope::new(error.to_string()),
+        status,
+        HttpErrorEnvelope::new(descriptor.operator_message.clone()).descriptor(descriptor),
     )
+}
+
+fn runtime_error_status(descriptor: &RuntimeErrorDescriptor) -> StatusCode {
+    match descriptor.domain {
+        RuntimeErrorDomain::Validation => StatusCode::BAD_REQUEST,
+        RuntimeErrorDomain::NotFound => StatusCode::NOT_FOUND,
+        RuntimeErrorDomain::Conflict => StatusCode::CONFLICT,
+        RuntimeErrorDomain::Policy => StatusCode::FORBIDDEN,
+        RuntimeErrorDomain::Provider => {
+            if descriptor.retryable {
+                StatusCode::SERVICE_UNAVAILABLE
+            } else {
+                StatusCode::BAD_GATEWAY
+            }
+        }
+        RuntimeErrorDomain::Storage | RuntimeErrorDomain::Io if descriptor.retryable => {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
 }
 
 pub(crate) fn http_error(
@@ -1113,8 +1154,13 @@ pub async fn serve_unix(
 
 #[cfg(test)]
 mod tests {
-    use super::{router, AppState};
-    use crate::{config::AppConfig, host::RuntimeHost, provider::StubProvider};
+    use super::{error_response, router, AppState};
+    use crate::{
+        config::AppConfig,
+        host::RuntimeHost,
+        provider::StubProvider,
+        runtime_error::{RuntimeError, RuntimeErrorDomain},
+    };
     use axum::{
         body::{to_bytes, Body},
         http::{header, Request, StatusCode},
@@ -1158,5 +1204,38 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], b"<html>holon ui</html>");
+    }
+
+    #[test]
+    fn typed_runtime_errors_map_to_compatible_http_envelope() {
+        let (status, axum::Json(body)) = error_response(
+            RuntimeError::not_found("task_not_found", "task task_123 not found")
+                .with_safe_context("task_id", "task_123")
+                .into(),
+        );
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["error"], "task task_123 not found");
+        assert_eq!(body["code"], "task_not_found");
+        assert_eq!(body["domain"], "not_found");
+        assert_eq!(body["retryable"], false);
+        assert_eq!(body["context"]["task_id"], "task_123");
+        assert!(body.get("hint").is_none());
+        assert_eq!(
+            serde_json::from_value::<RuntimeErrorDomain>(body["domain"].clone()).unwrap(),
+            RuntimeErrorDomain::NotFound
+        );
+    }
+
+    #[test]
+    fn unknown_runtime_errors_remain_internal_server_errors() {
+        let (status, axum::Json(body)) =
+            error_response(anyhow::anyhow!("unexpected runtime failure"));
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["code"], "runtime_error");
+        assert_eq!(body["domain"], "unknown");
+        assert_eq!(body["retryable"], false);
     }
 }

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -701,7 +701,7 @@ mod tests {
                 source_chain: (0..STATE_BOOTSTRAP_FAILURE_ARTIFACT_ENTRY_LIMIT + 4)
                     .map(|_| long_text.clone())
                     .collect(),
-                context: crate::runtime_error::RuntimeErrorContext {
+                context: Box::new(crate::runtime_error::RuntimeErrorContext {
                     message_id: Some(long_text.clone()),
                     turn_id: Some(long_text.clone()),
                     run_id: Some(long_text.clone()),
@@ -712,7 +712,7 @@ mod tests {
                     causation_id: Some(long_text.clone()),
                     provider: Some(long_text.clone()),
                     model_ref: Some(long_text.clone()),
-                },
+                }),
                 metadata: (0..STATE_BOOTSTRAP_FAILURE_ARTIFACT_ENTRY_LIMIT + 4)
                     .map(|index| (format!("{index}-{long_text}"), long_text.clone()))
                     .collect(),

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -338,6 +338,9 @@ fn slim_state_failure_artifact(
         truncate_state_bootstrap_string(&artifact.kind, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
     artifact.summary =
         truncate_state_bootstrap_string(&artifact.summary, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
+    artifact.recovery_hint = artifact
+        .recovery_hint
+        .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
     artifact.provider = artifact
         .provider
         .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
@@ -347,6 +350,22 @@ fn slim_state_failure_artifact(
     artifact.task_id = artifact
         .task_id
         .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
+    for field in [
+        &mut artifact.context.message_id,
+        &mut artifact.context.turn_id,
+        &mut artifact.context.run_id,
+        &mut artifact.context.work_item_id,
+        &mut artifact.context.tool_execution_id,
+        &mut artifact.context.task_id,
+        &mut artifact.context.correlation_id,
+        &mut artifact.context.causation_id,
+        &mut artifact.context.provider,
+        &mut artifact.context.model_ref,
+    ] {
+        *field = field
+            .take()
+            .map(|text| truncate_state_bootstrap_string(&text, STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT));
+    }
     artifact.source_chain = artifact
         .source_chain
         .into_iter()
@@ -671,6 +690,9 @@ mod tests {
                 category: FailureArtifactCategory::Transport,
                 kind: long_text.clone(),
                 summary: long_text.clone(),
+                domain: Some(crate::runtime_error::RuntimeErrorDomain::Provider),
+                retryable: Some(true),
+                recovery_hint: Some(long_text.clone()),
                 provider: Some(long_text.clone()),
                 model_ref: Some(long_text.clone()),
                 status: Some(500),
@@ -679,6 +701,18 @@ mod tests {
                 source_chain: (0..STATE_BOOTSTRAP_FAILURE_ARTIFACT_ENTRY_LIMIT + 4)
                     .map(|_| long_text.clone())
                     .collect(),
+                context: crate::runtime_error::RuntimeErrorContext {
+                    message_id: Some(long_text.clone()),
+                    turn_id: Some(long_text.clone()),
+                    run_id: Some(long_text.clone()),
+                    work_item_id: Some(long_text.clone()),
+                    tool_execution_id: Some(long_text.clone()),
+                    task_id: Some(long_text.clone()),
+                    correlation_id: Some(long_text.clone()),
+                    causation_id: Some(long_text.clone()),
+                    provider: Some(long_text.clone()),
+                    model_ref: Some(long_text.clone()),
+                },
                 metadata: (0..STATE_BOOTSTRAP_FAILURE_ARTIFACT_ENTRY_LIMIT + 4)
                     .map(|index| (format!("{index}-{long_text}"), long_text.clone()))
                     .collect(),
@@ -701,9 +735,52 @@ mod tests {
         for text in [
             artifact.kind.as_str(),
             artifact.summary.as_str(),
+            artifact.recovery_hint.as_deref().expect("recovery hint"),
             artifact.provider.as_deref().expect("provider"),
             artifact.model_ref.as_deref().expect("model ref"),
             artifact.task_id.as_deref().expect("task id"),
+        ] {
+            assert!(text.chars().count() <= STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
+        }
+        for text in [
+            artifact.context.message_id.as_deref().expect("message id"),
+            artifact.context.turn_id.as_deref().expect("turn id"),
+            artifact.context.run_id.as_deref().expect("run id"),
+            artifact
+                .context
+                .work_item_id
+                .as_deref()
+                .expect("work item id"),
+            artifact
+                .context
+                .tool_execution_id
+                .as_deref()
+                .expect("tool execution id"),
+            artifact
+                .context
+                .task_id
+                .as_deref()
+                .expect("context task id"),
+            artifact
+                .context
+                .correlation_id
+                .as_deref()
+                .expect("correlation id"),
+            artifact
+                .context
+                .causation_id
+                .as_deref()
+                .expect("causation id"),
+            artifact
+                .context
+                .provider
+                .as_deref()
+                .expect("context provider"),
+            artifact
+                .context
+                .model_ref
+                .as_deref()
+                .expect("context model ref"),
         ] {
             assert!(text.chars().count() <= STATE_BOOTSTRAP_TEXT_PREVIEW_LIMIT);
         }

--- a/src/http/tasks.rs
+++ b/src/http/tasks.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime_error::RuntimeError;
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ToolExecutionArtifactContent {
@@ -44,7 +45,7 @@ pub async fn task_status(
         .map_err(error_response)?
         .is_some_and(|task| task.agent_id == agent_id)
     {
-        return Err(not_found(format!("task {task_id} not found")));
+        return Err(task_not_found_response(&task_id));
     }
     let snapshot = runtime
         .managed_tasks()
@@ -72,7 +73,7 @@ pub async fn task_output(
         .map_err(error_response)?
         .is_some_and(|task| task.agent_id == agent_id)
     {
-        return Err(not_found(format!("task {task_id} not found")));
+        return Err(task_not_found_response(&task_id));
     }
     let output = runtime
         .managed_tasks()
@@ -201,7 +202,7 @@ pub async fn task_input(
         .map_err(error_response)?
         .is_some_and(|task| task.agent_id == agent_id)
     {
-        return Err(not_found(format!("task {task_id} not found")));
+        return Err(task_not_found_response(&task_id));
     }
     let authority_class = request
         .authority_class
@@ -232,7 +233,7 @@ pub async fn task_stop(
         .map_err(error_response)?
         .is_some_and(|task| task.agent_id == agent_id)
     {
-        return Err(not_found(format!("task {task_id} not found")));
+        return Err(task_not_found_response(&task_id));
     }
     let authority_class = request
         .authority_class
@@ -555,7 +556,14 @@ pub async fn work_item(
         .into_iter()
         .find(|item| item.id == work_item_id && item.agent_id == agent_id)
     else {
-        return Err(not_found(format!("work item {work_item_id} not found")));
+        return Err(error_response(
+            RuntimeError::not_found(
+                "work_item_not_found",
+                format!("work item {work_item_id} not found"),
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .into(),
+        ));
     };
     Ok(Json(work_item))
 }
@@ -597,7 +605,11 @@ pub async fn timer(
         .map_err(error_response)?
         .filter(|timer| timer.agent_id == agent_id)
     else {
-        return Err(not_found(format!("timer {timer_id} not found")));
+        return Err(error_response(
+            RuntimeError::not_found("timer_not_found", format!("timer {timer_id} not found"))
+                .with_safe_context("timer_id", timer_id)
+                .into(),
+        ));
     };
     Ok(Json(timer))
 }
@@ -675,12 +687,13 @@ pub async fn cancel_timer(
 }
 
 fn timer_lifecycle_error(err: anyhow::Error) -> (StatusCode, Json<Value>) {
-    let message = err.to_string();
-    if message.starts_with("timer ") && message.ends_with(" not found") {
-        not_found(message)
-    } else if message.starts_with("cannot ") {
-        bad_request(message)
-    } else {
-        error_response(err)
-    }
+    error_response(err)
+}
+
+fn task_not_found_response(task_id: &str) -> (StatusCode, Json<Value>) {
+    error_response(
+        RuntimeError::not_found("task_not_found", format!("task {task_id} not found"))
+            .with_safe_context("task_id", task_id)
+            .into(),
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod queue;
 pub mod run_once;
 pub mod runtime;
 pub mod runtime_db;
+pub mod runtime_error;
 pub mod runtime_event;
 pub mod skills;
 pub mod solve;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -691,14 +691,15 @@ pub fn provider_transport_diagnostics(
         })
 }
 
-pub fn provider_error_contains_code(error: &anyhow::Error, code: &str) -> bool {
+pub fn provider_error_code(error: &anyhow::Error) -> Option<&str> {
     error
         .chain()
-        .any(|source| source.to_string().contains(code))
+        .find_map(|source| source.downcast_ref::<retry::ProviderTransportError>())
+        .and_then(|error| error.code.as_deref())
 }
 
 pub fn provider_error_is_context_length_exceeded(error: &anyhow::Error) -> bool {
-    provider_error_contains_code(error, "context_length_exceeded")
+    provider_error_code(error) == Some("context_length_exceeded")
 }
 
 pub(crate) fn provider_turn_error(
@@ -732,12 +733,13 @@ pub(crate) fn aggregate_attempt_token_usage(
 }
 
 pub(crate) use catalog::build_candidate;
-pub(crate) use retry::classify_provider_error;
 #[cfg(test)]
 pub(crate) use retry::provider_max_attempts;
+pub(crate) use retry::{classify_provider_error, ProviderTransportError};
 #[cfg(test)]
 pub(crate) use retry::{
-    provider_transport_error, ProviderFailureClassification, ProviderFailureKind, RetryDisposition,
+    provider_transport_error, provider_transport_error_with_code, ProviderFailureClassification,
+    ProviderFailureKind, RetryDisposition,
 };
 #[cfg(test)]
 pub(crate) use tool_schema::validate_emitted_tool_schema;

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -273,8 +273,10 @@ pub(crate) fn classify_status_error_with_trace(
             disposition: RetryDisposition::FailFast,
         },
     };
-    provider_transport_error(
+    let code = status_error_code(&body);
+    provider_transport_error_with_code(
         classification,
+        code,
         Some(status.as_u16()),
         Some(ProviderTransportDiagnostics {
             stage: stage.to_string(),
@@ -286,8 +288,13 @@ pub(crate) fn classify_status_error_with_trace(
             http_trace: trace.and_then(|trace| trace.diagnostics(Some(status.as_u16()))),
             source_chain: status_error_source_chain(provider, status),
         }),
-        format!("{context} with status {status}: {body}"),
+        format!("{context} with status {status}"),
     )
+}
+
+fn status_error_code(body: &str) -> Option<&'static str> {
+    body.contains("Items are not persisted when `store` is set to false")
+        .then_some("non_persisted_item_id")
 }
 
 fn status_error_source_chain(provider: Option<&str>, status: StatusCode) -> Vec<String> {
@@ -460,6 +467,10 @@ pub(crate) fn format_provider_failure(
 
 #[cfg(test)]
 mod tests {
+    use reqwest::StatusCode;
+
+    use super::{classify_status_error_with_trace, ProviderTransportError};
+
     #[test]
     fn transport_url_sanitizer_removes_credentials_query_and_fragment() {
         assert_eq!(
@@ -467,6 +478,32 @@ mod tests {
                 "https://user:secret@example.com/v1/responses?api_key=token#frag"
             ),
             "https://example.com/v1/responses"
+        );
+    }
+
+    #[test]
+    fn status_error_display_excludes_response_body_but_preserves_typed_code() {
+        let error = classify_status_error_with_trace(
+            "OpenAI compact request failed",
+            "response_status",
+            Some("openai"),
+            Some("openai/gpt-5.4"),
+            Some("https://api.openai.com/v1/responses/compact"),
+            StatusCode::NOT_FOUND,
+            r#"{"error":{"message":"Items are not persisted when `store` is set to false","access_token":"short-secret"}}"#.into(),
+            None,
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "OpenAI compact request failed with status 404 Not Found"
+        );
+        assert!(!error.to_string().contains("short-secret"));
+        assert_eq!(
+            error
+                .downcast_ref::<ProviderTransportError>()
+                .and_then(|error| error.code.as_deref()),
+            Some("non_persisted_item_id")
         );
     }
 

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -44,6 +44,7 @@ pub(crate) struct ProviderFailureClassification {
 #[error("{message}")]
 pub(crate) struct ProviderTransportError {
     pub classification: ProviderFailureClassification,
+    pub code: Option<String>,
     pub status: Option<u16>,
     pub diagnostics: Option<ProviderTransportDiagnostics>,
     message: String,
@@ -119,8 +120,19 @@ pub(crate) fn provider_transport_error(
     diagnostics: Option<ProviderTransportDiagnostics>,
     message: impl Into<String>,
 ) -> anyhow::Error {
+    provider_transport_error_with_code(classification, None, status, diagnostics, message)
+}
+
+pub(crate) fn provider_transport_error_with_code(
+    classification: ProviderFailureClassification,
+    code: Option<&str>,
+    status: Option<u16>,
+    diagnostics: Option<ProviderTransportDiagnostics>,
+    message: impl Into<String>,
+) -> anyhow::Error {
     ProviderTransportError {
         classification,
+        code: code.map(ToString::to_string),
         status,
         diagnostics,
         message: message.into(),

--- a/src/provider/transports/openai/chat/send.rs
+++ b/src/provider/transports/openai/chat/send.rs
@@ -205,8 +205,9 @@ pub(crate) fn classify_openai_chat_completion_error(
         format!("{}: {}", error_type, error_message)
     };
 
-    provider_transport_error(
+    crate::provider::retry::provider_transport_error_with_code(
         classification,
+        error_code,
         Some(status.as_u16()),
         Some(crate::provider::ProviderTransportDiagnostics {
             stage: "response_status".into(),

--- a/src/provider/transports/openai/responses/compaction.rs
+++ b/src/provider/transports/openai/responses/compaction.rs
@@ -524,9 +524,7 @@ fn unsupported_compact_endpoint_status(error: &anyhow::Error) -> Option<u16> {
 
 fn is_non_persisted_compact_item_id_error(error: &anyhow::Error) -> bool {
     error_status(error) == Some(404)
-        && error
-            .to_string()
-            .contains("Items are not persisted when `store` is set to false")
+        && crate::provider::provider_error_code(error) == Some("non_persisted_item_id")
 }
 
 pub(super) fn error_status(error: &anyhow::Error) -> Option<u16> {

--- a/src/provider/transports/openai/responses/parse.rs
+++ b/src/provider/transports/openai/responses/parse.rs
@@ -290,7 +290,13 @@ fn classify_openai_streaming_error(
     let detail = code
         .map(|code| format!("{code}: {message}"))
         .unwrap_or_else(|| message.to_string());
-    provider_transport_error(classification, None, None, format!("{context}: {detail}"))
+    crate::provider::retry::provider_transport_error_with_code(
+        classification,
+        code,
+        None,
+        None,
+        format!("{context}: {detail}"),
+    )
 }
 
 fn classify_openai_incomplete_response(response: &Value) -> anyhow::Error {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -82,6 +82,7 @@ use crate::{
         },
         RuntimeDb,
     },
+    runtime_error::describe_runtime_error,
     runtime_event::RuntimeEventKind,
     skills::{
         effective_skill_root_registrations, find_skill_by_entrypoint, find_skill_by_script_path,
@@ -1679,14 +1680,30 @@ impl RuntimeHandle {
                     )
                     .await?;
                 } else {
-                    error!("failed to process message {}: {err:#}", message.id);
-                    self.ensure_runtime_failure_terminal(None, 0).await?;
+                    let descriptor = describe_runtime_error(&err);
+                    let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
+                    error!(
+                        message_id = %message.id,
+                        turn_id = %terminal.turn_id,
+                        domain = ?descriptor.domain,
+                        code = %descriptor.code,
+                        retryable = descriptor.retryable,
+                        error = %descriptor.operator_message,
+                        "failed to process message"
+                    );
                     self.inner.storage.append_event(&AuditEvent::legacy(
                         "runtime_error",
                         serde_json::json!({
                             "message_id": message.id,
+                            "turn_id": terminal.turn_id,
                             "message_kind": message.kind,
-                            "error": err.to_string(),
+                            "domain": descriptor.domain,
+                            "code": descriptor.code,
+                            "retryable": descriptor.retryable,
+                            "error": descriptor.operator_message,
+                            "recovery_hint": descriptor.recovery_hint,
+                            "safe_context": descriptor.safe_context,
+                            "source_chain": descriptor.source_chain,
                             "token_usage": provider_attempt_timeline(&err)
                                 .and_then(|timeline| timeline.aggregated_token_usage.clone()),
                             "provider_attempt_timeline": provider_attempt_timeline(&err),

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -186,7 +186,7 @@ impl RuntimeHandle {
             task_id: None,
             exit_status: None,
             source_chain,
-            context,
+            context: Box::new(context),
             metadata,
         }
     }
@@ -228,7 +228,7 @@ impl RuntimeHandle {
             task_id: None,
             exit_status: None,
             source_chain: descriptor.source_chain.clone(),
-            context,
+            context: Box::new(context),
             metadata,
         }
     }

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::provider::ProviderAttemptTimeline;
+use crate::runtime_error::{describe_runtime_error, RuntimeErrorContext, RuntimeErrorDescriptor};
 use crate::types::{FailureArtifact, FailureArtifactCategory, TurnTerminalRecord};
 
 impl RuntimeHandle {
@@ -69,6 +70,8 @@ impl RuntimeHandle {
     fn failure_artifact_for_provider_timeline(
         error_summary: &str,
         attempt_timeline: &ProviderAttemptTimeline,
+        descriptor: &RuntimeErrorDescriptor,
+        mut context: RuntimeErrorContext,
     ) -> FailureArtifact {
         let latest_attempt = attempt_timeline.attempts.iter().rev().find(|attempt| {
             attempt.failure_kind.is_some() || attempt.transport_diagnostics.is_some()
@@ -159,12 +162,18 @@ impl RuntimeHandle {
         let source_chain = latest_attempt
             .and_then(|attempt| attempt.transport_diagnostics.as_ref())
             .map(|diag| diag.source_chain.clone())
-            .unwrap_or_default();
+            .filter(|chain| !chain.is_empty())
+            .unwrap_or_else(|| descriptor.source_chain.clone());
+        context.provider = latest_attempt.map(|attempt| attempt.provider.clone());
+        context.model_ref = latest_attempt.map(|attempt| attempt.model_ref.clone());
 
         FailureArtifact {
             category: Self::provider_failure_category(&kind),
             kind,
             summary: error_summary.to_string(),
+            domain: Some(descriptor.domain),
+            retryable: Some(descriptor.retryable),
+            recovery_hint: descriptor.recovery_hint.clone(),
             provider: latest_attempt
                 .map(|attempt| attempt.provider.clone())
                 .or_else(|| metadata.get("provider").cloned()),
@@ -177,6 +186,7 @@ impl RuntimeHandle {
             task_id: None,
             exit_status: None,
             source_chain,
+            context,
             metadata,
         }
     }
@@ -184,6 +194,8 @@ impl RuntimeHandle {
     fn failure_artifact_for_runtime_error(
         message: &MessageEnvelope,
         failure_text: &str,
+        descriptor: &RuntimeErrorDescriptor,
+        context: RuntimeErrorContext,
     ) -> FailureArtifact {
         let mut metadata = std::collections::BTreeMap::new();
         metadata.insert(
@@ -205,14 +217,18 @@ impl RuntimeHandle {
         );
         FailureArtifact {
             category: FailureArtifactCategory::Runtime,
-            kind: "runtime_error".into(),
+            kind: descriptor.code.clone(),
             summary: failure_text.to_string(),
+            domain: Some(descriptor.domain),
+            retryable: Some(descriptor.retryable),
+            recovery_hint: descriptor.recovery_hint.clone(),
             provider: None,
             model_ref: None,
             status: None,
             task_id: None,
             exit_status: None,
-            source_chain: Vec::new(),
+            source_chain: descriptor.source_chain.clone(),
+            context,
             metadata,
         }
     }
@@ -221,14 +237,21 @@ impl RuntimeHandle {
         message: &MessageEnvelope,
         failure_text: &str,
         error: &anyhow::Error,
+        context: RuntimeErrorContext,
     ) -> FailureArtifact {
+        let descriptor = describe_runtime_error(error);
         if let Some(timeline) = provider_attempt_timeline(error) {
             if !timeline.attempts.is_empty() {
-                return Self::failure_artifact_for_provider_timeline(failure_text, timeline);
+                return Self::failure_artifact_for_provider_timeline(
+                    failure_text,
+                    timeline,
+                    &descriptor,
+                    context,
+                );
             }
         }
 
-        Self::failure_artifact_for_runtime_error(message, failure_text)
+        Self::failure_artifact_for_runtime_error(message, failure_text, &descriptor, context)
     }
 
     pub(super) fn summarize_runtime_failure_error(error: &anyhow::Error) -> String {
@@ -285,7 +308,9 @@ impl RuntimeHandle {
             .as_str()
             .map(ToString::to_string)
             .unwrap_or_else(|| "message".to_string());
-        let error_summary = Self::summarize_runtime_failure_error(error);
+        let descriptor = describe_runtime_error(error);
+        let error_summary =
+            Self::summarize_runtime_failure_error(&anyhow::anyhow!(descriptor.operator_message));
         format!(
             "Turn failed while processing {}: {}",
             message_kind, error_summary
@@ -299,17 +324,34 @@ impl RuntimeHandle {
     ) -> Result<()> {
         let failure_text = Self::concise_runtime_failure_text(message, error);
         let attempt_timeline = provider_attempt_timeline(error);
-        let failure_artifact = Self::failure_artifact(message, &failure_text, error);
+        let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
+        let (run_id, current_work_item_id) = {
+            let guard = self.inner.agent.lock().await;
+            (
+                guard.state.current_run_id.clone(),
+                guard
+                    .state
+                    .current_turn_work_item_id
+                    .clone()
+                    .or_else(|| guard.state.current_work_item_id.clone()),
+            )
+        };
+        let context = RuntimeErrorContext {
+            message_id: Some(message.id.clone()),
+            turn_id: Some(terminal.turn_id.clone()),
+            run_id,
+            work_item_id: message.work_item_id.clone().or(current_work_item_id),
+            task_id: message.task_id.clone(),
+            correlation_id: message.correlation_id.clone(),
+            causation_id: message.causation_id.clone(),
+            ..RuntimeErrorContext::default()
+        };
+        let descriptor = describe_runtime_error(error);
+        let failure_artifact = Self::failure_artifact(message, &failure_text, error, context);
         let token_usage = attempt_timeline
             .as_ref()
             .and_then(|timeline| timeline.aggregated_token_usage.clone());
-        let error_chain = error
-            .chain()
-            .skip(1)
-            .map(ToString::to_string)
-            .filter(|line| !line.trim().is_empty())
-            .collect::<Vec<_>>();
-        let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
+        let error_chain = failure_artifact.source_chain.clone();
         let mut brief = brief::make_failure(&message.agent_id, message, failure_text.clone());
         brief.turn_id = Some(terminal.turn_id.clone());
         brief.turn_index = Some(terminal.turn_index);
@@ -326,7 +368,7 @@ impl RuntimeHandle {
                 "authority_class": message.authority_class,
                 "delivery_surface": message.delivery_surface,
                 "admission_context": message.admission_context,
-                "error": error.to_string(),
+                "error": descriptor.operator_message,
                 "error_chain": error_chain,
                 "text": failure_text,
                 "failure_artifact": failure_artifact.clone(),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1771,7 +1771,13 @@ impl RuntimeHandle {
                     }
                 }
                 Some(command_task::ManagedTaskHandle::Async(_)) => {
-                    return Err(anyhow!("task {} has an unexpected async handle", task_id));
+                    return Err(RuntimeError::new(
+                        RuntimeErrorDomain::Task,
+                        "task_handle_type_mismatch",
+                        format!("task {task_id} has an unexpected async handle"),
+                    )
+                    .with_safe_context("task_id", task_id)
+                    .into());
                 }
                 None => {
                     command_handle_missing = true;

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3418,7 +3418,7 @@ fn task_failure_artifact(
         task_id: Some(task.id.clone()),
         exit_status,
         source_chain,
-        context: RuntimeErrorContext {
+        context: Box::new(RuntimeErrorContext {
             message_id: task.parent_message_id.clone(),
             turn_id: detail_string(&task.detail, "parent_turn_id"),
             work_item_id: task.work_item_id.clone(),
@@ -3426,7 +3426,7 @@ fn task_failure_artifact(
             correlation_id: detail_string(&task.detail, "correlation_id"),
             causation_id: detail_string(&task.detail, "causation_id"),
             ..RuntimeErrorContext::default()
-        },
+        }),
         metadata,
     })
 }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2,6 +2,9 @@ use super::message_dispatch::message_text;
 use super::waiting::WorkItemBlockerClearance;
 use super::{task_state_reducer, *};
 use crate::config::{ModelRef, ProviderId};
+use crate::runtime_error::{
+    sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext, RuntimeErrorDomain,
+};
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
@@ -1521,7 +1524,7 @@ impl RuntimeHandle {
         let task = self
             .task_record(task_id)
             .await?
-            .ok_or_else(|| anyhow!("task {} not found", task_id))?;
+            .ok_or_else(|| task_not_found_error(task_id))?;
         let mut snapshot = TaskStatusSnapshot::from_task_record(&task);
 
         if task.is_child_agent_task()
@@ -1571,7 +1574,7 @@ impl RuntimeHandle {
             let task = self
                 .task_record(task_id)
                 .await?
-                .ok_or_else(|| anyhow!("task {} not found", task_id))?;
+                .ok_or_else(|| task_not_found_error(task_id))?;
             let status = self.task_output_status(&task)?;
             let ready = task_output_ready(&task, &status);
 
@@ -1803,7 +1806,12 @@ impl RuntimeHandle {
                             && detail_string(&task.detail, "child_agent_id").is_some()
                     });
                     if !can_cleanup_interrupted_child {
-                        return Err(anyhow!("task {} is not currently running", task_id));
+                        return Err(RuntimeError::validation(
+                            "task_not_running",
+                            format!("task {task_id} is not currently running"),
+                        )
+                        .with_safe_context("task_id", task_id)
+                        .into());
                     }
                 }
             }
@@ -1833,10 +1841,13 @@ impl RuntimeHandle {
             TaskStatus::Cancelled => "cancelled",
             _ => unreachable!("stop_task only emits cancelling or cancelled"),
         };
-        let stopped_kind = existing
-            .as_ref()
-            .map(|task| task.kind)
-            .ok_or_else(|| anyhow!("task {} is not currently running", task_id))?;
+        let stopped_kind = existing.as_ref().map(|task| task.kind).ok_or_else(|| {
+            RuntimeError::validation(
+                "task_not_running",
+                format!("task {task_id} is not currently running"),
+            )
+            .with_safe_context("task_id", task_id)
+        })?;
         let mut detail = existing.as_ref().and_then(|task| task.detail.clone());
         if let Some(detail_map) = detail.as_mut().and_then(|value| value.as_object_mut()) {
             detail_map.insert("task_status".into(), serde_json::json!(status_text));
@@ -1893,7 +1904,7 @@ impl RuntimeHandle {
         let task = self
             .task_record(task_id)
             .await?
-            .ok_or_else(|| anyhow!("task {} not found", task_id))?;
+            .ok_or_else(|| task_not_found_error(task_id))?;
         let snapshot = TaskStatusSnapshot::from_task_record(&task);
         let command = snapshot.command.clone();
         if matches!(
@@ -1934,7 +1945,7 @@ impl RuntimeHandle {
         let task = self
             .task_record(task_id)
             .await?
-            .ok_or_else(|| anyhow!("task {} not found", task_id))?;
+            .ok_or_else(|| task_not_found_error(task_id))?;
         let snapshot = TaskStatusSnapshot::from_task_record(&task);
         let command = snapshot.command.clone();
         if matches!(
@@ -2021,11 +2032,32 @@ impl RuntimeHandle {
                 response_tx,
             })
             .await
-            .map_err(|_| anyhow!("task {} is not currently running", task.id))?;
+            .map_err(|_| {
+                RuntimeError::validation(
+                    "task_not_running",
+                    format!("task {} is not currently running", task.id),
+                )
+                .with_safe_context("task_id", &task.id)
+            })?;
         let bytes_written = response_rx
             .await
-            .map_err(|_| anyhow!("task {} input delivery was interrupted", task.id))?
-            .map_err(|error| anyhow!("task {} input delivery failed: {}", task.id, error))?;
+            .map_err(|_| {
+                RuntimeError::new(
+                    RuntimeErrorDomain::Task,
+                    "task_input_interrupted",
+                    format!("task {} input delivery was interrupted", task.id),
+                )
+                .with_safe_context("task_id", &task.id)
+                .with_retryable(true)
+            })?
+            .map_err(|_| {
+                RuntimeError::new(
+                    RuntimeErrorDomain::Task,
+                    "task_input_failed",
+                    format!("task {} input delivery failed", task.id),
+                )
+                .with_safe_context("task_id", &task.id)
+            })?;
 
         let input_target = command
             .as_ref()
@@ -2232,7 +2264,12 @@ impl RuntimeHandle {
         };
         let mut record = self.validate_owned_work_item(&agent_id, &work_item_id)?;
         if record.state == WorkItemState::Completed {
-            return Err(anyhow!("cannot pick completed work item {}", work_item_id));
+            return Err(RuntimeError::validation(
+                "work_item_completed",
+                format!("cannot pick completed work item {work_item_id}"),
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .into());
         }
         let normalized_reason = reason.and_then(|value| {
             let trimmed = value.trim();
@@ -2488,10 +2525,12 @@ impl RuntimeHandle {
         let agent_id = self.agent_id().await?;
         let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
         if existing.state == WorkItemState::Completed {
-            return Err(anyhow!(
-                "cannot update completed work item {}",
-                work_item_id
-            ));
+            return Err(RuntimeError::validation(
+                "work_item_completed",
+                format!("cannot update completed work item {work_item_id}"),
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .into());
         }
         let mut record = existing.clone();
         let mut wrote_item = false;
@@ -3002,15 +3041,29 @@ impl RuntimeHandle {
             .runtime_db
             .work_items()
             .latest(work_item_id)?
-            .ok_or_else(|| anyhow!("unknown work item {}", work_item_id))?;
+            .ok_or_else(|| {
+                RuntimeError::not_found(
+                    "work_item_not_found",
+                    format!("unknown work item {work_item_id}"),
+                )
+                .with_safe_context("work_item_id", work_item_id)
+            })?;
         if record.agent_id != agent_id {
-            return Err(anyhow!(
-                "work item {} belongs to another agent",
-                work_item_id
-            ));
+            return Err(RuntimeError::policy(
+                "work_item_access_denied",
+                format!("work item {work_item_id} belongs to another agent"),
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .with_safe_context("agent_id", agent_id)
+            .into());
         }
         Ok(record)
     }
+}
+
+fn task_not_found_error(task_id: &str) -> RuntimeError {
+    RuntimeError::not_found("task_not_found", format!("task {task_id} not found"))
+        .with_safe_context("task_id", task_id)
 }
 
 fn continuation_summary(
@@ -3113,6 +3166,21 @@ pub(super) fn task_from_message(message: &MessageEnvelope, agent_id: &str) -> Re
             detail
                 .entry("parent_turn_id")
                 .or_insert_with(|| serde_json::json!(parent_turn_id));
+        }
+    }
+    if message.correlation_id.is_some() || message.causation_id.is_some() {
+        let detail = detail.get_or_insert_with(|| serde_json::json!({}));
+        if let Some(detail) = detail.as_object_mut() {
+            if let Some(correlation_id) = message.correlation_id.as_ref() {
+                detail
+                    .entry("correlation_id")
+                    .or_insert_with(|| serde_json::json!(correlation_id));
+            }
+            if let Some(causation_id) = message.causation_id.as_ref() {
+                detail
+                    .entry("causation_id")
+                    .or_insert_with(|| serde_json::json!(causation_id));
+            }
         }
     }
 
@@ -3266,6 +3334,11 @@ fn task_failure_artifact(
         metadata.insert("output_path".into(), path);
     }
     let has_error = detail_string(&task.detail, "error").is_some();
+    let source_chain = detail_string(&task.detail, "error")
+        .map(|error| sanitize_runtime_error_text(&error))
+        .filter(|error| !error.is_empty())
+        .into_iter()
+        .collect();
     if has_error {
         metadata.insert("error_present".into(), "true".into());
     }
@@ -3330,12 +3403,24 @@ fn task_failure_artifact(
         category: FailureArtifactCategory::Task,
         kind: kind.to_string(),
         summary,
+        domain: Some(RuntimeErrorDomain::Task),
+        retryable: Some(false),
+        recovery_hint: None,
         provider: None,
         model_ref: None,
         status: None,
         task_id: Some(task.id.clone()),
         exit_status,
-        source_chain: Vec::new(),
+        source_chain,
+        context: RuntimeErrorContext {
+            message_id: task.parent_message_id.clone(),
+            turn_id: detail_string(&task.detail, "parent_turn_id"),
+            work_item_id: task.work_item_id.clone(),
+            task_id: Some(task.id.clone()),
+            correlation_id: detail_string(&task.detail, "correlation_id"),
+            causation_id: detail_string(&task.detail, "causation_id"),
+            ..RuntimeErrorContext::default()
+        },
         metadata,
     })
 }

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -14,10 +14,11 @@ pub(crate) use crate::{
     host::RuntimeHost,
     prompt::{render_section, PromptSection, PromptStability},
     provider::{
-        provider_turn_error, AgentProvider, ConversationMessage, ModelBlock,
-        ProviderAttemptOutcome, ProviderAttemptRecord, ProviderAttemptTimeline,
+        provider_transport_error_with_code, provider_turn_error, AgentProvider,
+        ConversationMessage, ModelBlock, ProviderAttemptOutcome, ProviderAttemptRecord,
+        ProviderAttemptTimeline, ProviderFailureClassification, ProviderFailureKind,
         ProviderHttpTraceDiagnostics, ProviderTransportDiagnostics, ProviderTurnRequest,
-        ProviderTurnResponse, ReqwestTransportDiagnostics, StubProvider,
+        ProviderTurnResponse, ReqwestTransportDiagnostics, RetryDisposition, StubProvider,
     },
     storage::AppStorage,
     system::{ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind},
@@ -1055,7 +1056,16 @@ impl AgentProvider for ContextLengthExceededProvider {
                 winning_model_ref: None,
                 pending_fallback_model_ref: None
             },
-            anyhow!("context_length_exceeded: input too long"),
+            provider_transport_error_with_code(
+                ProviderFailureClassification {
+                    kind: ProviderFailureKind::ContractError,
+                    disposition: RetryDisposition::FailFast,
+                },
+                Some("context_length_exceeded"),
+                None,
+                None,
+                "context_length_exceeded: input too long",
+            ),
         ))
     }
 }

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -336,6 +336,19 @@ async fn disallowed_tool_call_is_auditable_and_continuation_stays_valid() {
         failure_event.data["summary"].as_str(),
         Some("Failed: CreateTask not exposed for round")
     );
+    assert_eq!(failure_event.data["tool_error"]["domain"].as_str(), None);
+    let tool_execution_id = failure_event.data["tool_execution_id"]
+        .as_str()
+        .expect("tool execution id");
+    let canonical = runtime
+        .storage()
+        .read_tool_execution_by_id(tool_execution_id)
+        .unwrap()
+        .expect("canonical tool execution");
+    assert_eq!(
+        canonical.output["tool_error"]["kind"],
+        "tool_not_exposed_for_round"
+    );
 
     let transcript = runtime.storage().read_recent_transcript(10).unwrap();
     assert_eq!(
@@ -1589,6 +1602,20 @@ async fn runtime_failure_artifacts_preserve_provider_attempt_timeline() {
     assert_eq!(
         failure.data["failure_artifact"]["metadata"]["http_trace_path"],
         ".holon/http-trace/default/trace-1-1.jsonl"
+    );
+    assert_eq!(failure.data["failure_artifact"]["domain"], "provider");
+    assert_eq!(failure.data["failure_artifact"]["retryable"], false);
+    assert_eq!(
+        failure.data["failure_artifact"]["context"]["message_id"],
+        message.id
+    );
+    assert_eq!(
+        failure.data["failure_artifact"]["context"]["provider"],
+        "openai"
+    );
+    assert_eq!(
+        failure.data["failure_artifact"]["context"]["model_ref"],
+        "openai/gpt-5.4"
     );
     assert!(failure.data["token_usage"].is_null());
     assert!(failure.data["provider_attempt_timeline"]["winning_model_ref"].is_null());

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1693,7 +1693,10 @@ impl TurnExecution<'_> {
                         authority_class: authority_class.clone(),
                         status: crate::types::ToolExecutionStatus::Error,
                         input: call.input.clone(),
-                        output: serde_json::json!({ "error": audit_error }),
+                        output: serde_json::json!({
+                            "error": audit_error,
+                            "tool_error": &error,
+                        }),
                         summary: format!("Failed: {tool_name} not exposed for round"),
                         invocation_surface: None,
                     };
@@ -1956,7 +1959,10 @@ impl TurnExecution<'_> {
                             authority_class: authority_class.clone(),
                             status: crate::types::ToolExecutionStatus::Error,
                             input: call.input.clone(),
-                            output: serde_json::json!({ "error": audit_error }),
+                            output: serde_json::json!({
+                                "error": audit_error,
+                                "tool_error": &error,
+                            }),
                             summary: format!("Failed: {tool_name}"),
                             invocation_surface: None,
                         };

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -2461,9 +2461,11 @@ fn does_not_invalidate_checkpoint_for_failed_state_mutation() {
         error: Some(ToolError {
             kind: "invalid_input".to_string(),
             message: "bad input".to_string(),
+            domain: None,
             details: None,
             recovery_hint: None,
             retryable: false,
+            source_chain: Vec::new(),
         }),
     };
     assert!(!tool_result_invalidates_checkpoint_anchor(&envelope));
@@ -2597,9 +2599,11 @@ fn round_updated_work_item_false_for_failed_work_item_tool() {
         error: Some(ToolError {
             kind: "invalid".to_string(),
             message: "bad".to_string(),
+            domain: None,
             details: None,
             recovery_hint: None,
             retryable: false,
+            source_chain: Vec::new(),
         }),
     }];
     assert!(!round_updated_work_item(&round));

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use crate::ingress::WakeHint;
+use crate::runtime_error::RuntimeError;
 use crate::types::{
     WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WaitConditionSummary, WakeSource,
     WorkItemRecord, WorkItemState,
@@ -127,10 +128,12 @@ impl RuntimeHandle {
         if let Some(work_item_id) = work_item_id.as_deref() {
             let existing = self.validate_owned_work_item(agent_id, work_item_id)?;
             if existing.state != WorkItemState::Open {
-                return Err(anyhow!(
-                    "cannot wait on completed work item {}",
-                    work_item_id
-                ));
+                return Err(RuntimeError::validation(
+                    "work_item_completed",
+                    format!("cannot wait on completed work item {work_item_id}"),
+                )
+                .with_safe_context("work_item_id", work_item_id)
+                .into());
             }
             let mut updated = existing.clone();
             if existing.blocked_by.as_deref() != Some(reason.as_str())
@@ -500,14 +503,27 @@ impl RuntimeHandle {
             .inner
             .storage
             .latest_timer_record(timer_id)?
-            .ok_or_else(|| anyhow!("timer {timer_id} not found"))?;
+            .ok_or_else(|| {
+                RuntimeError::not_found("timer_not_found", format!("timer {timer_id} not found"))
+                    .with_safe_context("timer_id", timer_id)
+            })?;
         if timer.agent_id != self.agent_id().await? {
-            return Err(anyhow!("timer {timer_id} not found"));
+            return Err(RuntimeError::not_found(
+                "timer_not_found",
+                format!("timer {timer_id} not found"),
+            )
+            .with_safe_context("timer_id", timer_id)
+            .into());
         }
         match timer.status {
             TimerStatus::Cancelled => return Ok(timer),
             TimerStatus::Completed => {
-                return Err(anyhow!("cannot cancel completed timer {timer_id}"))
+                return Err(RuntimeError::validation(
+                    "timer_completed",
+                    format!("cannot cancel completed timer {timer_id}"),
+                )
+                .with_safe_context("timer_id", timer_id)
+                .into())
             }
             TimerStatus::Active => {}
         }

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -97,6 +97,10 @@ impl RuntimeDbRetryableError {
             source: source.to_string(),
         }
     }
+
+    pub fn operation(&self) -> &'static str {
+        self.operation
+    }
 }
 
 impl fmt::Display for RuntimeDbRetryableError {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -169,6 +169,19 @@ impl RuntimeStateTransitionConflict {
         }
     }
 
+    pub(crate) fn concurrent_mutation(domain: &'static str, record_id: impl Into<String>) -> Self {
+        Self {
+            domain,
+            record_id: record_id.into(),
+            code: "revision_conflict",
+            existing_status: "changed".into(),
+            incoming_status: "expected_snapshot".into(),
+            expected_revision: None,
+            actual_revision: None,
+            retryable: true,
+        }
+    }
+
     pub fn domain(&self) -> &'static str {
         self.domain
     }

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -15,7 +15,7 @@ use crate::{
             upsert_task_tx, upsert_wait_condition_tx, upsert_work_item_continuation_tx,
             wait_condition_transition,
         },
-        RuntimeDb, RuntimeIndexChange,
+        RuntimeDb, RuntimeIndexChange, RuntimeStateTransitionConflict,
     },
     runtime_error::RuntimeError,
     types::{

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -470,10 +470,11 @@ fn validate_agent_state_mutation_tx(
     if let Some(expected) = mutation.expected.as_ref() {
         let actual = agent_state_tx(tx, &mutation.record.id)?;
         if actual.as_ref() != Some(expected.as_ref()) {
-            return Err(anyhow!(
-                "agent state {} changed before runtime transition commit",
-                mutation.record.id
-            ));
+            return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+                "agent_state",
+                &mutation.record.id,
+            )
+            .into());
         }
     }
     Ok(())
@@ -990,9 +991,13 @@ mod tests {
             .transitions()
             .commit_work_item_focus(&command(&second))
             .unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("changed before runtime transition commit"));
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("concurrent agent state mutation should return typed conflict");
+        assert_eq!(conflict.domain(), "agent_state");
+        assert_eq!(conflict.record_id(), "agent-a");
+        assert_eq!(conflict.code(), "revision_conflict");
+        assert!(conflict.retryable());
         assert_eq!(
             db.agent_states()
                 .latest("agent-a")?

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -17,6 +17,7 @@ use crate::{
         },
         RuntimeDb, RuntimeIndexChange,
     },
+    runtime_error::RuntimeError,
     types::{
         AgentState, AuditEvent, QueueEntryRecord, TaskRecord, TranscriptEntry, WaitConditionRecord,
         WorkItemContinuationFrame, WorkItemRecord, WorkItemState,
@@ -490,19 +491,34 @@ fn validate_focus_target_tx(tx: &Transaction<'_>, state: &AgentState) -> Result<
         )
         .optional()?;
     let Some((owner_agent_id, payload_json)) = target else {
-        return Err(anyhow!(
-            "cannot focus missing work item {work_item_id} for agent {}",
-            state.id
-        ));
+        return Err(RuntimeError::not_found(
+            "work_item_not_found",
+            format!(
+                "cannot focus missing work item {work_item_id} for agent {}",
+                state.id
+            ),
+        )
+        .with_safe_context("work_item_id", work_item_id)
+        .with_safe_context("agent_id", &state.id)
+        .into());
     };
     let record: WorkItemRecord = serde_json::from_str(&payload_json)?;
     if owner_agent_id != state.id || record.agent_id != state.id {
-        return Err(anyhow!(
-            "cannot focus work item {work_item_id} owned by another agent"
-        ));
+        return Err(RuntimeError::policy(
+            "work_item_access_denied",
+            format!("cannot focus work item {work_item_id} owned by another agent"),
+        )
+        .with_safe_context("work_item_id", work_item_id)
+        .with_safe_context("agent_id", &state.id)
+        .into());
     }
     if record.state != WorkItemState::Open {
-        return Err(anyhow!("cannot focus completed work item {work_item_id}"));
+        return Err(RuntimeError::validation(
+            "work_item_completed",
+            format!("cannot focus completed work item {work_item_id}"),
+        )
+        .with_safe_context("work_item_id", work_item_id)
+        .into());
     }
     Ok(())
 }

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -604,6 +604,14 @@ mod tests {
             "<redacted-sensitive-error-context>"
         );
         assert_eq!(
+            sanitize_runtime_error_text(r#"provider failed: {"access_token":"secret"}"#),
+            "<redacted-sensitive-error-context>"
+        );
+        assert_eq!(
+            sanitize_runtime_error_text("provider failed: x-api-key: short-secret"),
+            "<redacted-sensitive-error-context>"
+        );
+        assert_eq!(
             sanitize_runtime_error_text(
                 r#"provider failed: {"detail":"raw backend response body"}"#
             ),

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -1,0 +1,625 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Error as AnyhowError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    provider::{provider_attempt_timeline, provider_transport_diagnostics, ProviderTransportError},
+    runtime_db::{RuntimeDbRetryableError, RuntimeStateTransitionConflict},
+    tool::ToolError,
+};
+
+const SOURCE_CHAIN_MAX_ENTRIES: usize = 8;
+const ERROR_TEXT_MAX_CHARS: usize = 512;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeErrorDomain {
+    Runtime,
+    Storage,
+    Policy,
+    Io,
+    Conflict,
+    NotFound,
+    Validation,
+    Provider,
+    Tool,
+    Task,
+    Http,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct RuntimeErrorContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_execution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_ref: Option<String>,
+}
+
+impl RuntimeErrorContext {
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct RuntimeErrorDescriptor {
+    pub domain: RuntimeErrorDomain,
+    pub code: String,
+    pub retryable: bool,
+    pub operator_message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub safe_context: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_chain: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeError {
+    descriptor: RuntimeErrorDescriptor,
+}
+
+impl RuntimeError {
+    pub fn new(
+        domain: RuntimeErrorDomain,
+        code: impl Into<String>,
+        operator_message: impl Into<String>,
+    ) -> Self {
+        Self {
+            descriptor: RuntimeErrorDescriptor {
+                domain,
+                code: code.into(),
+                retryable: false,
+                operator_message: sanitize_runtime_error_text(&operator_message.into()),
+                recovery_hint: None,
+                safe_context: BTreeMap::new(),
+                source_chain: Vec::new(),
+            },
+        }
+    }
+
+    pub fn not_found(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(RuntimeErrorDomain::NotFound, code, message)
+    }
+
+    pub fn validation(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(RuntimeErrorDomain::Validation, code, message)
+    }
+
+    pub fn policy(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(RuntimeErrorDomain::Policy, code, message)
+    }
+
+    pub fn with_retryable(mut self, retryable: bool) -> Self {
+        self.descriptor.retryable = retryable;
+        self
+    }
+
+    pub fn with_recovery_hint(mut self, hint: impl Into<String>) -> Self {
+        self.descriptor.recovery_hint = Some(sanitize_runtime_error_text(&hint.into()));
+        self
+    }
+
+    pub fn with_safe_context(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = key.into();
+        if is_safe_context_key(&key) {
+            self.descriptor
+                .safe_context
+                .insert(key, sanitize_runtime_error_text(&value.into()));
+        }
+        self
+    }
+
+    pub fn descriptor(&self) -> &RuntimeErrorDescriptor {
+        &self.descriptor
+    }
+}
+
+impl std::fmt::Display for RuntimeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.descriptor.operator_message)
+    }
+}
+
+impl std::error::Error for RuntimeError {}
+
+pub fn describe_runtime_error(error: &AnyhowError) -> RuntimeErrorDescriptor {
+    let source_chain = collect_runtime_error_source_chain(error);
+
+    if let Some(runtime_error) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<RuntimeError>())
+    {
+        let mut descriptor = runtime_error.descriptor().clone();
+        descriptor.source_chain = merge_source_chains(descriptor.source_chain, source_chain);
+        return descriptor;
+    }
+
+    if let Some(tool_error) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<ToolError>())
+    {
+        return descriptor_from_tool_error(tool_error, source_chain);
+    }
+
+    if let Some(provider_error) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<ProviderTransportError>())
+    {
+        let diagnostics = provider_transport_diagnostics(error);
+        let provider_chain = diagnostics
+            .map(|diagnostics| diagnostics.source_chain.clone())
+            .unwrap_or_default();
+        let kind = provider_error.classification.kind.as_str();
+        let code = provider_error.code.as_deref().unwrap_or(kind);
+        let retryable = provider_error.classification.disposition.as_str() == "retryable";
+        let mut safe_context = BTreeMap::new();
+        if let Some(status) = provider_error.status {
+            safe_context.insert("status".into(), status.to_string());
+        }
+        if let Some(diagnostics) = diagnostics {
+            insert_optional_context(
+                &mut safe_context,
+                "provider",
+                diagnostics.provider.as_deref(),
+            );
+            insert_optional_context(
+                &mut safe_context,
+                "model_ref",
+                diagnostics.model_ref.as_deref(),
+            );
+            insert_optional_context(&mut safe_context, "stage", Some(&diagnostics.stage));
+        }
+        return RuntimeErrorDescriptor {
+            domain: RuntimeErrorDomain::Provider,
+            code: code.to_string(),
+            retryable,
+            operator_message: format!("provider request failed: {kind}"),
+            recovery_hint: provider_recovery_hint(kind),
+            safe_context,
+            source_chain: merge_source_chains(provider_chain, source_chain),
+        };
+    }
+
+    if let Some(conflict) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<RuntimeStateTransitionConflict>())
+    {
+        let mut safe_context = BTreeMap::from([
+            ("record_type".into(), conflict.domain().to_string()),
+            ("record_id".into(), conflict.record_id().to_string()),
+            (
+                "existing_status".into(),
+                conflict.existing_status().to_string(),
+            ),
+            (
+                "incoming_status".into(),
+                conflict.incoming_status().to_string(),
+            ),
+        ]);
+        if let Some(revision) = conflict.expected_revision() {
+            safe_context.insert("expected_revision".into(), revision.to_string());
+        }
+        if let Some(revision) = conflict.actual_revision() {
+            safe_context.insert("actual_revision".into(), revision.to_string());
+        }
+        return RuntimeErrorDescriptor {
+            domain: RuntimeErrorDomain::Conflict,
+            code: conflict.code().to_string(),
+            retryable: conflict.retryable(),
+            operator_message: sanitize_runtime_error_text(&conflict.to_string()),
+            recovery_hint: conflict
+                .retryable()
+                .then(|| "retry with fresh state".into()),
+            safe_context,
+            source_chain,
+        };
+    }
+
+    if let Some(db_error) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<RuntimeDbRetryableError>())
+    {
+        let source_chain = vec![format!(
+            "runtime database operation {} is temporarily unavailable",
+            db_error.operation()
+        )];
+        return RuntimeErrorDescriptor {
+            domain: RuntimeErrorDomain::Storage,
+            code: "runtime_db_busy".into(),
+            retryable: true,
+            operator_message: format!(
+                "runtime database operation {} is temporarily unavailable",
+                db_error.operation()
+            ),
+            recovery_hint: Some("retry the operation".into()),
+            safe_context: BTreeMap::from([("operation".into(), db_error.operation().to_string())]),
+            source_chain,
+        };
+    }
+
+    if let Some(io_error) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<std::io::Error>())
+    {
+        let mut safe_context = BTreeMap::new();
+        if let Some(code) = io_error.raw_os_error() {
+            safe_context.insert("os_error".into(), code.to_string());
+        }
+        safe_context.insert("io_kind".into(), format!("{:?}", io_error.kind()));
+        return RuntimeErrorDescriptor {
+            domain: RuntimeErrorDomain::Io,
+            code: "io_error".into(),
+            retryable: matches!(
+                io_error.kind(),
+                std::io::ErrorKind::Interrupted
+                    | std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::WouldBlock
+            ),
+            operator_message: "I/O operation failed".into(),
+            recovery_hint: None,
+            safe_context,
+            source_chain,
+        };
+    }
+
+    if let Some(attempt) =
+        provider_attempt_timeline(error).and_then(|timeline| timeline.attempts.last())
+    {
+        let kind = attempt.failure_kind.as_deref().unwrap_or("unknown");
+        let retryable = attempt.disposition.as_deref() == Some("retryable");
+        let mut safe_context = BTreeMap::from([
+            ("provider".into(), attempt.provider.clone()),
+            ("model_ref".into(), attempt.model_ref.clone()),
+        ]);
+        if let Some(diagnostics) = attempt.transport_diagnostics.as_ref() {
+            safe_context.insert("stage".into(), diagnostics.stage.clone());
+            if let Some(status) = diagnostics.status {
+                safe_context.insert("status".into(), status.to_string());
+            }
+        }
+        let provider_chain = attempt
+            .transport_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.source_chain.clone())
+            .unwrap_or_default();
+        return RuntimeErrorDescriptor {
+            domain: RuntimeErrorDomain::Provider,
+            code: kind.to_string(),
+            retryable,
+            operator_message: format!("provider request failed: {kind}"),
+            recovery_hint: provider_recovery_hint(kind),
+            safe_context,
+            source_chain: merge_source_chains(provider_chain, source_chain),
+        };
+    }
+
+    RuntimeErrorDescriptor {
+        domain: RuntimeErrorDomain::Unknown,
+        code: "runtime_error".into(),
+        retryable: false,
+        operator_message: sanitize_runtime_error_text(&error.to_string()),
+        recovery_hint: None,
+        safe_context: BTreeMap::new(),
+        source_chain,
+    }
+}
+
+pub fn collect_runtime_error_source_chain(error: &AnyhowError) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    error
+        .chain()
+        .filter_map(|source| {
+            if let Some(tool_error) = source.downcast_ref::<ToolError>() {
+                return Some(tool_error.message.clone());
+            }
+            if source.downcast_ref::<ProviderTransportError>().is_some() {
+                return None;
+            }
+            if let Some(runtime_error) = source.downcast_ref::<RuntimeError>() {
+                return Some(runtime_error.descriptor.operator_message.clone());
+            }
+            Some(source.to_string())
+        })
+        .map(|message| sanitize_runtime_error_text(&message))
+        .filter(|message| !message.is_empty())
+        .filter(|message| seen.insert(message.clone()))
+        .take(SOURCE_CHAIN_MAX_ENTRIES)
+        .collect()
+}
+
+pub fn sanitize_runtime_error_text(raw: &str) -> String {
+    let trimmed = raw
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.contains("authorization:")
+        || lower.contains("bearer ")
+        || lower.contains("api_key")
+        || lower.contains("api-key")
+        || lower.contains("access_token")
+        || lower.contains("access-token")
+        || lower.contains("x-api-key")
+        || lower.contains("capability_secret")
+        || lower.contains("/api/callbacks/wake/")
+        || lower.contains("/api/callbacks/enqueue/")
+        || lower.contains("/callbacks/wake/")
+        || lower.contains("/callbacks/enqueue/")
+    {
+        return "<redacted-sensitive-error-context>".into();
+    }
+
+    let public_prefix = trimmed
+        .find('{')
+        .map(|index| {
+            let prefix = trimmed[..index].trim_end_matches([' ', ':']);
+            if prefix.is_empty() {
+                "<redacted-structured-error-context>".to_string()
+            } else {
+                format!("{prefix}: <redacted-structured-error-context>")
+            }
+        })
+        .unwrap_or_else(|| trimmed.to_string());
+    let sanitized = public_prefix
+        .split_whitespace()
+        .map(sanitize_error_token)
+        .collect::<Vec<_>>()
+        .join(" ");
+    truncate_chars(&sanitized, ERROR_TEXT_MAX_CHARS)
+}
+
+fn descriptor_from_tool_error(
+    tool_error: &ToolError,
+    source_chain: Vec<String>,
+) -> RuntimeErrorDescriptor {
+    let mut safe_context = BTreeMap::new();
+    if let Some(details) = tool_error
+        .details
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+    {
+        for (key, value) in details {
+            if is_safe_context_key(key) {
+                if let Some(value) = value.as_str() {
+                    safe_context.insert(key.clone(), sanitize_runtime_error_text(value));
+                } else if value.is_number() || value.is_boolean() {
+                    safe_context.insert(key.clone(), value.to_string());
+                }
+            }
+        }
+    }
+    RuntimeErrorDescriptor {
+        domain: RuntimeErrorDomain::Tool,
+        code: tool_error.kind.clone(),
+        retryable: tool_error.retryable,
+        operator_message: sanitize_runtime_error_text(&tool_error.message),
+        recovery_hint: tool_error
+            .recovery_hint
+            .as_deref()
+            .map(sanitize_runtime_error_text),
+        safe_context,
+        source_chain,
+    }
+}
+
+fn merge_source_chains(primary: Vec<String>, secondary: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    primary
+        .into_iter()
+        .chain(secondary)
+        .map(|message| sanitize_runtime_error_text(&message))
+        .filter(|message| !message.is_empty())
+        .filter(|message| seen.insert(message.clone()))
+        .take(SOURCE_CHAIN_MAX_ENTRIES)
+        .collect()
+}
+
+fn provider_recovery_hint(kind: &str) -> Option<String> {
+    match kind {
+        "auth_error" => Some("check provider authentication and credentials".into()),
+        "rate_limited" => Some("retry after the provider rate limit resets".into()),
+        "timeout" | "connection" | "server_error" => Some("retry the provider request".into()),
+        _ => None,
+    }
+}
+
+fn insert_optional_context(context: &mut BTreeMap<String, String>, key: &str, value: Option<&str>) {
+    if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+        context.insert(key.into(), sanitize_runtime_error_text(value));
+    }
+}
+
+fn is_safe_context_key(key: &str) -> bool {
+    matches!(
+        key,
+        "agent_id"
+            | "field"
+            | "task_id"
+            | "timer_id"
+            | "work_item_id"
+            | "message_id"
+            | "turn_id"
+            | "run_id"
+            | "tool_execution_id"
+            | "provider"
+            | "model_ref"
+            | "stage"
+            | "status"
+            | "record_type"
+            | "record_id"
+            | "existing_status"
+            | "incoming_status"
+            | "expected_revision"
+            | "actual_revision"
+            | "operation"
+            | "io_kind"
+            | "os_error"
+    )
+}
+
+fn sanitize_error_token(raw: &str) -> String {
+    let (prefix, token, suffix) = split_token_punctuation(raw);
+    let sanitized = if let Ok(mut url) = url::Url::parse(token) {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        url.set_query(None);
+        url.set_fragment(None);
+        url.to_string()
+    } else if std::path::Path::new(token).is_absolute() {
+        std::path::Path::new(token)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| format!("<redacted-path>/{name}"))
+            .unwrap_or_else(|| "<redacted-path>".into())
+    } else {
+        token.to_string()
+    };
+    format!("{prefix}{sanitized}{suffix}")
+}
+
+fn split_token_punctuation(raw: &str) -> (&str, &str, &str) {
+    let start = raw
+        .char_indices()
+        .find(|(_, ch)| !matches!(ch, '(' | '[' | '{' | '"' | '\''))
+        .map(|(index, _)| index)
+        .unwrap_or(raw.len());
+    let end = raw
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !matches!(ch, ')' | ']' | '}' | ',' | ';' | '"' | '\''))
+        .map(|(index, ch)| index + ch.len_utf8())
+        .unwrap_or(start);
+    (&raw[..start], &raw[start..end], &raw[end..])
+}
+
+fn truncate_chars(value: &str, limit: usize) -> String {
+    if value.chars().count() <= limit {
+        return value.to_string();
+    }
+    let mut truncated = value
+        .chars()
+        .take(limit.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_runtime_error_survives_anyhow_context() {
+        let error = AnyhowError::from(
+            RuntimeError::not_found("task_not_found", "task task_123 not found")
+                .with_safe_context("task_id", "task_123"),
+        )
+        .context("failed to read task status");
+
+        let descriptor = describe_runtime_error(&error);
+
+        assert_eq!(descriptor.domain, RuntimeErrorDomain::NotFound);
+        assert_eq!(descriptor.code, "task_not_found");
+        assert_eq!(descriptor.safe_context["task_id"], "task_123");
+        assert!(descriptor
+            .source_chain
+            .iter()
+            .any(|message| message == "failed to read task status"));
+    }
+
+    #[test]
+    fn source_chain_is_bounded_deduplicated_and_redacted() {
+        let error = AnyhowError::msg(
+            "failed for /home/operator/private/config.json at https://user:secret@example.test/path?token=secret",
+        )
+        .context("Authorization: Bearer top-secret")
+        .context("outer failure");
+
+        let descriptor = describe_runtime_error(&error);
+        let rendered = descriptor.source_chain.join(" ");
+
+        assert!(descriptor.source_chain.len() <= SOURCE_CHAIN_MAX_ENTRIES);
+        assert!(!rendered.contains("/home/operator"));
+        assert!(!rendered.contains("top-secret"));
+        assert!(!rendered.contains("user:secret"));
+        assert!(!rendered.contains("?token="));
+    }
+
+    #[test]
+    fn unknown_errors_fail_closed_for_retryability() {
+        let descriptor = describe_runtime_error(&AnyhowError::msg("unexpected failure"));
+
+        assert_eq!(descriptor.domain, RuntimeErrorDomain::Unknown);
+        assert_eq!(descriptor.code, "runtime_error");
+        assert!(!descriptor.retryable);
+    }
+
+    #[test]
+    fn tool_error_source_chain_does_not_serialize_details() {
+        let error = AnyhowError::from(
+            ToolError::new("provider_failed", "provider request failed")
+                .with_details(serde_json::json!({"authorization": "secret-value"})),
+        )
+        .context("tool dispatch failed");
+
+        let descriptor = describe_runtime_error(&error);
+        let rendered = descriptor.source_chain.join(" ");
+
+        assert!(rendered.contains("tool dispatch failed"));
+        assert!(rendered.contains("provider request failed"));
+        assert!(!rendered.contains("secret-value"));
+        assert!(!rendered.contains("authorization"));
+    }
+
+    #[test]
+    fn sanitizer_redacts_json_secrets_and_structured_bodies() {
+        assert_eq!(
+            sanitize_runtime_error_text(r#"provider failed: {"api_key":"secret"}"#),
+            "<redacted-sensitive-error-context>"
+        );
+        assert_eq!(
+            sanitize_runtime_error_text(
+                r#"provider failed: {"detail":"raw backend response body"}"#
+            ),
+            "provider failed: <redacted-structured-error-context>"
+        );
+        assert_eq!(
+            sanitize_runtime_error_text(
+                "callback failed for https://example.test/api/callbacks/wake/cb_secret"
+            ),
+            "<redacted-sensitive-error-context>"
+        );
+        assert_eq!(
+            sanitize_runtime_error_text(
+                "callback failed for https://example.test/callbacks/enqueue/cb_secret"
+            ),
+            "<redacted-sensitive-error-context>"
+        );
+    }
+}

--- a/src/tool/error.rs
+++ b/src/tool/error.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+use crate::runtime_error::{
+    collect_runtime_error_source_chain, describe_runtime_error, RuntimeErrorDomain,
+};
+
 const MODEL_VISIBLE_DETAILS_MAX_CHARS: usize = 1_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -10,10 +14,14 @@ pub struct ToolError {
     pub kind: String,
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<RuntimeErrorDomain>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub details: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recovery_hint: Option<String>,
     pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_chain: Vec<String>,
 }
 
 impl ToolError {
@@ -21,10 +29,17 @@ impl ToolError {
         Self {
             kind: kind.into(),
             message: message.into(),
+            domain: None,
             details: None,
             recovery_hint: None,
             retryable: false,
+            source_chain: Vec::new(),
         }
+    }
+
+    pub fn with_domain(mut self, domain: RuntimeErrorDomain) -> Self {
+        self.domain = Some(domain);
+        self
     }
 
     pub fn with_details(mut self, details: Value) -> Self {
@@ -39,6 +54,11 @@ impl ToolError {
 
     pub fn with_retryable(mut self, retryable: bool) -> Self {
         self.retryable = retryable;
+        self
+    }
+
+    pub fn with_source_chain(mut self, source_chain: Vec<String>) -> Self {
+        self.source_chain = source_chain;
         self
     }
 
@@ -62,6 +82,9 @@ impl ToolError {
         }
         receipt.insert("kind".to_string(), Value::String(self.kind.clone()));
         receipt.insert("message".to_string(), Value::String(self.message.clone()));
+        if let Some(domain) = self.domain {
+            receipt.insert("domain".to_string(), json!(domain));
+        }
         if let Some(recovery_hint) = self.recovery_hint.as_deref() {
             receipt.insert("hint".to_string(), Value::String(recovery_hint.to_string()));
         }
@@ -97,13 +120,35 @@ impl ToolError {
     }
 
     pub fn from_anyhow(error: &AnyhowError) -> Self {
-        error
+        if let Some(mut tool_error) = error
             .chain()
             .find_map(|cause| cause.downcast_ref::<ToolError>())
             .cloned()
-            .unwrap_or_else(|| {
-                ToolError::new("tool_execution_failed", error.to_string()).with_retryable(false)
-            })
+        {
+            if tool_error.source_chain.is_empty() {
+                tool_error.source_chain = collect_runtime_error_source_chain(error);
+            }
+            return tool_error;
+        }
+
+        let descriptor = describe_runtime_error(error);
+        let details = (!descriptor.safe_context.is_empty()).then(|| json!(descriptor.safe_context));
+        let kind = if descriptor.domain == RuntimeErrorDomain::Unknown
+            && descriptor.code == "runtime_error"
+        {
+            "tool_execution_failed".to_string()
+        } else {
+            descriptor.code
+        };
+        Self {
+            kind,
+            message: descriptor.operator_message,
+            domain: Some(descriptor.domain),
+            details,
+            recovery_hint: descriptor.recovery_hint,
+            retryable: descriptor.retryable,
+            source_chain: descriptor.source_chain,
+        }
     }
 }
 
@@ -224,5 +269,53 @@ mod tests {
 
         assert_eq!(tool_error.kind, "execution_root_violation");
         assert_eq!(tool_error.recovery_hint.as_deref(), Some("omit `workdir`"));
+        assert!(tool_error
+            .source_chain
+            .iter()
+            .any(|message| message == "failed to resolve command task"));
+    }
+
+    #[test]
+    fn tool_error_from_anyhow_projects_typed_runtime_error() {
+        let error = anyhow::Error::from(
+            crate::runtime_error::RuntimeError::not_found(
+                "task_not_found",
+                "task task_123 not found",
+            )
+            .with_safe_context("task_id", "task_123"),
+        )
+        .context("failed to read task");
+
+        let tool_error = ToolError::from_anyhow(&error);
+
+        assert_eq!(tool_error.kind, "task_not_found");
+        assert_eq!(tool_error.domain, Some(RuntimeErrorDomain::NotFound));
+        assert_eq!(tool_error.details.as_ref().unwrap()["task_id"], "task_123");
+        assert!(tool_error
+            .source_chain
+            .iter()
+            .any(|message| message == "failed to read task"));
+    }
+
+    #[test]
+    fn tool_error_from_anyhow_preserves_unknown_fallback_code() {
+        let tool_error = ToolError::from_anyhow(&anyhow::anyhow!("unclassified failure"));
+
+        assert_eq!(tool_error.kind, "tool_execution_failed");
+        assert_eq!(tool_error.domain, Some(RuntimeErrorDomain::Unknown));
+        assert!(!tool_error.retryable);
+    }
+
+    #[test]
+    fn tool_error_deserializes_legacy_shape_with_taxonomy_defaults() {
+        let tool_error: ToolError = serde_json::from_value(serde_json::json!({
+            "kind": "tool_execution_failed",
+            "message": "legacy failure",
+            "retryable": false
+        }))
+        .unwrap();
+
+        assert_eq!(tool_error.domain, None);
+        assert!(tool_error.source_chain.is_empty());
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4770,6 +4770,10 @@ fn cursor_not_found_detection_uses_typed_http_error() {
         message: "cursor evt_123 was not found".into(),
         code: Some("cursor_not_found".into()),
         hint: None,
+        domain: None,
+        retryable: None,
+        context: Default::default(),
+        correlation: Default::default(),
     };
     let err = anyhow::Error::new(err);
     assert!(is_cursor_not_found_error(&err));

--- a/src/types.rs
+++ b/src/types.rs
@@ -1555,7 +1555,7 @@ pub struct FailureArtifact {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_chain: Vec<String>,
     #[serde(default, skip_serializing_if = "RuntimeErrorContext::is_empty")]
-    pub context: RuntimeErrorContext,
+    pub context: Box<RuntimeErrorContext>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, String>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use crate::config::ModelRouteRef;
 use crate::ids;
 use crate::model_catalog::ResolvedRuntimeModelPolicy;
+use crate::runtime_error::{RuntimeErrorContext, RuntimeErrorDomain};
 use crate::system::{
     ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind,
 };
@@ -1536,6 +1537,12 @@ pub struct FailureArtifact {
     pub kind: String,
     pub summary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<RuntimeErrorDomain>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_ref: Option<String>,
@@ -1547,6 +1554,8 @@ pub struct FailureArtifact {
     pub exit_status: Option<i32>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_chain: Vec<String>,
+    #[serde(default, skip_serializing_if = "RuntimeErrorContext::is_empty")]
+    pub context: RuntimeErrorContext,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, String>,
 }
@@ -6145,6 +6154,25 @@ mod tests {
             payload["output_summary_preview"].as_str().unwrap().len()
                 < "large-task-output".repeat(1024).len()
         );
+    }
+
+    #[test]
+    fn failure_artifact_deserializes_legacy_shape_with_taxonomy_defaults() {
+        let artifact: FailureArtifact = serde_json::from_value(serde_json::json!({
+            "category": "runtime",
+            "kind": "runtime_error",
+            "summary": "legacy failure",
+            "source_chain": [],
+            "metadata": {}
+        }))
+        .unwrap();
+
+        assert_eq!(artifact.category, FailureArtifactCategory::Runtime);
+        assert_eq!(artifact.kind, "runtime_error");
+        assert_eq!(artifact.domain, None);
+        assert_eq!(artifact.retryable, None);
+        assert_eq!(artifact.recovery_hint, None);
+        assert!(artifact.context.is_empty());
     }
 
     #[test]

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -32,6 +32,7 @@ runtime_async_tests!(
     tool_schema_and_dispatch_errors_are_recorded_without_corrupting_runtime_state,
     runtime_provider_failure_surfaces_failure_brief_and_transcript_entry,
     runtime_failure_brief_and_transcript_sanitize_long_provider_error,
+    runtime_failure_brief_and_transcript_redact_short_provider_secret,
     command_task_runs_to_completion_and_persists_detail,
     task_output_returns_completed_command_task_output,
     task_output_non_blocking_reports_running_command_task,

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -31,7 +31,7 @@ runtime_async_tests!(
     exec_command_spawn_failure_returns_shell_recovery_hint,
     tool_schema_and_dispatch_errors_are_recorded_without_corrupting_runtime_state,
     runtime_provider_failure_surfaces_failure_brief_and_transcript_entry,
-    runtime_failure_brief_sanitizes_long_provider_error_but_transcript_keeps_full_error,
+    runtime_failure_brief_and_transcript_sanitize_long_provider_error,
     command_task_runs_to_completion_and_persists_detail,
     task_output_returns_completed_command_task_output,
     task_output_non_blocking_reports_running_command_task,

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -364,6 +364,11 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
         .send()
         .await?;
     assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+    let missing: serde_json::Value = missing.json().await?;
+    assert_eq!(missing["code"], "task_not_found");
+    assert_eq!(missing["domain"], "not_found");
+    assert_eq!(missing["retryable"], false);
+    assert_eq!(missing["context"]["task_id"], "missing-task");
 
     server.abort();
     Ok(())
@@ -538,6 +543,11 @@ pub async fn work_item_routes_list_and_return_work_item_detail() -> Result<()> {
         .send()
         .await?;
     assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+    let missing: serde_json::Value = missing.json().await?;
+    assert_eq!(missing["code"], "work_item_not_found");
+    assert_eq!(missing["domain"], "not_found");
+    assert_eq!(missing["retryable"], false);
+    assert_eq!(missing["context"]["work_item_id"], "missing-work");
 
     server.abort();
     Ok(())

--- a/tests/support/runtime_providers.rs
+++ b/tests/support/runtime_providers.rs
@@ -810,6 +810,16 @@ impl AgentProvider for VerboseRuntimeFailureProvider {
     }
 }
 
+/// Provider that fails with a short structured secret in the error body.
+pub struct SensitiveRuntimeFailureProvider;
+
+#[async_trait]
+impl AgentProvider for SensitiveRuntimeFailureProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        anyhow::bail!(r#"provider failed: {"access_token":"short-secret"}"#)
+    }
+}
+
 /// Provider that demonstrates workspace usage
 pub struct UseWorkspaceProvider {
     calls: Mutex<usize>,

--- a/tests/support/runtime_providers.rs
+++ b/tests/support/runtime_providers.rs
@@ -816,7 +816,7 @@ pub struct SensitiveRuntimeFailureProvider;
 #[async_trait]
 impl AgentProvider for SensitiveRuntimeFailureProvider {
     async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
-        anyhow::bail!(r#"provider failed: {"access_token":"short-secret"}"#)
+        anyhow::bail!("{}", r#"provider failed: {"access_token":"short-secret"}"#)
     }
 }
 

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -1071,6 +1071,13 @@ pub async fn runtime_provider_failure_surfaces_failure_brief_and_transcript_entr
                 == Some("operator_prompt")
             && event.data.get("error").and_then(|value| value.as_str())
                 == Some("provider transport broke")
+            && event.data.get("domain").and_then(|value| value.as_str()) == Some("unknown")
+            && event.data.get("code").and_then(|value| value.as_str()) == Some("runtime_error")
+            && event
+                .data
+                .get("retryable")
+                .and_then(|value| value.as_bool())
+                == Some(false)
     }));
 
     let summary = runtime.agent_summary().await?;
@@ -1090,12 +1097,18 @@ pub async fn runtime_provider_failure_surfaces_failure_brief_and_transcript_entr
         .expect("runtime failure should include normalized failure artifact");
     assert_eq!(artifact.category, FailureArtifactCategory::Runtime);
     assert_eq!(artifact.kind, "runtime_error");
+    assert_eq!(
+        artifact.domain,
+        Some(holon::runtime_error::RuntimeErrorDomain::Unknown)
+    );
+    assert_eq!(artifact.retryable, Some(false));
+    assert!(artifact.context.message_id.is_some());
+    assert!(artifact.context.turn_id.is_some());
     assert!(artifact.summary.contains("provider transport broke"));
     Ok(())
 }
 
-pub async fn runtime_failure_brief_sanitizes_long_provider_error_but_transcript_keeps_full_error(
-) -> Result<()> {
+pub async fn runtime_failure_brief_and_transcript_sanitize_long_provider_error() -> Result<()> {
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(VerboseRuntimeFailureProvider))?;
     attach_default_workspace(&host).await?;
@@ -1149,11 +1162,20 @@ pub async fn runtime_failure_brief_sanitizes_long_provider_error_but_transcript_
         .rev()
         .find(|entry| entry.kind == TranscriptEntryKind::RuntimeFailure)
         .expect("runtime failure transcript entry should exist");
-    assert!(failure_entry
+    assert!(!failure_entry
         .data
         .get("error")
         .and_then(|value| value.as_str())
         .is_some_and(|error| error.contains("raw backend body")));
+    assert!(!failure_entry
+        .data
+        .get("error_chain")
+        .and_then(|value| value.as_array())
+        .is_some_and(|chain| chain.iter().any(|value| {
+            value
+                .as_str()
+                .is_some_and(|error| error.contains("raw backend body"))
+        })));
 
     Ok(())
 }
@@ -2307,8 +2329,17 @@ pub async fn command_task_nonzero_exit_produces_failed_output_and_runtime_state(
         .expect("failed command task should expose normalized task artifact");
     assert_eq!(task_artifact.category, FailureArtifactCategory::Task);
     assert_eq!(task_artifact.kind, "command_task_exit_nonzero");
+    assert_eq!(
+        task_artifact.domain,
+        Some(holon::runtime_error::RuntimeErrorDomain::Task)
+    );
+    assert_eq!(task_artifact.retryable, Some(false));
     assert_eq!(task_artifact.exit_status, Some(7));
     assert_eq!(task_artifact.task_id.as_deref(), Some(task.id.as_str()));
+    assert_eq!(
+        task_artifact.context.task_id.as_deref(),
+        Some(task.id.as_str())
+    );
     assert_eq!(task_artifact.summary, "command task exited with status 7");
     assert!(!task_artifact.summary.contains("before_fail"));
     assert_eq!(

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -48,9 +48,9 @@ use crate::support::runtime_helpers::{
 };
 use crate::support::runtime_providers::{
     DelayedTextProvider, DelegatedBoundaryProvider, FileEditingProvider, LongShellProvider,
-    RecordingPromptProvider, RuntimeFailureProvider, ShellProvider,
-    SleepOnlyCompletionAfterTextProvider, TerminalResultBriefProvider, ToolErrorProvider,
-    ToolUsingProvider, TruncatedShellReinjectionProvider, UseWorkspaceProvider,
+    RecordingPromptProvider, RuntimeFailureProvider, SensitiveRuntimeFailureProvider,
+    ShellProvider, SleepOnlyCompletionAfterTextProvider, TerminalResultBriefProvider,
+    ToolErrorProvider, ToolUsingProvider, TruncatedShellReinjectionProvider, UseWorkspaceProvider,
     VerboseRuntimeFailureProvider, WakeHintProvider, WorktreeCapturingProvider,
     WorktreeLifecycleProvider,
 };
@@ -1176,6 +1176,59 @@ pub async fn runtime_failure_brief_and_transcript_sanitize_long_provider_error()
                 .as_str()
                 .is_some_and(|error| error.contains("raw backend body"))
         })));
+
+    Ok(())
+}
+
+pub async fn runtime_failure_brief_and_transcript_redact_short_provider_secret() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(SensitiveRuntimeFailureProvider))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "trigger sensitive runtime failure".into(),
+            },
+        ))
+        .await?;
+
+    eventually_for(Duration::from_secs(10), || {
+        let briefs = runtime.storage().read_recent_briefs(10)?;
+        Ok(briefs.iter().any(|brief| {
+            brief.kind == BriefKind::Failure
+                && brief.text.contains("<redacted-sensitive-error-context>")
+        }))
+    })
+    .await?;
+
+    let failure_brief = runtime
+        .recent_briefs(10)
+        .await?
+        .into_iter()
+        .rev()
+        .find(|brief| brief.kind == BriefKind::Failure)
+        .expect("failure brief should exist");
+    assert!(!failure_brief.text.contains("short-secret"));
+    assert!(!failure_brief.text.contains("access_token"));
+
+    let failure_entry = runtime
+        .recent_transcript(20)
+        .await?
+        .into_iter()
+        .rev()
+        .find(|entry| entry.kind == TranscriptEntryKind::RuntimeFailure)
+        .expect("runtime failure transcript entry should exist");
+    let serialized = failure_entry.data.to_string();
+    assert!(serialized.contains("<redacted-sensitive-error-context>"));
+    assert!(!serialized.contains("short-secret"));
+    assert!(!serialized.contains("access_token"));
 
     Ok(())
 }

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2001,6 +2001,20 @@ export interface components {
                         failure_artifact?: {
                             /** @enum {string} */
                             category: "transport" | "protocol" | "runtime" | "task" | "unknown";
+                            context?: {
+                                causation_id?: string | null;
+                                correlation_id?: string | null;
+                                message_id?: string | null;
+                                model_ref?: string | null;
+                                provider?: string | null;
+                                run_id?: string | null;
+                                task_id?: string | null;
+                                tool_execution_id?: string | null;
+                                turn_id?: string | null;
+                                work_item_id?: string | null;
+                            };
+                            /** @enum {string|null} */
+                            domain?: "runtime" | "storage" | "policy" | "io" | "conflict" | "not_found" | "validation" | "provider" | "tool" | "task" | "http" | "unknown" | null;
                             /** Format: int32 */
                             exit_status?: number | null;
                             kind: string;
@@ -2009,6 +2023,8 @@ export interface components {
                             };
                             model_ref?: string | null;
                             provider?: string | null;
+                            recovery_hint?: string | null;
+                            retryable?: boolean | null;
                             source_chain?: string[];
                             /** Format: uint16 */
                             status?: number | null;
@@ -3381,6 +3397,20 @@ export interface components {
                 failure_artifact?: {
                     /** @enum {string} */
                     category: "transport" | "protocol" | "runtime" | "task" | "unknown";
+                    context?: {
+                        causation_id?: string | null;
+                        correlation_id?: string | null;
+                        message_id?: string | null;
+                        model_ref?: string | null;
+                        provider?: string | null;
+                        run_id?: string | null;
+                        task_id?: string | null;
+                        tool_execution_id?: string | null;
+                        turn_id?: string | null;
+                        work_item_id?: string | null;
+                    };
+                    /** @enum {string|null} */
+                    domain?: "runtime" | "storage" | "policy" | "io" | "conflict" | "not_found" | "validation" | "provider" | "tool" | "task" | "http" | "unknown" | null;
                     /** Format: int32 */
                     exit_status?: number | null;
                     kind: string;
@@ -3389,6 +3419,8 @@ export interface components {
                     };
                     model_ref?: string | null;
                     provider?: string | null;
+                    recovery_hint?: string | null;
+                    retryable?: boolean | null;
                     source_chain?: string[];
                     /** Format: uint16 */
                     status?: number | null;


### PR DESCRIPTION
## 概要

- 新增 `Runtime Error Taxonomy` RFC，并引入统一的 `RuntimeErrorDomain`、`RuntimeErrorDescriptor`、`RuntimeErrorContext` 与 typed `RuntimeError` 边界描述。
- 在 `ToolError`、HTTP error envelope、本地 client、`FailureArtifact`、audit/log payload 中做 additive projection，保留既有 string code、旧 JSON 兼容性与 provider wire/retry 行为。
- 复用现有 message/turn/run/work-item/tool/task/provider/model 标识建立 correlation/causation 上下文，不新增数据库列或第二套 tracing identity。
- 将 task/work-item/provider 等关键路径改为 typed 分类，移除依赖自由字符串 `contains`/前后缀的关键错误判断，并对 source chain、safe context、URL/path/secret 做有界 redaction。
- 补充跨 `anyhow::Context`、provider attempt timeline、HTTP status/client decode、failure artifact correlation、bootstrap bounds 等回归测试。

## 兼容性

- 既有 required JSON fields 与稳定 string codes 保持不变；新增字段使用 serde defaults/空值省略。
- 未替换全部 `anyhow`，仅在跨层边界提取统一 descriptor。
- 不引入 SQLite migration、高基数 metrics 标签或 provider retry/wire 行为变化。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --lib -- --test-threads=1`
- `git diff --check origin/main...HEAD`

Closes #2269
