### PR TITLE
fix: make GET /api/agents/{id}/state uses storage snapshot for unloaded public agents, no runtime startup

### DIFF
--- a/docs/implementation-decisions/097-storage-backed-agent-state-projection.md
+++ b/docs/implementation-decisions/097-storage-backed-agent-state-projection.md
@@ -1,0 +1,25 @@
+# 097 Storage-Backed Agent State Projection
+
+## Choice
+
+Treat `GET /api/agents/{agent_id}/state` as a read projection that does not own
+runtime activation.
+
+`RuntimeHost` selects a loaded runtime when one already exists. Otherwise it
+assembles the same HTTP snapshot from read-only agent storage and Runtime DB
+read models. The projection reports its `loaded` or `storage` source through
+diagnostics.
+
+## Reason
+
+Most `/state` fields are persisted facts or derived read models. Starting a
+runtime merely to read them turns bootstrap, resume, and reconnect traffic into
+an implicit lifecycle operation and multiplies that cost across the agent
+roster.
+
+## Preserved Boundary
+
+The storage fallback never calls `get_or_create_agent` or `spawn_runtime`.
+Explicit control, ingress, and scheduling paths remain responsible for runtime
+activation. `ProjectionGate` still bounds and coalesces projection work
+regardless of source.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -107,3 +107,4 @@ Current decision notes:
 - [093 Image Generation Route Calibration](./093-image-generation-route-calibration.md)
 - [094 OpenAI Codex Reasoning Effort](./094-openai-codex-reasoning-effort.md)
 - [096 Bounded HTTP Projection Gate](./096-bounded-http-projection-gate.md)
+- [097 Storage-Backed Agent State Projection](./097-storage-backed-agent-state-projection.md)

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -72,6 +72,12 @@ static PROJECTION_STATE_WORKSPACE: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.workspace");
 static PROJECTION_STATE_SERIALIZATION: MetricAccumulator =
     MetricAccumulator::new("projection.agent_state.serialization");
+static PROJECTION_STATE_SOURCE_LOADED: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_state.source.loaded");
+static PROJECTION_STATE_SOURCE_STORAGE: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_state.source.storage");
+static PROJECTION_STATE_RUNTIME_SPAWN_AVOIDED: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_state.runtime_spawn_avoided");
 static PROJECTION_AGENTS_LIST: MetricAccumulator = MetricAccumulator::new("projection.agents_list");
 static PROJECTION_GATE_LEADERS: AtomicU64 = AtomicU64::new(0);
 static PROJECTION_GATE_JOINED_WAITERS: AtomicU64 = AtomicU64::new(0);
@@ -326,6 +332,21 @@ pub fn record_projection_state_serialization(elapsed: Duration) {
     PROJECTION_STATE_SERIALIZATION.record(elapsed, None);
 }
 
