### PR TITLE
test: detect runtime contract drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,18 @@ transport-types-check: ## Check OpenAPI and generated TypeScript transport type 
 	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
 	cd $(OPENAPI_TOOLS_DIR) && npm ci && npm run check
 
-snapshots-check: ## Check CLI, OpenAPI, HTTP route, and model tool schema snapshots
+snapshots-check: ## Check CLI, OpenAPI, HTTP route, runtime status, and model tool schema snapshots
 	cargo test --test cli_snapshot
 	cargo test --test openapi_snapshot
 	cargo test --test http_route_snapshot
+	cargo test --test runtime_status_inventory_snapshot
 	cargo test --test tool_schema_inventory_snapshot
 
-snapshots-refresh: ## Refresh CLI, OpenAPI, HTTP route, and model tool schema snapshots
+snapshots-refresh: ## Refresh CLI, OpenAPI, HTTP route, runtime status, and model tool schema snapshots
 	cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored
 	cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
 	cargo test --test http_route_snapshot refresh_http_route_inventory_snapshot -- --ignored
+	cargo test --test runtime_status_inventory_snapshot refresh_runtime_status_enum_inventory_snapshot -- --ignored
 	cargo test --test tool_schema_inventory_snapshot refresh_tool_schema_inventory_snapshot -- --ignored
 
 build: ## Build all Rust targets (cargo build --all-targets)

--- a/docs/website/guides/documentation-workflow.md
+++ b/docs/website/guides/documentation-workflow.md
@@ -103,10 +103,11 @@ The generated `dist/` directory is ignored and should not be committed.
 
 ## Refresh generated contract snapshots
 
-OpenAPI, HTTP route, CLI, and model tool schema snapshots are checked
-separately by the main CI. Run `make snapshots-check` before publishing a
-contract change. When a change is intentional, run `make snapshots-refresh`,
-review the generated diff, and then rerun `make snapshots-check`.
+OpenAPI, HTTP route, CLI, runtime status enum, and model tool schema snapshots
+are checked separately by the main CI. Run `make snapshots-check` before
+publishing a contract change. When a change is intentional, run
+`make snapshots-refresh`, review the generated diff, and then rerun
+`make snapshots-check`.
 
 ## Publishing note
 

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -54,6 +54,10 @@ behavior changes.
   Versioned inventory for Holon's model-facing built-in tool schemas, result envelopes, and stability labels.
   <!-- mdorigin:index kind=article -->
 
+- [Runtime status enum inventory](./runtime-status-enum-inventory.md)
+  Machine-readable baseline for stable serialized runtime lifecycle and status enums.
+  <!-- mdorigin:index kind=article -->
+
 - [Supported Models](./models.md)
   Complete reference of all built-in models and providers supported by Holon.
   <!-- mdorigin:index kind=article -->

