### PR TITLE
feat: publish Docker image and add live acceptance cases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.holon
+.benchmark-results
+.claude
+.playwright-mcp
+build
+coverage
+dist
+e2e-manual/**/artifacts
+holon-output
+holon-output-*
+node_modules
+target
+web-gui/app/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/ci.yml"
+      - ".dockerignore"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "Dockerfile"
       - "src/**"
       - "tests/**"
       - "agent_templates/**"
@@ -16,12 +18,15 @@ on:
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
+      - "scripts/docker-smoke.sh"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/ci.yml"
+      - ".dockerignore"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "Dockerfile"
       - "src/**"
       - "tests/**"
       - "agent_templates/**"
@@ -36,6 +41,28 @@ permissions:
   contents: read
 
 jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          tags: holon:ci
+          cache-from: type=gha,scope=holon-docker
+          cache-to: type=gha,mode=max,scope=holon-docker
+
+      - name: Smoke test image
+        run: scripts/docker-smoke.sh holon:ci
+
   rust:
     name: Rust
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -66,6 +66,8 @@ jobs:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -147,6 +149,12 @@ jobs:
           \`\`\`
 
           Replace \`holon-linux-amd64.tar.gz\` with \`holon-darwin-amd64.tar.gz\` or \`holon-darwin-arm64.tar.gz\` on macOS.
+
+          Docker:
+
+          \`\`\`bash
+          docker pull ghcr.io/holon-run/holon:${GITHUB_REF_NAME#v}
+          \`\`\`
           EOF
 
       - name: Publish GitHub release
@@ -182,3 +190,43 @@ jobs:
           fi
           git commit -m "Update Holon formula for ${GITHUB_REF_NAME}"
           git push origin main
+
+  container:
+    name: Publish container image
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=holon-docker
+          cache-to: type=gha,mode=max,scope=holon-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:24-bookworm-slim AS web-builder
+
+WORKDIR /src/web-gui/app
+COPY web-gui/app/package.json web-gui/app/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci
+COPY web-gui/app/ ./
+RUN npm run build
+
+FROM rust:bookworm AS rust-builder
+
+WORKDIR /src
+COPY . .
+COPY --from=web-builder /src/web-gui/app/dist ./web-gui/app/dist
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git/db,sharing=locked \
+    --mount=type=cache,target=/src/target,sharing=locked \
+    cargo build --release --locked \
+    && cp target/release/holon /tmp/holon
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gzip \
+        openssh-client \
+        tar \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --home-dir /var/lib/holon --uid 10001 holon \
+    && mkdir -p /workspace \
+    && chown holon:holon /workspace
+
+COPY --from=rust-builder /tmp/holon /usr/local/bin/holon
+
+ENV HOME=/var/lib/holon \
+    HOLON_HOME=/var/lib/holon \
+    HOLON_WORKSPACE_DIR=/workspace
+
+WORKDIR /workspace
+USER holon
+EXPOSE 7878
+
+ENTRYPOINT ["holon"]
+CMD ["serve", "--listen", "0.0.0.0:7878"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime fmt fmt-check lint check ci run clean
+.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime docker-build docker-smoke docker-live-acceptance fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
 OPENAPI_TOOLS_DIR := web-gui/openapi-tools
 CONCURRENT_REPEATS ?= 3
+DOCKER_IMAGE ?= holon:dev
 CONCURRENT_LIFECYCLE_TESTS := \
 	runtime_tasks \
 	runtime_waiting_and_reactivation \
@@ -142,6 +143,15 @@ test-live-runtime: ## Run end-to-end runtime and workspace-tool live tests
 		'Test binaries: live_prompt_continuity, live_workspace_tools'
 	cargo test --test live_prompt_continuity -- --ignored --nocapture
 	cargo test --test live_workspace_tools -- --ignored --nocapture
+
+docker-build: ## Build the local Holon runtime image
+	docker build --tag "$(DOCKER_IMAGE)" .
+
+docker-smoke: docker-build ## Start the image and verify the real service readiness boundary
+	scripts/docker-smoke.sh "$(DOCKER_IMAGE)"
+
+docker-live-acceptance: docker-build ## Run manual Docker acceptance with a real LLM (requires HOLON_LIVE_MODEL and credentials)
+	python3 scripts/docker-live-acceptance.py --image "$(DOCKER_IMAGE)" --skip-build
 
 fmt:
 	cargo fmt

--- a/README.md
+++ b/README.md
@@ -77,6 +77,35 @@ arm64 from [GitHub Releases](https://github.com/holon-run/holon/releases/latest)
 
 The examples below assume `holon` is installed on `PATH`.
 
+### Docker
+
+Release images are published to GitHub Container Registry. The container runs
+`holon serve` in the foreground and requires a control token because it listens
+on a non-loopback address:
+
+```bash
+docker run --rm \
+  -p 127.0.0.1:7878:7878 \
+  -e HOLON_CONTROL_TOKEN='replace-with-a-long-random-token' \
+  -e HOLON_MODEL='openai/gpt-5.4' \
+  -e OPENAI_API_KEY \
+  -v holon-home:/var/lib/holon \
+  ghcr.io/holon-run/holon:latest
+```
+
+Replace the model and credential environment variable when using another
+provider. Holon validates that the configured model provider is available
+before the service starts.
+
+The base image includes Git and common shell/network utilities. Mount a
+writable workspace at `/workspace`, or derive a project-specific image when
+the agent needs additional development toolchains. The published image is
+currently Linux amd64.
+
+For release-level container smoke and optional real-LLM workspace/WorkItem
+acceptance cases, see
+[Docker release acceptance](docs/testing/docker-acceptance.md).
+
 ## Provider setup
 
 Holon needs a model provider before it can run agents. The recommended path is:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,6 +77,31 @@ holon --help
 
 下文示例假设 `holon` 已在 `PATH` 中。
 
+### Docker
+
+发布镜像会推送到 GitHub Container Registry。容器以前台方式运行
+`holon serve`；由于监听非 loopback 地址，必须配置 control token：
+
+```bash
+docker run --rm \
+  -p 127.0.0.1:7878:7878 \
+  -e HOLON_CONTROL_TOKEN='replace-with-a-long-random-token' \
+  -e HOLON_MODEL='openai/gpt-5.4' \
+  -e OPENAI_API_KEY \
+  -v holon-home:/var/lib/holon \
+  ghcr.io/holon-run/holon:latest
+```
+
+使用其他 provider 时，请替换模型和凭据环境变量。Holon 会在服务启动前校验
+配置的模型 provider 是否可用。
+
+基础镜像包含 Git 和常用 shell/网络工具。需要操作项目时，请把可写 workspace
+挂载到 `/workspace`；如果 Agent 需要额外开发工具链，可以基于该镜像派生项目镜像。
+当前发布镜像仅支持 Linux amd64。
+
+容器发布级 smoke，以及可选的真实 LLM workspace/WorkItem 验收用例，请参考
+[Docker 发布验收](docs/testing/docker-acceptance.md)。
+
 ## Provider 配置
 
 Holon 需要配置模型提供商后才能运行 Agent。推荐方式：

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,6 +21,18 @@ The release workflow builds and uploads:
 - `holon-darwin-arm64.tar.gz`
 - `checksums.txt`
 
+After the GitHub release is published successfully, the same tag also builds
+and publishes the Linux amd64 container image:
+
+- `ghcr.io/holon-run/holon:<version>`
+- `ghcr.io/holon-run/holon:latest`
+
+The image runs `holon serve --listen 0.0.0.0:7878` in the foreground. A
+non-loopback listener requires `HOLON_CONTROL_TOKEN`, so container deployments
+must provide one. The service also validates its configured model provider at
+startup, so deployments must provide `HOLON_MODEL` and the corresponding
+provider credentials.
+
 The workflow also generates `Formula/holon.rb`. If `HOMEBREW_TAP_TOKEN` is
 configured, it pushes the formula to `holon-run/homebrew-tap`; otherwise the
 formula is available as a workflow artifact.
@@ -35,6 +47,13 @@ Before pushing the tag, verify:
   release-prep PR as the PR reference
 - supported binary assets are Linux amd64, macOS amd64, and macOS arm64
 - `checksums.txt` will be included with the release assets
+- `make docker-smoke` passes against the production Dockerfile
+- for workspace, WorkItem, scheduling, persistence, or container-runtime
+  changes, the manual real-LLM Docker cases in
+  `docs/testing/docker-acceptance.md` have been run with
+  `make docker-live-acceptance`, or the release notes explicitly record why
+  they were skipped
+- the GHCR image is currently declared as Linux amd64 only
 - `Formula/holon.rb` will be generated, and either pushed to
   `holon-run/homebrew-tap` or retained as a workflow artifact when
   `HOMEBREW_TAP_TOKEN` is not configured

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -1,0 +1,205 @@
+# Docker Release Acceptance
+
+This plan defines release-level acceptance testing for the real Holon process.
+It complements Rust module and integration tests; it does not replace them.
+
+## Goal
+
+Verify that the built and published Holon artifact works across the process,
+HTTP, persistence, workspace, worktree, restart, and upgrade boundaries that
+unit tests cannot fully represent.
+
+The primary test subject is:
+
+```text
+Docker container -> holon serve -> public CLI/HTTP contracts
+```
+
+Tests must not construct `RuntimeHost` directly.
+
+## Environment model
+
+- Run `holon serve` in the foreground as the container's main process.
+- Give every scenario an isolated Docker network, `HOLON_HOME`, workspace
+  parent directory, and randomly generated control token.
+- Do not expose a fixed host port. Use an internal Docker network or a random
+  published port.
+- Mount the parent of a temporary Git repository so Holon can create sibling
+  managed worktrees.
+- Use a deterministic scripted provider for default acceptance tests. Keep
+  real-provider checks in a separate opt-in live suite.
+- Preserve container logs, a bounded runtime-data summary, and workspace or
+  worktree metadata when a scenario fails.
+- For upgrade tests, start an old release image and the candidate image
+  against the same persistent volume in sequence.
+
+The base image contains Holon plus basic shell, Git, SSH, CA, archive, and HTTP
+utilities. Project-specific acceptance fixtures may derive from it to install
+additional language toolchains.
+
+## Manual real-LLM suite
+
+`make docker-live-acceptance` runs the production image against a real model.
+It is intentionally manual: it requires network access, consumes provider
+quota, and may expose model nondeterminism. It must not be added to
+credential-free CI.
+
+Set the model and its credential environment variable:
+
+```bash
+HOLON_LIVE_MODEL='openai/gpt-5.4' \
+OPENAI_API_KEY='...' \
+make docker-live-acceptance DOCKER_IMAGE=holon:live-acceptance
+```
+
+The runner infers the standard credential variable for OpenAI, Anthropic,
+DeepSeek, and xAI. For a built-in provider whose variables cannot be inferred,
+pass comma-separated variable names:
+
+```bash
+HOLON_LIVE_MODEL='openrouter/model' \
+HOLON_LIVE_CREDENTIAL_ENVS='OPENROUTER_API_KEY' \
+OPENROUTER_API_KEY='...' \
+make docker-live-acceptance
+```
+
+Alternatively, set `HOLON_LIVE_DOCKER_ENV_FILE` to an untracked Docker env
+file. The runner records only that an env file was used, not its path or
+contents.
+
+The checked-in case definitions live in
+`tests/manual/docker-live-acceptance.json`. The runner is
+`scripts/docker-live-acceptance.py`. Run one case with:
+
+```bash
+python3 scripts/docker-live-acceptance.py \
+  --image holon:live-acceptance \
+  --skip-build \
+  --case workspace-restart-lifecycle
+```
+
+Evidence is written below `target/docker-live-acceptance/<timestamp>/` and
+includes prompts, state snapshots, WorkItem read models, event pages,
+transcripts, briefs, tool execution details, Git state, and container logs.
+Credential values are never written deliberately. Set
+`HOLON_LIVE_KEEP=1` only when containers and volumes must be retained for
+interactive diagnosis.
+
+### Checked-in cases
+
+#### `workspace-restart-lifecycle`
+
+1. Start `holon serve` in the production image with an isolated `HOLON_HOME`.
+2. Attach a mounted Git repository through the authenticated HTTP control
+   plane.
+3. Ask the real model to inspect workspace state, switch to the repository,
+   and create a managed worktree through canonical tools.
+4. Restart the real container while retaining the home volume and workspace.
+5. Ask the model to recover the registered execution root, switch into it,
+   return to the canonical root, and remove it.
+6. Assert successful workspace tool events, persisted attachment state, a
+   clean canonical repository, and exactly one remaining Git worktree.
+
+#### `workitem-wait-restart-complete`
+
+1. Ask the real model to create and pick one WorkItem with a fixed plan marker
+   and todo list.
+2. Require `WaitFor(wake=operator_input)` and assert the WorkItem is current,
+   open, `needs_input`, and `waiting_for_operator`.
+3. Restart the container with the same home volume and assert focus, wait
+   state, and plan artifact survived.
+4. Ask the model to rediscover the current item through `ListWorkItems` and
+   `GetWorkItem`, update its todos, and complete the exact same WorkItem.
+5. Assert the required tools succeeded and the durable completion result
+   contains the generated completion marker.
+
+These cases validate the complete boundary:
+
+```text
+real LLM -> tool selection -> holon serve -> runtime persistence -> HTTP evidence
+```
+
+They complement the ignored Rust live tests, which construct `RuntimeHost`
+directly and therefore do not cover image packaging, HTTP authentication,
+container restart, or persistent Docker volumes.
+
+## Phases
+
+### Phase 0: image smoke
+
+Implemented by `make docker-smoke` and run in CI.
+
+1. Build the production Dockerfile.
+2. Run `holon --version` inside the image and compare it with `Cargo.toml`.
+3. Start `holon serve` with an isolated named volume and random host port.
+4. Poll the authenticated `/api/control/runtime/readiness` endpoint.
+5. Remove the container and volume on both success and failure.
+
+This phase is a fast packaging and process-boundary gate, not a full runtime
+acceptance suite.
+
+### Phase 1: workspace main paths
+
+The manual real-LLM suite covers the first restart/worktree path. A future
+deterministic harness should expand coverage to:
+
+1. Attach and switch a workspace, restart the service, and verify that the
+   binding and active projection persist.
+2. Spawn isolated child work that modifies files while leaving the canonical
+   workspace unchanged.
+3. Verify automatic cleanup of clean task-owned worktrees.
+4. Verify retention and review metadata for dirty worktrees.
+5. Run parallel tasks and multiple agents against conflicting occupancy and
+   verify explicit, recoverable outcomes.
+6. Read canonical and worktree files through the HTTP workspace API.
+7. Reject traversal, symlink escape, stale execution-root generations, and
+   unauthorized worktree artifact access.
+
+### Phase 2: recovery and upgrade
+
+Exercise:
+
+1. Force-kill `holon serve`, restart it with the same home, and recover agents,
+   WorkItems, tasks, waits, and workspace state.
+2. Interrupt tool execution, task completion, and worktree cleanup at
+   controlled points; reconciliation must not duplicate side effects.
+3. Start from the current recommended release's runtime data and upgrade to
+   the candidate image.
+4. Cover a locked database, missing workspace path, and orphaned worktree,
+   verifying diagnostics and retention behavior.
+
+### Phase 3: published artifact
+
+After a tag release:
+
+1. Pull `ghcr.io/holon-run/holon:<version>` by tag.
+2. Run the same image smoke against the pulled digest.
+3. Verify the OCI version/revision labels and image tag agree with the GitHub
+   release tag.
+4. Promote Phase 1 and Phase 2 to release gates after their deterministic
+   harness is stable.
+
+## Host-only coverage
+
+Keep a smaller host test lane for behavior hidden or changed by containers:
+
+- `holon daemon start/status/restart/stop`
+- Unix socket creation and cleanup
+- host file ownership and permission behavior
+- installation paths and downloaded tarballs
+- platform-specific macOS behavior
+
+Docker acceptance must not be reported as covering these boundaries.
+
+## Pass criteria
+
+- Tests exercise the compiled Holon process through supported CLI and HTTP
+  interfaces.
+- No default or CI test depends on the operator's local Holon home, a fixed
+  port, or real cloud credentials. The opt-in live suite accepts only
+  explicitly forwarded credentials.
+- Every scenario is repeatable and cleans up resources after success.
+- Failures retain enough bounded evidence to identify process logs, runtime
+  state, and affected workspace artifacts.
+- Phase 0 runs in normal CI. Later phases become release gates only after they
+  are deterministic and have an explicit failure-artifact contract.

--- a/scripts/docker-live-acceptance.py
+++ b/scripts/docker-live-acceptance.py
@@ -1,0 +1,677 @@
+#!/usr/bin/env python3
+"""Manual Docker acceptance against a real LLM and the public Holon HTTP API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "tests/manual/docker-live-acceptance.json"
+TERMINAL_STATUSES = {"awake_idle", "asleep", "awaiting_task"}
+
+
+def run(
+    args: list[str],
+    *,
+    check: bool = True,
+    capture: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        check=check,
+        text=True,
+        capture_output=capture,
+        env=env,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n")
+
+
+def inferred_credential_env(model: str) -> str | None:
+    provider = model.split("/", 1)[0].split("@", 1)[0]
+    return {
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_AUTH_TOKEN",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "deepseek-anthropic": "DEEPSEEK_API_KEY",
+        "xai": "XAI_API_KEY",
+    }.get(provider)
+
+
+class CaseHarness:
+    def __init__(
+        self,
+        *,
+        case_id: str,
+        image: str,
+        model: str,
+        credential_envs: list[str],
+        env_file: Path | None,
+        evidence_root: Path,
+        timeout_seconds: int,
+        keep: bool,
+    ) -> None:
+        suffix = secrets.token_hex(4)
+        self.case_id = case_id
+        self.image = image
+        self.model = model
+        self.credential_envs = credential_envs
+        self.env_file = env_file
+        self.evidence = evidence_root / case_id
+        self.timeout_seconds = timeout_seconds
+        self.keep = keep
+        self.volume = f"holon-live-{case_id}-{suffix}"
+        self.network = f"holon-live-{case_id}-{suffix}"
+        self.container = f"holon-live-{case_id}-{suffix}"
+        self.token = secrets.token_urlsafe(24)
+        self.base_url = ""
+        self.workspace_parent = self.evidence / "workspace"
+        self.log_index = 0
+        self.evidence.mkdir(parents=True, exist_ok=True)
+
+    def docker(self, *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return run(["docker", *args], **kwargs)
+
+    def initialize_workspace(self) -> None:
+        self.workspace_parent.mkdir(parents=True, exist_ok=True)
+        self.workspace_parent.chmod(0o777)
+        self.docker(
+            "run",
+            "--rm",
+            "--volume",
+            f"{self.workspace_parent}:/acceptance",
+            "--entrypoint",
+            "bash",
+            self.image,
+            "-lc",
+            "set -euo pipefail; "
+            "mkdir -p /acceptance/repo; cd /acceptance/repo; "
+            "git init -b main; "
+            "git config user.email holon-live@example.invalid; "
+            "git config user.name 'Holon Live Acceptance'; "
+            "printf 'holon live acceptance\\n' > README.md; "
+            "git add README.md; git commit -m 'acceptance fixture'",
+        )
+
+    def start(self) -> None:
+        self.docker("volume", "create", self.volume)
+        if self.docker("network", "inspect", self.network, check=False).returncode != 0:
+            self.docker("network", "create", self.network)
+        args = [
+            "run",
+            "--detach",
+            "--name",
+            self.container,
+            "--network",
+            self.network,
+            "--env",
+            f"HOLON_CONTROL_TOKEN={self.token}",
+            "--env",
+            f"HOLON_MODEL={self.model}",
+            "--env",
+            "HOLON_MODEL_FALLBACKS=",
+            "--env",
+            "HOLON_DISABLE_PROVIDER_FALLBACK=true",
+            "--publish",
+            "127.0.0.1::7878",
+            "--volume",
+            f"{self.volume}:/var/lib/holon",
+            "--volume",
+            f"{self.workspace_parent}:/acceptance",
+        ]
+        for name in self.credential_envs:
+            args.extend(["--env", name])
+        if self.env_file is not None:
+            args.extend(["--env-file", str(self.env_file)])
+        args.append(self.image)
+        self.docker(*args)
+
+        port = ""
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and not port:
+            result = self.docker("port", self.container, "7878/tcp", check=False)
+            if result.returncode == 0:
+                lines = result.stdout.strip().splitlines()
+                if lines:
+                    port = lines[0].rsplit(":", 1)[-1]
+            if not port:
+                time.sleep(0.25)
+        require(bool(port), "failed to resolve the container's published port")
+        self.base_url = f"http://127.0.0.1:{port}"
+        self.wait_readiness()
+
+    def stop(self) -> None:
+        self.capture_logs()
+        self.docker("rm", "-f", self.container, check=False)
+        self.base_url = ""
+
+    def restart(self) -> None:
+        self.stop()
+        self.start()
+
+    def cleanup(self) -> None:
+        if self.keep:
+            print(
+                f"Keeping container resources for {self.case_id}: "
+                f"container={self.container} volume={self.volume} network={self.network}",
+                file=sys.stderr,
+            )
+            return
+        self.docker("rm", "-f", self.container, check=False)
+        self.docker("volume", "rm", self.volume, check=False)
+        self.docker("network", "rm", self.network, check=False)
+
+    def capture_logs(self) -> None:
+        result = self.docker("logs", self.container, check=False)
+        self.log_index += 1
+        path = self.evidence / f"container-{self.log_index}.log"
+        path.write_text(result.stdout + result.stderr)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: Any | None = None,
+        *,
+        expected_status: int = 200,
+    ) -> Any:
+        data = None
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                status = response.status
+                payload = response.read()
+        except urllib.error.HTTPError as error:
+            status = error.code
+            payload = error.read()
+        if status != expected_status:
+            raise AssertionError(
+                f"{method} {path} returned {status}, expected {expected_status}: "
+                f"{payload.decode(errors='replace')}"
+            )
+        if not payload:
+            return None
+        return json.loads(payload)
+
+    def wait_readiness(self) -> None:
+        deadline = time.monotonic() + 90
+        last_error = ""
+        while time.monotonic() < deadline:
+            running = self.docker(
+                "inspect",
+                "--format",
+                "{{.State.Running}}",
+                self.container,
+                check=False,
+            )
+            require(
+                running.returncode == 0 and running.stdout.strip() == "true",
+                f"container exited before readiness; see {self.evidence}",
+            )
+            try:
+                self.request("GET", "/api/control/runtime/readiness")
+                return
+            except Exception as error:  # readiness is intentionally polled
+                last_error = str(error)
+                time.sleep(1)
+        self.capture_logs()
+        raise TimeoutError(f"Holon did not become ready: {last_error}")
+
+    def state(self, label: str) -> dict[str, Any]:
+        value = self.request("GET", "/api/agents/default/state")
+        write_json(self.evidence / f"{label}-state.json", value)
+        return value
+
+    def work_items(self, label: str) -> list[dict[str, Any]]:
+        value = self.request("GET", "/api/agents/default/work-items?limit=50")
+        write_json(self.evidence / f"{label}-work-items.json", value)
+        return value
+
+    def events(self, label: str) -> list[dict[str, Any]]:
+        page = self.request(
+            "GET", "/api/agents/default/events?limit=500&order=asc"
+        )
+        write_json(self.evidence / f"{label}-events.json", page)
+        return page["events"]
+
+    def capture_context(self, label: str) -> None:
+        write_json(
+            self.evidence / f"{label}-briefs.json",
+            self.request("GET", "/api/agents/default/briefs?limit=50"),
+        )
+        write_json(
+            self.evidence / f"{label}-transcript.json",
+            self.request("GET", "/api/agents/default/transcript?limit=200"),
+        )
+        self.state(label)
+        self.work_items(label)
+        self.events(label)
+
+    def prompt(self, label: str, text: str) -> tuple[int, dict[str, Any]]:
+        before = self.state(f"{label}-before")
+        baseline = int(before["agent"]["agent"]["turn_index"])
+        response = self.request(
+            "POST",
+            "/api/control/agents/default/prompt",
+            {"text": text},
+        )
+        write_json(self.evidence / f"{label}-prompt-response.json", response)
+        (self.evidence / f"{label}-prompt.txt").write_text(text + "\n")
+
+        deadline = time.monotonic() + self.timeout_seconds
+        last_state = before
+        while time.monotonic() < deadline:
+            last_state = self.request("GET", "/api/agents/default/state")
+            agent = last_state["agent"]["agent"]
+            if (
+                int(agent["turn_index"]) > baseline
+                and agent["status"] in TERMINAL_STATUSES
+                and agent.get("current_run_id") is None
+                and int(last_state["session"]["pending_count"]) == 0
+            ):
+                write_json(self.evidence / f"{label}-after-state.json", last_state)
+                self.capture_context(label)
+                return baseline, last_state
+            time.sleep(1)
+        write_json(self.evidence / f"{label}-timeout-state.json", last_state)
+        self.capture_logs()
+        raise TimeoutError(
+            f"timed out after {self.timeout_seconds}s waiting for phase {label}"
+        )
+
+    def successful_tool_events(
+        self, label: str, baseline_turn: int
+    ) -> list[dict[str, Any]]:
+        events = self.events(f"{label}-tool-check")
+        failures = [
+            event
+            for event in events
+            if event["event_type"] == "tool_execution_failed"
+            and int(event["payload"].get("turn_index", 0)) > baseline_turn
+        ]
+        require(not failures, f"tool failures occurred in {label}: {failures}")
+        return [
+            event
+            for event in events
+            if event["event_type"] == "tool_executed"
+            and event["payload"].get("status") == "success"
+            and int(event["payload"].get("turn_index", 0)) > baseline_turn
+        ]
+
+    def assert_tools(
+        self, label: str, baseline_turn: int, expected: list[str]
+    ) -> list[dict[str, Any]]:
+        events = self.successful_tool_events(label, baseline_turn)
+        actual = [event["payload"].get("tool_name") for event in events]
+        missing = [name for name in expected if name not in actual]
+        require(not missing, f"{label} missing successful tools {missing}; got {actual}")
+        return events
+
+    def tool_detail(self, event: dict[str, Any], label: str) -> dict[str, Any]:
+        execution_id = event["payload"]["tool_execution_id"]
+        detail = self.request(
+            "GET",
+            f"/api/agents/default/tool-executions/{execution_id}",
+        )
+        write_json(self.evidence / f"{label}-{execution_id}.json", detail)
+        return detail
+
+    def agent_home_file(self, relative_path: str, label: str) -> dict[str, Any]:
+        encoded_path = "/".join(
+            urllib.parse.quote(part, safe="") for part in relative_path.split("/")
+        )
+        value = self.request(
+            "GET",
+            f"/api/workspaces/agent_home%3Adefault/files/{encoded_path}",
+        )
+        write_json(self.evidence / f"{label}.json", value)
+        return value
+
+
+def result_value(detail: dict[str, Any]) -> dict[str, Any]:
+    output = detail.get("output", {})
+    return output.get("envelope", {}).get("result", output.get("result", output))
+
+
+def find_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
+    for case in manifest["cases"]:
+        if case["id"] == case_id:
+            return case
+    raise KeyError(case_id)
+
+
+def run_workspace_case(harness: CaseHarness, case: dict[str, Any]) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    attached = harness.request(
+        "POST",
+        "/api/control/agents/default/workspace/attach",
+        {"path": "/acceptance/repo"},
+    )
+    write_json(harness.evidence / "workspace-attach.json", attached)
+    workspace_id = attached["workspace_id"]
+    branch = f"live-acceptance-{secrets.token_hex(4)}"
+
+    create_phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "workspace-create",
+        create_phase["prompt"].format(
+            case_id=case["id"],
+            workspace_id=workspace_id,
+            branch=branch,
+        ),
+    )
+    create_events = harness.assert_tools(
+        "workspace-create", baseline, create_phase["expected_tools"]
+    )
+    create_event = next(
+        event
+        for event in create_events
+        if event["payload"].get("tool_name") == "CreateWorktree"
+    )
+    create_detail = harness.tool_detail(create_event, "workspace-create")
+    created = result_value(create_detail)
+    execution_root_id = created.get("execution_root_id")
+    require(
+        isinstance(execution_root_id, str) and execution_root_id,
+        f"CreateWorktree result missing execution_root_id: {created}",
+    )
+
+    harness.restart()
+    recovered_state = harness.state("workspace-after-restart")
+    require(
+        workspace_id
+        in recovered_state["agent"]["agent"].get("attached_workspaces", []),
+        "attached canonical workspace did not survive service restart",
+    )
+
+    recover_phase = case["phases"][1]
+    baseline, final_state = harness.prompt(
+        "workspace-recover",
+        recover_phase["prompt"].format(
+            case_id=case["id"],
+            workspace_id=workspace_id,
+            execution_root_id=execution_root_id,
+        ),
+    )
+    harness.assert_tools(
+        "workspace-recover", baseline, recover_phase["expected_tools"]
+    )
+    git_state = harness.docker(
+        "exec",
+        harness.container,
+        "bash",
+        "-lc",
+        "set -euo pipefail; "
+        "git -C /acceptance/repo status --porcelain; "
+        "printf '%s\\n' '--- worktrees ---'; "
+        "git -C /acceptance/repo worktree list --porcelain",
+    ).stdout
+    (harness.evidence / "workspace-final-git.txt").write_text(git_state)
+    status, worktrees = git_state.split("--- worktrees ---\n", 1)
+    require(not status.strip(), f"canonical repository is dirty:\n{status}")
+    require(
+        worktrees.count("worktree ") == 1,
+        f"managed worktree was not removed cleanly:\n{worktrees}",
+    )
+    active = final_state["workspace"]["workspaces"][0]
+    require(
+        active["is_active"] and active["workspace_id"] == workspace_id,
+        f"canonical workspace was not active after cleanup: {active}",
+    )
+    require(
+        active.get("worktree") is None,
+        f"active workspace still reports a worktree after cleanup: {active}",
+    )
+
+
+def run_workitem_case(harness: CaseHarness, case: dict[str, Any]) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    marker = secrets.token_hex(4)
+    objective = f"live-workitem-{marker}"
+    plan_marker = f"LIVE-WORKITEM-CHECKPOINT-{marker}"
+    completion_marker = f"LIVE-WORKITEM-COMPLETE-{marker}"
+
+    wait_phase = case["phases"][0]
+    baseline, state = harness.prompt(
+        "workitem-wait",
+        wait_phase["prompt"].format(
+            case_id=case["id"],
+            objective=objective,
+            plan_marker=plan_marker,
+        ),
+    )
+    harness.assert_tools("workitem-wait", baseline, wait_phase["expected_tools"])
+    items = harness.work_items("workitem-wait-assert")
+    matches = [item for item in items if item["objective"] == objective]
+    require(len(matches) == 1, f"expected exactly one matching WorkItem: {matches}")
+    item = matches[0]
+    work_item_id = item["id"]
+    require(item["state"] == "open", f"WorkItem should remain open: {item}")
+    require(
+        item["plan_status"] == "needs_input",
+        f"WorkItem should need input: {item}",
+    )
+    require(
+        item["readiness"] == "waiting_for_operator",
+        f"WorkItem should wait for operator: {item}",
+    )
+    require(
+        [(todo["text"], todo["state"]) for todo in item.get("todo_list", [])]
+        == [
+            ("phase-one", "completed"),
+            ("phase-two", "in_progress"),
+            ("phase-three", "pending"),
+        ],
+        f"WorkItem todos do not match the checked-in case: {item}",
+    )
+    require(
+        state["agent"]["agent"].get("current_work_item_id") == work_item_id,
+        "created WorkItem was not current after WaitFor",
+    )
+    plan = harness.agent_home_file(
+        f"work-items/{work_item_id}/plan.md", "workitem-plan"
+    )
+    require(
+        plan_marker in plan.get("content", ""),
+        "WorkItem plan artifact did not preserve the required marker",
+    )
+
+    harness.restart()
+    restart_state = harness.state("workitem-after-restart")
+    restart_items = harness.work_items("workitem-after-restart")
+    restored = next(item for item in restart_items if item["id"] == work_item_id)
+    require(restored["state"] == "open", "WorkItem was not restored as open")
+    require(
+        restored["readiness"] == "waiting_for_operator",
+        f"WorkItem wait did not survive restart: {restored}",
+    )
+    require(
+        restart_state["agent"]["agent"].get("current_work_item_id")
+        == work_item_id,
+        "current WorkItem focus did not survive restart",
+    )
+
+    complete_phase = case["phases"][1]
+    baseline, _ = harness.prompt(
+        "workitem-complete",
+        complete_phase["prompt"].format(
+            case_id=case["id"],
+            work_item_id=work_item_id,
+            plan_marker=plan_marker,
+            completion_marker=completion_marker,
+        ),
+    )
+    harness.assert_tools(
+        "workitem-complete", baseline, complete_phase["expected_tools"]
+    )
+    final_items = harness.work_items("workitem-final")
+    completed = next(item for item in final_items if item["id"] == work_item_id)
+    require(completed["state"] == "completed", f"WorkItem not completed: {completed}")
+    require(
+        len(completed.get("todo_list", [])) == 3
+        and all(
+            todo["state"] == "completed"
+            for todo in completed.get("todo_list", [])
+        ),
+        f"WorkItem todos were not all completed: {completed}",
+    )
+    require(
+        completion_marker in (completed.get("result_summary") or ""),
+        f"completion result did not preserve marker {completion_marker}: {completed}",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", default="holon:dev")
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=["workspace-restart-lifecycle", "workitem-wait-restart-complete"],
+        dest="cases",
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--evidence-dir", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    require(shutil.which("docker") is not None, "docker is required")
+    model = os.environ.get("HOLON_LIVE_MODEL", "").strip()
+    require(model, "set HOLON_LIVE_MODEL to the real model route to test")
+
+    raw_names = os.environ.get("HOLON_LIVE_CREDENTIAL_ENVS", "").strip()
+    credential_envs = [name.strip() for name in raw_names.split(",") if name.strip()]
+    env_file_value = os.environ.get("HOLON_LIVE_DOCKER_ENV_FILE", "").strip()
+    env_file = Path(env_file_value).resolve() if env_file_value else None
+    if not credential_envs and env_file is None:
+        inferred = inferred_credential_env(model)
+        require(
+            inferred is not None,
+            "set HOLON_LIVE_CREDENTIAL_ENVS or HOLON_LIVE_DOCKER_ENV_FILE "
+            f"for model {model}",
+        )
+        credential_envs = [inferred]
+    for name in credential_envs:
+        require(name in os.environ, f"required credential environment {name} is unset")
+    if env_file is not None:
+        require(env_file.is_file(), f"env file does not exist: {env_file}")
+
+    if not args.skip_build:
+        run(["docker", "build", "--tag", args.image, str(ROOT)], capture=False)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    evidence_root = (
+        args.evidence_dir.resolve()
+        if args.evidence_dir
+        else ROOT / "target/docker-live-acceptance" / timestamp
+    )
+    evidence_root.mkdir(parents=True, exist_ok=True)
+    manifest = json.loads(args.manifest.read_text())
+    write_json(
+        evidence_root / "run.json",
+        {
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "image": args.image,
+            "model": model,
+            "cases": args.cases
+            or [
+                "workspace-restart-lifecycle",
+                "workitem-wait-restart-complete",
+            ],
+            "credential_env_names": credential_envs,
+            "env_file_used": env_file is not None,
+        },
+    )
+
+    selected = args.cases or [
+        "workspace-restart-lifecycle",
+        "workitem-wait-restart-complete",
+    ]
+    timeout_seconds = int(os.environ.get("HOLON_LIVE_TIMEOUT_SECONDS", "600"))
+    keep = os.environ.get("HOLON_LIVE_KEEP", "") == "1"
+    failures: list[str] = []
+    for case_id in selected:
+        case = find_case(manifest, case_id)
+        print(f"Running {case_id} with {model}")
+        harness = CaseHarness(
+            case_id=case_id,
+            image=args.image,
+            model=model,
+            credential_envs=credential_envs,
+            env_file=env_file,
+            evidence_root=evidence_root,
+            timeout_seconds=timeout_seconds,
+            keep=keep,
+        )
+        try:
+            if case_id == "workspace-restart-lifecycle":
+                run_workspace_case(harness, case)
+            else:
+                run_workitem_case(harness, case)
+            harness.capture_context("final")
+            print(f"PASS {case_id}")
+        except Exception as error:
+            failures.append(f"{case_id}: {error}")
+            (harness.evidence / "failure.txt").write_text(f"{type(error).__name__}: {error}\n")
+            try:
+                harness.capture_context("failure")
+            except Exception:
+                pass
+            try:
+                harness.capture_logs()
+            except Exception:
+                pass
+            print(f"FAIL {case_id}: {error}", file=sys.stderr)
+        finally:
+            harness.cleanup()
+
+    print(f"Evidence: {evidence_root}")
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (AssertionError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2)

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:-holon:dev}"
+container="holon-docker-smoke-$$"
+volume="holon-docker-smoke-$$"
+token="holon-docker-smoke-token-$$"
+
+cleanup() {
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  docker volume rm "$volume" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+expected_version="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+actual_version="$(docker run --rm "$image" --version)"
+if [ "$actual_version" != "holon $expected_version" ]; then
+  echo "unexpected image version: $actual_version (expected holon $expected_version)" >&2
+  exit 1
+fi
+
+docker volume create "$volume" >/dev/null
+docker run --detach \
+  --name "$container" \
+  --env "HOLON_CONTROL_TOKEN=$token" \
+  --env "HOLON_MODEL=openai/gpt-5.4" \
+  --env "OPENAI_API_KEY=holon-docker-smoke-not-a-real-key" \
+  --publish 127.0.0.1::7878 \
+  --volume "$volume:/var/lib/holon" \
+  "$image" >/dev/null
+
+host_port="$(
+  docker port "$container" 7878/tcp \
+    | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p' \
+    | head -n 1
+)"
+if [ -z "$host_port" ]; then
+  echo "failed to resolve the published Holon port" >&2
+  docker logs "$container" >&2
+  exit 1
+fi
+
+for _ in $(seq 1 60); do
+  if curl --fail --silent \
+    --header "Authorization: Bearer $token" \
+    "http://127.0.0.1:$host_port/api/control/runtime/readiness" \
+    >/dev/null; then
+    echo "Docker smoke passed for $image on port $host_port."
+    exit 0
+  fi
+  if [ "$(docker inspect --format '{{.State.Running}}' "$container")" != "true" ]; then
+    echo "Holon container exited before becoming ready" >&2
+    docker logs "$container" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Holon did not become ready within 60 seconds" >&2
+docker logs "$container" >&2
+exit 1

--- a/tests/manual/docker-live-acceptance.json
+++ b/tests/manual/docker-live-acceptance.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "workspace-restart-lifecycle",
+      "description": "Create a managed worktree through a real model, restart holon serve, then recover and remove the persisted worktree.",
+      "phases": [
+        {
+          "id": "create",
+          "expected_tools": [
+            "GetWorkspaceState",
+            "SwitchWorkspace",
+            "CreateWorktree"
+          ],
+          "prompt": "Live Docker acceptance case {case_id}. Use the named Holon tools, not shell git/worktree commands. First call GetWorkspaceState. Switch to workspace_id {workspace_id}. Create a linked worktree from base_ref main with branch {branch}, activate=true, and keep the returned execution_root_id. Call GetWorkspaceState while that worktree is active. Switch back to workspace_id {workspace_id}, call GetWorkspaceState again, and finish without removing the worktree. Do not modify files and do not create a WorkItem."
+        },
+        {
+          "id": "recover",
+          "expected_tools": [
+            "GetWorkspaceState",
+            "SwitchWorkspace",
+            "RemoveWorktree"
+          ],
+          "prompt": "Continue live Docker acceptance case {case_id} after a real holon serve restart. Call GetWorkspaceState and confirm execution_root_id {execution_root_id} is still registered. Switch to that exact execution_root_id and call GetWorkspaceState. Switch back to canonical workspace_id {workspace_id}. Remove execution_root_id {execution_root_id} with branch_policy keep. Call GetWorkspaceState one final time and only then report completion. Do not use shell git/worktree commands and do not create a WorkItem."
+        }
+      ]
+    },
+    {
+      "id": "workitem-wait-restart-complete",
+      "description": "Create and focus a durable WorkItem through a real model, wait for operator input, restart holon serve, then resume and complete the same item.",
+      "phases": [
+        {
+          "id": "wait",
+          "expected_tools": [
+            "CreateWorkItem",
+            "PickWorkItem",
+            "WaitFor"
+          ],
+          "prompt": "Live Docker acceptance case {case_id}. Create exactly one WorkItem with objective {objective}. Seed its plan with the literal marker {plan_marker}, set plan_status needs_input, and use exactly these todos: phase-one completed, phase-two in_progress, phase-three pending. Pick the new WorkItem so it is current. Then call WaitFor with wake operator_input and a concrete reason that includes {plan_marker}. Do not modify project files and do not complete the WorkItem in this turn."
+        },
+        {
+          "id": "complete",
+          "expected_tools": [
+            "ListWorkItems",
+            "GetWorkItem",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "prompt": "Resume live Docker acceptance case {case_id} after a real holon serve restart. Call ListWorkItems with filter current and include_todo_list=true, then GetWorkItem for {work_item_id} with include_todo_list=true. Confirm it is the same item whose plan contains {plan_marker}. Update that WorkItem to plan_status ready with all three existing todos completed. Complete exactly WorkItem {work_item_id}. In the same round, report a concise completion result containing the literal marker {completion_marker}. Do not create another WorkItem and do not modify project files."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a multi-stage, non-root production Docker image for `holon serve`
- add CI image build/smoke coverage and publish Linux amd64 images to GHCR on tagged releases
- add an opt-in real-LLM Docker acceptance runner with checked-in workspace and WorkItem restart/lifecycle cases
- document container usage, release checks, evidence capture, and future deterministic acceptance phases

## Acceptance coverage

The manual live suite exercises the real boundary:

`real LLM -> tool selection -> holon serve -> persisted runtime state -> authenticated HTTP evidence`

Checked-in cases cover:

1. workspace attachment, switching, managed worktree creation, service restart, execution-root recovery, and cleanup
2. WorkItem creation/focus, `WaitFor(operator_input)`, service restart, durable plan/todo recovery, update, and completion of the same item

## Verification

- `make docker-smoke DOCKER_IMAGE=holon:review`
- Python compile and manifest JSON validation
- shell syntax validation for `scripts/docker-smoke.sh`
- GitHub workflow YAML parsing
- `git diff --check`
- credential preflight confirms the live runner refuses to start when the required provider secret is absent

## Manual follow-up

`make docker-live-acceptance` was not run because no real provider credential was available in this environment. It is intentionally opt-in and the checked-in documentation describes the required model/credential variables and retained evidence.
