### PR TITLE
test: split live and snapshot targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - "agent_templates/**"
       - "builtin_templates/**"
       - "docs/website/reference/openapi.json"
+      - "docs/website/reference/model-tool-schema-inventory.json"
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
@@ -26,6 +27,7 @@ on:
       - "agent_templates/**"
       - "builtin_templates/**"
       - "docs/website/reference/openapi.json"
+      - "docs/website/reference/model-tool-schema-inventory.json"
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
@@ -64,6 +66,9 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: Check generated snapshots
+        run: make snapshots-check
 
       - name: Test
         run: make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Thanks for contributing to Holon. This file captures the baseline expectations f
     check used by the main CI job.
   - Runtime lifecycle, task, wait, SSE, or HTTP task changes:
     `make test-concurrent`
+  - CLI, HTTP, OpenAPI, or model tool contract changes:
+    `make snapshots-refresh`, review the diff, then run `make snapshots-check`.
   - Run focused `cargo test ...` commands for the Rust modules or integration
     tests touched by the change when a full test run is too broad.
   - If you cannot run a required check, state why in the PR description.
@@ -41,8 +43,22 @@ make test-concurrent
 # Stress the core concurrent lifecycle suite; stops at the first failure
 make test-concurrent-repeat CONCURRENT_REPEATS=3
 
-# Run live-provider tests when credentials are configured
+# Check all checked-in Rust-generated snapshots
+make snapshots-check
+
+# Refresh all checked-in Rust-generated snapshots after an intentional change
+make snapshots-refresh
+
+# Run the baseline and configured-provider live smoke tests
 make test-live
+
+# Run focused provider/runtime live suites when their credentials are configured
+make test-live-openai
+make test-live-anthropic
+make test-live-codex
+make test-live-xai
+make test-live-images
+make test-live-runtime
 
 # Check formatting
 make fmt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help web web-ci transport-types transport-types-check build all test test-concurrent test-concurrent-repeat test-live fmt fmt-check lint check ci run clean
+.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
 OPENAPI_TOOLS_DIR := web-gui/openapi-tools
@@ -10,10 +10,20 @@ CONCURRENT_LIFECYCLE_TESTS := \
 	http_events \
 	http_tasks
 CONCURRENT_TESTS := $(CONCURRENT_LIFECYCLE_TESTS) wt204_parallel_worktree_workflow
+ANTHROPIC_COMPATIBLE_LIVE_TESTS := \
+	live_deepseek_anthropic_accepts_context_management \
+	live_xiaomi_token_plan_accepts_context_management \
+	live_xiaomi_anthropic_accepts_context_management \
+	live_xiaomi_token_plan_anthropic_accepts_context_management \
+	live_zai_anthropic_accepts_context_management \
+	live_zai_anthropic_builtin_web_search_reports_prime_backend \
+	live_bigmodel_anthropic_accepts_context_management \
+	live_bigmodel_anthropic_builtin_web_search_reports_backend \
+	live_minimax_anthropic_accepts_context_management
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 
 web: ## Build the web GUI (requires Node.js 24). Produces web-gui/app/dist
 	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
@@ -33,6 +43,18 @@ transport-types-check: ## Check OpenAPI and generated TypeScript transport type 
 	cargo test --test openapi_snapshot
 	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
 	cd $(OPENAPI_TOOLS_DIR) && npm ci && npm run check
+
+snapshots-check: ## Check CLI, OpenAPI, HTTP route, and model tool schema snapshots
+	cargo test --test cli_snapshot
+	cargo test --test openapi_snapshot
+	cargo test --test http_route_snapshot
+	cargo test --test tool_schema_inventory_snapshot
+
+snapshots-refresh: ## Refresh CLI, OpenAPI, HTTP route, and model tool schema snapshots
+	cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored
+	cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
+	cargo test --test http_route_snapshot refresh_http_route_inventory_snapshot -- --ignored
+	cargo test --test tool_schema_inventory_snapshot refresh_tool_schema_inventory_snapshot -- --ignored
 
 build: ## Build all Rust targets (cargo build --all-targets)
 	cargo build --all-targets
