### PR TITLE
fix: present TaskOutput timeline metadata

### DIFF
--- a/src/tool/summary.rs
+++ b/src/tool/summary.rs
@@ -104,7 +104,11 @@ fn summarize_task_output_result(result: &Value) -> String {
         .and_then(Value::as_str)
         .unwrap_or("unknown");
     let task = result.get("task").unwrap_or(result);
-    let task_id = task.get("id").and_then(Value::as_str).unwrap_or("unknown");
+    let task_id = task
+        .get("task_id")
+        .or_else(|| task.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
     let truncated = task
         .get("output_truncated")
         .and_then(Value::as_bool)
@@ -242,6 +246,44 @@ mod tests {
         assert_eq!(
             tool_result_summary(&result.envelope),
             "completed exit_status=2 truncated=false"
+        );
+    }
+
+    #[test]
+    fn task_output_summary_uses_task_id_and_keeps_legacy_id_compatibility() {
+        let result = ToolResult::success(
+            "TaskOutput",
+            json!({
+                "retrieval_status": "timeout",
+                "task": {
+                    "task_id": "task-current",
+                    "id": "task-legacy",
+                    "output_truncated": false,
+                    "exit_status": null
+                }
+            }),
+            None,
+        );
+        assert_eq!(
+            tool_result_summary(&result.envelope),
+            "retrieval_status=timeout task_id=task-current output_truncated=false exit_status=unknown"
+        );
+
+        let legacy = ToolResult::success(
+            "TaskOutput",
+            json!({
+                "retrieval_status": "success",
+                "task": {
+                    "id": "task-legacy",
+                    "output_truncated": true,
+                    "exit_status": 0
+                }
+            }),
+            None,
+        );
+        assert_eq!(
+            tool_result_summary(&legacy.envelope),
+            "retrieval_status=success task_id=task-legacy output_truncated=true exit_status=0"
         );
     }
 

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -919,6 +919,7 @@ function taskOutputAuditSummaryField(
   payload: Record<string, unknown> | undefined,
   field: "task_id" | "retrieval_status",
 ): string | undefined {
+  // Keep this parser aligned with Rust's summarize_task_output_result key=value summary format.
   const summary = stringField(payload, "summary");
   if (!summary) return undefined;
   const prefix = `${field}=`;

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -698,7 +698,10 @@ function toolExecutionRelatedStateObjectRef(
   }
   // Task tools: TaskOutput, TaskStatus, TaskStop, TaskInput
   if (isTaskOperationTool(toolName)) {
-    const taskId = stringField(payload, "task_id");
+    const taskId =
+      toolName === "TaskOutput"
+        ? extractTaskFromOutput(payload).taskId
+        : stringField(payload, "task_id") ?? stringField(asRecord(payload?.input), "task_id");
     if (taskId) return { kind: "task", id: `task:${taskId}`, status: "unknown" };
   }
   return undefined;
@@ -879,16 +882,28 @@ function extractTaskFromOutput(payload: Record<string, unknown> | undefined): {
   outputPreview?: string;
   truncated?: boolean;
 } {
-  const result = asRecord(payload?.task_output_result) ?? unwrapToolResult(payload);
+  const explicitResult = asRecord(payload?.task_output_result);
+  const result = explicitResult ?? unwrapToolResult(payload);
+  const rootAuditPayload = explicitResult == null && result === payload;
   const task = asRecord(result.task) ?? asRecord(result.task_record);
-  const taskId = firstStringField(task, ["task_id", "id"]) ?? stringField(result, "task_id") ?? stringField(payload, "task_id");
+  const input = asRecord(payload?.input);
+  const taskId =
+    firstStringField(task, ["task_id", "id"]) ??
+    stringField(result, "task_id") ??
+    stringField(payload, "task_id") ??
+    stringField(input, "task_id") ??
+    taskOutputAuditSummaryField(payload, "task_id");
   const resultStatus = stringField(result, "status");
   const taskStatus =
     firstStringField(task, ["status"]) ?? (resultStatus && !isTaskOutputRetrievalStatus(resultStatus) ? resultStatus : undefined);
   const retrievalStatus =
-    stringField(result, "retrieval_status") ?? (resultStatus && isTaskOutputRetrievalStatus(resultStatus) ? resultStatus : undefined);
+    stringField(result, "retrieval_status") ??
+    (resultStatus && isTaskOutputRetrievalStatus(resultStatus) ? resultStatus : undefined) ??
+    taskOutputAuditSummaryField(payload, "retrieval_status");
   const kind = stringField(task, "kind") ?? stringField(result, "kind");
-  const summary = stringField(task, "summary") ?? stringField(result, "summary") ?? stringField(result, "result_summary");
+  const summary =
+    stringField(task, "summary") ??
+    (rootAuditPayload ? undefined : stringField(result, "summary") ?? stringField(result, "result_summary"));
   const exitStatus = numberField(task, "exit_status") ?? numberField(result, "exit_status");
   const outputPreview =
     stringField(task, "output_preview") ??
@@ -898,6 +913,20 @@ function extractTaskFromOutput(payload: Record<string, unknown> | undefined): {
     stringField(result, "stderr");
   const truncated = task?.output_truncated === true || result.output_truncated === true || result.truncated === true;
   return { task, taskId, taskStatus, retrievalStatus, kind, summary, exitStatus, outputPreview, truncated };
+}
+
+function taskOutputAuditSummaryField(
+  payload: Record<string, unknown> | undefined,
+  field: "task_id" | "retrieval_status",
+): string | undefined {
+  const summary = stringField(payload, "summary");
+  if (!summary) return undefined;
+  const prefix = `${field}=`;
+  const value = summary
+    .split(/\s+/)
+    .find((part) => part.startsWith(prefix))
+    ?.slice(prefix.length);
+  return value && value !== "unknown" ? value : undefined;
 }
 
 function isTaskOutputRetrievalStatus(status: string): boolean {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -366,6 +366,54 @@ describe("reduceAgentSessionTimeline", () => {
     expect(timeline[0].body).not.toBe("timeout");
   });
 
+  it("rewrites audit-only TaskOutput metadata instead of displaying raw key/value summary", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("task-output-audit-success", "TaskOutput", {
+            input: { task_id: "task_finished" },
+            summary:
+              "retrieval_status=success task_id=task_finished output_truncated=false exit_status=0",
+          }),
+          toolEvent("task-output-audit-timeout", "TaskOutput", {
+            input: { task_id: "task_waiting" },
+            summary:
+              "retrieval_status=timeout task_id=task_waiting output_truncated=false exit_status=unknown",
+          }),
+          toolEvent("task-output-audit-legacy", "TaskOutput", {
+            summary:
+              "retrieval_status=timeout task_id=unknown output_truncated=false exit_status=unknown",
+          }),
+        ],
+      },
+    });
+
+    expect(timeline).toHaveLength(3);
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        body: "Task output · task_finished",
+        executionMeta: expect.objectContaining({ taskId: "task_finished" }),
+        relatedStateObjectRef: { kind: "task", id: "task:task_finished", status: "unknown" },
+      }),
+    );
+    expect(timeline[1]).toEqual(
+      expect.objectContaining({
+        body: "Task output · task_waiting · retrieval timeout",
+        executionMeta: expect.objectContaining({ taskId: "task_waiting" }),
+        relatedStateObjectRef: { kind: "task", id: "task:task_waiting", status: "unknown" },
+      }),
+    );
+    expect(timeline[2]).toEqual(
+      expect.objectContaining({
+        body: "Task output · retrieval timeout",
+        executionMeta: expect.objectContaining({ taskId: undefined }),
+        relatedStateObjectRef: undefined,
+      }),
+    );
+    expect(timeline.map((item) => item.body).join("\n")).not.toContain("retrieval_status=");
+    expect(timeline.map((item) => item.body).join("\n")).not.toContain("output_truncated=");
+  });
+
   it("projects TaskOutput with truncated flag", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {


### PR DESCRIPTION
## Summary

Fixes #2341.

- read `TaskOutputResult.task.task_id` when generating the canonical backend summary, with legacy `id` compatibility
- keep raw TaskOutput retrieval key/value metadata out of the Web timeline
- recover task identity from structured results, sanitized tool input, or bounded legacy audit summaries
- render timeout/not-ready states as user-facing labels and preserve task navigation links

## Verification

- `cargo fmt --all -- --check`
- `cargo test task_output_summary_uses_task_id_and_keeps_legacy_id_compatibility -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm run typecheck` (`web-gui/app`)
- `npm test` (`web-gui/app`, 197 tests passed)
