### PR TITLE
fix: reuse markdown-content styles in file browser for complete markdown rendering

### DIFF
--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -509,7 +509,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
                 </p>
               ) : null}
               {isMarkdownFile && showRendered ? (
-                <div className="file-browser-markdown" ref={contentScrollRef}>
+                <div className="file-browser-markdown markdown-content" ref={contentScrollRef}>
                   <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                     {selectedFile.content}
                   </Markdown>


### PR DESCRIPTION
## Problem

The file browser markdown rendering (`.file-browser-markdown`) only defined styles for 4 element types (h1-h4, p, inline code). Lists, blockquotes, links, tables, code blocks, images, and overflow handling were all unstyled, making markdown files look broken in the right panel file browser.

In contrast, the timeline already has a complete markdown style set under `.markdown-content`.

## Fix

Add the `markdown-content` class to the file browser markdown container alongside the existing `file-browser-markdown` class. This reuses the timeline's complete markdown styles:

- **Lists**: ul/ol/li list-style, padding, nesting hierarchy
- **Blockquotes**: left border + muted background
- **Links**: accent color + hover underline
- **Tables**: overflow scroll, border-collapse, cell borders
- **Code blocks**: dark pre background, transparent code, horizontal scroll
- **Images**: max-width constraint
- **Overflow**: `overflow-wrap: anywhere` for long URLs
- **Margins**: first/last-child margin reset

The container-level properties (padding, font-size, background) remain from `.file-browser-markdown`. CSS specificity ensures inline code keeps its gray background while block code inside pre gets the dark block styling.

## Verification

- `npm run typecheck` passes (exit 0)
- One-line change: className value updated
