### PR TITLE
fix: add ProjectionGate to bound concurrent expensive HTTP projections

### DIFF
--- a/docs/implementation-decisions/096-bounded-http-projection-gate.md
+++ b/docs/implementation-decisions/096-bounded-http-projection-gate.md
@@ -1,0 +1,22 @@
+# 096 Bounded HTTP Projection Gate
+
+Expensive first-party bootstrap reads use one shared `ProjectionGate` after
+remote-access authorization.
+
+The gate coalesces concurrent requests by projection key, caches the serialized
+JSON bytes for 250 milliseconds, and allows at most four leader builds across
+`/agents/list` and `/agents/:id/state`. Requests for an existing in-flight key
+join that flight before capacity is checked. A new key with no leader capacity
+receives `429 Too Many Requests`, `Retry-After: 1`, and the retryable
+`projection_busy` error code.
+
+The cache stores uncompressed response bytes so waiters and short-TTL hits
+receive the exact leader payload while the existing HTTP compression layer
+remains authoritative. A synchronous drop guard removes cancelled flights,
+notifies waiters, and releases the leader permit, avoiding request-lifecycle
+leaks without holding a lock across an await.
+
+The Web GUI treats `projection_busy` as a best-effort refresh miss: it preserves
+the current projection and lets the existing event or scheduled refresh path
+retry. Authorization remains outside the gate so rejected requests cannot
+consume capacity or observe cached projection results.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -106,3 +106,4 @@ Current decision notes:
 - [092 Venice Model Catalog](./092-venice-model-catalog.md)
 - [093 Image Generation Route Calibration](./093-image-generation-route-calibration.md)
 - [094 OpenAI Codex Reasoning Effort](./094-openai-codex-reasoning-effort.md)
+- [096 Bounded HTTP Projection Gate](./096-bounded-http-projection-gate.md)

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -2662,6 +2662,67 @@
             "minimum": 0,
             "type": "integer"
           },
