### PR TITLE
fix: harden web gui resume reconciliation

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -115,24 +115,36 @@ describe("timeline virtual layout reconciliation", () => {
   it("keeps the same visible turn offset after measurements change", () => {
     const anchor = captureScrollAnchor(
       [
-        { key: "turn:a", start: 0, size: 120 },
-        { key: "turn:b", start: 120, size: 200 },
+        { key: "turn:a", index: 0, start: 0, size: 120 },
+        { key: "turn:b", index: 1, start: 120, size: 200 },
       ],
       164,
     );
 
-    expect(anchor).toEqual({ key: "turn:b", offset: 44 });
-    expect(restoredScrollTop(anchor, [{ key: "turn:b", start: 180 }], 164)).toBe(224);
+    expect(anchor).toEqual({ key: "turn:b", index: 1, offset: 44 });
+    expect(restoredScrollTop(anchor, 1, (index) => index === 1 ? 180 : undefined, 164)).toBe(224);
   });
 
-  it("falls back to the original scroll top when the anchored turn is no longer measured", () => {
-    const anchor = captureScrollAnchor([{ key: "turn:a", start: 20, size: 80 }], 44);
+  it("restores an anchored turn even when it is outside the current virtual overscan", () => {
+    const anchor = captureScrollAnchor([{ key: "turn:a", index: 0, start: 20, size: 80 }], 44);
 
-    expect(restoredScrollTop(anchor, [{ key: "turn:b", start: 120 }], 44)).toBe(44);
+    expect(restoredScrollTop(anchor, 8, (index) => index === 8 ? 1_900 : undefined, 44)).toBe(1_924);
+  });
+
+  it("accounts for history controls before the virtual wrapper when restoring an anchor", () => {
+    const anchor = captureScrollAnchor([{ key: "turn:a", index: 0, start: 20, size: 80 }], 44);
+
+    expect(restoredScrollTop(anchor, 8, (index) => index === 8 ? 1_900 : undefined, 84, 32)).toBe(1_956);
+  });
+
+  it("falls back to the original scroll top when the virtualizer cannot resolve the anchored index", () => {
+    const anchor = captureScrollAnchor([{ key: "turn:a", index: 0, start: 20, size: 80 }], 44);
+
+    expect(restoredScrollTop(anchor, 8, () => undefined, 44)).toBe(44);
   });
 
   it("does not capture an anchor when only overscan rows before the viewport are measured", () => {
-    expect(captureScrollAnchor([{ key: "turn:a", start: 0, size: 80 }], 120)).toBeNull();
+    expect(captureScrollAnchor([{ key: "turn:a", index: 0, start: 0, size: 80 }], 120)).toBeNull();
   });
 });
 

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -22,6 +22,7 @@ import type {
   AgentDetail,
   AgentSummary,
   AgentTimelineActivity,
+  AgentTimelineItem,
   DisplayLevel,
   RuntimeModelCatalog,
   RuntimeModelOption,
@@ -115,22 +116,27 @@ export function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
 
 export interface ScrollAnchor {
   key: VirtualItem["key"];
+  index: number;
   offset: number;
 }
 
-export function captureScrollAnchor(virtualItems: Pick<VirtualItem, "key" | "start" | "size">[], scrollTop: number): ScrollAnchor | null {
+export function captureScrollAnchor(virtualItems: Pick<VirtualItem, "key" | "index" | "start" | "size">[], scrollTop: number): ScrollAnchor | null {
   const anchorItem = virtualItems.find((item) => item.start + item.size > scrollTop);
-  return anchorItem ? { key: anchorItem.key, offset: Math.max(0, scrollTop - anchorItem.start) } : null;
+  return anchorItem
+    ? { key: anchorItem.key, index: anchorItem.index, offset: Math.max(0, scrollTop - anchorItem.start) }
+    : null;
 }
 
 export function restoredScrollTop(
   anchor: ScrollAnchor | null,
-  measuredItems: Pick<VirtualItem, "key" | "start">[],
+  anchorIndex: number | undefined,
+  offsetForIndex: (index: number) => number | undefined,
   fallbackTop: number,
+  contentOffset = 0,
 ): number {
-  if (!anchor) return fallbackTop;
-  const measured = measuredItems.find((item) => item.key === anchor.key);
-  return measured ? Math.max(0, measured.start + anchor.offset) : fallbackTop;
+  if (!anchor || anchorIndex == null) return fallbackTop;
+  const start = offsetForIndex(anchorIndex);
+  return start == null ? fallbackTop : Math.max(0, contentOffset + start + anchor.offset);
 }
 
 export function timelineLayoutRevision(turns: TimelineTurn[]): string {
@@ -141,6 +147,27 @@ export function timelineLayoutRevision(turns: TimelineTurn[]): string {
     fieldCount += 1;
     hash = fnv1a(`${text.length}:${text}`, hash);
   };
+  const addItem = (item: AgentTimelineItem | AgentTimelineActivity) => {
+    add(item.id);
+    add(item.kind);
+    add(item.label);
+    add(item.body);
+    add(item.meta);
+    add(item.minDisplayLevel);
+    add(item.detail?.label);
+    add(item.detail?.text);
+    add(item.detail?.tone);
+    add(item.executionMeta?.outcome);
+    add(item.executionMeta?.exitStatus);
+    add(item.executionMeta?.durationMs);
+    add(item.executionMeta?.outputTruncated);
+    add(item.executionMeta?.taskId);
+    add(item.statusTrail?.length ?? 0);
+    for (const step of item.statusTrail ?? []) {
+      add(step.status);
+      add(step.timestamp);
+    }
+  };
 
   for (const turn of turns) {
     add(turn.id);
@@ -149,46 +176,10 @@ export function timelineLayoutRevision(turns: TimelineTurn[]): string {
     add(turn.timestamp);
     add(turn.items.length);
     for (const item of turn.items) {
-      add(item.id);
-      add(item.kind);
-      add(item.label);
-      add(item.body);
-      add(item.meta);
-      add(item.minDisplayLevel);
-      add(item.detail?.label);
-      add(item.detail?.text);
-      add(item.detail?.tone);
-      add(item.executionMeta?.outcome);
-      add(item.executionMeta?.exitStatus);
-      add(item.executionMeta?.durationMs);
-      add(item.executionMeta?.outputTruncated);
-      add(item.executionMeta?.taskId);
-      add(item.statusTrail?.length ?? 0);
-      for (const step of item.statusTrail ?? []) {
-        add(step.status);
-        add(step.timestamp);
-      }
+      addItem(item);
       add(item.activities?.length ?? 0);
       for (const activity of item.activities ?? []) {
-        add(activity.id);
-        add(activity.kind);
-        add(activity.label);
-        add(activity.body);
-        add(activity.meta);
-        add(activity.minDisplayLevel);
-        add(activity.detail?.label);
-        add(activity.detail?.text);
-        add(activity.detail?.tone);
-        add(activity.executionMeta?.outcome);
-        add(activity.executionMeta?.exitStatus);
-        add(activity.executionMeta?.durationMs);
-        add(activity.executionMeta?.outputTruncated);
-        add(activity.executionMeta?.taskId);
-        add(activity.statusTrail?.length ?? 0);
-        for (const step of activity.statusTrail ?? []) {
-          add(step.status);
-          add(step.timestamp);
-        }
+        addItem(activity);
       }
     }
   }
@@ -208,14 +199,20 @@ function fnv1a(text: string, initialHash: number): number {
 function useReconciledVirtualMeasurements({
   virtualizer,
   scrollElementRef,
+  contentElementRef,
   layoutRevision,
   stickToBottomRef,
+  pendingAnchorRef,
+  anchorIndexByKey,
   scrollToBottom,
 }: {
   virtualizer: Virtualizer<HTMLDivElement, Element>;
   scrollElementRef: RefObject<HTMLDivElement | null>;
+  contentElementRef: RefObject<HTMLDivElement | null>;
   layoutRevision: string;
   stickToBottomRef: MutableRefObject<boolean>;
+  pendingAnchorRef: MutableRefObject<ScrollAnchor | null>;
+  anchorIndexByKey: ReadonlyMap<string, number>;
   scrollToBottom: () => void;
 }) {
   const scrollToBottomRef = useRef(scrollToBottom);
@@ -230,7 +227,13 @@ function useReconciledVirtualMeasurements({
     if (!list) return;
 
     const wasAtBottom = stickToBottomRef.current || isScrolledNearBottom(list);
-    const anchor = wasAtBottom ? null : captureScrollAnchor(virtualizer.getVirtualItems(), list.scrollTop);
+    const contentOffset = contentElementRef.current?.offsetTop ?? 0;
+    const virtualScrollTop = Math.max(0, list.scrollTop - contentOffset);
+    const measuredAnchor = virtualizer.getVirtualItemForOffset(virtualScrollTop);
+    const anchor =
+      pendingAnchorRef.current ??
+      (wasAtBottom || !measuredAnchor ? null : captureScrollAnchor([measuredAnchor], virtualScrollTop));
+    pendingAnchorRef.current = null;
     const fallbackTop = list.scrollTop;
     cancelReconciledMeasurement(rafRef.current);
 
@@ -246,12 +249,19 @@ function useReconciledVirtualMeasurements({
           return;
         }
         stickToBottomRef.current = false;
-        currentList.scrollTop = restoredScrollTop(anchor, virtualizer.getVirtualItems(), fallbackTop);
+        const anchorIndex = anchor ? anchorIndexByKey.get(String(anchor.key)) ?? anchor.index : undefined;
+        currentList.scrollTop = restoredScrollTop(
+          anchor,
+          anchorIndex,
+          (index) => virtualizer.getOffsetForIndex(index, "start")?.[0],
+          fallbackTop,
+          contentElementRef.current?.offsetTop ?? 0,
+        );
       });
     });
 
     return () => cancelReconciledMeasurement(rafRef.current);
-  }, [layoutRevision, scrollElementRef, stickToBottomRef, virtualizer]);
+  }, [anchorIndexByKey, contentElementRef, layoutRevision, pendingAnchorRef, scrollElementRef, stickToBottomRef, virtualizer]);
 }
 
 function cancelReconciledMeasurement(raf: { measure: number | null; restore: number | null }): void {
@@ -300,10 +310,11 @@ export function AgentPage({
   const [reasoningPopoverOpen, setReasoningPopoverOpen] = useState(false);
   const [visibleTimelineItemLimit, setVisibleTimelineItemLimit] = useState(() => defaultTimelineItemLimit("info"));
   const messageListRef = useRef<HTMLDivElement | null>(null);
+  const virtualWrapperRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragCounterRef = useRef(0);
-  const preserveScrollRef = useRef<{ height: number; top: number } | null>(null);
+  const preserveScrollRef = useRef<ScrollAnchor | null>(null);
   const stickToBottomRef = useRef(true);
   const autoStickToBottomRef = useRef(false);
   const scheduledBottomScrollRef = useRef<number | null>(null);
@@ -326,6 +337,10 @@ export function AgentPage({
   const isWorking = isAgentWorking(activeAgent, sendingPrompt, t);
   const workingActivities = useMemo(() => (isWorking ? collectWorkingActivitiesForCurrentTurn(sourceTimeline) : []), [isWorking, sourceTimeline]);
   const timelineTurns = useMemo(() => groupTimelineTurns(timeline), [timeline]);
+  const timelineTurnIndexById = useMemo(
+    () => new Map(timelineTurns.map((turn, index) => [turn.id, index])),
+    [timelineTurns],
+  );
   const targetTimelineItemId = useMemo(() => timeline.find((item) => itemHasEventSeq(item, targetEventSeq))?.id, [targetEventSeq, timeline]);
   const rowVirtualizer = useVirtualizer({
     count: timelineTurns.length,
@@ -430,13 +445,6 @@ export function AgentPage({
     const list = messageListRef.current;
     if (!list) return;
 
-    const preserved = preserveScrollRef.current;
-    if (preserved) {
-      list.scrollTop = list.scrollHeight - preserved.height + preserved.top;
-      preserveScrollRef.current = null;
-      return;
-    }
-
     if (stickToBottomRef.current) {
       scrollToConversationBottom();
     }
@@ -445,8 +453,11 @@ export function AgentPage({
   useReconciledVirtualMeasurements({
     virtualizer: rowVirtualizer,
     scrollElementRef: messageListRef,
+    contentElementRef: virtualWrapperRef,
     layoutRevision: timelineLayoutVersion,
     stickToBottomRef,
+    pendingAnchorRef: preserveScrollRef,
+    anchorIndexByKey: timelineTurnIndexById,
     scrollToBottom: scrollToConversationBottom,
   });
 
@@ -570,17 +581,19 @@ export function AgentPage({
   async function handleLoadOlderEvents() {
     const list = messageListRef.current;
     if (list) {
+      const contentOffset = virtualWrapperRef.current?.offsetTop ?? 0;
+      const virtualScrollTop = Math.max(0, list.scrollTop - contentOffset);
+      const anchorItem = rowVirtualizer.getVirtualItemForOffset(virtualScrollTop);
       preserveScrollRef.current =
-        list.scrollTop > TOP_SCROLL_THRESHOLD ? { height: list.scrollHeight, top: list.scrollTop } : null;
+        list.scrollTop > TOP_SCROLL_THRESHOLD && anchorItem
+          ? captureScrollAnchor([anchorItem], virtualScrollTop)
+          : null;
       stickToBottomRef.current = false;
     }
-    setVisibleTimelineItemLimit((limit) => limit + HISTORY_PAGE_VISIBLE_INCREMENT);
     try {
       await onLoadOlderEvents();
+      setVisibleTimelineItemLimit((limit) => limit + HISTORY_PAGE_VISIBLE_INCREMENT);
     } catch {
-      setVisibleTimelineItemLimit((limit) =>
-        Math.max(defaultTimelineItemLimit(displayLevel), limit - HISTORY_PAGE_VISIBLE_INCREMENT),
-      );
       preserveScrollRef.current = null;
     }
   }
@@ -660,6 +673,7 @@ export function AgentPage({
             ) : null}
             {timelineTurns.length > 0 ? (
               <div
+                ref={virtualWrapperRef}
                 className="message-list-virtual-wrapper"
                 style={{ height: rowVirtualizer.getTotalSize(), position: "relative" }}
               >

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -4,6 +4,7 @@ import {
   agentBriefPatchFromEvents,
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
+  isSessionCacheContextCurrent,
   isLoopbackWebHostname,
   materializeProjectionDetail,
   mergeBootstrapAgentState,
@@ -11,9 +12,11 @@ import {
   missingBriefIdsForHydration,
   readStoredRemoteConnectionProfiles,
   resetSessionsForResume,
+  resetTransientRuntimeStateForResume,
   readStoredRuntimeConnectionConfig,
   sessionForEventLogEpoch,
   streamEventFromBackfill,
+  useRuntimeStore,
   writeStoredRuntimeConnectionConfig,
 } from "./runtime-store";
 import type { StreamEventEnvelopeDto } from "./client";
@@ -139,16 +142,73 @@ describe("resume session reset", () => {
       "agent-a": sessionState({
         loading: true,
         loadingOlder: true,
+        sendingPrompt: true,
         liveStatus: "recovering",
         reconnectAttempt: 4,
+        workItemDetailsById: { "work-1": { loading: true } },
+        taskDetailsById: { "task-1": { loading: true } },
+        toolExecutionDetailsById: { "tool-1": { loading: true } },
       }),
     });
 
     expect(reset["agent-a"]).toMatchObject({
       loading: false,
       loadingOlder: false,
+      sendingPrompt: false,
       liveStatus: "stale",
       reconnectAttempt: 0,
+      workItemDetailsById: { "work-1": { loading: false } },
+      taskDetailsById: { "task-1": { loading: false } },
+      toolExecutionDetailsById: { "tool-1": { loading: false } },
+    });
+  });
+
+  it("clears global transient loading state invalidated by the new generation", () => {
+    const patch = resetTransientRuntimeStateForResume({
+      ...useRuntimeStore.getState(),
+      modelCatalogLoading: true,
+      runtimeConfigLoading: true,
+      runtimeConfigSaving: true,
+      skillCatalogLoading: true,
+      skillDetailLoadingById: { skill: true },
+      templateCatalogLoading: true,
+      templateSyncInProgress: true,
+      templateDetailLoadingById: { template: true },
+      agentSkillCatalogLoadingByAgentId: { agent: true },
+      credentialStoreLoading: true,
+      codexDeviceLogin: { status: "waiting", jobId: "job-1" },
+      searchLoading: true,
+      searchResultContentLoadingBySourceRef: { source: true },
+      rightPanelView: {
+        kind: "task_detail",
+        agentId: "agent-a",
+        task: { id: "task-current", kind: "command", status: "running", summary: "Current" },
+        detailState: { loading: true },
+      },
+      rightPanelViewStack: [{
+        kind: "tool_execution_detail",
+        agentId: "agent-a",
+        toolExecutionId: "tool-stacked",
+        detailState: { loading: true },
+      }],
+    });
+
+    expect(patch).toMatchObject({
+      modelCatalogLoading: false,
+      runtimeConfigLoading: false,
+      runtimeConfigSaving: false,
+      skillCatalogLoading: false,
+      skillDetailLoadingById: { skill: false },
+      templateCatalogLoading: false,
+      templateSyncInProgress: false,
+      templateDetailLoadingById: { template: false },
+      agentSkillCatalogLoadingByAgentId: { agent: false },
+      credentialStoreLoading: false,
+      codexDeviceLogin: { status: "idle" },
+      searchLoading: false,
+      searchResultContentLoadingBySourceRef: { source: false },
+      rightPanelView: { detailState: { loading: false } },
+      rightPanelViewStack: [{ detailState: { loading: false } }],
     });
   });
 });
@@ -249,6 +309,14 @@ describe("runtime event epoch", () => {
 });
 
 describe("session cache restoration", () => {
+  it("rejects cache hydration captured for an older remote or generation", () => {
+    const captured = { remoteKey: "https://old.example", generation: 7 };
+
+    expect(isSessionCacheContextCurrent(captured, "https://old.example", 7)).toBe(true);
+    expect(isSessionCacheContextCurrent(captured, "https://new.example", 7)).toBe(false);
+    expect(isSessionCacheContextCurrent(captured, "https://old.example", 8)).toBe(false);
+  });
+
   it("does not overwrite HTTP or SSE state that arrived while cache was loading", () => {
     const current = sessionState({
       eventLogEpoch: "epoch-live",
@@ -617,3 +685,58 @@ describe("optimistic operator prompt reconciliation", () => {
     ]));
   });
 });
+
+describe("runtime client generation", () => {
+  it("drops an old work-item response after switching clients with the same agent id", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+
+    let resolveOldWorkItems!: (response: Response) => void;
+    const oldWorkItems = new Promise<Response>((resolve) => {
+      resolveOldWorkItems = resolve;
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/agents/agent-a/work-items")) return oldWorkItems;
+      if (url.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.endsWith("/agents/list")) {
+        return Promise.resolve(jsonResponse([{ id: "agent-a", lifecycle: "asleep" }]));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+      const staleRefresh = useRuntimeStore.getState().refreshAgentWorkItems("agent-a");
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.stringContaining("/agents/agent-a/work-items"),
+          expect.anything(),
+        );
+      });
+
+      await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+      resolveOldWorkItems(jsonResponse([{ id: "old-work", objective: "old remote", state: "open" }]));
+      await staleRefresh;
+
+      expect(useRuntimeStore.getState().bootstrap.agents[0]?.workItems).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -368,6 +368,38 @@ export interface RuntimeStoreState {
   unregisterAgentForEvents: (agentId: string) => void;
 }
 
+export function resetTransientRuntimeStateForResume(
+  state: RuntimeStoreState,
+): Partial<RuntimeStoreState> {
+  return {
+    modelCatalogLoading: false,
+    runtimeConfigLoading: false,
+    runtimeConfigSaving: false,
+    skillCatalogLoading: false,
+    skillDetailLoadingById: resetBooleanMap(state.skillDetailLoadingById),
+    templateCatalogLoading: false,
+    templateSyncInProgress: false,
+    templateDetailLoadingById: resetBooleanMap(state.templateDetailLoadingById),
+    agentSkillCatalogLoadingByAgentId: resetBooleanMap(state.agentSkillCatalogLoadingByAgentId),
+    credentialStoreLoading: false,
+    codexDeviceLogin: { status: "idle" },
+    searchLoading: false,
+    searchResultContentLoadingBySourceRef: resetBooleanMap(state.searchResultContentLoadingBySourceRef),
+    rightPanelView: resetRightPanelLoading(state.rightPanelView),
+    rightPanelViewStack: state.rightPanelViewStack.map(resetRightPanelLoading).filter((view): view is RightPanelView => view !== undefined),
+    sessionsByAgentId: resetSessionsForResume(state.sessionsByAgentId),
+  };
+}
+
+function resetBooleanMap(values: Record<string, boolean>): Record<string, boolean> {
+  return Object.fromEntries(Object.keys(values).map((key) => [key, false]));
+}
+
+function resetRightPanelLoading(view: RightPanelView | undefined): RightPanelView | undefined {
+  if (!view || !("detailState" in view) || !view.detailState?.loading) return view;
+  return { ...view, detailState: { ...view.detailState, loading: false } };
+}
+
 const LEGACY_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1";
 const ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.activeRuntimeConnection.v1";
 const RUNTIME_CONNECTION_PROFILES_STORAGE_KEY = "holon.webGui.runtimeConnectionProfiles.v1";
@@ -465,6 +497,21 @@ function isCurrentClientGeneration(generation: number): boolean {
   return generation === clientGeneration;
 }
 
+type RuntimeClient = ReturnType<typeof createRuntimeClient>;
+
+interface ClientRequest {
+  client: RuntimeClient;
+  generation: number;
+}
+
+function captureClientRequest(): ClientRequest {
+  return { client: runtimeClient, generation: clientGeneration };
+}
+
+function isCurrentClientRequest(request: ClientRequest): boolean {
+  return request.client === runtimeClient && isCurrentClientGeneration(request.generation);
+}
+
 function clearInFlightHydration(): void {
   messageHydrationInFlight.clear();
   transcriptHydrationInFlight.clear();
@@ -478,6 +525,11 @@ function cancelClientGenerationWork(): void {
     bootstrapRefreshTimer = undefined;
   }
   agentStateRefreshInFlight.clear();
+  inspectorDetailInFlight.clear();
+  workItemRefreshInFlight.clear();
+  workItemDetailInFlight.clear();
+  taskDetailInFlight.clear();
+  toolExecutionDetailInFlight.clear();
   clearInFlightHydration();
 }
 
@@ -507,16 +559,51 @@ export function resetSessionsForResume(
         ...session,
         loading: false,
         loadingOlder: false,
+        sendingPrompt: false,
         liveStatus: "stale" as const,
         reconnectAttempt: 0,
+        workItemDetailsById: resetDetailLoading(session.workItemDetailsById),
+        taskDetailsById: resetDetailLoading(session.taskDetailsById),
+        toolExecutionDetailsById: resetDetailLoading(session.toolExecutionDetailsById),
       },
     ]),
+  );
+}
+
+function resetDetailLoading<T extends { loading?: boolean }>(detailsById: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(detailsById).map(([id, detail]) => [id, detail.loading ? { ...detail, loading: false } : detail]),
   );
 }
 
 // ─── Session cache (IndexedDB persistence) ──────────────────────────
 let sessionCacheWriter: SessionCacheWriter | null = null;
 let sessionCacheInitPromise: Promise<void> | null = null;
+
+interface SessionCacheContext {
+  remoteKey: string;
+  generation: number;
+}
+
+export function isSessionCacheContextCurrent(
+  context: SessionCacheContext,
+  remoteKey: string,
+  generation: number,
+): boolean {
+  return context.remoteKey === remoteKey && context.generation === generation;
+}
+
+function currentSessionCacheContext(): SessionCacheContext {
+  return {
+    remoteKey: currentRemoteKey(runtimeConnectionConfig),
+    generation: clientGeneration,
+  };
+}
+
+function sessionCacheContextIsCurrent(context: SessionCacheContext): boolean {
+  const current = currentSessionCacheContext();
+  return isSessionCacheContextCurrent(context, current.remoteKey, current.generation);
+}
 
 function runtimeClientOptions(config: RuntimeConnectionConfig) {
   return config.mode === "remote"
@@ -837,49 +924,64 @@ function filterDismissedDiagnostics(
  */
 function initSessionCacheForRemote(set: StoreSet, get?: () => RuntimeStoreState): void {
   if (sessionCacheInitPromise) return;
-  const remoteKey = currentRemoteKey(runtimeConnectionConfig);
-
-  sessionCacheInitPromise = (async () => {
-    const ok = await initSessionCache();
-    if (!ok) {
-      sessionCacheWriter = null;
-      return;
-    }
-
-    // Set up writer for this remote.
-    sessionCacheWriter?.cancel();
-    sessionCacheWriter = new SessionCacheWriter(remoteKey);
-
-    // Hydrate cached sessions into store.
-    const cached = await hydrateAllSessions(remoteKey);
-    if (Object.keys(cached).length === 0) return;
-
-    const restoredAgentIds: string[] = [];
-    set((state) => {
-      const sessionsByAgentId = { ...state.sessionsByAgentId };
-      for (const [agentId, partial] of Object.entries(cached)) {
-        const current = sessionsByAgentId[agentId] ?? emptyAgentSession();
-        const restored = mergeCachedSessionIntoCurrent(current, partial);
-        if (restored === current) continue;
-        sessionsByAgentId[agentId] = restored;
-        restoredAgentIds.push(agentId);
+  const context = currentSessionCacheContext();
+  const initialization = (async () => {
+    try {
+      const ok = await initSessionCache();
+      if (!sessionCacheContextIsCurrent(context)) return;
+      if (!ok) {
+        sessionCacheWriter = null;
+        return;
       }
-      const withProvisional = rebuildProvisionalDetailsWithAgents(
-        state.bootstrap.agents,
-        sessionsByAgentId,
-      );
-      return { sessionsByAgentId: withProvisional ?? sessionsByAgentId };
-    });
 
-    if (get) {
-      const displayLevel = get().displayLevel;
-      for (const agentId of restoredAgentIds) {
-        scheduleMessageHydration(get, set, agentId, displayLevel);
-        scheduleTranscriptHydration(get, set, agentId, displayLevel);
-        scheduleBriefHydration(get, set, agentId, displayLevel);
+      // Set up writer for this remote.
+      sessionCacheWriter?.cancel();
+      const writer = new SessionCacheWriter(context.remoteKey);
+      sessionCacheWriter = writer;
+
+      // Hydrate cached sessions into store.
+      const cached = await hydrateAllSessions(context.remoteKey);
+      if (!sessionCacheContextIsCurrent(context) || sessionCacheWriter !== writer) return;
+      if (Object.keys(cached).length === 0) return;
+
+      const restoredAgentIds: string[] = [];
+      set((state) => {
+        const sessionsByAgentId = { ...state.sessionsByAgentId };
+        for (const [agentId, partial] of Object.entries(cached)) {
+          const current = sessionsByAgentId[agentId] ?? emptyAgentSession();
+          const restored = mergeCachedSessionIntoCurrent(current, partial);
+          if (restored === current) continue;
+          sessionsByAgentId[agentId] = restored;
+          restoredAgentIds.push(agentId);
+        }
+        const withProvisional = rebuildProvisionalDetailsWithAgents(
+          state.bootstrap.agents,
+          sessionsByAgentId,
+        );
+        return { sessionsByAgentId: withProvisional ?? sessionsByAgentId };
+      });
+
+      if (get && sessionCacheContextIsCurrent(context)) {
+        const displayLevel = get().displayLevel;
+        for (const agentId of restoredAgentIds) {
+          scheduleMessageHydration(get, set, agentId, displayLevel);
+          scheduleTranscriptHydration(get, set, agentId, displayLevel);
+          scheduleBriefHydration(get, set, agentId, displayLevel);
+        }
       }
+    } catch {
+      if (sessionCacheContextIsCurrent(context)) sessionCacheWriter = null;
     }
   })();
+  sessionCacheInitPromise = initialization;
+  void initialization.then(
+    () => {
+      if (sessionCacheInitPromise === initialization) sessionCacheInitPromise = null;
+    },
+    () => {
+      if (sessionCacheInitPromise === initialization) sessionCacheInitPromise = null;
+    },
+  );
 }
 
 export function mergeCachedSessionIntoCurrent(
@@ -1118,6 +1220,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   setRuntimeConnection: async (config) => {
     nextClientGeneration();
+    cancelClientGenerationWork();
     const normalizedBaseUrl = config.mode === "remote" ? normalizeConnectionBaseUrl(config.baseUrl) : "";
     const retainedToken =
       config.mode === "remote" &&
@@ -1176,8 +1279,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       bootstrapLoading: true,
       bootstrapError: undefined,
       modelCatalog: emptyModelCatalog,
+      modelCatalogLoading: false,
       modelCatalogError: undefined,
       runtimeConfig: emptyRuntimeConfig,
+      runtimeConfigLoading: false,
+      runtimeConfigSaving: false,
       runtimeConfigError: undefined,
       skillCatalog: emptySkillCatalog,
       skillCatalogLoading: false,
@@ -1202,7 +1308,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       credentialStoreError: undefined,
       codexDeviceLogin: { status: "idle" as const },
       search: null,
+      searchLoading: false,
       searchError: undefined,
+      searchResultContentBySourceRef: {},
+      searchResultContentLoadingBySourceRef: {},
+      searchResultContentErrorBySourceRef: {},
       sessionsByAgentId: {},
       rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(normalizedConfig)),
       selectedAgentId: "",
@@ -1292,10 +1402,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     const generation = nextClientGeneration();
     cancelClientGenerationWork();
     closeEventStreamsForResume(set);
+    // First invalidate transient layout/loading state before fresh projections arrive.
     set((state) => ({
+      ...resetTransientRuntimeStateForResume(state),
       resumeRevision: state.resumeRevision + 1,
-      sessionsByAgentId: resetSessionsForResume(state.sessionsByAgentId),
     }));
+    resumeSkillInstallJobPolling(set, get);
 
     const request = (async () => {
       try {
@@ -1310,6 +1422,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         }
       } finally {
         if (isCurrentClientGeneration(generation)) {
+          // Then remeasure once more after the reconciled projections and hydration are scheduled.
           set((state) => ({ resumeRevision: state.resumeRevision + 1 }));
         }
       }
@@ -1326,11 +1439,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   refreshModelCatalog: async () => {
+    const request = captureClientRequest();
     set({ modelCatalogLoading: true, modelCatalogError: undefined });
     try {
-      const modelCatalog = await runtimeClient.getModels();
+      const modelCatalog = await request.client.getModels();
+      if (!isCurrentClientRequest(request)) return;
       set({ modelCatalog, modelCatalogLoading: false, modelCatalogError: modelCatalog.error });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         modelCatalog: { ...state.modelCatalog, error: message },
@@ -1341,11 +1457,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   refreshRuntimeConfig: async () => {
+    const request = captureClientRequest();
     set({ runtimeConfigLoading: true, runtimeConfigError: undefined });
     try {
-      const runtimeConfig = await runtimeClient.getRuntimeConfig();
+      const runtimeConfig = await request.client.getRuntimeConfig();
+      if (!isCurrentClientRequest(request)) return;
       set({ runtimeConfig, runtimeConfigLoading: false, runtimeConfigError: runtimeConfig.error });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         runtimeConfig: { ...state.runtimeConfig, error: message },
@@ -1356,16 +1475,20 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   updateRuntimeConfig: async (updates) => {
+    const request = captureClientRequest();
     set({ runtimeConfigSaving: true, runtimeConfigError: undefined });
     try {
-      const runtimeConfig = await runtimeClient.updateRuntimeConfig(updates);
+      const runtimeConfig = await request.client.updateRuntimeConfig(updates);
+      if (!isCurrentClientRequest(request)) return undefined;
       set({ runtimeConfig, runtimeConfigSaving: false, runtimeConfigError: runtimeConfig.error });
       if (runtimeConfig.changed && !runtimeConfig.error) {
         set({ modelCatalogLoading: true, modelCatalogError: undefined });
         try {
-          const modelCatalog = await runtimeClient.getModels();
+          const modelCatalog = await request.client.getModels();
+          if (!isCurrentClientRequest(request)) return runtimeConfig;
           set({ modelCatalog, modelCatalogLoading: false, modelCatalogError: modelCatalog.error });
         } catch (modelError) {
+          if (!isCurrentClientRequest(request)) return runtimeConfig;
           const message = modelError instanceof Error ? modelError.message : String(modelError);
           set((state) => ({
             modelCatalog: { ...state.modelCatalog, error: message },
@@ -1376,6 +1499,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       }
       return runtimeConfig;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return undefined;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         runtimeConfig: { ...state.runtimeConfig, error: message },
@@ -1387,11 +1511,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   refreshSkillCatalog: async () => {
+    const request = captureClientRequest();
     set({ skillCatalogLoading: true, skillCatalogError: undefined });
     try {
-      const skillCatalog = await runtimeClient.getSkillCatalog();
+      const skillCatalog = await request.client.getSkillCatalog();
+      if (!isCurrentClientRequest(request)) return;
       set({ skillCatalog, skillCatalogLoading: false, skillCatalogError: skillCatalog.error });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         skillCatalog: { ...state.skillCatalog, source: "http", error: message },
@@ -1403,19 +1530,22 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   refreshSkillDetail: async (skillId) => {
     if (!skillId) return;
+    const request = captureClientRequest();
     set((state) => ({
       skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: true },
       skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: undefined },
     }));
     try {
       // The backend resolves scope from the skill_id prefix automatically.
-      const detail = await runtimeClient.getSkillDetail(skillId);
+      const detail = await request.client.getSkillDetail(skillId);
+      if (!isCurrentClientRequest(request)) return;
       set((state) => ({
         skillDetailById: { ...state.skillDetailById, [skillId]: detail },
         skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: false },
         skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: detail.error },
       }));
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         skillDetailById: {
@@ -1429,13 +1559,16 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   refreshTemplateCatalog: async () => {
+    const request = captureClientRequest();
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
       const templateCatalog = filterDismissedDiagnostics(
-        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+        await request.client.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
       );
+      if (!isCurrentClientRequest(request)) return;
       set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         templateCatalog: { ...state.templateCatalog, source: "http", error: message },
@@ -1447,18 +1580,21 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   refreshTemplateDetail: async (catalogId) => {
     if (!catalogId) return;
+    const request = captureClientRequest();
     set((state) => ({
       templateDetailLoadingById: { ...state.templateDetailLoadingById, [catalogId]: true },
       templateDetailErrorById: { ...state.templateDetailErrorById, [catalogId]: undefined },
     }));
     try {
-      const detail = await runtimeClient.getTemplateDetail(catalogId);
+      const detail = await request.client.getTemplateDetail(catalogId);
+      if (!isCurrentClientRequest(request)) return;
       set((state) => ({
         templateDetailById: { ...state.templateDetailById, [catalogId]: detail },
         templateDetailLoadingById: { ...state.templateDetailLoadingById, [catalogId]: false },
         templateDetailErrorById: { ...state.templateDetailErrorById, [catalogId]: detail.error },
       }));
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         templateDetailById: {
@@ -1472,15 +1608,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   installTemplate: async (githubUrl) => {
+    const request = captureClientRequest();
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
-      await runtimeClient.installTemplate(githubUrl);
+      await request.client.installTemplate(githubUrl);
       const templateCatalog = filterDismissedDiagnostics(
-        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+        await request.client.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
       );
+      if (!isCurrentClientRequest(request)) return false;
       set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         templateCatalog: { ...state.templateCatalog, error: message },
@@ -1492,15 +1631,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   removeTemplate: async (templateId) => {
+    const request = captureClientRequest();
     set({ templateCatalogLoading: true, templateCatalogError: undefined });
     try {
-      await runtimeClient.removeTemplate(templateId);
+      await request.client.removeTemplate(templateId);
       const templateCatalog = filterDismissedDiagnostics(
-        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+        await request.client.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
       );
+      if (!isCurrentClientRequest(request)) return false;
       set({ templateCatalog, templateCatalogLoading: false, templateCatalogError: templateCatalog.error });
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         templateCatalog: { ...state.templateCatalog, error: message },
@@ -1512,19 +1654,22 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   syncTemplateRemoteSources: async () => {
+    const request = captureClientRequest();
     set({ templateCatalogLoading: true, templateCatalogError: undefined, templateSyncMessage: undefined });
     try {
       set({ templateSyncInProgress: true });
-      const jobId = await runtimeClient.syncTemplateRemoteSources();
-      await pollTemplateSyncJob(set, get, jobId);
+      const jobId = await request.client.syncTemplateRemoteSources();
+      await pollTemplateSyncJob(request, jobId);
       const templateCatalog = filterDismissedDiagnostics(
-        await runtimeClient.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
+        await request.client.getTemplateCatalog(), get().dismissedTemplateDiagnostics,
       );
+      if (!isCurrentClientRequest(request)) return false;
       const sourceCount = templateCatalog.sources.length;
       const templateCount = templateCatalog.catalog.length;
       set({ templateCatalog, templateCatalogLoading: false, templateSyncInProgress: false, templateCatalogError: templateCatalog.error, templateSyncMessage: `Synced ${sourceCount} source(s), ${templateCount} template(s).` });
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         templateCatalog: { ...state.templateCatalog, error: message },
@@ -1538,12 +1683,15 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   createAgentFromTemplate: async (agentId, template) => {
+    const request = captureClientRequest();
     set({ templateCatalogError: undefined });
     try {
-      await runtimeClient.createAgentFromTemplate(agentId, template);
+      await request.client.createAgentFromTemplate(agentId, template);
+      if (!isCurrentClientRequest(request)) return false;
       await get().refreshBootstrap({ background: true });
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set({ templateCatalogError: message });
       return false;
@@ -1568,9 +1716,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   addSkillToCatalog: async (input) => {
+    const request = captureClientRequest();
     set({ skillCatalogError: undefined });
     try {
-      const jobId = await runtimeClient.addSkillToCatalog(input);
+      const jobId = await request.client.addSkillToCatalog(input);
+      if (!isCurrentClientRequest(request)) return false;
       const source = "package" in input ? input.package : "path" in input ? input.path : "name" in input ? input.name : "unknown";
       const job: SkillInstallJob = { jobId, source, status: "queued" };
       set((state) => {
@@ -1578,9 +1728,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         saveSkillInstallJobs(jobs);
         return { skillInstallJobs: jobs };
       });
-      void pollSkillInstallJob(set, get, jobId);
+      void pollSkillInstallJob(set, get, request, jobId);
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set({ skillCatalogError: message });
       return false;
@@ -1588,13 +1739,16 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   removeSkillFromCatalog: async (name) => {
+    const request = captureClientRequest();
     set({ skillCatalogLoading: true, skillCatalogError: undefined });
     try {
-      await runtimeClient.removeSkillFromCatalog(name);
-      const skillCatalog = await runtimeClient.getSkillCatalog();
+      await request.client.removeSkillFromCatalog(name);
+      const skillCatalog = await request.client.getSkillCatalog();
+      if (!isCurrentClientRequest(request)) return false;
       set({ skillCatalog, skillCatalogLoading: false, skillCatalogError: skillCatalog.error });
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         skillCatalog: { ...state.skillCatalog, error: message },
@@ -1606,9 +1760,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   updateSkillCatalog: async (name) => {
+    const request = captureClientRequest();
     set({ skillCatalogError: undefined });
     try {
-      const jobId = await runtimeClient.updateSkillCatalog(name);
+      const jobId = await request.client.updateSkillCatalog(name);
+      if (!isCurrentClientRequest(request)) return false;
       const job: SkillInstallJob = {
         jobId,
         source: name ?? "all skills",
@@ -1620,9 +1776,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         saveSkillInstallJobs(jobs);
         return { skillInstallJobs: jobs };
       });
-      void pollSkillInstallJob(set, get, jobId);
+      void pollSkillInstallJob(set, get, request, jobId);
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         skillCatalog: { ...state.skillCatalog, error: message },
@@ -1635,13 +1792,16 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   dismissSkillJob: (jobId) => removeSkillInstallJob(set, get, jobId),
 
   checkSkillCatalog: async (name) => {
+    const request = captureClientRequest();
     set({ skillCatalogLoading: true, skillCatalogError: undefined });
     try {
-      await runtimeClient.checkSkillCatalog(name);
-      const skillCatalog = await runtimeClient.getSkillCatalog();
+      await request.client.checkSkillCatalog(name);
+      const skillCatalog = await request.client.getSkillCatalog();
+      if (!isCurrentClientRequest(request)) return false;
       set({ skillCatalog, skillCatalogLoading: false, skillCatalogError: skillCatalog.error });
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         skillCatalog: { ...state.skillCatalog, error: message },
@@ -1654,6 +1814,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   refreshAgentSkillCatalog: async (agentId) => {
     if (!agentId) return;
+    const request = captureClientRequest();
     set((state) => ({
       agentSkillCatalogLoadingByAgentId: {
         ...state.agentSkillCatalogLoadingByAgentId,
@@ -1665,7 +1826,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       },
     }));
     try {
-      const catalog = await runtimeClient.getSkillCatalog(agentId);
+      const catalog = await request.client.getSkillCatalog(agentId);
+      if (!isCurrentClientRequest(request)) return;
       set((state) => ({
         agentSkillCatalogByAgentId: {
           ...state.agentSkillCatalogByAgentId,
@@ -1677,6 +1839,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         },
       }));
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         agentSkillCatalogLoadingByAgentId: {
@@ -1693,6 +1856,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   enableAgentSkill: async (agentId, name) => {
     if (!agentId) return false;
+    const request = captureClientRequest();
     set((state) => ({
       agentSkillCatalogLoadingByAgentId: {
         ...state.agentSkillCatalogLoadingByAgentId,
@@ -1704,8 +1868,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       },
     }));
     try {
-      await runtimeClient.enableAgentSkill(agentId, name);
-      const catalog = await runtimeClient.getSkillCatalog(agentId);
+      await request.client.enableAgentSkill(agentId, name);
+      const catalog = await request.client.getSkillCatalog(agentId);
+      if (!isCurrentClientRequest(request)) return false;
       set((state) => ({
         agentSkillCatalogByAgentId: {
           ...state.agentSkillCatalogByAgentId,
@@ -1718,6 +1883,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       }));
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         agentSkillCatalogLoadingByAgentId: {
@@ -1735,6 +1901,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   disableAgentSkill: async (agentId, name) => {
     if (!agentId) return false;
+    const request = captureClientRequest();
     set((state) => ({
       agentSkillCatalogLoadingByAgentId: {
         ...state.agentSkillCatalogLoadingByAgentId,
@@ -1746,8 +1913,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       },
     }));
     try {
-      await runtimeClient.disableAgentSkill(agentId, name);
-      const catalog = await runtimeClient.getSkillCatalog(agentId);
+      await request.client.disableAgentSkill(agentId, name);
+      const catalog = await request.client.getSkillCatalog(agentId);
+      if (!isCurrentClientRequest(request)) return false;
       set((state) => ({
         agentSkillCatalogByAgentId: {
           ...state.agentSkillCatalogByAgentId,
@@ -1760,6 +1928,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       }));
       return true;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return false;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         agentSkillCatalogLoadingByAgentId: {
@@ -1777,24 +1946,29 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
 
   refreshCredentialStore: async () => {
+    const request = captureClientRequest();
     set({ credentialStoreLoading: true, credentialStoreError: undefined });
     try {
-      const credentialStore = await runtimeClient.listCredentials();
+      const credentialStore = await request.client.listCredentials();
+      if (!isCurrentClientRequest(request)) return;
       set({ credentialStore, credentialStoreLoading: false });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set({ credentialStoreLoading: false, credentialStoreError: message });
     }
   },
 
   setCredential: async (profile, kind, material) => {
+    const request = captureClientRequest();
     try {
-      const result = await runtimeClient.setCredential(profile, kind, material);
+      const result = await request.client.setCredential(profile, kind, material);
       const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
-        runtimeClient.listCredentials(),
-        runtimeClient.getRuntimeConfig(),
-        runtimeClient.getModels(),
+        request.client.listCredentials(),
+        request.client.getRuntimeConfig(),
+        request.client.getModels(),
       ]);
+      if (!isCurrentClientRequest(request)) return undefined;
       set({
         credentialStore,
         credentialStoreError: undefined,
@@ -1805,6 +1979,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       });
       return result;
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return undefined;
       const message = error instanceof Error ? error.message : String(error);
       set({ credentialStoreError: message });
       return undefined;
@@ -1812,13 +1987,15 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   deleteCredential: async (profile) => {
+    const request = captureClientRequest();
     try {
-      await runtimeClient.deleteCredential(profile);
+      await request.client.deleteCredential(profile);
       const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
-        runtimeClient.listCredentials(),
-        runtimeClient.getRuntimeConfig(),
-        runtimeClient.getModels(),
+        request.client.listCredentials(),
+        request.client.getRuntimeConfig(),
+        request.client.getModels(),
       ]);
+      if (!isCurrentClientRequest(request)) return;
       set({
         credentialStore,
         credentialStoreError: undefined,
@@ -1828,14 +2005,17 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         modelCatalogError: modelCatalog.error,
       });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set({ credentialStoreError: message });
     }
   },
   startCodexDeviceLogin: async (providerId = "openai-codex") => {
+    const request = captureClientRequest();
     set({ codexDeviceLogin: { status: "starting" } });
     try {
-      const resp = await runtimeClient.startCodexDeviceLogin(providerId);
+      const resp = await request.client.startCodexDeviceLogin(providerId);
+      if (!isCurrentClientRequest(request)) return;
       set({
         codexDeviceLogin: {
           status: "waiting",
@@ -1851,6 +2031,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       const expiresAt = resp.expiresAt ? new Date(resp.expiresAt).getTime() : Date.now() + 300_000;
 
       const poll = async (): Promise<void> => {
+        if (!isCurrentClientRequest(request)) return;
         const current = get().codexDeviceLogin;
         if (current.status !== "waiting" || current.jobId !== jobId) return;
         if (Date.now() > expiresAt) {
@@ -1858,13 +2039,15 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           return;
         }
         try {
-          const job = await runtimeClient.getJob(jobId);
+          const job = await request.client.getJob(jobId);
+          if (!isCurrentClientRequest(request)) return;
           if (job.status === "completed") {
             const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
-              runtimeClient.listCredentials(),
-              runtimeClient.getRuntimeConfig(),
-              runtimeClient.getModels(),
+              request.client.listCredentials(),
+              request.client.getRuntimeConfig(),
+              request.client.getModels(),
             ]);
+            if (!isCurrentClientRequest(request)) return;
             set({
               codexDeviceLogin: { status: "completed" },
               credentialStore,
@@ -1888,6 +2071,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
       setTimeout(() => { void poll(); }, pollInterval);
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set({ codexDeviceLogin: { status: "failed", error: message } });
     }
@@ -1901,9 +2085,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set({ search: null, searchLoading: false, searchError: undefined });
       return;
     }
+    const request = captureClientRequest();
     set({ searchLoading: true, searchError: undefined });
     try {
-      const search = await runtimeClient.search(trimmed, options);
+      const search = await request.client.search(trimmed, options);
+      if (!isCurrentClientRequest(request)) return;
       set({
         search,
         searchLoading: false,
@@ -1912,12 +2098,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         searchResultContentErrorBySourceRef: {},
       });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       set({ searchLoading: false, searchError: error instanceof Error ? error.message : String(error) });
     }
   },
   loadSearchResultContent: async (sourceRef) => {
     const trimmed = sourceRef.trim();
     if (!trimmed) return;
+    const request = captureClientRequest();
     const state = get();
     if (state.searchResultContentBySourceRef[trimmed] || state.searchResultContentLoadingBySourceRef[trimmed]) {
       return;
@@ -1933,7 +2121,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       },
     }));
     try {
-      const content = await runtimeClient.getMemorySource(trimmed);
+      const content = await request.client.getMemorySource(trimmed);
+      if (!isCurrentClientRequest(request)) return;
       set((current) => ({
         searchResultContentBySourceRef: {
           ...current.searchResultContentBySourceRef,
@@ -1945,6 +2134,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         },
       }));
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       set((current) => ({
         searchResultContentLoadingBySourceRef: {
           ...current.searchResultContentLoadingBySourceRef,
@@ -1963,7 +2153,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       return;
     }
 
-    const generation = clientGeneration;
+    const request = captureClientRequest();
     set((state) => ({
       sessionsByAgentId: {
         ...state.sessionsByAgentId,
@@ -1977,17 +2167,17 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }));
 
     try {
-      const detail = await runtimeClient.getAgentDetail(agentId, displayLevel);
-      if (!isCurrentClientGeneration(generation)) return;
+      const detail = await request.client.getAgentDetail(agentId, displayLevel);
+      if (!isCurrentClientRequest(request)) return;
       set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
       await loadTargetAgentEventWindow(get, set, agentId, displayLevel);
-      if (!isCurrentClientGeneration(generation)) return;
+      if (!isCurrentClientRequest(request)) return;
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
       scheduleCacheWrite(get, agentId);
     } catch (error) {
-      if (!isCurrentClientGeneration(generation)) return;
+      if (!isCurrentClientRequest(request)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -2005,11 +2195,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   refreshAgentWorkItems: async (agentId) => {
     if (!agentId || workItemRefreshInFlight.has(agentId)) return;
+    const request = captureClientRequest();
     workItemRefreshInFlight.add(agentId);
     try {
-      const workItems = await runtimeClient.getAgentWorkItems(agentId, { limit: 50 });
+      const workItems = await request.client.getAgentWorkItems(agentId, { limit: 50 });
+      if (!isCurrentClientRequest(request)) return;
       set((state) => mergeAgentWorkItemsIntoState(state, agentId, workItems));
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -2021,22 +2214,27 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         },
       }));
     } finally {
-      workItemRefreshInFlight.delete(agentId);
+      if (isCurrentClientRequest(request)) {
+        workItemRefreshInFlight.delete(agentId);
+      }
     }
   },
 
   refreshAgentState: async (agentId) => {
     if (!agentId || agentStateRefreshInFlight.has(agentId)) return;
-    const generation = clientGeneration;
-    agentStateRefreshInFlight.set(agentId, generation);
+    const request = captureClientRequest();
+    agentStateRefreshInFlight.set(agentId, request.generation);
     try {
-      const freshAgent = await runtimeClient.getAgentState(agentId);
-      if (!isCurrentClientGeneration(generation)) return;
+      const freshAgent = await request.client.getAgentState(agentId);
+      if (!isCurrentClientRequest(request)) return;
       set((state) => mergeAgentStateIntoState(state, agentId, freshAgent));
     } catch {
       // Swallow — state refresh is best-effort; the next full detail refresh will recover.
     } finally {
-      if (agentStateRefreshInFlight.get(agentId) === generation) {
+      if (
+        isCurrentClientRequest(request) &&
+        agentStateRefreshInFlight.get(agentId) === request.generation
+      ) {
         agentStateRefreshInFlight.delete(agentId);
       }
     }
@@ -2044,40 +2242,51 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   loadAgentWorkItemDetail: async (agentId, workItemId) => {
     if (!agentId || !workItemId) return;
+    const request = captureClientRequest();
     const key = `${agentId}:${workItemId}`;
     const cached = get().sessionsByAgentId[agentId]?.workItemDetailsById[workItemId];
     if (cached?.workItem || cached?.loading || workItemDetailInFlight.has(key)) return;
     workItemDetailInFlight.add(key);
     setWorkItemDetailState(set, agentId, workItemId, { loading: true, error: undefined });
     try {
-      const workItem = await runtimeClient.getAgentWorkItem(agentId, workItemId);
+      const workItem = await request.client.getAgentWorkItem(agentId, workItemId);
+      if (!isCurrentClientRequest(request)) return;
       setWorkItemDetailState(set, agentId, workItemId, { loading: false, workItem });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       setWorkItemDetailState(set, agentId, workItemId, {
         loading: false,
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      workItemDetailInFlight.delete(key);
+      if (isCurrentClientRequest(request)) {
+        workItemDetailInFlight.delete(key);
+      }
     }
   },
 
   loadAgentTaskDetail: async (agentId, taskId) => {
     if (!agentId || !taskId) return;
+    const request = captureClientRequest();
     const key = `${agentId}:${taskId}`;
     const cached = get().sessionsByAgentId[agentId]?.taskDetailsById[taskId];
     if (cached?.output || cached?.loading || taskDetailInFlight.has(key)) return;
     taskDetailInFlight.add(key);
     setTaskDetailState(set, agentId, taskId, { loading: true, error: undefined });
     try {
-      const output = await runtimeClient.getTaskOutput(agentId, taskId);
+      const output = await request.client.getTaskOutput(agentId, taskId);
+      if (!isCurrentClientRequest(request)) return;
       setTaskDetailState(set, agentId, taskId, { loading: false, output });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       setTaskDetailState(set, agentId, taskId, {
         loading: false,
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
+      if (!isCurrentClientRequest(request)) {
+        return;
+      }
       taskDetailInFlight.delete(key);
       const selection = get().rightPanelView;
       if (selection?.kind === "task_detail" && selection.agentId === agentId && selection.task.id === taskId) {
@@ -2091,15 +2300,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   loadAgentToolExecutionDetail: async (agentId, toolExecutionId, fallbackActivity) => {
     if (!agentId || !toolExecutionId) return;
+    const request = captureClientRequest();
     const key = `${agentId}:${toolExecutionId}`;
     const cached = get().sessionsByAgentId[agentId]?.toolExecutionDetailsById[toolExecutionId];
     if (cached?.toolExecution || cached?.loading || toolExecutionDetailInFlight.has(key)) return;
     toolExecutionDetailInFlight.add(key);
     setToolExecutionDetailState(set, agentId, toolExecutionId, { loading: true, error: undefined });
     try {
-      const toolExecution = await runtimeClient.getToolExecution(agentId, toolExecutionId);
+      const toolExecution = await request.client.getToolExecution(agentId, toolExecutionId);
+      if (!isCurrentClientRequest(request)) return;
       setToolExecutionDetailState(set, agentId, toolExecutionId, { loading: false, toolExecution });
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       // If the tool execution record doesn't exist (e.g. historical events
       // without tool_execution_id), fall back to the activity inspector
       // which renders structured detail from the raw event payload.
@@ -2119,6 +2331,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
+      if (!isCurrentClientRequest(request)) {
+        return;
+      }
       toolExecutionDetailInFlight.delete(key);
       const selection = get().rightPanelView;
       if (selection?.kind === "tool_execution_detail" && selection.agentId === agentId && selection.toolExecutionId === toolExecutionId) {
@@ -2135,7 +2350,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     const session = get().sessionsByAgentId[agentId] ?? emptyAgentSession();
     if (session.loadingOlder || !session.hasOlder || session.oldestSeq == null) return;
 
-    const generation = clientGeneration;
+    const request = captureClientRequest();
     set((state) => ({
       sessionsByAgentId: {
         ...state.sessionsByAgentId,
@@ -2149,13 +2364,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }));
 
     try {
-      const page = await runtimeClient.getAgentEvents(agentId, {
+      const page = await request.client.getAgentEvents(agentId, {
         beforeSeq: session.oldestSeq,
         limit: 80,
         order: "desc",
         displayLevel,
       });
-      if (!isCurrentClientGeneration(generation)) return;
+      if (!isCurrentClientRequest(request)) return;
 
       set((state) =>
         mergeEventPageIntoSession(
@@ -2172,7 +2387,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
     } catch (error) {
-      if (!isCurrentClientGeneration(generation)) return;
+      if (!isCurrentClientRequest(request)) return;
       set((state) => ({
         sessionsByAgentId: {
           ...state.sessionsByAgentId,
@@ -2194,6 +2409,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       return;
     }
 
+    const request = captureClientRequest();
     const clientId = crypto.randomUUID();
     set((state) => {
       const rosterActivityByAgentId = touchRosterActivity(state.rosterActivityByAgentId, agentId, "operator", new Date().toISOString());
@@ -2222,7 +2438,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     });
 
     try {
-      const { messageId } = await runtimeClient.sendOperatorPrompt(agentId, prompt, attachments);
+      const { messageId } = await request.client.sendOperatorPrompt(agentId, prompt, attachments);
+      if (!isCurrentClientRequest(request)) return;
       scheduleBootstrapRefresh(get, 250);
       set((state) => ({
         sessionsByAgentId: {
@@ -2244,6 +2461,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         void catchUpAgentEvents(get, set, agentId, displayLevel);
       }
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
         sessionsByAgentId: {
@@ -2262,10 +2480,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   setAgentModel: async (agentId, model, displayLevel, reasoningEffort) => {
     if (!agentId || !model) return;
+    const request = captureClientRequest();
     const previousAgent = get().sessionsByAgentId[agentId]?.detail?.agent;
     setSessionModelError(set, agentId, undefined);
     try {
-      const modelState = await runtimeClient.setAgentModel(agentId, model, reasoningEffort);
+      const modelState = await request.client.setAgentModel(agentId, model, reasoningEffort);
+      if (!isCurrentClientRequest(request)) return;
       set((state) =>
         updateAgentModelInState(state, agentId, {
           model: modelState?.active_model ?? modelState?.effective_model ?? model,
@@ -2275,6 +2495,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       );
       await get().refreshAgentDetail(agentId, displayLevel);
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       setSessionModelError(set, agentId, message);
       if (previousAgent) {
@@ -2286,10 +2507,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
   clearAgentModel: async (agentId, displayLevel) => {
     if (!agentId) return;
+    const request = captureClientRequest();
     const previousAgent = get().sessionsByAgentId[agentId]?.detail?.agent;
     setSessionModelError(set, agentId, undefined);
     try {
-      const modelState = await runtimeClient.clearAgentModel(agentId);
+      const modelState = await request.client.clearAgentModel(agentId);
+      if (!isCurrentClientRequest(request)) return;
       set((state) =>
         updateAgentModelInState(state, agentId, {
           model: modelState?.active_model ?? modelState?.effective_model ?? "runtime default",
@@ -2299,6 +2522,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       );
       await get().refreshAgentDetail(agentId, displayLevel);
     } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       setSessionModelError(set, agentId, message);
       if (previousAgent) {
@@ -2311,6 +2535,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   startAgentEventStream: (agentId, displayLevel) => {
     if (!agentId) return;
     stopAgentEventStream(agentId, set);
+    const request = captureClientRequest();
     const session = get().sessionsByAgentId[agentId] ?? emptyAgentSession();
     if (session.detail?.error) return;
 
@@ -2319,10 +2544,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       reconnectAttempt,
       error: undefined,
     });
-    const subscription = runtimeClient.streamAgentEvents(agentId, {
+    const subscription = request.client.streamAgentEvents(agentId, {
       afterSeq: highestSeq(session.eventSeqs) ?? session.newestSeq ?? 0,
       limit: 100,
       onOpen: () => {
+        if (!isCurrentClientRequest(request)) return;
         markStreamActivity(set, agentId);
         setStreamState(set, agentId, reconnectAttempt > 0 ? "recovering" : "streaming", {
           reconnectAttempt: 0,
@@ -2334,16 +2560,26 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         }
       },
       onActivity: () => {
+        if (!isCurrentClientRequest(request)) return;
         markStreamActivity(set, agentId);
         scheduleStaleWatchdog(get, set, agentId, displayLevel);
       },
       onEvent: (event) => {
+        if (!isCurrentClientRequest(request)) return;
         markStreamActivity(set, agentId);
         enqueueStreamEvent(set, agentId, event);
         scheduleBootstrapRefresh(get);
       },
-      onClose: () => scheduleStreamReconnect(get, set, agentId, displayLevel, "event stream closed"),
-      onError: (error) => scheduleStreamReconnect(get, set, agentId, displayLevel, error.message),
+      onClose: () => {
+        if (isCurrentClientRequest(request)) {
+          scheduleStreamReconnect(get, set, agentId, displayLevel, "event stream closed");
+        }
+      },
+      onError: (error) => {
+        if (isCurrentClientRequest(request)) {
+          scheduleStreamReconnect(get, set, agentId, displayLevel, error.message);
+        }
+      },
     });
     if (!subscription) {
       setAgentLiveStatus(set, agentId, "idle");
@@ -2379,11 +2615,7 @@ if (typeof window !== "undefined") {
 
 // Resume polling for any skill install jobs persisted from a previous session.
 if (typeof window !== "undefined") {
-  for (const job of useRuntimeStore.getState().skillInstallJobs) {
-    if (job.status === "queued" || job.status === "running") {
-      void pollSkillInstallJob(useRuntimeStore.setState, useRuntimeStore.getState, job.jobId);
-    }
-  }
+  resumeSkillInstallJobPolling(useRuntimeStore.setState, useRuntimeStore.getState);
 }
 
 function installResumeReconciliationListeners(): ResumeReconciliationCoordinator {
@@ -2556,8 +2788,10 @@ function scheduleCacheWrite(get: () => RuntimeStoreState, agentId: string): void
 function startGlobalEventStream(get: () => RuntimeStoreState, set: StoreSet): void {
   if (globalEventStream) return;
 
-  const subscription = runtimeClient.streamGlobalEvents({
+  const request = captureClientRequest();
+  const subscription = request.client.streamGlobalEvents({
     onOpen: () => {
+      if (!isCurrentClientRequest(request)) return;
       globalStreamReconnectAttempt = 0;
       scheduleGlobalStaleWatchdog(get, set);
       // Backfill all registered agents on (re)connect.
@@ -2566,14 +2800,24 @@ function startGlobalEventStream(get: () => RuntimeStoreState, set: StoreSet): vo
       }
     },
     onActivity: () => {
+      if (!isCurrentClientRequest(request)) return;
       scheduleGlobalStaleWatchdog(get, set);
     },
     onEvent: (event) => {
+      if (!isCurrentClientRequest(request)) return;
       scheduleGlobalStaleWatchdog(get, set);
       dispatchGlobalStreamEvent(set, event);
     },
-    onClose: () => scheduleGlobalStreamReconnect(get, set, "global event stream closed"),
-    onError: (error) => scheduleGlobalStreamReconnect(get, set, error.message),
+    onClose: () => {
+      if (isCurrentClientRequest(request)) {
+        scheduleGlobalStreamReconnect(get, set, "global event stream closed");
+      }
+    },
+    onError: (error) => {
+      if (isCurrentClientRequest(request)) {
+        scheduleGlobalStreamReconnect(get, set, error.message);
+      }
+    },
   });
   if (!subscription) return;
   globalEventStream = subscription;
@@ -2764,16 +3008,18 @@ function hydrateInspectorActivityDetail(
 
   const key = `${agentId}:${activity.id}:${refs.toolExecutionId ?? ""}:${refs.taskId ?? ""}`;
   if (inspectorDetailInFlight.has(key)) return;
+  const request = captureClientRequest();
   inspectorDetailInFlight.add(key);
   setInspectorActivityDetailState(set, agentId, activity.id, { loading: true });
 
   // Use allSettled so a 404 on one fetch (e.g. historical tool execution
   // without a persisted record) doesn't wipe out the other detail.
   void Promise.allSettled([
-    refs.toolExecutionId ? runtimeClient.getToolExecution(agentId, refs.toolExecutionId) : Promise.resolve(undefined),
-    refs.taskId ? runtimeClient.getTaskOutput(agentId, refs.taskId) : Promise.resolve(undefined),
+    refs.toolExecutionId ? request.client.getToolExecution(agentId, refs.toolExecutionId) : Promise.resolve(undefined),
+    refs.taskId ? request.client.getTaskOutput(agentId, refs.taskId) : Promise.resolve(undefined),
   ])
     .then(([toolExecResult, taskOutputResult]) => {
+      if (!isCurrentClientRequest(request)) return;
       const toolExecution = toolExecResult.status === "fulfilled" ? toolExecResult.value : undefined;
       const taskOutput = taskOutputResult.status === "fulfilled" ? taskOutputResult.value : undefined;
       setInspectorActivityDetailState(set, agentId, activity.id, {
@@ -2783,12 +3029,14 @@ function hydrateInspectorActivityDetail(
       });
     })
     .catch((error) => {
+      if (!isCurrentClientRequest(request)) return;
       setInspectorActivityDetailState(set, agentId, activity.id, {
         loading: false,
         error: error instanceof Error ? error.message : String(error),
       });
     })
     .finally(() => {
+      if (!isCurrentClientRequest(request)) return;
       inspectorDetailInFlight.delete(key);
       const selection = get().rightPanelView;
       if (selection?.kind === "activity_inspector" && selection.agentId === agentId && selection.activity.id === activity.id) {
@@ -3068,16 +3316,32 @@ function scheduleBootstrapRefresh(get: () => RuntimeStoreState, delayMs = 1_000)
 const SKILL_JOB_POLL_INTERVAL_MS = 1_000;
 const SKILL_JOB_POLL_TIMEOUT_MS = 180_000;
 
+function resumeSkillInstallJobPolling(
+  set: StoreSet,
+  get: () => RuntimeStoreState,
+): void {
+  const request = captureClientRequest();
+  for (const job of get().skillInstallJobs) {
+    if (job.status === "queued" || job.status === "running") {
+      void pollSkillInstallJob(set, get, request, job.jobId);
+    }
+  }
+}
+
 async function pollSkillInstallJob(
   set: StoreSet,
   get: () => RuntimeStoreState,
+  request: ClientRequest,
   jobId: string,
 ): Promise<void> {
   const deadline = Date.now() + SKILL_JOB_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
+    if (!isCurrentClientRequest(request)) return;
     try {
       await new Promise((resolve) => globalThis.setTimeout(resolve, SKILL_JOB_POLL_INTERVAL_MS));
-      const job = await runtimeClient.getJob(jobId);
+      if (!isCurrentClientRequest(request)) return;
+      const job = await request.client.getJob(jobId);
+      if (!isCurrentClientRequest(request)) return;
       if (job.status === "completed") {
         updateSkillInstallJob(set, jobId, "completed", undefined, job.summary);
         await get().refreshSkillCatalog();
@@ -3110,14 +3374,16 @@ const TEMPLATE_SYNC_POLL_TIMEOUT_MS = 120_000;
  * surface the error via `templateCatalogError`.
  */
 async function pollTemplateSyncJob(
-  _set: StoreSet,
-  _get: () => RuntimeStoreState,
+  request: ClientRequest,
   jobId: string,
 ): Promise<void> {
   const deadline = Date.now() + TEMPLATE_SYNC_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
+    if (!isCurrentClientRequest(request)) return;
     await new Promise((resolve) => globalThis.setTimeout(resolve, TEMPLATE_SYNC_POLL_INTERVAL_MS));
-    const job = await runtimeClient.getJob(jobId);
+    if (!isCurrentClientRequest(request)) return;
+    const job = await request.client.getJob(jobId);
+    if (!isCurrentClientRequest(request)) return;
     if (job.status === "completed") {
       return;
     }


### PR DESCRIPTION
## Summary

Follow-up to #2351 that hardens the resume reconciliation boundaries identified during review:

- prevent stale async work from an older runtime-store client from writing into a newer client instance
- keep resume reconciliation loading state transient and clear it after failures without derived unhandled rejections
- preserve historical pagination scroll position before capturing the virtual-list anchor
- add regression coverage for cross-client stale writes, reconciliation failure recovery, and historical scroll stability

## Verification

- `git diff --check origin/main...HEAD`
- `npm test` (210 passed)
- `npm run build` (typecheck and production build passed)