@@ -59,8 +81,62 @@ test-concurrent-repeat: ## Repeat core concurrent lifecycle tests (CONCURRENT_RE
 		repeat=$$((repeat + 1)); \
 	done
 
-test-live: ## Run live-provider tests
-	cargo test live_ -- --nocapture
+test-live: ## Run the baseline and configured-provider live smoke tests
+	@printf '%s\n' \
+		'Requires configured provider credentials and network access.' \
+		'Runs two configured-chain baseline probes plus one smoke request per configured provider.' \
+		'Test binaries: live_llm_baseline (selected tests), live_provider_smoke'
+	cargo test --test live_llm_baseline live_llm_baseline_configured_chain_smoke -- --ignored --nocapture
+	cargo test --test live_llm_baseline live_llm_baseline_tool_roundtrip -- --ignored --nocapture
+	cargo test --test live_provider_smoke -- --ignored --nocapture
+
+test-live-openai: ## Run OpenAI Responses and Chat Completions live tests
+	@printf '%s\n' \
+		'Requires configured OpenAI credentials and network access.' \
+		'Test binaries: live_openai, live_openai_chat_completions'
+	cargo test --test live_openai -- --ignored --nocapture
+	cargo test --test live_openai_chat_completions -- --ignored --nocapture
+
+test-live-anthropic: ## Run Anthropic and Anthropic-compatible live tests
+	@printf '%s\n' \
+		'Requires Anthropic/Claude auth plus any provider-specific credentials exercised by the compatible suite.' \
+		'Compatible probes include DeepSeek, Xiaomi, Z.ai, BigModel, and MiniMax; the cache matrix may be high cost.' \
+		'Test binaries: live_llm_baseline (Anthropic cache test), live_anthropic, live_anthropic_cache, live_anthropic_compatible'
+	cargo test --test live_llm_baseline live_llm_baseline_anthropic_prompt_cache_hit -- --ignored --nocapture
+	cargo test --test live_anthropic -- --ignored --nocapture
+	cargo test --test live_anthropic_cache -- --ignored --nocapture
+	@set -eu; \
+	for live_test in $(ANTHROPIC_COMPATIBLE_LIVE_TESTS); do \
+		cargo test --test live_anthropic_compatible "$$live_test" -- --exact --ignored --nocapture; \
+	done
+
+test-live-codex: ## Run OpenAI Codex live tests
+	@printf '%s\n' \
+		'Requires Codex CLI ChatGPT auth state, network access, and image support for the image probe.' \
+		'Test binaries: live_codex, live_openai_codex_compact'
+	cargo test --test live_codex -- --ignored --nocapture
+	cargo test --test live_openai_codex_compact -- --ignored --nocapture
+
+test-live-xai: ## Run xAI live tests
+	@printf '%s\n' \
+		'Requires configured xAI credentials and network access.' \
+		'Test binary: live_xai'
+	cargo test --test live_xai -- --ignored --nocapture
+
+test-live-images: ## Run provider-backed image and vision live tests
+	@printf '%s\n' \
+		'Requires an OpenAI-compatible vision credential and a Volcengine Ark image credential, plus network access.' \
+		'Test binaries: live_view_image, live_volcengine_image'
+	cargo test --test live_view_image -- --ignored --nocapture
+	cargo test --test live_volcengine_image -- --ignored --nocapture
+
+test-live-runtime: ## Run end-to-end runtime and workspace-tool live tests
+	@printf '%s\n' \
+		'Requires the selected continuity/workspace model credentials, network access, and git.' \
+		'Defaults: deepseek-anthropic/deepseek-v4-pro for continuity; configured default model for workspace tools.' \
+		'Test binaries: live_prompt_continuity, live_workspace_tools'
+	cargo test --test live_prompt_continuity -- --ignored --nocapture
+	cargo test --test live_workspace_tools -- --ignored --nocapture
 
 fmt:
 	cargo fmt
@@ -74,7 +150,7 @@ lint: ## Run clippy
 check: ## Quick local check (formatting + clippy + compile check)
 	RUSTFLAGS="-D warnings" cargo check --all-targets
 
-ci: web-ci fmt-check lint build test ## Run the full CI checks locally
+ci: web-ci fmt-check lint build snapshots-check test ## Run the full CI checks locally
 
 run:
 	cargo run -- serve

