### PR TITLE
fix: bound Web GUI refresh projections

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -58,6 +58,8 @@ static STORAGE_PERSIST_STATE: MetricAccumulator = MetricAccumulator::new("storag
 // Projection/API substeps
 static PROJECTION_STATE_TASKS: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.tasks");
+static PROJECTION_STATE_AGENT: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_state.agent");
 static PROJECTION_STATE_TIMERS: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.timers");
 static PROJECTION_STATE_WORK_ITEMS: MetricAccumulator =
@@ -66,6 +68,10 @@ static PROJECTION_STATE_WAITING: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.waiting_intents");
 static PROJECTION_STATE_TRIGGERS: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.external_triggers");
+static PROJECTION_STATE_WORKSPACE: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_state.workspace");
+static PROJECTION_STATE_SERIALIZATION: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_state.serialization");
 static PROJECTION_AGENTS_LIST: MetricAccumulator = MetricAccumulator::new("projection.agents_list");
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -262,6 +268,11 @@ pub fn record_projection_state_tasks(elapsed: Duration) {
     PROJECTION_STATE_TASKS.record(elapsed, None);
 }
 
+pub fn record_projection_state_agent(elapsed: Duration) {
+    process_started_at();
+    PROJECTION_STATE_AGENT.record(elapsed, None);
+}
+
 pub fn record_projection_state_timers(elapsed: Duration) {
     process_started_at();
     PROJECTION_STATE_TIMERS.record(elapsed, None);
@@ -280,6 +291,16 @@ pub fn record_projection_state_waiting_intents(elapsed: Duration) {
 pub fn record_projection_state_external_triggers(elapsed: Duration) {
     process_started_at();
     PROJECTION_STATE_TRIGGERS.record(elapsed, None);
+}
+
+pub fn record_projection_state_workspace(elapsed: Duration) {
+    process_started_at();
+    PROJECTION_STATE_WORKSPACE.record(elapsed, None);
+}
+
+pub fn record_projection_state_serialization(elapsed: Duration) {
+    process_started_at();
+    PROJECTION_STATE_SERIALIZATION.record(elapsed, None);
 }
 
 pub fn record_projection_agents_list(elapsed: Duration) {
@@ -306,6 +327,15 @@ pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
             PROJECTION_RUNTIME_CACHE_READ.snapshot(false),
             OBJECT_QUERY_CACHE_HIT.snapshot(false),
             OBJECT_QUERY_CACHE_MISS.snapshot(false),
+            PROJECTION_AGENTS_LIST.snapshot(false),
+            PROJECTION_STATE_AGENT.snapshot(false),
+            PROJECTION_STATE_TASKS.snapshot(false),
+            PROJECTION_STATE_TIMERS.snapshot(false),
+            PROJECTION_STATE_WORK_ITEMS.snapshot(false),
+            PROJECTION_STATE_WAITING.snapshot(false),
+            PROJECTION_STATE_TRIGGERS.snapshot(false),
+            PROJECTION_STATE_WORKSPACE.snapshot(false),
+            PROJECTION_STATE_SERIALIZATION.snapshot(false),
         ],
         db: vec![DB_CONNECTION_OPEN.snapshot(false)],
         scheduler: vec![
@@ -418,11 +448,14 @@ mod tests {
         record_tool_execution("ExecCommand", Duration::from_millis(20), Some(512));
         record_storage_append_event(Duration::from_millis(1));
         record_storage_persist_state(Duration::from_millis(2));
+        record_projection_state_agent(Duration::from_millis(4));
         record_projection_state_tasks(Duration::from_millis(3));
         record_projection_state_timers(Duration::from_millis(1));
         record_projection_state_work_items(Duration::from_millis(2));
         record_projection_state_waiting_intents(Duration::from_millis(1));
         record_projection_state_external_triggers(Duration::from_millis(1));
+        record_projection_state_workspace(Duration::from_millis(1));
+        record_projection_state_serialization(Duration::from_millis(1));
         record_projection_agents_list(Duration::from_millis(10));
 
         let snapshot = performance_snapshot();
@@ -459,5 +492,24 @@ mod tests {
             .provider
             .iter()
             .any(|metric| metric.name == "provider.retry" && metric.count >= 1));
+        for name in [
+            "projection.agents_list",
+            "projection.agent_state.agent",
+            "projection.agent_state.tasks",
+            "projection.agent_state.timers",
+            "projection.agent_state.work_items",
+            "projection.agent_state.waiting_intents",
+            "projection.agent_state.external_triggers",
+            "projection.agent_state.workspace",
+            "projection.agent_state.serialization",
+        ] {
+            assert!(
+                snapshot
+                    .projections
+                    .iter()
+                    .any(|metric| metric.name == name && metric.count >= 1),
+                "missing projection metric {name}"
+            );
+        }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -81,7 +81,7 @@ pub(crate) use crate::{
     storage::EventLogPageOrder,
     system::{ExecutionScopeKind, HostLocalBoundary},
     types::{
-        AdmissionContext, AgentRegistryStatus, AgentSummary, AgentVisibility, AuditEvent,
+        AdmissionContext, AgentRegistryStatus, AgentState, AgentVisibility, AuditEvent,
         AuthorityClass, CallbackDeliveryPayload, CallbackDeliveryResult, ControlAction,
         ExternalTriggerStateSnapshot, MessageBody, MessageDeliverySurface, MessageEnvelope,
         MessageKind, MessageOrigin, OperatorTransportBinding, OperatorTransportBindingStatus,
@@ -760,7 +760,11 @@ pub(crate) fn traced_json<T: Serialize>(
     started_at: std::time::Instant,
     value: T,
 ) -> Result<AxumResponse, (StatusCode, Json<Value>)> {
+    let serialization_started = std::time::Instant::now();
     let bytes = serde_json::to_vec(&value).map_err(|err| error_response(err.into()))?;
+    if route == "/agents/{agent_id}/state" {
+        diagnostics::record_projection_state_serialization(serialization_started.elapsed());
+    }
     let build_elapsed = started_at.elapsed();
     diagnostics::record_http_json_response(route, build_elapsed, bytes.len());
     if build_elapsed >= HTTP_SLOW_RESPONSE_WARN_AFTER

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -217,8 +217,12 @@ pub async fn agent_state(
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    runtime.prune_stale_attached_workspaces().await.ok();
-    let agent = runtime.agent_summary().await.map_err(error_response)?;
+    let agent_started = std::time::Instant::now();
+    let projection = runtime
+        .lightweight_agent_state_projection()
+        .await
+        .map_err(error_response)?;
+    crate::diagnostics::record_projection_state_agent(agent_started.elapsed());
     let tasks_started = std::time::Instant::now();
     let tasks = runtime
         .active_tasks(STATE_BOOTSTRAP_TASK_LIMIT)
@@ -232,10 +236,8 @@ pub async fn agent_state(
     let timers = runtime.recent_timers(50).await.map_err(error_response)?;
     crate::diagnostics::record_projection_state_timers(timers_started.elapsed());
     let work_items_started = std::time::Instant::now();
-    let work_items = runtime
-        .storage()
-        .work_queue_read_model()
-        .map_err(error_response)?
+    let work_items = projection
+        .work_queue
         .items
         .into_iter()
         .take(STATE_BOOTSTRAP_WORK_ITEM_LIMIT)
@@ -251,22 +253,33 @@ pub async fn agent_state(
         .map(ExternalTriggerStateSnapshot::from)
         .collect();
     crate::diagnostics::record_projection_state_external_triggers(triggers_started.elapsed());
-    let workspace = state_workspace_snapshot(&agent, &state);
-    let mut agent_dto = crate::http_dto::SlimAgentDto::from(&agent);
-    agent_dto.agent.last_turn_terminal = agent
+    let workspace_started = std::time::Instant::now();
+    let workspace = state_workspace_snapshot(&projection.agent, &state);
+    crate::diagnostics::record_projection_state_workspace(workspace_started.elapsed());
+    let mut agent_dto = crate::http_dto::SlimAgentDto {
+        identity: projection.identity,
+        agent: (&projection.agent).into(),
+        scheduling_posture: projection.scheduling_posture,
+        active_task_count: projection.active_task_count,
+        lifecycle: projection.lifecycle,
+        model: (&projection.model).into(),
+        closure: (&projection.closure).into(),
+        active_children: projection.active_children.iter().map(Into::into).collect(),
+    };
+    agent_dto.agent.last_turn_terminal = projection
         .agent
         .last_turn_terminal
         .clone()
         .map(slim_state_turn_terminal_record);
-    agent_dto.agent.last_runtime_failure = agent
+    agent_dto.agent.last_runtime_failure = projection
         .agent
         .last_runtime_failure
         .clone()
         .map(slim_state_runtime_failure);
     let session = crate::http_dto::StateSessionSnapshotDto {
-        current_run_id: agent.agent.current_run_id.clone(),
-        pending_count: agent.agent.pending,
-        last_turn: agent
+        current_run_id: projection.agent.current_run_id.clone(),
+        pending_count: projection.agent.pending,
+        last_turn: projection
             .agent
             .last_turn_terminal
             .clone()
@@ -441,7 +454,7 @@ fn truncate_state_bootstrap_string(text: &str, limit: usize) -> String {
 }
 
 fn state_workspace_snapshot(
-    agent: &AgentSummary,
+    agent: &AgentState,
     state: &AppState,
 ) -> crate::http_dto::StateWorkspaceSnapshotDto {
     let all_entries = state.host.workspace_entries().unwrap_or_default();
@@ -453,7 +466,7 @@ fn state_workspace_snapshot(
     let mut workspaces: Vec<AgentWorkspaceInfo> = Vec::new();
 
     // Add active workspace first (with full runtime info).
-    if let Some(active_entry) = agent.agent.active_workspace_entry.as_ref() {
+    if let Some(active_entry) = agent.active_workspace_entry.as_ref() {
         seen_ids.insert(active_entry.workspace_id.clone());
 
         // Try to enrich with registry data (alias, repo_name).
@@ -462,7 +475,7 @@ fn state_workspace_snapshot(
             .find(|e| e.workspace_id == active_entry.workspace_id);
         let worktree = build_worktree_info(
             active_entry.projection_metadata.as_ref(),
-            agent.agent.worktree_session.as_ref(),
+            agent.worktree_session.as_ref(),
         );
 
         workspaces.push(AgentWorkspaceInfo {
@@ -481,7 +494,7 @@ fn state_workspace_snapshot(
     }
 
     // Add remaining attached workspaces (identity-only info from registry).
-    for ws_id in &agent.agent.attached_workspaces {
+    for ws_id in &agent.attached_workspaces {
         if seen_ids.contains(ws_id) {
             continue;
         }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -4,11 +4,25 @@ use std::path::{Path, PathBuf};
 use crate::runtime::closure::{derive_closure_decision, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
-    AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
-    ChildAgentObservabilitySnapshot, ChildAgentPhase, ExecutionRootEntry, TaskRecord, TaskStatus,
-    TokenUsage, WaitingReason, WorkItemState, WorkspaceOccupancyRecord,
-    WorkspaceProjectionMetadata, WorktreeSession,
+    AgentLifecycleHint, AgentListEntry, AgentModelState, AgentPostureProjection,
+    AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason, ChildAgentObservabilitySnapshot,
+    ChildAgentPhase, ChildAgentSummary, ExecutionRootEntry, TaskRecord, TaskStatus, TokenUsage,
+    WaitingReason, WorkItemState, WorkspaceOccupancyRecord, WorkspaceProjectionMetadata,
+    WorktreeSession,
 };
+use crate::work_item_scheduling::WorkQueueReadModel;
+
+pub(crate) struct LightweightAgentStateProjection {
+    pub(crate) identity: AgentIdentityView,
+    pub(crate) agent: AgentState,
+    pub(crate) scheduling_posture: AgentPostureProjection,
+    pub(crate) active_task_count: usize,
+    pub(crate) lifecycle: AgentLifecycleHint,
+    pub(crate) model: AgentModelState,
+    pub(crate) closure: ClosureDecision,
+    pub(crate) active_children: Vec<ChildAgentSummary>,
+    pub(crate) work_queue: WorkQueueReadModel,
+}
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {
     let selected_cwd = match cwd {
@@ -155,6 +169,20 @@ impl RuntimeHandle {
         runtime_error_override: Option<bool>,
     ) -> Result<ClosureDecision> {
         let work_queue_projection = self.inner.storage.work_queue_prompt_projection()?;
+        self.closure_decision_for_state_with_work_queue(
+            state,
+            runtime_error_override,
+            work_queue_projection,
+        )
+        .await
+    }
+
+    async fn closure_decision_for_state_with_work_queue(
+        &self,
+        state: &AgentState,
+        runtime_error_override: Option<bool>,
+        work_queue_projection: WorkQueueReadModel,
+    ) -> Result<ClosureDecision> {
         let projection = scheduler::SchedulerProjection::from_state_with_work_queue_at(
             &self.inner.storage,
             state,
@@ -416,6 +444,39 @@ impl RuntimeHandle {
     pub async fn agent_summary(&self) -> Result<AgentSummary> {
         // Fast path: return current agent summary.
         self.build_agent_summary().await
+    }
+
+    pub(crate) async fn lightweight_agent_state_projection(
+        &self,
+    ) -> Result<LightweightAgentStateProjection> {
+        let agent = self.agent_state().await?;
+        let work_queue = self.inner.storage.work_queue_read_model()?;
+        let scheduling_posture = self
+            .inner
+            .storage
+            .agent_posture_projection_with_work_queue(&agent, &work_queue)?;
+        let closure = self
+            .closure_decision_for_state_with_work_queue(&agent, None, work_queue.clone())
+            .await?;
+        let active_children = if let Some(bridge) = self.inner.host_bridge.as_ref() {
+            bridge.child_summaries(&agent.id).await?
+        } else {
+            Vec::new()
+        };
+        Ok(LightweightAgentStateProjection {
+            identity: self.agent_identity_view().await?,
+            active_task_count: self.inner.storage.active_task_count_for_agent(&agent.id)?,
+            lifecycle: crate::types::AgentLifecycleHint::from_status(
+                &agent.id,
+                agent.status.clone(),
+            ),
+            model: self.model_state_for(&agent),
+            agent,
+            scheduling_posture,
+            closure,
+            active_children,
+            work_queue,
+        })
     }
 
     /// Get a full AgentSummary for a different agent through the host bridge.
@@ -883,6 +944,9 @@ impl RuntimeHandle {
     }
 
     pub async fn attach_workspace(&self, workspace: &WorkspaceEntry) -> Result<()> {
+        // Workspace cleanup is a mutation concern. Keep GET projections read-only while
+        // opportunistically repairing stale attachments before applying a new binding.
+        self.prune_stale_attached_workspaces().await?;
         let mut guard = self.inner.agent.lock().await;
         if !guard
             .state

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -887,6 +887,15 @@ impl AppStorage {
         self.read_models().agent_posture(agent)
     }
 
+    pub fn agent_posture_projection_with_work_queue(
+        &self,
+        agent: &AgentState,
+        work_queue: &WorkQueueReadModel,
+    ) -> Result<AgentPostureProjection> {
+        self.read_models()
+            .agent_posture_with_work_queue(agent, work_queue)
+    }
+
     pub fn waiting_contract_anchor(&self) -> Result<Option<WorkItemRecord>> {
         self.read_models().waiting_contract_anchor()
     }

--- a/src/storage/read_models.rs
+++ b/src/storage/read_models.rs
@@ -184,24 +184,46 @@ impl RuntimeReadModels {
     }
 
     pub fn agent_posture(&self, agent: &AgentState) -> Result<AgentPostureProjection> {
+        if let Some(posture) = self.agent_posture_before_work_queue(agent)? {
+            return Ok(posture);
+        }
+        let work_queue = self.work_queue()?;
+        self.agent_posture_from_work_queue(&work_queue)
+    }
+
+    pub fn agent_posture_with_work_queue(
+        &self,
+        agent: &AgentState,
+        work_queue: &WorkQueueReadModel,
+    ) -> Result<AgentPostureProjection> {
+        if let Some(posture) = self.agent_posture_before_work_queue(agent)? {
+            return Ok(posture);
+        }
+        self.agent_posture_from_work_queue(work_queue)
+    }
+
+    fn agent_posture_before_work_queue(
+        &self,
+        agent: &AgentState,
+    ) -> Result<Option<AgentPostureProjection>> {
         if matches!(agent.status, AgentStatus::Stopped) {
-            return Ok(AgentPostureProjection {
+            return Ok(Some(AgentPostureProjection {
                 posture: AgentSchedulingPosture::Archived,
                 reason: "agent lifecycle is stopped".into(),
                 work_item_id: None,
                 task_id: None,
                 run_id: None,
-            });
+            }));
         }
 
         if let Some(run_id) = agent.current_run_id.clone() {
-            return Ok(AgentPostureProjection {
+            return Ok(Some(AgentPostureProjection {
                 posture: AgentSchedulingPosture::ActiveTurn,
                 reason: "agent has an active turn".into(),
                 work_item_id: agent.current_turn_work_item_id.clone(),
                 task_id: None,
                 run_id: Some(run_id),
-            });
+            }));
         }
 
         if self
@@ -209,16 +231,22 @@ impl RuntimeReadModels {
             .queue_entries()
             .has_queued_for_agent(&agent.id)?
         {
-            return Ok(AgentPostureProjection {
+            return Ok(Some(AgentPostureProjection {
                 posture: AgentSchedulingPosture::HasQueuedInput,
                 reason: "agent has queued input".into(),
                 work_item_id: None,
                 task_id: None,
                 run_id: None,
-            });
+            }));
         }
 
-        let work_queue = self.work_queue()?;
+        Ok(None)
+    }
+
+    fn agent_posture_from_work_queue(
+        &self,
+        work_queue: &WorkQueueReadModel,
+    ) -> Result<AgentPostureProjection> {
         if let Some(item) = work_queue
             .current_runnable
             .as_ref()

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 use serde_json::Value;
+use std::{future::Future, pin::Pin};
 
 use crate::{
     runtime::RuntimeHandle,
@@ -109,7 +110,21 @@ pub(crate) fn builtin_tool_definitions_for_apply_patch_surface(
         .collect()
 }
 
-pub(crate) async fn execute_builtin_tool(
+pub(crate) fn execute_builtin_tool<'a>(
+    runtime: &'a RuntimeHandle,
+    agent_id: &'a str,
+    authority_class: &'a AuthorityClass,
+    call: &'a ToolCall,
+) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+    Box::pin(execute_builtin_tool_inner(
+        runtime,
+        agent_id,
+        authority_class,
+        call,
+    ))
+}
+
+async fn execute_builtin_tool_inner(
     runtime: &RuntimeHandle,
     agent_id: &str,
     authority_class: &AuthorityClass,

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -18,6 +18,7 @@ http_async_tests!(
     runtime_search_route_filters_memory_results_by_agent_ids,
     agent_brief_route_returns_full_brief_by_id,
     agent_state_route_scopes_work_items_to_requested_agent,
+    agent_state_route_does_not_prune_stale_workspaces,
     agent_state_route_includes_bootstrap_projection_fields_when_present,
     list_skills_includes_all_agent_skill_roots,
     agent_skills_endpoint_uses_effective_registry_snapshot,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -409,6 +409,44 @@ pub async fn agent_state_route_scopes_work_items_to_requested_agent() -> Result<
     Ok(())
 }
 
+pub async fn agent_state_route_does_not_prune_stale_workspaces() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let stale_dir = tempdir()?;
+    let workspace = host.ensure_workspace_entry(stale_dir.path().to_path_buf())?;
+    let workspace_id = workspace.workspace_id.clone();
+    runtime.attach_workspace(&workspace).await?;
+    drop(stale_dir);
+    let detached_before = runtime
+        .storage()
+        .read_recent_events(100)?
+        .into_iter()
+        .filter(|event| event.kind == "workspace_detached")
+        .count();
+
+    let response = reqwest::Client::new()
+        .get(format!("{base}/api/agents/default/state"))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let state = runtime.agent_state().await?;
+    assert!(
+        state.attached_workspaces.contains(&workspace_id),
+        "GET /state must not mutate stale workspace attachments"
+    );
+    let detached_after = runtime
+        .storage()
+        .read_recent_events(100)?
+        .into_iter()
+        .filter(|event| event.kind == "workspace_detached")
+        .count();
+    assert_eq!(detached_after, detached_before);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present() -> Result<()> {
     let mut config = test_config();
     let (host, base, server) = spawn_server_with_config(config.clone()).await?;

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -179,6 +179,60 @@ describe("projectModelOptions", () => {
 });
 
 describe("createRuntimeClient", () => {
+  it("loads agent state without fetching the full roster", async () => {
+    const seen: string[] = [];
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        seen.push(url);
+        if (url.endsWith("/agents/agent-one/state")) {
+          return Response.json(agentStateFixture("agent-one"));
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch,
+    });
+
+    await expect(client.getAgentState("agent-one")).resolves.toEqual(
+      expect.objectContaining({
+        id: "agent-one",
+        profile: "public · self_owned · public_named",
+      }),
+    );
+    expect(seen).toEqual(["http://example.test:7878/api/agents/agent-one/state"]);
+  });
+
+  it("loads agent detail without fetching the full roster", async () => {
+    const seen: string[] = [];
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        seen.push(url);
+        if (url.endsWith("/agents/agent-one/state")) {
+          return Response.json(agentStateFixture("agent-one"));
+        }
+        if (url.includes("/agents/agent-one/events?")) {
+          return Response.json({ events: [], has_older: false });
+        }
+        if (url.endsWith("/agents/agent-one/work-items?limit=50")) {
+          return Response.json([]);
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch,
+    });
+
+    await expect(client.getAgentDetail("agent-one")).resolves.toEqual(
+      expect.objectContaining({
+        agent: expect.objectContaining({ id: "agent-one" }),
+        source: "http",
+      }),
+    );
+    expect(seen).not.toContain("http://example.test:7878/api/agents/list");
+  });
+
   it("preserves the configured remote connection mode even when the runtime auth mode is local", async () => {
     const fetchImpl = async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -139,21 +139,17 @@ async function fetchAgentDetail(
   displayLevel: DisplayLevel,
 ): Promise<AgentDetail> {
   const encodedAgentId = encodeURIComponent(agentId);
-  const [entry, state, events, workItems] = await Promise.all([
-    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers })
-      .then((agents) => agents.find((agent) => agent.identity?.agent_id === agentId))
-      .catch(() => undefined),
+  const [state, events, workItems] = await Promise.all([
     getJson<AgentStateDto>(fetchImpl, baseUrl, `/agents/${encodedAgentId}/state`, { headers }),
     fetchAgentEvents(baseUrl, fetchImpl, headers, agentId, { limit: 80, order: "desc", displayLevel }).catch(emptyEventPage),
     // Return undefined on failure so projectAgent falls back to state.work_items.
     // Returning [] would shadow the state endpoint's work_items (empty array is not nullish).
     fetchAgentWorkItems(baseUrl, fetchImpl, headers, agentId, { limit: 50 }).catch(() => undefined),
   ]);
-  const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
   const transcriptEntriesById = await fetchTranscriptEntriesForEvents(baseUrl, fetchImpl, headers, agentId, events.events ?? []);
   const briefRecordsById = await fetchBriefRecordsForEvents(baseUrl, fetchImpl, headers, agentId, events.events ?? []);
   const agent = projectAgent(
-    fallbackEntry,
+    { identity: state.agent?.identity ?? { agent_id: agentId } },
     state,
     newestBriefFromEvents(events.events ?? [], briefRecordsById),
     workItems,
@@ -180,14 +176,13 @@ async function fetchAgentState(
   agentId: string,
 ): Promise<AgentSummary> {
   const encodedAgentId = encodeURIComponent(agentId);
-  const [entry, state] = await Promise.all([
-    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers })
-      .then((agents) => agents.find((agent) => agent.identity?.agent_id === agentId))
-      .catch(() => undefined),
-    getJson<AgentStateDto>(fetchImpl, baseUrl, `/agents/${encodedAgentId}/state`, { headers }),
-  ]);
-  const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
-  return projectAgent(fallbackEntry, state);
+  const state = await getJson<AgentStateDto>(
+    fetchImpl,
+    baseUrl,
+    `/agents/${encodedAgentId}/state`,
+    { headers },
+  );
+  return projectAgent({ identity: state.agent?.identity ?? { agent_id: agentId } }, state);
 }
 
 interface AgentListEntryDto {

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   agentBriefPatchFromEvents,
+  buildResumeRefreshes,
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
   isSessionCacheContextCurrent,
@@ -14,6 +15,7 @@ import {
   resetSessionsForResume,
   resetTransientRuntimeStateForResume,
   readStoredRuntimeConnectionConfig,
+  runWithConcurrencyLimit,
   sessionForEventLogEpoch,
   streamEventFromBackfill,
   useRuntimeStore,
@@ -731,6 +733,59 @@ describe("runtime client generation", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe("bounded resume refresh scheduling", () => {
+  it("uses detail for the selected agent instead of scheduling duplicate state and detail refreshes", () => {
+    expect(buildResumeRefreshes(["agent-a", "agent-b", "agent-c"], "agent-b")).toEqual([
+      { agentId: "agent-a", detail: false },
+      { agentId: "agent-b", detail: true },
+      { agentId: "agent-c", detail: false },
+    ]);
+  });
+
+  it("limits concurrent refreshes", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const releases: Array<() => void> = [];
+
+    const scheduled = runWithConcurrencyLimit(
+      Array.from({ length: 10 }, (_, index) => index),
+      4,
+      async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        active -= 1;
+      },
+    );
+
+    await vi.waitFor(() => expect(active).toBe(4));
+    while (releases.length) {
+      releases.shift()?.();
+      await Promise.resolve();
+    }
+    await scheduled;
+
+    expect(maxActive).toBe(4);
+  });
+
+  it("stops starting queued refreshes after the generation becomes stale", async () => {
+    let current = true;
+    const started: number[] = [];
+
+    await runWithConcurrencyLimit(
+      [1, 2, 3, 4, 5],
+      1,
+      async (value) => {
+        started.push(value);
+        current = false;
+      },
+      () => current,
+    );
+
+    expect(started).toEqual([1]);
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -476,6 +476,8 @@ const workItemDetailInFlight = new Set<string>();
 const taskDetailInFlight = new Set<string>();
 const toolExecutionDetailInFlight = new Set<string>();
 const agentStateRefreshInFlight = new Map<string, number>();
+const agentDetailRefreshInFlight = new Map<string, { generation: number; promise: Promise<void> }>();
+const agentDetailRequestSequence = new Map<string, number>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 let clientGeneration = 0;
@@ -525,12 +527,43 @@ function cancelClientGenerationWork(): void {
     bootstrapRefreshTimer = undefined;
   }
   agentStateRefreshInFlight.clear();
+  agentDetailRefreshInFlight.clear();
+  agentDetailRequestSequence.clear();
   inspectorDetailInFlight.clear();
   workItemRefreshInFlight.clear();
   workItemDetailInFlight.clear();
   taskDetailInFlight.clear();
   toolExecutionDetailInFlight.clear();
   clearInFlightHydration();
+}
+
+export async function runWithConcurrencyLimit<T>(
+  values: readonly T[],
+  limit: number,
+  run: (value: T) => Promise<void>,
+  shouldContinue: () => boolean = () => true,
+): Promise<void> {
+  const workerCount = Math.min(values.length, Math.max(1, Math.floor(limit)));
+  let nextIndex = 0;
+  const worker = async () => {
+    while (shouldContinue()) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= values.length) return;
+      await run(values[index]);
+    }
+  };
+  await Promise.all(Array.from({ length: workerCount }, worker));
+}
+
+export function buildResumeRefreshes(
+  agentIds: readonly string[],
+  selectedAgentId: string,
+): Array<{ agentId: string; detail: boolean }> {
+  return agentIds.map((agentId) => ({
+    agentId,
+    detail: agentId === selectedAgentId,
+  }));
 }
 
 function closeEventStreamsForResume(set: StoreSet): void {
@@ -1413,13 +1446,25 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       try {
         await get().refreshBootstrap({ background: true, syncEvents: false });
         if (!isCurrentClientGeneration(generation)) return;
-        await Promise.all(get().bootstrap.agents.map((agent) => get().refreshAgentState(agent.id)));
+        const selectedAgentId = get().selectedAgentId;
+        const refreshes = buildResumeRefreshes(
+          get().bootstrap.agents.map((agent) => agent.id),
+          selectedAgentId,
+        );
+        await runWithConcurrencyLimit(
+          refreshes,
+          4,
+          async ({ agentId, detail }) => {
+            if (detail) {
+              await get().refreshAgentDetail(agentId, get().displayLevel);
+            } else {
+              await get().refreshAgentState(agentId);
+            }
+          },
+          () => isCurrentClientGeneration(generation),
+        );
         if (!isCurrentClientGeneration(generation)) return;
         syncGlobalEventRoster(get, set);
-        const selectedAgentId = get().selectedAgentId;
-        if (selectedAgentId) {
-          await get().refreshAgentDetail(selectedAgentId, get().displayLevel);
-        }
       } finally {
         if (isCurrentClientGeneration(generation)) {
           // Then remeasure once more after the reconciled projections and hydration are scheduled.
@@ -2154,6 +2199,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }
 
     const request = captureClientRequest();
+    const key = `${agentId}:${displayLevel}`;
+    const existing = agentDetailRefreshInFlight.get(key);
+    if (existing?.generation === request.generation) {
+      return existing.promise;
+    }
+    const sequence = (agentDetailRequestSequence.get(agentId) ?? 0) + 1;
+    agentDetailRequestSequence.set(agentId, sequence);
     set((state) => ({
       sessionsByAgentId: {
         ...state.sessionsByAgentId,
@@ -2166,31 +2218,50 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       },
     }));
 
-    try {
-      const detail = await request.client.getAgentDetail(agentId, displayLevel);
-      if (!isCurrentClientRequest(request)) return;
-      set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
-      await loadTargetAgentEventWindow(get, set, agentId, displayLevel);
-      if (!isCurrentClientRequest(request)) return;
-      scheduleMessageHydration(get, set, agentId, displayLevel);
-      scheduleTranscriptHydration(get, set, agentId, displayLevel);
-      scheduleBriefHydration(get, set, agentId, displayLevel);
-      scheduleCacheWrite(get, agentId);
-    } catch (error) {
-      if (!isCurrentClientRequest(request)) return;
-      set((state) => ({
-        sessionsByAgentId: {
-          ...state.sessionsByAgentId,
-          [agentId]: {
-            ...emptyAgentSession(),
-            ...state.sessionsByAgentId[agentId],
-            loading: false,
-            liveStatus: "error",
-            error: error instanceof Error ? error.message : String(error),
+    let promise!: Promise<void>;
+    promise = (async () => {
+      try {
+        const detail = await request.client.getAgentDetail(agentId, displayLevel);
+        if (
+          !isCurrentClientRequest(request) ||
+          agentDetailRequestSequence.get(agentId) !== sequence
+        ) return;
+        set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
+        await loadTargetAgentEventWindow(get, set, agentId, displayLevel);
+        if (
+          !isCurrentClientRequest(request) ||
+          agentDetailRequestSequence.get(agentId) !== sequence
+        ) return;
+        scheduleMessageHydration(get, set, agentId, displayLevel);
+        scheduleTranscriptHydration(get, set, agentId, displayLevel);
+        scheduleBriefHydration(get, set, agentId, displayLevel);
+        scheduleCacheWrite(get, agentId);
+      } catch (error) {
+        if (
+          !isCurrentClientRequest(request) ||
+          agentDetailRequestSequence.get(agentId) !== sequence
+        ) return;
+        set((state) => ({
+          sessionsByAgentId: {
+            ...state.sessionsByAgentId,
+            [agentId]: {
+              ...emptyAgentSession(),
+              ...state.sessionsByAgentId[agentId],
+              loading: false,
+              liveStatus: "error",
+              error: error instanceof Error ? error.message : String(error),
+            },
           },
-        },
-      }));
-    }
+        }));
+      } finally {
+        const current = agentDetailRefreshInFlight.get(key);
+        if (current?.promise === promise) {
+          agentDetailRefreshInFlight.delete(key);
+        }
+      }
+    })();
+    agentDetailRefreshInFlight.set(key, { generation: request.generation, promise });
+    return promise;
   },
 
   refreshAgentWorkItems: async (agentId) => {
@@ -2568,7 +2639,6 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         if (!isCurrentClientRequest(request)) return;
         markStreamActivity(set, agentId);
         enqueueStreamEvent(set, agentId, event);
-        scheduleBootstrapRefresh(get);
       },
       onClose: () => {
         if (isCurrentClientRequest(request)) {
@@ -2890,7 +2960,6 @@ function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto)
   }
 
   enqueueStreamEvent(set, agentId, event);
-  scheduleBootstrapRefresh(useRuntimeStore.getState);
 }
 
 async function backfillAgentEvents(set: StoreSet, agentId: string, force = false): Promise<void> {


### PR DESCRIPTION
## Summary

- remove hidden `/agents/list` reads from per-agent state/detail requests
- bound resume reconciliation to four concurrent agent projections and avoid selected-agent state/detail duplication
- stop ordinary event-stream traffic from scheduling full roster refreshes
- singleflight agent detail refreshes per display level and reject stale same-generation responses
- replace `/state`'s full `AgentSummary` build with a lightweight projection that reuses one work-queue read
- keep `/state` read-only by moving stale workspace pruning to workspace attachment mutation
- expose agent list/state projection substeps in runtime performance diagnostics

Closes #2357 as the first of two planned delivery stages. A follow-up PR will add cross-client ProjectionGate singleflight, short TTL reuse, concurrency admission, and 429 backoff.

## Runtime concept

This changes refresh and projection semantics rather than masking overload with logging controls. The Web GUI now has bounded client-side fan-out, while `/state` computes only its published wire fields and does not mutate workspace state during a GET.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test diagnostics::tests --lib` (13 passed)
- `cargo test --test http_control agent_state_route_ -- --nocapture` (4 passed)
- `cargo test runtime::tests::workspace::prune_ --lib` (5 passed)
- `cargo test --all-targets` reached one unrelated timing failure in `exec_command_batch_does_not_wait_for_background_pipe_holders`; isolated rerun passed
- `npm test` (24 files, 217 tests passed)
- `npm run build`


## Behavioral note

Moving stale workspace pruning from the read-only `/state` GET path into `attach_workspace` also makes pruning failures explicit: workspace attachment now returns the cleanup error instead of silently discarding it with `.ok()`. This intentionally keeps mutation repair and failure reporting on the mutation boundary.
