### PR TITLE
docs: validate runtime contract references

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -4,6 +4,19 @@ on:
   push:
     branches: [main]
     paths:
+      - 'README.md'
+      - 'docs/architecture-overview.md'
+      - 'docs/runtime-spec.md'
+      - 'docs/rfcs/**'
+      - 'docs/website/**'
+      - '.github/workflows/docs-site.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'docs/architecture-overview.md'
+      - 'docs/runtime-spec.md'
+      - 'docs/rfcs/**'
       - 'docs/website/**'
       - '.github/workflows/docs-site.yml'
   workflow_dispatch:
@@ -36,8 +49,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefix .tools
 
-      - name: Check internal links
-        run: python3 .tools/check-links.py
+      - name: Check internal links and contract references
+        run: |
+          python3 .tools/check-links.py
+          python3 .tools/test-check-contract-refs.py
+          python3 .tools/check-contract-refs.py
 
       - name: Build directory indexes
         run: npm --prefix .tools run build:index
@@ -55,6 +71,7 @@ jobs:
           path: docs/website/dist/cloudflare
 
       - name: Deploy to Cloudflare Workers
+        if: github.event_name != 'pull_request'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -14,7 +14,7 @@ Use it to:
 
 For canonical contracts, see [RFCs](rfcs/README.md). For a user-facing
 explanation, see the [website concepts](./website/concepts/README.md).
