### PR TITLE
test: add lifecycle transition fault contracts

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -265,6 +265,8 @@ struct RuntimeInner {
     recovered_timers: Mutex<Option<Vec<TimerRecord>>>,
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
+    #[cfg(test)]
+    transition_faults: StdMutex<std::collections::VecDeque<TransitionFaultPoint>>,
 }
 
 #[derive(Debug, Clone)]
@@ -606,6 +608,36 @@ impl CurrentRunAbortSnapshot {
 }
 
 impl RuntimeHandle {
+    fn take_transition_fault(&self) -> Option<TransitionFaultPoint> {
+        #[cfg(test)]
+        {
+            return self
+                .inner
+                .transition_faults
+                .lock()
+                .expect("transition fault plan lock poisoned")
+                .pop_front();
+        }
+        #[cfg(not(test))]
+        {
+            None
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_next_transition_fault(&self, fault: TransitionFaultPoint) {
+        let mut faults = self
+            .inner
+            .transition_faults
+            .lock()
+            .expect("transition fault plan lock poisoned");
+        assert!(
+            faults.is_empty(),
+            "a transition fault is already armed for this runtime fixture"
+        );
+        faults.push_back(fault);
+    }
+
     pub(crate) async fn apply_transition_commit(
         &self,
         commit: TransitionCommit,
@@ -1533,7 +1565,7 @@ impl RuntimeHandle {
                 transcript_entries: Vec::new(),
                 audit_events,
                 notify_scheduler,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         Ok(self.apply_transition_commit(commit).await.applied)

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::sync::Mutex as StdMutex;
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
@@ -315,6 +317,8 @@ impl RuntimeHandle {
                 recovered_timers: Mutex::new(Some(active_timers)),
                 suppress_next_continue_active_tick: Mutex::new(false),
                 shutdown_requested: AtomicBool::new(false),
+                #[cfg(test)]
+                transition_faults: StdMutex::new(std::collections::VecDeque::new()),
             }),
         };
         Ok(runtime)

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -124,7 +124,7 @@ impl RuntimeHandle {
                     audit_events,
                     index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                     notify_scheduler: true,
-                    fault: None,
+                    fault: self.take_transition_fault(),
                 },
             )?;
             self.apply_transition_commit(commit).await;

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -265,7 +265,7 @@ impl RuntimeHandle {
                 )],
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: false,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -424,7 +424,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         }),
                     )],
                     notify_scheduler: false,
-                    fault: None,
+                    fault: self.runtime.take_transition_fault(),
                 },
             )?;
             if !commit.applied {

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -207,7 +207,7 @@ impl RuntimeHandle {
                 commit_on_idempotent: emit_event
                     && !task_will_change
                     && is_terminal_task_status(&task.status),
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2231,7 +2231,7 @@ impl RuntimeHandle {
                 audit_events: vec![self.work_item_written_event("created", &record, Value::Null)],
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;
@@ -2484,7 +2484,7 @@ impl RuntimeHandle {
                 audit_events,
                 index_changes,
                 notify_scheduler: true,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;
@@ -2644,7 +2644,7 @@ impl RuntimeHandle {
                     audit_events,
                     index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                     notify_scheduler: true,
-                    fault: None,
+                    fault: self.take_transition_fault(),
                 },
             )?;
             self.apply_transition_commit(commit).await;
@@ -2710,7 +2710,7 @@ impl RuntimeHandle {
                 audit_events,
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;
@@ -2900,7 +2900,7 @@ impl RuntimeHandle {
                 audit_events,
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;
@@ -3002,7 +3002,7 @@ impl RuntimeHandle {
                 )],
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: false,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;

--- a/src/runtime/tests/contracts/mod.rs
+++ b/src/runtime/tests/contracts/mod.rs
@@ -1,0 +1,4 @@
+mod queue;
+mod task;
+mod wait;
+mod work_item;

--- a/src/runtime/tests/contracts/queue.rs
+++ b/src/runtime/tests/contracts/queue.rs
@@ -1,0 +1,60 @@
+use super::super::support::*;
+use crate::types::QueueEntryRecord;
+
+#[tokio::test]
+async fn queue_runtime_path_rolls_back_each_pre_commit_fault() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-fault-contract".into(),
+            agent_id: "default".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        harness
+            .runtime()
+            .storage()
+            .append_queue_entry(&queued)
+            .unwrap();
+        let before = harness.snapshot();
+        let mut processed = queued.clone();
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at = now + chrono::Duration::seconds(1);
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .commit_queue_settlement(
+                processed.clone(),
+                vec![AuditEvent::legacy(
+                    "queue_fault_contract",
+                    serde_json::json!({}),
+                )],
+                true,
+            )
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+
+        assert!(harness
+            .runtime()
+            .commit_queue_settlement(
+                processed.clone(),
+                vec![AuditEvent::legacy(
+                    "queue_fault_contract",
+                    serde_json::json!({}),
+                )],
+                true,
+            )
+            .await
+            .unwrap());
+        let after = harness.snapshot();
+        assert_eq!(after.queue_entries, vec![processed]);
+        assert_eq!(after.audit_events.len(), before.audit_events.len() + 1);
+    }
+}

--- a/src/runtime/tests/contracts/task.rs
+++ b/src/runtime/tests/contracts/task.rs
@@ -1,0 +1,46 @@
+use super::super::support::*;
+
+#[tokio::test]
+async fn task_runtime_path_rolls_back_each_pre_commit_fault() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let now = Utc::now();
+        let task = TaskRecord {
+            id: "task-fault-contract".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("task fault contract".into()),
+            detail: None,
+            recovery: None,
+        };
+        let before = harness.snapshot();
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .persist_task_transition(&task, "task_fault_contract")
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+
+        harness
+            .runtime()
+            .persist_task_transition(&task, "task_fault_contract")
+            .await
+            .unwrap();
+        let after = harness.snapshot();
+        assert_eq!(after.tasks, vec![task]);
+        assert_eq!(after.audit_events.len(), before.audit_events.len() + 1);
+        assert_eq!(
+            after.index_outbox_high_watermark,
+            before.index_outbox_high_watermark + 1
+        );
+    }
+}

