### PR TITLE
feat: gate canonical scheduler authority

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -10,6 +10,7 @@ import os
 import re
 import secrets
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -126,6 +127,7 @@ class CaseHarness:
         model: str,
         credential_envs: list[str],
         env_file: Path | None,
+        runtime_env: dict[str, str],
         evidence_root: Path,
         timeout_seconds: int,
         keep: bool,
@@ -136,6 +138,7 @@ class CaseHarness:
         self.model = model
         self.credential_envs = credential_envs
         self.env_file = env_file
+        self.runtime_env = runtime_env
         self.evidence = evidence_root / case_id
         self.timeout_seconds = timeout_seconds
         self.keep = keep
@@ -199,6 +202,8 @@ class CaseHarness:
         ]
         for name in self.credential_envs:
             args.extend(["--env", name])
+        for name, value in sorted(self.runtime_env.items()):
+            args.extend(["--env", f"{name}={value}"])
         if self.env_file is not None:
             args.extend(["--env-file", str(self.env_file)])
         args.append(self.image)
@@ -415,6 +420,31 @@ class CaseHarness:
         write_json(self.evidence / f"{label}-work-items.json", value)
         return value
 
+    def wait_work_item(
+        self,
+        *,
+        objective_marker: str,
+        expected_state: str,
+        label: str,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_seconds
+        matches: list[dict[str, Any]] = []
+        while time.monotonic() < deadline:
+            items = self.request("GET", self.agent_path("work-items?limit=50"))
+            matches = [
+                item for item in items if objective_marker in item.get("objective", "")
+            ]
+            if len(matches) == 1 and matches[0].get("state") == expected_state:
+                write_json(self.evidence / f"{label}-work-items.json", items)
+                self.wait_agent_idle()
+                return matches[0]
+            time.sleep(1)
+        write_json(self.evidence / f"{label}-timeout-work-items.json", matches)
+        self.capture_context(f"{label}-timeout")
+        raise TimeoutError(
+            f"timed out waiting for WorkItem {objective_marker} to reach {expected_state}"
+        )
+
     def brief(self, brief_id: str, label: str) -> dict[str, Any]:
         encoded_id = urllib.parse.quote(brief_id, safe="")
         value = self.request("GET", self.agent_path(f"briefs/{encoded_id}"))
@@ -551,10 +581,105 @@ class CaseHarness:
         write_json(self.evidence / f"{label}.json", value)
         return value
 
+    def runtime_db_snapshot(self, label: str) -> dict[str, Any]:
+        snapshot_dir = self.evidence / f"{label}-runtime-state"
+        if snapshot_dir.exists():
+            shutil.rmtree(snapshot_dir)
+        snapshot_dir.mkdir(parents=True)
+        self.docker(
+            "cp",
+            f"{self.container}:/var/lib/holon/state/.",
+            str(snapshot_dir),
+        )
+        database = snapshot_dir / "runtime.sqlite"
+        require(database.is_file(), "runtime database snapshot is missing")
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        try:
+            snapshot = {
+                "work_items": sqlite_rows(
+                    connection,
+                    "SELECT work_item_id, agent_id, state, objective, revision, "
+                    "current_focus, completed_at, payload_json "
+                    "FROM work_items ORDER BY created_at",
+                ),
+                "messages": sqlite_rows(
+                    connection,
+                    "SELECT message_id, agent_id, turn_id, work_item_id, kind, "
+                    "created_at, payload_json FROM messages ORDER BY created_at",
+                ),
+                "queue_entries": sqlite_rows(
+                    connection,
+                    "SELECT message_id, agent_id, priority, status, created_at, "
+                    "updated_at, payload_json FROM queue_entries "
+                    "ORDER BY created_at, updated_at",
+                ),
+                "scheduler_protocol_config": sqlite_rows(
+                    connection,
+                    "SELECT protocol_mode, config_revision, latest_preflight_revision "
+                    "FROM scheduler_protocol_config",
+                ),
+                "scheduler_work_demands": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, work_item_id, scheduling_generation, status, "
+                    "status_reference_id, payload_json FROM scheduler_work_demands",
+                ),
+                "scheduler_agent_slots": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, slot_kind, activation_id, work_item_id, "
+                    "admitted_generation FROM scheduler_agent_slots",
+                ),
+                "scheduler_activations": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, activation_id, authority_id, work_item_id, "
+                    "admitted_generation, admission_kind, lifecycle_state, "
+                    "idempotency_key, payload_json FROM scheduler_activations",
+                ),
+                "scheduler_activation_settlements": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, settlement_id, activation_id, payload_json "
+                    "FROM scheduler_activation_settlements",
+                ),
+                "scheduler_protocol_command_results": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, command_kind, command_identity, decision, "
+                    "conflict_kind, conflict_code, result_references_json, "
+                    "pre_state_fence_json, post_state_fence_json "
+                    "FROM scheduler_protocol_command_results ORDER BY created_at",
+                ),
+                "scheduler_shadow_comparisons": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, scenario_class, boundary, comparison_identity, "
+                    "comparison_outcome, authority_mode, input_identity "
+                    "FROM scheduler_shadow_comparisons ORDER BY created_at",
+                ),
+            }
+        finally:
+            connection.close()
+        write_json(self.evidence / f"{label}-runtime-db.json", snapshot)
+        return snapshot
+
 
 def result_value(detail: dict[str, Any]) -> dict[str, Any]:
     output = detail.get("output", {})
     return output.get("envelope", {}).get("result", output.get("result", output))
+
+
+def sqlite_rows(connection: sqlite3.Connection, query: str) -> list[dict[str, Any]]:
+    return [dict(row) for row in connection.execute(query).fetchall()]
+
+
+def require_processed_queue_entries(
+    queue_entries: list[dict[str, Any]], message_ids: set[str]
+) -> None:
+    matching = [
+        row for row in queue_entries if row.get("message_id") in message_ids
+    ]
+    require(
+        len(matching) == len(message_ids)
+        and all(row.get("status") == "processed" for row in matching),
+        f"work_queue messages did not reach processed current state: {matching}",
+    )
 
 
 def find_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
@@ -939,11 +1064,175 @@ def run_workitem_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     )
 
 
+def run_scheduler_protocol_case(harness: CaseHarness, case: dict[str, Any]) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    marker = secrets.token_hex(4)
+    objective_marker = f"SCHEDULER-AUTONOMOUS-{marker}"
+    completion_marker = f"SCHEDULER-COMPLETE-{marker}"
+    objective = (
+        f"{objective_marker}. Complete this WorkItem only after the Runtime resumes it "
+        "through an autonomous work_queue SystemTick. On that autonomous turn, inspect "
+        "the exact current item with ListWorkItems using filter current and optionally "
+        "GetWorkItem, update both existing todos to completed, then emit a concise "
+        f"completion result containing {completion_marker} immediately followed by "
+        "CompleteWorkItem for that exact item. Do not wait for more operator input."
+    )
+
+    phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "scheduler-autonomous",
+        phase["prompt"].format(
+            case_id=case["id"],
+            objective=json.dumps(objective, ensure_ascii=False),
+            objective_marker=objective_marker,
+            completion_marker=completion_marker,
+        ),
+    )
+    item = harness.wait_work_item(
+        objective_marker=objective_marker,
+        expected_state="completed",
+        label="scheduler-autonomous-completed",
+    )
+    required, forbidden = phase_tools(phase)
+    harness.assert_tools("scheduler-autonomous", baseline, required, forbidden)
+
+    items = harness.work_items("scheduler-autonomous-assert")
+    matches = [item for item in items if objective_marker in item["objective"]]
+    require(len(matches) == 1, f"expected one scheduler WorkItem: {matches}")
+    require(
+        matches[0]["id"] == item["id"],
+        f"scheduler WorkItem identity changed during completion: {matches}",
+    )
+    item = matches[0]
+    work_item_id = item["id"]
+    require(item["state"] == "completed", f"scheduler WorkItem not completed: {item}")
+    require(
+        len(item.get("todo_list", [])) == 2
+        and all(todo["state"] == "completed" for todo in item["todo_list"]),
+        f"scheduler WorkItem todos were not completed: {item}",
+    )
+    result_brief_id = item.get("result_brief_id")
+    require(
+        isinstance(result_brief_id, str) and result_brief_id,
+        f"scheduler WorkItem omitted result brief: {item}",
+    )
+    result_brief = harness.brief(result_brief_id, "scheduler-result")
+    require(
+        result_brief.get("work_item_id") == work_item_id
+        and completion_marker in (result_brief.get("text") or ""),
+        f"scheduler completion brief mismatch: {result_brief}",
+    )
+
+    harness.restart()
+    restarted_items = harness.work_items("scheduler-after-restart")
+    restarted = next(item for item in restarted_items if item["id"] == work_item_id)
+    require(
+        restarted["state"] == "completed"
+        and restarted.get("result_brief_id") == result_brief_id,
+        f"scheduler WorkItem identity did not survive restart: {restarted}",
+    )
+
+    snapshot = harness.runtime_db_snapshot("scheduler")
+    message_rows = [
+        row
+        for row in snapshot["messages"]
+        if row.get("work_item_id") == work_item_id
+        and "work_queue" in row.get("payload_json", "")
+        and (
+            "SystemTick" in row.get("payload_json", "")
+            or "system_tick" in row.get("payload_json", "")
+        )
+    ]
+    require(message_rows, "autonomous work_queue SystemTick evidence is missing")
+    message_ids = {row["message_id"] for row in message_rows}
+    # queue_entries is a message_id-keyed current-state view, so queued and
+    # dequeued are intentionally overwritten by the terminal processed row.
+    require_processed_queue_entries(snapshot["queue_entries"], message_ids)
+
+    enabled = case.get("scheduler_protocol_commands_enabled")
+    require(
+        enabled in {True, False},
+        "scheduler case must declare scheduler_protocol_commands_enabled",
+    )
+    demands = [
+        row
+        for row in snapshot["scheduler_work_demands"]
+        if row["work_item_id"] == work_item_id
+    ]
+    activations = [
+        row
+        for row in snapshot["scheduler_activations"]
+        if row["work_item_id"] == work_item_id
+    ]
+    activation_ids = {row["activation_id"] for row in activations}
+    settlements = [
+        row
+        for row in snapshot["scheduler_activation_settlements"]
+        if row["activation_id"] in activation_ids
+    ]
+    command_rows = [
+        row
+        for row in snapshot["scheduler_protocol_command_results"]
+        if row["command_identity"] == work_item_id
+        or any(
+            message_id in row["command_identity"] for message_id in message_ids
+        )
+    ]
+
+    if not enabled:
+        require(not demands, f"legacy mode wrote canonical demand facts: {demands}")
+        require(not activations, f"legacy mode wrote canonical activations: {activations}")
+        require(not settlements, f"legacy mode wrote canonical settlements: {settlements}")
+        require(not command_rows, f"legacy mode wrote protocol commands: {command_rows}")
+        return
+
+    require(
+        len(demands) == 1 and demands[0]["status"] == "terminal",
+        f"canonical demand did not settle terminal: {demands}",
+    )
+    require(
+        len(activations) == 1 and activations[0]["lifecycle_state"] == "settled",
+        f"canonical activation did not settle exactly once: {activations}",
+    )
+    require(
+        len(settlements) == 1,
+        f"canonical settlement is missing or duplicated: {settlements}",
+    )
+    slots = [
+        row
+        for row in snapshot["scheduler_agent_slots"]
+        if row["agent_id"] == harness.agent_id
+    ]
+    require(
+        len(slots) == 1
+        and slots[0]["slot_kind"] == "idle"
+        and slots[0]["activation_id"] is None,
+        f"canonical activation slot was not released: {slots}",
+    )
+    command_kinds = {row["command_kind"] for row in command_rows}
+    require(
+        {
+            "register_work_demand",
+            "issue_activation_authority",
+            "admit_activation",
+            "settle_activation",
+        }.issubset(command_kinds),
+        f"canonical command chain is incomplete: {command_rows}",
+    )
+    require(
+        all(row["conflict_kind"] is None for row in command_rows),
+        f"canonical command chain contains conflicts: {command_rows}",
+    )
+
+
 CASE_RUNNERS = {
     "runtime-auth-model-delivery": run_runtime_case,
     "memory-agent-home-persistence": run_memory_case,
     "workspace-restart-lifecycle": run_workspace_case,
     "workitem-wait-restart-complete": run_workitem_case,
+    "scheduler-autonomous-legacy": run_scheduler_protocol_case,
+    "scheduler-autonomous-authoritative": run_scheduler_protocol_case,
 }
 
 
@@ -971,6 +1260,22 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             and case["timeout_seconds"] > 0,
             f"{case_id} timeout_seconds must be positive",
         )
+        runtime_env = case.get("runtime_env", {})
+        require(isinstance(runtime_env, dict), f"{case_id} runtime_env must be an object")
+        require(
+            all(
+                isinstance(name, str)
+                and name.startswith("HOLON_")
+                and isinstance(value, str)
+                for name, value in runtime_env.items()
+            ),
+            f"{case_id} runtime_env must contain HOLON_ string entries",
+        )
+        if "scheduler_protocol_commands_enabled" in case:
+            require(
+                isinstance(case["scheduler_protocol_commands_enabled"], bool),
+                f"{case_id} scheduler_protocol_commands_enabled must be boolean",
+            )
         phases = case.get("phases")
         require(isinstance(phases, list) and phases, f"{case_id} needs phases")
         phase_ids: set[str] = set()
@@ -1278,6 +1583,7 @@ def main(argv: list[str] | None = None) -> int:
             model=model,
             credential_envs=credential_envs,
             env_file=env_file,