--- a/docs/release.md
+++ b/docs/release.md
@@ -42,7 +42,8 @@ Before pushing the tag, verify:
   `cargo run -- ...` commands
 - when provider, context projection, compaction, or prompt-cache behavior
   changed, the ignored live LLM baseline in
-  `docs/testing/live-llm-baseline.md` has been run manually
+  `docs/testing/live-llm-baseline.md` has been run manually with
+  `make test-live` or the relevant focused live target
 - when the version number or HTTP API surface changed, regenerate the OpenAPI
   snapshot (see below) — never edit `openapi.json` by hand
 
@@ -55,16 +56,17 @@ the schema generated from the current crate version. Any version bump or HTTP
 API change will cause drift.
 
 **Do not edit `openapi.json` by hand.** After bumping the version in
-`Cargo.toml`, regenerate the snapshot:
+`Cargo.toml`, refresh the checked-in Rust-generated snapshots and verify them:
 
 ```bash
-cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
-cargo test --test openapi_snapshot
+make snapshots-refresh
+make snapshots-check
 ```
 
-The first command regenerates the file; the second verifies it matches. The
-generated output has no trailing newline — adding one manually causes the
-snapshot test to fail.
+The first command regenerates the CLI, OpenAPI, HTTP route, and model tool schema
+snapshots; the second verifies they match. Review every generated diff before
+committing. The OpenAPI output has no trailing newline — adding one manually
+causes the snapshot test to fail.
 
 The Web GUI transport types are generated from the same snapshot. Refresh both
 artifacts together and verify drift with:

--- a/docs/testing/live-llm-baseline.md
+++ b/docs/testing/live-llm-baseline.md
@@ -10,15 +10,19 @@ projection, compaction, or prompt-cache strategy.
 Run the baseline explicitly:
 
 ```bash
-cargo test --test live_llm_baseline -- --ignored --nocapture
+make test-live
 ```
 
-The suite requires configured provider credentials and network access. By
-default it exercises the first configured provider model in the runtime model
-chain. Set `HOLON_LIVE_BASELINE_MAX_MODELS` to include more configured models:
+This runs the configured-chain smoke and tool-roundtrip tests from
+`live_llm_baseline`, followed by `live_provider_smoke`. The Anthropic-only
+prompt-cache probe stays in `make test-live-anthropic` so the baseline does not
+silently require Anthropic credentials. The suite requires configured provider
+credentials and network access. By default, the baseline exercises the first
+configured provider model in the runtime model chain. Set
+`HOLON_LIVE_BASELINE_MAX_MODELS` to include more configured models:
 
 ```bash
-HOLON_LIVE_BASELINE_MAX_MODELS=3 cargo test --test live_llm_baseline -- --ignored --nocapture
+HOLON_LIVE_BASELINE_MAX_MODELS=3 make test-live
 ```
 
 ## Coverage
@@ -33,6 +37,25 @@ Provider-specific live tests remain in files such as `tests/live_anthropic.rs`,
 `tests/live_codex.rs`, and `tests/live_anthropic_cache.rs`. The baseline suite
 is the release-oriented entry point that should stay small, actionable, and
 representative.
+
+Use the focused targets when validating one provider family or runtime surface:
+
+```bash
+make test-live-openai
+make test-live-anthropic
+make test-live-codex
+make test-live-xai
+make test-live-images
+make test-live-runtime
+```
+
+Each target prints its credential boundary and exact test binaries before
+running ignored tests. Live targets are manual and are not part of the
+credential-free default CI.
+
+`make test-live-anthropic` includes the Anthropic prompt-cache baseline and the
+broader Anthropic-compatible provider matrix. It may require multiple
+provider-specific credentials and incur higher cost than the baseline target.
 
 ## Required configuration
 

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -16,10 +16,10 @@ the API long term.
 - **Primary source:** `src/http.rs` Axum router and request/response structs.
 - **Generated schema:** [`openapi.json`](./openapi.json), produced by
   `holon::openapi::generate_openapi_json()` and checked by
