### PR TITLE
feat: compact default model route labels

### DIFF
--- a/docs/rfcs/extensible-model-provider-configuration.md
+++ b/docs/rfcs/extensible-model-provider-configuration.md
@@ -68,6 +68,16 @@ existing built-in alias/catalog endpoint rule, falling back to the provider's
 `default` endpoint. Writers always persist canonical route refs. Reading legacy
 data does not silently rewrite it.
 
+Human-facing labels may use a compact presentation projection:
+
+- `provider@default/model` is displayed as `provider/model`
+- non-default routes such as `provider@plan/model` remain fully qualified
+
+This compact form is presentation only. It is not a canonical serialization,
+persisted identity, API value, map key, cursor, or replacement for legacy input
+semantics. Machine-readable surfaces and runtime lineage continue to use the
+full `provider@endpoint/model` route ref.
+
 Existing data can be inspected and explicitly migrated with:
 
 ```bash

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -169,6 +169,13 @@ impl ModelRouteRef {
             self.model
         )
     }
+
+    pub fn as_compact_display(&self) -> String {
+        if self.endpoint == ProviderEndpointId::default_endpoint() {
+            return self.model_ref().as_string();
+        }
+        self.as_string()
+    }
 }
 
 impl Serialize for ModelRouteRef {
@@ -1317,6 +1324,33 @@ mod tests {
         assert_eq!(
             route_ref.as_string(),
             "openrouter@default/anthropic/claude-3.5-sonnet"
+        );
+    }
+
+    #[test]
+    fn model_route_ref_compact_display_only_omits_default_endpoint() {
+        let default_route =
+            ModelRouteRef::parse("openrouter@default/anthropic/claude-3.5-sonnet").unwrap();
+        assert_eq!(
+            default_route.as_compact_display(),
+            "openrouter/anthropic/claude-3.5-sonnet"
+        );
+        assert_eq!(
+            default_route.as_string(),
+            "openrouter@default/anthropic/claude-3.5-sonnet"
+        );
+        assert_eq!(
+            serde_json::to_string(&default_route).unwrap(),
+            r#""openrouter@default/anthropic/claude-3.5-sonnet""#
+        );
+
+        let plan_route = ModelRouteRef::parse("volcengine@plan/glm-5.2").unwrap();
+        assert_eq!(plan_route.as_compact_display(), "volcengine@plan/glm-5.2");
+
+        let token_plan_route = ModelRouteRef::parse("dashscope@token-plan/qwen3.7-max").unwrap();
+        assert_eq!(
+            token_plan_route.as_compact_display(),
+            "dashscope@token-plan/qwen3.7-max"
         );
     }
 

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -17,6 +17,7 @@ use super::{
     ProviderGenerateImageRequest, ProviderGenerateImageResponse, ProviderNativeWebSearchRequest,
     ProviderTurnRequest, ProviderTurnResponse,
 };
+use crate::config::ModelRouteRef;
 use crate::prompt::PromptStability;
 
 #[derive(Clone)]
@@ -224,6 +225,28 @@ mod tests {
             advertised_tool_type: "web_search_20250305".into(),
             backend_kind: backend_kind.into(),
         }
+    }
+
+    #[test]
+    fn runtime_model_hint_compacts_only_canonical_default_routes() {
+        assert_eq!(
+            runtime_model_hint(
+                "openai@default/gpt-5.4",
+                "anthropic@default/claude-sonnet-4-6"
+            ),
+            "Runtime: active_model=anthropic/claude-sonnet-4-6 requested_model=openai/gpt-5.4"
+        );
+        assert_eq!(
+            runtime_model_hint(
+                "dashscope@token-plan/qwen3.7-max",
+                "volcengine@plan/glm-5.2"
+            ),
+            "Runtime: active_model=volcengine@plan/glm-5.2 requested_model=dashscope@token-plan/qwen3.7-max"
+        );
+        assert_eq!(
+            runtime_model_hint("openai/gpt-5.4", "openai/gpt-5.4"),
+            "Runtime: active_model=openai/gpt-5.4"
+        );
     }
 
     #[test]
@@ -735,9 +758,19 @@ fn request_for_model_attempt(
 }
 
 fn runtime_model_hint(requested_model_ref: &str, active_model_ref: &str) -> String {
+    let requested_model_display = compact_model_route_display(requested_model_ref);
+    let active_model_display = compact_model_route_display(active_model_ref);
     if requested_model_ref == active_model_ref || requested_model_ref.is_empty() {
-        format!("Runtime: active_model={active_model_ref}")
+        format!("Runtime: active_model={active_model_display}")
     } else {
-        format!("Runtime: active_model={active_model_ref} requested_model={requested_model_ref}")
+        format!(
+            "Runtime: active_model={active_model_display} requested_model={requested_model_display}"
+        )
     }
+}
+
+fn compact_model_route_display(model_ref: &str) -> String {
+    ModelRouteRef::parse(model_ref)
+        .map(|model_ref| model_ref.as_compact_display())
+        .unwrap_or_else(|_| model_ref.to_string())
 }

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -169,10 +169,13 @@ impl RunOnceResponse {
         }
 
         if let Some(active_model) = self.active_model.as_ref() {
-            let mut line = format!("Model: {}", active_model.as_string());
+            let mut line = format!("Model: {}", active_model.as_compact_display());
             if let Some(requested_model) = self.requested_model.as_ref() {
                 if requested_model != active_model {
-                    line.push_str(&format!(" (requested {})", requested_model.as_string()));
+                    line.push_str(&format!(
+                        " (requested {})",
+                        requested_model.as_compact_display()
+                    ));
                 }
             }
             sections.push(line);
@@ -1367,6 +1370,49 @@ mod tests {
             "default".into(),
             ContextConfig::default(),
         )
+    }
+
+    #[test]
+    fn render_text_uses_compact_model_labels_without_changing_response_identity() {
+        let requested_model = ModelRouteRef::parse("openai@default/gpt-5.4").unwrap();
+        let active_model = ModelRouteRef::parse("volcengine@plan/glm-5.2").unwrap();
+        let response = RunOnceResponse {
+            agent_id: "default".into(),
+            final_status: RunFinalStatus::Completed,
+            waiting_reason: None,
+            final_text: String::new(),
+            raw_final_text: None,
+            sleep_reason: None,
+            failure_artifact: None,
+            tasks: Vec::new(),
+            message_count: 0,
+            changed_files: Vec::new(),
+            token_usage: TokenUsage::new(0, 0),
+            input_tokens: 0,
+            output_tokens: 0,
+            provider_cache_usage: None,
+            requested_model: Some(requested_model.clone()),
+            active_model: Some(active_model.clone()),
+            fallback_active: true,
+            model_rounds: 0,
+            tool_calls: 0,
+            shell_commands: 0,
+            exec_command_items: 0,
+            batched_exec_command_items: 0,
+        };
+
+        assert_eq!(
+            response.render_text(),
+            "Model: volcengine@plan/glm-5.2 (requested openai/gpt-5.4)"
+        );
+        assert_eq!(
+            response.requested_model.unwrap().as_string(),
+            "openai@default/gpt-5.4"
+        );
+        assert_eq!(
+            response.active_model.unwrap().as_string(),
+            "volcengine@plan/glm-5.2"
+        );
     }
 
     #[tokio::test]

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -79,7 +79,7 @@ pub(super) fn clamp_model_picker_selection(
 }
 
 fn inherit_default_row(agent: &AgentSummary) -> ModelPickerRow {
-    let default_model = agent.model.runtime_default_model.as_string();
+    let default_model = agent.model.runtime_default_model.as_compact_display();
     let current = agent.model.override_model.is_none();
     let title = if current {
         format!("inherit runtime default: {default_model} (current)")

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -937,7 +937,7 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
         format!("Status: {:?}", agent.agent.status),
         format!(
             "Model: {} ({:?})",
-            agent.model.effective_model.as_string(),
+            agent.model.effective_model.as_compact_display(),
             agent.model.source
         ),
         format!("Pending queue: {}", agent.agent.pending),
@@ -948,7 +948,7 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
         ),
     ];
     if let Some(model_override) = agent.model.override_model.as_ref() {
-        lines.push(format!("Override: {}", model_override.as_string()));
+        lines.push(format!("Override: {}", model_override.as_compact_display()));
         if let Some(effort) = agent.model.override_reasoning_effort.as_deref() {
             lines.push(format!("Override effort: {}", effort));
         }
@@ -958,7 +958,7 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
     }
     lines.push(format!(
         "Runtime default: {}",
-        agent.model.runtime_default_model.as_string()
+        agent.model.runtime_default_model.as_compact_display()
     ));
     if !agent.model.effective_fallback_models.is_empty() {
         lines.push(format!(
@@ -967,7 +967,7 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
                 .model
                 .effective_fallback_models
                 .iter()
-                .map(|model| model.as_string())
+                .map(|model| model.as_compact_display())
                 .collect::<Vec<_>>()
                 .join(", ")
         ));
@@ -1265,7 +1265,7 @@ mod tests {
         let inherited = sample_agent_summary();
         assert_eq!(
             render_model_status(&inherited),
-            "model: anthropic@default/claude-sonnet-4-6"
+            "model: anthropic/claude-sonnet-4-6"
         );
 
         let mut overridden = sample_agent_summary();
@@ -1274,7 +1274,7 @@ mod tests {
         overridden.model.active_model = Some(route_ref("openai/gpt-5.4"));
         assert_eq!(
             render_model_status(&overridden),
-            "model: openai@default/gpt-5.4 (agent override)"
+            "model: openai/gpt-5.4 (agent override)"
         );
 
         let mut fallback = overridden;
@@ -1283,7 +1283,7 @@ mod tests {
         fallback.model.fallback_active = true;
         assert_eq!(
             render_model_status(&fallback),
-            "model: anthropic@default/claude-sonnet-4-6 (fallback from openai@default/gpt-5.4)"
+            "model: anthropic/claude-sonnet-4-6 (fallback from openai/gpt-5.4)"
         );
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -741,7 +741,7 @@ fn statusbar_view_model_shows_workspace_label_execution_root_and_model() {
         .contains("opensource/src/github.com/holon-run/holon)"));
     assert!(view_model
         .context_line
-        .contains("anthropic@default/claude-sonnet-4-6"));
+        .contains("anthropic/claude-sonnet-4-6"));
     assert!(!view_model.context_line.contains("model:"));
 }
 
@@ -816,7 +816,7 @@ fn statusbar_view_model_converges_from_provider_round_model_event() {
 
     assert!(view_model
         .context_line
-        .contains("anthropic@default/claude-sonnet-4-6 (fallback from openai@default/gpt-5.4)"));
+        .contains("anthropic/claude-sonnet-4-6 (fallback from openai/gpt-5.4)"));
 }
 
 #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -141,17 +141,21 @@ pub(super) fn render_model_detail(agent: &AgentSummary) -> String {
             .unwrap_or(&agent.model.effective_model);
         return format!(
             "{} (fallback from {})",
-            model.as_string(),
-            requested.as_string()
+            model.as_compact_display(),
+            requested.as_compact_display()
         );
     }
     if agent.model.override_model.is_some() {
         if let Some(effort) = agent.model.override_reasoning_effort.as_deref() {
-            return format!("{} (agent override, effort={})", model.as_string(), effort);
+            return format!(
+                "{} (agent override, effort={})",
+                model.as_compact_display(),
+                effort
+            );
         }
-        return format!("{} (agent override)", model.as_string());
+        return format!("{} (agent override)", model.as_compact_display());
     }
-    model.as_string()
+    model.as_compact_display()
 }
 
 fn statusbar_detail(app: &TuiApp, slash_visible: bool) -> String {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -12,6 +12,7 @@ import { useVirtualizer, type VirtualItem, type Virtualizer } from "@tanstack/re
 
 import { Button } from "../../components/ui/Button";
 import { EmptyState } from "../../components/ui/EmptyState";
+import { compactModelRouteDisplay } from "../../lib/model-route-ref";
 import { deriveAgentDisplayStatus } from "../../runtime/agent-status";
 import { debugAgentSessionEvents, filterTimelineByDisplayLevel } from "../../runtime/session-reducer";
 import { TimelineTurnGroup, WorkingIndicator } from "./AgentTimeline";
@@ -971,7 +972,7 @@ function shortModelLabel(model: string): string {
 }
 
 function modelButtonTitle(model: string, reasoningEffort: string | undefined, isModelOverride: boolean): string {
-  const details = [model];
+  const details = [compactModelRouteDisplay(model)];
   if (reasoningEffort) details.push(`reasoning effort: ${reasoningEffort}`);
   if (isModelOverride) details.push("model override");
   return details.join(" · ");

--- a/web-gui/app/src/features/dashboard/DashboardPage.tsx
+++ b/web-gui/app/src/features/dashboard/DashboardPage.tsx
@@ -6,6 +6,7 @@ import { Card } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { AgentStateBadge, StatusBadge } from "../../components/ui/StatusChip";
+import { compactModelRouteDisplay } from "../../lib/model-route-ref";
 import type { AgentSummary, DashboardMetric, RuntimeConnection } from "../../runtime/types";
 
 interface DashboardPageProps {
@@ -123,9 +124,9 @@ export function DashboardPage({ agents, metrics, connection, loading, onRefresh,
                       <dt>{t("dashboard.posture")}</dt>
                       <dd>{agent.posture}</dd>
                     </div>
-                    <div title={agent.model}>
+                    <div title={compactModelRouteDisplay(agent.model)}>
                       <dt>{t("dashboard.model")}</dt>
-                      <dd>{agent.model}</dd>
+                      <dd>{compactModelRouteDisplay(agent.model)}</dd>
                     </div>
                   </dl>
                   <footer>

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusBadge } from "../../components/ui/StatusChip";
+import { compactModelRouteDisplay } from "../../lib/model-route-ref";
 import { ToolExecutionContent } from "./ToolExecutionRenderers";
 import { TaskDetailContent, normalizeTaskDetailContent } from "./TaskDetailRenderers";
 import type { AgentSummary, SkillCatalogEntry, SkillCatalogState, TaskDetailState, TaskSummary, ToolExecutionDetailState, WorkItemDetailState, WorkItemSummary } from "../../runtime/types";
@@ -128,7 +129,7 @@ export function AgentOverviewPanel({
         <dl className="inspector-facts">
           <div>
             <dt>{t("agent.model")}</dt>
-            <dd>{agent.model}</dd>
+            <dd>{compactModelRouteDisplay(agent.model)}</dd>
           </div>
           <div>
             <dt>{t("agent.currentWork")}</dt>

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import type { MouseEvent, ReactNode } from "react";
 import { formatToolExecutionDetail } from "../inspector/ActivityInspectorPanel";
+import { compactModelRouteDisplay } from "../../lib/model-route-ref";
 import { useRuntimeStore } from "../../runtime/runtime-store";
 import { parseWorkspaceImageRef, WorkspaceImage } from "../../components/MarkdownContent";
 import type { RuntimeToolExecutionRecord } from "../../runtime/types";
@@ -868,7 +869,7 @@ function ListProviderModelsRenderer({ record }: { record: RuntimeToolExecutionRe
               {availability ? <span className={`tool-detail-badge tool-detail-badge--${availability === "available" ? "ok" : "warn"}`}>{availability}</span> : null}
               {selectable != null ? <span className={`tool-detail-badge tool-detail-badge--${selectable ? "ok" : "mute"}`}>{selectable ? "selectable" : "locked"}</span> : null}
             </div>
-            {modelRef ? <p className="tool-detail-result-snippet">{modelRef}</p> : null}
+            {modelRef ? <p className="tool-detail-result-snippet">{compactModelRouteDisplay(modelRef)}</p> : null}
             {unavailableReason ? <p className="tool-detail-result-snippet" style={{ color: "var(--danger)" }}>{unavailableReason}</p> : null}
           </section>
         );
@@ -906,8 +907,8 @@ function AgentGetRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
       {visibility ? <SimpleField label={t("inspector.mode")} value={visibility} /> : null}
       {ownership ? <SimpleField label="Ownership" value={ownership} /> : null}
       {profilePreset ? <SimpleField label="Preset" value={profilePreset} /> : null}
-      {effectiveModel ? <SimpleField label={t("inspector.model", { defaultValue: "Model" })} value={effectiveModel} /> : null}
-      {activeModel && activeModel !== effectiveModel ? <SimpleField label="Active" value={activeModel} /> : null}
+      {effectiveModel ? <SimpleField label={t("inspector.model", { defaultValue: "Model" })} value={compactModelRouteDisplay(effectiveModel)} /> : null}
+      {activeModel && activeModel !== effectiveModel ? <SimpleField label="Active" value={compactModelRouteDisplay(activeModel)} /> : null}
       {activeTaskCount != null ? <SimpleField label={t("inspector.tasks")} value={String(activeTaskCount)} /> : null}
       {children.length ? (
         <section className="tool-detail-field">

--- a/web-gui/app/src/lib/model-route-ref.test.ts
+++ b/web-gui/app/src/lib/model-route-ref.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { compactModelRouteDisplay } from "./model-route-ref";
+
+describe("compactModelRouteDisplay", () => {
+  it("omits only an exact default endpoint", () => {
+    expect(compactModelRouteDisplay("openai@default/gpt-5.6")).toBe("openai/gpt-5.6");
+    expect(compactModelRouteDisplay("volcengine@plan/glm-5.2")).toBe("volcengine@plan/glm-5.2");
+    expect(compactModelRouteDisplay("dashscope@token-plan/qwen3.7-max")).toBe("dashscope@token-plan/qwen3.7-max");
+  });
+
+  it("preserves model remainders containing slashes", () => {
+    expect(compactModelRouteDisplay("openrouter@default/anthropic/claude-3.5-sonnet")).toBe(
+      "openrouter/anthropic/claude-3.5-sonnet",
+    );
+  });
+
+  it("leaves legacy and malformed values unchanged", () => {
+    expect(compactModelRouteDisplay("openai/gpt-5.6")).toBe("openai/gpt-5.6");
+    expect(compactModelRouteDisplay("runtime default")).toBe("runtime default");
+    expect(compactModelRouteDisplay("openai@default/")).toBe("openai@default/");
+  });
+});

--- a/web-gui/app/src/lib/model-route-ref.ts
+++ b/web-gui/app/src/lib/model-route-ref.ts
@@ -1,0 +1,11 @@
+export function compactModelRouteDisplay(modelRouteRef: string): string {
+  const slashIndex = modelRouteRef.indexOf("/");
+  if (slashIndex < 0) return modelRouteRef;
+
+  const route = modelRouteRef.slice(0, slashIndex);
+  const model = modelRouteRef.slice(slashIndex + 1);
+  const defaultSuffix = "@default";
+  if (!route.endsWith(defaultSuffix) || model.length === 0) return modelRouteRef;
+
+  return `${route.slice(0, -defaultSuffix.length)}/${model}`;
+}


### PR DESCRIPTION
## Summary
- add an explicit compact presentation for `ModelRouteRef` that renders `provider@default/model` as `provider/model`
- use compact labels in CLI/TUI/runtime hints and Web GUI rendering surfaces while preserving canonical route values for parsing, serialization, persistence, comparison, DTOs, and API submissions
- document the presentation-only boundary and cover default/non-default/malformed values with Rust and Web GUI tests

## Verification
- `cargo test compact`
- `cargo test model_status_distinguishes_inherited_override_and_fallback`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm test` (`web-gui/app`: 225 passed)
- `npm run typecheck` (`web-gui/app`)
