### PR TITLE
test: add controlled lifecycle clock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ aide = { version = "0.15.1", features = ["axum"] }
 flate2 = "1.0"
 tempfile = "3.14"
 proptest = "1.6"
+tokio = { version = "1.43", features = ["test-util"] }
 
 [lib]
 name = "holon"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,6 @@
 mod bootstrap;
 mod callback;
+mod clock;
 mod closure;
 mod command_task;
 mod continuation;
@@ -247,6 +248,7 @@ struct RuntimeInner {
     notify: Notify,
     storage: AppStorage,
     runtime_db: RuntimeDb,
+    clock: Arc<dyn clock::Clock>,
     provider: RwLock<Arc<dyn AgentProvider>>,
     context_config: RwLock<ContextConfig>,
     config_snapshot: ArcSwap<ConfigSnapshot>,
@@ -608,6 +610,10 @@ impl CurrentRunAbortSnapshot {
 }
 
 impl RuntimeHandle {
+    pub(super) fn now(&self) -> chrono::DateTime<chrono::Utc> {
+        self.inner.clock.now()
+    }
+
     fn take_transition_fault(&self) -> Option<TransitionFaultPoint> {
         #[cfg(test)]
         {
@@ -1612,10 +1618,11 @@ impl RuntimeHandle {
             let scheduled = match poll {
                 scheduler_executor::RunLoopPoll::Shutdown => return Ok(()),
                 scheduler_executor::RunLoopPoll::Stopped(state, queue_len) => {
-                    let projection = scheduler::SchedulerProjection::from_state_with_queue_len(
+                    let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
                         &self.inner.storage,
                         &state,
                         queue_len,
+                        self.now(),
                     )?;
                     let decision = scheduler::decide_next_action(
                         &projection,
@@ -1634,10 +1641,11 @@ impl RuntimeHandle {
                         let guard = self.inner.agent.lock().await;
                         (guard.state.clone(), guard.queue.len())
                     };
-                    let projection = scheduler::SchedulerProjection::from_state_with_queue_len(
+                    let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
                         &self.inner.storage,
                         &idle_snapshot.0,
                         idle_snapshot.1,
+                        self.now(),
                     )?;
                     let decision = scheduler::decide_next_action(
                         &projection,
@@ -1659,15 +1667,10 @@ impl RuntimeHandle {
                         self.append_state_changed_events(&idle_state)?;
                     }
                     if let Some(next_recheck_at) = next_recheck_at {
-                        let now = Utc::now();
-                        if next_recheck_at > now {
-                            if let Ok(wait) = (next_recheck_at - now).to_std() {
-                                tokio::select! {
-                                    _ = self.inner.notify.notified() => {}
-                                    _ = tokio::time::sleep(wait) => {}
-                                }
-                            } else {
-                                self.inner.notify.notified().await;
+                        if next_recheck_at > self.now() {
+                            tokio::select! {
+                                _ = self.inner.notify.notified() => {}
+                                _ = self.inner.clock.sleep_until(next_recheck_at) => {}
                             }
                         }
                     } else {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 
 use super::{
+    clock::{Clock, SystemClock},
     scheduler_executor, workspace, AgentRuntimeProjectionCache, InitialWorkspaceBinding,
     RuntimeAgent, RuntimeHandle, RuntimeInner,
 };
@@ -134,6 +135,41 @@ impl RuntimeHandle {
             None,
             None,
             None,
+            Arc::new(SystemClock),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_clock(
+        agent_id: impl Into<String>,
+        data_dir: PathBuf,
+        initial_workspace: impl Into<InitialWorkspaceBinding>,
+        callback_base_url: String,
+        provider: Arc<dyn AgentProvider>,
+        default_agent_id: String,
+        context_config: ContextConfig,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Self> {
+        let base_context_config = context_config.clone();
+        Self::new_internal(
+            agent_id,
+            data_dir,
+            initial_workspace,
+            callback_base_url,
+            provider,
+            default_agent_id,
+            base_context_config,
+            context_config,
+            RuntimeModelCatalog::default(),
+            Vec::new(),
+            crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
+            crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS,
+            crate::web::WebConfig::default(),
+            None,
+            None,
+            None,
+            None,
+            clock,
         )
     }
 
@@ -169,6 +205,7 @@ impl RuntimeHandle {
             Some(runtime_db),
             Some(host_bridge),
             Some(event_bus),
+            Arc::new(SystemClock),
         )
     }
 
@@ -213,6 +250,7 @@ impl RuntimeHandle {
             Some(runtime_db),
             Some(host_bridge),
             Some(event_bus),
+            Arc::new(SystemClock),
         )
     }
 
@@ -234,6 +272,7 @@ impl RuntimeHandle {
         runtime_db: Option<RuntimeDb>,
         host_bridge: Option<RuntimeHostBridge>,
         event_bus: Option<EventBus>,
+        clock: Arc<dyn Clock>,
     ) -> Result<Self> {
         let x_search_config = provider_reconfig
             .as_ref()
@@ -301,6 +340,7 @@ impl RuntimeHandle {
                 notify: Notify::new(),
                 storage,
                 runtime_db,
+                clock,
                 provider: RwLock::new(provider),
                 config_snapshot: ArcSwap::from(config_snapshot),
                 context_config: RwLock::new(resolved_context_config),

--- a/src/runtime/clock.rs
+++ b/src/runtime/clock.rs
@@ -1,0 +1,57 @@
+use chrono::{DateTime, Utc};
+use std::{future::Future, pin::Pin, time::Duration};
+
+pub(crate) type SleepFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub(crate) trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+
+    fn sleep_until(&self, deadline: DateTime<Utc>) -> SleepFuture {
+        let duration = (deadline - self.now()).to_std().unwrap_or(Duration::ZERO);
+        Box::pin(tokio::time::sleep(duration))
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct TestClock {
+    now: std::sync::Mutex<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+impl TestClock {
+    pub(crate) fn new(now: DateTime<Utc>) -> Self {
+        Self {
+            now: std::sync::Mutex::new(now),
+        }
+    }
+
+    pub(crate) fn advance(&self, duration: std::time::Duration) {
+        let duration = chrono::Duration::from_std(duration)
+            .expect("test clock duration must fit chrono::Duration");
+        let mut now = self.now.lock().expect("test clock lock poisoned");
+        *now = now
+            .checked_add_signed(duration)
+            .expect("test clock advance must remain representable");
+    }
+
+    pub(crate) fn now(&self) -> DateTime<Utc> {
+        *self.now.lock().expect("test clock lock poisoned")
+    }
+}
+
+#[cfg(test)]
+impl Clock for TestClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.now()
+    }
+}

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -155,10 +155,11 @@ impl RuntimeHandle {
         runtime_error_override: Option<bool>,
     ) -> Result<ClosureDecision> {
         let work_queue_projection = self.inner.storage.work_queue_prompt_projection()?;
-        let projection = scheduler::SchedulerProjection::from_state_with_work_queue(
+        let projection = scheduler::SchedulerProjection::from_state_with_work_queue_at(
             &self.inner.storage,
             state,
             work_queue_projection,
+            self.now(),
         )?;
         let runtime_error = runtime_error_override.unwrap_or(projection.runtime_error);
         Ok(derive_closure_decision(&ClosureFacts {
@@ -1622,7 +1623,7 @@ impl RuntimeHandle {
         allow_runnable_work_override: bool,
     ) -> Result<()> {
         let sleeping_until = duration_ms.map(|duration_ms| {
-            chrono::Utc::now()
+            self.now()
                 + chrono::Duration::milliseconds(i64::try_from(duration_ms).unwrap_or(i64::MAX))
         });
         if sleeping_until.is_none() && allow_runnable_work_override {
@@ -1687,7 +1688,7 @@ impl RuntimeHandle {
     ) {
         let runtime = self.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(duration_ms)).await;
+            runtime.inner.clock.sleep_until(sleeping_until).await;
             let should_wake = {
                 let guard = runtime.inner.agent.lock().await;
                 guard.state.status == AgentStatus::Asleep

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -131,13 +131,14 @@ impl RuntimeHandle {
         let due_rechecks = self
             .inner
             .storage
-            .due_blocked_work_item_rechecks(scheduler_snapshot.id(), chrono::Utc::now())?;
+            .due_blocked_work_item_rechecks(scheduler_snapshot.id(), self.now())?;
         let scheduler_projection =
-            scheduler::SchedulerProjection::from_snapshot_with_queue_len_and_work_queue(
+            scheduler::SchedulerProjection::from_snapshot_with_queue_len_and_work_queue_at(
                 &self.inner.storage,
                 &scheduler_snapshot,
                 queue_len,
                 work_queue_projection.clone(),
+                self.now(),
             )?;
         let trigger = idle_tick_trigger_from_state(
             pending_wake_hint,
@@ -304,7 +305,7 @@ impl RuntimeHandle {
         let due_rechecks = self
             .inner
             .storage
-            .due_blocked_work_item_rechecks(agent_id, chrono::Utc::now())?;
+            .due_blocked_work_item_rechecks(agent_id, self.now())?;
         self.consume_work_item_rechecks(&due_rechecks).await
     }
 
@@ -457,10 +458,11 @@ impl RuntimeHandle {
                 guard.queue.len(),
             )
         };
-        let projection = scheduler::SchedulerProjection::from_snapshot_with_queue_len(
+        let projection = scheduler::SchedulerProjection::from_snapshot_with_queue_len_at(
             &self.inner.storage,
             &snapshot,
             queue_len,
+            self.now(),
         )?;
         let duplicate = self
             .duplicate_wake_hint_message_id(pending)?

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -53,8 +53,12 @@ impl RuntimeHandle {
             guard.state.clone()
         };
         let plan = self.build_message_dispatch_plan(&message, prior_closure, &scheduler_state)?;
-        let scheduler_projection =
-            scheduler::SchedulerProjection::from_state(&self.inner.storage, &scheduler_state)?;
+        let scheduler_projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
+            &self.inner.storage,
+            &scheduler_state,
+            scheduler_state.pending,
+            self.now(),
+        )?;
         let scheduler_decision = scheduler::decide_next_action(
             &scheduler_projection,
             scheduler::SchedulerBoundary::MessageProcessing,

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SchedulerProjection {
+    now: DateTime<Utc>,
     pub status: AgentStatus,
     pub queue_len: usize,
     pub active_run_id: Option<String>,
@@ -70,38 +71,53 @@ impl SchedulerProjection {
         state: &AgentState,
         queue_len: usize,
     ) -> Result<Self> {
-        let snapshot = SchedulerAgentSnapshot::from_state(state);
-        Self::from_snapshot_with_queue_len(storage, &snapshot, queue_len)
+        Self::from_state_with_queue_len_at(storage, state, queue_len, Utc::now())
     }
 
-    pub(crate) fn from_snapshot_with_queue_len(
+    pub(crate) fn from_state_with_queue_len_at(
+        storage: &AppStorage,
+        state: &AgentState,
+        queue_len: usize,
+        now: DateTime<Utc>,
+    ) -> Result<Self> {
+        let snapshot = SchedulerAgentSnapshot::from_state(state);
+        Self::from_snapshot_with_queue_len_at(storage, &snapshot, queue_len, now)
+    }
+
+    pub(crate) fn from_snapshot_with_queue_len_at(
         storage: &AppStorage,
         snapshot: &SchedulerAgentSnapshot,
         queue_len: usize,
+        now: DateTime<Utc>,
     ) -> Result<Self> {
         let work_queue = storage.work_queue_prompt_projection()?;
-        Self::from_snapshot_with_queue_len_and_work_queue(storage, snapshot, queue_len, work_queue)
+        Self::from_snapshot_with_queue_len_and_work_queue_at(
+            storage, snapshot, queue_len, work_queue, now,
+        )
     }
 
-    pub(crate) fn from_state_with_work_queue(
+    pub(crate) fn from_state_with_work_queue_at(
         storage: &AppStorage,
         state: &AgentState,
         work_queue: WorkQueueReadModel,
+        now: DateTime<Utc>,
     ) -> Result<Self> {
         let snapshot = SchedulerAgentSnapshot::from_state(state);
-        Self::from_snapshot_with_queue_len_and_work_queue(
+        Self::from_snapshot_with_queue_len_and_work_queue_at(
             storage,
             &snapshot,
             state.pending,
             work_queue,
+            now,
         )
     }
 
-    pub(crate) fn from_snapshot_with_queue_len_and_work_queue(
+    pub(crate) fn from_snapshot_with_queue_len_and_work_queue_at(
         storage: &AppStorage,
         snapshot: &SchedulerAgentSnapshot,
         queue_len: usize,
         work_queue: WorkQueueReadModel,
+        now: DateTime<Utc>,
     ) -> Result<Self> {
         let active_tasks =
             storage.latest_active_task_records_for_agent(&snapshot.id, usize::MAX)?;
@@ -154,6 +170,7 @@ impl SchedulerProjection {
             .filter(|timer| timer.agent_id == snapshot.id && timer.status == TimerStatus::Active)
             .count();
         Ok(Self {
+            now,
             status: snapshot.status.clone(),
             queue_len,
             active_run_id: snapshot.active_run_id.clone(),
@@ -850,7 +867,7 @@ pub(crate) fn wait_decision_for_projection(
                 // a recheck_after_ms fallback. (#1989)
                 if item
                     .recheck_at
-                    .is_some_and(|recheck_at| recheck_at <= Utc::now())
+                    .is_some_and(|recheck_at| recheck_at <= projection.now)
                     && item
                         .recheck_consumed_at
                         .zip(item.recheck_at)

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -352,10 +352,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             prior_closure,
             &candidate.prior_state,
         )?;
-        let projection = scheduler::SchedulerProjection::from_state_with_queue_len(
+        let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
             &self.runtime.inner.storage,
             &candidate.prior_state,
             candidate.queue_len,
+            self.runtime.now(),
         )?;
         let decision = scheduler::decide_next_action(
             &projection,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2561,6 +2561,7 @@ impl RuntimeHandle {
             wrote_item = true;
         }
         if let Some(blocked_by) = blocked_by {
+            let now = self.now();
             record.blocked_by = blocked_by;
             match record.blocked_by {
                 Some(_) => {
@@ -2568,7 +2569,7 @@ impl RuntimeHandle {
                     let recheck_after_ms = i64::try_from(recheck_after_ms).unwrap_or(i64::MAX);
                     let recheck_after = chrono::Duration::try_milliseconds(recheck_after_ms)
                         .unwrap_or(chrono::Duration::MAX);
-                    record.recheck_at = Some(Utc::now() + recheck_after);
+                    record.recheck_at = Some(now + recheck_after);
                     record.recheck_consumed_at = None;
                 }
                 None => {
@@ -2576,7 +2577,7 @@ impl RuntimeHandle {
                     record.recheck_consumed_at = None;
                 }
             }
-            record.updated_at = Utc::now();
+            record.updated_at = now;
             wrote_item = true;
         }
         if wrote_item {
@@ -2674,10 +2675,11 @@ impl RuntimeHandle {
             return Ok(Some(existing));
         }
 
+        let consumed_at = self.now();
         let mut record = WorkItemRecord {
             revision: existing.revision + 1,
-            recheck_consumed_at: Some(Utc::now()),
-            updated_at: Utc::now(),
+            recheck_consumed_at: Some(consumed_at),
+            updated_at: consumed_at,
             ..existing
         };
         let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1343,11 +1343,12 @@ async fn control_stop_clears_autonomous_sleep_and_wake_posture() {
     }));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sleep_wake_task_ignores_stale_sleeping_until() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
+    let clock = controlled_clock();
+    let runtime = RuntimeHandle::new_with_clock(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -1358,16 +1359,21 @@ async fn sleep_wake_task_ignores_stale_sleeping_until() {
         }),
         "default".into(),
         context_config(),
+        clock.clone(),
     )
     .unwrap();
 
     runtime.transition_to_sleep(Some(25)).await.unwrap();
+    assert_eq!(
+        runtime.agent_state().await.unwrap().sleeping_until,
+        Some(clock.now() + chrono::Duration::milliseconds(25))
+    );
     {
         let mut guard = runtime.inner.agent.lock().await;
-        guard.state.sleeping_until = Some(Utc::now() + chrono::Duration::seconds(60));
+        guard.state.sleeping_until = Some(clock.now() + chrono::Duration::seconds(60));
         runtime.storage().write_agent(&guard.state).unwrap();
     }
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    advance_lifecycle_time(&clock, std::time::Duration::from_millis(25)).await;
 
     let messages = runtime.storage().read_recent_messages(10).unwrap();
     assert!(!messages.iter().any(|message| {

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -573,7 +573,14 @@ fn compaction_events_and_briefs_do_not_change_scheduler_projection() {
         })
         .unwrap();
 
-    let before = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let now = Utc::now();
+    let before = scheduler::SchedulerProjection::from_state_with_queue_len_at(
+        &storage,
+        &agent,
+        agent.pending,
+        now,
+    )
+    .unwrap();
     storage
         .append_event(&AuditEvent::legacy(
             "turn_local_compaction_completed",
@@ -603,7 +610,13 @@ fn compaction_events_and_briefs_do_not_change_scheduler_projection() {
         ))
         .unwrap();
 
-    let after = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let after = scheduler::SchedulerProjection::from_state_with_queue_len_at(
+        &storage,
+        &agent,
+        agent.pending,
+        now,
+    )
+    .unwrap();
     assert_eq!(
         before, after,
         "compaction artifacts must not become scheduler truth"

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -39,7 +39,8 @@ use super::super::*;
 
 mod lifecycle;
 pub(crate) use lifecycle::{
-    assert_injected_transition_fault, DurableLifecycleSnapshot, LifecycleHarness, PRE_COMMIT_FAULTS,
+    advance_lifecycle_time, assert_injected_transition_fault, controlled_clock,
+    DurableLifecycleSnapshot, LifecycleHarness, PRE_COMMIT_FAULTS,
 };
 
 pub(crate) fn context_config() -> ContextConfig {

--- a/src/runtime/tests/support/lifecycle.rs
+++ b/src/runtime/tests/support/lifecycle.rs
@@ -19,9 +19,27 @@ pub(crate) struct DurableLifecycleSnapshot {
     pub(crate) index_outbox_high_watermark: i64,
 }
 
+pub(crate) fn controlled_clock() -> Arc<crate::runtime::clock::TestClock> {
+    Arc::new(crate::runtime::clock::TestClock::new(
+        chrono::DateTime::parse_from_rfc3339("2026-07-19T00:00:00Z")
+            .expect("valid controlled clock timestamp")
+            .with_timezone(&Utc),
+    ))
+}
+
+pub(crate) async fn advance_lifecycle_time(
+    clock: &crate::runtime::clock::TestClock,
+    duration: std::time::Duration,
+) {
+    clock.advance(duration);
+    tokio::time::advance(duration).await;
+    tokio::task::yield_now().await;
+}
+
 pub(crate) struct LifecycleHarness {
     data_dir: TempDir,
     workspace: TempDir,
+    clock: Arc<crate::runtime::clock::TestClock>,
     runtime: RuntimeHandle,
 }
 
@@ -29,16 +47,22 @@ impl LifecycleHarness {
     pub(crate) fn new() -> Self {
         let data_dir = tempdir().expect("create lifecycle data dir");
         let workspace = tempdir().expect("create lifecycle workspace");
-        let runtime = Self::open_runtime(&data_dir, &workspace);
+        let clock = controlled_clock();
+        let runtime = Self::open_runtime(&data_dir, &workspace, clock.clone());
         Self {
             data_dir,
             workspace,
+            clock,
             runtime,
         }
     }
 
-    fn open_runtime(data_dir: &TempDir, workspace: &TempDir) -> RuntimeHandle {
-        RuntimeHandle::new(
+    fn open_runtime(
+        data_dir: &TempDir,
+        workspace: &TempDir,
+        clock: Arc<crate::runtime::clock::TestClock>,
+    ) -> RuntimeHandle {
+        RuntimeHandle::new_with_clock(
             "default",
             data_dir.path().to_path_buf(),
             workspace.path().to_path_buf(),
@@ -46,6 +70,7 @@ impl LifecycleHarness {
             Arc::new(StubProvider::new("unused")),
             "default".into(),
             context_config(),
+            clock,
         )
         .expect("open lifecycle runtime")
     }
@@ -59,7 +84,15 @@ impl LifecycleHarness {
     }
 
     pub(crate) fn restart(&mut self) {
-        self.runtime = Self::open_runtime(&self.data_dir, &self.workspace);
+        self.runtime = Self::open_runtime(&self.data_dir, &self.workspace, self.clock.clone());
+    }
+
+    pub(crate) fn now(&self) -> chrono::DateTime<Utc> {
+        self.runtime.now()
+    }
+
+    pub(crate) async fn advance(&self, duration: std::time::Duration) {
+        advance_lifecycle_time(&self.clock, duration).await;
     }
 
     pub(crate) fn snapshot(&self) -> DurableLifecycleSnapshot {

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -270,6 +270,7 @@ async fn malformed_task_message_does_not_exit_runtime_loop() {
 async fn runtime_interrupts_inflight_task_after_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
+    let now = Utc::now();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     storage
         .append_task(&TaskRecord {
@@ -277,8 +278,8 @@ async fn runtime_interrupts_inflight_task_after_restart() {
             agent_id: "default".into(),
             kind: TaskKind::CommandTask,
             status: TaskStatus::Running,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
+            created_at: now - chrono::Duration::seconds(1),
+            updated_at: now - chrono::Duration::seconds(1),
             parent_message_id: None,
             work_item_id: None,
             summary: Some("recoverable command".into()),
@@ -313,7 +314,17 @@ async fn runtime_interrupts_inflight_task_after_restart() {
     )
     .unwrap();
     let runtime_task = tokio::spawn(runtime.clone().run());
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    wait_for_audit_events(
+        &runtime,
+        100,
+        |events| {
+            events
+                .iter()
+                .any(|event| event.kind == "task_interrupted_on_restart")
+        },
+        "task interruption on restart",
+    )
+    .await;
 
     let task = runtime
         .latest_task_records()

--- a/src/runtime/tests/timers.rs
+++ b/src/runtime/tests/timers.rs
@@ -1,28 +1,30 @@
 use super::super::*;
 use super::support::*;
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn runtime_fires_overdue_timer_after_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let now = clock.now();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     storage
         .append_timer(&TimerRecord {
             id: "timer-recover".into(),
             agent_id: "default".into(),
-            created_at: Utc::now(),
+            created_at: now - chrono::Duration::milliseconds(10),
             duration_ms: 10,
             interval_ms: None,
             repeat: false,
             status: TimerStatus::Active,
             summary: Some("timer recovered".into()),
-            next_fire_at: Some(Utc::now() - chrono::Duration::milliseconds(5)),
+            next_fire_at: Some(now - chrono::Duration::milliseconds(5)),
             last_fired_at: None,
             fire_count: 0,
         })
         .unwrap();
 
-    let runtime = RuntimeHandle::new(
+    let runtime = RuntimeHandle::new_with_clock(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -30,10 +32,17 @@ async fn runtime_fires_overdue_timer_after_restart() {
         Arc::new(StubProvider::new("timer done")),
         "default".into(),
         context_config(),
+        clock,
     )
     .unwrap();
     let runtime_task = tokio::spawn(runtime.clone().run());
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    wait_for_audit_events(
+        &runtime,
+        100,
+        |events| events.iter().any(|event| event.kind == "timer_fired"),
+        "recovered overdue timer",
+    )
+    .await;
 
     let timer = runtime
         .recent_timers(10)
@@ -46,16 +55,18 @@ async fn runtime_fires_overdue_timer_after_restart() {
     runtime_task.abort();
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn runtime_recovers_active_timer_without_next_fire_at() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let now = clock.now();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     storage
         .append_timer(&TimerRecord {
             id: "timer-missing-next-fire".into(),
             agent_id: "default".into(),
-            created_at: Utc::now() - chrono::Duration::milliseconds(20),
+            created_at: now - chrono::Duration::milliseconds(20),
             duration_ms: 10,
             interval_ms: None,
             repeat: false,
@@ -67,7 +78,7 @@ async fn runtime_recovers_active_timer_without_next_fire_at() {
         })
         .unwrap();
 
-    let runtime = RuntimeHandle::new(
+    let runtime = RuntimeHandle::new_with_clock(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -75,10 +86,17 @@ async fn runtime_recovers_active_timer_without_next_fire_at() {
         Arc::new(StubProvider::new("timer fallback done")),
         "default".into(),
         context_config(),
+        clock,
     )
     .unwrap();
     let runtime_task = tokio::spawn(runtime.clone().run());
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    wait_for_audit_events(
+        &runtime,
+        100,
+        |events| events.iter().any(|event| event.kind == "timer_fired"),
+        "recovered timer without next_fire_at",
+    )
+    .await;
 
     let timer = runtime
         .recent_timers(10)

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -254,7 +254,8 @@ fn work_item_record_revision_defaults_for_old_records() {
 async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
+    let clock = controlled_clock();
+    let runtime = RuntimeHandle::new_with_clock(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -262,6 +263,7 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
         Arc::new(StubProvider::new("done")),
         "default".into(),
         context_config(),
+        clock.clone(),
     )
     .unwrap();
 
@@ -269,7 +271,6 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
         .create_work_item("wait with fallback".into(), None, None, Vec::new())
         .await
         .unwrap();
-    let before = Utc::now();
     let blocked = runtime
         .update_work_item_fields_with_recheck(
             work.id.clone(),
@@ -283,7 +284,7 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
         .await
         .unwrap();
     let recheck_at = blocked.recheck_at.expect("blocked item has recheck_at");
-    assert!(recheck_at >= before + chrono::Duration::milliseconds(25));
+    assert_eq!(recheck_at, clock.now() + chrono::Duration::milliseconds(25));
     assert!(blocked.recheck_consumed_at.is_none());
 
     let updated = runtime
@@ -308,10 +309,11 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
     assert!(cleared.recheck_consumed_at.is_none());
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn runtime_wakes_itself_for_blocked_work_item_recheck_deadline() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut blocked = WorkItemRecord::new(
         "default",
@@ -319,10 +321,10 @@ async fn runtime_wakes_itself_for_blocked_work_item_recheck_deadline() {
         WorkItemState::Open,
     );
     blocked.blocked_by = Some("waiting for external wake".into());
-    blocked.recheck_at = Some(Utc::now() + chrono::Duration::milliseconds(50));
+    blocked.recheck_at = Some(clock.now() + chrono::Duration::milliseconds(50));
     storage.append_work_item(&blocked).unwrap();
 
-    let runtime = RuntimeHandle::new(
+    let runtime = RuntimeHandle::new_with_clock(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -330,10 +332,24 @@ async fn runtime_wakes_itself_for_blocked_work_item_recheck_deadline() {
         Arc::new(StubProvider::new("recheck observed")),
         "default".into(),
         context_config(),
+        clock.clone(),
     )
     .unwrap();
     let runtime_task = tokio::spawn(runtime.clone().run());
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    advance_lifecycle_time(&clock, std::time::Duration::from_millis(50)).await;
+    wait_for_audit_events(
+        &runtime,
+        200,
+        |events| {
+            events.iter().any(|event| {
+                event.kind == "system_tick_emitted"
+                    && event.data.get("subsystem").and_then(|value| value.as_str())
+                        == Some("work_item_recheck")
+            })
+        },
+        "work item recheck tick",
+    )
+    .await;
 
     let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
     assert!(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -7,7 +7,6 @@ use crate::types::{
     WorkItemRecord, WorkItemState,
 };
 use chrono::{DateTime, Utc};
-use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -78,7 +77,7 @@ impl RuntimeHandle {
             return Err(anyhow!("wait_for agent mismatch: {}", agent_id));
         }
 
-        let now = Utc::now();
+        let now = self.now();
         let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone())?;
         let recheck_at = recheck_after_ms.map(|delay| recheck_at_from(now, delay));
         let mut state = self.agent_state().await?;
@@ -475,7 +474,7 @@ impl RuntimeHandle {
         interval_ms: Option<u64>,
         summary: Option<String>,
     ) -> Result<TimerRecord> {
-        let created_at = Utc::now();
+        let created_at = self.now();
         let timer = TimerRecord {
             id: crate::ids::timer_id(),
             agent_id: self.agent_id().await?,
@@ -558,12 +557,8 @@ impl RuntimeHandle {
                 let Some(next_fire_at) = timer.next_fire_at else {
                     break;
                 };
-                let now = Utc::now();
-                if next_fire_at > now {
-                    let wait = (next_fire_at - now)
-                        .to_std()
-                        .unwrap_or_else(|_| Duration::from_millis(0));
-                    tokio::time::sleep(wait).await;
+                if next_fire_at > runtime.now() {
+                    runtime.inner.clock.sleep_until(next_fire_at).await;
                 }
                 if let Err(err) = runtime.fire_timer_record(&mut timer).await {
                     let _ = runtime.inner.storage.append_event(&AuditEvent::legacy(
@@ -583,8 +578,8 @@ impl RuntimeHandle {
     }
 
     async fn recover_timer(&self, timer: TimerRecord) -> Result<()> {
-        let timer = normalize_recovered_timer(timer);
-        let now = Utc::now();
+        let now = self.now();
+        let timer = normalize_recovered_timer(timer, now);
         if timer
             .next_fire_at
             .is_some_and(|next_fire_at| next_fire_at <= now)
@@ -632,7 +627,7 @@ impl RuntimeHandle {
         };
         self.enqueue(message).await?;
 
-        let fired_at = Utc::now();
+        let fired_at = self.now();
         timer.last_fired_at = Some(fired_at);
         timer.fire_count += 1;
         if let Some(interval_ms) = timer.interval_ms {
@@ -953,13 +948,13 @@ fn advance_time(base: chrono::DateTime<Utc>, delta_ms: u64) -> Result<chrono::Da
     Ok(base + delta)
 }
 
-fn normalize_recovered_timer(mut timer: TimerRecord) -> TimerRecord {
+fn normalize_recovered_timer(mut timer: TimerRecord, now: DateTime<Utc>) -> TimerRecord {
     if timer.next_fire_at.is_some() {
         return timer;
     }
 
     let anchor = timer.last_fired_at.unwrap_or(timer.created_at);
     let fallback_ms = timer.interval_ms.unwrap_or(timer.duration_ms);
-    timer.next_fire_at = advance_time(anchor, fallback_ms).ok().or(Some(Utc::now()));
+    timer.next_fire_at = advance_time(anchor, fallback_ms).ok().or(Some(now));
     timer
 }


### PR DESCRIPTION
## 概要

这是 #2258 的第 2/3 个阶段，为 lifecycle deadline/recovery tests 建立受控时钟：

- 引入 crate-private `Clock`/`SystemClock`，并提供仅在 `cfg(test)` 下可用的 `TestClock` 与 `RuntimeHandle::new_with_clock`；所有生产构造路径仍默认使用系统时间。
- 将 Wait recheck、scheduler overdue 判断、timer/sleep 等目标 lifecycle deadline 路径统一通过 runtime clock 计算和等待。
- 扩展 `LifecycleHarness`，让同一 fixture 在 restart 前后共享 wall clock，并同步推进 wall clock 与 Tokio paused time。
- 将 timer recovery、WorkItem recheck、stale sleep wake 和 Task restart interruption 等代表性测试改为 deterministic paused-time contracts，移除真实长时间 sleep。

## 边界

- 本 PR 不暴露用户配置或 public API，也不改变生产 lifecycle 行为。
- 本 PR 不一次替换全仓库所有 `Utc::now()`；非 deadline 的审计与通用时间戳仍保持既有语义。
- Task restart/recovery 当前没有持久化 UTC deadline；相关测试只控制既有瞬时 Tokio timeout，不引入新的 durable contract。
- post-commit/restart recovery matrix 与四领域 contract 重组留在第 3 个独立 PR。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib runtime::tests::timers`
- `cargo test --lib runtime::tests::work_items::update_work_item_sets_and_preserves_blocked_recheck_deadline`
- `cargo test --lib runtime::tests::work_items::runtime_wakes_itself_for_blocked_work_item_recheck_deadline`
- `cargo test --lib runtime::tests::runtime_state::sleep_wake_task_ignores_stale_sleeping_until`
- `cargo test --lib runtime::tests::task_recovery::runtime_interrupts_inflight_task_after_restart`
- `cargo test --all-targets`

以上命令均通过。

Part of #2258
