### PR TITLE
refactor: extract legacy importer

### DIFF
--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -44,21 +44,7 @@ impl RuntimeRegistry {
     pub(crate) fn new(config: AppConfig, runtime_db: RuntimeDb) -> Result<Self> {
         let host_storage =
             AppStorage::new_global(config.home_dir.join("host"), runtime_db.clone())?;
-        if !runtime_db.storage_domain_is_complete("workspace_entries", "db")? {
-            runtime_db
-                .workspace_entries()
-                .import_legacy(host_storage.read_recent_workspace_entries(usize::MAX)?)?;
-        }
-        if !runtime_db.storage_domain_is_complete("workspace_occupancies", "db")? {
-            runtime_db
-                .workspace_occupancies()
-                .import_legacy(host_storage.read_recent_workspace_occupancies(usize::MAX)?)?;
-        }
-        if !runtime_db.storage_domain_is_complete("agent_identities", "db")? {
-            runtime_db
-                .agent_identities()
-                .import_legacy(host_storage.read_recent_agent_identities(usize::MAX)?)?;
-        }
+        host_storage.legacy_importer().import_host_domains()?;
         let agent_identities = host_storage
             .latest_agent_identities()?
             .into_iter()

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -778,7 +778,7 @@ fn prepare_runtime_storage(
         )),
     };
 
-    let workspace_entries_complete = storage_domain_complete(&runtime_db, "workspace_entries")?;
+    let workspace_entries_complete = storage.legacy_importer().workspace_entries_complete()?;
     if let Some(workspace) = initial_workspace_entry.as_ref() {
         let known = storage.latest_workspace_entries()?;
         if !known
@@ -793,82 +793,7 @@ fn prepare_runtime_storage(
         }
     }
 
