### PR TITLE
test: clean temporary test resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Check generated snapshots
         run: make snapshots-check
 
+      - name: Audit test temp resources
+        run: make test-resource-lint
+
       - name: Test
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime fmt fmt-check lint check ci run clean
+.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
 OPENAPI_TOOLS_DIR := web-gui/openapi-tools
@@ -63,6 +63,9 @@ all: web build ## Build everything: web GUI then Rust
 
 test: ## Run the full Rust test suite serially
 	cargo test --all-targets -- --test-threads=1
+
+test-resource-lint: ## Audit permanent test temp directories against the reasoned allowlist
+	python3 scripts/check-test-temp-resources.py
 
 test-concurrent: ## Run runtime lifecycle integration tests with Rust's default test threads
 	@set -eu; \
@@ -150,7 +153,7 @@ lint: ## Run clippy
 check: ## Quick local check (formatting + clippy + compile check)
 	RUSTFLAGS="-D warnings" cargo check --all-targets
 
-ci: web-ci fmt-check lint build snapshots-check test ## Run the full CI checks locally
+ci: web-ci fmt-check lint build snapshots-check test-resource-lint test ## Run the full CI checks locally
 
 run:
 	cargo run -- serve

--- a/scripts/check-test-temp-resources.py
+++ b/scripts/check-test-temp-resources.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ALLOWLIST = ROOT / "tests" / "test-temp-resource-allowlist.txt"
+PERMANENT_TEMP_DIR = re.compile(r"\.(?:keep|into_path)\s*\(")
+
+
+def load_allowlist() -> dict[str, tuple[int, str]]:
+    entries: dict[str, tuple[int, str]] = {}
+    for line_number, raw_line in enumerate(
+        ALLOWLIST.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            raise ValueError(
+                f"{ALLOWLIST.relative_to(ROOT)}:{line_number}: "
+                "expected PATH<TAB>COUNT<TAB>REASON"
+            )
+        path, count_text, reason = parts
+        if path in entries:
+            raise ValueError(f"duplicate allowlist path: {path}")
+        entries[path] = (int(count_text), reason)
+    return entries
+
+
+def find_permanent_temp_dirs() -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for path in sorted((ROOT / "tests").rglob("*.rs")):
+        relative = path.relative_to(ROOT).as_posix()
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if PERMANENT_TEMP_DIR.search(line):
+                counts[relative] += 1
+    return counts
+
+
+def main() -> int:
+    try:
+        expected = load_allowlist()
+    except (OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    actual = find_permanent_temp_dirs()
+    failures: list[str] = []
+    for path in sorted(set(expected) | set(actual)):
+        expected_count = expected.get(path, (0, ""))[0]
+        actual_count = actual.get(path, 0)
+        if actual_count != expected_count:
+            failures.append(
+                f"{path}: expected {expected_count} permanent temp-dir call(s), "
+                f"found {actual_count}"
+            )
+
+    if failures:
+        print("test temp-resource audit failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            "Use RAII-owned TempDir values, or update the allowlist count and reason "
+            "when permanent retention is unavoidable.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"test temp-resource audit passed "
+        f"({sum(actual.values())} allowlisted permanent call(s))"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression_fixture.rs
+++ b/tests/regression_fixture.rs
@@ -9,7 +9,6 @@ use holon::{
     types::{AuthorityClass, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority},
 };
 use serde::Deserialize;
-use tempfile::tempdir;
 use tokio::sync::Mutex;
 mod support;
 
@@ -91,19 +90,13 @@ async fn fixture_coding_loop_regression_stays_green() -> Result<()> {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/write_and_verify.json");
     let fixture: RegressionFixture = serde_json::from_str(&fs::read_to_string(&fixture_path)?)?;
 
-    let workspace = tempdir()?.keep();
-    let data_dir = tempdir()?.keep();
+    let test_config = TestConfigBuilder::new().build();
+    let workspace = test_config.workspace_dir().to_path_buf();
     fs::create_dir_all(&workspace)?;
     let provider = FixtureProvider::new(fixture.steps.clone());
 
-    let harness = RuntimeHarness::with_config_and_provider(
-        TestConfigBuilder::new()
-            .with_workspace_dir(workspace.clone())
-            .with_data_dir(data_dir)
-            .build(),
-        Arc::new(provider),
-    )
-    .await?;
+    let harness =
+        RuntimeHarness::with_test_config_and_provider(test_config, Arc::new(provider)).await?;
     let runtime = harness.runtime.clone();
 
     runtime

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1,9 +1,9 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use holon::{
-    config::{AppConfig, ControlAuthMode},
+    config::ControlAuthMode,
     host::RuntimeHost,
     provider::{
         AgentProvider, ConversationMessage, ModelBlock, ProviderTurnRequest, ProviderTurnResponse,
@@ -14,18 +14,15 @@ use holon::{
     types::{AuthorityClass, ControlAction, FailureArtifactCategory, TaskStatus, TokenUsage},
 };
 use serde_json::json;
-use tempfile::tempdir;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 
 mod support;
 
-use support::{assert_run_once_completed_text, init_git_repo, TestConfigBuilder};
+use support::{assert_run_once_completed_text, init_git_repo, TestConfig, TestConfigBuilder};
 
-fn test_config(workspace_dir: PathBuf, home_dir: PathBuf) -> AppConfig {
+fn test_config() -> TestConfig {
     TestConfigBuilder::new()
-        .with_workspace_dir(workspace_dir)
-        .with_data_dir(home_dir)
         .with_control_auth_mode(ControlAuthMode::Auto)
         .build()
 }
@@ -46,10 +43,9 @@ fn run_request(text: impl Into<String>) -> RunOnceRequest {
 
 #[tokio::test]
 async fn run_once_returns_completed_text_for_simple_prompt() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir.clone()),
+        test_config.config().clone(),
         Arc::new(StubProvider::new("stub result")),
     )?;
 
@@ -94,10 +90,9 @@ impl AgentProvider for TokenReportingProvider {
 
 #[tokio::test]
 async fn run_once_surfaces_structured_token_usage_when_provider_reports_it() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(TokenReportingProvider),
     )?;
 
@@ -255,11 +250,9 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
 
 #[tokio::test]
 async fn run_once_prefers_completed_work_item_result_brief_over_latest_turn_text() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let provider = Arc::new(WorkItemDeliverySummaryProvider::new());
-    let host =
-        RuntimeHost::new_with_provider(test_config(workspace_dir, home_dir), provider.clone())?;
+    let host = RuntimeHost::new_with_provider(test_config.config().clone(), provider.clone())?;
     let runtime = host.default_runtime().await?;
     let work_item = runtime
         .create_work_item(
@@ -340,12 +333,9 @@ impl AgentProvider for ErrorProvider {
 
 #[tokio::test]
 async fn run_once_surfaces_runtime_error_as_failed_delivery() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
-    let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
-        Arc::new(ErrorProvider),
-    )?;
+    let test_config = test_config();
+    let host =
+        RuntimeHost::new_with_provider(test_config.config().clone(), Arc::new(ErrorProvider))?;
 
     let response = run_once_with_host(host, run_request("explode")).await?;
 
@@ -429,10 +419,9 @@ impl AgentProvider for FileEditingProvider {
 
 #[tokio::test]
 async fn run_once_collects_changed_files_from_mutating_tools() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(FileEditingProvider::new()),
     )?;
 
@@ -518,10 +507,10 @@ impl AgentProvider for MultiMutatingToolsProvider {
 
 #[tokio::test]
 async fn run_once_collects_changed_files_from_multiple_mutating_tools() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
+    let workspace_dir = test_config.workspace_dir().to_path_buf();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir.clone(), home_dir),
+        test_config.config().clone(),
         Arc::new(MultiMutatingToolsProvider::new()),
     )?;
 
@@ -764,10 +753,9 @@ impl AgentProvider for EmptyTerminalDeliveryProvider {
 
 #[tokio::test]
 async fn run_once_uses_last_assistant_message_without_terminal_delivery_round() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(TerminalDeliveryProvider::new()),
     )?;
 
@@ -783,10 +771,9 @@ async fn run_once_uses_last_assistant_message_without_terminal_delivery_round() 
 
 #[tokio::test]
 async fn run_once_keeps_last_assistant_message_without_structured_fallback() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(EmptyTerminalDeliveryProvider::new()),
     )?;
 
@@ -802,10 +789,9 @@ async fn run_once_keeps_last_assistant_message_without_structured_fallback() -> 
 
 #[tokio::test]
 async fn run_once_leaves_final_text_empty_without_assistant_text() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(SleepOnlyTerminalProvider::new()),
     )?;
 
@@ -875,10 +861,9 @@ impl AgentProvider for SleepTaskProvider {
 
 #[tokio::test]
 async fn run_once_waits_for_background_tasks_by_default() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(SleepTaskProvider::new(50)),
     )?;
 
@@ -953,10 +938,9 @@ impl AgentProvider for CommandTaskProvider {
 
 #[tokio::test]
 async fn run_once_waits_for_command_tasks_by_default() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(CommandTaskProvider::new("sleep 0.1; printf command_ok")),
     )?;
 
@@ -972,10 +956,9 @@ async fn run_once_waits_for_command_tasks_by_default() -> Result<()> {
 
 #[tokio::test]
 async fn run_once_no_wait_does_not_interrupt_session_local_sleep() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(SleepTaskProvider::new(500)),
     )?;
 
@@ -1001,10 +984,9 @@ async fn run_once_no_wait_does_not_interrupt_session_local_sleep() -> Result<()>
 
 #[tokio::test]
 async fn run_once_no_wait_stops_unfinished_command_tasks_before_exit() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(CommandTaskProvider::new("sleep 60")),
     )?;
 
@@ -1033,10 +1015,9 @@ async fn run_once_no_wait_stops_unfinished_command_tasks_before_exit() -> Result
 
 #[tokio::test]
 async fn run_once_no_wait_allows_short_tasks_to_finish_during_quiescence() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(SleepTaskProvider::new(50)),
     )?;
 
@@ -1058,10 +1039,9 @@ async fn run_once_no_wait_allows_short_tasks_to_finish_during_quiescence() -> Re
 
 #[tokio::test]
 async fn run_once_no_wait_allows_short_command_tasks_to_finish_during_quiescence() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(CommandTaskProvider::new(
             "sleep 0.1 && printf quick_command_ok",
         )),
@@ -1086,10 +1066,9 @@ async fn run_once_no_wait_allows_short_command_tasks_to_finish_during_quiescence
 
 #[tokio::test]
 async fn run_once_prefers_parent_final_result_over_delegated_task_briefs() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(DelegatedRunOnceProvider::new()),
     )?;
 
@@ -1227,10 +1206,9 @@ impl AgentProvider for TwoRoundProvider {
 
 #[tokio::test]
 async fn run_once_reports_completed_when_final_result_is_below_max_turns() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(StubProvider::new("stub result")),
     )?;
 
@@ -1251,10 +1229,9 @@ async fn run_once_reports_completed_when_final_result_is_below_max_turns() -> Re
 
 #[tokio::test]
 async fn run_once_reports_completed_when_final_result_lands_on_max_turn_boundary() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(StubProvider::new("stub result")),
     )?;
 