+pub fn record_projection_state_source_loaded() {
+    process_started_at();
+    PROJECTION_STATE_SOURCE_LOADED.record(Duration::ZERO, None);
+}
+
+pub fn record_projection_state_source_storage() {
+    process_started_at();
+    PROJECTION_STATE_SOURCE_STORAGE.record(Duration::ZERO, None);
+}
+
+pub fn record_projection_state_runtime_spawn_avoided() {
+    process_started_at();
+    PROJECTION_STATE_RUNTIME_SPAWN_AVOIDED.record(Duration::ZERO, None);
+}
+
 pub fn record_projection_agents_list(elapsed: Duration) {
     process_started_at();
     PROJECTION_AGENTS_LIST.record(elapsed, None);
@@ -411,6 +432,9 @@ pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
             PROJECTION_STATE_TRIGGERS.snapshot(false),
             PROJECTION_STATE_WORKSPACE.snapshot(false),
             PROJECTION_STATE_SERIALIZATION.snapshot(false),
+            PROJECTION_STATE_SOURCE_LOADED.snapshot(false),
+            PROJECTION_STATE_SOURCE_STORAGE.snapshot(false),
+            PROJECTION_STATE_RUNTIME_SPAWN_AVOIDED.snapshot(false),
         ],
         projection_gate: ProjectionGateDiagnosticsSnapshot {
             leaders: PROJECTION_GATE_LEADERS.load(Ordering::Relaxed),
@@ -552,6 +576,9 @@ mod tests {
         record_projection_state_external_triggers(Duration::from_millis(1));
         record_projection_state_workspace(Duration::from_millis(1));
         record_projection_state_serialization(Duration::from_millis(1));
+        record_projection_state_source_loaded();
+        record_projection_state_source_storage();
+        record_projection_state_runtime_spawn_avoided();
         record_projection_agents_list(Duration::from_millis(10));
         record_projection_gate_cache_hit();
         record_projection_gate_cache_miss();
@@ -615,6 +642,9 @@ mod tests {
             "projection.agent_state.external_triggers",
             "projection.agent_state.workspace",
             "projection.agent_state.serialization",
+            "projection.agent_state.source.loaded",
+            "projection.agent_state.source.storage",
+            "projection.agent_state.runtime_spawn_avoided",
         ] {
             assert!(
                 snapshot

--- a/src/host.rs
+++ b/src/host.rs
@@ -33,7 +33,7 @@ use crate::{
     ids,
     prompt::{build_effective_prompt_with_apply_patch_surface, EffectivePrompt},
     provider::{build_provider_from_config, AgentProvider},
-    runtime::{InitialWorkspaceBinding, RuntimeHandle},
+    runtime::{InitialWorkspaceBinding, LightweightAgentStateProjection, RuntimeHandle},
     runtime_db::RuntimeDb,
     skills::{
         effective_skill_root_registrations, skills_runtime_view_from_catalog, SkillVisibility,
@@ -49,8 +49,8 @@ use crate::{
         ClosureOutcome, ExternalTriggerRecord, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
         RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-        TaskKind, TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        TaskKind, TaskRecord, TaskStatus, TimerRecord, TranscriptEntry, TranscriptEntryKind,
+        WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -60,6 +60,29 @@ pub struct PublicAgentActivitySnapshot {
     pub status: AgentStatus,
     pub active_task_count: usize,
     pub last_runtime_failure: Option<RuntimeFailureSummary>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentStateProjectionSource {
+    Loaded,
+    Storage,
+}
+
+impl AgentStateProjectionSource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Loaded => "loaded",
+            Self::Storage => "storage",
+        }
+    }
+}
+
+pub(crate) struct AgentStateReadProjection {
+    pub(crate) source: AgentStateProjectionSource,
+    pub(crate) agent: LightweightAgentStateProjection,
+    pub(crate) tasks: Vec<TaskRecord>,
+    pub(crate) timers: Vec<TimerRecord>,
+    pub(crate) external_triggers: Vec<ExternalTriggerRecord>,
 }
 
 #[derive(Clone)]
@@ -622,6 +645,141 @@ impl RuntimeHost {
         self.get_or_create_agent(agent_id)
             .await
             .map_err(PublicAgentError::Runtime)
+    }
+
+    pub(crate) async fn public_agent_state_projection(
+        &self,
+        agent_id: &str,
+        task_limit: usize,
+        timer_limit: usize,
+    ) -> std::result::Result<AgentStateReadProjection, PublicAgentError> {
+        let identity = self.public_agent_identity(agent_id)?;
+        let runtime = {
+            let agents = self.inner.agents.read().await;
+            agents
+                .get(agent_id)
+                .filter(|entry| !entry.task.is_finished())
+                .map(|entry| entry.runtime.clone())
+        };
+
+        if let Some(runtime) = runtime {
+            crate::diagnostics::record_projection_state_source_loaded();
+            tracing::debug!(
+                agent_id,
+                state_projection_source = AgentStateProjectionSource::Loaded.as_str(),
+                "building public agent state projection"
+            );
+            let agent_started = std::time::Instant::now();
+            let agent = runtime
+                .lightweight_agent_state_projection()
+                .await
+                .map_err(PublicAgentError::Runtime)?;
+            crate::diagnostics::record_projection_state_agent(agent_started.elapsed());
+
+            let tasks_started = std::time::Instant::now();
+            let tasks = runtime
+                .active_tasks(task_limit)
+                .await
+                .map_err(PublicAgentError::Runtime)?;
+            crate::diagnostics::record_projection_state_tasks(tasks_started.elapsed());
+
+            let timers_started = std::time::Instant::now();
+            let timers = runtime
+                .recent_timers(timer_limit)
+                .await
+                .map_err(PublicAgentError::Runtime)?;
+            crate::diagnostics::record_projection_state_timers(timers_started.elapsed());
+
+            let triggers_started = std::time::Instant::now();
+            let external_triggers = runtime
+                .latest_external_triggers()
+                .await
+                .map_err(PublicAgentError::Runtime)?;
+            crate::diagnostics::record_projection_state_external_triggers(
+                triggers_started.elapsed(),
+            );
+
+            return Ok(AgentStateReadProjection {
+                source: AgentStateProjectionSource::Loaded,
+                agent,
+                tasks,
+                timers,
+                external_triggers,
+            });
+        }
+
+        crate::diagnostics::record_projection_state_source_storage();
+        crate::diagnostics::record_projection_state_runtime_spawn_avoided();
+        tracing::debug!(
+            agent_id,
+            state_projection_source = AgentStateProjectionSource::Storage.as_str(),
+            "building public agent state projection"
+        );
+        let storage = self
+            .agent_storage_read_only(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+
+        let agent_started = std::time::Instant::now();
+        let agent_state = storage
+            .read_agent()
+            .map_err(PublicAgentError::Runtime)?
+            .unwrap_or_else(|| stopped_unloaded_agent(agent_id));
+        let work_queue = storage
+            .work_queue_read_model()
+            .map_err(PublicAgentError::Runtime)?;
+        let scheduling_posture = storage
+            .agent_posture_projection_with_work_queue(&agent_state, &work_queue)
+            .map_err(PublicAgentError::Runtime)?;
+        let closure = RuntimeHandle::closure_decision_from_storage(&storage, &agent_state)
+            .map_err(PublicAgentError::Runtime)?;
+        let active_children = self
+            .child_agent_summaries(agent_id)
+            .await
+            .map_err(PublicAgentError::Runtime)?;
+        let agent = LightweightAgentStateProjection {
+            identity: AgentIdentityView::from_record(&identity, &self.config().default_agent_id),
+            active_task_count: storage
+                .active_task_count_for_agent(agent_id)
+                .map_err(PublicAgentError::Runtime)?,
+            lifecycle: AgentLifecycleHint::from_status(agent_id, agent_state.status.clone()),
+            model: crate::runtime::agent_model_state_for_catalog(
+                &RuntimeModelCatalog::from_config(&self.config()),
+                &self.runtime_context_config(),
+                &agent_state,
+            ),
+            agent: agent_state,
+            scheduling_posture,
+            closure,
+            active_children,
+            work_queue,
+        };
+        crate::diagnostics::record_projection_state_agent(agent_started.elapsed());
+
+        let tasks_started = std::time::Instant::now();
+        let tasks = storage
+            .latest_active_task_records(task_limit)
+            .map_err(PublicAgentError::Runtime)?;
+        crate::diagnostics::record_projection_state_tasks(tasks_started.elapsed());
+
+        let timers_started = std::time::Instant::now();
+        let timers = storage
+            .read_recent_timers(timer_limit)
+            .map_err(PublicAgentError::Runtime)?;
+        crate::diagnostics::record_projection_state_timers(timers_started.elapsed());
+
+        let triggers_started = std::time::Instant::now();
+        let external_triggers = storage
+            .latest_external_triggers()
+            .map_err(PublicAgentError::Runtime)?;
+        crate::diagnostics::record_projection_state_external_triggers(triggers_started.elapsed());
+
+        Ok(AgentStateReadProjection {
+            source: AgentStateProjectionSource::Storage,
+            agent,
+            tasks,
+            timers,
+            external_triggers,
+        })
     }
 
     /// Get an agent for the local control/status API, allowing private child
@@ -1325,7 +1483,7 @@ impl RuntimeHost {
                 && record.kind == AgentKind::Child
                 && record.parent_agent_id.as_deref() == Some(parent_agent_id)
         }) {
-            let storage = self.agent_storage(&identity.agent_id)?;
+            let storage = self.agent_storage_read_only(&identity.agent_id)?;
             let state = storage
                 .read_agent()?
                 .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -2700,6 +2858,48 @@ mod tests {
             .find(|entry| entry.identity.agent_id == "release-bot")
             .expect("release-bot should be listed from DB-only state");
         assert_eq!(entry.status, AgentStatus::Asleep);
+    }
+
+    #[tokio::test]
+    async fn unloaded_public_agent_state_projection_reads_storage_without_starting_runtime() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        let mut state = AgentState::new(&agent_id);
+        state.status = AgentStatus::Asleep;
+        host.runtime_db().agent_states().upsert(&state).unwrap();
+
+        assert!(host.inner.agents.read().await.is_empty());
+        assert!(!host
+            .agent_data_dir(&agent_id)
+            .join(".holon/state/agent.json")
+            .exists());
+
+        let projection = host
+            .public_agent_state_projection(&agent_id, 10, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(projection.source, AgentStateProjectionSource::Storage);
+        assert_eq!(projection.agent.agent.status, AgentStatus::Asleep);
+        assert!(host.inner.agents.read().await.is_empty());
+        assert!(!host
+            .agent_data_dir(&agent_id)
+            .join(".holon/state/agent.json")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn loaded_public_agent_state_projection_prefers_runtime() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        host.default_runtime().await.unwrap();
+
+        let projection = host
+            .public_agent_state_projection(&agent_id, 10, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(projection.source, AgentStateProjectionSource::Loaded);
     }
 
     #[tokio::test]

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -226,36 +226,25 @@ async fn build_agent_state_projection(
     state: &Arc<AppState>,
     agent_id: &str,
 ) -> Result<Bytes, ProjectionFailure> {
-    let runtime = state
+    let projection = state
         .host
-        .get_public_agent(agent_id)
+        .public_agent_state_projection(agent_id, STATE_BOOTSTRAP_TASK_LIMIT, 50)
         .await
         .map_err(agent_access_error)
         .map_err(ProjectionFailure::from)?;
-    let agent_started = std::time::Instant::now();
-    let projection = runtime
-        .lightweight_agent_state_projection()
-        .await
-        .map_err(error_response)
-        .map_err(ProjectionFailure::from)?;
-    crate::diagnostics::record_projection_state_agent(agent_started.elapsed());
-    let tasks_started = std::time::Instant::now();
-    let tasks = runtime
-        .active_tasks(STATE_BOOTSTRAP_TASK_LIMIT)
-        .await
-        .map_err(error_response)
-        .map_err(ProjectionFailure::from)?
+    let source = projection.source;
+    let tasks = projection
+        .tasks
         .into_iter()
         .map(crate::http_dto::SlimTaskDto::from)
         .collect();
-    crate::diagnostics::record_projection_state_tasks(tasks_started.elapsed());
-    let timers_started = std::time::Instant::now();
-    let timers = runtime
-        .recent_timers(50)
-        .await
-        .map_err(error_response)
-        .map_err(ProjectionFailure::from)?;
-    crate::diagnostics::record_projection_state_timers(timers_started.elapsed());
+    let timers = projection.timers;
+    let external_triggers = projection
+        .external_triggers
+        .into_iter()
+        .map(ExternalTriggerStateSnapshot::from)
+        .collect();
+    let projection = projection.agent;
     let work_items_started = std::time::Instant::now();
     let work_items = projection
         .work_queue
@@ -265,16 +254,6 @@ async fn build_agent_state_projection(
         .map(slim_state_work_item_dto)
         .collect::<Vec<_>>();
     crate::diagnostics::record_projection_state_work_items(work_items_started.elapsed());
-    let triggers_started = std::time::Instant::now();
-    let external_triggers = runtime
-        .latest_external_triggers()
-        .await
-        .map_err(error_response)
-        .map_err(ProjectionFailure::from)?
-        .into_iter()
-        .map(ExternalTriggerStateSnapshot::from)
-        .collect();
-    crate::diagnostics::record_projection_state_external_triggers(triggers_started.elapsed());
     let workspace_started = std::time::Instant::now();
     let workspace = state_workspace_snapshot(&projection.agent, &state);
     crate::diagnostics::record_projection_state_workspace(workspace_started.elapsed());
@@ -307,6 +286,11 @@ async fn build_agent_state_projection(
             .clone()
             .map(slim_state_turn_terminal_record),
     };
+    tracing::debug!(
+        agent_id,
+        state_projection_source = source.as_str(),
+        "serializing public agent state projection"
+    );
     serialize_json(
         "/agents/{agent_id}/state",
         &crate::http_dto::AgentStateSnapshotDto {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -28,6 +28,7 @@ pub(crate) mod workspace_control;
 mod worktree;
 
 pub use first_run_intro::maybe_enqueue_first_run_intro;
+pub(crate) use lifecycle::LightweightAgentStateProjection;
 pub use tasks::{
     PickedWorkItem, WorkItemContinuationSummary, WorkItemFocusTransition,
     WorkItemFocusTransitionWarning,

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -14,6 +14,7 @@ macro_rules! http_async_tests {
 http_async_tests!(
     control_prompt_is_open_on_loopback_auto,
     agent_state_route_returns_aggregated_snapshot,
+    unloaded_agent_state_route_uses_storage_without_starting_runtime,
     runtime_search_route_returns_memory_search_results,
     runtime_search_route_filters_memory_results_by_agent_ids,
     agent_brief_route_returns_full_brief_by_id,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -20,7 +20,7 @@ use holon::{
     provider::{AgentProvider, StubProvider},
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
-        AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
+        AdmissionContext, AgentState, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority, TodoItem,
         TodoItemState, WorkItemState,
@@ -341,6 +341,38 @@ pub async fn agent_brief_route_returns_full_brief_by_id() -> Result<()> {
     assert_eq!(returned.id, brief.id);
     assert_eq!(returned.agent_id, "default");
     assert_eq!(returned.text, brief.text);
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn unloaded_agent_state_route_uses_storage_without_starting_runtime() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let agent_id = host.config().default_agent_id.clone();
+    let agent_state_path = host
+        .config()
+        .data_dir
+        .join("agents")
+        .join(&agent_id)
+        .join(".holon/state/agent.json");
+    let mut state = AgentState::new(&agent_id);
+    state.status = AgentStatus::Asleep;
+    host.runtime_db().agent_states().upsert(&state)?;
+
+    assert!(!agent_state_path.exists());
+
+    let response = reqwest::Client::new()
+        .get(format!("{base}/api/agents/{agent_id}/state"))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await?;
+
+    assert_eq!(payload["agent"]["agent"]["status"], "asleep");
+    assert!(
+        !agent_state_path.exists(),
+        "GET /state must not initialize agent storage or start a runtime"
+    );
 
     server.abort();
     Ok(())

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -796,12 +796,14 @@ describe("projection saturation refresh handling", () => {
 });
 
 describe("bounded resume refresh scheduling", () => {
-  it("uses detail for the selected agent instead of scheduling duplicate state and detail refreshes", () => {
+  it("only schedules a detail refresh for the selected agent", () => {
     expect(buildResumeRefreshes(["agent-a", "agent-b", "agent-c"], "agent-b")).toEqual([
-      { agentId: "agent-a", detail: false },
       { agentId: "agent-b", detail: true },
-      { agentId: "agent-c", detail: false },
     ]);
+  });
+
+  it("schedules no resume refresh when the selected agent is absent from the refreshed roster", () => {
+    expect(buildResumeRefreshes(["agent-a", "agent-c"], "agent-b")).toEqual([]);
   });
 
   it("limits concurrent refreshes", async () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -561,10 +561,9 @@ export function buildResumeRefreshes(
   agentIds: readonly string[],
   selectedAgentId: string,
 ): Array<{ agentId: string; detail: boolean }> {
-  return agentIds.map((agentId) => ({
-    agentId,
-    detail: agentId === selectedAgentId,
-  }));
+  return agentIds
+    .filter((agentId) => agentId === selectedAgentId)
+    .map((agentId) => ({ agentId, detail: true }));
 }
 
 function closeEventStreamsForResume(set: StoreSet): void {


### PR DESCRIPTION
Fix holon-run/holon#2360

## 变更内容：

1. **Rust 后端变更**：
- 在 `RuntimeHost` 新增 `public_agent_state_projection`，按 agent 是否加载自动选择：
  - 已加载：走原有 live runtime projection（保持兼容）
  - 未加载：从 storage read models 组装 snapshot，**绝不调用 `get_or_create_agent` / `spawn_runtime`**
- 新增 `AgentStateProjectionSource` 枚举和 `AgentStateReadProjection` 承载结果
- 在 `agent_state` HTTP handler 复用该方法，替代原先直接获取 runtime 的路径
- projection source 被包含在 diagnostics 中，方便调试投影来源
- 新增两个回归测试：
  - `unloaded_public_agent_state_projection_reads_storage_without_starting_runtime` 验证不启动 runtime
  - `loaded_public_agent_state_projection_prefers_runtime` 验证已加载时保持 live 投影
- 原有 7 项 `projection_gate` 测试全部回归通过

2. **Web GUI 变更**：
- 缩窄 resume/reconnect 后的 roster 刷新：`buildResumeRefreshes` 仅对 **selected agent** 做 detail refresh，其余 agent 不再触发 `/state` refresh，减少不必要的请求
- 保留原有并发控制和 reconcile 逻辑不变，只是缩小刷新范围

3. **文档**：
- 新增 `docs/implementation-decisions/097-storage-backed-agent-state-projection.md` 记录设计决策

## 验证：
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✔️
- 所有新增测试和回归测试 ✔️
- web-gui `npm run build` 类型检查+构建 ✔️
- 格式化检查 ✔️

这个修复使只读 `/state` 请求真正成为无副作用的 projection，满足公开 agent 可以被安全浏览而不隐式启动 runtime。