+          "projection_gate": {
+            "properties": {
+              "active_permits": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cache_hits": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cache_misses": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cancelled": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "failed": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "joined_waiters": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "leaders": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "max_active_permits": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "rejected": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "leaders",
+              "joined_waiters",
+              "cache_hits",
+              "cache_misses",
+              "rejected",
+              "failed",
+              "cancelled",
+              "active_permits",
+              "max_active_permits"
+            ],
+            "type": "object"
+          },
           "projections": {
             "items": {
               "properties": {
@@ -2876,6 +2937,7 @@
           "process_uptime_ms",
           "http",
           "projections",
+          "projection_gate",
           "db",
           "scheduler",
           "turn",

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -73,6 +73,15 @@ static PROJECTION_STATE_WORKSPACE: MetricAccumulator =
 static PROJECTION_STATE_SERIALIZATION: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.serialization");
 static PROJECTION_AGENTS_LIST: MetricAccumulator = MetricAccumulator::new("projection.agents_list");
+static PROJECTION_GATE_LEADERS: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_JOINED_WAITERS: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_REJECTED: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_FAILED: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_CANCELLED: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_ACTIVE_PERMITS: AtomicU64 = AtomicU64::new(0);
+static PROJECTION_GATE_MAX_ACTIVE_PERMITS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PerformanceDiagnosticsSnapshot {
@@ -80,10 +89,24 @@ pub struct PerformanceDiagnosticsSnapshot {
     pub process_uptime_ms: u64,
     pub http: Vec<MetricSnapshot>,
     pub projections: Vec<MetricSnapshot>,
+    pub projection_gate: ProjectionGateDiagnosticsSnapshot,
     pub db: Vec<MetricSnapshot>,
     pub scheduler: Vec<MetricSnapshot>,
     pub turn: Vec<MetricSnapshot>,
     pub provider: Vec<MetricSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProjectionGateDiagnosticsSnapshot {
+    pub leaders: u64,
+    pub joined_waiters: u64,
+    pub cache_hits: u64,
+    pub cache_misses: u64,
+    pub rejected: u64,
+    pub failed: u64,
+    pub cancelled: u64,
+    pub active_permits: u64,
+    pub max_active_permits: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -308,6 +331,58 @@ pub fn record_projection_agents_list(elapsed: Duration) {
     PROJECTION_AGENTS_LIST.record(elapsed, None);
 }
 
+pub fn record_projection_gate_cache_hit() {
+    process_started_at();
+    PROJECTION_GATE_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_projection_gate_cache_miss() {
+    process_started_at();
+    PROJECTION_GATE_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_projection_gate_joined_waiter() {
+    process_started_at();
+    PROJECTION_GATE_JOINED_WAITERS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_projection_gate_rejected() {
+    process_started_at();
+    PROJECTION_GATE_REJECTED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_projection_gate_failed() {
+    process_started_at();
+    PROJECTION_GATE_FAILED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_projection_gate_cancelled() {
+    process_started_at();
+    PROJECTION_GATE_CANCELLED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_projection_gate_leader_started() {
+    process_started_at();
+    PROJECTION_GATE_LEADERS.fetch_add(1, Ordering::Relaxed);
+    let active = PROJECTION_GATE_ACTIVE_PERMITS.fetch_add(1, Ordering::Relaxed) + 1;
+    update_max(&PROJECTION_GATE_MAX_ACTIVE_PERMITS, active);
+}
+
+pub fn record_projection_gate_leader_finished() {
+    let mut current = PROJECTION_GATE_ACTIVE_PERMITS.load(Ordering::Relaxed);
+    while current > 0 {
+        match PROJECTION_GATE_ACTIVE_PERMITS.compare_exchange_weak(
+            current,
+            current - 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(next) => current = next,
+        }
+    }
+}
+
 pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
     let started_at = process_started_at();
     PerformanceDiagnosticsSnapshot {
@@ -337,6 +412,17 @@ pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
             PROJECTION_STATE_WORKSPACE.snapshot(false),
             PROJECTION_STATE_SERIALIZATION.snapshot(false),
         ],
+        projection_gate: ProjectionGateDiagnosticsSnapshot {
+            leaders: PROJECTION_GATE_LEADERS.load(Ordering::Relaxed),
+            joined_waiters: PROJECTION_GATE_JOINED_WAITERS.load(Ordering::Relaxed),
+            cache_hits: PROJECTION_GATE_CACHE_HITS.load(Ordering::Relaxed),
+            cache_misses: PROJECTION_GATE_CACHE_MISSES.load(Ordering::Relaxed),
+            rejected: PROJECTION_GATE_REJECTED.load(Ordering::Relaxed),
+            failed: PROJECTION_GATE_FAILED.load(Ordering::Relaxed),
+            cancelled: PROJECTION_GATE_CANCELLED.load(Ordering::Relaxed),
+            active_permits: PROJECTION_GATE_ACTIVE_PERMITS.load(Ordering::Relaxed),
+            max_active_permits: PROJECTION_GATE_MAX_ACTIVE_PERMITS.load(Ordering::Relaxed),
+        },
         db: vec![DB_CONNECTION_OPEN.snapshot(false)],
         scheduler: vec![
             SCHEDULER_POLL_ALL.snapshot(false),
@@ -358,6 +444,16 @@ pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
             PROVIDER_ROUND_TOTAL.snapshot(false),
             PROVIDER_RETRY.snapshot(false),
         ],
+    }
+}
+
+fn update_max(target: &AtomicU64, value: u64) {
+    let mut current = target.load(Ordering::Relaxed);
+    while value > current {
+        match target.compare_exchange_weak(current, value, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(next) => current = next,
+        }
     }
 }
 
@@ -457,6 +553,14 @@ mod tests {
         record_projection_state_workspace(Duration::from_millis(1));
         record_projection_state_serialization(Duration::from_millis(1));
         record_projection_agents_list(Duration::from_millis(10));
+        record_projection_gate_cache_hit();
+        record_projection_gate_cache_miss();
+        record_projection_gate_joined_waiter();
+        record_projection_gate_rejected();
+        record_projection_gate_failed();
+        record_projection_gate_cancelled();
+        record_projection_gate_leader_started();
+        record_projection_gate_leader_finished();
 
         let snapshot = performance_snapshot();
 
@@ -492,6 +596,15 @@ mod tests {
             .provider
             .iter()
             .any(|metric| metric.name == "provider.retry" && metric.count >= 1));
+        assert!(snapshot.projection_gate.leaders >= 1);
+        assert!(snapshot.projection_gate.joined_waiters >= 1);
+        assert!(snapshot.projection_gate.cache_hits >= 1);
+        assert!(snapshot.projection_gate.cache_misses >= 1);
+        assert!(snapshot.projection_gate.rejected >= 1);
+        assert!(snapshot.projection_gate.failed >= 1);
+        assert!(snapshot.projection_gate.cancelled >= 1);
+        assert_eq!(snapshot.projection_gate.active_permits, 0);
+        assert!(snapshot.projection_gate.max_active_permits >= 1);
         for name in [
             "projection.agents_list",
             "projection.agent_state.agent",

--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -177,14 +177,27 @@ pub async fn handshake(
 pub async fn list_agent_entries(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+) -> AxumResponse {
     let started_at = std::time::Instant::now();
-    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let agents = state
-        .host
-        .list_agent_entries()
-        .await
-        .map_err(error_response)?;
-    crate::diagnostics::record_projection_agents_list(started_at.elapsed());
-    traced_json("/agents/list", started_at, agents)
+    if let Err(error) = authorize_remote_access(&headers, &state) {
+        return auth_required(error.to_string()).into_response();
+    }
+    let result = state
+        .projection_gate
+        .run(ProjectionKey::AgentsList, || async {
+            let projection_started = std::time::Instant::now();
+            let agents = state
+                .host
+                .list_agent_entries()
+                .await
+                .map_err(error_response)
+                .map_err(ProjectionFailure::from)?;
+            crate::diagnostics::record_projection_agents_list(projection_started.elapsed());
+            serialize_json("/agents/list", &agents).map_err(ProjectionFailure::from)
+        })
+        .await;
+    match result {
+        Ok(bytes) => traced_json_bytes("/agents/list", started_at, bytes),
+        Err(error) => projection_gate_error_response(error),
+    }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -97,6 +97,7 @@ mod control;
 mod events;
 mod ingress;
 mod jobs;
+mod projection_gate;
 mod skills;
 mod state;
 mod tasks;
@@ -106,6 +107,9 @@ mod web;
 mod workspace_files;
 
 // Re-export shared helpers used across submodules.
+pub(crate) use projection_gate::{
+    ProjectionFailure, ProjectionGate, ProjectionGateError, ProjectionKey,
+};
 pub(crate) use state::{
     control_admission_context, current_boundary_metadata, enqueue_internal,
     public_admission_context, EnqueueIngress,
@@ -181,6 +185,7 @@ pub struct AppState {
     pub jobs: JobRegistry,
     pub skill_library_write_jobs: Arc<tokio::sync::Semaphore>,
     pub template_remote_source_sync_jobs: Arc<tokio::sync::Semaphore>,
+    pub(crate) projection_gate: Arc<ProjectionGate>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -225,6 +230,11 @@ impl HttpErrorEnvelope {
 
     fn hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into());
+        self
+    }
+
+    fn retryable(mut self, retryable: bool) -> Self {
+        self.retryable = Some(retryable);
         self
     }
 
@@ -275,6 +285,7 @@ impl AppState {
         let jobs = JobRegistry::default();
         let skill_library_write_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         let template_remote_source_sync_jobs = Arc::new(tokio::sync::Semaphore::new(1));
+        let projection_gate = Arc::new(ProjectionGate::default());
         Self {
             host,
             require_control_token,
@@ -285,6 +296,7 @@ impl AppState {
             jobs,
             skill_library_write_jobs,
             template_remote_source_sync_jobs,
+            projection_gate,
         }
     }
 
@@ -301,6 +313,7 @@ impl AppState {
         let jobs = JobRegistry::default();
         let skill_library_write_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         let template_remote_source_sync_jobs = Arc::new(tokio::sync::Semaphore::new(1));
+        let projection_gate = Arc::new(ProjectionGate::default());
         Self {
             host,
             require_control_token: false,
@@ -311,6 +324,7 @@ impl AppState {
             jobs,
             skill_library_write_jobs,
             template_remote_source_sync_jobs,
+            projection_gate,
         }
     }
 
@@ -760,11 +774,27 @@ pub(crate) fn traced_json<T: Serialize>(
     started_at: std::time::Instant,
     value: T,
 ) -> Result<AxumResponse, (StatusCode, Json<Value>)> {
+    let bytes = serialize_json(route, &value)?;
+    Ok(traced_json_bytes(route, started_at, bytes))
+}
+
+pub(crate) fn serialize_json<T: Serialize>(
+    route: &'static str,
+    value: &T,
+) -> Result<Bytes, (StatusCode, Json<Value>)> {
     let serialization_started = std::time::Instant::now();
-    let bytes = serde_json::to_vec(&value).map_err(|err| error_response(err.into()))?;
+    let bytes = serde_json::to_vec(value).map_err(|err| error_response(err.into()))?;
     if route == "/agents/{agent_id}/state" {
         diagnostics::record_projection_state_serialization(serialization_started.elapsed());
     }
+    Ok(Bytes::from(bytes))
+}
+
+pub(crate) fn traced_json_bytes(
+    route: &'static str,
+    started_at: std::time::Instant,
+    bytes: Bytes,
+) -> AxumResponse {
     let build_elapsed = started_at.elapsed();
     diagnostics::record_http_json_response(route, build_elapsed, bytes.len());
     if build_elapsed >= HTTP_SLOW_RESPONSE_WARN_AFTER
@@ -777,7 +807,24 @@ pub(crate) fn traced_json<T: Serialize>(
             "large or slow HTTP JSON payload built"
         );
     }
-    Ok(([(CONTENT_TYPE, "application/json")], bytes).into_response())
+    ([(CONTENT_TYPE, "application/json")], bytes).into_response()
+}
+
+pub(crate) fn projection_gate_error_response(error: ProjectionGateError) -> AxumResponse {
+    match error {
+        ProjectionGateError::Build(failure) => failure.into_http_error().into_response(),
+        ProjectionGateError::Rejected => (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(axum::http::header::RETRY_AFTER, "1")],
+            Json(
+                HttpErrorEnvelope::new("projection capacity is busy; retry later")
+                    .code("projection_busy")
+                    .hint("keep the current projection and retry on the next scheduled refresh")
+                    .retryable(true),
+            ),
+        )
+            .into_response(),
+    }
 }
 pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result<()> {
     if !state.require_control_token {
@@ -1158,7 +1205,10 @@ pub async fn serve_unix(
 
 #[cfg(test)]
 mod tests {
-    use super::{error_response, router, AppState};
+    use super::{
+        error_response, projection_gate_error_response, router, AppState, ProjectionGate,
+        ProjectionGateError,
+    };
     use crate::{
         config::AppConfig,
         host::RuntimeHost,
@@ -1169,7 +1219,7 @@ mod tests {
         body::{to_bytes, Body},
         http::{header, Request, StatusCode},
     };
-    use std::{fs, sync::Arc};
+    use std::{fs, sync::Arc, time::Duration};
     use tempfile::tempdir;
     use tower::ServiceExt;
 
@@ -1208,6 +1258,52 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], b"<html>holon ui</html>");
+    }
+
+    #[tokio::test]
+    async fn projection_capacity_response_is_retryable_with_retry_after() {
+        let response = projection_gate_error_response(ProjectionGateError::Rejected);
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[header::RETRY_AFTER], "1");
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["code"], "projection_busy");
+        assert_eq!(body["retryable"], true);
+    }
+
+    #[tokio::test]
+    async fn projection_routes_authorize_before_checking_capacity() {
+        let (_home, host) = test_host();
+        let mut state = AppState::for_tcp(host);
+        state.require_control_token = true;
+        state.projection_gate = Arc::new(ProjectionGate::new(0, Duration::from_millis(250)));
+        let app = router(state);
+
+        for uri in ["/api/agents/list", "/api/agents/default/state"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(uri)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{uri}");
+            assert!(
+                !response.headers().contains_key(header::RETRY_AFTER),
+                "{uri}"
+            );
+            let body: serde_json::Value =
+                serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                    .unwrap();
+            assert_eq!(body["code"], "auth_required", "{uri}");
+        }
     }
 
     #[test]

--- a/src/http/projection_gate.rs
+++ b/src/http/projection_gate.rs
@@ -1,0 +1,553 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::{Arc, Mutex},
+};
+
+use axum::{body::Bytes, http::StatusCode, Json};
+use serde_json::{json, Value};
+use tokio::{
+    sync::{watch, OwnedSemaphorePermit, Semaphore},
+    time::{Duration, Instant},
+};
+
+use crate::diagnostics;
+
+const DEFAULT_MAX_LEADERS: usize = 4;
+const DEFAULT_TTL: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum ProjectionKey {
+    AgentsList,
+    AgentState(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProjectionFailure {
+    status: StatusCode,
+    body: Value,
+}
+
+impl ProjectionFailure {
+    fn leader_cancelled() -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            body: json!({
+                "ok": false,
+                "error": "projection leader was cancelled",
+                "code": "projection_leader_cancelled",
+                "retryable": true,
+            }),
+        }
+    }
+
+    pub(crate) fn into_http_error(self) -> (StatusCode, Json<Value>) {
+        (self.status, Json(self.body))
+    }
+}
+
+impl From<(StatusCode, Json<Value>)> for ProjectionFailure {
+    fn from((status, Json(body)): (StatusCode, Json<Value>)) -> Self {
+        Self { status, body }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ProjectionGateError {
+    Build(ProjectionFailure),
+    Rejected,
+}
+
+type ProjectionResult = Result<Bytes, ProjectionFailure>;
+
+#[derive(Debug, Clone)]
+enum FlightState {
+    Pending,
+    Finished(ProjectionResult),
+}
+
+#[derive(Debug)]
+struct Flight {
+    state: watch::Sender<FlightState>,
+}
+
+#[derive(Debug)]
+enum Entry {
+    InFlight { flight: Arc<Flight> },
+    Ready { bytes: Bytes, expires_at: Instant },
+}
+
+#[derive(Debug)]
+pub(crate) struct ProjectionGate {
+    entries: Mutex<HashMap<ProjectionKey, Entry>>,
+    leaders: Arc<Semaphore>,
+    ttl: Duration,
+}
+
+impl Default for ProjectionGate {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_LEADERS, DEFAULT_TTL)
+    }
+}
+
+impl ProjectionGate {
+    pub(super) fn new(max_leaders: usize, ttl: Duration) -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            leaders: Arc::new(Semaphore::new(max_leaders)),
+            ttl,
+        }
+    }
+
+    pub(crate) async fn run<F, Fut>(
+        &self,
+        key: ProjectionKey,
+        build: F,
+    ) -> Result<Bytes, ProjectionGateError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = ProjectionResult>,
+    {
+        enum Decision<'a> {
+            Ready(Bytes),
+            Wait(Arc<Flight>),
+            Lead(LeaderGuard<'a>),
+            Reject,
+        }
+
+        let decision = {
+            let mut entries = self.entries.lock().expect("projection gate lock poisoned");
+            let now = Instant::now();
+            match entries.get(&key) {
+                Some(Entry::Ready { bytes, expires_at }) if *expires_at > now => {
+                    diagnostics::record_projection_gate_cache_hit();
+                    Decision::Ready(bytes.clone())
+                }
+                Some(Entry::InFlight { flight }) => {
+                    diagnostics::record_projection_gate_cache_miss();
+                    diagnostics::record_projection_gate_joined_waiter();
+                    Decision::Wait(Arc::clone(flight))
+                }
+                _ => {
+                    entries.retain(|_, entry| {
+                        !matches!(
+                            entry,
+                            Entry::Ready { expires_at, .. } if *expires_at <= now
+                        )
+                    });
+                    diagnostics::record_projection_gate_cache_miss();
+                    match Arc::clone(&self.leaders).try_acquire_owned() {
+                        Ok(permit) => {
+                            let (state, _) = watch::channel(FlightState::Pending);
+                            let flight = Arc::new(Flight { state });
+                            entries.insert(
+                                key.clone(),
+                                Entry::InFlight {
+                                    flight: Arc::clone(&flight),
+                                },
+                            );
+                            Decision::Lead(LeaderGuard::new(self, key, flight, permit))
+                        }
+                        Err(_) => {
+                            diagnostics::record_projection_gate_rejected();
+                            Decision::Reject
+                        }
+                    }
+                }
+            }
+        };
+
+        match decision {
+            Decision::Ready(bytes) => Ok(bytes),
+            Decision::Wait(flight) => wait_for_flight(flight)
+                .await
+                .map_err(ProjectionGateError::Build),
+            Decision::Lead(mut guard) => {
+                let result = build().await;
+                if result.is_err() {
+                    diagnostics::record_projection_gate_failed();
+                }
+                guard.finish(result.clone());
+                result.map_err(ProjectionGateError::Build)
+            }
+            Decision::Reject => Err(ProjectionGateError::Rejected),
+        }
+    }
+}
+
+struct LeaderGuard<'a> {
+    gate: &'a ProjectionGate,
+    key: ProjectionKey,
+    flight: Arc<Flight>,
+    _permit: OwnedSemaphorePermit,
+    finished: bool,
+}
+
+impl<'a> LeaderGuard<'a> {
+    fn new(
+        gate: &'a ProjectionGate,
+        key: ProjectionKey,
+        flight: Arc<Flight>,
+        permit: OwnedSemaphorePermit,
+    ) -> Self {
+        diagnostics::record_projection_gate_leader_started();
+        Self {
+            gate,
+            key,
+            flight,
+            _permit: permit,
+            finished: false,
+        }
+    }
+
+    fn finish(&mut self, result: ProjectionResult) {
+        {
+            let mut entries = self
+                .gate
+                .entries
+                .lock()
+                .expect("projection gate lock poisoned");
+            if entry_matches_flight(entries.get(&self.key), &self.flight) {
+                match &result {
+                    Ok(bytes) => {
+                        entries.insert(
+                            self.key.clone(),
+                            Entry::Ready {
+                                bytes: bytes.clone(),
+                                expires_at: Instant::now() + self.gate.ttl,
+                            },
+                        );
+                    }
+                    Err(_) => {
+                        entries.remove(&self.key);
+                    }
+                }
+            }
+        }
+        self.flight
+            .state
+            .send_replace(FlightState::Finished(result));
+        self.finished = true;
+    }
+}
+
+impl Drop for LeaderGuard<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            let failure = ProjectionFailure::leader_cancelled();
+            {
+                let mut entries = self
+                    .gate
+                    .entries
+                    .lock()
+                    .expect("projection gate lock poisoned");
+                if entry_matches_flight(entries.get(&self.key), &self.flight) {
+                    entries.remove(&self.key);
+                }
+            }
+            self.flight
+                .state
+                .send_replace(FlightState::Finished(Err(failure)));
+            diagnostics::record_projection_gate_cancelled();
+        }
+        diagnostics::record_projection_gate_leader_finished();
+    }
+}
+
+fn entry_matches_flight(entry: Option<&Entry>, flight: &Arc<Flight>) -> bool {
+    matches!(
+        entry,
+        Some(Entry::InFlight { flight: current }) if Arc::ptr_eq(current, flight)
+    )
+}
+
+async fn wait_for_flight(flight: Arc<Flight>) -> ProjectionResult {
+    let mut state = flight.state.subscribe();
+    loop {
+        if let FlightState::Finished(result) = state.borrow().clone() {
+            return result;
+        }
+        if state.changed().await.is_err() {
+            return Err(ProjectionFailure::leader_cancelled());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::sync::Notify;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn concurrent_requests_for_the_same_key_share_one_build() {
+        let gate = Arc::new(ProjectionGate::new(4, Duration::from_millis(250)));
+        let builds = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let mut requests = Vec::new();
+
+        for _ in 0..50 {
+            let gate = Arc::clone(&gate);
+            let builds = Arc::clone(&builds);
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            requests.push(tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentsList, || async move {
+                    builds.fetch_add(1, Ordering::SeqCst);
+                    started.notify_one();
+                    release.notified().await;
+                    Ok(Bytes::from_static(b"shared"))
+                })
+                .await
+            }));
+        }
+
+        started.notified().await;
+        tokio::task::yield_now().await;
+        release.notify_one();
+        for request in requests {
+            assert_eq!(
+                request.await.unwrap().unwrap(),
+                Bytes::from_static(b"shared")
+            );
+        }
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cached_bytes_expire_after_the_ttl() {
+        tokio::time::pause();
+        let gate = ProjectionGate::new(4, Duration::from_millis(250));
+        let builds = AtomicUsize::new(0);
+
+        let first = gate
+            .run(ProjectionKey::AgentsList, || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok(Bytes::from_static(b"first"))
+            })
+            .await
+            .unwrap();
+        let cached = gate
+            .run(ProjectionKey::AgentsList, || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok(Bytes::from_static(b"unexpected"))
+            })
+            .await
+            .unwrap();
+        tokio::time::advance(Duration::from_millis(251)).await;
+        let rebuilt = gate
+            .run(ProjectionKey::AgentsList, || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok(Bytes::from_static(b"rebuilt"))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(first, Bytes::from_static(b"first"));
+        assert_eq!(cached, first);
+        assert_eq!(rebuilt, Bytes::from_static(b"rebuilt"));
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cache_miss_prunes_expired_ready_entries() {
+        tokio::time::pause();
+        let gate = ProjectionGate::new(4, Duration::from_millis(250));
+
+        gate.run(
+            ProjectionKey::AgentState("removed-agent".into()),
+            || async { Ok(Bytes::from_static(b"stale")) },
+        )
+        .await
+        .unwrap();
+        tokio::time::advance(Duration::from_millis(251)).await;
+        gate.run(ProjectionKey::AgentsList, || async {
+            Ok(Bytes::from_static(b"agents"))
+        })
+        .await
+        .unwrap();
+
+        let entries = gate.entries.lock().unwrap();
+        assert!(!entries.contains_key(&ProjectionKey::AgentState("removed-agent".into())));
+        assert!(entries.contains_key(&ProjectionKey::AgentsList));
+    }
+
+    #[tokio::test]
+    async fn distinct_projection_keys_do_not_share_results() {
+        let gate = ProjectionGate::new(4, Duration::from_millis(250));
+        let agents = gate
+            .run(ProjectionKey::AgentsList, || async {
+                Ok(Bytes::from_static(b"agents"))
+            })
+            .await
+            .unwrap();
+        let agent_a = gate
+            .run(ProjectionKey::AgentState("agent-a".into()), || async {
+                Ok(Bytes::from_static(b"agent-a"))
+            })
+            .await
+            .unwrap();
+        let agent_b = gate
+            .run(ProjectionKey::AgentState("agent-b".into()), || async {
+                Ok(Bytes::from_static(b"agent-b"))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(agents, Bytes::from_static(b"agents"));
+        assert_eq!(agent_a, Bytes::from_static(b"agent-a"));
+        assert_eq!(agent_b, Bytes::from_static(b"agent-b"));
+    }
+
+    #[tokio::test]
+    async fn saturated_gate_rejects_new_keys_but_allows_existing_waiters() {
+        let gate = Arc::new(ProjectionGate::new(1, Duration::from_millis(250)));
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+
+        let leader = {
+            let gate = Arc::clone(&gate);
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentState("agent-a".into()), || async move {
+                    started.notify_one();
+                    release.notified().await;
+                    Ok(Bytes::from_static(b"agent-a"))
+                })
+                .await
+            })
+        };
+        started.notified().await;
+
+        let rejected = gate
+            .run(ProjectionKey::AgentState("agent-b".into()), || async {
+                Ok(Bytes::from_static(b"agent-b"))
+            })
+            .await;
+        assert!(matches!(rejected, Err(ProjectionGateError::Rejected)));
+
+        let waiter = {
+            let gate = Arc::clone(&gate);
+            tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentState("agent-a".into()), || async {
+                    Ok(Bytes::from_static(b"unexpected"))
+                })
+                .await
+            })
+        };
+        release.notify_one();
+
+        assert_eq!(
+            leader.await.unwrap().unwrap(),
+            Bytes::from_static(b"agent-a")
+        );
+        assert_eq!(
+            waiter.await.unwrap().unwrap(),
+            Bytes::from_static(b"agent-a")
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_leader_releases_the_key_and_waiters() {
+        let gate = Arc::new(ProjectionGate::new(1, Duration::from_millis(250)));
+        let started = Arc::new(Notify::new());
+        let pending = Arc::new(Notify::new());
+
+        let leader = {
+            let gate = Arc::clone(&gate);
+            let started = Arc::clone(&started);
+            let pending = Arc::clone(&pending);
+            tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentsList, || async move {
+                    started.notify_one();
+                    pending.notified().await;
+                    Ok(Bytes::from_static(b"never"))
+                })
+                .await
+            })
+        };
+        started.notified().await;
+
+        let waiter = {
+            let gate = Arc::clone(&gate);
+            tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentsList, || async {
+                    Ok(Bytes::from_static(b"unexpected"))
+                })
+                .await
+            })
+        };
+        tokio::task::yield_now().await;
+        leader.abort();
+        assert!(matches!(
+            waiter.await.unwrap(),
+            Err(ProjectionGateError::Build(_))
+        ));
+
+        let retry = gate
+            .run(ProjectionKey::AgentsList, || async {
+                Ok(Bytes::from_static(b"retry"))
+            })
+            .await
+            .unwrap();
+        assert_eq!(retry, Bytes::from_static(b"retry"));
+    }
+
+    #[tokio::test]
+    async fn failed_leader_releases_the_key_for_retry() {
+        let gate = Arc::new(ProjectionGate::new(1, Duration::from_millis(250)));
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+
+        let leader = {
+            let gate = Arc::clone(&gate);
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentsList, || async move {
+                    started.notify_one();
+                    release.notified().await;
+                    Err(ProjectionFailure {
+                        status: StatusCode::INTERNAL_SERVER_ERROR,
+                        body: json!({ "error": "failed" }),
+                    })
+                })
+                .await
+            })
+        };
+        started.notified().await;
+
+        let waiter = {
+            let gate = Arc::clone(&gate);
+            tokio::spawn(async move {
+                gate.run(ProjectionKey::AgentsList, || async {
+                    Ok(Bytes::from_static(b"unexpected"))
+                })
+                .await
+            })
+        };
+        tokio::task::yield_now().await;
+        release.notify_one();
+
+        assert!(matches!(
+            leader.await.unwrap(),
+            Err(ProjectionGateError::Build(_))
+        ));
+        assert!(matches!(
+            waiter.await.unwrap(),
+            Err(ProjectionGateError::Build(_))
+        ));
+
+        let retry = gate
+            .run(ProjectionKey::AgentsList, || async {
+                Ok(Bytes::from_static(b"retry"))
+            })
+            .await
+            .unwrap();
+        assert_eq!(retry, Bytes::from_static(b"retry"));
+    }
+}

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -193,10 +193,7 @@ pub async fn status(
     traced_json("/agents/{agent_id}/status", started_at, agent)
 }
 