@@ -1276,10 +1253,9 @@ async fn run_once_reports_completed_when_final_result_lands_on_max_turn_boundary
 #[tokio::test]
 async fn run_once_reports_completed_when_final_text_arrives_after_last_allowed_model_round(
 ) -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(TwoRoundProvider::new()),
     )?;
 
@@ -1306,10 +1282,9 @@ async fn run_once_multi_round_single_turn_does_not_exceed_max_turns() -> Result<
     // consumed, regardless of the number of model rounds within that turn.
     // Before the fix, the counter used total_model_rounds, which would
     // incorrectly report MaxTurnsExceeded for this scenario.
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(TwoRoundProvider::new()),
     )?;
 
@@ -1333,10 +1308,9 @@ async fn run_once_injects_turn_budget_warning_on_last_allowed_turn() -> Result<(
     // With max_turns=1, the single turn is the last allowed turn.
     // The budget warning is injected via the runtime_reminder projection path
     // on round 2+ within that turn.
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(BudgetWarningCheckProvider::new()),
     )?;
 
@@ -1356,10 +1330,9 @@ async fn run_once_injects_turn_budget_warning_on_last_allowed_turn() -> Result<(
 
 #[tokio::test]
 async fn run_once_max_turns_respects_wait_for_command_tasks() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(CommandTaskProvider::new("sleep 0.5; printf command_ok")),
     )?;
 