-    let recovered_agent_for_import = storage.read_legacy_agent_for_import()?;
-    if !workspace_entries_complete {
-        runtime_db
-            .workspace_entries()
-            .import_legacy(storage.read_recent_workspace_entries(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "workspace_occupancies")? {
-        runtime_db
-            .workspace_occupancies()
-            .import_legacy(storage.read_recent_workspace_occupancies(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "agent_identities")? {
-        runtime_db
-            .agent_identities()
-            .import_legacy(storage.read_recent_agent_identities(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "work_items")? {
-        let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
-        for record in &mut legacy_work_items {
-            crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
-        }
-        runtime_db.work_items().import_legacy(legacy_work_items)?;
-    }
-    if !storage_domain_complete(&runtime_db, "agent_states")? {
-        runtime_db
-            .agent_states()
-            .import_legacy(recovered_agent_for_import.clone())?;
-    }
-    if !storage_domain_complete(&runtime_db, "tasks")? {
-        runtime_db
-            .tasks()
-            .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "external_triggers")? {
-        runtime_db
-            .external_triggers()
-            .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "wait_conditions")? {
-        runtime_db
-            .wait_conditions()
-            .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "queue_entries")? {
-        runtime_db
-            .queue_entries()
-            .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "timers")? {
-        runtime_db
-            .timers()
-            .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "messages")? {
-        runtime_db
-            .messages()
-            .import_legacy(storage.read_all_message_values()?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "transcript_entries")? {
-        runtime_db
-            .transcript_entries()
-            .import_legacy(storage.read_all_transcript()?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "work_item_delegations")? {
-        runtime_db
-            .work_item_delegations()
-            .import_legacy(storage.read_recent_work_item_delegations(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "work_item_continuations")? {
-        runtime_db.work_item_continuations().import_empty()?;
-    }
-    if !storage_domain_complete(&runtime_db, "context_episode_anchors")? {
-        runtime_db
-            .context_episodes()
-            .import_legacy(storage.read_recent_context_episodes(usize::MAX)?)?;
-    }
+    storage.legacy_importer().import_runtime_domains()?;
 
     let snapshot = storage.recovery_snapshot(&agent_id)?;
     let mut queue = RuntimeQueue::default();
@@ -991,37 +916,9 @@ fn prepare_runtime_storage(
         },
     );
     storage.write_agent(&state)?;
-    let turn_records_complete = storage_domain_complete(&runtime_db, "turn_records")?;
-    let evidence_complete = storage_domain_complete(&runtime_db, "evidence")?;
-    let legacy_messages =
-        (!turn_records_complete || !evidence_complete).then(|| storage.read_all_message_values());
-    let legacy_messages = legacy_messages.transpose()?;
-    if !turn_records_complete {
-        runtime_db.turn_records().import_legacy(
-            legacy_messages.clone().unwrap_or_default(),
-            storage.read_recent_tool_executions(usize::MAX)?,
-            storage.read_recent_briefs(usize::MAX)?,
-            storage.read_recent_delivery_summaries(usize::MAX)?,
-            storage.read_recent_wait_conditions(usize::MAX)?,
-        )?;
-    }
-    if !evidence_complete {
-        runtime_db.evidence().import_legacy(
-            legacy_messages.unwrap_or_default(),
-            storage.read_all_transcript()?,
-            storage.read_recent_tool_executions(usize::MAX)?,
-            storage.read_recent_briefs(usize::MAX)?,
-            storage.read_recent_delivery_summaries(usize::MAX)?,
-        )?;
-    }
-    if !storage_domain_complete(&runtime_db, "audit_events")? {
-        runtime_db
-            .audit_events()
-            .import_legacy(Some(&state.id), Vec::new())?;
-    }
-    runtime_db.validate_expected_storage_domains(
-        crate::runtime_db::RuntimeDb::expected_storage_domains(),
-    )?;
+    storage
+        .legacy_importer()
+        .import_derived_domains(&state.id)?;
     storage.enable_audit_event_index(runtime_db.clone(), Some(state.id.clone()))?;
     let projection_cache = AgentRuntimeProjectionCache::rebuild(
         state.id.clone(),
@@ -1044,14 +941,6 @@ fn prepare_runtime_storage(
         active_timers: snapshot.active_timers,
         projection_cache,
     })
-}
-
-fn storage_domain_complete(runtime_db: &RuntimeDb, domain: &str) -> Result<bool> {
-    let expected = RuntimeDb::expected_storage_domains()
-        .iter()
-        .find(|expected| expected.domain == domain)
-        .ok_or_else(|| anyhow!("unknown runtime storage domain {domain}"))?;
-    runtime_db.storage_domain_is_complete(expected.domain, expected.canonical_source)
 }
 
 fn visual_observation_response_format() -> ProviderResponseFormatRequest {

--- a/src/storage/legacy.rs
+++ b/src/storage/legacy.rs
@@ -50,6 +50,7 @@ impl<'a> LegacyImporter<'a> {
         } else {
             self.read_agent_file()?
         };
+        // Re-entrant with host registry bootstrap; completeness guards keep imports at most once.
         self.import_host_domains()?;
         if !self.storage_domain_complete("work_items")? {
             let mut legacy_work_items = self.storage.read_recent_work_items(usize::MAX)?;

--- a/src/storage/legacy.rs
+++ b/src/storage/legacy.rs
@@ -1,0 +1,181 @@
+//! One-time legacy storage import orchestration.
+
+use std::fs;
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::{runtime_db::RuntimeDb, types::AgentState};
+
+use super::AppStorage;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LegacyImporter<'a> {
+    storage: &'a AppStorage,
+}
+
+impl<'a> LegacyImporter<'a> {
+    pub(super) fn new(storage: &'a AppStorage) -> Self {
+        Self { storage }
+    }
+
+    pub(crate) fn workspace_entries_complete(&self) -> Result<bool> {
+        self.storage_domain_complete("workspace_entries")
+    }
+
+    pub(crate) fn import_host_domains(&self) -> Result<()> {
+        let runtime_db = &self.storage.runtime_db;
+        if !self.storage_domain_complete("workspace_entries")? {
+            runtime_db
+                .workspace_entries()
+                .import_legacy(self.storage.read_recent_workspace_entries(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("workspace_occupancies")? {
+            runtime_db
+                .workspace_occupancies()
+                .import_legacy(self.storage.read_recent_workspace_occupancies(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("agent_identities")? {
+            runtime_db
+                .agent_identities()
+                .import_legacy(self.storage.read_recent_agent_identities(usize::MAX)?)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn import_runtime_domains(&self) -> Result<()> {
+        let runtime_db = &self.storage.runtime_db;
+        let agent_states_complete = self.storage_domain_complete("agent_states")?;
+        let recovered_agent_for_import = if agent_states_complete {
+            None
+        } else {
+            self.read_agent_file()?
+        };
+        self.import_host_domains()?;
+        if !self.storage_domain_complete("work_items")? {
+            let mut legacy_work_items = self.storage.read_recent_work_items(usize::MAX)?;
+            for record in &mut legacy_work_items {
+                crate::work_item_plan::refresh_plan_artifact_metadata(
+                    self.storage.data_dir(),
+                    record,
+                )?;
+            }
+            runtime_db.work_items().import_legacy(legacy_work_items)?;
+        }
+        if !agent_states_complete {
+            runtime_db
+                .agent_states()
+                .import_legacy(recovered_agent_for_import)?;
+        }
+        if !self.storage_domain_complete("tasks")? {
+            runtime_db
+                .tasks()
+                .import_legacy(self.storage.read_recent_tasks(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("external_triggers")? {
+            runtime_db
+                .external_triggers()
+                .import_legacy(self.storage.read_recent_external_triggers(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("wait_conditions")? {
+            runtime_db
+                .wait_conditions()
+                .import_legacy(self.storage.read_recent_wait_conditions(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("queue_entries")? {
+            runtime_db
+                .queue_entries()
+                .import_legacy(self.storage.read_recent_queue_entries(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("timers")? {
+            runtime_db
+                .timers()
+                .import_legacy(self.storage.read_recent_timers(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("messages")? {
+            runtime_db
+                .messages()
+                .import_legacy(self.storage.read_all_message_values()?)?;
+        }
+        if !self.storage_domain_complete("transcript_entries")? {
+            runtime_db
+                .transcript_entries()
+                .import_legacy(self.storage.read_all_transcript()?)?;
+        }
+        if !self.storage_domain_complete("work_item_delegations")? {
+            runtime_db
+                .work_item_delegations()
+                .import_legacy(self.storage.read_recent_work_item_delegations(usize::MAX)?)?;
+        }
+        if !self.storage_domain_complete("work_item_continuations")? {
+            runtime_db.work_item_continuations().import_empty()?;
+        }
+        if !self.storage_domain_complete("context_episode_anchors")? {
+            runtime_db
+                .context_episodes()
+                .import_legacy(self.storage.read_recent_context_episodes(usize::MAX)?)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn import_derived_domains(&self, agent_id: &str) -> Result<()> {
+        let runtime_db = &self.storage.runtime_db;
+        let turn_records_complete = self.storage_domain_complete("turn_records")?;
+        let evidence_complete = self.storage_domain_complete("evidence")?;
+        let legacy_messages = (!turn_records_complete || !evidence_complete)
+            .then(|| self.storage.read_all_message_values())
+            .transpose()?;
+        if !turn_records_complete {
+            runtime_db.turn_records().import_legacy(
+                legacy_messages.clone().unwrap_or_default(),
+                self.storage.read_recent_tool_executions(usize::MAX)?,
+                self.storage.read_recent_briefs(usize::MAX)?,
+                self.storage.read_recent_delivery_summaries(usize::MAX)?,
+                self.storage.read_recent_wait_conditions(usize::MAX)?,
+            )?;
+        }
+        if !evidence_complete {
+            runtime_db.evidence().import_legacy(
+                legacy_messages.unwrap_or_default(),
+                self.storage.read_all_transcript()?,
+                self.storage.read_recent_tool_executions(usize::MAX)?,
+                self.storage.read_recent_briefs(usize::MAX)?,
+                self.storage.read_recent_delivery_summaries(usize::MAX)?,
+            )?;
+        }
+        if !self.storage_domain_complete("audit_events")? {
+            runtime_db
+                .audit_events()
+                .import_legacy(Some(agent_id), Vec::new())?;
+        }
+        runtime_db.validate_expected_storage_domains(RuntimeDb::expected_storage_domains())
+    }
+
+    fn read_agent_file(&self) -> Result<Option<AgentState>> {
+        let path = self.storage.state_dir().join("agent.json");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let agent: AgentState = serde_json::from_str(&content)?;
+        if let Some(storage_agent_id) = self.storage.agent_id.as_deref() {
+            anyhow::ensure!(
+                agent.id == storage_agent_id,
+                "agent-scoped legacy import for `{}` cannot import agent state for `{}`",
+                storage_agent_id,
+                agent.id
+            );
+        }
+        Ok(Some(agent))
+    }
+
+    fn storage_domain_complete(&self, domain: &str) -> Result<bool> {
+        let expected = RuntimeDb::expected_storage_domains()
+            .iter()
+            .find(|expected| expected.domain == domain)
+            .ok_or_else(|| anyhow!("unknown runtime storage domain {domain}"))?;
+        self.storage
+            .runtime_db
+            .storage_domain_is_complete(expected.domain, expected.canonical_source)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -35,6 +35,7 @@ const RUNTIME_CACHE_DIR: &str = "cache";
 mod activity;
 mod events;
 mod index_outbox;
+mod legacy;
 mod memory;
 mod read_models;
 mod recovery;
@@ -45,6 +46,7 @@ pub use activity::{FileActivityMarker, PollActivityMarker};
 pub use events::RuntimeEventLog;
 pub(crate) use events::{EventBus, EventLogPage, EventLogPageOrder, PublishedAuditEvent};
 pub use index_outbox::RuntimeIndexOutbox;
+pub(crate) use legacy::LegacyImporter;
 pub use read_models::RuntimeReadModels;
 pub use recovery::RecoverySnapshot;
 pub use store::RuntimeStore;
@@ -66,7 +68,6 @@ fn take_recent<T>(mut records_desc: Vec<T>, limit: usize) -> Vec<T> {
 pub struct AppStorage {
     data_dir: PathBuf,
     agent_id: Option<String>,
-    agent_path: PathBuf,
     runtime_db: RuntimeDb,
     store: RuntimeStore,
 }
@@ -225,7 +226,6 @@ impl AppStorage {
         );
         Ok(Self {
             agent_id,
-            agent_path: state_dir.join("agent.json"),
             runtime_db,
             store,
             data_dir,
@@ -324,6 +324,10 @@ impl AppStorage {
 
     pub fn store(&self) -> RuntimeStore {
         self.store.clone()
+    }
+
+    pub(crate) fn legacy_importer(&self) -> LegacyImporter<'_> {
+        LegacyImporter::new(self)
     }
 
     pub fn poll_activity_marker(&self) -> Result<PollActivityMarker> {
@@ -498,21 +502,6 @@ impl AppStorage {
             return runtime_db.agent_states().latest(&agent_id);
         }
         return Ok(None);
-    }
-
-    pub(crate) fn read_legacy_agent_for_import(&self) -> Result<Option<AgentState>> {
-        self.read_agent_file()
-    }
-
-    fn read_agent_file(&self) -> Result<Option<AgentState>> {
-        let path = if self.agent_path.exists() {
-            &self.agent_path
-        } else {
-            return Ok(None);
-        };
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        Ok(Some(serde_json::from_str(&content)?))
     }
 
     pub fn read_recent_events(&self, limit: usize) -> Result<Vec<AuditEvent>> {
@@ -2590,7 +2579,7 @@ mod tests {
     }
 
     #[test]
-    fn read_agent_maps_legacy_paused_status_to_stopped() {
+    fn legacy_importer_maps_paused_agent_status_to_stopped() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
@@ -2603,8 +2592,55 @@ mod tests {
         )
         .unwrap();
 
-        let restored = storage.read_legacy_agent_for_import().unwrap().unwrap();
+        assert_eq!(storage.read_agent().unwrap(), None);
+        storage.legacy_importer().import_runtime_domains().unwrap();
+        let restored = storage.read_agent().unwrap().unwrap();
         assert_eq!(restored.status, AgentStatus::Stopped);
+    }
+
+    #[test]
+    fn legacy_importer_does_not_reopen_agent_file_after_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let agent_path = dir.path().join(".holon/state/agent.json");
+        std::fs::write(
+            &agent_path,
+            serde_json::to_string_pretty(&AgentState::new("default")).unwrap(),
+        )
+        .unwrap();
+
+        storage.legacy_importer().import_runtime_domains().unwrap();
+        std::fs::write(&agent_path, "{ invalid legacy state").unwrap();
+
+        storage.legacy_importer().import_runtime_domains().unwrap();
+        assert_eq!(
+            storage.read_agent().unwrap().map(|agent| agent.id),
+            Some("default".into())
+        );
+    }
+
+    #[test]
+    fn legacy_importer_rejects_agent_state_outside_storage_scope() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-a").unwrap();
+        std::fs::write(
+            dir.path().join(".holon/state/agent.json"),
+            serde_json::to_string_pretty(&AgentState::new("agent-b")).unwrap(),
+        )
+        .unwrap();
+
+        let error = storage
+            .legacy_importer()
+            .import_runtime_domains()
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot import agent state for `agent-b`"),
+            "{error:#}"
+        );
+        assert_eq!(storage.read_agent().unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

- 将一次性 legacy persistence migration orchestration 抽取到 `storage::LegacyImporter`
- 让 runtime bootstrap 与 host registry 只调用明确的 host/runtime/derived domain import 阶段
- 从 `AppStorage` 移除 legacy `agent.json` 路径与读取职责，保留过渡期 collaborator accessor
- 保持既有 domain checkpoint、恢复顺序、存储格式与 repository import 实现不变

## 行为边界

- legacy agent file 仅在 `agent_states` 尚未完成 cutover 时读取，完成后不会重新打开
- agent-scoped storage 拒绝导入其他 agent 的 legacy state
- derived domains 仍在恢复后的 agent state 写入之后导入，并执行完整 expected-domain 校验

## 验证

- `cargo fmt --all`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --lib legacy_importer_`
- `cargo test --lib storage::tests`
- `cargo test --all-targets`

Closes #2271