--- a/src/runtime/tests/contracts/wait.rs
+++ b/src/runtime/tests/contracts/wait.rs
@@ -1,0 +1,60 @@
+use super::super::support::*;
+use crate::runtime::WaitForWakeKind;
+use chrono::DateTime;
+
+#[tokio::test]
+async fn wait_runtime_path_rolls_back_each_pre_commit_fault() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let work_item = harness
+            .runtime()
+            .create_work_item("wait fault contract".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let before = harness.snapshot();
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .register_wait_for(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::External,
+                Some("github:holon-run/holon#2258".into()),
+                "waiting for lifecycle contract".into(),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+
+        let registered = harness
+            .runtime()
+            .register_wait_for(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::External,
+                Some("github:holon-run/holon#2258".into()),
+                "waiting for lifecycle contract".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        let after = harness.snapshot();
+        let mut expected_condition = registered.condition;
+        expected_condition.created_at =
+            DateTime::from_timestamp_millis(expected_condition.created_at.timestamp_millis())
+                .unwrap();
+        expected_condition.updated_at =
+            DateTime::from_timestamp_millis(expected_condition.updated_at.timestamp_millis())
+                .unwrap();
+        assert_eq!(after.wait_conditions, vec![expected_condition]);
+        assert_eq!(after.work_items[0].revision, work_item.revision + 1);
+        assert_eq!(
+            after.index_outbox_high_watermark,
+            before.index_outbox_high_watermark + 1
+        );
+    }
+}

--- a/src/runtime/tests/contracts/work_item.rs
+++ b/src/runtime/tests/contracts/work_item.rs
@@ -1,0 +1,31 @@
+use super::super::support::*;
+
+#[tokio::test]
+async fn work_item_runtime_path_rolls_back_each_pre_commit_fault() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let before = harness.snapshot();
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .create_work_item("fault contract".into(), None, None, Vec::new())
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+
+        let created = harness
+            .runtime()
+            .create_work_item("fault contract retry".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let after = harness.snapshot();
+        assert_eq!(after.work_items, vec![created]);
+        assert_eq!(
+            after.index_outbox_high_watermark,
+            before.index_outbox_high_watermark + 1
+        );
+    }
+}

--- a/src/runtime/tests/mod.rs
+++ b/src/runtime/tests/mod.rs
@@ -1,4 +1,5 @@
 mod agent_and_tools;