@@ -1512,11 +1485,11 @@ impl AgentProvider for WorktreeTaskProvider {
 
 #[tokio::test]
 async fn run_once_includes_worktree_task_metadata() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
+    let workspace_dir = test_config.workspace_dir().to_path_buf();
     init_git_repo(&workspace_dir)?;
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(WorktreeTaskProvider::new()),
     )?;
 
@@ -1538,13 +1511,11 @@ async fn run_once_includes_worktree_task_metadata() -> Result<()> {
 
 #[tokio::test]
 async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
+    let home_dir = test_config.data_dir().to_path_buf();
     let provider = Arc::new(StubProvider::new("persistent result"));
-    let first_host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir.clone(), home_dir.clone()),
-        provider.clone(),
-    )?;
+    let first_host =
+        RuntimeHost::new_with_provider(test_config.config().clone(), provider.clone())?;
 
     let first = run_once_with_host(
         first_host.clone(),
@@ -1563,8 +1534,7 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
         .expect("persistent agent state should be stored after the first run");
     assert!(first_state.total_message_count > 0);
 
-    let second_host =
-        RuntimeHost::new_with_provider(test_config(workspace_dir, home_dir.clone()), provider)?;
+    let second_host = RuntimeHost::new_with_provider(test_config.config().clone(), provider)?;
     let listed_agents = second_host
         .list_agents()
         .await?
@@ -1595,10 +1565,9 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
 
 #[tokio::test]
 async fn run_once_rejects_template_without_create_agent() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(StubProvider::new("ignored")),
     )?;
 
