### PR TITLE
fix: migrate provider catalogs to sparse route policies

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1645,7 +1645,12 @@ fn reasoning_effort_options(
             &["low", "medium", "high"][..]
         }
         ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
-        ("xiaomi" | "xiaomi-token-plan", "mimo-v2.5-pro" | "mimo-v2.5") => &["none", "high"][..],
+        ("xiaomi", "mimo-v2.5-pro" | "mimo-v2.5")
+            if endpoint
+                .is_none_or(|endpoint| matches!(endpoint.as_str(), "default" | "token-plan")) =>
+        {
+            &["none", "high"][..]
+        }
         ("volcengine", _)
             if endpoint.is_none_or(|endpoint| {
                 matches!(endpoint.as_str(), "default" | "coding" | "plan")
@@ -3569,6 +3574,38 @@ mod tests {
     }
 
     #[test]
+    fn volcengine_doubao_routes_inherit_canonical_intrinsic_capabilities() {
+        let catalog = BuiltInModelCatalog::new();
+
+        for endpoint in ["default", "coding", "plan"] {
+            let pro = catalog.resolve_route_policy(
+                &ModelRouteRef::parse(&format!("volcengine@{endpoint}/doubao-seed-2-0-pro-260215"))
+                    .unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert!(pro.capabilities.supports_reasoning, "{endpoint}");
+            assert!(pro.capabilities.image_input, "{endpoint}");
+
+            let code = catalog.resolve_route_policy(
+                &ModelRouteRef::parse(&format!(
+                    "volcengine@{endpoint}/doubao-seed-2-0-code-preview-260215"
+                ))
+                .unwrap(),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert!(code.capabilities.image_input, "{endpoint}");
+        }
+    }
+
+    #[test]
     fn moonshot_catalog_tracks_current_models_and_retirements() {
         let catalog = BuiltInModelCatalog::new();
         let moonshot = ProviderId::parse("moonshot").unwrap();
@@ -3765,6 +3802,29 @@ mod tests {
                 "{model}"
             );
         }
+    }
+
+    #[test]
+    fn built_in_catalog_registers_each_canonical_model_metadata_once() {
+        let mut registrations = HashMap::<ModelRef, Vec<ModelRef>>::new();
+        for entry in built_in_entries() {
+            let legacy_model_ref = entry.model_ref;
+            let (provider, _) =
+                built_in_provider_endpoint_identity(&legacy_model_ref.provider).unwrap();
+            registrations
+                .entry(ModelRef::new(provider, legacy_model_ref.model.clone()))
+                .or_default()
+                .push(legacy_model_ref);
+        }
+
+        let duplicates = registrations
+            .into_iter()
+            .filter(|(_, legacy_refs)| legacy_refs.len() > 1)
+            .collect::<Vec<_>>();
+        assert!(
+            duplicates.is_empty(),
+            "canonical model metadata must be registered once: {duplicates:#?}"
+        );
     }
 
     #[test]

--- a/src/model_catalog/providers/china.rs
+++ b/src/model_catalog/providers/china.rs
@@ -32,8 +32,46 @@ pub(super) fn stepfun_model(
     }
 }
 
+fn route_definition(
+    legacy_provider: &str,
+    canonical_provider: &str,
+    endpoint: &str,
+    model: &str,
+    context_window_tokens: Option<usize>,
+    max_output_tokens: Option<u32>,
+) -> BuiltInModelRouteDefinition {
+    BuiltInModelRouteDefinition {
+        legacy_provider: provider_id(legacy_provider),
+        model_ref: ModelRef::new(provider_id(canonical_provider), model),
+        endpoint: ProviderEndpointId::parse(endpoint).expect("valid endpoint"),
+        policy: BuiltInModelRoutePolicy {
+            context_window_tokens: context_window_tokens.map(Some),
+            default_max_output_tokens: max_output_tokens.map(Some),
+            max_output_tokens_upper_limit: max_output_tokens.map(Some),
+            ..BuiltInModelRoutePolicy::default()
+        },
+    }
+}
+
+fn volcengine_route_definition(
+    legacy_provider: &str,
+    endpoint: &str,
+    model: &str,
+    display_name: Option<&str>,
+) -> BuiltInModelRouteDefinition {
+    BuiltInModelRouteDefinition {
+        legacy_provider: provider_id(legacy_provider),
+        model_ref: ModelRef::new(provider_id("volcengine"), model),
+        endpoint: ProviderEndpointId::parse(endpoint).expect("valid endpoint"),
+        policy: BuiltInModelRoutePolicy {
+            display_name: display_name.map(str::to_owned),
+            ..BuiltInModelRoutePolicy::default()
+        },
+    }
+}
+
 pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
-    ["step-3.7-flash", "step-3.5-flash-2603", "step-3.5-flash"]
+    let mut definitions = ["step-3.7-flash", "step-3.5-flash-2603", "step-3.5-flash"]
         .into_iter()
         .map(|model| BuiltInModelRouteDefinition {
             legacy_provider: provider_id("stepfun-plan"),
@@ -41,7 +79,105 @@ pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
             endpoint: ProviderEndpointId::parse("plan").expect("valid endpoint"),
             policy: BuiltInModelRoutePolicy::default(),
         })
-        .collect()
+        .collect::<Vec<_>>();
+    definitions.extend(["mimo-v2.5-pro", "mimo-v2.5"].into_iter().map(|model| {
+        BuiltInModelRouteDefinition {
+            legacy_provider: provider_id("xiaomi-token-plan"),
+            model_ref: ModelRef::new(provider_id("xiaomi"), model),
+            endpoint: ProviderEndpointId::parse("token-plan").expect("valid endpoint"),
+            policy: BuiltInModelRoutePolicy::default(),
+        }
+    }));
+    definitions.extend(
+        [
+            ("qwen3.7-max", None, None),
+            ("qwen3.7-plus", None, None),
+            ("qwen3.6-plus", None, None),
+            ("qwen3.6-flash", None, None),
+            ("deepseek-v4-pro", None, Some(65_536)),
+            ("deepseek-v4-flash", None, Some(65_536)),
+            ("deepseek-v3.2", None, None),
+            ("kimi-k2.7-code", None, Some(65_536)),
+            ("kimi-k2.6", None, Some(65_536)),
+            ("kimi-k2.5", None, None),
+            ("glm-5.2", Some(1_000_000), Some(65_536)),
+            ("glm-5.1", None, Some(65_536)),
+            ("glm-5", None, None),
+            ("MiniMax-M2.5", None, None),
+        ]
+        .into_iter()
+        .map(|(model, context, output)| {
+            route_definition(
+                "dashscope-token-plan",
+                "dashscope",
+                "token-plan",
+                model,
+                context,
+                output,
+            )
+        }),
+    );
+    definitions.extend(
+        [
+            "qwen3.7-plus",
+            "qwen3.6-plus",
+            "qwen3.5-plus",
+            "qwen3-max-2026-01-23",
+            "qwen3-coder-next",
+            "qwen3-coder-plus",
+            "MiniMax-M2.5",
+            "glm-5",
+            "glm-4.7",
+            "kimi-k2.5",
+        ]
+        .into_iter()
+        .map(|model| {
+            route_definition(
+                "dashscope-coding-plan",
+                "dashscope",
+                "coding-plan",
+                model,
+                None,
+                None,
+            )
+        }),
+    );
+    definitions.extend(
+        [
+            (
+                "doubao-seed-2-0-code-preview-260215",
+                Some("Doubao Seed 2.0 Code"),
+            ),
+            ("doubao-seed-2-0-pro-260215", None),
+            ("doubao-seed-2-0-lite-260215", None),
+            ("deepseek-v3-2-251201", None),
+        ]
+        .into_iter()
+        .map(|(model, display_name)| {
+            volcengine_route_definition("volcengine-coding", "coding", model, display_name)
+        }),
+    );
+    definitions.extend(
+        [
+            (
+                "doubao-seed-2-0-code-preview-260215",
+                Some("Doubao Seed 2.0 Code"),
+            ),
+            ("doubao-seed-2-0-pro-260215", None),
+            ("doubao-seed-2-0-lite-260215", None),
+            ("ark-code-latest", None),
+            ("deepseek-v4-pro", None),
+            ("deepseek-v4-flash", None),
+            ("kimi-k2.6", None),
+            ("kimi-k2.7-code", None),
+            ("glm-5.2", None),
+        ]
+        .into_iter()
+        .map(|(model, display_name)| {
+            volcengine_route_definition("volcengine-agent", "plan", model, display_name)
+        }),
+    );
+    definitions
 }
 
 pub(super) fn early_entries() -> Vec<BuiltInModelMetadata> {
@@ -218,220 +354,13 @@ pub(super) fn early_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "dashscope-token-plan",
-            "qwen3.7-max",
-            "qwen3.7-max",
-            1_000_000,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "qwen3.7-plus",
-            "qwen3.7-plus",
-            1_000_000,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "qwen3.6-plus",
-            "qwen3.6-plus",
-            1_000_000,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "qwen3.6-flash",
-            "qwen3.6-flash",
-            1_000_000,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "deepseek-v4-pro",
-            "DeepSeek V4 Pro",
-            1_000_000,
-            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "deepseek-v4-flash",
-            "DeepSeek V4 Flash",
-            1_000_000,
-            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
+            "dashscope",
             "deepseek-v3.2",
             "DeepSeek V3.2",
             128_000,
             32_768,
             true,
             false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "kimi-k2.7-code",
-            "kimi-k2.7-code",
-            262_144,
-            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "kimi-k2.6",
-            "kimi-k2.6",
-            262_144,
-            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "kimi-k2.5",
-            "kimi-k2.5",
-            262_144,
-            32_768,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "glm-5.2",
-            "glm-5.2",
-            1_000_000,
-            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "glm-5.1",
-            "glm-5.1",
-            202_752,
-            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "glm-5",
-            "glm-5",
-            202_752,
-            16_384,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-token-plan",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5",
-            196_608,
-            32_768,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "qwen3.7-plus",
-            "qwen3.7-plus",
-            1_000_000,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "qwen3.6-plus",
-            "qwen3.6-plus",
-            1_000_000,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "qwen3.5-plus",
-            "qwen3.5-plus",
-            1_000_000,
-            65_536,
-            true,
-            true,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "qwen3-max-2026-01-23",
-            "qwen3-max-2026-01-23",
-            262_144,
-            65_536,
-            false,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "qwen3-coder-next",
-            "qwen3-coder-next",
-            262_144,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "qwen3-coder-plus",
-            "qwen3-coder-plus",
-            1_000_000,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5",
-            196_608,
-            32_768,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "glm-5",
-            "glm-5",
-            202_752,
-            16_384,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "glm-4.7",
-            "glm-4.7",
-            202_752,
-            16_384,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-coding-plan",
-            "kimi-k2.5",
-            "kimi-k2.5",
-            262_144,
-            32_768,
-            true,
-            true,
         ),
         stepfun_model("stepfun", "step-3.7-flash", "Step 3.7 Flash", true),
         stepfun_model(
@@ -502,42 +431,6 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "volcengine-coding",
-            "doubao-seed-2-0-code-preview-260215",
-            "Doubao Seed 2.0 Code",
-            256_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-coding",
-            "doubao-seed-2-0-pro-260215",
-            "Doubao Seed 2.0 Pro",
-            256_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-coding",
-            "doubao-seed-2-0-lite-260215",
-            "Doubao Seed 2.0 Lite",
-            256_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-coding",
-            "deepseek-v3-2-251201",
-            "DeepSeek V3.2",
-            128_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-coding",
             "deepseek-v4-pro",
             "DeepSeek V4 Pro",
             1_000_000,
@@ -575,88 +468,6 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "volcengine-coding",
-            "glm-5.2",
-            "GLM-5.2",
-            204_800,
-            128_000,
-            true,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "ark-code-latest",
-            "Ark Code Latest",
-            256_000,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "doubao-seed-2-0-code-preview-260215",
-            "Doubao Seed 2.0 Code",
-            256_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "doubao-seed-2-0-pro-260215",
-            "Doubao Seed 2.0 Pro",
-            256_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "doubao-seed-2-0-lite-260215",
-            "Doubao Seed 2.0 Lite",
-            256_000,
-            4_096,
-            false,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "deepseek-v4-pro",
-            "DeepSeek V4 Pro",
-            1_000_000,
-            8_192,
-            true,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "deepseek-v4-flash",
-            "DeepSeek V4 Flash",
-            1_000_000,
-            8_192,
-            true,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "kimi-k2.6",
-            "Kimi K2.6",
-            262_144,
-            32_768,
-            true,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
-            "kimi-k2.7-code",
-            "Kimi K2.7 Code",
-            262_144,
-            // Volcengine API rejects max_tokens > 32768 for kimi-k2.7-code
-            32_768,
-            true,
-            false,
-        ),
-        catalog_model(
-            "volcengine-agent",
             "glm-5.2",
             "GLM-5.2",
             204_800,
@@ -717,24 +528,6 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "xiaomi",
-            "mimo-v2.5",
-            "Xiaomi MiMo V2.5",
-            1_048_576,
-            131_072,
-            true,
-            true,
-        ),
-        catalog_model(
-            "xiaomi-token-plan",
-            "mimo-v2.5-pro",
-            "Xiaomi MiMo V2.5 Pro",
-            1_048_576,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "xiaomi-token-plan",
             "mimo-v2.5",
             "Xiaomi MiMo V2.5",
             1_048_576,

--- a/src/model_catalog/providers/mod.rs
+++ b/src/model_catalog/providers/mod.rs
@@ -26,5 +26,7 @@ pub(super) fn entries_for_registration(
 }
 
 pub(super) fn route_definitions() -> Vec<super::BuiltInModelRouteDefinition> {
-    china::route_definitions()
+    let mut definitions = china::route_definitions();
+    definitions.extend(tencent_tokenhub::route_definitions());
+    definitions
 }

--- a/src/model_catalog/providers/tencent_tokenhub.rs
+++ b/src/model_catalog/providers/tencent_tokenhub.rs
@@ -1,7 +1,6 @@
 use super::super::*;
 
 fn tencent_tokenhub_model(
-    provider: &str,
     model: &str,
     display_name: &str,
     context_window_tokens: Option<usize>,
@@ -9,7 +8,7 @@ fn tencent_tokenhub_model(
     supports_reasoning: bool,
     image_input: bool,
 ) -> BuiltInModelMetadata {
-    let model_ref = ModelRef::new(provider_id(provider), model);
+    let model_ref = ModelRef::new(provider_id("tencent-tokenhub"), model);
     BuiltInModelMetadata {
         default_verbosity: default_verbosity_for_model(&model_ref),
         model_ref,
@@ -220,14 +219,20 @@ pub(crate) fn is_tencent_tokenhub_model_id(id: &str) -> bool {
 }
 
 pub(super) fn entries() -> Vec<BuiltInModelMetadata> {
-    ["tencent-tokenhub", "tencent-tokenhub-messages"]
-        .into_iter()
-        .flat_map(|provider| {
-            TENCENT_TOKENHUB_MODELS.iter().map(move |model| {
-                tencent_tokenhub_model(
-                    provider, model.0, model.1, model.2, model.3, model.4, model.5,
-                )
-            })
+    TENCENT_TOKENHUB_MODELS
+        .iter()
+        .map(|model| tencent_tokenhub_model(model.0, model.1, model.2, model.3, model.4, model.5))
+        .collect()
+}
+
+pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
+    TENCENT_TOKENHUB_MODELS
+        .iter()
+        .map(|model| BuiltInModelRouteDefinition {
+            legacy_provider: provider_id("tencent-tokenhub-messages"),
+            model_ref: ModelRef::new(provider_id("tencent-tokenhub"), model.0),
+            endpoint: ProviderEndpointId::parse("messages").expect("valid endpoint"),
+            policy: BuiltInModelRoutePolicy::default(),
         })
         .collect()
 }

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -877,6 +877,40 @@ mod tests {
     }
 
     #[test]
+    fn resolved_model_availability_preserves_volcengine_plan_vision_capability() {
+        let mut fixture = test_config(Some("openai-key"));
+        let built_ins = crate::config::built_in_provider_registry_with_settings(
+            &std::collections::HashMap::from([(
+                "VOLCENGINE_AGENT_API_KEY".to_string(),
+                "volcengine-plan-key".to_string(),
+            )]),
+        )
+        .unwrap();
+        let route_provider = ProviderId::parse("volcengine-agent").unwrap();
+        fixture.config.providers.insert(
+            route_provider.clone(),
+            built_ins.get(&route_provider).unwrap().clone(),
+        );
+
+        let availability = resolved_model_availability(&fixture.config);
+        let pro = availability
+            .iter()
+            .find(|entry| {
+                entry.model == "volcengine/doubao-seed-2-0-pro-260215" && entry.endpoint == "plan"
+            })
+            .expect("Volcengine plan Doubao Pro availability");
+
+        assert!(pro.available);
+        assert_eq!(pro.route_provider, "volcengine-agent");
+        assert!(pro.policy.capabilities.supports_reasoning);
+        assert!(pro.policy.capabilities.image_input);
+        assert!(pro
+            .resolved_capabilities
+            .as_ref()
+            .is_some_and(|capabilities| capabilities.image_input));
+    }
+
+    #[test]
     fn provider_doctor_includes_chain_model_availability() {
         let fixture = test_config(Some("openai-key"));
         let doctor = provider_doctor(&fixture.config);

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -148,6 +148,36 @@ describe("projectModelOptions", () => {
     );
   });
 
+  it("projects resolved vision capability for an available Volcengine plan route", () => {
+    const options = projectModelOptions({
+      model_availability: [
+        {
+          model: "volcengine/doubao-seed-2-0-pro-260215",
+          provider: "volcengine",
+          provider_family: "volcengine",
+          endpoint: "plan",
+          route_provider: "volcengine-agent",
+          available: true,
+          policy: {
+            capabilities: {
+              image_input: true,
+              supports_reasoning: true,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(options[0]).toEqual(
+      expect.objectContaining({
+        routeRef: "volcengine@plan/doubao-seed-2-0-pro-260215",
+        routeProvider: "volcengine-agent",
+        available: true,
+        supportsImageInput: true,
+      }),
+    );
+  });
+
   it("preserves route identity and image capabilities from available models", () => {
     const options = projectModelOptions({
       available_models: [


### PR DESCRIPTION
## Summary

- migrate Tencent TokenHub, Xiaomi, DashScope, and Volcengine catalogs to shared canonical model metadata with sparse endpoint route policies
- enforce a full-catalog invariant that each canonical model's intrinsic metadata is registered exactly once
- preserve endpoint aliases, discovery behavior, and model-level-only `models.catalog` semantics
- add focused runtime diagnostics and Web GUI regressions for Doubao plan/coding vision capability inheritance

This is the second and final implementation PR for #2363, following #2367.

Closes #2363.

## Verification

- `cargo fmt --all -- --check`
- `cargo test model_catalog` (55 passed)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm test -- --run src/runtime/client.test.ts` (26 passed)
