### PR TITLE
fix: reconcile Web GUI state after resume

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -66,6 +66,7 @@ export function App() {
   const displayLevel = useRuntimeStore((state) =>
     state.displayLevelsByAgentId[selectedAgentId] ?? "info",
   );
+  const resumeRevision = useRuntimeStore((state) => state.resumeRevision);
   const rightPanelOpen = useRuntimeStore((state) => state.rightPanelOpen);
   const rightPanelView = useRuntimeStore((state) => state.rightPanelView);
   const navCollapsed = useRuntimeStore((state) => state.navCollapsed);
@@ -589,6 +590,7 @@ export function App() {
             loadingOlderEvents={selectedAgentSession?.loadingOlder ?? false}
             historyError={selectedAgentSession?.historyError}
             targetEventSeq={selectedAgentSession?.targetEventSeq}
+            resumeRevision={resumeRevision}
             onRefreshModels={refreshModelCatalog}
             onSetModel={(model, reasoningEffort) => setAgentModel(activeAgent.id, model, displayLevel, reasoningEffort)}
             onClearModel={() => clearAgentModel(activeAgent.id, displayLevel)}

--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -2,11 +2,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   attachmentKindForFile,
+  captureScrollAnchor,
   readStoredComposerDraft,
   resizeComposerTextarea,
+  restoredScrollTop,
   storedComposerDraftKey,
+  timelineLayoutRevision,
   writeStoredComposerDraft,
 } from "./AgentPage";
+import type { TimelineTurn } from "./timeline-utils";
 
 class MemoryStorage implements Storage {
   private readonly items = new Map<string, string>();
@@ -99,3 +103,56 @@ describe("composer attachments", () => {
     expect(attachmentKindForFile({ type: "" })).toBe("file");
   });
 });
+
+describe("timeline virtual layout reconciliation", () => {
+  it("changes the layout revision when hydrated content replaces a preview under the same turn id", () => {
+    const preview = timelineTurn("turn:assistant", "Short preview");
+    const hydrated = timelineTurn("turn:assistant", "Short preview\n\nExpanded hydrated transcript body.");
+
+    expect(timelineLayoutRevision([hydrated])).not.toBe(timelineLayoutRevision([preview]));
+  });
+
+  it("keeps the same visible turn offset after measurements change", () => {
+    const anchor = captureScrollAnchor(
+      [
+        { key: "turn:a", start: 0, size: 120 },
+        { key: "turn:b", start: 120, size: 200 },
+      ],
+      164,
+    );
+
+    expect(anchor).toEqual({ key: "turn:b", offset: 44 });
+    expect(restoredScrollTop(anchor, [{ key: "turn:b", start: 180 }], 164)).toBe(224);
+  });
+
+  it("falls back to the original scroll top when the anchored turn is no longer measured", () => {
+    const anchor = captureScrollAnchor([{ key: "turn:a", start: 20, size: 80 }], 44);
+
+    expect(restoredScrollTop(anchor, [{ key: "turn:b", start: 120 }], 44)).toBe(44);
+  });
+
+  it("does not capture an anchor when only overscan rows before the viewport are measured", () => {
+    expect(captureScrollAnchor([{ key: "turn:a", start: 0, size: 80 }], 120)).toBeNull();
+  });
+});
+
+function timelineTurn(turnId: string, body: string): TimelineTurn {
+  return {
+    id: turnId,
+    kind: "runtime",
+    label: "Turn",
+    timestamp: "2026-07-19T00:00:00.000Z",
+    items: [
+      {
+        id: "assistant-message",
+        kind: "assistant",
+        label: "Assistant",
+        body,
+        timestamp: "2026-07-19T00:00:00.000Z",
+        meta: "assistant",
+        minDisplayLevel: "info",
+        sourceIds: ["event:1"],
+      },
+    ],
+  };
+}

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -6,16 +6,16 @@ import {
 } from "lucide-react";
 import {
   useEffect, useLayoutEffect, useMemo, useRef, useState,
-  type DragEvent, type FormEvent, type KeyboardEvent,
+  type DragEvent, type FormEvent, type KeyboardEvent, type MutableRefObject, type RefObject,
 } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useVirtualizer, type VirtualItem, type Virtualizer } from "@tanstack/react-virtual";
 
 import { Button } from "../../components/ui/Button";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { deriveAgentDisplayStatus } from "../../runtime/agent-status";
 import { debugAgentSessionEvents, filterTimelineByDisplayLevel } from "../../runtime/session-reducer";
 import { TimelineTurnGroup, WorkingIndicator } from "./AgentTimeline";