-For the contributor reading path, see the [RFC README](rfcs/README.md#recommended-reading-path).
+For the contributor reading path, see the [RFC README](rfcs/README.md#current-runtime-specs).
 
 ## One Sentence
 

--- a/docs/rfcs/runtime-ledger-files-and-relations.md
+++ b/docs/rfcs/runtime-ledger-files-and-relations.md
@@ -155,8 +155,9 @@ The current runtime storage creates the following files under
 ## Current implementation usage
 
 The current implementation centralizes ledger paths and basic append/read
-helpers in `src/storage.rs`. Higher-level runtime modules decide when each
-domain record is created and how recent or latest-state views are reconstructed.
+helpers in [`src/storage/mod.rs`](../../src/storage/mod.rs). Higher-level
+runtime modules decide when each domain record is created and how recent or
+latest-state views are reconstructed.
 
 This section describes the current implementation, not the final desired
 contract. It should be kept close to the code while the ledger refactor is in

--- a/docs/rfcs/turn-local-context-compaction.md
+++ b/docs/rfcs/turn-local-context-compaction.md
@@ -14,10 +14,12 @@ This note describes a focused compaction design for one specific failure mode:
 
 This is different from Holon's existing cross-turn compaction.
 
-Existing cross-turn compaction is handled before prompt assembly through
-`src/context.rs::maybe_compact_agent()`. That logic compacts durable message
-history. It does **not** compact the in-memory provider conversation that is
-built inside `src/runtime/turn.rs::run_agent_loop()`.
+Existing cross-turn context projection is assembled before provider execution
+through [`src/context/mod.rs`](../../src/context/mod.rs) `build_context()`.
+That logic bounds and projects durable history. It does **not** compact the
+in-memory provider conversation built inside
+[`src/runtime/turn/execution.rs`](../../src/runtime/turn/execution.rs)
+`run_agent_loop()`.
 
 The result is that Holon can still exceed context inside a single turn even if
 long-lived session memory is already under control.
@@ -33,12 +35,9 @@ The current turn loop behaves roughly like this:
 5. append tool results to in-memory `conversation`
 6. build the next continuation request from the full accumulated conversation
 
-Relevant code paths today:
-
-- `src/runtime/turn.rs:76`
-- `src/runtime/turn.rs:136`
-- `src/runtime/turn.rs:195`
-- `src/runtime/turn.rs:496`
+Relevant code paths today are
+[`src/context/mod.rs`](../../src/context/mod.rs) and
+[`src/runtime/turn/execution.rs`](../../src/runtime/turn/execution.rs).
 
 So the dangerous growth is not mainly:
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -31,7 +31,7 @@
 | Original section | Current home |
 |------------------|--------------|
 | Agent State | [Agent state spec](./website/spec/agent-state.md) |
-| Agent Initialization Contract | Implementation detail; see `src/runtime/agent_init.rs` and `src/agent_template.rs` |
+| Agent Initialization Contract | Implementation detail; see [`src/agent_template.rs`](../src/agent_template.rs) |
 | Agent Identity And Visibility Contract | [Agent state spec](./website/spec/agent-state.md) — lifecycle, identity, visibility, ownership, profile presets |
 | Agent Model Selection | [Agent state spec](./website/spec/agent-state.md) |
 | Agent Inspection Surface Contract | Control-plane API; see `/agents/list`, `/agents/:id/status`, `/agents/:id/state` |
@@ -117,11 +117,13 @@ focused spec page. They remain in source code, RFCs, or CLI reference:
 - **Provider transport contract** (selection, retry, fallback, token usage):
   `src/provider/`, `src/types.rs` `ProviderAttemptTimeline`
 - **Provider prompt frame** (prompt assembly and lowering):
-  `src/prompt/`, `src/provider/openai.rs`, `src/provider/anthropic.rs`
+  [`src/prompt/`](../src/prompt/),
+  [`src/provider/transports/openai/`](../src/provider/transports/openai/),
+  [`src/provider/transports/anthropic.rs`](../src/provider/transports/anthropic.rs)
 - **Failure artifact envelope** (operator-facing failure normalization):
   `src/types.rs` `FailureArtifact`
 - **Agent initialization** (template selection, agent_home materialization):
-  `src/runtime/agent_init.rs`, `src/agent_template.rs`
+  [`src/agent_template.rs`](../src/agent_template.rs)
 - **Memory search index** (FTS indexing, CJK, rebuild markers):
   `src/memory/`, tool schema inventory
 - **Local operator console** (TUI contract):

--- a/docs/website/.tools/check-contract-refs.py
+++ b/docs/website/.tools/check-contract-refs.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Check repository links and declared implementation references in runtime docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WEBSITE_DIR = REPO_ROOT / "docs" / "website"
+
+TOP_LEVEL_DOCS = (
+    Path("README.md"),
+    Path("docs/architecture-overview.md"),
+    Path("docs/runtime-spec.md"),
+)
+AUTHORITATIVE_GLOBS = (
+    "docs/website/spec/**/*.md",
+    "docs/website/reference/**/*.md",
+)
+RFC_GLOB = "docs/rfcs/**/*.md"
+
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+CODE_SPAN_RE = re.compile(r"`([^`\n]+)`")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+IGNORE_RE = re.compile(r"<!--\s*contract-ref-ignore:\s*(.*?)\s*-->")
+IMPLEMENTATION_HEADING_RE = re.compile(
+    r"^#{1,6}\s+Implementation references?\s*$", re.IGNORECASE
+)
+REPOSITORY_PATH_RE = re.compile(
+    r"^(?:src|tests|docs|scripts|builtin_templates|agent_templates|web-gui|\.github)/"
+    r"[A-Za-z0-9_./-]+$"
+)
+REPOSITORY_ROOT_FILES = {"Cargo.lock", "Cargo.toml", "Makefile"}
+EXTERNAL_SCHEMES = {"http", "https", "mailto", "tel", "data"}
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    source: Path
+    line: int
+    target: str
+
+    def format(self, repo_root: Path) -> str:
+        return f"{self.source.relative_to(repo_root).as_posix()}:{self.line}:{self.target}"
+
+
+def markdown_files(repo_root: Path) -> list[tuple[Path, bool]]:
+    """Return checked files and whether code-span implementation refs are enabled."""
+    files: dict[Path, bool] = {}
+    for relative in TOP_LEVEL_DOCS:
+        path = repo_root / relative
+        if path.is_file():
+            files[path] = False
+    for pattern in AUTHORITATIVE_GLOBS:
+        for path in repo_root.glob(pattern):
+            if path.is_file():
+                files[path] = True
+    for path in repo_root.glob(RFC_GLOB):
+        if path.is_file():
+            files.setdefault(path, False)
+    return sorted(files.items())
+
+
+def strip_link_title(raw_target: str) -> str:
+    target = raw_target.strip()
+    if target.startswith("<") and ">" in target:
+        return target[1 : target.index(">")]
+    return target.split(maxsplit=1)[0]
+
+
+def has_placeholder(path: str) -> bool:
+    return any(token in path for token in ("*", "{", "}", "<", ">", "$"))
+
+
+def candidate_paths(source: Path, path: str, repo_root: Path) -> list[Path]:
+    decoded = unquote(path)
+    if decoded.startswith("/"):
+        base = (
+            repo_root / "docs" / "website"
+            if source.is_relative_to(repo_root / "docs" / "website")
+            else repo_root
+        )
+        resolved = base / decoded.lstrip("/")
+    else:
+        resolved = source.parent / decoded
+
+    if decoded.endswith("/"):
+        candidates = [resolved / "README.md", resolved / "index.md", resolved]
+    elif not resolved.suffix:
+        candidates = [
+            resolved.with_suffix(".md"),
+            resolved / "README.md",
+            resolved / "index.md",
+            resolved,
+        ]
+    else:
+        candidates = [resolved]
+    return candidates
+
+
+def resolve_target(source: Path, path: str, repo_root: Path) -> Path | None:
+    for candidate in candidate_paths(source, path, repo_root):
+        if candidate.exists():
+            return candidate.resolve()
+    return None
+
+
+def heading_slug(text: str) -> str:
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = text.replace("`", "").replace("*", "")
+    text = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", text)
+    text = text.strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    return re.sub(r"\s+", "-", text)
+
+
+def anchors_for(path: Path) -> set[str]:
+    anchors: set[str] = set()
+    slug_counts: dict[str, int] = {}
+    in_fence = False
+    fence_marker = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        fence = FENCE_RE.match(line)
+        if fence:
+            marker = fence.group(1)[0]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+            continue
+        if in_fence:
+            continue
+        for explicit in re.findall(r'<a\s+(?:name|id)=["\']([^"\']+)["\']', line):
+            anchors.add(explicit)
+        heading = HEADING_RE.match(line)
+        if not heading:
+            continue
+        base = heading_slug(heading.group(2))
+        if not base:
+            continue
+        count = slug_counts.get(base, 0)
+        slug_counts[base] = count + 1
+        anchors.add(base if count == 0 else f"{base}-{count}")
+    return anchors
+
+
+def visible_markdown_text(text: str) -> str:
+    """Mask fenced blocks while preserving source offsets and line numbers."""
+    visible: list[str] = []
+    in_fence = False
+    fence_marker = ""
+    for raw_line in text.splitlines(keepends=True):
+        line = raw_line.rstrip("\r\n")
+        fence = FENCE_RE.match(line)
+        if fence:
+            marker = fence.group(1)[0]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+            visible.append("".join("\n" if char == "\n" else " " for char in raw_line))
+        elif in_fence:
+            visible.append("".join("\n" if char == "\n" else " " for char in raw_line))
+        else:
+            visible.append(raw_line)
+    return "".join(visible)
+
+
+def reasoned_ignore_follows(text: str, end: int) -> bool:
+    line_end = text.find("\n", end)
+    suffix = text[end : line_end if line_end >= 0 else len(text)]
+    ignore = IGNORE_RE.search(suffix)
+    return bool(
+        ignore
+        and ignore.group(1).strip()
+        and re.fullmatch(r"[\s.,;:]*", suffix[: ignore.start()])
+    )
+
+
+def repository_reference(token: str) -> str | None:
+    target = token.strip().rstrip(".,;:")
+    if has_placeholder(target) or "::" in target:
+        return None
+    if target in REPOSITORY_ROOT_FILES or REPOSITORY_PATH_RE.fullmatch(target):
+        return target
+    return None
+
+
+def check_markdown_link(
+    source: Path,
+    line_number: int,
+    raw_target: str,
+    repo_root: Path,
+    anchor_cache: dict[Path, set[str]],
+) -> Diagnostic | None:
+    target = strip_link_title(raw_target)
+    parsed = urlsplit(target)
+    if parsed.scheme.lower() in EXTERNAL_SCHEMES or target.startswith("//"):
+        return None
+    if has_placeholder(parsed.path):
+        return None
+
+    resolved = source.resolve() if not parsed.path else resolve_target(
+        source, parsed.path, repo_root
+    )
+    if resolved is None:
+        return Diagnostic(source, line_number, target)
+
+    if parsed.fragment and resolved.suffix.lower() == ".md":
+        anchors = anchor_cache.setdefault(resolved, anchors_for(resolved))
+        if unquote(parsed.fragment) not in anchors:
+            return Diagnostic(source, line_number, target)
+    return None
+
+
+def check_file(
+    source: Path,
+    repo_root: Path,
+    check_declared_refs: bool,
+    anchor_cache: dict[Path, set[str]],
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    text = source.read_text(encoding="utf-8")
+    visible_text = visible_markdown_text(text)
+    markdown_matches = list(MARKDOWN_LINK_RE.finditer(visible_text))
+    markdown_ranges = [match.span() for match in markdown_matches]
+
+    for match in markdown_matches:
+        if reasoned_ignore_follows(text, match.end()):
+            continue
+        line_number = text.count("\n", 0, match.start()) + 1
+        diagnostic = check_markdown_link(
+            source, line_number, match.group(1), repo_root, anchor_cache
+        )
+        if diagnostic:
+            diagnostics.append(diagnostic)
+
+    in_fence = False
+    fence_marker = ""
+    in_last_verified = False
+    in_implementation_section = False
+    line_start = 0
+
+    for line_number, raw_line in enumerate(text.splitlines(keepends=True), 1):
+        line = raw_line.rstrip("\r\n")
+        fence = FENCE_RE.match(line)
+        if fence:
+            marker = fence.group(1)[0]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+            line_start += len(raw_line)
+            continue
+        if in_fence:
+            line_start += len(raw_line)
+            continue
+
+        if IMPLEMENTATION_HEADING_RE.match(line):
+            in_implementation_section = True
+        elif in_implementation_section and HEADING_RE.match(line):
+            in_implementation_section = False
+
+        if "**Last verified:**" in line:
+            in_last_verified = True
+        elif in_last_verified and not line.lstrip().startswith(">"):
+            in_last_verified = False
+
+        code_matches = list(CODE_SPAN_RE.finditer(line))
+
+        if check_declared_refs and (in_last_verified or in_implementation_section):
+            for match in code_matches:
+                start = line_start + match.start()
+                end = line_start + match.end()
+                if any(
+                    link_start <= start and end <= link_end
+                    for link_start, link_end in markdown_ranges
+                ):
+                    continue
+                if reasoned_ignore_follows(text, end):
+                    continue
+                target = repository_reference(match.group(1))
+                if target and not (repo_root / target).exists():
+                    diagnostics.append(Diagnostic(source, line_number, target))
+
+        line_start += len(raw_line)
+
+    return diagnostics
+
+
+def check_repository(repo_root: Path = REPO_ROOT) -> list[Diagnostic]:
+    anchor_cache: dict[Path, set[str]] = {}
+    diagnostics: list[Diagnostic] = []
+    for source, check_declared_refs in markdown_files(repo_root):
+        diagnostics.extend(
+            check_file(source, repo_root, check_declared_refs, anchor_cache)
+        )
+    return diagnostics
+
+
+def main(repo_root: Path | None = None) -> int:
+    repo_root = repo_root or REPO_ROOT
+    diagnostics = check_repository(repo_root)
+    for diagnostic in diagnostics:
+        print(diagnostic.format(repo_root))
+    if diagnostics:
+        print(f"FOUND {len(diagnostics)} BROKEN CONTRACT REFERENCE(S)")
+        return 1
+    print("ALL CONTRACT REFERENCES OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/website/.tools/test-check-contract-refs.py
+++ b/docs/website/.tools/test-check-contract-refs.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Unit tests for check-contract-refs.py."""
+
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-contract-refs.py")
+SPEC = importlib.util.spec_from_file_location("check_contract_refs", SCRIPT)
+CHECKER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHECKER
+SPEC.loader.exec_module(CHECKER)
+
+
+class ContractReferenceCheckerTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        (self.root / "docs/website/spec").mkdir(parents=True)
+        (self.root / "docs/website/reference").mkdir(parents=True)
+        (self.root / "docs/rfcs").mkdir(parents=True)
+        (self.root / "src/runtime").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def write(self, relative, text):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def diagnostics(self):
+        return CHECKER.check_repository(self.root)
+
+    def test_relative_site_root_and_anchor_links(self):
+        self.write(
+            "docs/website/reference/target.md",
+            "# Target heading\n\n## Repeated\n\n## Repeated\n",
+        )
+        self.write(
+            "docs/website/spec/source.md",
+            "\n".join(
+                (
+                    "[relative](../reference/target.md#target-heading)",
+                    "[site root](/reference/target#repeated-1)",
+                )
+            ),
+        )
+        self.assertEqual(self.diagnostics(), [])
+
+    def test_multiline_markdown_link_is_checked(self):
+        self.write(
+            "docs/website/spec/source.md",
+            "[broken\nlink](missing.md)\n",
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(1, "missing.md")],
+        )
+
+    def test_directory_route_fragment_resolves_index_page(self):
+        self.write("docs/website/concepts/README.md", "# Present\n")
+        self.write(
+            "docs/website/spec/source.md",
+            "[missing anchor](/concepts/#missing)\n",
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(1, "/concepts/#missing")],
+        )
+
+    def test_heading_slug_preserves_word_underscore(self):
+        self.write("docs/website/reference/target.md", "# foo_bar\n")
+        self.write(
+            "docs/website/spec/source.md",
+            "[anchor](../reference/target.md#foo_bar)\n",
+        )
+        self.assertEqual(self.diagnostics(), [])
+
+    def test_missing_path_and_anchor_report_exact_lines(self):
+        source = self.write(
+            "docs/website/spec/source.md",
+            "[missing](missing.md)\n[anchor](#not-present)\n",
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(1, "missing.md"), (2, "#not-present")],
+        )
+        self.assertEqual(
+            diagnostics[0].format(self.root),
+            f"{source.relative_to(self.root).as_posix()}:1:missing.md",
+        )
+
+    def test_last_verified_checks_only_repository_paths(self):
+        self.write("src/runtime/current.rs", "")
+        self.write(
+            "docs/website/spec/source.md",
+            "\n".join(
+                (
+                    "> **Last verified:** against `src/runtime/current.rs`,",
+                    "> `AgentStatus`, and `src/runtime/missing.rs`.",
+                    "",
+                    "Ordinary example: `src/runtime/not-checked.rs`.",
+                )
+            ),
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(2, "src/runtime/missing.rs")],
+        )
+
+    def test_fenced_examples_placeholders_and_rfc_code_spans_are_ignored(self):
+        self.write(
+            "docs/website/spec/source.md",
+            "\n".join(
+                (
+                    "```markdown",
+                    "[example](missing.md)",
+                    "```",
+                    "> **Last verified:** `src/runtime/{future}.rs`.",
+                )
+            ),
+        )
+        self.write(
+            "docs/rfcs/proposed.md",
+            "Proposed path: `src/runtime/future.rs`.\n",
+        )
+        self.assertEqual(self.diagnostics(), [])
+
+    def test_reasoned_line_ignore_suppresses_reference(self):
+        self.write(
+            "docs/website/spec/source.md",
+            (
+                "> **Last verified:** `src/runtime/future.rs` "
+                "<!-- contract-ref-ignore: proposed source split -->\n"
+            ),
+        )
+        self.assertEqual(self.diagnostics(), [])
+
+    def test_reasoned_ignore_suppresses_only_adjacent_reference(self):
+        self.write(
+            "docs/website/spec/source.md",
+            (
+                "> **Last verified:** `src/runtime/missing.rs` and "
+                "`src/runtime/future.rs` "
+                "<!-- contract-ref-ignore: proposed source split -->\n"
+            ),
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(1, "src/runtime/missing.rs")],
+        )
+
+    def test_blank_ignore_reason_does_not_suppress_reference(self):
+        self.write(
+            "docs/website/spec/source.md",
+            (
+                "> **Last verified:** `src/runtime/future.rs` "
+                "<!-- contract-ref-ignore: -->\n"
+            ),
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(diagnostics[0].target, "src/runtime/future.rs")
+
+    def test_declared_refs_cover_ci_and_root_contract_files(self):
+        self.write(
+            "docs/website/spec/source.md",
+            (
+                "## Implementation references\n\n"
+                "- `.github/workflows/missing.yml`\n"
+                "- `Cargo.toml`\n"
+            ),
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(3, ".github/workflows/missing.yml"), (4, "Cargo.toml")],
+        )
+
+    def test_code_formatted_link_is_checked_once(self):
+        self.write(
+            "docs/website/spec/source.md",
+            "## Implementation references\n\n"
+            "[`src/runtime/missing.rs`](missing.md)\n",
+        )
+        diagnostics = self.diagnostics()
+        self.assertEqual(
+            [(item.line, item.target) for item in diagnostics],
+            [(3, "missing.md")],
+        )
+
+    def test_main_prints_machine_locatable_diagnostic(self):
+        self.write("docs/website/spec/source.md", "[missing](missing.md)\n")
+        output = io.StringIO()
+        with redirect_stdout(output):
+            status = CHECKER.main(self.root)
+        self.assertEqual(status, 1)
+        self.assertIn(
+            "docs/website/spec/source.md:1:missing.md", output.getvalue()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -87,16 +87,20 @@ These are maintainer-facing documents; you do not need them to use Holon.
   How Holon's memory layers preserve continuity across turns — work items, work refs, episodes, durable ledger, and indexed search.
   <!-- mdorigin:index kind=article -->
 
+- [Documentation layers](./documentation-layers.md)
+  How Holon separates product docs, current-contract reference, and maintainer design records.
+  <!-- mdorigin:index kind=article -->
+
 - [Trust boundaries](./trust-boundaries.md)
   How Holon classifies origin, trust, and priority to keep long-lived agents secure.
   <!-- mdorigin:index kind=article -->
 
-- [Security and execution boundaries](./security-and-execution-boundaries.md)
-  What Holon does and does not sandbox and how to run agents safely.
+- [External triggers](./external-triggers.md)
+  How Holon agents wait for and receive external events through webhook wake endpoints and callback URLs.
   <!-- mdorigin:index kind=article -->
 
-- [Documentation layers](./documentation-layers.md)
-  How Holon separates user-facing docs, current-contract reference, and maintainer design records — and which layer to read for which question.
+- [Security and execution boundaries](./security-and-execution-boundaries.md)
+  What Holon does and does not sandbox: local execution, workspace binding, remote access, capability secrets, and trust metadata.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/getting-started/README.md
+++ b/docs/website/getting-started/README.md
@@ -76,12 +76,12 @@ This is a short orientation for contributors. End users don't need to know the r
 
 <!-- INDEX:START -->
 
-- [Onboarding guide](./onboarding.md)
-  Interactive setup with `holon onboard` — provider, credential, model, and search configuration.
+- [Create your first agent](./first-agent.md)
+  From zero to your first Holon agent: install, start, TUI basics, create an agent, and configure models.
   <!-- mdorigin:index kind=article -->
 
-- [Create your first agent](./first-agent.md)
-  From zero to your first Holon agent: build, start, TUI basics, create an agent, and configure models.
+- [Onboarding guide](./onboarding.md)
+  Interactive setup with `holon onboard` — provider, credential, model, and search configuration.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -63,16 +63,16 @@ Edit and build the Holon documentation website.
 
 <!-- INDEX:START -->
 
+- [Durable agent workflow](./durable-agent-workflow.md)
+  The end-to-end durable agent story: create an agent, start long-running work, survive disconnects, wait for events, and deliver final briefs.
+  <!-- mdorigin:index kind=article -->
+
 - [holon solve](./solve.md)
   Use holon solve to automate GitHub issues and pull requests in headless mode.
   <!-- mdorigin:index kind=article -->
 
 - [Local runtime](./local-runtime.md)
   A conservative workflow for running and inspecting Holon locally.
-  <!-- mdorigin:index kind=article -->
-
-- [Web GUI](./web-gui.md)
-  Use Holon's embedded web interface to manage agents, monitor runtime state, and configure settings from a browser.
   <!-- mdorigin:index kind=article -->
 
 - [TUI guide](./tui.md)
@@ -103,6 +103,10 @@ Edit and build the Holon documentation website.
   Programmatic access to Holon's HTTP control plane with curl examples and endpoint reference.
   <!-- mdorigin:index kind=article -->
 
+- [Web GUI](./web-gui.md)
+  Use Holon's embedded web interface to manage agents, monitor runtime state, and configure settings from a browser.
+  <!-- mdorigin:index kind=article -->
+
 - [Troubleshooting](./troubleshooting.md)
   Solutions for common Holon issues covering daemon, configuration, model, and TUI problems.
   <!-- mdorigin:index kind=article -->
@@ -115,12 +119,20 @@ Edit and build the Holon documentation website.
   Reusable SKILL.md workflows, skill locations, and how to develop custom skills.
   <!-- mdorigin:index kind=article -->
 
-- [Durable agent workflow](./durable-agent-workflow.md)
-  The end-to-end durable agent story: create an agent, start long-running work, survive disconnects, wait for events, and deliver final briefs.
+- [WebFetch and WebSearch guide](./webfetch-websearch.md)
+  Agent tools for fetching web pages and searching the web — tool reference, extract modes, search providers, and usage patterns.
   <!-- mdorigin:index kind=article -->
 
 - [Work items guide](./work-items.md)
   Durable objective tracking with work items, plans, todo lists, and lifecycle management.
+  <!-- mdorigin:index kind=article -->
+
+- [ViewImage guide](./view-image.md)
+  Agent tool for inspecting local images through vision models — model selection, visual observation, durable metadata, and caching.
+  <!-- mdorigin:index kind=article -->
+
+- [Image Generation guide](./image-generation.md)
+  Agent tool for generating images from text prompts — model selection, size and format options, output management, and caching.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/guides/documentation-workflow.md
+++ b/docs/website/guides/documentation-workflow.md
@@ -27,6 +27,49 @@ docs/website/
 Keep public-facing website copy concise. Detailed runtime contracts and design
 records still belong under the repository `docs/` tree.
 
+## Check contract references
+
+The docs CI checks repository-local Markdown links and heading anchors in:
+
+- `README.md`, `docs/architecture-overview.md`, and `docs/runtime-spec.md`
+- `docs/website/spec/` and `docs/website/reference/`
+- real Markdown links in `docs/rfcs/`
+
+Focused specs may also declare implementation paths in their `Last verified`
+quote or an `Implementation references` section. Write repository paths there
+as code spans, for example:
+
+```markdown
+> **Last verified:** against `src/runtime/scheduler.rs` and
+> `src/runtime/waiting.rs`.
+```
+
+Elsewhere, use a real Markdown link when a source path should be enforced:
+
+```markdown
+[`src/http/mod.rs`](../../../src/http/mod.rs)
+```
+
+Fenced examples, placeholders, and ordinary code spans are not interpreted as
+current implementation contracts. A historical or proposed reference on an
+otherwise checked line can be excluded only by placing a non-empty reason
+immediately after that specific reference:
+
+```markdown
+`src/runtime/proposed.rs` <!-- contract-ref-ignore: proposed file from accepted RFC -->
+```
+
+Run the checks from the repository root:
+
+```bash
+python3 docs/website/.tools/check-links.py
+python3 docs/website/.tools/test-check-contract-refs.py
+python3 docs/website/.tools/check-contract-refs.py
+```
+
+Failures use `file:line:target` diagnostics so editors and CI logs can locate
+the declaration directly.
+
 ## Preview locally
 
 ```bash
@@ -57,6 +100,13 @@ mdorigin build cloudflare --root . --search dist/search
 ```
 
 The generated `dist/` directory is ignored and should not be committed.
+
+## Refresh generated contract snapshots
+
+OpenAPI, HTTP route, CLI, and model tool schema snapshots are checked
+separately by the main CI. Run `make snapshots-check` before publishing a
+contract change. When a change is intentional, run `make snapshots-refresh`,
+review the generated diff, and then rerun `make snapshots-check`.
 
 ## Publishing note
 

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -42,6 +42,10 @@ behavior changes.
   How to think about Holon's headless integration surface.
   <!-- mdorigin:index kind=article -->
 
+- [OpenAPI schema](./openapi.json)
+  Generated baseline OpenAPI 3.1 schema for Holon's current HTTP control-plane surface.
+  <!-- mdorigin:index kind=article -->
+
 - [API contract inventory](./api-contract-inventory.md)
   Post-baseline stability inventory for Holon's HTTP control-plane API parameters, responses, and Phase 2 contract work.
   <!-- mdorigin:index kind=article -->

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -19,7 +19,7 @@ behavior changes.
 <!-- INDEX:START -->
 
 - [CLI reference](./cli.md)
-  Holon's current command-line interface — verified against holon --help (v0.14.1).
+  Holon's command-line interface — verified against holon --help (v0.30.0).
   <!-- mdorigin:index kind=article -->
 
 - [CLI contract inventory](./cli-contract-inventory.md)
@@ -42,16 +42,16 @@ behavior changes.
   How to think about Holon's headless integration surface.
   <!-- mdorigin:index kind=article -->
 
-- [OpenAPI schema](./openapi.json)
-  Generated baseline OpenAPI 3.1 schema for Holon's current HTTP control-plane surface.
-  <!-- mdorigin:index kind=article -->
-
 - [API contract inventory](./api-contract-inventory.md)
   Post-baseline stability inventory for Holon's HTTP control-plane API parameters, responses, and Phase 2 contract work.
   <!-- mdorigin:index kind=article -->
 
 - [Model tool schema inventory](./model-tool-schema-inventory.md)
   Versioned inventory for Holon's model-facing built-in tool schemas, result envelopes, and stability labels.
+  <!-- mdorigin:index kind=article -->
+
+- [Supported Models](./models.md)
+  Complete reference of all built-in models and providers supported by Holon.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -13,7 +13,8 @@ gaps that still need stabilization before scripts and integrations can rely on
 the API long term.
 
 - **Last reviewed against:** `holon` v0.14.1, `main` at `bff2293`.
-- **Primary source:** `src/http.rs` Axum router and request/response structs.
+- **Primary source:** [`src/http/mod.rs`](../../../src/http/mod.rs) Axum router
+  and request/response structs.
 - **Generated schema:** [`openapi.json`](./openapi.json), produced by
   `holon::openapi::generate_openapi_json()` and checked by
   `make snapshots-check`.
@@ -41,7 +42,7 @@ the API long term.
 
 | Surface | Current behavior | Stability |
 |---------|------------------|-----------|
-| HTTP TCP | Routes are served by the Axum router in `src/http.rs`. | Candidate stable |
+| HTTP TCP | Routes are served by the Axum router in [`src/http/mod.rs`](../../../src/http/mod.rs). | Candidate stable |
 | Unix socket client fallback | `LocalClient` tries the configured Unix socket first when present, then falls back to HTTP. | Candidate stable for local clients; not documented as a general remote API |
 | Bearer auth | When `require_control_token` is true, read routes and `/control/*` routes require `Authorization: Bearer <token>`. | Candidate stable |
 | Local mode | When no control token is required, the server trusts the local process boundary. | Candidate stable, but should be tied to explicit deployment guidance |

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -653,7 +653,7 @@ endpoint. A good integration should be able to ask:
 
 ### Routes not yet documented
 
-The following routes exist in `src/http.rs` but are not yet fully documented
+The following routes exist in [`src/http/mod.rs`](../../../src/http/mod.rs) but are not yet fully documented
 on this reference page:
 
 - `GET /api/agents/:id/skills`

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -9,7 +9,9 @@ generated: auto-generated from holon source — do not edit directly
 Holon includes built-in configuration for **33 provider accounts**
 across **42 endpoints** and **256 models**.
 
-This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
+This page is auto-generated from the Holon source code
+([`src/model_catalog.rs`](../../../src/model_catalog.rs) and
+[`src/config/mod.rs`](../../../src/config/mod.rs)).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
 
 Note: subscription-scoped providers such as `dashscope-token-plan` and

--- a/docs/website/spec/README.md
+++ b/docs/website/spec/README.md
@@ -58,7 +58,7 @@ Each spec page follows a consistent shape:
   <!-- mdorigin:index kind=article -->
 
 - [Tasks](./tasks.md)
-  Current task lifecycle, background blocking, terminal re-entry, and command/child-agent supervision contract.
+  Current task lifecycle, terminal re-entry, and command/child-agent supervision contract.
   <!-- mdorigin:index kind=article -->
 
 - [Tools](./tools.md)
@@ -70,7 +70,7 @@ Each spec page follows a consistent shape:
   <!-- mdorigin:index kind=article -->
 
 - [Trust and provenance](./trust-and-provenance.md)
-  Current origin classification, admission/authentication, authority, and provenance tracking contract.
+  Current provenance, admission/authentication, instruction authority, and execution policy contract.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -13,7 +13,7 @@ as of the last review date noted below.
 > **Last verified:** 2026-05-27 against `src/types.rs` `AgentState`,
 > `AgentStatus`, `AgentIdentityView`, `AgentSchedulingPosture`,
 > `AgentPostureProjection`, `ClosureDecision`, `ContinuationResolution`,
-> `RuntimePosture`, and `AgentSummary`; `src/storage.rs`
+> `RuntimePosture`, and `AgentSummary`; `src/storage/mod.rs`
 > `agent_posture_projection`; `src/runtime/lifecycle.rs` `agent_summary`;
 > `src/runtime/closure.rs` closure derivation; and `src/tool/tools/agent_get.rs`.
 

--- a/docs/website/spec/trust-and-provenance.md
+++ b/docs/website/spec/trust-and-provenance.md
@@ -12,8 +12,8 @@ policy — and how those labels flow through the runtime.
 
 > **Last verified:** 2026-05-27 against `src/types.rs` `MessageEnvelope`,
 > `MessageOrigin`, `AuthorityClass`, `MessageDeliverySurface`,
-> `AdmissionContext`, `src/policy.rs`, `src/ingress.rs`, `src/http.rs`,
-> `src/context.rs`, `src/prompt/mod.rs`, `src/operator_event.rs`,
+> `AdmissionContext`, `src/policy.rs`, `src/ingress.rs`, `src/http/mod.rs`,
+> `src/context/mod.rs`, `src/prompt/mod.rs`, `src/operator_event.rs`,
 > `src/presentation.rs`, `src/runtime/message_dispatch.rs`, and
 > `src/runtime/operator_dispatch.rs`.
 
@@ -148,7 +148,8 @@ public contract. Current code keeps compatibility in two places:
   `trusted_operator`, `trusted_system`, `trusted_integration`, and
   `untrusted_external`.
 
-`src/context.rs` still renders a `trust=` label in model context for backward
+[`src/context/mod.rs`](../../../src/context/mod.rs) still renders a `trust=`
+label in model context for backward
 readability, but it is derived from `authority_class`. New docs and new
 contracts should name `authority_class` directly.
 
@@ -225,14 +226,18 @@ Validated implementation points:
   compatibility.
 - `src/policy.rs` defines default authority by origin and kind/origin admission
   checks.
-- `src/http.rs` prevents public enqueue from using runtime-owned kinds,
+- [`src/http/mod.rs`](../../../src/http/mod.rs) prevents public enqueue from
+  using runtime-owned kinds,
   `Interject` priority, privileged origins, or authority overrides.
-- `src/context.rs` and `src/prompt/mod.rs` expose authority/provenance labels to
-  the model and preserve the external-evidence trust boundary in prompt
-  instructions.
-- `src/runtime/message_dispatch.rs`, `src/runtime/operator_dispatch.rs`, and
-  `src/runtime/turn.rs` include provenance labels in queue, processing,
-  transcript, and interjection events.
+- [`src/context/mod.rs`](../../../src/context/mod.rs) and
+  [`src/prompt/mod.rs`](../../../src/prompt/mod.rs) expose
+  authority/provenance labels to the model and preserve the external-evidence
+  trust boundary in prompt instructions.
+- [`src/runtime/message_dispatch.rs`](../../../src/runtime/message_dispatch.rs),
+  [`src/runtime/operator_dispatch.rs`](../../../src/runtime/operator_dispatch.rs),
+  and [`src/runtime/turn/execution.rs`](../../../src/runtime/turn/execution.rs)
+  include provenance labels in queue, processing, transcript, and interjection
+  events.
 - `src/operator_event.rs` and `src/presentation.rs` keep raw event provenance
   available while rendering operator-origin messages as user messages.
 

--- a/src/bin/holon-docgen.rs
+++ b/src/bin/holon-docgen.rs
@@ -65,7 +65,9 @@ generated: auto-generated from holon source — do not edit directly
 Holon includes built-in configuration for **{provider_account_count} provider accounts**
 across **{endpoint_count} endpoints** and **{model_count} models**.
 
-This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
+This page is auto-generated from the Holon source code
+([`src/model_catalog.rs`](../../../src/model_catalog.rs) and
+[`src/config/mod.rs`](../../../src/config/mod.rs)).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
 
 Note: subscription-scoped providers such as `dashscope-token-plan` and


### PR DESCRIPTION
## 变更概述

- 新增低误判的 runtime contract reference checker，检查显式 Markdown 内部链接、heading anchors，以及 focused spec 的 `Last verified` / `Implementation references` 源码路径声明
- 固定失败诊断格式为 `file:line:target`，并以 13 个单元测试覆盖 missing path/link/anchor、跨行链接、目录路由、重复 heading、fenced example、placeholder 与逐目标带理由豁免
- 修复当前 authoritative docs 中迁移前源码路径，更新 generated model reference 与目录索引
- 扩展 docs workflow 触发范围至顶层 runtime docs/RFC，并在 PR 中运行检查但跳过 Cloudflare 部署
- 补充文档维护指南，说明受检范围、引用写法、豁免规则和 snapshot 工作流

## 验证

- `python3 docs/website/.tools/test-check-contract-refs.py`
- `python3 docs/website/.tools/check-contract-refs.py`
- `python3 docs/website/.tools/check-links.py`
- Python 3.9：13 个 checker tests 通过
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo fmt --all -- --check`
- generated model reference 一致性检查
- `git diff --check`

本机完整 docs search/build 无法完成：当前主机为 glibc 2.35，而锁定的 `@indexbind/native-linux-x64-gnu` 0.6.3 预编译件要求 glibc 2.39。Node 22.23.1 下依赖安装、link checker、contract checker 和 index generation 均已通过；完整 docs build 交由 GitHub Actions runner 验证。

Closes #2274 的第一阶段；结构化 enum/tool result contract drift 将在本 PR 合并后的独立 PR 中交付。