+            runtime_env=dict(case.get("runtime_env", {})),
             evidence_root=evidence_root,
             timeout_seconds=(
                 int(timeout_override)

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -326,6 +326,65 @@ pub enum ScenarioMode {
     Authoritative,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerScenarioClass {
+    ReducerOnlyCandidates,
+    ExactTaskRejoin,
+    ExactWaitResume,
+    ExplicitlyBoundOperatorInput,
+    WorkItemAutonomousContinuation,
+    OrdinarySemanticOperatorBinding,
+    OperatorInterjection,
+    Settlement,
+    Delivery,
+}
+
+impl SchedulerScenarioClass {
+    pub const PRODUCTION_AUTHORITY: [Self; 7] = [
+        Self::ReducerOnlyCandidates,
+        Self::WorkItemAutonomousContinuation,
+        Self::ExactTaskRejoin,
+        Self::ExactWaitResume,
+        Self::OperatorInterjection,
+        Self::Settlement,
+        Self::Delivery,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReducerOnlyCandidates => "reducer_only_candidates",
+            Self::ExactTaskRejoin => "exact_task_rejoin",
+            Self::ExactWaitResume => "exact_wait_resume",
+            Self::ExplicitlyBoundOperatorInput => "explicitly_bound_operator_input",
+            Self::WorkItemAutonomousContinuation => "work_item_autonomous_continuation",
+            Self::OrdinarySemanticOperatorBinding => "ordinary_semantic_operator_binding",
+            Self::OperatorInterjection => "operator_interjection",
+            Self::Settlement => "settlement",
+            Self::Delivery => "delivery",
+        }
+    }
+}
+
+impl std::str::FromStr for SchedulerScenarioClass {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "reducer_only_candidates" => Ok(Self::ReducerOnlyCandidates),
+            "exact_task_rejoin" => Ok(Self::ExactTaskRejoin),
+            "exact_wait_resume" => Ok(Self::ExactWaitResume),
+            "explicitly_bound_operator_input" => Ok(Self::ExplicitlyBoundOperatorInput),
+            "work_item_autonomous_continuation" => Ok(Self::WorkItemAutonomousContinuation),
+            "ordinary_semantic_operator_binding" => Ok(Self::OrdinarySemanticOperatorBinding),
+            "operator_interjection" => Ok(Self::OperatorInterjection),
+            "settlement" => Ok(Self::Settlement),
+            "delivery" => Ok(Self::Delivery),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RolloutManifest {
     pub revision: u64,
@@ -684,6 +743,12 @@ pub struct SettleActivationCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterWorkDemandCommand {
+    pub work_item_id: String,
+    pub demand: WorkDemand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LegacyCompletionReport {
     pub turn_terminal: String,
     pub operator_delivery: String,
@@ -728,6 +793,7 @@ pub struct TriggerWaitCommand {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ProtocolCommand {
+    RegisterWorkDemand(RegisterWorkDemandCommand),
     IssueActivationAuthority(IssueActivationAuthorityCommand),
     AdmitActivation(AdmitActivationCommand),
     SettleActivation(SettleActivationCommand),
@@ -1023,6 +1089,7 @@ pub struct Outcome {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Decision {
+    WorkDemandRegistered,
     AuthorityIssued,
     Admitted,
     Settled,
@@ -1444,6 +1511,9 @@ pub fn reduce_command(snapshot: &Snapshot, command: &ProtocolCommand) -> Protoco
     if let Some(outcome) = replay_or_conflict(snapshot, command) {
         return outcome;
     }
+    if let ProtocolCommand::RegisterWorkDemand(command) = command {
+        return register_work_demand(snapshot, command);
+    }
     if let ProtocolCommand::IssueActivationAuthority(command) = command {
         return issue_activation_authority(snapshot, command);
     }
@@ -1522,6 +1592,21 @@ fn replay_or_conflict(
     command: &ProtocolCommand,
 ) -> Option<ProtocolCommandOutcome> {
     match command {
+        ProtocolCommand::RegisterWorkDemand(command) => {
+            if let Some(existing) = snapshot.work.get(&command.work_item_id) {
+                return Some(if existing == &command.demand {
+                    duplicate_command(snapshot, "work_demand_already_registered")
+                } else {
+                    rejected_command(
+                        snapshot,
+                        command_conflict(
+                            ProtocolConflictKind::IdentityConflict,
+                            "work_demand_registration_conflict",
+                        ),
+                    )
+                });
+            }
+        }
         ProtocolCommand::IssueActivationAuthority(command) => {
             if let Some(existing) = snapshot.activation_authorities.get(&command.authority_id) {
                 return Some(if authority_matches_issue(existing, command) {
@@ -1648,6 +1733,9 @@ fn lower_command(
     command: &ProtocolCommand,
 ) -> Result<Event, ProtocolConflict> {
     match command {
+        ProtocolCommand::RegisterWorkDemand(_) => {
+            unreachable!("work demand registration is reduced directly")
+        }
         ProtocolCommand::IssueActivationAuthority(_) => {
             unreachable!("authority issuance is reduced directly")
         }
@@ -1716,6 +1804,51 @@ fn lower_command(
                 trigger_generation: command.trigger_generation,
             })
         }
+    }
+}
+
+fn register_work_demand(
+    snapshot: &Snapshot,
+    command: &RegisterWorkDemandCommand,
+) -> ProtocolCommandOutcome {
+    if command.work_item_id.is_empty()
+        || command.demand.metadata_revision == 0
+        || command.demand.scheduling_generation == 0
+        || command.demand.locality.is_empty()
+        || command.demand.cost_class.is_empty()
+    {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::InvalidCommand,
+                "work_demand_registration_fields_required",
+            ),
+        );
+    }
+    if command.demand.status != WorkStatus::Runnable {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::UnsupportedCommand,
+                "initial_work_demand_must_be_runnable",
+            ),
+        );
+    }
+
+    let mut next = snapshot.clone();
+    next.work
+        .insert(command.work_item_id.clone(), command.demand.clone());
+    ProtocolCommandOutcome {
+        outcome: Outcome {
+            decision: Decision::WorkDemandRegistered,
+            transitions: vec![format!(
+                "work:{}:registered:generation:{}",
+                command.work_item_id, command.demand.scheduling_generation
+            )],
+            diagnostics: Vec::new(),
+            snapshot: next,
+        },
+        conflict: None,
     }
 }
 
@@ -3245,13 +3378,14 @@ const MAXIMUM_P99_LATENCY_REGRESSION_BPS: u32 = 1_000;
 const MAXIMUM_OBSERVATIONAL_DIVERGENCE_BPS: u32 = 100;
 
 fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
+    let scenario_class = scenario_class.parse::<SchedulerScenarioClass>().ok()?;
     let gate = match scenario_class {
-        "reducer_only_candidates" => RolloutClassGate {
+        SchedulerScenarioClass::ReducerOnlyCandidates => RolloutClassGate {
             minimum_shadow_samples: 10_000,
             minimum_shadow_duration_secs: 72 * 60 * 60,
             required_evidence: &["deterministic_replay", "duplicate_command_idempotency"],
         },
-        "exact_task_rejoin" => RolloutClassGate {
+        SchedulerScenarioClass::ExactTaskRejoin => RolloutClassGate {
             minimum_shadow_samples: 1_000,
             minimum_shadow_duration_secs: 7 * 24 * 60 * 60,
             required_evidence: &[
@@ -3260,7 +3394,7 @@ fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
                 "restart_before_rejoin_settlement",
             ],
         },
-        "exact_wait_resume" => RolloutClassGate {
+        SchedulerScenarioClass::ExactWaitResume => RolloutClassGate {
             minimum_shadow_samples: 1_000,
             minimum_shadow_duration_secs: 7 * 24 * 60 * 60,
             required_evidence: &[
@@ -3270,7 +3404,8 @@ fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
                 "rearm",
             ],
         },
-        "explicitly_bound_operator_input" => RolloutClassGate {
+        SchedulerScenarioClass::ExplicitlyBoundOperatorInput
+        | SchedulerScenarioClass::OperatorInterjection => RolloutClassGate {
             minimum_shadow_samples: 1_000,
             minimum_shadow_duration_secs: 7 * 24 * 60 * 60,
             required_evidence: &[
@@ -3279,7 +3414,25 @@ fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
                 "wrong_agent_target",
             ],
         },
-        "work_item_autonomous_continuation" => RolloutClassGate {
+        SchedulerScenarioClass::Settlement => RolloutClassGate {
+            minimum_shadow_samples: 1_000,
+            minimum_shadow_duration_secs: 7 * 24 * 60 * 60,
+            required_evidence: &[
+                "duplicate_settlement",
+                "missing_settlement_recovery",
+                "restart_before_settlement_commit",
+            ],
+        },
+        SchedulerScenarioClass::Delivery => RolloutClassGate {
+            minimum_shadow_samples: 1_000,
+            minimum_shadow_duration_secs: 7 * 24 * 60 * 60,
+            required_evidence: &[
+                "duplicate_delivery",
+                "delivery_retry",
+                "restart_before_delivery_commit",
+            ],
+        },
+        SchedulerScenarioClass::WorkItemAutonomousContinuation => RolloutClassGate {
             minimum_shadow_samples: 2_000,
             minimum_shadow_duration_secs: 14 * 24 * 60 * 60,
             required_evidence: &[
@@ -3289,7 +3442,7 @@ fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
                 "work_item_rollback",
             ],
         },
-        "ordinary_semantic_operator_binding" => RolloutClassGate {
+        SchedulerScenarioClass::OrdinarySemanticOperatorBinding => RolloutClassGate {
             minimum_shadow_samples: 5_000,
             minimum_shadow_duration_secs: 14 * 24 * 60 * 60,
             required_evidence: &[
@@ -3299,7 +3452,6 @@ fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
                 "zero_wrong_automatic_bindings",
             ],
         },
-        _ => return None,
     };
     Some(gate)
 }

--- a/src/domain/scheduler_semantic.rs
+++ b/src/domain/scheduler_semantic.rs
@@ -9,14 +9,17 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-use super::scheduler_protocol::{activation_provenance_has_valid_authority, ActivationProvenance};
+use super::scheduler_protocol::{
+    activation_provenance_has_valid_authority, ActivationProvenance, SchedulerScenarioClass,
+};
 use crate::types::{
     AdmissionContext, AuthorityClass, MessageDeliverySurface, MessageEnvelope, MessageOrigin,
 };
 
 pub const MAX_CONFIDENCE_BPS: u16 = 10_000;
 pub const SEMANTIC_CONTRACT_REVISION: u64 = 2;
-pub const SEMANTIC_OPERATOR_BINDING_SCENARIO: &str = "ordinary_semantic_operator_binding";
+pub const SEMANTIC_OPERATOR_BINDING_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::OrdinarySemanticOperatorBinding;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -268,12 +268,37 @@ struct RuntimeInner {
     recovered_timers: Mutex<Option<Vec<TimerRecord>>>,
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
+    scheduler_protocol_production_commands_enabled: AtomicBool,
     #[cfg(test)]
     transition_faults: StdMutex<std::collections::VecDeque<TransitionFaultPoint>>,
     #[cfg(test)]
     omit_next_scheduler_claim_shadow_comparison: AtomicBool,
     #[cfg(test)]
     transition_warnings: StdMutex<Vec<PostCommitWarning>>,
+}
+
+const SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV: &str =
+    "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS";
+
+fn scheduler_protocol_production_commands_enabled_from_env() -> Result<bool> {
+    let Some(value) = std::env::var_os(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV) else {
+        return Ok(false);
+    };
+    match value.to_string_lossy().trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(anyhow!(
+            "{SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV} expects a boolean"
+        )),
+    }
+}
+
+fn canonical_settlement_id(message_id: &str) -> String {
+    format!("settlement:message:{message_id}")
+}
+
+fn canonical_missing_settlement_id(message_id: &str) -> String {
+    format!("missing-settlement:message:{message_id}")
 }
 
 #[derive(Debug, Clone)]
@@ -617,6 +642,19 @@ impl CurrentRunAbortSnapshot {
 impl RuntimeHandle {
     pub(super) fn now(&self) -> chrono::DateTime<chrono::Utc> {
         self.inner.clock.now()
+    }
+
+    fn scheduler_protocol_production_commands_enabled(&self) -> bool {
+        self.inner
+            .scheduler_protocol_production_commands_enabled
+            .load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_scheduler_protocol_production_commands_enabled(&self, enabled: bool) {
+        self.inner
+            .scheduler_protocol_production_commands_enabled
+            .store(enabled, Ordering::SeqCst);
     }
 
     fn take_transition_fault(&self) -> Option<TransitionFaultPoint> {
@@ -1609,6 +1647,9 @@ impl RuntimeHandle {
                             updated_at: Utc::now(),
                         },
                     ),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
                     scheduler_authority_scenarios: Vec::new(),
                     agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                         expected: Some(Box::new(expected_persisted_state)),
@@ -1649,6 +1690,7 @@ impl RuntimeHandle {
         audit_events: Vec<AuditEvent>,
         notify_scheduler: bool,
     ) -> Result<bool> {
+        let scheduler_protocol_commands = self.canonical_queue_settlement_commands(&record).await?;
         let shadow_comparison = {
             let guard = self.inner.agent.lock().await;
             let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
@@ -1678,9 +1720,12 @@ impl RuntimeHandle {
                 agent_id: record.agent_id.clone(),
                 operation: crate::runtime_db::transitions::QueueOperation::Settle,
                 mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record),
+                scheduler_claim_work_item: None,
+                scheduler_protocol_bootstrap: None,
+                scheduler_protocol_commands,
                 scheduler_authority_scenarios: vec![
-                    scheduler::SETTLEMENT_SCENARIO.into(),
-                    scheduler::DELIVERY_SCENARIO.into(),
+                    scheduler::SETTLEMENT_SCENARIO,
+                    scheduler::DELIVERY_SCENARIO,
                 ],
                 agent_state: None,
                 message_evidence: Vec::new(),
@@ -1695,6 +1740,123 @@ impl RuntimeHandle {
             },
         )?;
         Ok(self.apply_transition_commit(commit).await.applied)
+    }
+
+    async fn canonical_queue_settlement_commands(
+        &self,
+        record: &QueueEntryRecord,
+    ) -> Result<Vec<crate::domain::scheduler_protocol::ProtocolCommand>> {
+        if !self.scheduler_protocol_production_commands_enabled() {
+            return Ok(Vec::new());
+        }
+        let Some(message) = self.inner.storage.read_message_by_id(&record.message_id)? else {
+            return Err(anyhow!(
+                "canonical queue settlement requires persisted message evidence"
+            ));
+        };
+        if !matches!(
+            (&message.kind, &message.origin),
+            (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                if subsystem == "work_queue"
+        ) {
+            return Ok(Vec::new());
+        }
+
+        use crate::domain::scheduler_protocol::{
+            ActivationDisposition, ActivationSettlement, AgentDispatchDisposition,
+            MissingSettlementRecord, ProtocolCommand, SettleActivationCommand,
+        };
+
+        let snapshot = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(&record.agent_id)?
+            .ok_or_else(|| anyhow!("canonical queue settlement has no scheduler partition"))?;
+        let activation_id = scheduler_executor::canonical_activation_id(&record.message_id);
+        let activation = snapshot
+            .activations
+            .get(&activation_id)
+            .ok_or_else(|| anyhow!("canonical queue settlement has no matching activation"))?;
+        let work_item_id = activation.work_item_id.clone();
+        let work_queue = self.inner.storage.work_queue_prompt_projection()?;
+        let scheduling_state = work_queue
+            .items
+            .iter()
+            .find(|candidate| candidate.id == work_item_id)
+            .map(|candidate| candidate.scheduling_state);
+
+        let command = if record.status == QueueEntryStatus::Processed {
+            match scheduling_state {
+                Some(crate::types::WorkItemSchedulingState::Runnable) => {
+                    ProtocolCommand::SettleActivation(SettleActivationCommand {
+                        settlement: ActivationSettlement {
+                            id: canonical_settlement_id(&record.message_id),
+                            activation_id,
+                            turn_terminal: message.turn_id.clone(),
+                            disposition: ActivationDisposition::WorkContinues,
+                            agent_dispatch: AgentDispatchDisposition::Open,
+                            operator_delivery: None,
+                            evidence: vec![
+                                format!("message:{}", record.message_id),
+                                format!("work_item:{work_item_id}"),
+                            ],
+                            created_at: record.updated_at.to_rfc3339(),
+                        },
+                    })
+                }
+                Some(crate::types::WorkItemSchedulingState::Completed) => {
+                    let brief = self
+                        .inner
+                        .storage
+                        .read_recent_briefs(usize::MAX)?
+                        .into_iter()
+                        .filter(|brief| {
+                            brief.kind.is_success()
+                                && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
+                                && !brief.text.trim().is_empty()
+                        })
+                        .max_by_key(|brief| brief.created_at)
+                        .ok_or_else(|| {
+                            anyhow!("canonical WorkItem completion requires a result brief binding")
+                        })?;
+                    let turn_terminal = message.turn_id.clone().ok_or_else(|| {
+                        anyhow!("canonical WorkItem completion requires a turn identity")
+                    })?;
+                    ProtocolCommand::SettleActivation(SettleActivationCommand {
+                        settlement: ActivationSettlement {
+                            id: canonical_settlement_id(&record.message_id),
+                            activation_id,
+                            turn_terminal: Some(turn_terminal.clone()),
+                            disposition: ActivationDisposition::WorkCompleted {
+                                continuation: None,
+                            },
+                            agent_dispatch: AgentDispatchDisposition::Open,
+                            operator_delivery: Some(brief.id.clone()),
+                            evidence: vec![
+                                format!("message:{}", record.message_id),
+                                format!("work_item:{work_item_id}"),
+                                format!("turn:{turn_terminal}"),
+                                format!("brief:{}", brief.id),
+                            ],
+                            created_at: record.updated_at.to_rfc3339(),
+                        },
+                    })
+                }
+                _ => ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
+                    id: canonical_missing_settlement_id(&record.message_id),
+                    activation_id,
+                    created_at: record.updated_at.to_rfc3339(),
+                }),
+            }
+        } else {
+            ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
+                id: canonical_missing_settlement_id(&record.message_id),
+                activation_id,
+                created_at: record.updated_at.to_rfc3339(),
+            })
+        };
+        Ok(vec![command])
     }
 
     pub(crate) fn persist_transcript_evidence(&self, entry: &TranscriptEntry) -> Result<()> {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -40,8 +40,9 @@ use crate::{
 
 use super::{
     clock::{Clock, SystemClock},
-    scheduler_executor, workspace, AgentRuntimeProjectionCache, InitialWorkspaceBinding,
-    RuntimeAgent, RuntimeHandle, RuntimeInner,
+    scheduler_executor, scheduler_protocol_production_commands_enabled_from_env, workspace,
+    AgentRuntimeProjectionCache, InitialWorkspaceBinding, RuntimeAgent, RuntimeHandle,
+    RuntimeInner,
 };
 
 /// Snapshot of config-derived runtime fields that can be hot-swapped at runtime.
@@ -357,6 +358,9 @@ impl RuntimeHandle {
                 recovered_timers: Mutex::new(Some(active_timers)),
                 suppress_next_continue_active_tick: Mutex::new(false),
                 shutdown_requested: AtomicBool::new(false),
+                scheduler_protocol_production_commands_enabled: AtomicBool::new(
+                    scheduler_protocol_production_commands_enabled_from_env()?,
+                ),
                 #[cfg(test)]
                 transition_faults: StdMutex::new(std::collections::VecDeque::new()),
                 #[cfg(test)]

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -802,8 +802,11 @@ impl RuntimeHandle {
                     agent_id: message.agent_id.clone(),
                     operation: crate::runtime_db::transitions::QueueOperation::Admit,
                     mutation: crate::runtime_db::transitions::QueueMutation::Upsert(queue_record),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
                     scheduler_authority_scenarios: vec![
-                        scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO.into(),
+                        scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
                     ],
                     agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                         expected: Some(Box::new(expected_persisted_state)),

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::domain::scheduler_protocol::SchedulerScenarioClass;
 use crate::domain::scheduler_semantic::{
     structural_semantic_proposal, SemanticProposalProviderConfig, SemanticProposalProviderIdentity,
     SemanticProposalResponse, SemanticValidationPolicy, SemanticWaitCandidate,
@@ -19,13 +20,18 @@ use crate::work_item_scheduling::WorkItemSchedulingProjection;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-pub(crate) const REDUCER_ONLY_CANDIDATES_SCENARIO: &str = "reducer_only_candidates";
-pub(crate) const WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO: &str =
-    "work_item_autonomous_continuation";
-pub(crate) const WAIT_RESUME_SCENARIO: &str = "wait_resume";
-pub(crate) const SETTLEMENT_SCENARIO: &str = "settlement";
-pub(crate) const DELIVERY_SCENARIO: &str = "delivery";
-pub(crate) const INTERJECTION_SCENARIO: &str = "operator_interjection";
+pub(crate) const REDUCER_ONLY_CANDIDATES_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::ReducerOnlyCandidates;
+pub(crate) const WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::WorkItemAutonomousContinuation;
+pub(crate) const EXACT_TASK_REJOIN_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::ExactTaskRejoin;
+pub(crate) const EXACT_WAIT_RESUME_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::ExactWaitResume;
+pub(crate) const SETTLEMENT_SCENARIO: SchedulerScenarioClass = SchedulerScenarioClass::Settlement;
+pub(crate) const DELIVERY_SCENARIO: SchedulerScenarioClass = SchedulerScenarioClass::Delivery;
+pub(crate) const INTERJECTION_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::OperatorInterjection;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SchedulerProjection {
@@ -677,7 +683,7 @@ pub(crate) enum RestrictedSchedulerCandidate {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SchedulerShadowComparison {
-    pub scenario_class: &'static str,
+    pub scenario_class: SchedulerScenarioClass,
     pub comparison_identity: String,
     pub boundary: &'static str,
     pub input_identity: String,
@@ -979,24 +985,46 @@ pub(crate) fn scheduler_decision_event(decision: &SchedulerDecision) -> AuditEve
     )
 }
 
+pub(crate) fn scheduler_diagnostic_event(
+    agent_id: &str,
+    decision: &SchedulerDecision,
+    shadow: Option<&SchedulerShadowComparison>,
+) -> Result<AuditEvent> {
+    let payload = scheduler_diagnostic_audit_event(agent_id, decision, shadow);
+    AuditEvent::typed(
+        crate::runtime_event::RuntimeEventKind::SchedulerDiagnostic,
+        &payload,
+    )
+}
+
+pub(crate) fn scheduler_decision_events(
+    agent_id: &str,
+    decision: &SchedulerDecision,
+    shadow: Option<&SchedulerShadowComparison>,
+) -> Result<[AuditEvent; 2]> {
+    Ok([
+        scheduler_diagnostic_event(agent_id, decision, shadow)?,
+        scheduler_decision_event(decision),
+    ])
+}
+
 pub(crate) fn append_scheduler_decision(
     storage: &AppStorage,
     agent_id: &str,
     decision: &SchedulerDecision,
 ) -> Result<bool> {
-    let event = scheduler_decision_event(decision);
-    // Also emit the typed public diagnostic event alongside the legacy record.
-    let _ = append_scheduler_diagnostic_event(storage, agent_id, decision, None)?;
+    let events = scheduler_decision_events(agent_id, decision, None)?;
+    let legacy_event = &events[1];
     let duplicate = storage
         .read_recent_events(32)?
         .into_iter()
         .rev()
-        .find(|latest| latest.kind == event.kind)
-        .is_some_and(|latest| latest.data == event.data);
+        .find(|latest| latest.kind == legacy_event.kind)
+        .is_some_and(|latest| latest.data == legacy_event.data);
     if duplicate {
         return Ok(false);
     }
-    storage.append_event(&event)?;
+    storage.append_events(&events)?;
     Ok(true)
 }
 
@@ -1013,7 +1041,7 @@ pub(crate) fn scheduler_diagnostic_audit_event(
     let (scenario_class, shadow_matched, divergence_code) = shadow
         .map(|sc| {
             (
-                Some(sc.scenario_class.to_string()),
+                Some(sc.scenario_class.as_str().to_string()),
                 Some(sc.matched),
                 sc.divergence_code.map(|c| c.to_string()),
             )
@@ -1033,33 +1061,6 @@ pub(crate) fn scheduler_diagnostic_audit_event(
         task_id: decision.task_id.clone(),
         evidence: decision.evidence.clone(),
     }
-}
-
-/// Emit a typed scheduler diagnostic event alongside the legacy audit record.
-/// The legacy `scheduler_decision` event is retained for backward compatibility;
-/// the typed event extends observability into the public event stream.
-pub(crate) fn append_scheduler_diagnostic_event(
-    storage: &AppStorage,
-    agent_id: &str,
-    decision: &SchedulerDecision,
-    shadow: Option<&SchedulerShadowComparison>,
-) -> Result<bool> {
-    let payload = scheduler_diagnostic_audit_event(agent_id, decision, shadow);
-    let event = crate::types::AuditEvent::typed(
-        crate::runtime_event::RuntimeEventKind::SchedulerDiagnostic,
-        &payload,
-    )?;
-    let duplicate = storage
-        .read_recent_events(32)?
-        .into_iter()
-        .rev()
-        .find(|latest| latest.kind == event.kind)
-        .is_some_and(|latest| latest.data == event.data);
-    if duplicate {
-        return Ok(false);
-    }
-    storage.append_event(&event)?;
-    Ok(true)
 }
 
 pub(crate) fn message_processing_decision(
@@ -1147,13 +1148,16 @@ pub(crate) fn authority_scenarios_for_message_claim(
     projection: &SchedulerProjection,
     message: &MessageEnvelope,
     continuation_resolution: Option<&ContinuationResolution>,
-) -> Vec<&'static str> {
+) -> Vec<SchedulerScenarioClass> {
     let mut scenarios = Vec::with_capacity(1);
     if message_admission_scenario_applies(message, continuation_resolution) {
         scenarios.push(REDUCER_ONLY_CANDIDATES_SCENARIO);
     }
     if wait_resume_scenario_applies(projection, message) {
-        scenarios.push(WAIT_RESUME_SCENARIO);
+        scenarios.push(
+            wait_resume_scenario_class(message)
+                .expect("applicable wait resume has a registered scenario class"),
+        );
     }
     scenarios
 }
@@ -1242,7 +1246,8 @@ pub(crate) fn shadow_comparison_for_wait_resume(
         _ => unreachable!(),
     };
     Some(SchedulerShadowComparison {
-        scenario_class: WAIT_RESUME_SCENARIO,
+        scenario_class: wait_resume_scenario_class(message)
+            .expect("applicable wait resume has a registered scenario class"),
         comparison_identity: format!("wait_resume:{}", message.id),
         boundary: SchedulerBoundary::RunLoop.as_str(),
         input_identity,
@@ -1251,6 +1256,14 @@ pub(crate) fn shadow_comparison_for_wait_resume(
         matched,
         divergence_code: (!matched).then_some("wait_resume_outcome_mismatch"),
     })
+}
+
+fn wait_resume_scenario_class(message: &MessageEnvelope) -> Option<SchedulerScenarioClass> {
+    match message.kind {
+        MessageKind::TaskResult => Some(EXACT_TASK_REJOIN_SCENARIO),
+        MessageKind::SystemTick => Some(EXACT_WAIT_RESUME_SCENARIO),
+        _ => None,
+    }
 }
 
 fn wait_resume_scenario_applies(

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -74,6 +74,12 @@ pub(super) struct ScheduledMessage {
     pub(super) scheduler_decision: scheduler::SchedulerDecision,
 }
 
+struct CanonicalClaimPlan {
+    work_item: crate::types::WorkItemRecord,
+    bootstrap: Option<crate::domain::scheduler_protocol::Snapshot>,
+    commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
+}
+
 pub(super) struct SchedulerDecisionExecutor<'a> {
     runtime: &'a RuntimeHandle,
 }
@@ -346,10 +352,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &projection,
             &candidate.message,
             dispatch_plan.continuation_resolution.as_ref(),
-        )
-        .into_iter()
-        .map(str::to_owned)
-        .collect();
+        );
         let shadow_comparison = scheduler::shadow_comparison_for_message_admission(
             &projection,
             &candidate.message,
@@ -359,6 +362,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         .or_else(|| {
             scheduler::shadow_comparison_for_wait_resume(&projection, &candidate.message, &decision)
         });
+        let scheduler_decision_events = scheduler::scheduler_decision_events(
+            &candidate.message.agent_id,
+            &decision,
+            shadow_comparison.as_ref(),
+        )?;
         let shadow_comparison = shadow_comparison
             .map(scheduler_shadow_comparison_command)
             .transpose()?;
@@ -384,6 +392,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &persisted_message,
         )?
         .map(scheduler_semantic_shadow_command);
+        let canonical_claim =
+            self.canonical_work_queue_claim_plan(&projection, &candidate.message)?;
         scheduler::append_scheduling_advisories(
             &self.runtime.inner.storage,
             &candidate.prior_state,
@@ -427,6 +437,16 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     mutation: crate::runtime_db::transitions::QueueMutation::Consume(
                         queue_record.clone(),
                     ),
+                    scheduler_claim_work_item: canonical_claim
+                        .as_ref()
+                        .map(|plan| plan.work_item.clone()),
+                    scheduler_protocol_bootstrap: canonical_claim
+                        .as_ref()
+                        .and_then(|plan| plan.bootstrap.clone()),
+                    scheduler_protocol_commands: canonical_claim
+                        .as_ref()
+                        .map(|plan| plan.commands.clone())
+                        .unwrap_or_default(),
                     scheduler_authority_scenarios,
                     agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                         expected: Some(Box::new(guard.state.clone())),
@@ -435,7 +455,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
                     audit_events: vec![
-                        scheduler::scheduler_decision_event(&decision),
+                        scheduler_decision_events[0].clone(),
+                        scheduler_decision_events[1].clone(),
                         AuditEvent::legacy(
                             "queue_entry_claimed",
                             serde_json::json!({
@@ -486,6 +507,183 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         }))
     }
 
+    fn canonical_work_queue_claim_plan(
+        &self,
+        _projection: &scheduler::SchedulerProjection,
+        message: &MessageEnvelope,
+    ) -> Result<Option<CanonicalClaimPlan>> {
+        if !self
+            .runtime
+            .scheduler_protocol_production_commands_enabled()
+        {
+            return Ok(None);
+        }
+        if !matches!(
+            (&message.kind, &message.origin),
+            (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                if subsystem == "work_queue"
+        ) {
+            return Ok(None);
+        }
+
+        let work_item_id = message
+            .work_item_id
+            .as_deref()
+            .ok_or_else(|| anyhow!("canonical work queue claim requires a WorkItem binding"))?;
+        let work_item = self
+            .runtime
+            .inner
+            .storage
+            .latest_work_item(work_item_id)?
+            .ok_or_else(|| anyhow!("canonical work queue claim references unknown WorkItem"))?;
+        let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
+        if work_item.agent_id != message.agent_id
+            || work_item.state != crate::types::WorkItemState::Open
+            || !work_queue.items.iter().any(|candidate| {
+                candidate.id == work_item.id
+                    && candidate.scheduling_state == crate::types::WorkItemSchedulingState::Runnable
+            })
+        {
+            return Err(anyhow!(
+                "canonical work queue claim requires a runnable same-agent WorkItem"
+            ));
+        }
+
+        use crate::domain::scheduler_protocol::{
+            ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
+            ActivationPriority, ActivationProvenance, ActivationSlot, ActivationTrust,
+            AdmitActivationCommand, AgentActivation, AgentDispatchState,
+            IssueActivationAuthorityCommand, PreemptionPolicy, ProtocolCommand,
+            RegisterWorkDemandCommand, RolloutState, Snapshot, WorkDemand, WorkStatus,
+        };
+
+        let existing = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
+        let new_demand = || WorkDemand {
+            metadata_revision: work_item.revision.max(1),
+            scheduling_generation: work_item.revision.max(1),
+            status: WorkStatus::Runnable,
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        };
+        let (bootstrap, expected_dispatch_revision, scheduling_generation, register) =
+            if let Some(snapshot) = existing.as_ref() {
+                if let Some(demand) = snapshot.work.get(work_item_id) {
+                    if demand.status != WorkStatus::Runnable {
+                        return Err(anyhow!(
+                            "canonical WorkItem demand is not runnable for claim"
+                        ));
+                    }
+                    (
+                        None,
+                        snapshot.dispatch_revision,
+                        demand.scheduling_generation,
+                        None,
+                    )
+                } else {
+                    let demand = new_demand();
+                    (
+                        None,
+                        snapshot.dispatch_revision,
+                        demand.scheduling_generation,
+                        Some(ProtocolCommand::RegisterWorkDemand(
+                            RegisterWorkDemandCommand {
+                                work_item_id: work_item.id.clone(),
+                                demand,
+                            },
+                        )),
+                    )
+                }
+            } else {
+                let demand = new_demand();
+                (
+                    Some(Snapshot {
+                        slot: ActivationSlot::Idle,
+                        dispatch: AgentDispatchState::Open,
+                        dispatch_revision: 0,
+                        focus: None,
+                        work: Default::default(),
+                        waits: Default::default(),
+                        activations: Default::default(),
+                        activation_authorities: Default::default(),
+                        activation_admissions: Default::default(),
+                        settlements: Default::default(),
+                        missing_settlements: Default::default(),
+                        rollout: RolloutState::default(),
+                        admitted_generations: Default::default(),
+                        continuation_admissions: Default::default(),
+                    }),
+                    0,
+                    demand.scheduling_generation,
+                    Some(ProtocolCommand::RegisterWorkDemand(
+                        RegisterWorkDemandCommand {
+                            work_item_id: work_item.id.clone(),
+                            demand,
+                        },
+                    )),
+                )
+            };
+
+        let activation_id = canonical_activation_id(&message.id);
+        let activation = AgentActivation {
+            id: activation_id.clone(),
+            agent_id: message.agent_id.clone(),
+            state: ActivationLifecycleState::Admitted,
+            cause: ActivationCause::WorkItemRunnable {
+                work_item_id: work_item.id.clone(),
+                scheduling_generation,
+            },
+            binding: ActivationBinding::WorkItem {
+                work_item_id: work_item.id.clone(),
+            },
+            priority: match message.priority {
+                Priority::Interject => ActivationPriority::Interject,
+                Priority::Next => ActivationPriority::Next,
+                Priority::Normal => ActivationPriority::Normal,
+                Priority::Background => ActivationPriority::Background,
+            },
+            preemption: PreemptionPolicy::NonPreemptive,
+            source_revision: Some(work_item.revision),
+            idempotency_key: format!("work-queue-message:{}", message.id),
+            provenance: ActivationProvenance {
+                origin: ActivationOrigin::System,
+                trust: ActivationTrust::RuntimeInstruction,
+                source_id: message.id.clone(),
+                correlation_id: message.correlation_id.clone(),
+                causation_id: message.causation_id.clone(),
+            },
+        };
+        let authority_id = format!("authority:{activation_id}");
+        let authority = IssueActivationAuthorityCommand {
+            authority_id: authority_id.clone(),
+            activation: activation.clone(),
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision,
+        };
+        let admission = AdmitActivationCommand {
+            authority_id,
+            activation,
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision,
+        };
+        let mut commands = Vec::with_capacity(3);
+        commands.extend(register);
+        commands.push(ProtocolCommand::IssueActivationAuthority(authority));
+        commands.push(ProtocolCommand::AdmitActivation(admission));
+
+        Ok(Some(CanonicalClaimPlan {
+            work_item,
+            bootstrap,
+            commands,
+        }))
+    }
+
     fn append_posture_decision(
         &self,
         boundary: &'static str,
@@ -507,6 +705,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
     }
 }
 
+pub(super) fn canonical_activation_id(message_id: &str) -> String {
+    format!("activation:message:{message_id}")
+}
+
 fn scheduler_semantic_shadow_command(
     decision: scheduler::SchedulerSemanticShadowDecision,
 ) -> crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerSemanticShadowCommand {
@@ -525,7 +727,7 @@ pub(super) fn scheduler_shadow_comparison_command(
 > {
     Ok(
         crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerShadowComparisonCommand {
-            scenario_class: comparison.scenario_class.into(),
+            scenario_class: comparison.scenario_class.as_str().into(),
             comparison_identity: comparison.comparison_identity,
             boundary: comparison.boundary.into(),
             input_identity: comparison.input_identity,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::support::*;
+use crate::domain::scheduler_protocol::{ActivationSlot, SchedulerScenarioClass, WorkStatus};
 use crate::types::{
     ActiveSkillRecord, AuthorityClass, QueueEntryStatus, SkillActivationSource,
     SkillActivationState, SkillLoadReason, SkillScope, WaitConditionKind, WaitConditionRecord,
@@ -348,7 +349,7 @@ async fn non_model_reentry_external_events_do_not_run_interactive_turn() {
 }
 
 #[tokio::test]
-async fn run_loop_claim_persists_message_shadow_comparison_in_the_same_transition() {
+async fn run_loop_claim_atomically_persists_scheduler_events_and_shadow_comparison() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -439,15 +440,38 @@ async fn run_loop_claim_persists_message_shadow_comparison_in_the_same_transitio
     assert_eq!(authority_mode, "shadow");
     assert_eq!(input_identity, format!("message:{}", message.id));
     let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
-    assert!(events.iter().any(|event| {
-        event.kind == "scheduler_decision"
-            && event.data["boundary"] == "run_loop"
-            && event.data["message_id"] == message.id
-    }));
+    let claim_events = events
+        .iter()
+        .filter(|event| event.data["message_id"] == message.id)
+        .filter(|event| {
+            matches!(
+                event.kind.as_str(),
+                "scheduler_diagnostic" | "scheduler_decision" | "queue_entry_claimed"
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        claim_events
+            .iter()
+            .map(|event| event.kind.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "scheduler_diagnostic",
+            "scheduler_decision",
+            "queue_entry_claimed"
+        ]
+    );
+    assert_eq!(claim_events[0].data["boundary"], "run_loop");
+    assert_eq!(
+        claim_events[0].data["scenario_class"],
+        "reducer_only_candidates"
+    );
+    assert_eq!(claim_events[0].data["shadow_matched"], true);
+    assert_eq!(claim_events[1].data["boundary"], "run_loop");
 }
 
 #[tokio::test]
-async fn run_loop_claim_fault_rolls_back_scheduler_decision_with_claim_facts() {
+async fn run_loop_claim_fault_rolls_back_scheduler_events_with_claim_facts() {
     for fault in PRE_COMMIT_FAULTS {
         let dir = tempdir().unwrap();
         let workspace = tempdir().unwrap();
@@ -541,6 +565,11 @@ async fn run_loop_claim_fault_rolls_back_scheduler_decision_with_claim_facts() {
         assert_eq!(comparison_count, 0);
         let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
         assert!(!events.iter().any(|event| {
+            event.kind == "scheduler_diagnostic"
+                && event.data["boundary"] == "run_loop"
+                && event.data["message_id"] == message.id
+        }));
+        assert!(!events.iter().any(|event| {
             event.kind == "scheduler_decision"
                 && event.data["boundary"] == "run_loop"
                 && event.data["message_id"] == message.id
@@ -548,6 +577,229 @@ async fn run_loop_claim_fault_rolls_back_scheduler_decision_with_claim_facts() {
         assert!(!events.iter().any(|event| {
             event.kind == "queue_entry_claimed" && event.data["message_id"] == message.id
         }));
+    }
+}
+
+#[tokio::test]
+async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    let work_item = runtime
+        .create_work_item("canonical production loop".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "run canonical work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(
+        claimed.slot,
+        ActivationSlot::Running {
+            activation_id: activation_id.clone(),
+            work_item_id: work_item.id.clone(),
+            admitted_generation: work_item.revision,
+            recovery_for: None,
+        }
+    );
+    assert!(claimed.activations.contains_key(&activation_id));
+
+    runtime
+        .commit_queue_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            vec![AuditEvent::legacy(
+                "queue_entry_settled",
+                serde_json::json!({
+                    "message_id": message.id,
+                    "status": QueueEntryStatus::Processed,
+                }),
+            )],
+            true,
+        )
+        .await
+        .unwrap();
+
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(settled.slot, ActivationSlot::Idle);
+    assert_eq!(
+        settled.work.get(&work_item.id).map(|demand| &demand.status),
+        Some(&WorkStatus::Runnable)
+    );
+    assert_eq!(
+        settled
+            .work
+            .get(&work_item.id)
+            .map(|demand| demand.scheduling_generation),
+        Some(work_item.revision + 1)
+    );
+    assert!(settled
+        .settlements
+        .contains_key(&canonical_settlement_id(&message.id)));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
+    );
+}
+
+#[tokio::test]
+async fn production_protocol_settlement_fault_rolls_back_queue_and_canonical_facts() {
+    for fault in PRE_COMMIT_FAULTS {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        runtime.set_scheduler_protocol_production_commands_enabled(true);
+        let work_item = runtime
+            .create_work_item(
+                "canonical settlement rollback".into(),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_queue".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "run canonical work".into(),
+            },
+        );
+        message.work_item_id = Some(work_item.id);
+        let message = runtime.enqueue(message).await.unwrap();
+        let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap();
+        assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+        let claimed = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap();
+        runtime.inject_next_transition_fault(fault);
+
+        let error = runtime
+            .commit_queue_settlement(
+                QueueEntryRecord {
+                    message_id: message.id.clone(),
+                    agent_id: message.agent_id.clone(),
+                    priority: message.priority.clone(),
+                    status: QueueEntryStatus::Processed,
+                    created_at: message.created_at,
+                    updated_at: Utc::now(),
+                },
+                Vec::new(),
+                true,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected runtime transition fault"),
+            "unexpected error for {fault:?}: {error:#}"
+        );
+
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .load_scheduler_protocol_snapshot("default")
+                .unwrap(),
+            claimed
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .queue_entries()
+                .latest_all()
+                .unwrap()
+                .into_iter()
+                .find(|entry| entry.message_id == message.id)
+                .map(|entry| entry.status),
+            Some(QueueEntryStatus::Dequeued)
+        );
     }
 }
 
@@ -838,7 +1090,7 @@ async fn authoritative_mode_allows_claims_outside_authoritative_scenario() {
 async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_partial_writes() {
     for (scenario_class, message, waiting_work_item) in [
         (
-            "reducer_only_candidates",
+            SchedulerScenarioClass::ReducerOnlyCandidates,
             MessageEnvelope::new(
                 "default",
                 MessageKind::WebhookEvent,
@@ -855,7 +1107,7 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
             None,
         ),
         (
-            "wait_resume",
+            SchedulerScenarioClass::ExactTaskRejoin,
             task_result_message("task-authoritative-claim"),
             Some("work-authoritative-claim"),
         ),
@@ -905,7 +1157,7 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
                    scenario_class, mode, rollback_target,
                    manifest_revision, preflight_revision, updated_at
                  ) VALUES (?1, 'shadow', 'off', NULL, NULL, CURRENT_TIMESTAMP)",
-                [scenario_class],
+                [scenario_class.as_str()],
             )
             .unwrap();
 
@@ -928,7 +1180,7 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
                      rollback_target = 'shadow',
                      updated_at = CURRENT_TIMESTAMP
                  WHERE scenario_class = ?1",
-                [scenario_class],
+                [scenario_class.as_str()],
             )
             .unwrap();
         runtime.omit_next_scheduler_claim_shadow_comparison();
@@ -937,7 +1189,10 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
             .poll()
             .await
         {
-            Ok(_) => panic!("expected missing authoritative evidence to reject {scenario_class}"),
+            Ok(_) => panic!(
+                "expected missing authoritative evidence to reject {}",
+                scenario_class.as_str()
+            ),
             Err(error) => error,
         };
 
@@ -945,7 +1200,8 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
             error
                 .to_string()
                 .contains("requires matched canonical evidence"),
-            "unexpected {scenario_class} error: {error:#}"
+            "unexpected {} error: {error:#}",
+            scenario_class.as_str()
         );
         assert_eq!(runtime.agent_state().await.unwrap(), state_before_claim);
         assert_eq!(runtime.inner.agent.lock().await.queue.len(), 1);
@@ -4550,6 +4806,9 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             }),
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: Vec::new(),
             scheduler_authority_scenarios: Vec::new(),
             agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                 expected: Some(Box::new(expected)),

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1340,7 +1340,7 @@ fn wait_resume_shadow_comparison_records_task_result_matching_active_wait() {
     .work_item_id("wi-1");
     let comparison = scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision)
         .expect("task result matching active wait should produce wait resume comparison");
-    assert_eq!(comparison.scenario_class, "wait_resume");
+    assert_eq!(comparison.scenario_class.as_str(), "exact_task_rejoin");
     assert!(comparison.matched);
     assert_eq!(comparison.divergence_code, None);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
@@ -1407,8 +1407,63 @@ fn wait_resume_claim_authority_scope_is_derived_without_shadow_evidence() {
 
     assert_eq!(
         scheduler::authority_scenarios_for_message_claim(&projection, &message, None),
-        vec![scheduler::WAIT_RESUME_SCENARIO]
+        vec![scheduler::EXACT_TASK_REJOIN_SCENARIO]
     );
+}
+
+#[test]
+fn system_wait_resume_uses_exact_wait_resume_authority_class() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-system".into(),
+            agent_id: "default".into(),
+            work_item_id: None,
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::System,
+            source: Some("test".into()),
+            subject_ref: None,
+            waiting_for: "system_tick".into(),
+            wake_sources: vec![WakeSource::SystemTick],
+            continuation: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        })
+        .unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "scheduler".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: String::new(),
+        },
+    );
+    let decision = scheduler::SchedulerDecision::new(
+        scheduler::SchedulerDecisionKind::StartModelTurn,
+        "system_wait_resume",
+    )
+    .message(&message)
+    .model_reentry(true);
+
+    assert_eq!(
+        scheduler::authority_scenarios_for_message_claim(&projection, &message, None),
+        vec![scheduler::EXACT_WAIT_RESUME_SCENARIO]
+    );
+    let comparison = scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision)
+        .expect("system tick matching an active wait should produce a comparison");
+    assert_eq!(comparison.scenario_class.as_str(), "exact_wait_resume");
 }
 
 #[test]
@@ -1587,7 +1642,7 @@ fn settlement_shadow_comparison_records_processed_settlement() {
     let record = make_settlement_record("msg-1", QueueEntryStatus::Processed);
     let comparison = scheduler::shadow_comparison_for_settlement(&projection, &record)
         .expect("processed settlement should produce comparison");
-    assert_eq!(comparison.scenario_class, "settlement");
+    assert_eq!(comparison.scenario_class.as_str(), "settlement");
     assert!(comparison.matched);
     assert_eq!(comparison.divergence_code, None);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
@@ -1708,7 +1763,7 @@ fn delivery_shadow_comparison_records_processed_with_completed_turn() {
     let record = make_settlement_record("msg-1", QueueEntryStatus::Processed);
     let comparison = scheduler::shadow_comparison_for_delivery(&projection, &record)
         .expect("processed delivery should produce comparison");
-    assert_eq!(comparison.scenario_class, "delivery");
+    assert_eq!(comparison.scenario_class.as_str(), "delivery");
     assert!(comparison.matched);
     assert_eq!(comparison.divergence_code, None);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
@@ -1860,7 +1915,7 @@ fn operator_interjection_shadow_comparison_for_after_provider_round() {
         scheduler::InterjectionBoundary::AfterProviderRound,
     )
     .expect("interjection should produce comparison");
-    assert_eq!(comparison.scenario_class, "operator_interjection");
+    assert_eq!(comparison.scenario_class.as_str(), "operator_interjection");
     assert!(comparison.matched);
     assert_eq!(comparison.divergence_code, None);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
@@ -1888,7 +1943,7 @@ fn operator_interjection_shadow_comparison_for_before_tool_execution() {
         scheduler::InterjectionBoundary::BeforeToolExecution,
     )
     .expect("interjection should produce comparison");
-    assert_eq!(comparison.scenario_class, "operator_interjection");
+    assert_eq!(comparison.scenario_class.as_str(), "operator_interjection");
     assert!(comparison.matched);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
     assert_eq!(
@@ -1916,7 +1971,7 @@ fn operator_interjection_shadow_comparison_for_after_tool_results() {
         scheduler::InterjectionBoundary::AfterToolResults,
     )
     .expect("interjection should produce comparison");
-    assert_eq!(comparison.scenario_class, "operator_interjection");
+    assert_eq!(comparison.scenario_class.as_str(), "operator_interjection");
     assert!(comparison.matched);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
     assert_eq!(observation["interjection_boundary"], "after_tool_results");
@@ -1940,7 +1995,7 @@ fn operator_interjection_shadow_comparison_for_before_provider_continuation() {
         scheduler::InterjectionBoundary::BeforeProviderContinuation,
     )
     .expect("interjection should produce comparison");
-    assert_eq!(comparison.scenario_class, "operator_interjection");
+    assert_eq!(comparison.scenario_class.as_str(), "operator_interjection");
     assert!(comparison.matched);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
     assert_eq!(

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -414,32 +414,32 @@ impl RuntimeHandle {
                         ),
                     }),
                 );
-                let mut commit =
-                    self.inner.runtime_db.transitions().commit_queue(
-                        &crate::runtime_db::transitions::QueueTransitionCommand {
-                            agent_id: message.agent_id.clone(),
-                            operation: crate::runtime_db::transitions::QueueOperation::Interject,
-                            mutation: crate::runtime_db::transitions::QueueMutation::Consume(
-                                queue_record,
-                            ),
-                            scheduler_authority_scenarios: vec![
-                                scheduler::INTERJECTION_SCENARIO.into()
-                            ],
-                            agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                                expected: Some(Box::new(expected_state)),
-                                record: Box::new(committed_state.clone()),
-                            }),
-                            message_evidence: Vec::new(),
-                            transcript_entries: vec![transcript],
-                            audit_events: vec![audit_event],
-                            scheduler_shadow_comparison: shadow_comparison,
-                            scheduler_delivery_shadow_comparison: None,
-                            scheduler_semantic_shadow: None,
-                            notify_scheduler: false,
-                            fault: None,
-                            brief_evidence: Vec::new(),
-                        },
-                    )?;
+                let mut commit = self.inner.runtime_db.transitions().commit_queue(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: message.agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Interject,
+                        mutation: crate::runtime_db::transitions::QueueMutation::Consume(
+                            queue_record,
+                        ),
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        scheduler_authority_scenarios: vec![scheduler::INTERJECTION_SCENARIO],
+                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                            expected: Some(Box::new(expected_state)),
+                            record: Box::new(committed_state.clone()),
+                        }),
+                        message_evidence: Vec::new(),
+                        transcript_entries: vec![transcript],
+                        audit_events: vec![audit_event],
+                        scheduler_shadow_comparison: shadow_comparison,
+                        scheduler_delivery_shadow_comparison: None,
+                        scheduler_semantic_shadow: None,
+                        notify_scheduler: false,
+                        fault: None,
+                        brief_evidence: Vec::new(),
+                    },
+                )?;
                 if !commit.applied {
                     return Err(anyhow::anyhow!(
                         "interjection settlement made no durable progress"

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -77,14 +77,16 @@ mod tests {
     use super::*;
     use crate::{
         domain::scheduler_protocol::{
-            self, ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
-            ActivationPriority, ActivationProvenance, ActivationSlot, ActivationTrust,
-            AdmitActivationCommand, AgentActivation, AgentDispatchState, Decision,
+            self, ActivationBinding, ActivationCause, ActivationDisposition,
+            ActivationLifecycleState, ActivationOrigin, ActivationPriority, ActivationProvenance,
+            ActivationSettlement, ActivationSlot, ActivationTrust, AdmitActivationCommand,
+            AgentActivation, AgentDispatchDisposition, AgentDispatchState, Continuation, Decision,
             IssueActivationAuthorityCommand, ObservationalDivergenceAllowance, PreemptionPolicy,
             ProtocolCommand, ProtocolMode, RollbackAction, RollbackPolicy, RollbackTrigger,
             RolloutClassEvidence, RolloutCommand, RolloutManifest, RolloutPreflightState,
-            ScenarioMode, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState,
-            WaitTrigger, WorkDemand, WorkStatus,
+            ScenarioMode, SchedulerScenarioClass, SettleActivationCommand, Snapshot,
+            WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WaitTrigger, WorkDemand,
+            WorkStatus,
         },
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
@@ -374,6 +376,41 @@ mod tests {
         })
     }
 
+    fn scheduler_protocol_admission_command(
+        agent_id: &str,
+        scheduling_generation: u64,
+    ) -> ProtocolCommand {
+        let ProtocolCommand::IssueActivationAuthority(authority) =
+            scheduler_protocol_authority_command(agent_id, scheduling_generation)
+        else {
+            unreachable!("scheduler authority helper must issue authority")
+        };
+        ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: authority.authority_id,
+            activation: authority.activation,
+            expected_scheduling_generation: authority.expected_scheduling_generation,
+            expected_dispatch_revision: authority.expected_dispatch_revision,
+        })
+    }
+
+    fn scheduler_protocol_completion_command(
+        settlement_id: &str,
+        continuation: Option<Continuation>,
+    ) -> ProtocolCommand {
+        ProtocolCommand::SettleActivation(SettleActivationCommand {
+            settlement: ActivationSettlement {
+                id: settlement_id.into(),
+                activation_id: "activation-a".into(),
+                turn_terminal: Some(format!("turn-terminal-{settlement_id}")),
+                disposition: ActivationDisposition::WorkCompleted { continuation },
+                agent_dispatch: AgentDispatchDisposition::Open,
+                operator_delivery: Some(format!("brief-{settlement_id}")),
+                evidence: vec![format!("trace-{settlement_id}")],
+                created_at: "2026-07-21T00:00:00Z".into(),
+            },
+        })
+    }
+
     fn scheduler_rollout_manifest(revision: u64, preflight_revision: u64) -> RolloutManifest {
         let evidence: BTreeSet<String> = [
             "restart",
@@ -452,6 +489,52 @@ mod tests {
                         "reservation_conflict",
                         "yield_return",
                         "work_item_rollback",
+                    ],
+                ),
+                "exact_task_rejoin" => (
+                    1_000,
+                    7 * 24 * 60 * 60,
+                    vec![
+                        "duplicate_task_result",
+                        "out_of_order_task_result",
+                        "restart_before_rejoin_settlement",
+                    ],
+                ),
+                "exact_wait_resume" => (
+                    1_000,
+                    7 * 24 * 60 * 60,
+                    vec![
+                        "duplicate_trigger",
+                        "stale_generation",
+                        "restart_after_consume",
+                        "rearm",
+                    ],
+                ),
+                "operator_interjection" => (
+                    1_000,
+                    7 * 24 * 60 * 60,
+                    vec![
+                        "duplicate_ingress",
+                        "stale_binding_revision",
+                        "wrong_agent_target",
+                    ],
+                ),
+                "settlement" => (
+                    1_000,
+                    7 * 24 * 60 * 60,
+                    vec![
+                        "duplicate_settlement",
+                        "missing_settlement_recovery",
+                        "restart_before_settlement_commit",
+                    ],
+                ),
+                "delivery" => (
+                    1_000,
+                    7 * 24 * 60 * 60,
+                    vec![
+                        "duplicate_delivery",
+                        "delivery_retry",
+                        "restart_before_delivery_commit",
                     ],
                 ),
                 _ => panic!("unsupported Phase 3 scenario {scenario_class}"),
@@ -1514,6 +1597,89 @@ mod tests {
     }
 
     #[test]
+    fn canonical_focused_completion_releases_focus_before_terminal_constraint() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let initial = scheduler_protocol_snapshot(1);
+        let authority = scheduler_protocol_authority_command(agent_id, 1);
+        let admission = scheduler_protocol_admission_command(agent_id, 1);
+        let completion = scheduler_protocol_completion_command("settlement-a", None);
+
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &initial)?;
+        db.transitions()
+            .commit_scheduler_protocol_command(agent_id, &authority, None)?;
+        db.transitions()
+            .commit_scheduler_protocol_command(agent_id, &admission, None)?;
+        let committed =
+            db.transitions()
+                .commit_scheduler_protocol_command(agent_id, &completion, None)?;
+        assert_eq!(committed.result.decision, Decision::Settled);
+
+        let persisted = db
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        assert_eq!(persisted.focus, None);
+        assert_eq!(persisted.work["work-a"].status, WorkStatus::Terminal);
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_completion_restores_caller_focus_and_generation() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let mut initial = scheduler_protocol_snapshot(1);
+        initial.work.insert(
+            "work-caller".into(),
+            WorkDemand {
+                metadata_revision: 4,
+                scheduling_generation: 4,
+                status: WorkStatus::Runnable,
+                capabilities: BTreeSet::from(["workspace_read".into()]),
+                locks: BTreeSet::new(),
+                locality: "workspace:holon".into(),
+                cost_class: "standard".into(),
+            },
+        );
+        let authority = scheduler_protocol_authority_command(agent_id, 1);
+        let admission = scheduler_protocol_admission_command(agent_id, 1);
+        let completion = scheduler_protocol_completion_command(
+            "settlement-a",
+            Some(Continuation {
+                admission_id: "continuation-a".into(),
+                caller_work_item_id: "work-caller".into(),
+                expected_caller_generation: 4,
+            }),
+        );
+
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &initial)?;
+        db.transitions()
+            .commit_scheduler_protocol_command(agent_id, &authority, None)?;
+        db.transitions()
+            .commit_scheduler_protocol_command(agent_id, &admission, None)?;
+        let committed =
+            db.transitions()
+                .commit_scheduler_protocol_command(agent_id, &completion, None)?;
+        assert_eq!(committed.result.decision, Decision::Settled);
+
+        let persisted = db
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        assert_eq!(persisted.focus.as_deref(), Some("work-caller"));
+        assert_eq!(persisted.work["work-a"].status, WorkStatus::Terminal);
+        assert_eq!(persisted.work["work-caller"].status, WorkStatus::Runnable);
+        assert_eq!(persisted.work["work-caller"].scheduling_generation, 5);
+        assert_eq!(
+            persisted.continuation_admissions["continuation-a"].admitted_caller_generation,
+            5
+        );
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_protocol_repository_faults_roll_back_snapshot_and_ledger() -> Result<()> {
         for fault in [
             TransitionFaultPoint::AfterValidation,
@@ -2066,10 +2232,8 @@ mod tests {
     #[test]
     fn scheduler_authoritative_scenarios_require_matched_evidence_and_restart_safe_rollback(
     ) -> Result<()> {
-        for scenario_class in [
-            "reducer_only_candidates",
-            "work_item_autonomous_continuation",
-        ] {
+        for scenario in SchedulerScenarioClass::PRODUCTION_AUTHORITY {
+            let scenario_class = scenario.as_str();
             let (_temp_dir, db_path, lock_path) = temp_paths()?;
             let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             db.transitions().initialize_scheduler_protocol_partition(
@@ -2153,7 +2317,10 @@ mod tests {
                 agent_id: "agent-a".into(),
                 operation: QueueOperation::Admit,
                 mutation: QueueMutation::Upsert(matched_queue_record.clone()),
-                scheduler_authority_scenarios: vec![scenario_class.into()],
+                scheduler_claim_work_item: None,
+                scheduler_protocol_bootstrap: None,
+                scheduler_protocol_commands: Vec::new(),
+                scheduler_authority_scenarios: vec![scenario],
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),
@@ -2385,7 +2552,12 @@ mod tests {
                         agent_id: "agent-a".into(),
                         operation: QueueOperation::Admit,
                         mutation: QueueMutation::Upsert(queue_record),
-                        scheduler_authority_scenarios: vec![SCENARIO_CLASS.into()],
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        scheduler_authority_scenarios: vec![SCENARIO_CLASS
+                            .parse::<SchedulerScenarioClass>()
+                            .expect("registered scheduler scenario class")],
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -79,10 +79,12 @@ mod tests {
         domain::scheduler_protocol::{
             self, ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
             ActivationPriority, ActivationProvenance, ActivationSlot, ActivationTrust,
-            AgentActivation, AgentDispatchState, Decision, IssueActivationAuthorityCommand,
-            ObservationalDivergenceAllowance, PreemptionPolicy, ProtocolCommand, ProtocolMode,
-            RollbackAction, RollbackPolicy, RollbackTrigger, RolloutClassEvidence, RolloutCommand,
-            RolloutManifest, RolloutPreflightState, ScenarioMode, Snapshot, WorkDemand, WorkStatus,
+            AdmitActivationCommand, AgentActivation, AgentDispatchState, Decision,
+            IssueActivationAuthorityCommand, ObservationalDivergenceAllowance, PreemptionPolicy,
+            ProtocolCommand, ProtocolMode, RollbackAction, RollbackPolicy, RollbackTrigger,
+            RolloutClassEvidence, RolloutCommand, RolloutManifest, RolloutPreflightState,
+            ScenarioMode, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState,
+            WaitTrigger, WorkDemand, WorkStatus,
         },
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
@@ -1361,6 +1363,153 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(ledger_rows, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_wait_resume_persists_consumed_wait_and_activation_atomically() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let wait_id = "wait-a";
+        let wait_generation = 2;
+        let trigger_id = "trigger-a";
+        let trigger_generation = 1;
+        let scheduling_generation = 2;
+        let dispatch_revision = 1;
+        let activation = AgentActivation {
+            id: "activation-wait-resume".into(),
+            agent_id: agent_id.into(),
+            state: ActivationLifecycleState::Admitted,
+            cause: ActivationCause::WaitResume {
+                wait_id: wait_id.into(),
+                wait_generation,
+                trigger_id: trigger_id.into(),
+                trigger_generation,
+            },
+            binding: ActivationBinding::WaitOwner {
+                wait_id: wait_id.into(),
+                owner_work_item_id: "work-a".into(),
+            },
+            priority: ActivationPriority::Normal,
+            preemption: PreemptionPolicy::NonPreemptive,
+            source_revision: Some(1),
+            idempotency_key: "activation-wait-resume".into(),
+            provenance: ActivationProvenance {
+                origin: ActivationOrigin::System,
+                trust: ActivationTrust::RuntimeInstruction,
+                source_id: "wait-trigger".into(),
+                correlation_id: Some("correlation-wait-resume".into()),
+                causation_id: Some(trigger_id.into()),
+            },
+        };
+        let authority_id = "authority-wait-resume";
+        let authority =
+            ProtocolCommand::IssueActivationAuthority(IssueActivationAuthorityCommand {
+                authority_id: authority_id.into(),
+                activation: activation.clone(),
+                expected_scheduling_generation: scheduling_generation,
+                expected_dispatch_revision: dispatch_revision,
+            });
+        let admission = ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: authority_id.into(),
+            activation,
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision: dispatch_revision,
+        });
+        let mut initial = scheduler_protocol_snapshot(scheduling_generation);
+        initial.work.get_mut("work-a").expect("work").status = WorkStatus::Waiting {
+            wait_id: wait_id.into(),
+        };
+        initial.dispatch = AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: wait_id.into(),
+                generation: wait_generation,
+            },
+        };
+        initial.dispatch_revision = dispatch_revision;
+        initial.waits.insert(
+            wait_id.into(),
+            WaitRecord {
+                current_generation: wait_generation,
+                generations: BTreeMap::from([(
+                    wait_generation,
+                    WaitGenerationRecord {
+                        owner_work_item_id: "work-a".into(),
+                        state: WaitState::Triggered,
+                        trigger: Some(WaitTrigger {
+                            trigger_id: trigger_id.into(),
+                            trigger_generation,
+                        }),
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        );
+
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &initial)?;
+        db.transitions()
+            .commit_scheduler_protocol_command(agent_id, &authority, None)?;
+        let after_authority = db
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        let error = db
+            .transitions()
+            .commit_scheduler_protocol_command(
+                agent_id,
+                &admission,
+                Some(TransitionFaultPoint::AfterCanonicalWrites),
+            )
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected runtime transition fault"),
+            "unexpected wait resume fault: {error}"
+        );
+        assert_eq!(
+            db.transitions()
+                .load_scheduler_protocol_snapshot(agent_id)?,
+            after_authority
+        );
+        let rolled_back: (String, Option<String>) = db.connection()?.query_row(
+            "SELECT lifecycle_state, consuming_activation_id
+             FROM scheduler_wait_generations
+             WHERE agent_id = ?1 AND wait_id = ?2 AND generation = ?3",
+            params![agent_id, wait_id, wait_generation],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(rolled_back, ("triggered".into(), None));
+
+        let committed = db
+            .transitions()
+            .commit_scheduler_protocol_command(agent_id, &admission, None)?;
+        assert_eq!(committed.result.decision, Decision::Admitted);
+        drop(db);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let persisted: (String, Option<String>) = reopened.connection()?.query_row(
+            "SELECT lifecycle_state, consuming_activation_id
+             FROM scheduler_wait_generations
+             WHERE agent_id = ?1 AND wait_id = ?2 AND generation = ?3",
+            params![agent_id, wait_id, wait_generation],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(
+            persisted,
+            ("consumed".into(), Some("activation-wait-resume".into()))
+        );
+        assert_eq!(
+            reopened
+                .transitions()
+                .load_scheduler_protocol_snapshot(agent_id)?
+                .waits[wait_id]
+                .generations[&wait_generation]
+                .consuming_activation_id
+                .as_deref(),
+            Some("activation-wait-resume")
+        );
         Ok(())
     }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -7,6 +7,7 @@ pub(crate) mod scheduler_protocol_repository;
 
 use anyhow::{anyhow, bail, Result};
 use rusqlite::{OptionalExtension, Transaction};
+use std::collections::BTreeMap;
 
 use crate::{
     runtime_db::{
@@ -26,7 +27,7 @@ use crate::{
     types::{
         AgentState, AuditEvent, BriefRecord, MessageEnvelope, QueueEntryRecord, QueueEntryStatus,
         TaskRecord, TranscriptEntry, WaitConditionRecord, WorkItemContinuationFrame,
-        WorkItemRecord, WorkItemState,
+        WorkItemRecord, WorkItemSchedulingState, WorkItemState,
     },
 };
 
@@ -161,7 +162,11 @@ pub(crate) struct QueueTransitionCommand {
     pub agent_id: String,
     pub operation: QueueOperation,
     pub mutation: QueueMutation,
-    pub scheduler_authority_scenarios: Vec<String>,
+    pub scheduler_claim_work_item: Option<WorkItemRecord>,
+    pub scheduler_protocol_bootstrap: Option<crate::domain::scheduler_protocol::Snapshot>,
+    pub scheduler_protocol_commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
+    pub scheduler_authority_scenarios:
+        Vec<crate::domain::scheduler_protocol::SchedulerScenarioClass>,
     pub agent_state: Option<AgentStateMutation>,
     pub message_evidence: Vec<MessageEnvelope>,
     pub transcript_entries: Vec<TranscriptEntry>,
@@ -350,6 +355,18 @@ impl RuntimeTransitionRepository<'_> {
             validate_queue_operation(command)?;
             validate_queue_mutation_tx(tx, &command.mutation)?;
             validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            validate_scheduler_claim_work_item_tx(
+                tx,
+                &command.agent_id,
+                command.operation,
+                command.scheduler_claim_work_item.as_ref(),
+            )?;
+            let scheduler_protocol = scheduler_protocol_repository::validate_protocol_commands_tx(
+                tx,
+                &command.agent_id,
+                command.scheduler_protocol_bootstrap.as_ref(),
+                &command.scheduler_protocol_commands,
+            )?;
             scheduler_protocol_repository::validate_required_shadow_comparisons_tx(
                 tx,
                 &command.scheduler_authority_scenarios,
@@ -395,6 +412,11 @@ impl RuntimeTransitionRepository<'_> {
             if !applied {
                 return Ok(TransitionCommit::default());
             }
+            scheduler_protocol_repository::persist_protocol_commands_tx(
+                tx,
+                &command.agent_id,
+                scheduler_protocol,
+            )?;
             scheduler_protocol_repository::persist_shadow_comparison_tx(
                 tx,
                 &command.agent_id,
@@ -599,6 +621,84 @@ fn validate_focus_target_tx(tx: &Transaction<'_>, state: &AgentState) -> Result<
             format!("cannot focus completed work item {work_item_id}"),
         )
         .with_safe_context("work_item_id", work_item_id)
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_scheduler_claim_work_item_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    operation: QueueOperation,
+    expected: Option<&WorkItemRecord>,
+) -> Result<()> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    if operation != QueueOperation::Claim {
+        return Err(anyhow!(
+            "scheduler WorkItem claim guard is only valid for queue claim"
+        ));
+    }
+    let actual = tx
+        .query_row(
+            "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+            [&expected.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<WorkItemRecord>(&payload))
+        .transpose()?;
+    if actual.as_ref() != Some(expected)
+        || expected.agent_id != agent_id
+        || expected.state != WorkItemState::Open
+    {
+        return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+            "scheduler_claim_work_item",
+            &expected.id,
+        )
+        .into());
+    }
+    let mut statement = tx.prepare(
+        "SELECT payload_json
+         FROM wait_conditions
+         WHERE agent_id = ?1
+           AND work_item_id = ?2
+           AND status = 'active'
+         ORDER BY created_at ASC, wait_condition_id ASC",
+    )?;
+    let active_wait_conditions = statement
+        .query_map([agent_id, expected.id.as_str()], |row| {
+            row.get::<_, String>(0)
+        })?
+        .map(|row| Ok(serde_json::from_str::<WaitConditionRecord>(&row?)?))
+        .collect::<Result<Vec<_>>>()?;
+    let is_yielded = tx.query_row(
+        "SELECT EXISTS(
+               SELECT 1
+               FROM work_item_continuations
+               WHERE agent_id = ?1
+                 AND suspended_work_item_id = ?2
+                 AND state = 'active'
+             )",
+        [agent_id, expected.id.as_str()],
+        |row| row.get::<_, bool>(0),
+    )?;
+    let trigger_delivery_by_id = BTreeMap::new();
+    let scheduling = crate::work_item_scheduling::derive_work_item_scheduling(
+        crate::work_item_scheduling::WorkItemSchedulingFacts {
+            work_item: expected,
+            is_current: false,
+            is_yielded,
+            active_wait_conditions: &active_wait_conditions,
+            trigger_delivery_by_id: &trigger_delivery_by_id,
+        },
+    );
+    if scheduling.scheduling_state != WorkItemSchedulingState::Runnable {
+        return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+            "scheduler_claim_work_item",
+            &expected.id,
+        )
         .into());
     }
     Ok(())
@@ -1205,6 +1305,9 @@ mod tests {
                     agent_id: "agent-a".into(),
                     operation: QueueOperation::Settle,
                     mutation: QueueMutation::Upsert(processed),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
                     scheduler_authority_scenarios: Vec::new(),
                     agent_state: Some(AgentStateMutation {
                         expected: Some(Box::new(initial_state.clone())),
@@ -1229,6 +1332,71 @@ mod tests {
             assert!(db.transcript_entries().all(Some("agent-a"))?.is_empty());
             assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_claim_revalidates_runnable_work_item_inside_transaction() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let work_item = work_item("work-stale-claim");
+        db.work_items().insert_new(&work_item)?;
+        db.wait_conditions().upsert(&wait_condition(
+            "wait-stale-claim",
+            &work_item.id,
+            "task-1",
+        ))?;
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-stale-claim".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&queued)?;
+        let mut claimed = queued.clone();
+        claimed.status = QueueEntryStatus::Dequeued;
+        claimed.updated_at += chrono::Duration::seconds(1);
+
+        let error = db
+            .transitions()
+            .commit_queue(&QueueTransitionCommand {
+                agent_id: "agent-a".into(),
+                operation: QueueOperation::Claim,
+                mutation: QueueMutation::Consume(claimed),
+                scheduler_claim_work_item: Some(work_item.clone()),
+                scheduler_protocol_bootstrap: None,
+                scheduler_protocol_commands: Vec::new(),
+                scheduler_authority_scenarios: Vec::new(),
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                audit_events: vec![AuditEvent::legacy(
+                    "queue_entry_claimed",
+                    serde_json::json!({}),
+                )],
+                scheduler_semantic_shadow: None,
+                scheduler_shadow_comparison: None,
+                scheduler_delivery_shadow_comparison: None,
+                notify_scheduler: false,
+                fault: None,
+                brief_evidence: Vec::new(),
+            })
+            .unwrap_err();
+
+        let conflict = error
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .expect("non-runnable WorkItem claim should return typed conflict");
+        assert_eq!(conflict.domain(), "scheduler_claim_work_item");
+        assert_eq!(conflict.record_id(), work_item.id);
+        assert!(conflict.retryable());
+        assert_eq!(db.queue_entries().latest_all()?, vec![queued]);
+        assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+        assert!(db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized("agent-a")?
+            .is_none());
         Ok(())
     }
 
@@ -1287,7 +1455,12 @@ mod tests {
                     agent_id: "agent-a".into(),
                     operation: QueueOperation::Claim,
                     mutation: QueueMutation::Consume(claimed),
-                    scheduler_authority_scenarios: vec!["reducer_only_candidates".into()],
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    scheduler_authority_scenarios: vec![
+                        crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
+                    ],
                     agent_state: Some(AgentStateMutation {
                         expected: Some(Box::new(initial_state.clone())),
                         record: Box::new(running_state),
@@ -1376,7 +1549,12 @@ mod tests {
             agent_id: "agent-a".into(),
             operation: QueueOperation::Claim,
             mutation: QueueMutation::Consume(claimed.clone()),
-            scheduler_authority_scenarios: vec!["reducer_only_candidates".into()],
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: Vec::new(),
+            scheduler_authority_scenarios: vec![
+                crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
+            ],
             agent_state: None,
             message_evidence: Vec::new(),
             transcript_entries: Vec::new(),
@@ -1464,7 +1642,12 @@ mod tests {
                 agent_id: "agent-a".into(),
                 operation: QueueOperation::Claim,
                 mutation: QueueMutation::Consume(claimed),
-                scheduler_authority_scenarios: vec!["reducer_only_candidates".into()],
+                scheduler_claim_work_item: None,
+                scheduler_protocol_bootstrap: None,
+                scheduler_protocol_commands: Vec::new(),
+                scheduler_authority_scenarios: vec![
+                    crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
+                ],
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -18,7 +18,7 @@ use crate::domain::scheduler_protocol::{
     ProtocolMode, RollbackAction, RollbackTrigger, RolloutCommand, RolloutManifest,
     RolloutPreflightRecord, RolloutPreflightState, RolloutState, ScenarioAuthority,
     ScenarioHardBlockerRecord, ScenarioMode, Snapshot, WaitGenerationRecord, WaitIdentity,
-    WaitRecord, WorkDemand, WorkStatus,
+    WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
 use crate::domain::scheduler_semantic::{
     resolve_semantic_proposal, validate_semantic_decision_input, validate_semantic_provider_config,
@@ -1274,6 +1274,11 @@ fn persist_agent_snapshot_tx(
                 ),
                 None => (None, None),
             };
+            let staged_state = if record.state == WaitState::Consumed {
+                enum_token(&WaitState::Triggered)?
+            } else {
+                enum_token(&record.state)?
+            };
             tx.execute(
                 "INSERT INTO scheduler_wait_generations (
                    agent_id,
@@ -1301,7 +1306,7 @@ fn persist_agent_snapshot_tx(
                     wait_id,
                     to_i64(*generation, "wait generation")?,
                     &record.owner_work_item_id,
-                    enum_token(&record.state)?,
+                    staged_state,
                     trigger_id,
                     trigger_generation,
                     serde_json::to_string(record)?,
@@ -1432,12 +1437,15 @@ fn persist_agent_snapshot_tx(
         for (generation, record) in &wait.generations {
             tx.execute(
                 "UPDATE scheduler_wait_generations
-                 SET consuming_activation_id = ?4, payload_json = ?5
+                 SET lifecycle_state = ?4,
+                     consuming_activation_id = ?5,
+                     payload_json = ?6
                  WHERE agent_id = ?1 AND wait_id = ?2 AND generation = ?3",
                 params![
                     agent_id,
                     wait_id,
                     to_i64(*generation, "wait generation")?,
+                    enum_token(&record.state)?,
                     record.consuming_activation_id.as_deref(),
                     serde_json::to_string(record)?,
                 ],

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -17,8 +17,8 @@ use crate::domain::scheduler_protocol::{
     Decision, MissingSettlementRecord, ProtocolCommand, ProtocolConflict, ProtocolConflictKind,
     ProtocolMode, RollbackAction, RollbackTrigger, RolloutCommand, RolloutManifest,
     RolloutPreflightRecord, RolloutPreflightState, RolloutState, ScenarioAuthority,
-    ScenarioHardBlockerRecord, ScenarioMode, Snapshot, WaitGenerationRecord, WaitIdentity,
-    WaitRecord, WaitState, WorkDemand, WorkStatus,
+    ScenarioHardBlockerRecord, ScenarioMode, SchedulerScenarioClass, Snapshot,
+    WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
 use crate::domain::scheduler_semantic::{
     resolve_semantic_proposal, validate_semantic_decision_input, validate_semantic_provider_config,
@@ -66,6 +66,19 @@ pub(super) struct PreparedSemanticShadowDecision {
     payload_hash: String,
     authority_mode: ScenarioMode,
     already_recorded: bool,
+}
+
+pub(super) struct PreparedProtocolCommands {
+    snapshot: Snapshot,
+    initialized_partition: bool,
+    results: Vec<PreparedProtocolCommandResult>,
+}
+
+struct PreparedProtocolCommandResult {
+    command_kind: &'static str,
+    command_identity: String,
+    payload_hash: String,
+    result: SchedulerProtocolCommandResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -154,20 +167,133 @@ enum CommandTransactionOutcome<T> {
 
 pub(super) fn validate_required_shadow_comparisons_tx(
     tx: &Transaction<'_>,
-    required_scenarios: &[String],
+    required_scenarios: &[SchedulerScenarioClass],
     commands: [Option<&SchedulerShadowComparisonCommand>; 2],
 ) -> Result<()> {
     for scenario_class in required_scenarios {
-        if effective_scenario_mode_tx(tx, scenario_class)? != ScenarioMode::Authoritative {
+        if effective_scenario_mode_tx(tx, scenario_class.as_str())? != ScenarioMode::Authoritative {
             continue;
         }
         let has_evidence = commands
             .iter()
             .flatten()
-            .any(|command| command.scenario_class == *scenario_class);
+            .any(|command| command.scenario_class == scenario_class.as_str());
         if !has_evidence {
-            bail!("scheduler scenario {scenario_class} requires matched canonical evidence");
+            bail!(
+                "scheduler scenario {} requires matched canonical evidence",
+                scenario_class.as_str()
+            );
         }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_protocol_commands_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    bootstrap: Option<&Snapshot>,
+    commands: &[ProtocolCommand],
+) -> Result<Option<PreparedProtocolCommands>> {
+    if commands.is_empty() {
+        return Ok(None);
+    }
+    for command in commands {
+        validate_command_agent(agent_id, command)?;
+    }
+
+    let initialized_partition = !scheduler_protocol_partition_exists_tx(tx, agent_id)?;
+    let mut snapshot = if initialized_partition {
+        let mut snapshot = bootstrap
+            .cloned()
+            .ok_or_else(|| anyhow!("canonical scheduler claim requires bootstrap state"))?;
+        validate_agent_partition(agent_id, &snapshot)?;
+        snapshot.rollout = load_rollout(tx)?;
+        scheduler_protocol::assert_invariants(&snapshot)
+            .map_err(|error| anyhow!("invalid scheduler protocol bootstrap: {error}"))?;
+        snapshot
+    } else {
+        load_snapshot_tx(tx, agent_id)?
+    };
+    let mut results = Vec::new();
+
+    for command in commands {
+        let (command_kind, command_identity) = command_identity(command)?;
+        let payload_hash = canonical_command_hash(command_kind, command)?;
+        if let Some(stored) =
+            stored_command_result_tx(tx, agent_id, command_kind, &command_identity)?
+        {
+            if stored.payload_hash != payload_hash {
+                bail!(
+                    "scheduler protocol command identity conflict for agent {}, command {} {}",
+                    agent_id,
+                    command_kind,
+                    command_identity
+                );
+            }
+            continue;
+        }
+
+        let pre_state_fence = snapshot_fence(&snapshot)?;
+        let outcome = scheduler_protocol::reduce_command(&snapshot, command);
+        scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
+            anyhow!("scheduler protocol reducer produced invalid state: {error}")
+        })?;
+        if outcome.outcome.decision == Decision::Rejected {
+            let code = outcome
+                .conflict
+                .as_ref()
+                .map(|conflict| conflict.code.as_str())
+                .or_else(|| outcome.outcome.diagnostics.first().map(String::as_str))
+                .unwrap_or("rejected_without_diagnostic");
+            bail!("canonical scheduler command {command_kind} rejected: {code}");
+        }
+        let post_state_fence = snapshot_fence(&outcome.outcome.snapshot)?;
+        let decision = outcome.outcome.decision.clone();
+        let result = SchedulerProtocolCommandResult {
+            decision: decision.clone(),
+            conflict: outcome.conflict,
+            transitions: outcome.outcome.transitions,
+            diagnostics: outcome.outcome.diagnostics,
+            fact_references: decision_fact_references(&decision, command_fact_references(command)),
+            pre_state_fence,
+            post_state_fence,
+        };
+        snapshot = outcome.outcome.snapshot;
+        results.push(PreparedProtocolCommandResult {
+            command_kind,
+            command_identity,
+            payload_hash,
+            result,
+        });
+    }
+
+    Ok(Some(PreparedProtocolCommands {
+        snapshot,
+        initialized_partition,
+        results,
+    }))
+}
+
+pub(super) fn persist_protocol_commands_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    prepared: Option<PreparedProtocolCommands>,
+) -> Result<()> {
+    let Some(prepared) = prepared else {
+        return Ok(());
+    };
+    if prepared.initialized_partition || !prepared.results.is_empty() {
+        persist_agent_snapshot_tx(tx, agent_id, &prepared.snapshot)?;
+    }
+    for result in prepared.results {
+        insert_command_result_tx(
+            tx,
+            agent_id,
+            result.command_kind,
+            &result.command_identity,
+            &result.payload_hash,
+            &result.result,
+        )?;
     }
     Ok(())
 }
@@ -261,13 +387,14 @@ pub(super) fn validate_semantic_shadow_decision_tx(
         .validate()
         .map_err(|error| anyhow!("invalid semantic validation policy: {error:?}"))?;
 
-    let authority_mode = effective_scenario_mode_tx(tx, SEMANTIC_OPERATOR_BINDING_SCENARIO)?;
+    let authority_mode =
+        effective_scenario_mode_tx(tx, SEMANTIC_OPERATOR_BINDING_SCENARIO.as_str())?;
     match authority_mode {
         ScenarioMode::Off => return Ok(None),
         ScenarioMode::Authoritative => {
             bail!(
                 "scheduler scenario {} is authoritative, but semantic production authority is not wired",
-                SEMANTIC_OPERATOR_BINDING_SCENARIO
+                SEMANTIC_OPERATOR_BINDING_SCENARIO.as_str()
             );
         }
         ScenarioMode::Shadow => {}
@@ -466,6 +593,21 @@ impl RuntimeTransitionRepository<'_> {
 
     pub(crate) fn load_scheduler_protocol_snapshot(&self, agent_id: &str) -> Result<Snapshot> {
         self.load_scheduler_protocol_snapshot_with_hook(agent_id, || Ok(()))
+    }
+
+    pub(crate) fn load_scheduler_protocol_snapshot_if_initialized(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<Snapshot>> {
+        let connection = self.db.connection()?;
+        let transaction = Transaction::new_unchecked(&connection, TransactionBehavior::Deferred)?;
+        if !scheduler_protocol_partition_exists_tx(&transaction, agent_id)? {
+            transaction.commit()?;
+            return Ok(None);
+        }
+        let snapshot = load_snapshot_tx(&transaction, agent_id)?;
+        transaction.commit()?;
+        Ok(Some(snapshot))
     }
 
     fn load_scheduler_protocol_snapshot_with_hook(
@@ -766,6 +908,9 @@ fn snapshot_fence(snapshot: &Snapshot) -> Result<serde_json::Value> {
 
 fn command_identity(command: &ProtocolCommand) -> Result<(&'static str, String)> {
     Ok(match command {
+        ProtocolCommand::RegisterWorkDemand(command) => {
+            ("register_work_demand", command.work_item_id.clone())
+        }
         ProtocolCommand::IssueActivationAuthority(command) => {
             ("issue_activation_authority", command.authority_id.clone())
         }
@@ -796,6 +941,9 @@ fn canonical_command_hash(command_kind: &str, command: &ProtocolCommand) -> Resu
 
 fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
     match command {
+        ProtocolCommand::RegisterWorkDemand(command) => {
+            vec![format!("work:{}", command.work_item_id)]
+        }
         ProtocolCommand::IssueActivationAuthority(command) => {
             vec![format!("activation_authority:{}", command.authority_id)]
         }
@@ -820,6 +968,7 @@ fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
 
 fn validate_command_agent(agent_id: &str, command: &ProtocolCommand) -> Result<()> {
     let command_agent_id = match command {
+        ProtocolCommand::RegisterWorkDemand(_) => None,
         ProtocolCommand::IssueActivationAuthority(command) => Some(&command.activation.agent_id),
         ProtocolCommand::AdmitActivation(command) => Some(&command.activation.agent_id),
         ProtocolCommand::SettleActivation(_)
@@ -1190,6 +1339,11 @@ fn persist_agent_snapshot_tx(
 
     for (work_item_id, demand) in &snapshot.work {
         let (status, status_reference_id) = work_status_columns(&demand.status);
+        let staged_status = if matches!(demand.status, WorkStatus::Terminal) {
+            "runnable"
+        } else {
+            status
+        };
         tx.execute(
             "INSERT INTO scheduler_work_demands (
                agent_id,
@@ -1221,7 +1375,7 @@ fn persist_agent_snapshot_tx(
                 work_item_id,
                 to_i64(demand.metadata_revision, "work metadata revision")?,
                 to_i64(demand.scheduling_generation, "work scheduling generation")?,
-                status,
+                staged_status,
                 status_reference_id,
                 serde_json::to_string(&demand.capabilities)?,
                 serde_json::to_string(&demand.locks)?,
@@ -1477,6 +1631,20 @@ fn persist_agent_snapshot_tx(
             &now,
         ],
     )?;
+
+    for (work_item_id, demand) in &snapshot.work {
+        if matches!(demand.status, WorkStatus::Terminal) {
+            tx.execute(
+                "UPDATE scheduler_work_demands
+                 SET status = 'terminal',
+                     status_reference_id = NULL,
+                     payload_json = ?3,
+                     updated_at = ?4
+                 WHERE agent_id = ?1 AND work_item_id = ?2",
+                params![agent_id, work_item_id, serde_json::to_string(demand)?, &now,],
+            )?;
+        }
+    }
 
     for (settlement_id, settlement) in &snapshot.settlements {
         tx.execute(

--- a/src/storage/events.rs
+++ b/src/storage/events.rs
@@ -207,6 +207,48 @@ impl RuntimeEventLog {
         result
     }
 
+    pub fn append_many(&self, events: &[AuditEvent]) -> Result<()> {
+        let started = std::time::Instant::now();
+        self.ensure_writable()?;
+        let _guard = self
+            .append_mutex
+            .lock()
+            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        let sink = self
+            .audit_event_index
+            .lock()
+            .map_err(|_| anyhow::anyhow!("audit event index mutex poisoned"))?
+            .clone();
+        let (agent_id, events) = if let Some(sink) = sink {
+            let agent_id = sink.agent_id.clone();
+            let events = sink
+                .runtime_db
+                .audit_events()
+                .append_many(agent_id.as_deref(), events)?;
+            (agent_id, events)
+        } else {
+            let events = self
+                .runtime_db
+                .audit_events()
+                .append_many(self.agent_id.as_deref(), events)?;
+            (self.agent_id.clone(), events)
+        };
+        for event in &events {
+            if let Err(error) = self.publish(agent_id.clone(), event) {
+                tracing::warn!(
+                    error = %error,
+                    event_id = %event.id,
+                    event_kind = %event.kind,
+                    event_seq = event.event_seq,
+                    agent_id = agent_id.as_deref().unwrap_or("<global>"),
+                    "failed to publish committed audit event"
+                );
+            }
+        }
+        crate::diagnostics::record_storage_append_event(started.elapsed());
+        Ok(())
+    }
+
     pub(super) fn append_with_append_mutex_held(&self, event: &AuditEvent) -> Result<()> {
         self.ensure_writable()?;
         let sink = self

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -357,6 +357,10 @@ impl AppStorage {
         self.store.event_log().append(event)
     }
 
+    pub fn append_events(&self, events: &[AuditEvent]) -> Result<()> {
+        self.store.event_log().append_many(events)
+    }
+
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
         self.store.append_brief(brief)
     }

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -116,6 +116,62 @@
           "prompt": "Resume live Docker acceptance case {case_id} after a real holon serve restart. Call ListWorkItems with filter current and include_todo_list=true, then GetWorkItem for {work_item_id} with include_todo_list=true. Confirm it is the same item whose plan contains {plan_marker}. Update that WorkItem to plan_status ready with all three existing todos completed. After UpdateWorkItem succeeds, your very next assistant response must contain an operator-facing text block with a concise completion result and the literal marker {completion_marker}, immediately followed by the CompleteWorkItem tool call for exactly WorkItem {work_item_id} in that same response. The completion text must precede CompleteWorkItem; calling CompleteWorkItem alone and reporting the marker in a later response is a contract failure. Do not place the completion text before UpdateWorkItem, do not put another tool between the completion text and CompleteWorkItem, and do not use transitional text such as \"Now complete it\". Do not create another WorkItem and do not modify project files."
         }
       ]
+    },
+    {
+      "id": "scheduler-autonomous-legacy",
+      "tier": "extended",
+      "tags": ["scheduler", "workitem", "legacy", "restart", "persistence"],
+      "timeout_seconds": 600,
+      "description": "Verify real-LLM autonomous WorkItem scheduling with canonical production commands explicitly disabled.",
+      "scheduler_protocol_commands_enabled": false,
+      "runtime_env": {
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "false"
+      },
+      "phases": [
+        {
+          "id": "autonomous-complete",
+          "required_tools": [
+            "CreateWorkItem",
+            "ListWorkItems",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "forbidden_tools": [
+            "ApplyPatch",
+            "ExecCommand",
+            "WaitFor"
+          ],
+          "prompt": "Scheduler Docker E2E case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: scheduler-seed completed, autonomous-completion pending. Do not PickWorkItem, UpdateWorkItem, CompleteWorkItem, or WaitFor in this operator-triggered turn. After CreateWorkItem succeeds, end this response with a concise acknowledgement. The objective governs the later autonomous work_queue turn. Do not modify files. The expected completion marker is {completion_marker}."
+        }
+      ]
+    },
+    {
+      "id": "scheduler-autonomous-authoritative",
+      "tier": "extended",
+      "tags": ["scheduler", "workitem", "authoritative", "restart", "persistence"],
+      "timeout_seconds": 600,
+      "description": "Verify the feature-flagged canonical production claim and settlement chain through a real-LLM autonomous WorkItem turn.",
+      "scheduler_protocol_commands_enabled": true,
+      "runtime_env": {
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true"
+      },
+      "phases": [
+        {
+          "id": "autonomous-complete",
+          "required_tools": [
+            "CreateWorkItem",
+            "ListWorkItems",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "forbidden_tools": [
+            "ApplyPatch",
+            "ExecCommand",
+            "WaitFor"
+          ],
+          "prompt": "Scheduler Docker E2E case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: scheduler-seed completed, autonomous-completion pending. Do not PickWorkItem, UpdateWorkItem, CompleteWorkItem, or WaitFor in this operator-triggered turn. After CreateWorkItem succeeds, end this response with a concise acknowledgement. The objective governs the later autonomous work_queue turn. Do not modify files. The expected completion marker is {completion_marker}."
+        }
+      ]
     }
   ]
 }

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -11,10 +11,11 @@ use model::{
     ActivationSlot, ActivationState, ActivationTrust, AdmissionCause, AdmitActivationCommand,
     AgentActivation, AgentDispatchDisposition, AgentDispatchState, Decision, Event,
     IssueActivationAuthorityCommand, MissingSettlementRecord, ObservationalDivergenceAllowance,
-    PreemptionPolicy, ProtocolCommand, ProtocolConflictKind, ProtocolMode, RollbackAction,
-    RollbackPolicy, RollbackTrigger, RolloutClassEvidence, RolloutManifest, RolloutPreflightState,
-    RolloutState, ScenarioMode, SettleActivationCommand, Settlement, Snapshot,
-    WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WaitTrigger, WorkDemand, WorkStatus,
+    PreemptionPolicy, ProtocolCommand, ProtocolConflictKind, ProtocolMode,
+    RegisterWorkDemandCommand, RollbackAction, RollbackPolicy, RollbackTrigger,
+    RolloutClassEvidence, RolloutManifest, RolloutPreflightState, RolloutState, ScenarioMode,
+    SettleActivationCommand, Settlement, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord,
+    WaitState, WaitTrigger, WorkDemand, WorkStatus,
 };
 use proptest::prelude::*;
 use serde::Deserialize;
@@ -2243,6 +2244,54 @@ fn typed_settlement_has_one_canonical_identity_and_idempotent_replay() {
         conflicting.outcome.diagnostics,
         ["activation_terminal_settlement_already_recorded"]
     );
+}
+
+#[test]
+fn work_demand_registration_is_typed_idempotent_and_conflict_safe() {
+    let snapshot = minimal_snapshot(1);
+    let demand = WorkDemand {
+        metadata_revision: 3,
+        scheduling_generation: 1,
+        status: WorkStatus::Runnable,
+        capabilities: BTreeSet::from(["workspace_write".into()]),
+        locks: BTreeSet::from(["workspace:holon".into()]),
+        locality: "workspace:holon".into(),
+        cost_class: "standard".into(),
+    };
+    let command = ProtocolCommand::RegisterWorkDemand(RegisterWorkDemandCommand {
+        work_item_id: "work-b".into(),
+        demand: demand.clone(),
+    });
+
+    let registered = reduce_command(&snapshot, &command);
+    assert_eq!(registered.outcome.decision, Decision::WorkDemandRegistered);
+    assert_eq!(registered.outcome.snapshot.work["work-b"], demand);
+    assert_invariants(&registered.outcome.snapshot).expect("registered demand must be canonical");
+
+    let replay = reduce_command(&registered.outcome.snapshot, &command);
+    assert_eq!(replay.outcome.decision, Decision::DuplicateIgnored);
+    assert_eq!(replay.outcome.snapshot, registered.outcome.snapshot);
+
+    let conflicting = reduce_command(
+        &registered.outcome.snapshot,
+        &ProtocolCommand::RegisterWorkDemand(RegisterWorkDemandCommand {
+            work_item_id: "work-b".into(),
+            demand: WorkDemand {
+                metadata_revision: 4,
+                ..registered.outcome.snapshot.work["work-b"].clone()
+            },
+        }),
+    );
+    assert_eq!(conflicting.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        conflicting.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::IdentityConflict
+    );
+    assert_eq!(
+        conflicting.outcome.diagnostics,
+        ["work_demand_registration_conflict"]
+    );
+    assert_eq!(conflicting.outcome.snapshot, registered.outcome.snapshot);
 }
 
 #[test]

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -129,6 +129,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 model="deepseek/deepseek-v4-flash",
                 credential_envs=[],
                 env_file=None,
+                runtime_env={},
                 evidence_root=Path(directory),
                 timeout_seconds=1,
                 keep=False,
@@ -152,6 +153,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 model="deepseek/deepseek-v4-flash",
                 credential_envs=[],
                 env_file=None,
+                runtime_env={},
                 evidence_root=Path(directory),
                 timeout_seconds=1,
                 keep=False,
@@ -177,6 +179,59 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "runtime failure occurred in complete: provider: connection closed",
             ):
                 harness.assert_tools("complete", 3, ["CompleteWorkItem"])
+
+    def test_scheduler_extended_cases_declare_explicit_feature_flag(self) -> None:
+        selected = runner.select_cases(
+            self.manifest, requested=None, suite="extended", tags=["scheduler"]
+        )
+        self.assertEqual(
+            [case["id"] for case in selected],
+            [
+                "scheduler-autonomous-legacy",
+                "scheduler-autonomous-authoritative",
+            ],
+        )
+        self.assertEqual(
+            [
+                (
+                    case["scheduler_protocol_commands_enabled"],
+                    case["runtime_env"][
+                        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS"
+                    ],
+                )
+                for case in selected
+            ],
+            [(False, "false"), (True, "true")],
+        )
+        for case in selected:
+            phase = case["phases"][0]
+            self.assertEqual(
+                phase["required_tools"],
+                [
+                    "CreateWorkItem",
+                    "ListWorkItems",
+                    "UpdateWorkItem",
+                    "CompleteWorkItem",
+                ],
+            )
+            self.assertNotIn("GetWorkItem", phase["required_tools"])
+            self.assertNotIn("PickWorkItem", phase["forbidden_tools"])
+
+    def test_scheduler_queue_oracle_uses_current_processed_state(self) -> None:
+        runner.require_processed_queue_entries(
+            [
+                {"message_id": "other", "status": "queued"},
+                {"message_id": "scheduler-tick", "status": "processed"},
+            ],
+            {"scheduler-tick"},
+        )
+        with self.assertRaisesRegex(
+            AssertionError, "did not reach processed current state"
+        ):
+            runner.require_processed_queue_entries(
+                [{"message_id": "scheduler-tick", "status": "dequeued"}],
+                {"scheduler-tick"},
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

- 修复 canonical `WaitResume` 与 focused completion / continuation restoration 的持久化顺序，避免 authority facts 与 legacy 状态部分提交
- 统一 production Runtime 与 rollout manifest 的 scenario class，并将 primary run-loop typed diagnostic 与 queue mutation 原子提交
- 通过默认关闭的 `HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS` 接入 canonical production bootstrap、claim 与 settlement authority，保留默认 legacy 行为
- 增加 payload CAS guard、事务内 Runnable 重验、成功 claim→settlement 闭环及 settlement fault rollback 回归
- 扩展 Docker E2E runner 与 manifest，以确定性数据库/事件 oracle 覆盖 legacy 与 authoritative scheduler 路径、重启与持久化

## Rollout 边界

- feature flag 缺省为 `false`
- `false`：继续使用现有 legacy production 行为
- `true`：production claim/settlement 同步写入 canonical protocol authority
- 非法布尔值在 bootstrap 阶段直接报错

## 验证

- `make docker-e2e-validate`
- `make ci`
- Docker production image + real LLM `deepseek/deepseek-v4-flash`：
  - `scheduler-autonomous-legacy` PASS
  - `scheduler-autonomous-authoritative` PASS
- rebase 到最新 `origin/main` 后重新执行上述完整质量门并通过

## Review 重点

- canonical claim/settlement 与 legacy queue mutation 的事务边界
- feature flag 关闭时是否严格保持旧行为
- authoritative evidence、payload CAS 与 Runnable revalidation 的 fail-closed 语义
- Docker E2E oracle 是否足以区分真实 canonical authority 链与仅有表面完成状态