+mod contracts;
 mod message_dispatch;
 mod runtime_state;
 mod scheduler;

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -37,6 +37,11 @@ pub(crate) use crate::{
 
 use super::super::*;
 
+mod lifecycle;
+pub(crate) use lifecycle::{
+    assert_injected_transition_fault, DurableLifecycleSnapshot, LifecycleHarness, PRE_COMMIT_FAULTS,
+};
+
 pub(crate) fn context_config() -> ContextConfig {
     let available_tools =
         crate::tool::ToolRegistry::new(PathBuf::from("/tmp/holon-test-workspace"))

--- a/src/runtime/tests/support/lifecycle.rs
+++ b/src/runtime/tests/support/lifecycle.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+pub(crate) const PRE_COMMIT_FAULTS: [crate::runtime_db::transitions::TransitionFaultPoint; 4] = [
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterValidation,
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterAuditWrites,
+    crate::runtime_db::transitions::TransitionFaultPoint::BeforeCommit,
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DurableLifecycleSnapshot {
+    pub(crate) agent_state: Option<AgentState>,
+    pub(crate) work_items: Vec<WorkItemRecord>,
+    pub(crate) wait_conditions: Vec<crate::types::WaitConditionRecord>,
+    pub(crate) queue_entries: Vec<QueueEntryRecord>,
+    pub(crate) tasks: Vec<TaskRecord>,
+    pub(crate) audit_events: Vec<AuditEvent>,
+    pub(crate) transcript_entries: Vec<crate::types::TranscriptEntry>,
+    pub(crate) index_outbox_high_watermark: i64,
+}
+
+pub(crate) struct LifecycleHarness {
+    data_dir: TempDir,
+    workspace: TempDir,
+    runtime: RuntimeHandle,
+}
+
+impl LifecycleHarness {
+    pub(crate) fn new() -> Self {
+        let data_dir = tempdir().expect("create lifecycle data dir");
+        let workspace = tempdir().expect("create lifecycle workspace");
+        let runtime = Self::open_runtime(&data_dir, &workspace);
+        Self {
+            data_dir,
+            workspace,
+            runtime,
+        }
+    }
+
+    fn open_runtime(data_dir: &TempDir, workspace: &TempDir) -> RuntimeHandle {
+        RuntimeHandle::new(
+            "default",
+            data_dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("unused")),
+            "default".into(),
+            context_config(),
+        )
+        .expect("open lifecycle runtime")
+    }
+
+    pub(crate) fn runtime(&self) -> &RuntimeHandle {
+        &self.runtime
+    }
+
+    pub(crate) fn arm_fault(&self, fault: crate::runtime_db::transitions::TransitionFaultPoint) {
+        self.runtime.inject_next_transition_fault(fault);
+    }
+
+    pub(crate) fn restart(&mut self) {
+        self.runtime = Self::open_runtime(&self.data_dir, &self.workspace);
+    }
+
+    pub(crate) fn snapshot(&self) -> DurableLifecycleSnapshot {
+        let runtime_db = &self.runtime.inner.runtime_db;
+        DurableLifecycleSnapshot {
+            agent_state: runtime_db
+                .agent_states()
+                .latest("default")
+                .expect("read agent state"),
+            work_items: runtime_db
+                .work_items()
+                .latest_all()
+                .expect("read work items"),
+            wait_conditions: runtime_db
+                .wait_conditions()
+                .latest_all()
+                .expect("read wait conditions"),
+            queue_entries: runtime_db
+                .queue_entries()
+                .latest_all()
+                .expect("read queue entries"),
+            tasks: runtime_db.tasks().latest_all().expect("read tasks"),
+            audit_events: self
+                .runtime
+                .storage()
+                .read_recent_events(usize::MAX)
+                .expect("read audit events"),
+            transcript_entries: self
+                .runtime
+                .storage()
+                .read_all_transcript()
+                .expect("read transcript"),
+            index_outbox_high_watermark: runtime_db
+                .runtime_index_outbox()
+                .high_watermark_for_agent("default")
+                .expect("read index outbox"),
+        }
+    }
+
+    pub(crate) fn assert_unchanged(&self, before: &DurableLifecycleSnapshot) {
+        assert_eq!(&self.snapshot(), before);
+    }
+}
+
+pub(crate) fn assert_injected_transition_fault(error: &anyhow::Error) {
+    assert!(
+        error
+            .to_string()
+            .contains("injected runtime transition fault"),
+        "unexpected transition error: {error:#}"
+    );
+}

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -264,7 +264,7 @@ impl RuntimeHandle {
                 audit_events,
                 index_changes,
                 notify_scheduler: true,
-                fault: None,
+                fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;


### PR DESCRIPTION
## 概要

这是 #2258 的第 1/3 个阶段，建立 lifecycle transition fault contract 基线：

- 为 `RuntimeHandle` 增加仅在 `cfg(test)` 下可用、fixture-scoped 的下一次 transition fault plan。
- 将既有 `TransitionFaultPoint` 接入 WorkItem、Wait、Queue、Task 的完整 runtime transition 路径；生产构建仍固定不注入 fault。
- 新增共享 `LifecycleHarness`，统一临时 runtime fixture、restart、durable snapshot 与 rollback 断言。
- 新增四套 pre-commit contract tests，逐一覆盖 validation、canonical write、audit write 和 commit 前 fault，并验证失败无部分提交、成功重试只提交一次。

## 边界

- 本 PR 不改变生产 lifecycle 语义，也不暴露用户配置或 public API。
- 本 PR 仅建立 pre-commit rollback 基线；受控时钟和 post-commit/restart recovery matrix 将在后续两个独立 PR 中完成。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib runtime::tests::contracts`
- `cargo test --all-targets`

以上命令均通过。

Part of #2258