--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -1,5 +1,6 @@
 {
   "source_of_truth": {
+    "covered_result_schemas": "typed stable result structs deriving schemars::JsonSchema",
     "input_schemas": "typed Rust argument structs deriving schemars::JsonSchema",
     "model_rendering": "src/tool/tools/mod.rs render_tool_result_for_model()",
     "result_envelope": "src/tool/spec.rs ToolResultEnvelope",
@@ -60,7 +61,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WaitForResult"
+        "success_result": "WaitForResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -89,7 +91,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "AgentGetResult"
+        "success_result": "AgentGetResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -130,7 +133,38 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "EnqueueResult"
+        "success_result": "EnqueueResult",
+        "success_result_schema": {
+          "properties": {
+            "enqueued": {
+              "type": "boolean"
+            },
+            "follow_up_text": {
+              "type": "string"
+            },
+            "priority": {
+              "enum": [
+                "interject",
+                "next",
+                "normal",
+                "background"
+              ],
+              "type": "string"
+            },
+            "summary_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "enqueued",
+            "priority",
+            "follow_up_text"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -289,7 +323,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "SpawnAgentResult"
+        "success_result": "SpawnAgentResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -322,7 +357,170 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "ListTasksResult"
+        "success_result": "ListTasksResult",
+        "success_result_schema": {
+          "properties": {
+            "limit": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "returned": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "tasks": {
+              "items": {
+                "properties": {
+                  "command": {
+                    "properties": {
+                      "accepts_input": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "cmd": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cmd_digest": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "exit_status": {
+                        "format": "int32",
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "input_target": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "login": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "output_path": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "promoted_from_exec_command": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "result_summary": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "shell": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "terminal_reentry": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "tty": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "workdir": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "enum": [
+                      "queued",
+                      "running",
+                      "cancelling",
+                      "completed",
+                      "failed",
+                      "cancelled",
+                      "interrupted"
+                    ],
+                    "type": "string"
+                  },
+                  "summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "updated_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "wait_policy": {
+                    "enum": [
+                      "background"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "kind",
+                  "status",
+                  "updated_at",
+                  "wait_policy"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total_active": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "total_active",
+            "returned",
+            "limit",
+            "tasks"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -351,7 +549,470 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "TaskStatusResult"
+        "success_result": "TaskStatusResult",
+        "success_result_schema": {
+          "properties": {
+            "summary_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "task": {
+              "properties": {
+                "child_agent_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "child_observability": {
+                  "properties": {
+                    "blocked_reason": {
+                      "enum": [
+                        "managed_task_queued",
+                        "managed_task_running",
+                        "managed_task_cancelling",
+                        "awaiting_managed_task",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "current_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_progress_brief": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_result_brief": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "phase": {
+                      "enum": [
+                        "running",
+                        "blocked",
+                        "waiting",
+                        "terminal"
+                      ],
+                      "type": "string"
+                    },
+                    "waiting_reason": {
+                      "enum": [
+                        "awaiting_operator_input",
+                        "awaiting_external_change",
+                        "awaiting_task_result",
+                        "awaiting_timer",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "work_summary": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "phase"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "child_supervision": {
+                  "properties": {
+                    "child_agent_id": {
+                      "type": "string"
+                    },
+                    "child_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cleanup_owner": {
+                      "type": "string"
+                    },
+                    "cleanup_status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "delegation_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "followup_target": {
+                      "type": "string"
+                    },
+                    "parent_agent_id": {
+                      "type": "string"
+                    },
+                    "parent_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "supervision_task_id": {
+                      "type": "string"
+                    },
+                    "workspace_mode": {
+                      "enum": [
+                        "inherit",
+                        "worktree",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "worktree": {
+                      "properties": {
+                        "actual_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "auto_cleaned_up": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "changed_files": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_reason": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_cwd": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "projection_kind": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "retained_for_review": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "worktree_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "worktree_path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "parent_agent_id",
+                    "child_agent_id",
+                    "supervision_task_id",
+                    "cleanup_owner",
+                    "followup_target"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "command": {
+                  "properties": {
+                    "accepts_input": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "cmd": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cmd_digest": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "exit_status": {
+                      "format": "int32",
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "input_target": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "login": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "output_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "promoted_from_exec_command": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "result_summary": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "shell": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "terminal_reentry": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "tty": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "workdir": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "parent_message_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "enum": [
+                    "queued",
+                    "running",
+                    "cancelling",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                    "interrupted"
+                  ],
+                  "type": "string"
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "task_id": {
+                  "type": "string"
+                },
+                "token_usage": {
+                  "properties": {
+                    "last_turn": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "total": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": "object"
+                    },
+                    "total_model_rounds": {
+                      "format": "uint64",
+                      "minimum": 0.0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "total_model_rounds"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "updated_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "wait_policy": {
+                  "enum": [
+                    "background"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_id",
+                "kind",
+                "status",
+                "created_at",
+                "updated_at",
+                "wait_policy"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "task"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -384,7 +1045,488 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "TaskInputResult"
+        "success_result": "TaskInputResult",
+        "success_result_schema": {
+          "properties": {
+            "accepted_input": {
+              "type": "boolean"
+            },
+            "bytes_written": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "input_target": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "summary_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "task": {
+              "properties": {
+                "child_agent_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "child_observability": {
+                  "properties": {
+                    "blocked_reason": {
+                      "enum": [
+                        "managed_task_queued",
+                        "managed_task_running",
+                        "managed_task_cancelling",
+                        "awaiting_managed_task",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "current_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_progress_brief": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_result_brief": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "phase": {
+                      "enum": [
+                        "running",
+                        "blocked",
+                        "waiting",
+                        "terminal"
+                      ],
+                      "type": "string"
+                    },
+                    "waiting_reason": {
+                      "enum": [
+                        "awaiting_operator_input",
+                        "awaiting_external_change",
+                        "awaiting_task_result",
+                        "awaiting_timer",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "work_summary": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "phase"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "child_supervision": {
+                  "properties": {
+                    "child_agent_id": {
+                      "type": "string"
+                    },
+                    "child_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cleanup_owner": {
+                      "type": "string"
+                    },
+                    "cleanup_status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "delegation_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "followup_target": {
+                      "type": "string"
+                    },
+                    "parent_agent_id": {
+                      "type": "string"
+                    },
+                    "parent_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "supervision_task_id": {
+                      "type": "string"
+                    },
+                    "workspace_mode": {
+                      "enum": [
+                        "inherit",
+                        "worktree",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "worktree": {
+                      "properties": {
+                        "actual_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "auto_cleaned_up": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "changed_files": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_reason": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_cwd": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "projection_kind": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "retained_for_review": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "worktree_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "worktree_path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "parent_agent_id",
+                    "child_agent_id",
+                    "supervision_task_id",
+                    "cleanup_owner",
+                    "followup_target"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "command": {
+                  "properties": {
+                    "accepts_input": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "cmd": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cmd_digest": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "exit_status": {
+                      "format": "int32",
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "input_target": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "login": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "output_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "promoted_from_exec_command": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "result_summary": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "shell": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "terminal_reentry": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "tty": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "workdir": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "parent_message_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "enum": [
+                    "queued",
+                    "running",
+                    "cancelling",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                    "interrupted"
+                  ],
+                  "type": "string"
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "task_id": {
+                  "type": "string"
+                },
+                "token_usage": {
+                  "properties": {
+                    "last_turn": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "total": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": "object"
+                    },
+                    "total_model_rounds": {
+                      "format": "uint64",
+                      "minimum": 0.0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "total_model_rounds"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "updated_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "wait_policy": {
+                  "enum": [
+                    "background"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_id",
+                "kind",
+                "status",
+                "created_at",
+                "updated_at",
+                "wait_policy"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "task",
+            "accepted_input"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -427,7 +1569,505 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "custom_text_receipt",
-        "success_result": "TaskOutputResult"
+        "success_result": "TaskOutputResult",
+        "success_result_schema": {
+          "properties": {
+            "retrieval_status": {
+              "enum": [
+                "success",
+                "timeout",
+                "not_ready"
+              ],
+              "type": "string"
+            },
+            "task": {
+              "properties": {
+                "artifacts": {
+                  "items": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "child_supervision": {
+                  "properties": {
+                    "child_agent_id": {
+                      "type": "string"
+                    },
+                    "child_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cleanup_owner": {
+                      "type": "string"
+                    },
+                    "cleanup_status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "delegation_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "followup_target": {
+                      "type": "string"
+                    },
+                    "parent_agent_id": {
+                      "type": "string"
+                    },
+                    "parent_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "supervision_task_id": {
+                      "type": "string"
+                    },
+                    "workspace_mode": {
+                      "enum": [
+                        "inherit",
+                        "worktree",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "worktree": {
+                      "properties": {
+                        "actual_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "auto_cleaned_up": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "changed_files": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_reason": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_cwd": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "projection_kind": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "retained_for_review": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "worktree_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "worktree_path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "parent_agent_id",
+                    "child_agent_id",
+                    "supervision_task_id",
+                    "cleanup_owner",
+                    "followup_target"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "exit_status": {
+                  "format": "int32",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "failure_artifact": {
+                  "properties": {
+                    "category": {
+                      "enum": [
+                        "transport",
+                        "protocol",
+                        "runtime",
+                        "task",
+                        "unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "context": {
+                      "properties": {
+                        "causation_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "correlation_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "message_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "model_ref": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "provider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "run_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "task_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "tool_execution_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "turn_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "work_item_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "domain": {
+                      "enum": [
+                        "runtime",
+                        "storage",
+                        "policy",
+                        "io",
+                        "conflict",
+                        "not_found",
+                        "validation",
+                        "provider",
+                        "tool",
+                        "task",
+                        "http",
+                        "unknown",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "exit_status": {
+                      "format": "int32",
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "properties": {},
+                      "required": [],
+                      "type": "object"
+                    },
+                    "model_ref": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "provider": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "recovery_hint": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "retryable": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "source_chain": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "status": {
+                      "format": "uint16",
+                      "maximum": 65535.0,
+                      "minimum": 0.0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "task_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "category",
+                    "kind",
+                    "summary"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "output_artifact": {
+                  "format": "uint",
+                  "minimum": 0.0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "output_preview": {
+                  "type": "string"
+                },
+                "output_truncated": {
+                  "type": "boolean"
+                },
+                "result_summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "enum": [
+                    "queued",
+                    "running",
+                    "cancelling",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                    "interrupted"
+                  ],
+                  "type": "string"
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "task_id": {
+                  "type": "string"
+                },
+                "token_usage": {
+                  "properties": {
+                    "last_turn": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "total": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": "object"
+                    },
+                    "total_model_rounds": {
+                      "format": "uint64",
+                      "minimum": 0.0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "total_model_rounds"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "task_id",
+                "kind",
+                "status",
+                "output_preview",
+                "output_truncated"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "retrieval_status",
+            "task"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -456,7 +2096,478 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "TaskStopResult"
+        "success_result": "TaskStopResult",
+        "success_result_schema": {
+          "properties": {
+            "force_stop_requested": {
+              "type": "boolean"
+            },
+            "stop_requested": {
+              "type": "boolean"
+            },
+            "summary_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "task": {
+              "properties": {
+                "child_agent_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "child_observability": {
+                  "properties": {
+                    "blocked_reason": {
+                      "enum": [
+                        "managed_task_queued",
+                        "managed_task_running",
+                        "managed_task_cancelling",
+                        "awaiting_managed_task",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "current_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_progress_brief": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_result_brief": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "phase": {
+                      "enum": [
+                        "running",
+                        "blocked",
+                        "waiting",
+                        "terminal"
+                      ],
+                      "type": "string"
+                    },
+                    "waiting_reason": {
+                      "enum": [
+                        "awaiting_operator_input",
+                        "awaiting_external_change",
+                        "awaiting_task_result",
+                        "awaiting_timer",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "work_summary": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "phase"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "child_supervision": {
+                  "properties": {
+                    "child_agent_id": {
+                      "type": "string"
+                    },
+                    "child_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cleanup_owner": {
+                      "type": "string"
+                    },
+                    "cleanup_status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "delegation_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "followup_target": {
+                      "type": "string"
+                    },
+                    "parent_agent_id": {
+                      "type": "string"
+                    },
+                    "parent_work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "supervision_task_id": {
+                      "type": "string"
+                    },
+                    "workspace_mode": {
+                      "enum": [
+                        "inherit",
+                        "worktree",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "worktree": {
+                      "properties": {
+                        "actual_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "auto_cleaned_up": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "branch_cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "changed_files": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "cleanup_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_reason": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "cleanup_status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "original_cwd": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "projection_kind": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "retained_for_review": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "worktree_branch": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "worktree_path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "parent_agent_id",
+                    "child_agent_id",
+                    "supervision_task_id",
+                    "cleanup_owner",
+                    "followup_target"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "command": {
+                  "properties": {
+                    "accepts_input": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "cmd": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "cmd_digest": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "exit_status": {
+                      "format": "int32",
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "input_target": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "login": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "output_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "promoted_from_exec_command": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "result_summary": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "shell": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "terminal_reentry": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "tty": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "workdir": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "parent_message_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "enum": [
+                    "queued",
+                    "running",
+                    "cancelling",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                    "interrupted"
+                  ],
+                  "type": "string"
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "task_id": {
+                  "type": "string"
+                },
+                "token_usage": {
+                  "properties": {
+                    "last_turn": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "total": {
+                      "properties": {
+                        "input_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "output_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "format": "uint64",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens"
+                      ],
+                      "type": "object"
+                    },
+                    "total_model_rounds": {
+                      "format": "uint64",
+                      "minimum": 0.0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "total_model_rounds"
+                  ],
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "updated_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "wait_policy": {
+                  "enum": [
+                    "background"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_id",
+                "kind",
+                "status",
+                "created_at",
+                "updated_at",
+                "wait_policy"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "task",
+            "stop_requested",
+            "force_stop_requested"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -482,7 +2593,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "ListModelProvidersResult"
+        "success_result": "ListModelProvidersResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -529,7 +2641,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "ListProviderModelsResult"
+        "success_result": "ListProviderModelsResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -605,7 +2718,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WorkItemMutationResult"
+        "success_result": "WorkItemMutationResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -645,7 +2759,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "PickWorkItemResult"
+        "success_result": "PickWorkItemResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -678,7 +2793,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "GetWorkItemResult"
+        "success_result": "GetWorkItemResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -732,7 +2848,136 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "custom_text_receipt",
-        "success_result": "tool-specific JSON payload"
+        "success_result": "GenerateImageResult",
+        "success_result_schema": {
+          "properties": {
+            "images": {
+              "items": {
+                "properties": {
+                  "byte_count": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "mime": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "sha256": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "properties": {
+                      "height": {
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "width": {
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "uri": {
+                    "type": "string"
+                  },
+                  "workspace_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "id",
+                  "workspace_id",
+                  "path",
+                  "uri",
+                  "sha256",
+                  "mime",
+                  "byte_count",
+                  "size",
+                  "created_at"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "model": {
+              "type": "string"
+            },
+            "parameters": {
+              "properties": {
+                "background": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "output_format": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "summary_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "images",
+            "provider",
+            "model",
+            "prompt",
+            "parameters"
+          ],
+          "type": "object"
+        }
       },
       "stability": "stable"
     },
@@ -788,7 +3033,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "ListWorkItemsResult"
+        "success_result": "ListWorkItemsResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -864,7 +3110,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WorkItemMutationResult"
+        "success_result": "WorkItemMutationResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -893,7 +3140,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WorkItemMutationResult"
+        "success_result": "WorkItemMutationResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -933,7 +3181,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "MemorySearchResponse"
+        "success_result": "MemorySearchResponse",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -970,7 +3219,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "MemoryGetResponse"
+        "success_result": "MemoryGetResponse",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -992,7 +3242,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WorkspaceStateResult"
+        "success_result": "WorkspaceStateResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1020,7 +3271,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "AttachWorkspaceResult"
+        "success_result": "AttachWorkspaceResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1048,7 +3300,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "DetachWorkspaceResult"
+        "success_result": "DetachWorkspaceResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1095,7 +3348,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "SwitchWorkspaceResult"
+        "success_result": "SwitchWorkspaceResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1152,7 +3406,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "CreateWorktreeResult"
+        "success_result": "CreateWorktreeResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1203,7 +3458,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "RemoveWorktreeResult"
+        "success_result": "RemoveWorktreeResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1231,7 +3487,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "custom_text_receipt",
-        "success_result": "ApplyPatchResult"
+        "success_result": "ApplyPatchResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1314,7 +3571,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "custom_text_receipt",
-        "success_result": "ExecCommandResult"
+        "success_result": "ExecCommandResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1429,7 +3687,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "custom_text_receipt",
-        "success_result": "ExecCommandBatchResult"
+        "success_result": "ExecCommandBatchResult",
+        "success_result_schema": null
       },
       "stability": "stable"
     },
@@ -1459,7 +3718,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "custom_text_receipt",
-        "success_result": "tool-specific JSON payload"
+        "success_result": "tool-specific JSON payload",
+        "success_result_schema": null
       },
       "stability": "experimental"
     },
@@ -1504,7 +3764,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WebFetchResult"
+        "success_result": "WebFetchResult",
+        "success_result_schema": null
       },
       "stability": "experimental"
     },
@@ -1546,7 +3807,8 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "WebSearchResult"
+        "success_result": "WebSearchResult",
+        "success_result_schema": null
       },
       "stability": "experimental"
     },
@@ -1600,10 +3862,11 @@
         "canonical": "ToolResultEnvelope",
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
-        "success_result": "XSearchResult"
+        "success_result": "XSearchResult",
+        "success_result_schema": null
       },
       "stability": "experimental"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/docs/website/reference/model-tool-schema-inventory.md
+++ b/docs/website/reference/model-tool-schema-inventory.md
@@ -27,8 +27,17 @@ Each built-in tool entry records:
 - model-facing input schema
 - freeform grammar, when the tool accepts non-JSON input
 - result envelope family and model rendering contract
+- a typed success-result JSON Schema when that stable result surface is in the
+  current coverage set
 - related HTTP or CLI surfaces when commands wrap tool or runtime APIs
 - model-visible tool description
+
+The version 2 inventory starts result-schema coverage with `Enqueue`,
+`GenerateImage`, `ListTasks`, `TaskStatus`, `TaskInput`, `TaskOutput`, and
+`TaskStop`. Uncovered tools keep their result type name and an explicit
+`null` schema; this avoids presenting an inferred or partial shape as a stable
+contract. Coverage can expand only when the concrete Rust result type derives
+`schemars::JsonSchema`.
 
 ## Capability families
 

--- a/docs/website/reference/runtime-status-enum-inventory.json
+++ b/docs/website/reference/runtime-status-enum-inventory.json
@@ -1,0 +1,99 @@
+{
+  "enums": [
+    {
+      "name": "AgentStatus",
+      "serialized_values": [
+        "booting",
+        "awake_idle",
+        "awake_running",
+        "awaiting_task",
+        "asleep",
+        "stopped"
+      ],
+      "source": "src/types.rs"
+    },
+    {
+      "name": "WorkItemState",
+      "serialized_values": [
+        "open",
+        "completed"
+      ],
+      "source": "src/domain/work_item.rs"
+    },
+    {
+      "name": "WorkItemPlanStatus",
+      "serialized_values": [
+        "draft",
+        "ready",
+        "needs_input"
+      ],
+      "source": "src/domain/work_item.rs"
+    },
+    {
+      "name": "WorkItemReadiness",
+      "serialized_values": [
+        "runnable",
+        "yielded",
+        "waiting_for_operator",
+        "blocked",
+        "completed"
+      ],
+      "source": "src/domain/work_item.rs"
+    },
+    {
+      "name": "TaskStatus",
+      "serialized_values": [
+        "queued",
+        "running",
+        "cancelling",
+        "completed",
+        "failed",
+        "cancelled",
+        "interrupted"
+      ],
+      "source": "src/types.rs"
+    },
+    {
+      "name": "WaitConditionStatus",
+      "serialized_values": [
+        "active",
+        "resolved",
+        "cancelled",
+        "expired"
+      ],
+      "source": "src/types.rs"
+    },
+    {
+      "name": "TimerStatus",
+      "serialized_values": [
+        "active",
+        "completed",
+        "cancelled"
+      ],
+      "source": "src/types.rs"
+    },
+    {
+      "name": "QueueEntryStatus",
+      "serialized_values": [
+        "queued",
+        "dequeued",
+        "processed",
+        "interjected",
+        "aborted",
+        "dropped",
+        "interrupted"
+      ],
+      "source": "src/types.rs"
+    },
+    {
+      "name": "ToolResultStatus",
+      "serialized_values": [
+        "success",
+        "error"
+      ],
+      "source": "src/tool/spec.rs"
+    }
+  ],
+  "source_of_truth": "typed Rust enums deriving schemars::JsonSchema",
+  "version": 1
+}

--- a/docs/website/reference/runtime-status-enum-inventory.md
+++ b/docs/website/reference/runtime-status-enum-inventory.md
@@ -1,0 +1,41 @@
+---
+title: Runtime status enum inventory
+summary: Machine-readable baseline for stable serialized runtime lifecycle and status enums.
+order: 27
+---
+
+# Runtime status enum inventory
+
+Holon's stable runtime lifecycle labels are generated from typed Rust enums and
+checked in as
+[`runtime-status-enum-inventory.json`](./runtime-status-enum-inventory.json).
+
+- **Primary source:** the named Rust enum definitions and their serde rename
+  attributes.
+- **Generated inventory:**
+  `holon::contract_inventory::runtime_status_enum_inventory()`.
+- **Drift check:** `make snapshots-check`.
+- **Refresh:** `make snapshots-refresh`, followed by review of the generated
+  JSON diff.
+
+## Current coverage
+
+The first baseline covers:
+
+- `AgentStatus`
+- `WorkItemState`
+- `WorkItemPlanStatus`
+- `WorkItemReadiness`
+- `TaskStatus`
+- `WaitConditionStatus`
+- `TimerStatus`
+- `QueueEntryStatus`
+- `ToolResultStatus`
+
+The checked values are the serialized snake_case contract, not the Rust
+variant spelling. Adding or removing a variant, or changing its serialized
+name, fails the snapshot check until the change is intentionally refreshed.
+
+This inventory is deliberately narrow. It does not classify every internal
+enum as stable, parse Rust source text, or turn prose-only states into a
+machine contract.

--- a/src/contract_inventory.rs
+++ b/src/contract_inventory.rs
@@ -1,0 +1,103 @@
+//! Machine-readable inventories for stable runtime contracts.
+
+use schemars::{generate::SchemaSettings, JsonSchema};
+use serde_json::{json, Value};
+
+use crate::{
+    tool::spec::ToolResultStatus,
+    types::{
+        AgentStatus, QueueEntryStatus, TaskStatus, TimerStatus, WaitConditionStatus,
+        WorkItemPlanStatus, WorkItemReadiness, WorkItemState,
+    },
+};
+
+/// Generate the checked-in inventory of stable serialized runtime status enums.
+///
+/// The Rust enum definitions and their serde attributes remain the source of
+/// truth. The generated inventory is snapshot-tested so variant additions,
+/// removals, and serialized-name changes require an intentional refresh.
+pub fn runtime_status_enum_inventory() -> Value {
+    json!({
+        "version": 1,
+        "source_of_truth": "typed Rust enums deriving schemars::JsonSchema",
+        "enums": [
+            enum_contract::<AgentStatus>("AgentStatus", "src/types.rs"),
+            enum_contract::<WorkItemState>("WorkItemState", "src/domain/work_item.rs"),
+            enum_contract::<WorkItemPlanStatus>("WorkItemPlanStatus", "src/domain/work_item.rs"),
+            enum_contract::<WorkItemReadiness>("WorkItemReadiness", "src/domain/work_item.rs"),
+            enum_contract::<TaskStatus>("TaskStatus", "src/types.rs"),
+            enum_contract::<WaitConditionStatus>("WaitConditionStatus", "src/types.rs"),
+            enum_contract::<TimerStatus>("TimerStatus", "src/types.rs"),
+            enum_contract::<QueueEntryStatus>("QueueEntryStatus", "src/types.rs"),
+            enum_contract::<ToolResultStatus>("ToolResultStatus", "src/tool/spec.rs"),
+        ],
+    })
+}
+
+fn enum_contract<T: JsonSchema>(name: &str, source: &str) -> Value {
+    json!({
+        "name": name,
+        "source": source,
+        "serialized_values": serialized_enum_values::<T>(name),
+    })
+}
+
+fn serialized_enum_values<T: JsonSchema>(name: &str) -> Vec<String> {
+    let schema = SchemaSettings::draft07()
+        .into_generator()
+        .into_root_schema_for::<T>();
+    let schema = serde_json::to_value(schema)
+        .unwrap_or_else(|error| panic!("failed to serialize schema for {name}: {error}"));
+    schema_enum_values(&schema, name)
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .unwrap_or_else(|| panic!("status contract {name} contains a non-string variant"))
+                .to_string()
+        })
+        .collect()
+}
+
+fn schema_enum_values<'a>(schema: &'a Value, name: &str) -> Vec<&'a Value> {
+    if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+        return values.iter().collect();
+    }
+
+    schema
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("status contract {name} is not a string enum schema"))
+        .iter()
+        .flat_map(|variant_schema| {
+            if let Some(values) = variant_schema.get("enum").and_then(Value::as_array) {
+                return values.iter().collect::<Vec<_>>();
+            }
+            if let Some(value) = variant_schema.get("const") {
+                return vec![value];
+            }
+            panic!("status contract {name} contains a non-enum variant schema")
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::schema_enum_values;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_enum_values_from_documented_variant_schema() {
+        let schema = json!({
+            "oneOf": [
+                {"type": "string", "enum": ["queued", "processed"]},
+                {"type": "string", "const": "interrupted", "description": "Replay on recovery."}
+            ]
+        });
+
+        assert_eq!(
+            schema_enum_values(&schema, "QueueEntryStatus"),
+            vec![&json!("queued"), &json!("processed"), &json!("interrupted")]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cli;
 pub mod client;
 pub mod config;
 pub mod context;
+pub mod contract_inventory;
 pub mod daemon;
 pub mod diagnostics;
 pub mod domain;

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -7,6 +7,10 @@
 //! - `tools`: Builtin tool modules, one per tool
 
 use crate::tool::names as tn;
+use crate::types::{
+    EnqueueResult, GenerateImageResult, TaskInputResult, TaskOutputResult, TaskStatusResult,
+    TaskStopResult,
+};
 use anyhow::Result;
 use serde_json::{json, Value};
 
@@ -45,7 +49,8 @@ pub fn model_tool_schema_inventory() -> Result<Value> {
         .filter(|definition| model_facing_names.contains(&definition.spec.name))
         .map(|definition| {
             let name = definition.spec.name.clone();
-            json!({
+            let success_result_schema = tool_success_result_schema(&definition.spec.name)?;
+            Ok(json!({
                 "name": name,
                 "family": definition.family.label(),
                 "stability": tool_stability_level(&definition.spec.name),
@@ -54,21 +59,23 @@ pub fn model_tool_schema_inventory() -> Result<Value> {
                 "result_envelope": {
                     "canonical": "ToolResultEnvelope",
                     "success_result": tool_success_result_contract(&definition.spec.name),
+                    "success_result_schema": success_result_schema,
                     "error_result": "ToolError",
                     "model_rendering": tool_model_rendering_contract(&definition.spec.name),
                 },
                 "related_surfaces": related_surfaces_for_tool(&definition.spec.name),
                 "description": definition.spec.description,
-            })
+            }))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(json!({
-        "version": 1,
+        "version": 2,
         "source_of_truth": {
             "tool_definitions": "src/tool/tools/mod.rs builtin_tool_definitions()",
             "input_schemas": "typed Rust argument structs deriving schemars::JsonSchema",
             "result_envelope": "src/tool/spec.rs ToolResultEnvelope",
+            "covered_result_schemas": "typed stable result structs deriving schemars::JsonSchema",
             "model_rendering": "src/tool/tools/mod.rs render_tool_result_for_model()",
         },
         "stability_policy": {
@@ -101,6 +108,7 @@ fn tool_success_result_contract(name: &str) -> &'static str {
         tn::ENQUEUE => "EnqueueResult",
         tn::EXEC_COMMAND => "ExecCommandResult",
         tn::EXEC_COMMAND_BATCH => "ExecCommandBatchResult",
+        tn::GENERATE_IMAGE => "GenerateImageResult",
         tn::GET_WORK_ITEM => "GetWorkItemResult",
         tn::GET_WORKSPACE_STATE => "WorkspaceStateResult",
         tn::LIST_MODEL_PROVIDERS => "ListModelProvidersResult",
@@ -125,6 +133,20 @@ fn tool_success_result_contract(name: &str) -> &'static str {
         tn::X_SEARCH => "XSearchResult",
         _ => "tool-specific JSON payload",
     }
+}
+
+fn tool_success_result_schema(name: &str) -> Result<Option<Value>> {
+    let schema = match name {
+        tn::ENQUEUE => schema::tool_result_schema::<EnqueueResult>()?,
+        tn::GENERATE_IMAGE => schema::tool_result_schema::<GenerateImageResult>()?,
+        tn::LIST_TASKS => schema::tool_result_schema::<tools::task_list::ListTasksResult>()?,
+        tn::TASK_INPUT => schema::tool_result_schema::<TaskInputResult>()?,
+        tn::TASK_OUTPUT => schema::tool_result_schema::<TaskOutputResult>()?,
+        tn::TASK_STATUS => schema::tool_result_schema::<TaskStatusResult>()?,
+        tn::TASK_STOP => schema::tool_result_schema::<TaskStopResult>()?,
+        _ => return Ok(None),
+    };
+    Ok(Some(schema))
 }
 
 fn tool_model_rendering_contract(name: &str) -> &'static str {

--- a/src/tool/schema_support.rs
+++ b/src/tool/schema_support.rs
@@ -6,14 +6,23 @@ use std::any::TypeId;
 use crate::tool::tools::spawn_agent::SpawnAgentArgs;
 
 pub(crate) fn tool_input_schema<T: JsonSchema + 'static>() -> Result<Value> {
+    let mut schema = normalized_schema::<T>()?;
+    if TypeId::of::<T>() == TypeId::of::<SpawnAgentArgs>() {
+        enforce_public_named_spawn_contract(&mut schema);
+    }
+    Ok(schema)
+}
+
+pub(crate) fn tool_result_schema<T: JsonSchema>() -> Result<Value> {
+    normalized_schema::<T>()
+}
+
+fn normalized_schema<T: JsonSchema>() -> Result<Value> {
     let mut schema = serde_json::to_value(root_schema_for::<T>())
         .map_err(|error| anyhow!("tool schema should serialize: {error}"))?;
     normalize_object_defaults(&mut schema);
     normalize_numeric_bound_literals(&mut schema);
     prune_schema_metadata(&mut schema);
-    if TypeId::of::<T>() == TypeId::of::<SpawnAgentArgs>() {
-        enforce_public_named_spawn_contract(&mut schema);
-    }
     Ok(schema)
 }
 

--- a/src/tool/spec.rs
+++ b/src/tool/spec.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -42,7 +43,7 @@ pub struct ToolResult {
     pub sleep_duration_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolResultStatus {
     Success,

--- a/src/tool/tools/task_list.rs
+++ b/src/tool/tools/task_list.rs
@@ -24,7 +24,7 @@ pub(crate) struct ListTasksArgs {
     pub(crate) limit: Option<usize>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, JsonSchema)]
 pub(crate) struct ListTasksResult {
     pub(crate) total_active: usize,
     pub(crate) returned: usize,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1217,7 +1217,7 @@ pub enum MessageKind {
     InternalFollowup,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum Priority {
     // TODO: remove `interrupt` alias after older ledgers and request clients have migrated.
@@ -2138,7 +2138,7 @@ fn default_external_trigger_scope() -> ExternalTriggerScope {
     ExternalTriggerScope::Agent
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WaitConditionStatus {
     Active,
@@ -2472,7 +2472,7 @@ pub struct OperatorNotificationRecord {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct EnqueueResult {
     pub enqueued: bool,
     pub priority: Priority,
@@ -3836,7 +3836,7 @@ impl Default for TimerStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueueEntryStatus {
     Queued,

--- a/tests/runtime_status_inventory_snapshot.rs
+++ b/tests/runtime_status_inventory_snapshot.rs
@@ -1,0 +1,37 @@
+//! Stable runtime status enum inventory drift test.
+//!
+//! Refresh workflow for intentional status contract changes:
+//!
+//! ```bash
+//! make snapshots-refresh
+//! make snapshots-check
+//! ```
+
+const SNAPSHOT_PATH: &str = "docs/website/reference/runtime-status-enum-inventory.json";
+
+#[test]
+fn runtime_status_enum_inventory_snapshot_matches_generated_inventory() {
+    let live =
+        serde_json::to_string_pretty(&holon::contract_inventory::runtime_status_enum_inventory())
+            .expect("serialize generated runtime status enum inventory");
+    let stored = std::fs::read_to_string(SNAPSHOT_PATH)
+        .unwrap_or_else(|err| panic!("failed to read {SNAPSHOT_PATH}: {err}"));
+
+    if live.replace("\r\n", "\n") != stored.replace("\r\n", "\n") {
+        eprintln!(
+            "Runtime status enum inventory drift detected. Refresh intentionally with:\n  make snapshots-refresh\n"
+        );
+        eprintln!("=== GENERATED RUNTIME STATUS ENUM INVENTORY ===");
+        eprintln!("{live}");
+        panic!("generated runtime status enum inventory does not match checked-in snapshot");
+    }
+}
+
+#[test]
+#[ignore]
+fn refresh_runtime_status_enum_inventory_snapshot() {
+    let live =
+        serde_json::to_string_pretty(&holon::contract_inventory::runtime_status_enum_inventory())
+            .expect("serialize generated runtime status enum inventory");
+    std::fs::write(SNAPSHOT_PATH, live).expect("write runtime status enum inventory snapshot");
+}


### PR DESCRIPTION
## 概要

这是 #2274 的第二阶段，接续 #2350 已建立的低误判文档引用检查，为可机器比较的 runtime contract 增加 drift baseline。

- 从 deriving `schemars::JsonSchema` 的 typed Rust enums 生成 9 个稳定 lifecycle/status enum 的序列化值 inventory
- 将 model-facing tool schema inventory 升级到 v2，并为首批 7 个稳定 tool result 类型记录完整 JSON Schema；未覆盖结果保持显式 `null`
- 将新增 inventory 纳入现有 `make snapshots-refresh` / `make snapshots-check` 与主 CI snapshot 门禁
- 补充 reference 文档、索引及维护工作流说明

## 契约边界

- Rust enum/type 与 serde 属性仍是 source of truth，不解析 Rust 源码文本
- status baseline 仅覆盖明确列出的 9 个稳定 enum
- tool result schema 仅覆盖具有具体 typed result 且 deriving `JsonSchema` 的首批类型，不从 prose 或动态 JSON 推断结构
- intentional contract change 通过 refresh、review checked-in JSON diff、再运行 check 完成

## 验证

- `make snapshots-check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `python3 docs/website/.tools/check-links.py`（从 `docs/website` 执行）
- `git diff --check`

Follow-up to #2274.