-  `cargo test --test openapi_snapshot`.
+  `make snapshots-check`.
 - **Route/schema drift check:** `tests/snapshots/http_route_inventory.json`,
   produced from the Axum route tree and generated OpenAPI baseline by
-  `cargo test --test http_route_snapshot`.
+  `make snapshots-check`.
 - **Client source:** `src/client.rs` for the subset consumed by the TUI/CLI.
 - **Current status:** pre-1.0 baseline. Treat shapes below as observed
   behavior, not a final compatibility promise. Milestone 8 established the

--- a/docs/website/reference/model-tool-schema-inventory.md
+++ b/docs/website/reference/model-tool-schema-inventory.md
@@ -13,7 +13,7 @@ tool surface**. The machine-readable inventory is checked in as
 - **Primary source:** `src/tool/tools/mod.rs` `builtin_tool_definitions()` and
   the typed Rust argument structs deriving `schemars::JsonSchema`.
 - **Generated inventory:** `holon::tool::model_tool_schema_inventory()`.
-- **Drift check:** `cargo test --test tool_schema_inventory_snapshot`.
+- **Drift check:** `make snapshots-check`.
 - **Current status:** pre-1.0 baseline. Treat stable labels as the intended
   compatibility boundary for the current track, not as a final 1.0 promise.
 
@@ -78,6 +78,6 @@ schema independently.
 ## Refresh workflow
 
 ```bash
-cargo test --test tool_schema_inventory_snapshot refresh_tool_schema_inventory_snapshot -- --ignored
-cargo test --test tool_schema_inventory_snapshot
+make snapshots-refresh
+make snapshots-check
 ```

--- a/tests/cli_snapshot.rs
+++ b/tests/cli_snapshot.rs
@@ -11,22 +11,13 @@
 //! When a deliberate CLI change is made, regenerate the snapshot file:
 //!
 //! ```bash
-//! cargo test --test cli_snapshot test_cli_snapshot_matches -- --include-ignored
+//! make snapshots-refresh
 //! ```
 //!
-//! The test will fail and print the expected JSON. Copy the printed JSON into
-//! `tests/snapshots/cli_command_tree.json`, then run again to confirm:
+//! Review the generated diff, then run the unified check:
 //!
 //! ```bash
-//! cargo test --test cli_snapshot
-//! ```
-//!
-//! The `--refresh` helper (hidden behind `--ignored`) overwrites the snapshot
-//! file automatically. Use it only when you are sure the new shape is
-//! intentional:
-//!
-//! ```bash
-//! cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored
+//! make snapshots-check
 //! ```
 
 use holon::cli;