-import { collectWorkingActivitiesForCurrentTurn, groupTimelineTurns, itemHasEventSeq } from "./timeline-utils";
+import { collectWorkingActivitiesForCurrentTurn, groupTimelineTurns, itemHasEventSeq, type TimelineTurn } from "./timeline-utils";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type {
@@ -42,6 +42,7 @@ interface AgentPageProps {
   modelCatalogError?: string;
   historyError?: string;
   targetEventSeq?: number;
+  resumeRevision?: number;
   onRefreshModels: () => Promise<void>;
   onSetModel: (model: string, reasoningEffort?: string) => Promise<void>;
   onClearModel: () => Promise<void>;
@@ -112,6 +113,158 @@ export function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.overflowY = textarea.scrollHeight > COMPOSER_TEXTAREA_MAX_HEIGHT ? "auto" : "hidden";
 }
 
+export interface ScrollAnchor {
+  key: VirtualItem["key"];
+  offset: number;
+}
+
+export function captureScrollAnchor(virtualItems: Pick<VirtualItem, "key" | "start" | "size">[], scrollTop: number): ScrollAnchor | null {
+  const anchorItem = virtualItems.find((item) => item.start + item.size > scrollTop);
+  return anchorItem ? { key: anchorItem.key, offset: Math.max(0, scrollTop - anchorItem.start) } : null;
+}
+
+export function restoredScrollTop(
+  anchor: ScrollAnchor | null,
+  measuredItems: Pick<VirtualItem, "key" | "start">[],
+  fallbackTop: number,
+): number {
+  if (!anchor) return fallbackTop;
+  const measured = measuredItems.find((item) => item.key === anchor.key);
+  return measured ? Math.max(0, measured.start + anchor.offset) : fallbackTop;
+}
+
+export function timelineLayoutRevision(turns: TimelineTurn[]): string {
+  let hash = 2166136261;
+  let fieldCount = 0;
+  const add = (value: unknown) => {
+    const text = value == null ? "" : String(value);
+    fieldCount += 1;
+    hash = fnv1a(`${text.length}:${text}`, hash);
+  };
+
+  for (const turn of turns) {
+    add(turn.id);
+    add(turn.kind);
+    add(turn.label);
+    add(turn.timestamp);
+    add(turn.items.length);
+    for (const item of turn.items) {
+      add(item.id);
+      add(item.kind);
+      add(item.label);
+      add(item.body);
+      add(item.meta);
+      add(item.minDisplayLevel);
+      add(item.detail?.label);
+      add(item.detail?.text);
+      add(item.detail?.tone);
+      add(item.executionMeta?.outcome);
+      add(item.executionMeta?.exitStatus);
+      add(item.executionMeta?.durationMs);
+      add(item.executionMeta?.outputTruncated);
+      add(item.executionMeta?.taskId);
+      add(item.statusTrail?.length ?? 0);
+      for (const step of item.statusTrail ?? []) {
+        add(step.status);
+        add(step.timestamp);
+      }
+      add(item.activities?.length ?? 0);
+      for (const activity of item.activities ?? []) {
+        add(activity.id);
+        add(activity.kind);
+        add(activity.label);
+        add(activity.body);
+        add(activity.meta);
+        add(activity.minDisplayLevel);
+        add(activity.detail?.label);
+        add(activity.detail?.text);
+        add(activity.detail?.tone);
+        add(activity.executionMeta?.outcome);
+        add(activity.executionMeta?.exitStatus);
+        add(activity.executionMeta?.durationMs);
+        add(activity.executionMeta?.outputTruncated);
+        add(activity.executionMeta?.taskId);
+        add(activity.statusTrail?.length ?? 0);
+        for (const step of activity.statusTrail ?? []) {
+          add(step.status);
+          add(step.timestamp);
+        }
+      }
+    }
+  }
+
+  return `${turns.length}:${fieldCount}:${hash.toString(36)}`;
+}
+
+function fnv1a(text: string, initialHash: number): number {
+  let hash = initialHash;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function useReconciledVirtualMeasurements({
+  virtualizer,
+  scrollElementRef,
+  layoutRevision,
+  stickToBottomRef,
+  scrollToBottom,
+}: {
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
+  scrollElementRef: RefObject<HTMLDivElement | null>;
+  layoutRevision: string;
+  stickToBottomRef: MutableRefObject<boolean>;
+  scrollToBottom: () => void;
+}) {
+  const scrollToBottomRef = useRef(scrollToBottom);
+  const rafRef = useRef<{ measure: number | null; restore: number | null }>({ measure: null, restore: null });
+
+  useLayoutEffect(() => {
+    scrollToBottomRef.current = scrollToBottom;
+  }, [scrollToBottom]);
+
+  useLayoutEffect(() => {
+    const list = scrollElementRef.current;
+    if (!list) return;
+
+    const wasAtBottom = stickToBottomRef.current || isScrolledNearBottom(list);
+    const anchor = wasAtBottom ? null : captureScrollAnchor(virtualizer.getVirtualItems(), list.scrollTop);
+    const fallbackTop = list.scrollTop;
+    cancelReconciledMeasurement(rafRef.current);
+
+    rafRef.current.measure = window.requestAnimationFrame(() => {
+      rafRef.current.measure = null;
+      virtualizer.measure();
+      rafRef.current.restore = window.requestAnimationFrame(() => {
+        rafRef.current.restore = null;
+        const currentList = scrollElementRef.current;
+        if (!currentList) return;
+        if (wasAtBottom) {
+          scrollToBottomRef.current();
+          return;
+        }
+        stickToBottomRef.current = false;
+        currentList.scrollTop = restoredScrollTop(anchor, virtualizer.getVirtualItems(), fallbackTop);
+      });
+    });
+
+    return () => cancelReconciledMeasurement(rafRef.current);
+  }, [layoutRevision, scrollElementRef, stickToBottomRef, virtualizer]);
+}
+
+function cancelReconciledMeasurement(raf: { measure: number | null; restore: number | null }): void {
+  if (raf.measure !== null) {
+    window.cancelAnimationFrame(raf.measure);
+    raf.measure = null;
+  }
+  if (raf.restore !== null) {
+    window.cancelAnimationFrame(raf.restore);
+    raf.restore = null;
+  }
+}
+
 export function AgentPage({
   agent,
   detail,
@@ -126,6 +279,7 @@ export function AgentPage({
   modelCatalogError,
   historyError,
   targetEventSeq,
+  resumeRevision = 0,
   onRefreshModels,
   onSetModel,
   onClearModel,
@@ -185,6 +339,7 @@ export function AgentPage({
   const canSendPrompt = (trimmedPrompt.length > 0 || attachments.length > 0) && !sendingPrompt;
   const newestTimelineItem = timeline[timeline.length - 1];
   const timelineVersion = `${timeline.length}:${newestTimelineItem?.id ?? ""}:${timeline[0]?.id ?? ""}:${detail?.events?.length ?? 0}:${hasOlderEvents}`;
+  const timelineLayoutVersion = useMemo(() => `${resumeRevision}:${timelineLayoutRevision(timelineTurns)}`, [resumeRevision, timelineTurns]);
   const hasHiddenTimelineItems = timeline.length >= visibleTimelineItemLimit && sourceTimeline.length > visibleTimelineItemLimit;
   const groupedModelOptions = useMemo(() => groupModelOptionsByProvider(modelCatalog.options), [modelCatalog.options]);
   const activeModelOption = useMemo(() => modelCatalog.options.find((option) => option.routeRef === activeAgent.model), [activeAgent.model, modelCatalog.options]);
@@ -286,6 +441,14 @@ export function AgentPage({
       scrollToConversationBottom();
     }
   }, [timelineVersion]);
+
+  useReconciledVirtualMeasurements({
+    virtualizer: rowVirtualizer,
+    scrollElementRef: messageListRef,
+    layoutRevision: timelineLayoutVersion,
+    stickToBottomRef,
+    scrollToBottom: scrollToConversationBottom,
+  });
 
   useLayoutEffect(() => {
     if (!targetTimelineItemId) return;

--- a/web-gui/app/src/runtime/resume-reconciliation.test.ts
+++ b/web-gui/app/src/runtime/resume-reconciliation.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ResumeReconciliationCoordinator } from "./resume-reconciliation";
+
+const scheduler = {
+  setTimeout: (callback: () => void, delayMs: number) =>
+    setTimeout(callback, delayMs) as unknown as number,
+  clearTimeout: (timer: number) => clearTimeout(timer),
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("ResumeReconciliationCoordinator", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces visibility, pageshow, and online notifications into one reconciliation", async () => {
+    vi.useFakeTimers();
+    const reconcile = vi.fn(async () => undefined);
+    const coordinator = new ResumeReconciliationCoordinator(reconcile, scheduler, 100);
+
+    coordinator.schedule();
+    coordinator.schedule();
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    coordinator.dispose();
+  });
+
+  it("never overlaps reconciliations and runs one trailing reconciliation when needed", async () => {
+    vi.useFakeTimers();
+    const first = deferred();
+    const reconcile = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const coordinator = new ResumeReconciliationCoordinator(reconcile, scheduler, 100);
+
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(100);
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+
+    first.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(reconcile).toHaveBeenCalledTimes(2);
+    coordinator.dispose();
+  });
+
+  it("can schedule another reconciliation after a failed attempt", async () => {
+    vi.useFakeTimers();
+    const reconcile = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(undefined);
+    const coordinator = new ResumeReconciliationCoordinator(reconcile, scheduler, 100);
+
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(100);
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(reconcile).toHaveBeenCalledTimes(2);
+    coordinator.dispose();
+  });
+});

--- a/web-gui/app/src/runtime/resume-reconciliation.ts
+++ b/web-gui/app/src/runtime/resume-reconciliation.ts
@@ -1,0 +1,52 @@
+export interface ResumeReconciliationScheduler {
+  setTimeout(callback: () => void, delayMs: number): number;
+  clearTimeout(timer: number): void;
+}
+
+export class ResumeReconciliationCoordinator {
+  private timer: number | undefined;
+  private inFlight: Promise<void> | undefined;
+  private rerunRequested = false;
+
+  constructor(
+    private readonly reconcile: () => Promise<void>,
+    private readonly scheduler: ResumeReconciliationScheduler,
+    private readonly delayMs = 100,
+  ) {}
+
+  schedule(): void {
+    if (this.timer != null) {
+      this.scheduler.clearTimeout(this.timer);
+    }
+    this.timer = this.scheduler.setTimeout(() => {
+      this.timer = undefined;
+      this.run();
+    }, this.delayMs);
+  }
+
+  dispose(): void {
+    if (this.timer != null) {
+      this.scheduler.clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.rerunRequested = false;
+  }
+
+  private run(): void {
+    if (this.inFlight) {
+      this.rerunRequested = true;
+      return;
+    }
+
+    const reconciliation = this.reconcile();
+    this.inFlight = reconciliation;
+    const settle = () => {
+      if (this.inFlight !== reconciliation) return;
+      this.inFlight = undefined;
+      if (!this.rerunRequested) return;
+      this.rerunRequested = false;
+      this.schedule();
+    };
+    void reconciliation.then(settle, settle);
+  }
+}

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -6,9 +6,11 @@ import {
   hasEventIdentityConflict,
   isLoopbackWebHostname,
   materializeProjectionDetail,
+  mergeBootstrapAgentState,
   mergeCachedSessionIntoCurrent,
   missingBriefIdsForHydration,
   readStoredRemoteConnectionProfiles,
+  resetSessionsForResume,
   readStoredRuntimeConnectionConfig,
   sessionForEventLogEpoch,
   streamEventFromBackfill,
@@ -17,6 +19,7 @@ import {
 import type { StreamEventEnvelopeDto } from "./client";
 import type { AgentSessionState } from "./runtime-store";
 import { createSessionProjectionState, reduceSessionProjection } from "./session-projection";
+import type { AgentSummary } from "./types";
 
 class MemoryStorage implements Storage {
   private readonly items = new Map<string, string>();
@@ -60,6 +63,95 @@ function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionS
     ...overrides,
   };
 }
+
+function agentSummary(overrides: Partial<AgentSummary> = {}): AgentSummary {
+  return {
+    id: "agent-a",
+    badge: "A",
+    profile: "default",
+    lifecycle: "asleep",
+    focusSummary: "",
+    workspace: "",
+    attention: "",
+    model: "default",
+    footer: "",
+    subtitle: "",
+    lastBrief: "",
+    lastTurnTime: "",
+    pending: 0,
+    activeTaskCount: 0,
+    waitingCount: 0,
+    posture: "",
+    postureReason: "",
+    ...overrides,
+  };
+}
+
+describe("agent snapshot merging", () => {
+  it("lets a fresh bootstrap snapshot clear cached running state and counts", () => {
+    const cached = agentSummary({
+      lifecycle: "awake-running",
+      currentRunId: "run-old",
+      pending: 3,
+      activeTaskCount: 2,
+      waitingCount: 1,
+      tasks: [{ id: "task-old", kind: "command", status: "running", summary: "old" }],
+    });
+    const fresh = agentSummary({
+      lifecycle: "asleep",
+      currentRunId: null,
+      pending: 0,
+      activeTaskCount: 0,
+      waitingCount: 0,
+      tasks: [],
+    });
+
+    expect(mergeBootstrapAgentState(fresh, cached)).toMatchObject({
+      lifecycle: "asleep",
+      currentRunId: null,
+      pending: 0,
+      activeTaskCount: 0,
+      waitingCount: 0,
+    });
+  });
+
+  it("preserves rich detail omitted by the bootstrap snapshot", () => {
+    const cachedWorkItem = { id: "work-1", objective: "Preserve me", state: "open", current: true };
+    const cached = agentSummary({
+      currentWork: cachedWorkItem,
+      workItems: [cachedWorkItem],
+      tasks: [{ id: "task-old", kind: "command", status: "completed", summary: "cached" }],
+      attachedWorkspaces: [{ workspaceId: "ws-1", name: "repo", anchor: "/repo" }],
+    });
+
+    expect(mergeBootstrapAgentState(agentSummary(), cached)).toMatchObject({
+      currentWork: cachedWorkItem,
+      workItems: [cachedWorkItem],
+      tasks: cached.tasks,
+      attachedWorkspaces: cached.attachedWorkspaces,
+    });
+  });
+});
+
+describe("resume session reset", () => {
+  it("clears stale transport loading state before reconciliation restarts", () => {
+    const reset = resetSessionsForResume({
+      "agent-a": sessionState({
+        loading: true,
+        loadingOlder: true,
+        liveStatus: "recovering",
+        reconnectAttempt: 4,
+      }),
+    });
+
+    expect(reset["agent-a"]).toMatchObject({
+      loading: false,
+      loadingOlder: false,
+      liveStatus: "stale",
+      reconnectAttempt: 0,
+    });
+  });
+});
 
 describe("runtime event epoch", () => {
   it("drops seq-indexed history and hydration caches when the epoch changes", () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -8,6 +8,7 @@ import {
 } from "./client";
 import { EventGapRecoveryTracker, recoverEventGap } from "./event-gap-recovery";
 import { cacheClearRemote } from "./idb-cache";
+import { ResumeReconciliationCoordinator } from "./resume-reconciliation";
 import {
   currentRemoteKey,
   hydrateAllSessions,
@@ -75,6 +76,7 @@ export type { AgentLiveStatus, AgentSessionState };
 
 export interface BootstrapRefreshOptions {
   background?: boolean;
+  syncEvents?: boolean;
 }
 
 function createLiveAgentDetail(agent: AgentSummary | undefined): AgentDetail | null {
@@ -87,8 +89,8 @@ function createLiveAgentDetail(agent: AgentSummary | undefined): AgentDetail | n
   };
 }
 
-function mergeCachedAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummary): AgentSummary {
-  const merged: AgentSummary = {
+export function mergeBootstrapAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummary): AgentSummary {
+  return {
     ...httpAgent,
     currentWork: cachedAgent.currentWork ?? httpAgent.currentWork,
     workItems: cachedAgent.workItems?.length ? cachedAgent.workItems : httpAgent.workItems,
@@ -97,9 +99,6 @@ function mergeCachedAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummar
     // "tasks not included" (from /agents/list). Only overwrite cached tasks
     // when the HTTP source actually carries task data.
     tasks: httpAgent.tasks?.length ? httpAgent.tasks : (cachedAgent.tasks ?? []),
-    activeTaskCount: httpAgent.tasks?.length ? httpAgent.activeTaskCount : Math.max(cachedAgent.activeTaskCount ?? 0, httpAgent.activeTaskCount ?? 0),
-    waitingCount: Math.max(httpAgent.waitingCount, cachedAgent.waitingCount),
-    pending: Math.max(httpAgent.pending, cachedAgent.pending),
     // Trust HTTP state for workspace — it changes via UseWorkspace and must reflect fresh data.
     workspaceSummary: httpAgent.workspaceSummary ?? cachedAgent.workspaceSummary,
     // Unified workspaces array from /state endpoint; fall back to cache when
@@ -108,7 +107,10 @@ function mergeCachedAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummar
       ? httpAgent.attachedWorkspaces
       : cachedAgent.attachedWorkspaces,
   };
+}
 
+function mergeNewerLiveAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummary): AgentSummary {
+  const merged = mergeBootstrapAgentState(httpAgent, cachedAgent);
   if (!isLiveRunningAgent(cachedAgent)) return merged;
   return {
     ...merged,
@@ -130,7 +132,7 @@ function cachedAgentsByIdFromState(state: RuntimeStoreState): Record<string, Age
   for (const session of Object.values(state.sessionsByAgentId)) {
     const agent = session.detail?.agent;
     if (!agent) continue;
-    agentsById[agent.id] = agentsById[agent.id] ? mergeCachedAgentState(agentsById[agent.id], agent) : agent;
+    agentsById[agent.id] = agentsById[agent.id] ? mergeBootstrapAgentState(agentsById[agent.id], agent) : agent;
   }
   return agentsById;
 }
@@ -287,6 +289,7 @@ export interface RuntimeStoreState {
   rosterActivityByAgentId: Record<string, AgentRosterActivity>;
   sessionsByAgentId: Record<string, AgentSessionState>;
   skillInstallJobs: SkillInstallJob[];
+  resumeRevision: number;
 
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string, targetEventSeq?: number) => void;
@@ -318,6 +321,7 @@ export interface RuntimeStoreState {
   toggleNavCollapsed: () => void;
   setRuntimeConnection: (config: RuntimeConnectionConfig) => Promise<void>;
   refreshBootstrap: (options?: BootstrapRefreshOptions) => Promise<void>;
+  reconcileAfterResume: () => Promise<void>;
   refreshModelCatalog: () => Promise<void>;
   refreshRuntimeConfig: () => Promise<void>;
   updateRuntimeConfig: (updates: Array<{ key: string; value?: unknown; unset?: boolean }>) => Promise<RuntimeConfigState | undefined>;
@@ -439,15 +443,76 @@ const workItemRefreshInFlight = new Set<string>();
 const workItemDetailInFlight = new Set<string>();
 const taskDetailInFlight = new Set<string>();
 const toolExecutionDetailInFlight = new Set<string>();
-const agentStateRefreshInFlight = new Set<string>();
+const agentStateRefreshInFlight = new Map<string, number>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
+let clientGeneration = 0;
+let resumeReconciliationInFlight: Promise<void> | undefined;
+let resumeReconciliationCoordinator: ResumeReconciliationCoordinator | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
 const STREAM_STALE_TIMEOUT_MS = 45_000;
 const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
 const GLOBAL_STREAM_STALE_TIMEOUT_MS = 45_000;
 const GLOBAL_BACKFILL_LIMIT = 100;
+
+function nextClientGeneration(): number {
+  clientGeneration += 1;
+  return clientGeneration;
+}
+
+function isCurrentClientGeneration(generation: number): boolean {
+  return generation === clientGeneration;
+}
+
+function clearInFlightHydration(): void {
+  messageHydrationInFlight.clear();
+  transcriptHydrationInFlight.clear();
+  briefHydrationInFlight.clear();
+}
+
+function cancelClientGenerationWork(): void {
+  bootstrapRefreshInFlight = undefined;
+  if (bootstrapRefreshTimer != null) {
+    window.clearTimeout(bootstrapRefreshTimer);
+    bootstrapRefreshTimer = undefined;
+  }
+  agentStateRefreshInFlight.clear();
+  clearInFlightHydration();
+}
+
+function closeEventStreamsForResume(set: StoreSet): void {
+  stopGlobalEventStream(set);
+  for (const agentId of Array.from(activeEventStreams.keys())) {
+    stopAgentEventStream(agentId, set);
+  }
+  for (const timer of streamFlushTimers.values()) window.clearTimeout(timer);
+  streamFlushTimers.clear();
+  pendingStreamEvents.clear();
+  for (const timer of reconnectTimers.values()) window.clearTimeout(timer);
+  reconnectTimers.clear();
+  for (const timer of staleTimers.values()) window.clearTimeout(timer);
+  staleTimers.clear();
+  globalStreamSubscribedAgents.clear();
+  globalEventRecovery.clear();
+}
+
+export function resetSessionsForResume(
+  sessionsByAgentId: Record<string, AgentSessionState>,
+): Record<string, AgentSessionState> {
+  return Object.fromEntries(
+    Object.entries(sessionsByAgentId).map(([agentId, session]) => [
+      agentId,
+      {
+        ...session,
+        loading: false,
+        loadingOlder: false,
+        liveStatus: "stale" as const,
+        reconnectAttempt: 0,
+      },
+    ]),
+  );
+}
 
 // ─── Session cache (IndexedDB persistence) ──────────────────────────
 let sessionCacheWriter: SessionCacheWriter | null = null;
@@ -888,6 +953,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig)),
   sessionsByAgentId: {},
   skillInstallJobs: loadSkillInstallJobs(),
+  resumeRevision: 0,
 
   setRoute: (route) => set({ route }),
   openSkill: (skillId) => set({ route: "skillDetail", selectedSkillId: skillId }),
@@ -1051,6 +1117,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   toggleNavCollapsed: () => set((state) => ({ navCollapsed: !state.navCollapsed })),
 
   setRuntimeConnection: async (config) => {
+    nextClientGeneration();
     const normalizedBaseUrl = config.mode === "remote" ? normalizeConnectionBaseUrl(config.baseUrl) : "";
     const retainedToken =
       config.mode === "remote" &&
@@ -1073,6 +1140,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     runtimeClient = createRuntimeClient(runtimeClientOptions(normalizedConfig));
     writeStoredRuntimeConnectionConfig(normalizedConfig);
     bootstrapRefreshInFlight = undefined;
+    resumeReconciliationInFlight = undefined;
     for (const subscription of activeEventStreams.values()) subscription.close();
     activeEventStreams.clear();
     pendingStreamEvents.clear();
@@ -1141,6 +1209,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       selectedSkillId: "",
       selectedTemplateId: "",
       route: "dashboard",
+      resumeRevision: get().resumeRevision + 1,
     });
     await get().refreshBootstrap();
     // Initialize cache for the new remote (async, non-blocking).
@@ -1149,15 +1218,17 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   refreshBootstrap: async (options = {}) => {
     if (bootstrapRefreshInFlight) return bootstrapRefreshInFlight;
+    const generation = clientGeneration;
     if (options.background) {
       set({ bootstrapError: undefined });
     } else {
       set({ bootstrapLoading: true, bootstrapError: undefined });
     }
 
-    bootstrapRefreshInFlight = (async () => {
+    const request = (async () => {
       try {
         const bootstrap = await runtimeClient.getBootstrap();
+        if (!isCurrentClientGeneration(generation)) return;
         set((state) => {
           if (bootstrap.connection.source === "fixture" && state.bootstrap.connection.source === "http") {
             return {
@@ -1169,7 +1240,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           const cachedAgentsById = cachedAgentsByIdFromState(state);
           const agents = bootstrap.agents.map((agent) => {
             const cachedAgent = cachedAgentsById[agent.id];
-            return cachedAgent ? mergeCachedAgentState(agent, cachedAgent) : agent;
+            return cachedAgent ? mergeBootstrapAgentState(agent, cachedAgent) : agent;
           });
           return {
             bootstrap: sortBootstrapAgents(
@@ -1194,18 +1265,64 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           );
           return updated ? { sessionsByAgentId: updated } : {};
         });
-        syncGlobalEventRoster(get, set);
+        if (options.syncEvents !== false) {
+          syncGlobalEventRoster(get, set);
+        }
       } catch (error) {
+        if (!isCurrentClientGeneration(generation)) return;
         set({
           bootstrapLoading: false,
           bootstrapError: error instanceof Error ? error.message : String(error),
         });
-      } finally {
-        bootstrapRefreshInFlight = undefined;
       }
     })();
+    bootstrapRefreshInFlight = request;
+    void request.then(() => {
+      if (bootstrapRefreshInFlight === request) {
+        bootstrapRefreshInFlight = undefined;
+      }
+    });
 
-    return bootstrapRefreshInFlight;
+    return request;
+  },
+
+  reconcileAfterResume: async () => {
+    if (resumeReconciliationInFlight) return resumeReconciliationInFlight;
+
+    const generation = nextClientGeneration();
+    cancelClientGenerationWork();
+    closeEventStreamsForResume(set);
+    set((state) => ({
+      resumeRevision: state.resumeRevision + 1,
+      sessionsByAgentId: resetSessionsForResume(state.sessionsByAgentId),
+    }));
+
+    const request = (async () => {
+      try {
+        await get().refreshBootstrap({ background: true, syncEvents: false });
+        if (!isCurrentClientGeneration(generation)) return;
+        await Promise.all(get().bootstrap.agents.map((agent) => get().refreshAgentState(agent.id)));
+        if (!isCurrentClientGeneration(generation)) return;
+        syncGlobalEventRoster(get, set);
+        const selectedAgentId = get().selectedAgentId;
+        if (selectedAgentId) {
+          await get().refreshAgentDetail(selectedAgentId, get().displayLevel);
+        }
+      } finally {
+        if (isCurrentClientGeneration(generation)) {
+          set((state) => ({ resumeRevision: state.resumeRevision + 1 }));
+        }
+      }
+    })();
+    resumeReconciliationInFlight = request;
+    const clearRequest = () => {
+      if (resumeReconciliationInFlight === request) {
+        resumeReconciliationInFlight = undefined;
+      }
+    };
+    void request.then(clearRequest, clearRequest);
+
+    return request;
   },
 
   refreshModelCatalog: async () => {
@@ -1846,6 +1963,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       return;
     }
 
+    const generation = clientGeneration;
     set((state) => ({
       sessionsByAgentId: {
         ...state.sessionsByAgentId,
@@ -1860,13 +1978,16 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
     try {
       const detail = await runtimeClient.getAgentDetail(agentId, displayLevel);
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
       await loadTargetAgentEventWindow(get, set, agentId, displayLevel);
+      if (!isCurrentClientGeneration(generation)) return;
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
       scheduleCacheWrite(get, agentId);
     } catch (error) {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -1906,14 +2027,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   refreshAgentState: async (agentId) => {
     if (!agentId || agentStateRefreshInFlight.has(agentId)) return;
-    agentStateRefreshInFlight.add(agentId);
+    const generation = clientGeneration;
+    agentStateRefreshInFlight.set(agentId, generation);
     try {
       const freshAgent = await runtimeClient.getAgentState(agentId);
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => mergeAgentStateIntoState(state, agentId, freshAgent));
     } catch {
       // Swallow — state refresh is best-effort; the next full detail refresh will recover.
     } finally {
-      agentStateRefreshInFlight.delete(agentId);
+      if (agentStateRefreshInFlight.get(agentId) === generation) {
+        agentStateRefreshInFlight.delete(agentId);
+      }
     }
   },
 
@@ -2010,6 +2135,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     const session = get().sessionsByAgentId[agentId] ?? emptyAgentSession();
     if (session.loadingOlder || !session.hasOlder || session.oldestSeq == null) return;
 
+    const generation = clientGeneration;
     set((state) => ({
       sessionsByAgentId: {
         ...state.sessionsByAgentId,
@@ -2029,6 +2155,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         order: "desc",
         displayLevel,
       });
+      if (!isCurrentClientGeneration(generation)) return;
 
       set((state) =>
         mergeEventPageIntoSession(
@@ -2045,6 +2172,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
     } catch (error) {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -2245,6 +2373,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 // Initialize session cache on first load.
 if (typeof window !== "undefined") {
   initSessionCacheForRemote((partial) => useRuntimeStore.setState(partial), () => useRuntimeStore.getState());
+  resumeReconciliationCoordinator = installResumeReconciliationListeners();
+  void resumeReconciliationCoordinator;
 }
 
 // Resume polling for any skill install jobs persisted from a previous session.
@@ -2254,6 +2384,22 @@ if (typeof window !== "undefined") {
       void pollSkillInstallJob(useRuntimeStore.setState, useRuntimeStore.getState, job.jobId);
     }
   }
+}
+
+function installResumeReconciliationListeners(): ResumeReconciliationCoordinator {
+  const coordinator = new ResumeReconciliationCoordinator(
+    () => useRuntimeStore.getState().reconcileAfterResume(),
+    window,
+    100,
+  );
+  const scheduleIfVisible = () => {
+    if (document.visibilityState === "visible") coordinator.schedule();
+  };
+  const schedule = () => coordinator.schedule();
+  document.addEventListener("visibilitychange", scheduleIfVisible);
+  window.addEventListener("pageshow", schedule);
+  window.addEventListener("online", schedule);
+  return coordinator;
 }
 
 function emptyAgentSession(): AgentSessionState {
@@ -2504,6 +2650,7 @@ function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto)
 }
 
 async function backfillAgentEvents(set: StoreSet, agentId: string, force = false): Promise<void> {
+  const generation = clientGeneration;
   try {
     await recoverEventGap(globalEventRecovery, agentId, {
       force,
@@ -2514,6 +2661,7 @@ async function backfillAgentEvents(set: StoreSet, agentId: string, force = false
           order: "asc",
           limit: GLOBAL_BACKFILL_LIMIT,
         });
+        if (!isCurrentClientGeneration(generation)) return { eventLogEpoch: page.event_log_epoch, events: [] };
         return {
           eventLogEpoch: page.event_log_epoch,
           events: (page.events ?? [])
@@ -2521,7 +2669,11 @@ async function backfillAgentEvents(set: StoreSet, agentId: string, force = false
             .map((event) => streamEventFromBackfill(event, agentId, page.event_log_epoch)),
         };
       },
-      applyEvents: (events) => applyStreamEvents(set, agentId, events),
+      applyEvents: (events) => {
+        if (isCurrentClientGeneration(generation)) {
+          applyStreamEvents(set, agentId, events);
+        }
+      },
     });
   } catch {
     // Silently ignore backfill errors; the stream will retry.
@@ -3296,7 +3448,7 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
     ? resetSessionForEventConflict(epochSession, detail.eventLogEpoch)
     : epochSession;
   const liveDetailIsNewer = (current.newestSeq ?? 0) > Math.max(detail.eventCursorSeq ?? 0, detail.newestEventSeq ?? 0);
-  const agent = liveDetailIsNewer && current.detail ? mergeCachedAgentState(detail.agent, current.detail.agent) : detail.agent;
+  const agent = liveDetailIsNewer && current.detail ? mergeNewerLiveAgentState(detail.agent, current.detail.agent) : detail.agent;
   const detailBase: AgentDetail = {
     ...detail,
     agent,
@@ -3350,12 +3502,14 @@ async function catchUpAgentEvents(
   agentId: string,
   _displayLevel: DisplayLevel,
 ): Promise<void> {
+  const generation = clientGeneration;
   const afterSeq = get().sessionsByAgentId[agentId]?.newestSeq;
   const page = await runtimeClient.getAgentEvents(agentId, {
     afterSeq,
     limit: 100,
     order: "asc",
   });
+  if (!isCurrentClientGeneration(generation)) return;
   set((state) =>
     mergeEventPageIntoSession(state, agentId, page.events ?? [], page.oldest_seq ?? undefined, page.has_older, "debug", {
       newestSeq: page.cursor_seq ?? page.newest_seq ?? undefined,
@@ -3509,12 +3663,15 @@ function scheduleMessageHydration(
   if (!requestIds.length) return;
   requestIds.forEach((messageId) => inFlight.add(messageId));
 
+  const generation = clientGeneration;
   void runtimeClient
     .getAgentMessagesBatch(agentId, requestIds)
     .then((response) => {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => mergeHydratedMessagesIntoSession(state, agentId, response.messages ?? [], response.missing_message_ids ?? [], displayLevel));
     })
     .catch((error) => {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -3526,6 +3683,7 @@ function scheduleMessageHydration(
       }));
     })
     .finally(() => {
+      if (!isCurrentClientGeneration(generation)) return;
       const current = messageHydrationInFlight.get(agentId);
       if (!current) return;
       requestIds.forEach((messageId) => current.delete(messageId));
@@ -3552,9 +3710,11 @@ function scheduleTranscriptHydration(
   if (!requestIds.length) return;
   requestIds.forEach((entryId) => inFlight.add(entryId));
 
+  const generation = clientGeneration;
   void runtimeClient
     .getAgentTranscriptEntriesBatch(agentId, requestIds)
     .then((response) => {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) =>
         mergeHydratedTranscriptEntriesIntoSession(
           state,
@@ -3566,6 +3726,7 @@ function scheduleTranscriptHydration(
       );
     })
     .catch((error) => {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -3577,6 +3738,7 @@ function scheduleTranscriptHydration(
       }));
     })
     .finally(() => {
+      if (!isCurrentClientGeneration(generation)) return;
       const current = transcriptHydrationInFlight.get(agentId);
       if (!current) return;
       requestIds.forEach((entryId) => current.delete(entryId));
@@ -3603,12 +3765,15 @@ function scheduleBriefHydration(
   if (!requestIds.length) return;
   requestIds.forEach((briefId) => inFlight.add(briefId));
 
+  const generation = clientGeneration;
   void runtimeClient
     .getAgentBriefsById(agentId, requestIds)
     .then(({ recordsById, notFoundIds }) => {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => mergeHydratedBriefRecordsIntoSession(state, agentId, recordsById, notFoundIds, displayLevel));
     })
     .catch((error) => {
+      if (!isCurrentClientGeneration(generation)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -3620,6 +3785,7 @@ function scheduleBriefHydration(
       }));
     })
     .finally(() => {
+      if (!isCurrentClientGeneration(generation)) return;
       const current = briefHydrationInFlight.get(agentId);
       if (!current) return;
       requestIds.forEach((briefId) => current.delete(briefId));
@@ -3844,6 +4010,7 @@ async function loadTargetAgentEventWindow(
   agentId: string,
   displayLevel: DisplayLevel,
 ): Promise<void> {
+  const generation = clientGeneration;
   const session = get().sessionsByAgentId[agentId];
   const targetEventSeq = session?.targetEventSeq;
   if (targetEventSeq == null || session?.eventsBySeq[targetEventSeq]) return;
@@ -3867,6 +4034,7 @@ async function loadTargetAgentEventWindow(
       order: "asc",
       displayLevel,
     });
+    if (!isCurrentClientGeneration(generation)) return;
     set((state) =>
       mergeEventPageIntoSession(
         state,
@@ -3883,6 +4051,7 @@ async function loadTargetAgentEventWindow(
       ),
     );
   } catch (error) {
+    if (!isCurrentClientGeneration(generation)) return;
     set((state) => ({
       sessionsByAgentId: {
         ...state.sessionsByAgentId,

--- a/web-gui/app/src/runtime/useRuntimeDashboard.ts
+++ b/web-gui/app/src/runtime/useRuntimeDashboard.ts
@@ -28,10 +28,8 @@ export function useRuntimeDashboard(): RuntimeDashboardState {
     };
 
     const interval = window.setInterval(refreshIfVisible, DASHBOARD_AUTO_REFRESH_MS);
-    document.addEventListener("visibilitychange", refreshIfVisible);
     return () => {
       window.clearInterval(interval);
-      document.removeEventListener("visibilitychange", refreshIfVisible);
     };
   }, [refresh]);
 


### PR DESCRIPTION
## 背景

修复 Web GUI 在电脑休眠、页面长时间挂起或网络恢复后出现的会话状态与时间线重同步问题。本次改动来自 operator 报告，当前没有对应的开放 GitHub issue。

## 改动

- 增加合并触发、single-flight 的 resume reconciliation，统一处理 `visibilitychange`、`pageshow` 与 `online`，并通过 client generation 丢弃恢复前迟到的 detail、backfill 与 hydration 结果。
- 让新的 HTTP agent 快照能够把缓存中的 `running`、pending、task 与 waiting 计数降级或清零，同时继续保留 bootstrap 未携带的富详情。
- 在 hydration 或恢复改变时间线内容高度后重新测量虚拟列表；非贴底用户按可见 turn 锚点恢复滚动位置，贴底用户继续保持贴底。
- 补充 resume 协调、状态合并、transport reset、hydration 布局 revision 与滚动锚点回归测试。

## 验证

- `npm test`：24 个测试文件、207 个测试全部通过。
- `npm run build`：TypeScript typecheck 与 Vite production build 通过。
- `git diff --check`：通过。

## 边界

仅修改 Web GUI 客户端恢复与展示逻辑；未改变 Rust runtime、HTTP DTO 或事件协议。