@@ -1621,10 +1590,10 @@ async fn run_once_rejects_template_without_create_agent() -> Result<()> {
 
 #[tokio::test]
 async fn run_once_preserves_existing_workspace_binding_for_persistent_agents() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
+    let workspace_dir = test_config.workspace_dir().to_path_buf();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir.clone(), home_dir.clone()),
+        test_config.config().clone(),
         Arc::new(StubProvider::new("continued in existing workspace")),
     )?;
 
@@ -1697,10 +1666,9 @@ async fn run_once_preserves_existing_workspace_binding_for_persistent_agents() -
 
 #[tokio::test]
 async fn run_once_rejects_stopped_persistent_agent() -> Result<()> {
-    let home_dir = tempdir()?.keep();
-    let workspace_dir = tempdir()?.keep();
+    let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
-        test_config(workspace_dir, home_dir),
+        test_config.config().clone(),
         Arc::new(StubProvider::new("persistent result")),
     )?;
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,7 +27,7 @@ use holon::{
         WorkItemState,
     },
 };
-pub use tempfile::tempdir;
+pub use tempfile::{tempdir, TempDir};
 use tokio::sync::watch;
 use tokio::{
     net::{TcpListener, UnixListener},
@@ -45,6 +45,40 @@ pub struct TestConfigBuilder {
     prompt_budget_estimated_tokens: usize,
     compaction_trigger_estimated_tokens: usize,
     compaction_keep_recent_estimated_tokens: usize,
+}
+
+pub struct TestConfig {
+    config: AppConfig,
+    data_dir: Option<TempDir>,
+    workspace_dir: Option<TempDir>,
+}
+
+impl TestConfig {
+    pub fn config(&self) -> &AppConfig {
+        &self.config
+    }
+
+    pub fn config_mut(&mut self) -> &mut AppConfig {
+        &mut self.config
+    }
+
+    pub fn data_dir(&self) -> &Path {
+        &self.config.data_dir
+    }
+
+    pub fn workspace_dir(&self) -> &Path {
+        &self.config.workspace_dir
+    }
+
+    pub fn into_retained_config(mut self) -> AppConfig {
+        if let Some(data_dir) = self.data_dir.take() {
+            let _ = data_dir.keep();
+        }
+        if let Some(workspace_dir) = self.workspace_dir.take() {
+            let _ = workspace_dir.keep();
+        }
+        self.config
+    }
 }
 
 pub async fn test_work_item(
@@ -131,14 +165,22 @@ impl TestConfigBuilder {
         self
     }
 
-    pub fn build(self) -> AppConfig {
+    pub fn build(self) -> TestConfig {
+        let data_dir_owner = self
+            .data_dir
+            .is_none()
+            .then(|| tempdir().expect("temp data dir"));
+        let workspace_dir_owner = self
+            .workspace_dir
+            .is_none()
+            .then(|| tempdir().expect("temp workspace dir"));
         let data_dir = self
             .data_dir
-            .unwrap_or_else(|| tempdir().expect("temp data dir").keep());
+            .unwrap_or_else(|| data_dir_owner.as_ref().unwrap().path().to_path_buf());
         let workspace_dir = self
             .workspace_dir
-            .unwrap_or_else(|| tempdir().expect("temp workspace dir").keep());
-        AppConfig {
+            .unwrap_or_else(|| workspace_dir_owner.as_ref().unwrap().path().to_path_buf());
+        let config = AppConfig {
             default_agent_id: "default".into(),
             http_addr: self.http_addr,
             callback_base_url: "http://127.0.0.1:0".into(),
@@ -182,7 +224,16 @@ impl TestConfigBuilder {
                 data_dir.join(".codex"),
             ),
             web_config: holon::web::WebConfig::default(),
+        };
+        TestConfig {
+            config,
+            data_dir: data_dir_owner,
+            workspace_dir: workspace_dir_owner,
         }
+    }
+
+    pub fn build_retained(self) -> AppConfig {
+        self.build().into_retained_config()
     }
 }
 
@@ -216,19 +267,27 @@ pub fn init_git_repo(path: &Path) -> Result<()> {
 
 pub struct GitWorkspaceFixture {
     pub root: PathBuf,
+    temp_dir: TempDir,
 }
 
 impl GitWorkspaceFixture {
     pub fn new() -> Result<Self> {
-        let root = tempdir()?.keep();
+        let temp_dir = tempdir()?;
+        let root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
         init_git_repo(&root)?;
-        Ok(Self { root })
+        Ok(Self { root, temp_dir })
     }
 
     pub fn bare() -> Result<Self> {
-        let root = tempdir()?.keep();
+        let temp_dir = tempdir()?;
+        let root = temp_dir.path().join("repo");
         std::fs::create_dir_all(&root)?;
-        Ok(Self { root })
+        Ok(Self { root, temp_dir })
+    }
+
+    pub fn temp_root(&self) -> &Path {
+        self.temp_dir.path()
     }
 }
 
@@ -288,16 +347,33 @@ pub struct RuntimeHarness {
     pub host: RuntimeHost,
     pub runtime: RuntimeHandle,
     pub workspace_dir: PathBuf,
+    _config: Option<TestConfig>,
 }
 
 impl RuntimeHarness {
     pub async fn with_provider(provider: Arc<dyn AgentProvider>) -> Result<Self> {
-        Self::with_config_and_provider(TestConfigBuilder::new().build(), provider).await
+        Self::with_test_config_and_provider(TestConfigBuilder::new().build(), provider).await
+    }
+
+    pub async fn with_test_config_and_provider(
+        test_config: TestConfig,
+        provider: Arc<dyn AgentProvider>,
+    ) -> Result<Self> {
+        let config = test_config.config().clone();
+        Self::build(config, provider, Some(test_config)).await
     }
 
     pub async fn with_config_and_provider(
         config: AppConfig,
         provider: Arc<dyn AgentProvider>,
+    ) -> Result<Self> {
+        Self::build(config, provider, None).await
+    }
+
+    async fn build(
+        config: AppConfig,
+        provider: Arc<dyn AgentProvider>,
+        test_config: Option<TestConfig>,
     ) -> Result<Self> {
         std::fs::create_dir_all(&config.workspace_dir)?;
         let host = RuntimeHost::new_with_provider(config.clone(), provider)?;
@@ -307,25 +383,65 @@ impl RuntimeHarness {
             host,
             runtime,
             workspace_dir: config.workspace_dir.clone(),
+            _config: test_config,
         })
+    }
+}
+
+pub struct TestServerHandle {
+    server: JoinHandle<anyhow::Result<()>>,
+    _config: Option<TestConfig>,
+}
+
+impl TestServerHandle {
+    fn new(server: JoinHandle<anyhow::Result<()>>, test_config: Option<TestConfig>) -> Self {
+        Self {
+            server,
+            _config: test_config,
+        }
+    }
+
+    pub fn abort(&self) {
+        self.server.abort();
+    }
+}
+
+impl Drop for TestServerHandle {
+    fn drop(&mut self) {
+        self.server.abort();
     }
 }
 
 pub struct HttpHarness {
     pub host: RuntimeHost,
     pub base_url: String,
-    pub server: JoinHandle<anyhow::Result<()>>,
+    pub server: TestServerHandle,
 }
 
 impl HttpHarness {
     pub async fn with_provider(provider: Arc<dyn AgentProvider>) -> Result<Self> {
-        let config = TestConfigBuilder::new().build();
-        Self::with_config_and_provider(config, provider).await
+        Self::with_test_config_and_provider(TestConfigBuilder::new().build(), provider).await
+    }
+
+    pub async fn with_test_config_and_provider(
+        test_config: TestConfig,
+        provider: Arc<dyn AgentProvider>,
+    ) -> Result<Self> {
+        let config = test_config.config().clone();
+        Self::build(config, provider, Some(test_config)).await
     }
 
     pub async fn with_config_and_provider(
         config: AppConfig,
         provider: Arc<dyn AgentProvider>,
+    ) -> Result<Self> {
+        Self::build(config, provider, None).await
+    }
+
+    async fn build(
+        config: AppConfig,
+        provider: Arc<dyn AgentProvider>,
+        test_config: Option<TestConfig>,
     ) -> Result<Self> {
         std::fs::create_dir_all(&config.workspace_dir)?;
         init_git_repo(&config.workspace_dir)?;
@@ -342,7 +458,7 @@ impl HttpHarness {
         Ok(Self {
             host,
             base_url: format!("http://{}", addr),
-            server,
+            server: TestServerHandle::new(server, test_config),
         })
     }
 
@@ -607,7 +723,7 @@ where
 pub fn test_config() -> AppConfig {
     TestConfigBuilder::new()
         .with_control_auth_mode(ControlAuthMode::Auto)
-        .build()
+        .build_retained()
 }
 
 pub fn test_config_with_paths(
@@ -621,15 +737,14 @@ pub fn test_config_with_paths(
         .with_workspace_dir(workspace_dir)
         .with_http_addr(http_addr)
         .with_control_auth_mode(control_auth_mode)
-        .build()
+        .build_retained()
 }
 
-pub async fn spawn_server() -> Result<(
-    RuntimeHost,
-    String,
-    tokio::task::JoinHandle<anyhow::Result<()>>,
-)> {
-    let config = test_config();
+pub async fn spawn_server() -> Result<(RuntimeHost, String, TestServerHandle)> {
+    let test_config = TestConfigBuilder::new()
+        .with_control_auth_mode(ControlAuthMode::Auto)
+        .build();
+    let config = test_config.config().clone();
     let bind_addr = config.http_addr.clone();
     std::fs::create_dir_all(&config.workspace_dir)?;
     init_git_repo(&config.workspace_dir)?;
@@ -642,12 +757,14 @@ pub async fn spawn_server() -> Result<(
         axum::serve(listener, router).await?;
         Ok(())
     });
-    Ok((host, format!("http://{}", addr), server))
+    Ok((
+        host,
+        format!("http://{}", addr),
+        TestServerHandle::new(server, Some(test_config)),
+    ))
 }
 
-pub async fn spawn_server_for_host(
-    host: RuntimeHost,
-) -> Result<(String, tokio::task::JoinHandle<anyhow::Result<()>>)> {
+pub async fn spawn_server_for_host(host: RuntimeHost) -> Result<(String, TestServerHandle)> {
     let router: Router = http::router(AppState::for_tcp(host));
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
@@ -655,16 +772,15 @@ pub async fn spawn_server_for_host(
         axum::serve(listener, router).await?;
         Ok(())
     });
-    Ok((format!("http://{}", addr), server))
+    Ok((
+        format!("http://{}", addr),
+        TestServerHandle::new(server, None),
+    ))
 }
 
 pub async fn spawn_server_with_config(
     config: AppConfig,
-) -> Result<(
-    RuntimeHost,
-    String,
-    tokio::task::JoinHandle<anyhow::Result<()>>,
-)> {
+) -> Result<(RuntimeHost, String, TestServerHandle)> {
     std::fs::create_dir_all(&config.workspace_dir)?;
     init_git_repo(&config.workspace_dir)?;
     let bind_addr = config.http_addr.clone();
@@ -677,16 +793,16 @@ pub async fn spawn_server_with_config(
         axum::serve(listener, router).await?;
         Ok(())
     });
-    Ok((host, format!("http://{}", addr), server))
+    Ok((
+        host,
+        format!("http://{}", addr),
+        TestServerHandle::new(server, None),
+    ))
 }
 
 pub async fn spawn_server_with_runtime_config(
     config: AppConfig,
-) -> Result<(
-    RuntimeHost,
-    String,
-    tokio::task::JoinHandle<anyhow::Result<()>>,
-)> {
+) -> Result<(RuntimeHost, String, TestServerHandle)> {
     std::fs::create_dir_all(&config.workspace_dir)?;
     init_git_repo(&config.workspace_dir)?;
     let bind_addr = config.http_addr.clone();
@@ -699,7 +815,11 @@ pub async fn spawn_server_with_runtime_config(
         axum::serve(listener, router).await?;
         Ok(())
     });
-    Ok((host, format!("http://{}", addr), server))
+    Ok((
+        host,
+        format!("http://{}", addr),
+        TestServerHandle::new(server, None),
+    ))
 }
 
 // HTTP route support modules

--- a/tests/support/runtime_helpers.rs
+++ b/tests/support/runtime_helpers.rs
@@ -84,7 +84,7 @@ pub fn preserves_prior_tool_context(request: &ProviderTurnRequest) -> bool {
 pub fn test_config() -> AppConfig {
     TestConfigBuilder::new()
         .with_control_auth_mode(ControlAuthMode::Auto)
-        .build()
+        .build_retained()
 }
 
 /// Create an aggressive compaction configuration for testing
@@ -92,7 +92,7 @@ pub fn aggressive_compaction_config() -> AppConfig {
     let mut config = TestConfigBuilder::new()
         .with_control_auth_mode(ControlAuthMode::Auto)
         .with_compaction(2, 1, 1, 1, 4096)
-        .build();
+        .build_retained();
     let override_config = holon::model_catalog::ModelRuntimeOverride {
         prompt_budget_estimated_tokens: Some(4096),
         compaction_trigger_estimated_tokens: Some(1),

--- a/tests/test-temp-resource-allowlist.txt
+++ b/tests/test-temp-resource-allowlist.txt
@@ -1,0 +1,15 @@
+# PATH<TAB>COUNT<TAB>REASON
+tests/live_anthropic.rs	1	Live trace data is retained for provider diagnostics after an explicit live run.
+tests/scripted_agent_provider.rs	2	Legacy standalone config helper; migrate to shared TestConfig ownership.
+tests/support/http_callback.rs	2	Explicit-path HTTP helper still returns AppConfig without a resource owner.
+tests/support/http_client.rs	5	Tests exercise external cwd/worktree paths and legacy explicit-path server helpers.
+tests/support/http_control.rs	12	Legacy explicit-path HTTP configs cross restart and control-plane test boundaries.
+tests/support/http_events.rs	4	Legacy explicit-path HTTP configs cross restart and event-delivery boundaries.
+tests/support/http_ingress.rs	2	Legacy explicit-path HTTP config is passed into the server helper.
+tests/support/http_operator_ingress.rs	2	Legacy explicit-path HTTP config is passed into the server helper.
+tests/support/http_workspace.rs	1	Test intentionally removes a stale directory before the HTTP request.
+tests/support/mod.rs	2	Named build_retained compatibility path for legacy helpers; no default builder leak.
+tests/wt201_multiple_worktree_tasks.rs	2	Standalone worktree suite awaits migration to shared TestConfig ownership.
+tests/wt202_worktree_task_summary.rs	2	Standalone worktree suite awaits migration to shared TestConfig ownership.
+tests/wt204_parallel_worktree_workflow.rs	2	Standalone worktree suite awaits migration to shared TestConfig ownership.
+tests/wt205_worktree_lifecycle_edge_cases.rs	2	Standalone worktree suite awaits migration to shared TestConfig ownership.

--- a/tests/test_resource_cleanup.rs
+++ b/tests/test_resource_cleanup.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+mod support;
+
+use support::{GitWorkspaceFixture, TestConfigBuilder};
+
+fn create_then_return_test_resources() -> Result<(PathBuf, PathBuf)> {
+    let config = TestConfigBuilder::new().build();
+    let data_dir = config.data_dir().to_path_buf();
+    let workspace_dir = config.workspace_dir().to_path_buf();
+    let state_dir = data_dir.join("state");
+    std::fs::create_dir_all(&state_dir)?;
+    std::fs::create_dir_all(&workspace_dir)?;
+    for name in ["runtime.sqlite", "runtime.sqlite-wal", "runtime.sqlite-shm"] {
+        std::fs::write(state_dir.join(name), b"fixture")?;
+    }
+    Ok((data_dir, workspace_dir))
+}
+
+#[test]
+fn test_config_drop_cleans_early_return_sqlite_and_workspace_artifacts() -> Result<()> {
+    let (data_dir, workspace_dir) = create_then_return_test_resources()?;
+
+    assert!(!data_dir.exists(), "data dir should be removed by TempDir");
+    assert!(
+        !workspace_dir.exists(),
+        "workspace dir should be removed by TempDir"
+    );
+    Ok(())
+}
+
+#[test]
+fn git_workspace_fixture_drop_cleans_repository_root() -> Result<()> {
+    let (temp_root, repo_root) = {
+        let fixture = GitWorkspaceFixture::new()?;
+        let temp_root = fixture.temp_root().to_path_buf();
+        let repo_root = fixture.root.clone();
+        assert!(repo_root.join(".git").exists());
+        (temp_root, repo_root)
+    };
+
+    assert!(!repo_root.exists());
+    assert!(!temp_root.exists());
+    Ok(())
+}

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -5,62 +5,19 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use holon::{
-    config::{AppConfig, ControlAuthMode},
     host::RuntimeHost,
     provider::{AgentProvider, ModelBlock, ProviderTurnRequest, ProviderTurnResponse},
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{AuthorityClass, TaskStatus},
 };
-use tempfile::tempdir;
 use tokio::time::{sleep, Duration};
 
-fn test_config() -> AppConfig {
-    let home_dir = tempdir().unwrap().keep();
-    AppConfig {
-        default_agent_id: "default".into(),
-        http_addr: "127.0.0.1:0".into(),
-        callback_base_url: "http://127.0.0.1:0".into(),
-        home_dir: home_dir.clone(),
-        data_dir: home_dir.clone(),
-        socket_path: home_dir.join("run").join("holon.sock"),
-        workspace_dir: tempdir().unwrap().keep(),
-        context_window_messages: 8,
-        context_window_briefs: 8,
-        compaction_trigger_messages: 10,
-        compaction_keep_recent_messages: 4,
-        prompt_budget_estimated_tokens: 4096,
-        compaction_trigger_estimated_tokens: 2048,
-        compaction_keep_recent_estimated_tokens: 768,
-        recent_episode_candidates: 12,
-        max_relevant_episodes: 3,
-        control_token: Some("secret".into()),
-        control_auth_mode: ControlAuthMode::Auto,
-        api_cors: Default::default(),
-        config_file_path: home_dir.join("config.json"),
-        stored_config: Default::default(),
-        default_model: holon::config::ModelRouteRef::parse_compatible(
-            "anthropic/claude-sonnet-4-6",
-        )
-        .unwrap(),
-        fallback_models: Vec::new(),
-        vision_model: None,
-        image_generation_model: None,
-        vision_candidate_models: Vec::new(),
-        runtime_max_output_tokens: 8192,
-        default_tool_output_tokens: 8_000,
-        max_tool_output_tokens: 64_000,
-        disable_provider_fallback: false,
-        tui_alternate_screen: holon::config::AltScreenMode::Auto,
-        validated_model_overrides: std::collections::HashMap::new(),
-        validated_unknown_model_fallback: None,
-        model_discovery_cache: Default::default(),
-        providers: holon::config::provider_registry_for_tests(
-            None,
-            Some("dummy"),
-            home_dir.join(".codex"),
-        ),
-        web_config: holon::web::WebConfig::default(),
-    }
+mod support;
+
+use support::{TestConfig, TestConfigBuilder};
+
+fn test_config() -> TestConfig {
+    TestConfigBuilder::new().build()
 }
 
 fn git(path: &Path, args: &[&str]) -> Result<String> {
@@ -216,11 +173,12 @@ fn task_worktree_metadata(
 #[tokio::test]
 async fn wt203_task_owned_cleanup_removes_clean_terminal_worktree_and_branch() -> Result<()> {
     let config = test_config();
-    let workspace = config.workspace_dir.clone();
+    let workspace = config.workspace_dir().to_path_buf();
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
 
-    let host = RuntimeHost::new_with_provider(config, Arc::new(DelayedTextProvider))?;
+    let host =
+        RuntimeHost::new_with_provider(config.config().clone(), Arc::new(DelayedTextProvider))?;
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
 
@@ -254,11 +212,12 @@ async fn wt203_task_owned_cleanup_removes_clean_terminal_worktree_and_branch() -
 #[tokio::test]
 async fn wt203_task_owned_cleanup_treats_already_removed_worktree_as_completed() -> Result<()> {
     let config = test_config();
-    let workspace = config.workspace_dir.clone();
+    let workspace = config.workspace_dir().to_path_buf();
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
 
-    let host = RuntimeHost::new_with_provider(config, Arc::new(DelayedTextProvider))?;
+    let host =
+        RuntimeHost::new_with_provider(config.config().clone(), Arc::new(DelayedTextProvider))?;
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
 
@@ -303,11 +262,12 @@ async fn wt203_task_owned_cleanup_treats_already_removed_worktree_as_completed()
 #[tokio::test]
 async fn wt203_task_owned_cleanup_records_branch_mismatch_without_blocking() -> Result<()> {
     let config = test_config();
-    let workspace = config.workspace_dir.clone();
+    let workspace = config.workspace_dir().to_path_buf();
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
 
-    let host = RuntimeHost::new_with_provider(config, Arc::new(DelayedTextProvider))?;
+    let host =
+        RuntimeHost::new_with_provider(config.config().clone(), Arc::new(DelayedTextProvider))?;
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
 
@@ -349,11 +309,11 @@ async fn wt203_task_owned_cleanup_records_branch_mismatch_without_blocking() -> 
 #[tokio::test]
 async fn wt203_task_stop_cleans_clean_task_owned_worktree() -> Result<()> {
     let config = test_config();
-    let workspace = config.workspace_dir.clone();
+    let workspace = config.workspace_dir().to_path_buf();
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
 
-    let host = RuntimeHost::new_with_provider(config, Arc::new(SlowTextProvider))?;
+    let host = RuntimeHost::new_with_provider(config.config().clone(), Arc::new(SlowTextProvider))?;
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
 


### PR DESCRIPTION
## Summary

- make test fixtures own temporary homes, databases, workspaces, and worktrees through RAII by default
- add explicit retained-resource compatibility paths only where tests intentionally inspect artifacts after fixture teardown
- abort test server tasks from their owning handle and add cleanup regression coverage
- add a narrow permanent-`TempDir` conversion audit with a reviewed allowlist, exposed through `make test-resource-lint` and CI

This is the second and final PR for #2259, following #2348's provider-specific live-test and unified snapshot targets.

## Verification

- `cargo fmt --all -- --check`
- `make test-resource-lint`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `make snapshots-check`
- `make test-concurrent`
- `cargo test --all-targets -- --test-threads=1`

Closes #2259