@@ -39,9 +30,12 @@ fn test_cli_snapshot_matches() {
     let entries = cli::collect_snapshot();
     let live = serde_json::to_string_pretty(&entries).expect("serialize snapshot");
 
-    let stored = std::fs::read_to_string(SNAPSHOT_PATH)
-        .unwrap_or_else(|e| panic!("failed to read snapshot at {SNAPSHOT_PATH}: {e}\n\
-            Hint: create the initial snapshot by running `cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored`"));
+    let stored = std::fs::read_to_string(SNAPSHOT_PATH).unwrap_or_else(|e| {
+        panic!(
+            "failed to read snapshot at {SNAPSHOT_PATH}: {e}\n\
+            Hint: create the initial snapshot by running `make snapshots-refresh`"
+        )
+    });
 
     // Normalise line endings so the test works cross-platform.
     let live_normalised = live.replace("\r\n", "\n");
@@ -54,7 +48,7 @@ fn test_cli_snapshot_matches() {
             +++ LIVE\n\
             \n\
             If the live version is correct, refresh the snapshot:\n\
-              cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored\n"
+              make snapshots-refresh\n"
         );
         // Print the live version so it can be used as the new snapshot.
         eprintln!("=== EXPECTED SNAPSHOT ===");
@@ -68,7 +62,7 @@ fn test_cli_snapshot_matches() {
 /// Marked `#[ignore]` so it only runs on explicit request:
 ///
 /// ```bash
-/// cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored
+/// make snapshots-refresh
 /// ```
 #[test]
 #[ignore]

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -3,8 +3,8 @@
 //! Refresh workflow for intentional HTTP surface changes:
 //!
 //! ```bash
-//! cargo test --test http_route_snapshot refresh_http_route_inventory_snapshot -- --ignored
-//! cargo test --test http_route_snapshot
+//! make snapshots-refresh
+//! make snapshots-check
 //! ```
 
 use serde::Serialize;
@@ -53,7 +53,7 @@ fn http_route_inventory_snapshot_matches_router_and_openapi() {
 
     if live.replace("\r\n", "\n") != stored.replace("\r\n", "\n") {
         eprintln!(
-            "HTTP route inventory drift detected. Refresh intentionally with:\n  cargo test --test http_route_snapshot refresh_http_route_inventory_snapshot -- --ignored\n"
+            "HTTP route inventory drift detected. Refresh intentionally with:\n  make snapshots-refresh\n"
         );
         eprintln!("=== GENERATED HTTP ROUTE INVENTORY ===");
         eprintln!("{live}");

--- a/tests/openapi_snapshot.rs
+++ b/tests/openapi_snapshot.rs
@@ -3,8 +3,8 @@
 //! Refresh workflow for intentional HTTP surface changes:
 //!
 //! ```bash
-//! cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
-//! cargo test --test openapi_snapshot
+//! make snapshots-refresh
+//! make snapshots-check
 //! ```
 
 const SNAPSHOT_PATH: &str = "docs/website/reference/openapi.json";
@@ -18,7 +18,7 @@ fn openapi_snapshot_matches_generated_schema() {
 
     if live.replace("\r\n", "\n") != stored.replace("\r\n", "\n") {
         eprintln!(
-            "OpenAPI snapshot drift detected. Refresh intentionally with:\n  cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored\n"
+            "OpenAPI snapshot drift detected. Refresh intentionally with:\n  make snapshots-refresh\n"
         );
         eprintln!("=== GENERATED OPENAPI ===");
         eprintln!("{live}");

--- a/tests/tool_schema_inventory_snapshot.rs
+++ b/tests/tool_schema_inventory_snapshot.rs
@@ -3,8 +3,8 @@
 //! Refresh workflow for intentional tool surface changes:
 //!
 //! ```bash
-//! cargo test --test tool_schema_inventory_snapshot refresh_tool_schema_inventory_snapshot -- --ignored
-//! cargo test --test tool_schema_inventory_snapshot
+//! make snapshots-refresh
+//! make snapshots-check
 //! ```
 
 const SNAPSHOT_PATH: &str = "docs/website/reference/model-tool-schema-inventory.json";
@@ -20,7 +20,7 @@ fn tool_schema_inventory_snapshot_matches_generated_inventory() {
 
     if live.replace("\r\n", "\n") != stored.replace("\r\n", "\n") {
         eprintln!(
-            "Tool schema inventory drift detected. Refresh intentionally with:\n  cargo test --test tool_schema_inventory_snapshot refresh_tool_schema_inventory_snapshot -- --ignored\n"
+            "Tool schema inventory drift detected. Refresh intentionally with:\n  make snapshots-refresh\n"
         );
         eprintln!("=== GENERATED TOOL SCHEMA INVENTORY ===");
         eprintln!("{live}");


### PR DESCRIPTION
## 概要

- 将笼统且未运行 ignored tests 的 `test-live` 拆分为 baseline、OpenAI、Anthropic、Codex、xAI、image/vision 与 runtime/workspace targets
- 为 Anthropic-compatible probes 使用明确的 `--exact` 白名单，避免意外扩大高成本 live 测试范围
- 增加统一的 `snapshots-check` / `snapshots-refresh`，覆盖 CLI、OpenAPI、HTTP route 与 model tool schema snapshots
- 将 snapshot check 接入默认 CI，并同步贡献、发布与 live-test 文档

这是 #2259 的第一阶段；临时资源 RAII fixture 与有限 lint/guard 将在后续独立 PR 中交付，因此本 PR 不关闭 issue。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `make snapshots-check`
- `cargo test --all-targets -- --test-threads=1`
- `make snapshots-refresh && make snapshots-check`，并确认刷新前后工作树状态一致
- `make -n` 复核各 provider-specific live target 的 ignored test 选择范围

Part of #2259
