### PR TITLE
fix: gate markdown image inlining by route capability

### DIFF
--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -16,6 +16,7 @@ use super::{build_provider_for_route, AgentProvider};
 pub(crate) struct ProviderCandidate {
     pub(crate) model_ref: String,
     pub(crate) provider_name: String,
+    pub(crate) resolved_image_input: bool,
     pub(crate) provider: Arc<dyn AgentProvider>,
 }
 
@@ -79,6 +80,7 @@ pub(crate) fn build_candidate_from_model_route(
     Ok(ProviderCandidate {
         model_ref: route.route_ref.as_string(),
         provider_name: route.provider_name().to_string(),
+        resolved_image_input: route.capabilities.image_input,
         provider,
     })
 }

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -190,6 +190,7 @@ mod tests {
         ProviderCandidate {
             model_ref: model_ref.into(),
             provider_name: "anthropic".into(),
+            resolved_image_input: false,
             provider: Arc::new(PolicyProvider {
                 policy: Some(policy),
             }),
@@ -204,6 +205,7 @@ mod tests {
         ProviderCandidate {
             model_ref: model_ref.into(),
             provider_name: provider_name.into(),
+            resolved_image_input: false,
             provider: Arc::new(provider),
         }
     }
@@ -243,6 +245,7 @@ mod tests {
                 ProviderCandidate {
                     model_ref: "zai/glm-4.7".into(),
                     provider_name: "zai".into(),
+                    resolved_image_input: false,
                     provider: Arc::new(SearchProvider {
                         capability: Some(search_capability(
                             "zai",
@@ -254,6 +257,7 @@ mod tests {
                 ProviderCandidate {
                     model_ref: "deepseek/deepseek-v4-flash".into(),
                     provider_name: "deepseek".into(),
+                    resolved_image_input: false,
                     provider: Arc::new(SearchProvider { capability: None }),
                 },
             ],
@@ -267,12 +271,40 @@ mod tests {
         assert_eq!(capability.backend_kind, "zai_web_search_prime");
     }
 
+    #[test]
+    fn resolved_image_input_uses_current_turn_candidate() {
+        let provider = FallbackProvider {
+            candidates: vec![
+                ProviderCandidate {
+                    model_ref: "volcengine@plan/glm-5.2".into(),
+                    provider_name: "volcengine".into(),
+                    resolved_image_input: false,
+                    provider: Arc::new(PolicyProvider { policy: None }),
+                },
+                ProviderCandidate {
+                    model_ref: "anthropic/claude-sonnet-4-6".into(),
+                    provider_name: "anthropic".into(),
+                    resolved_image_input: true,
+                    provider: Arc::new(PolicyProvider { policy: None }),
+                },
+            ],
+        };
+
+        assert_eq!(provider.resolved_image_input_support(), Some(false));
+
+        let reversed = FallbackProvider {
+            candidates: provider.candidates.into_iter().rev().collect(),
+        };
+        assert_eq!(reversed.resolved_image_input_support(), Some(true));
+    }
+
     #[tokio::test]
     async fn generate_image_uses_current_turn_candidate() {
         let provider = FallbackProvider {
             candidates: vec![ProviderCandidate {
                 model_ref: "openai-codex/gpt-5.5".into(),
                 provider_name: "openai-codex".into(),
+                resolved_image_input: false,
                 provider: Arc::new(ImageProvider),
             }],
         };
@@ -635,6 +667,12 @@ impl AgentProvider for FallbackProvider {
 
     fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
         self.candidates.first()?.provider.builtin_web_search()
+    }
+
+    fn resolved_image_input_support(&self) -> Option<bool> {
+        self.candidates
+            .first()
+            .map(|candidate| candidate.resolved_image_input)
     }
 
     async fn generate_image(

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -511,6 +511,10 @@ pub trait AgentProvider: Send + Sync {
         None
     }
 
+    fn resolved_image_input_support(&self) -> Option<bool> {
+        None
+    }
+
     async fn complete_turn_with_diagnostics(
         &self,
         request: ProviderTurnRequest,

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -56,16 +56,19 @@ pub fn build_provider_turn_request(
     effective_prompt: &EffectivePrompt,
     available_tools: Vec<ToolSpec>,
     native_web_search: Option<ProviderNativeWebSearchRequest>,
+    inline_markdown_images: bool,
 ) -> ProviderTurnRequest {
     let (system_blocks, context_blocks) = build_prompt_content_blocks(
         &effective_prompt.system_sections,
         &effective_prompt.context_sections,
     );
     let mut conversation = vec![ConversationMessage::UserBlocks(context_blocks.clone())];
-    conversation.extend(markdown_image_messages_from_sections(
-        &effective_prompt.context_sections,
-        &effective_prompt.execution,
-    ));
+    if inline_markdown_images {
+        conversation.extend(markdown_image_messages_from_sections(
+            &effective_prompt.context_sections,
+            &effective_prompt.execution,
+        ));
+    }
 
     ProviderTurnRequest {
         continuation_scope_id: ContinuationScopeId::new(
@@ -425,7 +428,7 @@ mod tests {
             },
         ];
 
-        let request = build_provider_turn_request(&fixture_prompt(), tools.clone(), None);
+        let request = build_provider_turn_request(&fixture_prompt(), tools.clone(), None, true);
         assert_eq!(
             request
                 .tools
@@ -449,7 +452,7 @@ mod tests {
             freeform_grammar: None,
         }];
 
-        let request = build_provider_turn_request(&effective_prompt, tools, None);
+        let request = build_provider_turn_request(&effective_prompt, tools, None, true);
 
         assert_eq!(request.prompt_frame.system_prompt, "system prompt");
         assert_eq!(
@@ -493,7 +496,7 @@ mod tests {
         let mut effective_prompt = fixture_prompt();
         effective_prompt.cache_identity.agent_id.clear();
 
-        let request = build_provider_turn_request(&effective_prompt, vec![], None);
+        let request = build_provider_turn_request(&effective_prompt, vec![], None, true);
 
         assert_eq!(request.continuation_scope_id, None);
     }
@@ -517,7 +520,7 @@ mod tests {
             stability: PromptStability::TurnScoped,
         }];
 
-        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None);
+        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None, true);
 
         assert_eq!(request.conversation.len(), 2);
         let ConversationMessage::UserImage {
@@ -531,6 +534,33 @@ mod tests {
         assert_eq!(prompt, "Chart");
         assert_eq!(media_type, "image/png");
         assert!(!data_base64.is_empty());
+    }
+
+    #[test]
+    fn build_provider_turn_request_skips_markdown_images_when_disabled() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let mut effective_prompt = fixture_prompt();
+        effective_prompt.execution.workspace_id = Some("ws_test".to_string());
+        effective_prompt.execution.workspace_anchor = workspace.path().to_path_buf();
+        effective_prompt.execution.execution_root = workspace.path().to_path_buf();
+        effective_prompt.execution.cwd = workspace.path().to_path_buf();
+        effective_prompt.context_sections = vec![PromptSection {
+            name: "current_input".to_string(),
+            id: "current_input".to_string(),
+            content: "Please inspect ![Chart](workspace://ws_test/outputs/missing.png)."
+                .to_string(),
+            stability: PromptStability::TurnScoped,
+        }];
+
+        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None, false);
+
+        assert_eq!(request.conversation.len(), 1);
+        let ConversationMessage::UserBlocks(blocks) = &request.conversation[0] else {
+            panic!("expected original user blocks");
+        };
+        assert!(blocks[0]
+            .text
+            .contains("![Chart](workspace://ws_test/outputs/missing.png)"));
     }
 
     #[test]
@@ -552,7 +582,7 @@ mod tests {
             stability: PromptStability::TurnScoped,
         }];
 
-        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None);
+        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None, true);
 
         assert_eq!(request.conversation.len(), 1);
     }
@@ -696,7 +726,7 @@ mod tests {
             recent_turns_reprojection: None,
         };
 
-        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None);
+        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None, true);
 
         let system_blocks = request.prompt_frame.system_blocks;
         assert_eq!(system_blocks[0].text, "## identity\nstable system\n\n");

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -722,6 +722,7 @@ impl TurnExecution<'_> {
                     &effective_prompt,
                     available_tools.clone(),
                     native_web_search.clone(),
+                    provider.resolved_image_input_support().unwrap_or(true),
                 );
                 crate::diagnostics::record_provider_request_build(request_build_started.elapsed());
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);


### PR DESCRIPTION
## Summary

- preserve each configured model route's resolved `image_input` capability on its provider candidate
- expose the current turn candidate's resolved image support through `FallbackProvider`
- skip markdown image loading/inlining for routes that explicitly do not support images, while preserving the original markdown text
- retain the previous inline behavior for custom providers without route-level capability metadata

Closes #2332

## Verification

- `cargo fmt --all -- --check`
- `cargo test resolved_image_input_uses_current_turn_candidate -- --nocapture`
- `cargo test build_provider_turn_request_ -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- live text-only route probe: three `bigmodel@default/glm-5.2` requests retained the markdown reference and contained no image block/base64 payload; provider returned 429 before the existing fallback path
- live image-capable route probe: `openai-codex@default/gpt-5.6-sol` sent one `input_image` data URL, received HTTP 200, and completed with `IMAGE_OK`