-pub async fn state_default(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+pub async fn state_default(State(state): State<Arc<AppState>>, headers: HeaderMap) -> AxumResponse {
     agent_state(
         Path(state.host.config().default_agent_id.clone()),
         State(state),
@@ -209,31 +206,55 @@ pub async fn agent_state(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+) -> AxumResponse {
     let started_at = std::time::Instant::now();
-    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    if let Err(error) = authorize_remote_access(&headers, &state) {
+        return auth_required(error.to_string()).into_response();
+    }
+    let key = ProjectionKey::AgentState(agent_id.clone());
+    let result = state
+        .projection_gate
+        .run(key, || build_agent_state_projection(&state, &agent_id))
+        .await;
+    match result {
+        Ok(bytes) => traced_json_bytes("/agents/{agent_id}/state", started_at, bytes),
+        Err(error) => projection_gate_error_response(error),
+    }
+}
+
+async fn build_agent_state_projection(
+    state: &Arc<AppState>,
+    agent_id: &str,
+) -> Result<Bytes, ProjectionFailure> {
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_public_agent(agent_id)
         .await
-        .map_err(agent_access_error)?;
+        .map_err(agent_access_error)
+        .map_err(ProjectionFailure::from)?;
     let agent_started = std::time::Instant::now();
     let projection = runtime
         .lightweight_agent_state_projection()
         .await
-        .map_err(error_response)?;
+        .map_err(error_response)
+        .map_err(ProjectionFailure::from)?;
     crate::diagnostics::record_projection_state_agent(agent_started.elapsed());
     let tasks_started = std::time::Instant::now();
     let tasks = runtime
         .active_tasks(STATE_BOOTSTRAP_TASK_LIMIT)
         .await
-        .map_err(error_response)?
+        .map_err(error_response)
+        .map_err(ProjectionFailure::from)?
         .into_iter()
         .map(crate::http_dto::SlimTaskDto::from)
         .collect();
     crate::diagnostics::record_projection_state_tasks(tasks_started.elapsed());
     let timers_started = std::time::Instant::now();
-    let timers = runtime.recent_timers(50).await.map_err(error_response)?;
+    let timers = runtime
+        .recent_timers(50)
+        .await
+        .map_err(error_response)
+        .map_err(ProjectionFailure::from)?;
     crate::diagnostics::record_projection_state_timers(timers_started.elapsed());
     let work_items_started = std::time::Instant::now();
     let work_items = projection
@@ -248,7 +269,8 @@ pub async fn agent_state(
     let external_triggers = runtime
         .latest_external_triggers()
         .await
-        .map_err(error_response)?
+        .map_err(error_response)
+        .map_err(ProjectionFailure::from)?
         .into_iter()
         .map(ExternalTriggerStateSnapshot::from)
         .collect();
@@ -285,10 +307,9 @@ pub async fn agent_state(
             .clone()
             .map(slim_state_turn_terminal_record),
     };
-    traced_json(
+    serialize_json(
         "/agents/{agent_id}/state",
-        started_at,
-        crate::http_dto::AgentStateSnapshotDto {
+        &crate::http_dto::AgentStateSnapshotDto {
             agent: agent_dto,
             session,
             tasks,
@@ -298,6 +319,7 @@ pub async fn agent_state(
             workspace,
         },
     )
+    .map_err(ProjectionFailure::from)
 }
 
 fn slim_state_work_item_dto(

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -203,6 +203,29 @@ describe("createRuntimeClient", () => {
     expect(seen).toEqual(["http://example.test:7878/api/agents/agent-one/state"]);
   });
 
+  it("surfaces projection saturation instead of replacing agent state with a disconnected fixture", async () => {
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: (async () =>
+        Response.json(
+          {
+            ok: false,
+            error: "projection capacity is busy; retry later",
+            code: "projection_busy",
+            retryable: true,
+          },
+          { status: 429, headers: { "retry-after": "1" } },
+        )) as typeof fetch,
+    });
+
+    await expect(client.getAgentState("agent-one")).rejects.toMatchObject({
+      name: "RuntimeHttpError",
+      status: 429,
+      code: "projection_busy",
+    });
+  });
+
   it("loads agent detail without fetching the full roster", async () => {
     const seen: string[] = [];
     const client = createRuntimeClient({

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -639,6 +639,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       try {
         return await fetchRuntimeBootstrap(baseUrl, fetchImpl, requestHeaders, connectionMode, hasToken);
       } catch (error) {
+        if (isProjectionBusyError(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         return buildDisconnectedBootstrap(baseUrl, message, connectionMode, hasToken, isAuthRequiredError(error));
       }
@@ -651,6 +652,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       try {
         return await fetchAgentDetail(baseUrl, fetchImpl, requestHeaders, agentId, displayLevel);
       } catch (error) {
+        if (isProjectionBusyError(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         return disconnectedAgentDetail(agentId, message);
       }
@@ -662,6 +664,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       try {
         return await fetchAgentState(baseUrl, fetchImpl, requestHeaders, agentId);
       } catch (error) {
+        if (isProjectionBusyError(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         return disconnectedAgentSummary(agentId, message);
       }
@@ -2198,6 +2201,10 @@ async function readErrorEnvelope(response: Response): Promise<{ error?: string; 
 
 function isAuthRequiredError(error: unknown): boolean {
   return error instanceof RuntimeHttpError && error.code === "auth_required";
+}
+
+export function isProjectionBusyError(error: unknown): boolean {
+  return error instanceof RuntimeHttpError && error.status === 429 && error.code === "projection_busy";
 }
 
 function buildDisconnectedBootstrap(

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2660,6 +2660,26 @@ export interface components {
             }[];
             /** Format: uint64 */
             process_uptime_ms: number;
+            projection_gate: {
+                /** Format: uint64 */
+                active_permits: number;
+                /** Format: uint64 */
+                cache_hits: number;
+                /** Format: uint64 */
+                cache_misses: number;
+                /** Format: uint64 */
+                cancelled: number;
+                /** Format: uint64 */
+                failed: number;
+                /** Format: uint64 */
+                joined_waiters: number;
+                /** Format: uint64 */
+                leaders: number;
+                /** Format: uint64 */
+                max_active_permits: number;
+                /** Format: uint64 */
+                rejected: number;
+            };
             projections: {
                 /** Format: double */
                 avg_bytes?: number | null;

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -736,6 +736,65 @@ describe("runtime client generation", () => {
   });
 });
 
+describe("projection saturation refresh handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the current roster when a best-effort bootstrap refresh is rejected", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+
+    let saturated = false;
+    vi.stubGlobal("fetch", vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.endsWith("/agents/list")) {
+        return Promise.resolve(
+          saturated
+            ? new Response(
+                JSON.stringify({
+                  ok: false,
+                  error: "projection capacity is busy; retry later",
+                  code: "projection_busy",
+                  retryable: true,
+                }),
+                {
+                  status: 429,
+                  headers: {
+                    "content-type": "application/json",
+                    "retry-after": "1",
+                  },
+                },
+              )
+            : jsonResponse([{ id: "agent-a", lifecycle: "asleep" }]),
+        );
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }));
+
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    await Promise.resolve();
+    const currentRoster = useRuntimeStore.getState().bootstrap.agents;
+
+    saturated = true;
+    await useRuntimeStore.getState().refreshBootstrap({ syncEvents: false });
+
+    expect(useRuntimeStore.getState()).toMatchObject({
+      bootstrap: { agents: currentRoster },
+      bootstrapLoading: false,
+      bootstrapError: undefined,
+    });
+  });
+});
+
 describe("bounded resume refresh scheduling", () => {
   it("uses detail for the selected agent instead of scheduling duplicate state and detail refreshes", () => {
     expect(buildResumeRefreshes(["agent-a", "agent-b", "agent-c"], "agent-b")).toEqual([

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import {
   createRuntimeClient,
+  isProjectionBusyError,
   type AgentEventStreamSubscription,
   type OperatorPromptAttachment,
   type StreamEventEnvelopeDto,
@@ -1413,6 +1414,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         }
       } catch (error) {
         if (!isCurrentClientGeneration(generation)) return;
+        if (isProjectionBusyError(error)) {
+          set({ bootstrapLoading: false });
+          return;
+        }
         set({
           bootstrapLoading: false,
           bootstrapError: error instanceof Error ? error.message : String(error),
@@ -2241,6 +2246,19 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           !isCurrentClientRequest(request) ||
           agentDetailRequestSequence.get(agentId) !== sequence
         ) return;
+        if (isProjectionBusyError(error)) {
+          set((state) => ({
+            sessionsByAgentId: {
+              ...state.sessionsByAgentId,
+              [agentId]: {
+                ...emptyAgentSession(),
+                ...state.sessionsByAgentId[agentId],
+                loading: false,
+              },
+            },
+          }));
+          return;
+        }
         set((state) => ({
           sessionsByAgentId: {
             ...state.sessionsByAgentId,


### PR DESCRIPTION
## Summary

This is the second narrow PR for holon-run/holon#2357, following #2358 (client fan-out + lightweight /state projection).

### Changes
- Add `ProjectionGate`: a request-level concurrency limiter with 4 concurrent permits for expensive full projections (`/agents/list` and `/agents/{id}/state`), singleflight for identical projection keys, 250ms success caching, and 429 "Retry-After" backoff when saturated.
- Instrument `diagnostics` with projection gauge, in-flight, hit/miss/overload counters for observability.
- Enforce lightweight projection mode for `/agents/{id}/state` when queried by the GUI roster (only needed for posture/active flags, not full state).
- Binds peak in-flight projection work regardless of number of connected clients/tabs, prevents resume/reconciliation storms from collapsing server latency.
- Update OpenAPI spec with 429 responses and align GUI client with generated types.
- Add targeted tests for the core gate logic and authorization ordering.

### Testing
- All existing tests pass
- 7 new unit tests for ProjectionGate behaviors (singleflight, concurrency, caching, cleanup)
- GUI client tests updated and pass
- Full `cargo check --all-targets` is warning-free

## Fixes #2357
