### PR TITLE
fix: align template selectors with install IDs

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1701,6 +1701,20 @@ fn validate_template_install_id(install_id: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_template_catalog_selector_id(
+    source: AgentTemplateSourceKind,
+    selector_id: &str,
+) -> Result<()> {
+    match source {
+        AgentTemplateSourceKind::UserGlobal | AgentTemplateSourceKind::AgentHome => {
+            validate_template_install_id(selector_id)
+        }
+        AgentTemplateSourceKind::Builtin | AgentTemplateSourceKind::Remote => {
+            validate_template_id(selector_id)
+        }
+    }
+}
+
 fn resolve_template_catalog_entry(
     template: &str,
     home_dir: &Path,
@@ -1714,7 +1728,7 @@ fn resolve_template_catalog_entry(
                 catalog_agent_home,
             ));
         };
-        validate_template_id(template_id)?;
+        validate_template_catalog_selector_id(source, template_id)?;
         return resolve_prefixed_template_catalog_entry(
             source,
             template_id,
@@ -3648,6 +3662,75 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(agent.agents_md, "# Agent worker\n\nAgent-home worker\n");
+    }
+
+    #[tokio::test]
+    async fn local_catalog_ids_with_install_suffix_resolve_unchanged() {
+        let user_home = tempdir().unwrap();
+        let agent_home = tempdir().unwrap();
+        let install_id = "holon-reviewer@official";
+
+        let user_template = templates_root_for_home(user_home.path()).join(install_id);
+        fs::create_dir_all(&user_template).unwrap();
+        fs::write(
+            user_template.join(TEMPLATE_AGENTS_FILENAME),
+            "# User reviewer\n\nOfficial user-global reviewer\n",
+        )
+        .unwrap();
+
+        let agent_template = agent_home.path().join("agent_templates").join(install_id);
+        fs::create_dir_all(&agent_template).unwrap();
+        fs::write(
+            agent_template.join(TEMPLATE_AGENTS_FILENAME),
+            "# Agent reviewer\n\nOfficial agent-home reviewer\n",
+        )
+        .unwrap();
+
+        let catalog = discover_agent_templates_catalog(Some(user_home.path()), agent_home.path());
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "agent_home:holon-reviewer@official"));
+
+        let user = resolve_template(
+            "user_global:holon-reviewer@official",
+            user_home.path(),
+            agent_home.path(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            user.agents_md,
+            "# User reviewer\n\nOfficial user-global reviewer\n"
+        );
+
+        let agent = resolve_template(
+            "agent_home:holon-reviewer@official",
+            user_home.path(),
+            agent_home.path(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            agent.agents_md,
+            "# Agent reviewer\n\nOfficial agent-home reviewer\n"
+        );
+    }
+
+    #[test]
+    fn local_prefixed_selectors_still_reject_path_like_install_ids() {
+        let user_home = tempdir().unwrap();
+        let agent_home = tempdir().unwrap();
+
+        let error = resolve_template_catalog_entry(
+            "user_global:../reviewer@official",
+            user_home.path(),
+            agent_home.path(),
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("template install_id must not be path-like"));
     }
 
     #[test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -2954,6 +2954,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn private_child_spawn_accepts_user_global_catalog_id_with_install_suffix() {
+        let (home, host) = test_host();
+        let template_dir = home
+            .path()
+            .join(".agents/agent_templates/holon-reviewer@official");
+        fs::create_dir_all(&template_dir).unwrap();
+        fs::write(
+            template_dir.join("AGENTS.md"),
+            "# Official reviewer\n\nSynced reviewer template\n",
+        )
+        .unwrap();
+        let parent = host.default_runtime().await.unwrap();
+
+        let spawned = parent
+            .spawn_agent(
+                Some("review the implementation".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                Some("user_global:holon-reviewer@official".into()),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let child_home = host.agent_data_dir(&spawned.agent_id);
+        assert!(fs::read_to_string(child_home.join("AGENTS.md"))
+            .unwrap()
+            .starts_with("# Official reviewer\n\nSynced reviewer template\n"));
+        assert!(spawned.supervision_task_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn private_child_spawn_failure_preserves_safe_cause_in_tool_and_task_diagnostics() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+
+        let error = parent
+            .spawn_agent(
+                Some("review the implementation".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                Some("user_global:reviewer%official".into()),
+                None,
+            )
+            .await
+            .expect_err("invalid template selector should fail after task creation");
+        let tool_error = crate::tool::ToolError::from_anyhow(&error);
+
+        assert_eq!(tool_error.kind, "spawn_agent_failed");
+        assert_eq!(
+            tool_error.domain,
+            Some(crate::runtime_error::RuntimeErrorDomain::Task)
+        );
+        assert!(tool_error
+            .message
+            .contains("template install_id contains unsupported characters"));
+        assert!(tool_error
+            .source_chain
+            .iter()
+            .any(|cause| cause.contains("template install_id contains unsupported characters")));
+        let task_id = tool_error
+            .details
+            .as_ref()
+            .and_then(|details| details.get("task_id"))
+            .and_then(Value::as_str)
+            .expect("tool error should identify the failed supervision task");
+        let rendered = tool_error.render_for_model(Some(crate::tool::names::SPAWN_AGENT));
+        assert!(rendered.contains("template install_id contains unsupported characters"));
+
+        let task = parent
+            .storage()
+            .latest_task_record(task_id)
+            .unwrap()
+            .expect("failed supervision task should remain persisted");
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert_eq!(
+            task.detail.as_ref().unwrap()["error"],
+            "template install_id contains unsupported characters"
+        );
+
+        let output = parent.task_output(task_id, false, 0).await.unwrap();
+        let failure = output
+            .task
+            .failure_artifact
+            .expect("failed supervision task should expose a failure artifact");
+        assert!(failure
+            .source_chain
+            .iter()
+            .any(|cause| cause.contains("template install_id contains unsupported characters")));
+    }
+
+    #[tokio::test]
     async fn private_child_spawn_accepts_explicit_model_selection() {
         let fixture = provider_test_config(Some("dummy-token"));
         let host = RuntimeHost::new(fixture.config).unwrap();

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3,7 +3,8 @@ use super::waiting::WorkItemBlockerClearance;
 use super::{task_state_reducer, *};
 use crate::config::{ModelRef, ProviderId};
 use crate::runtime_error::{
-    sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext, RuntimeErrorDomain,
+    collect_runtime_error_source_chain, sanitize_runtime_error_text, RuntimeError,
+    RuntimeErrorContext, RuntimeErrorDomain,
 };
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
@@ -441,14 +442,38 @@ impl RuntimeHandle {
                 {
                     Ok(spawned) => spawned,
                     Err(err) => {
+                        let source_chain = collect_runtime_error_source_chain(&err);
+                        let direct_cause = source_chain
+                            .last()
+                            .cloned()
+                            .unwrap_or_else(|| "child agent initialization failed".to_string());
+                        let mut detail =
+                            task.detail.clone().unwrap_or_else(|| serde_json::json!({}));
+                        detail["error"] = serde_json::json!(direct_cause);
                         let failed_task = TaskRecord {
                             status: TaskStatus::Failed,
                             updated_at: Utc::now(),
+                            detail: Some(detail),
                             ..task.clone()
                         };
                         self.persist_task_status_direct(&failed_task, "task_spawn_failed")
                             .await?;
-                        return Err(err.context("failed to spawn child agent"));
+                        return Err(anyhow::Error::from(
+                            ToolError::new(
+                                "spawn_agent_failed",
+                                format!("failed to spawn child agent: {direct_cause}"),
+                            )
+                            .with_domain(RuntimeErrorDomain::Task)
+                            .with_details(serde_json::json!({
+                                "task_id": task.id,
+                                "preset": AgentProfilePreset::PrivateChild,
+                                "workspace_mode": if worktree { "worktree" } else { "inherit" },
+                            }))
+                            .with_recovery_hint(
+                                "correct the child template, model, or workspace configuration and retry SpawnAgent",
+                            )
+                            .with_source_chain(source_chain),
+                        ));
                     }
                 };
 


### PR DESCRIPTION
## 变更摘要

- 按模板来源选择正确的 selector ID 校验契约：`builtin:` 保持严格 template ID，`user_global:` 与 `agent_home:` 接受 discovery 已发布的本地 install ID（包括 `@official` 冲突后缀）。
- 在 private-child 初始化失败时，将安全清洗后的直接原因同时保留到模型可见工具错误、tool execution/audit 记录和监督任务的 failure artifact。
- 补充 catalog → resolver → `SpawnAgent` 以及失败原因投影的回归测试。

## 验证

- `cargo fmt --all -- --check`
- `cargo test local_catalog_ids_with_install_suffix_resolve_unchanged`
- `cargo test private_child_spawn_accepts_user_global_catalog_id_with_install_suffix`
- `cargo test private_child_spawn_failure_preserves_safe_cause_in_tool_and_task_output`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2345
