### PR TITLE
fix: make scheduler runtime failures observable

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -894,6 +894,11 @@ after restart. Command and migration result ledgers are loaded before accepting
 new commands so previously rejected stale commands and successful commands
 retain their original outcome.
 
+When bootstrap finds the persisted work-queue message still `Dequeued`, it
+records the missing settlement before terminally aborting that queue claim.
+This releases the canonical slot without replaying the original provider turn
+or tool calls.
+
 An optional serialized snapshot may be stored only as a versioned,
 checksummed recovery cache. Canonical rows remain the source of truth, and the
 cache must be discarded and rebuilt when its schema version, checksum, or
@@ -1229,6 +1234,13 @@ not the authority mechanism. In-flight commands complete only under their
 original authority and revision fences; they are never reinterpreted under the
 new mode.
 
+The production-command environment switch is only a capability ceiling. It
+must not grant authority by itself. A new WorkItem activation requires both
+the WorkItem autonomous-continuation class and the settlement class to be
+authoritative under the installed rollout state. Once admitted, terminal
+settlement remains drainable under the activation's original authority even
+if a hard blocker stops subsequent admissions.
+
 The blocker is an append-only authoritative fact containing the scenario
 class, stable blocker code, configuration/manifest/preflight revisions, and
 the trigger/action that caused rollback. It survives snapshot serialization
@@ -1312,6 +1324,14 @@ Required diagnostics include:
 - stale command conflicts;
 - incomplete rollback prerequisites; and
 - completion intent without terminal publication.
+
+Host supervision must also expose a top-level runtime-loop failure as a
+durable audit event and agent health signal before the failed loop exits.
+Recovery must rebuild a fresh Runtime from canonical storage; it must not rerun
+the same in-memory queue after a partially completed transition.
+Bootstrap diagnostics must report cross-model fractures such as a running
+activation without an active run, a completed WorkItem with a running
+activation, or a terminal Turn whose legacy queue record remains dequeued.
 
 ## Verification
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -2158,8 +2158,15 @@ impl RuntimeHost {
         runtime.enable_memory_index_notify(self.inner.memory_index_notify.clone());
         let runtime_task = tokio::spawn({
             let runtime = runtime.clone();
+            let agent_id = agent_id.to_string();
             async move {
-                let _ = runtime.run().await;
+                if let Err(error) = runtime.clone().run().await {
+                    runtime.record_runtime_loop_failure(&error).await;
+                    tracing::warn!(
+                        agent_id,
+                        "agent runtime loop stopped; the next host access will rebuild it"
+                    );
+                }
             }
         });
         Ok((runtime, runtime_task))
@@ -4769,6 +4776,88 @@ mod tests {
             event.kind == "message_acknowledged"
                 && event.data["summary"].as_str() == Some("Queued work: start me")
         }));
+    }
+
+    #[tokio::test]
+    async fn runtime_loop_failure_releases_claim_and_rebuilds_on_next_host_access() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        let runtime = host.default_runtime().await.unwrap();
+        runtime.inject_runtime_loop_failure_after_next_claim();
+        let message = runtime
+            .enqueue(MessageEnvelope::new(
+                &agent_id,
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "recover claimed message".into(),
+                },
+            ))
+            .await
+            .unwrap();
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let events = runtime.storage().read_recent_events(32).unwrap();
+            let task_finished = host
+                .inner
+                .agents
+                .read()
+                .await
+                .get(&agent_id)
+                .is_some_and(|entry| entry.task.is_finished());
+            if task_finished
+                && events
+                    .iter()
+                    .any(|event| event.kind == "agent_runtime_loop_failed")
+                && runtime
+                    .storage()
+                    .latest_queue_entries()
+                    .unwrap()
+                    .iter()
+                    .any(|entry| {
+                        entry.message_id == message.id
+                            && entry.status == QueueEntryStatus::Interrupted
+                    })
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for runtime loop failure event"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let state = runtime.agent_state().await.unwrap();
+        let failure = state
+            .last_runtime_failure
+            .expect("runtime loop failure should be visible in agent state");
+        assert!(failure
+            .summary
+            .contains("injected agent runtime loop failure after queue claim"));
+
+        let rebuilt = host.get_or_create_agent(&agent_id).await.unwrap();
+        assert_eq!(rebuilt.agent_state().await.unwrap().id, agent_id);
+        wait_for_brief_count(&rebuilt, 1).await;
+        assert!(rebuilt
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .iter()
+            .any(|entry| {
+                entry.message_id == message.id && entry.status == QueueEntryStatus::Processed
+            }));
+        let agents = host.inner.agents.read().await;
+        let entry = agents
+            .get(&agent_id)
+            .expect("rebuilt runtime should be registered");
+        assert!(
+            !entry.task.is_finished(),
+            "next host access should start a fresh runtime loop"
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -274,6 +274,8 @@ struct RuntimeInner {
     #[cfg(test)]
     omit_next_scheduler_claim_shadow_comparison: AtomicBool,
     #[cfg(test)]
+    fail_after_next_runtime_claim: AtomicBool,
+    #[cfg(test)]
     transition_warnings: StdMutex<Vec<PostCommitWarning>>,
 }
 
@@ -696,6 +698,14 @@ impl RuntimeHandle {
                 .swap(true, Ordering::SeqCst),
             "scheduler claim shadow comparison omission is already armed"
         );
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_runtime_loop_failure_after_next_claim(&self) {
+        self.inner
+            .fail_after_next_runtime_claim
+            .store(true, Ordering::SeqCst);
+        self.inner.notify.notify_one();
     }
 
     #[cfg(test)]
@@ -1750,9 +1760,7 @@ impl RuntimeHandle {
             return Ok(Vec::new());
         }
         let Some(message) = self.inner.storage.read_message_by_id(&record.message_id)? else {
-            return Err(anyhow!(
-                "canonical queue settlement requires persisted message evidence"
-            ));
+            return Ok(Vec::new());
         };
         if !matches!(
             (&message.kind, &message.origin),
@@ -1885,6 +1893,8 @@ impl RuntimeHandle {
         scheduler_executor::SchedulerDecisionExecutor::new(&self)
             .bootstrap_recovered()
             .await?;
+        self.recover_scheduler_bootstrap_claims().await?;
+        self.record_scheduler_bootstrap_diagnostics().await?;
 
         loop {
             let poll = scheduler_executor::SchedulerDecisionExecutor::new(&self)
@@ -1965,6 +1975,16 @@ impl RuntimeHandle {
             };
 
             let message = scheduled.message.clone();
+            #[cfg(test)]
+            if self
+                .inner
+                .fail_after_next_runtime_claim
+                .swap(false, Ordering::SeqCst)
+            {
+                return Err(anyhow!(
+                    "injected agent runtime loop failure after queue claim"
+                ));
+            }
             self.append_state_changed_events(&scheduled.running_state)?;
 
             if let Err(err) = self
@@ -2106,6 +2126,367 @@ impl RuntimeHandle {
                 .await?;
             }
         }
+    }
+
+    pub(crate) async fn record_runtime_loop_failure(&self, error: &anyhow::Error) {
+        let descriptor = describe_runtime_error(error);
+        let summary =
+            Self::summarize_runtime_failure_error(&anyhow!(descriptor.operator_message.clone()));
+        let occurred_at = Utc::now();
+        let agent_id = self.inner.agent.lock().await.state.id.clone();
+        let released_claims = match self.release_claimed_messages_for_runtime_restart().await {
+            Ok(released) => released,
+            Err(release_error) => {
+                tracing::error!(
+                    agent_id = %agent_id,
+                    error = %release_error,
+                    "failed to release claimed messages after runtime loop failure"
+                );
+                0
+            }
+        };
+        tracing::error!(
+            agent_id = %agent_id,
+            domain = ?descriptor.domain,
+            code = %descriptor.code,
+            retryable = descriptor.retryable,
+            error = %error,
+            "agent runtime loop failed"
+        );
+        if let Err(persist_error) = self.inner.storage.append_event(&AuditEvent::legacy(
+            "agent_runtime_loop_failed",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "error": summary,
+                "domain": descriptor.domain,
+                "code": descriptor.code,
+                "retryable": descriptor.retryable,
+                "recovery_hint": descriptor.recovery_hint,
+                "safe_context": descriptor.safe_context,
+                "source_chain": descriptor.source_chain,
+                "recovery": "bounded_restart",
+                "released_claims": released_claims,
+            }),
+        )) {
+            tracing::error!(
+                agent_id = %agent_id,
+                error = %persist_error,
+                "failed to persist agent runtime loop failure audit event"
+            );
+        }
+        let mut guard = self.inner.agent.lock().await;
+        guard.state.current_run_id = None;
+        guard.current_run_abort = None;
+        guard.state.last_runtime_failure = Some(RuntimeFailureSummary {
+            occurred_at,
+            summary,
+            phase: RuntimeFailurePhase::RuntimeTurn,
+            detail_hint: Some("the next host access will rebuild the runtime loop".into()),
+            failure_artifact: None,
+        });
+        if let Err(persist_error) = guard.persist_state(&self.inner.storage) {
+            tracing::error!(
+                agent_id = %agent_id,
+                error = %persist_error,
+                "failed to persist agent runtime loop failure state"
+            );
+        }
+    }
+
+    async fn release_claimed_messages_for_runtime_restart(&self) -> Result<usize> {
+        let agent_id = self.inner.agent.lock().await.state.id.clone();
+        let claimed = self
+            .inner
+            .runtime_db
+            .queue_entries()
+            .recent(Some(&agent_id), usize::MAX)?
+            .into_iter()
+            .filter(|entry| entry.status == QueueEntryStatus::Dequeued)
+            .collect::<Vec<_>>();
+        let mut released = 0;
+        for mut entry in claimed {
+            entry.status = QueueEntryStatus::Interrupted;
+            entry.updated_at = Utc::now();
+            let message_id = entry.message_id.clone();
+            let commit = self.inner.runtime_db.transitions().commit_queue(
+                &crate::runtime_db::transitions::QueueTransitionCommand {
+                    agent_id: agent_id.clone(),
+                    operation: crate::runtime_db::transitions::QueueOperation::Release,
+                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    scheduler_authority_scenarios: Vec::new(),
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    audit_events: vec![AuditEvent::legacy(
+                        "queue_claim_released_for_runtime_restart",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "message_id": message_id,
+                            "status": QueueEntryStatus::Interrupted,
+                        }),
+                    )],
+                    scheduler_shadow_comparison: None,
+                    scheduler_delivery_shadow_comparison: None,
+                    scheduler_semantic_shadow: None,
+                    notify_scheduler: true,
+                    fault: None,
+                    brief_evidence: Vec::new(),
+                },
+            )?;
+            if commit.applied {
+                released += 1;
+            }
+            self.apply_transition_commit(commit).await;
+        }
+        Ok(released)
+    }
+
+    async fn recover_scheduler_bootstrap_claims(&self) -> Result<usize> {
+        if !self.scheduler_protocol_production_commands_enabled()
+            || self
+                .inner
+                .runtime_db
+                .transitions()
+                .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
+                != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+        {
+            return Ok(0);
+        }
+
+        let agent_id = self.inner.agent.lock().await.state.id.clone();
+        let Some(snapshot) = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
+        else {
+            return Ok(0);
+        };
+        let claimed = self
+            .inner
+            .runtime_db
+            .queue_entries()
+            .recent(Some(&agent_id), usize::MAX)?
+            .into_iter()
+            .filter(|entry| entry.status == QueueEntryStatus::Dequeued)
+            .collect::<Vec<_>>();
+        let mut recovered = 0;
+
+        for mut entry in claimed {
+            let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
+            let Some(activation) = snapshot.activations.get(&activation_id) else {
+                continue;
+            };
+            if activation.state != crate::domain::scheduler_protocol::ActivationState::Running {
+                continue;
+            }
+            let Some(message) = self.inner.storage.read_message_by_id(&entry.message_id)? else {
+                continue;
+            };
+            if !matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                    if subsystem == "work_queue"
+            ) || message.work_item_id.as_deref() != Some(activation.work_item_id.as_str())
+            {
+                continue;
+            }
+
+            let missing =
+                crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(
+                    crate::domain::scheduler_protocol::MissingSettlementRecord {
+                        id: canonical_missing_settlement_id(&entry.message_id),
+                        activation_id: activation_id.clone(),
+                        created_at: self.now().to_rfc3339(),
+                    },
+                );
+            let protocol_commit = self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_scheduler_protocol_command(&agent_id, &missing, None)?;
+            if !matches!(
+                protocol_commit.result.decision,
+                crate::domain::scheduler_protocol::Decision::SettlementMissing
+                    | crate::domain::scheduler_protocol::Decision::DuplicateIgnored
+            ) {
+                return Err(anyhow!(
+                    "scheduler bootstrap claim recovery was rejected: {}",
+                    protocol_commit.result.diagnostics.join(", ")
+                ));
+            }
+
+            entry.status = QueueEntryStatus::Aborted;
+            entry.updated_at = self.now();
+            let message_id = entry.message_id.clone();
+            let work_item_id = activation.work_item_id.clone();
+            let commit = self.inner.runtime_db.transitions().commit_queue(
+                &crate::runtime_db::transitions::QueueTransitionCommand {
+                    agent_id: agent_id.clone(),
+                    operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    scheduler_authority_scenarios: Vec::new(),
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    audit_events: vec![AuditEvent::legacy(
+                        "scheduler_bootstrap_claim_recovered",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "message_id": message_id,
+                            "activation_id": activation_id,
+                            "work_item_id": work_item_id,
+                            "queue_status": QueueEntryStatus::Aborted,
+                            "activation_status": "settlement_missing",
+                        }),
+                    )],
+                    scheduler_shadow_comparison: None,
+                    scheduler_delivery_shadow_comparison: None,
+                    scheduler_semantic_shadow: None,
+                    notify_scheduler: true,
+                    fault: None,
+                    brief_evidence: Vec::new(),
+                },
+            )?;
+            if commit.applied {
+                recovered += 1;
+            }
+            self.apply_transition_commit(commit).await;
+        }
+        Ok(recovered)
+    }
+
+    async fn record_scheduler_bootstrap_diagnostics(&self) -> Result<()> {
+        const STUCK_ACTIVATION_AGE: chrono::Duration = chrono::Duration::minutes(5);
+
+        let (agent_id, active_run_id) = {
+            let guard = self.inner.agent.lock().await;
+            (guard.state.id.clone(), guard.state.current_run_id.clone())
+        };
+        let Some(snapshot) = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
+        else {
+            return Ok(());
+        };
+        let queue_entries = self
+            .inner
+            .runtime_db
+            .queue_entries()
+            .recent(Some(&agent_id), usize::MAX)?;
+        let turns = self
+            .inner
+            .runtime_db
+            .turn_records()
+            .recent_for_agent(&agent_id, usize::MAX)?;
+        let work_items = self
+            .inner
+            .runtime_db
+            .work_items()
+            .latest_for_agent(&agent_id, usize::MAX)?;
+        let mut events = Vec::new();
+
+        for (activation_id, activation) in snapshot.activations.iter().filter(|(_, activation)| {
+            activation.state == crate::domain::scheduler_protocol::ActivationState::Running
+        }) {
+            let message_id = activation_id
+                .strip_prefix("activation:message:")
+                .map(ToString::to_string);
+            let queue_entry = message_id.as_deref().and_then(|message_id| {
+                queue_entries
+                    .iter()
+                    .find(|entry| entry.message_id == message_id)
+            });
+            let terminal_turn = message_id.as_deref().and_then(|message_id| {
+                turns.iter().find(|turn| {
+                    turn.terminal.is_some()
+                        && turn
+                            .trigger
+                            .as_ref()
+                            .and_then(|trigger| trigger.message_id.as_deref())
+                            == Some(message_id)
+                })
+            });
+            let mut base_evidence = vec![
+                format!("activation_id={activation_id}"),
+                format!("work_item_id={}", activation.work_item_id),
+                format!("admitted_generation={}", activation.admitted_generation),
+            ];
+            if active_run_id.is_none() {
+                events.push(scheduler::scheduler_invariant_diagnostic_event(
+                    &agent_id,
+                    "running_activation_without_active_run",
+                    Some(activation.work_item_id.clone()),
+                    message_id.clone(),
+                    base_evidence.clone(),
+                )?);
+            }
+            if work_items.iter().any(|work_item| {
+                work_item.id == activation.work_item_id
+                    && work_item.state == crate::types::WorkItemState::Completed
+            }) {
+                events.push(scheduler::scheduler_invariant_diagnostic_event(
+                    &agent_id,
+                    "completed_work_item_has_running_activation",
+                    Some(activation.work_item_id.clone()),
+                    message_id.clone(),
+                    base_evidence.clone(),
+                )?);
+            }
+            if let (Some(queue_entry), Some(turn)) = (queue_entry, terminal_turn) {
+                if queue_entry.status == QueueEntryStatus::Dequeued {
+                    let mut evidence = base_evidence.clone();
+                    evidence.push(format!("turn_id={}", turn.turn_id));
+                    evidence.push("queue_status=dequeued".into());
+                    events.push(scheduler::scheduler_invariant_diagnostic_event(
+                        &agent_id,
+                        "terminal_turn_has_dequeued_queue",
+                        Some(activation.work_item_id.clone()),
+                        message_id.clone(),
+                        evidence,
+                    )?);
+                }
+            }
+            if let Some(queue_entry) = queue_entry {
+                let age = self.now().signed_duration_since(queue_entry.updated_at);
+                if age >= STUCK_ACTIVATION_AGE {
+                    base_evidence.push(format!("age_seconds={}", age.num_seconds()));
+                    events.push(scheduler::scheduler_invariant_diagnostic_event(
+                        &agent_id,
+                        "running_activation_age_exceeded",
+                        Some(activation.work_item_id.clone()),
+                        message_id,
+                        base_evidence,
+                    )?);
+                }
+            }
+        }
+
+        if !events.is_empty() {
+            tracing::warn!(
+                agent_id = %agent_id,
+                diagnostic_count = events.len(),
+                "scheduler bootstrap invariants require attention"
+            );
+            let recent_events = self.inner.storage.read_recent_events(128)?;
+            events.retain(|event| {
+                !recent_events
+                    .iter()
+                    .any(|recent| recent.kind == event.kind && recent.data == event.data)
+            });
+        }
+        if !events.is_empty() {
+            self.inner.storage.append_events(&events)?;
+        }
+        Ok(())
     }
 
     async fn bootstrap_recovery(&self) -> Result<()> {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -366,6 +366,8 @@ impl RuntimeHandle {
                 #[cfg(test)]
                 omit_next_scheduler_claim_shadow_comparison: AtomicBool::new(false),
                 #[cfg(test)]
+                fail_after_next_runtime_claim: AtomicBool::new(false),
+                #[cfg(test)]
                 transition_warnings: StdMutex::new(Vec::new()),
             }),
         };

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -997,6 +997,31 @@ pub(crate) fn scheduler_diagnostic_event(
     )
 }
 
+pub(crate) fn scheduler_invariant_diagnostic_event(
+    agent_id: &str,
+    code: &str,
+    work_item_id: Option<String>,
+    message_id: Option<String>,
+    evidence: Vec<String>,
+) -> Result<AuditEvent> {
+    AuditEvent::typed(
+        crate::runtime_event::RuntimeEventKind::SchedulerDiagnostic,
+        &crate::types::SchedulerDiagnosticAuditEvent {
+            agent_id: agent_id.to_string(),
+            decision: "InvariantViolation".into(),
+            reason: code.to_string(),
+            boundary: Some("bootstrap_recovery".into()),
+            scenario_class: None,
+            shadow_matched: None,
+            divergence_code: Some(code.to_string()),
+            work_item_id,
+            message_id,
+            task_id: None,
+            evidence,
+        },
+    )
+}
+
 pub(crate) fn scheduler_decision_events(
     agent_id: &str,
     decision: &SchedulerDecision,

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -518,6 +518,23 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         {
             return Ok(None);
         }
+        if self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .scheduler_scenario_mode(scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO)?
+            != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+            || self
+                .runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
+                != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+        {
+            return Ok(None);
+        }
         if !matches!(
             (&message.kind, &message.origin),
             (MessageKind::SystemTick, MessageOrigin::System { subsystem })
@@ -548,6 +565,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 "canonical work queue claim requires a runnable same-agent WorkItem"
             ));
         }
+        let activation_id = canonical_activation_id(&message.id);
 
         use crate::domain::scheduler_protocol::{
             ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
@@ -563,6 +581,32 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .runtime_db
             .transitions()
             .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
+        if let Some(snapshot) = existing.as_ref() {
+            if let Some(activation) = snapshot.activations.get(&activation_id) {
+                let slot_matches = matches!(
+                    &snapshot.slot,
+                    ActivationSlot::Running {
+                        activation_id: running_activation_id,
+                        work_item_id: running_work_item_id,
+                        ..
+                    } if running_activation_id == &activation_id
+                        && running_work_item_id == work_item_id
+                );
+                if activation.state == crate::domain::scheduler_protocol::ActivationState::Running
+                    && activation.work_item_id == work_item_id
+                    && slot_matches
+                {
+                    return Ok(Some(CanonicalClaimPlan {
+                        work_item,
+                        bootstrap: None,
+                        commands: Vec::new(),
+                    }));
+                }
+                return Err(anyhow!(
+                    "canonical work queue replay references a non-running activation"
+                ));
+            }
+        }
         let new_demand = || WorkDemand {
             metadata_revision: work_item.revision.max(1),
             scheduling_generation: work_item.revision.max(1),
@@ -630,7 +674,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 )
             };
 
-        let activation_id = canonical_activation_id(&message.id);
         let activation = AgentActivation {
             id: activation_id.clone(),
             agent_id: message.agent_id.clone(),

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,6 +1,10 @@
 use super::super::*;
 use super::support::*;
-use crate::domain::scheduler_protocol::{ActivationSlot, SchedulerScenarioClass, WorkStatus};
+use crate::domain::scheduler_protocol::{
+    ActivationSlot, Decision, ObservationalDivergenceAllowance, ProtocolMode, RollbackAction,
+    RollbackPolicy, RollbackTrigger, RolloutClassEvidence, RolloutCommand, RolloutManifest,
+    ScenarioMode, SchedulerScenarioClass, WorkStatus,
+};
 use crate::types::{
     ActiveSkillRecord, AuthorityClass, QueueEntryStatus, SkillActivationSource,
     SkillActivationState, SkillLoadReason, SkillScope, WaitConditionKind, WaitConditionRecord,
@@ -10,6 +14,188 @@ use crate::types::{
 
 struct BlockingProvider {
     started: Arc<tokio::sync::Notify>,
+}
+
+async fn finish_claimed_test_run(runtime: &RuntimeHandle) {
+    let mut guard = runtime.inner.agent.lock().await;
+    scheduler::apply_idle_projection(&mut guard.state, &runtime.inner.storage).unwrap();
+    guard.current_run_abort = None;
+    guard.persist_state(&runtime.inner.storage).unwrap();
+}
+
+fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
+    let evidence = |items: &[&str]| {
+        ["restart", "fault_injection", "rollback_drill"]
+            .into_iter()
+            .chain(items.iter().copied())
+            .map(ToString::to_string)
+            .collect::<std::collections::BTreeSet<_>>()
+    };
+    let classes = [
+        (
+            SchedulerScenarioClass::WorkItemAutonomousContinuation,
+            2_000,
+            14 * 24 * 60 * 60,
+            evidence(&[
+                "concurrent_claim",
+                "reservation_conflict",
+                "yield_return",
+                "work_item_rollback",
+            ]),
+        ),
+        (
+            SchedulerScenarioClass::Settlement,
+            1_000,
+            7 * 24 * 60 * 60,
+            evidence(&[
+                "duplicate_settlement",
+                "missing_settlement_recovery",
+                "restart_before_settlement_commit",
+            ]),
+        ),
+    ]
+    .into_iter()
+    .map(
+        |(scenario, minimum_shadow_samples, minimum_shadow_duration_secs, evidence)| {
+            (
+                scenario.as_str().to_string(),
+                RolloutClassEvidence {
+                    configured_mode: ScenarioMode::Authoritative,
+                    minimum_shadow_samples,
+                    minimum_shadow_duration_secs,
+                    observed_shadow_samples: minimum_shadow_samples,
+                    observed_shadow_duration_secs: minimum_shadow_duration_secs,
+                    maximum_p99_latency_regression_bps: 500,
+                    observed_p99_latency_regression_bps: 0,
+                    hard_blocker_count: 0,
+                    unresolved_divergence_count: 0,
+                    required_evidence: evidence.clone(),
+                    verified_evidence: evidence,
+                    rollback_policy: RollbackPolicy {
+                        trigger: RollbackTrigger::AnyHardBlocker,
+                        action: RollbackAction::StopAdmissionsAndRevert {
+                            target: ScenarioMode::Shadow,
+                        },
+                    },
+                },
+            )
+        },
+    )
+    .collect();
+    let manifest = RolloutManifest {
+        revision: 1,
+        preflight_revision: 1,
+        preflight_for_manifest_revision: 1,
+        preflight_succeeded: true,
+        protocol_build: "holon-test".into(),
+        schema_build: "scheduler-protocol-schema-v1".into(),
+        schema_revision: 1,
+        fixture_corpus_revision: "runtime-state-production-authority-v1".into(),
+        classes,
+        safety_divergence_bps: 0,
+        canonical_state_divergence_bps: 0,
+        allowed_observational_divergence: std::collections::BTreeMap::from([(
+            "diagnostic_order".into(),
+            ObservationalDivergenceAllowance {
+                maximum_rate_bps: 0,
+                reviewed_by: "runtime-test".into(),
+            },
+        )]),
+        approver: "runtime-test".into(),
+        approved_at: "2026-07-23T00:00:00Z".into(),
+    };
+    let commands = [
+        (
+            "open",
+            RolloutCommand::OpenPreflight {
+                expected_config_revision: 0,
+                manifest_revision: 1,
+            },
+            Decision::RolloutPreflightOpened,
+        ),
+        (
+            "complete",
+            RolloutCommand::CompletePreflight {
+                expected_config_revision: 0,
+                expected_preflight_revision: 1,
+                manifest: manifest.clone(),
+            },
+            Decision::RolloutPreflightCompleted,
+        ),
+        (
+            "install",
+            RolloutCommand::InstallManifest {
+                expected_config_revision: 0,
+                manifest,
+            },
+            Decision::ManifestInstalled,
+        ),
+        (
+            "protocol",
+            RolloutCommand::ConfigureProtocol {
+                expected_config_revision: 1,
+                mode: ProtocolMode::Authoritative,
+            },
+            Decision::ProtocolConfigured,
+        ),
+        (
+            "continuation-shadow",
+            RolloutCommand::ChangeScenarioAuthority {
+                scenario_class: SchedulerScenarioClass::WorkItemAutonomousContinuation
+                    .as_str()
+                    .into(),
+                expected_config_revision: 2,
+                expected_manifest_revision: 1,
+                expected_preflight_revision: 1,
+                mode: ScenarioMode::Shadow,
+            },
+            Decision::ScenarioAuthorityChanged,
+        ),
+        (
+            "continuation-authoritative",
+            RolloutCommand::ChangeScenarioAuthority {
+                scenario_class: SchedulerScenarioClass::WorkItemAutonomousContinuation
+                    .as_str()
+                    .into(),
+                expected_config_revision: 3,
+                expected_manifest_revision: 1,
+                expected_preflight_revision: 1,
+                mode: ScenarioMode::Authoritative,
+            },
+            Decision::ScenarioAuthorityChanged,
+        ),
+        (
+            "settlement-shadow",
+            RolloutCommand::ChangeScenarioAuthority {
+                scenario_class: SchedulerScenarioClass::Settlement.as_str().into(),
+                expected_config_revision: 4,
+                expected_manifest_revision: 1,
+                expected_preflight_revision: 1,
+                mode: ScenarioMode::Shadow,
+            },
+            Decision::ScenarioAuthorityChanged,
+        ),
+        (
+            "settlement-authoritative",
+            RolloutCommand::ChangeScenarioAuthority {
+                scenario_class: SchedulerScenarioClass::Settlement.as_str().into(),
+                expected_config_revision: 5,
+                expected_manifest_revision: 1,
+                expected_preflight_revision: 1,
+                mode: ScenarioMode::Authoritative,
+            },
+            Decision::ScenarioAuthorityChanged,
+        ),
+    ];
+    for (identity, command, expected) in commands {
+        let committed = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .commit_scheduler_rollout_command(identity, &command, None)
+            .unwrap();
+        assert_eq!(committed.result.decision, expected);
+    }
 }
 
 struct OperatorInterjectionProbeProvider {
@@ -581,6 +767,265 @@ async fn run_loop_claim_fault_rolls_back_scheduler_events_with_claim_facts() {
 }
 
 #[tokio::test]
+async fn legacy_mode_with_production_capability_does_not_write_canonical_scheduler_state() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    let work_item = runtime
+        .create_work_item("legacy capability ceiling".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "remain on legacy authority".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id);
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_diagnostics_report_cross_model_scheduler_invariant_failures() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item("diagnose stuck activation".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "claim and leave unsettled".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    finish_claimed_test_run(&runtime).await;
+
+    let mut completed = runtime
+        .inner
+        .runtime_db
+        .work_items()
+        .latest(&work_item.id)
+        .unwrap()
+        .unwrap();
+    let expected_revision = completed.revision;
+    completed.revision += 1;
+    completed.state = WorkItemState::Completed;
+    completed.updated_at = Utc::now();
+    assert!(runtime
+        .inner
+        .runtime_db
+        .work_items()
+        .update_expected(&completed, expected_revision)
+        .unwrap());
+
+    let mut turn = crate::types::TurnRecord::new("default", "turn-stuck", 1);
+    turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
+    turn.terminal = Some(crate::types::TurnTerminalSummary {
+        kind: crate::types::TurnTerminalKind::Completed,
+        reason: None,
+        completed_at: Utc::now(),
+        duration_ms: 1,
+    });
+    runtime.storage().append_turn(&turn).unwrap();
+
+    runtime
+        .record_scheduler_bootstrap_diagnostics()
+        .await
+        .unwrap();
+
+    let reasons = runtime
+        .storage()
+        .read_recent_events(64)
+        .unwrap()
+        .into_iter()
+        .filter(|event| event.kind == "scheduler_diagnostic")
+        .filter_map(|event| event.data["reason"].as_str().map(ToString::to_string))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(reasons.contains("running_activation_without_active_run"));
+    assert!(reasons.contains("completed_work_item_has_running_activation"));
+    assert!(reasons.contains("terminal_turn_has_dequeued_queue"));
+}
+
+#[tokio::test]
+async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settlement() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "recover stale canonical claim".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "claim before restart".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    finish_claimed_test_run(&runtime).await;
+
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    assert_eq!(
+        snapshot
+            .activations
+            .get(&activation_id)
+            .map(|activation| activation.state.clone()),
+        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing)
+    );
+    assert_eq!(
+        snapshot
+            .work
+            .get(&work_item.id)
+            .map(|demand| &demand.status),
+        Some(&WorkStatus::NeedsSettlement {
+            activation_id: activation_id.clone(),
+        })
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Aborted)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(32)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_bootstrap_claim_recovered"
+                && event.data["message_id"] == message.id
+                && event.data["activation_id"] == activation_id
+        }));
+}
+
+#[tokio::test]
 async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -598,6 +1043,7 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
     )
     .unwrap();
     runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
     let work_item = runtime
         .create_work_item("canonical production loop".into(), None, None, Vec::new())
         .await
@@ -645,6 +1091,7 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
     );
     assert!(claimed.activations.contains_key(&activation_id));
 
+    finish_claimed_test_run(&runtime).await;
     runtime
         .commit_queue_settlement(
             QueueEntryRecord {
@@ -721,6 +1168,7 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_canonical_fac
         )
         .unwrap();
         runtime.set_scheduler_protocol_production_commands_enabled(true);
+        enable_production_protocol_authority(&runtime);
         let work_item = runtime
             .create_work_item(
                 "canonical settlement rollback".into(),
@@ -755,6 +1203,7 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_canonical_fac
             .transitions()
             .load_scheduler_protocol_snapshot("default")
             .unwrap();
+        finish_claimed_test_run(&runtime).await;
         runtime.inject_next_transition_fault(fault);
 
         let error = runtime

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -1414,7 +1414,7 @@ mod tests {
             .initialize_scheduler_protocol_partition(agent_id, &initial)?;
         let committed = db
             .transitions()
-            .commit_scheduler_protocol_command(agent_id, &command, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &command, None)?;
         assert!(committed.applied);
         assert!(!committed.replayed);
         assert_eq!(committed.result.decision, Decision::AuthorityIssued);
@@ -1429,7 +1429,7 @@ mod tests {
         );
         let replayed = reopened
             .transitions()
-            .commit_scheduler_protocol_command(agent_id, &command, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &command, None)?;
         assert!(!replayed.applied);
         assert!(replayed.replayed);
         assert_eq!(replayed.result, committed.result);
@@ -1446,6 +1446,33 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(ledger_rows, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_protocol_command_requires_authoritative_rollout_scenario() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let agent_id = "agent-a";
+        let initial = scheduler_protocol_snapshot(1);
+        let command = scheduler_protocol_authority_command(agent_id, 1);
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &initial)?;
+
+        let error = db
+            .transitions()
+            .commit_scheduler_protocol_command(agent_id, &command, None)
+            .unwrap_err();
+
+        assert!(error.to_string().contains(
+            "scheduler protocol production commands require authoritative scenario \
+             work_item_autonomous_continuation"
+        ));
+        assert_eq!(
+            db.transitions()
+                .load_scheduler_protocol_snapshot(agent_id)?,
+            initial
+        );
         Ok(())
     }
 
@@ -1533,13 +1560,13 @@ mod tests {
         db.transitions()
             .initialize_scheduler_protocol_partition(agent_id, &initial)?;
         db.transitions()
-            .commit_scheduler_protocol_command(agent_id, &authority, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &authority, None)?;
         let after_authority = db
             .transitions()
             .load_scheduler_protocol_snapshot(agent_id)?;
         let error = db
             .transitions()
-            .commit_scheduler_protocol_command(
+            .commit_scheduler_protocol_command_unchecked_for_test(
                 agent_id,
                 &admission,
                 Some(TransitionFaultPoint::AfterCanonicalWrites),
@@ -1567,7 +1594,7 @@ mod tests {
 
         let committed = db
             .transitions()
-            .commit_scheduler_protocol_command(agent_id, &admission, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
         assert_eq!(committed.result.decision, Decision::Admitted);
         drop(db);
 
@@ -1609,12 +1636,12 @@ mod tests {
         db.transitions()
             .initialize_scheduler_protocol_partition(agent_id, &initial)?;
         db.transitions()
-            .commit_scheduler_protocol_command(agent_id, &authority, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &authority, None)?;
         db.transitions()
-            .commit_scheduler_protocol_command(agent_id, &admission, None)?;
-        let committed =
-            db.transitions()
-                .commit_scheduler_protocol_command(agent_id, &completion, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
+        let committed = db
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &completion, None)?;
         assert_eq!(committed.result.decision, Decision::Settled);
 
         let persisted = db
@@ -1657,12 +1684,12 @@ mod tests {
         db.transitions()
             .initialize_scheduler_protocol_partition(agent_id, &initial)?;
         db.transitions()
-            .commit_scheduler_protocol_command(agent_id, &authority, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &authority, None)?;
         db.transitions()
-            .commit_scheduler_protocol_command(agent_id, &admission, None)?;
-        let committed =
-            db.transitions()
-                .commit_scheduler_protocol_command(agent_id, &completion, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
+        let committed = db
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &completion, None)?;
         assert_eq!(committed.result.decision, Decision::Settled);
 
         let persisted = db
@@ -1699,7 +1726,11 @@ mod tests {
 
             let error = db
                 .transitions()
-                .commit_scheduler_protocol_command(agent_id, &command, Some(fault))
+                .commit_scheduler_protocol_command_unchecked_for_test(
+                    agent_id,
+                    &command,
+                    Some(fault),
+                )
                 .unwrap_err();
             assert!(
                 error
@@ -1732,7 +1763,7 @@ mod tests {
 
             let retried = db
                 .transitions()
-                .commit_scheduler_protocol_command(agent_id, &command, None)?;
+                .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &command, None)?;
             assert!(retried.applied);
             assert!(!retried.replayed);
             assert_eq!(
@@ -1754,7 +1785,7 @@ mod tests {
         db.transitions()
             .initialize_scheduler_protocol_partition(agent_id, &initial)?;
         db.transitions()
-            .commit_scheduler_protocol_command(agent_id, &command, None)?;
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &command, None)?;
 
         let mut conflicting_command = command.clone();
         let ProtocolCommand::IssueActivationAuthority(conflicting_authority) =
@@ -1765,7 +1796,11 @@ mod tests {
         conflicting_authority.expected_dispatch_revision = 1;
         let error = db
             .transitions()
-            .commit_scheduler_protocol_command(agent_id, &conflicting_command, None)
+            .commit_scheduler_protocol_command_unchecked_for_test(
+                agent_id,
+                &conflicting_command,
+                None,
+            )
             .unwrap_err();
         let conflict = error
             .downcast_ref::<SchedulerProtocolCommandIdentityConflict>()

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -89,6 +89,7 @@ pub(crate) enum QueueOperation {
     Admit,
     Claim,
     Interject,
+    Release,
     Settle,
 }
 
@@ -361,6 +362,10 @@ impl RuntimeTransitionRepository<'_> {
                 command.operation,
                 command.scheduler_claim_work_item.as_ref(),
             )?;
+            scheduler_protocol_repository::validate_protocol_command_authority_tx(
+                tx,
+                &command.scheduler_protocol_commands,
+            )?;
             let scheduler_protocol = scheduler_protocol_repository::validate_protocol_commands_tx(
                 tx,
                 &command.agent_id,
@@ -380,7 +385,7 @@ impl RuntimeTransitionRepository<'_> {
                 QueueMutation::Consume(record) => match command.operation {
                     QueueOperation::Claim => try_claim_queued_message_tx(tx, record)?,
                     QueueOperation::Interject => try_interject_queued_message_tx(tx, record)?,
-                    QueueOperation::Admit | QueueOperation::Settle => {
+                    QueueOperation::Admit | QueueOperation::Release | QueueOperation::Settle => {
                         unreachable!("queue operation validation rejects this combination")
                     }
                 },
@@ -889,6 +894,12 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
             QueueOperation::Interject,
             QueueMutation::Consume(QueueEntryRecord {
                 status: QueueEntryStatus::Interjected,
+                ..
+            })
+        ) | (
+            QueueOperation::Release,
+            QueueMutation::Upsert(QueueEntryRecord {
+                status: QueueEntryStatus::Interrupted,
                 ..
             })
         ) | (

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -188,6 +188,72 @@ pub(super) fn validate_required_shadow_comparisons_tx(
     Ok(())
 }
 
+pub(super) fn validate_protocol_command_authority_tx(
+    tx: &Transaction<'_>,
+    commands: &[ProtocolCommand],
+) -> Result<()> {
+    let mut required_scenarios = BTreeSet::new();
+    for command in commands {
+        match command {
+            ProtocolCommand::RegisterWorkDemand(_) => {
+                required_scenarios.insert(SchedulerScenarioClass::WorkItemAutonomousContinuation);
+            }
+            ProtocolCommand::IssueActivationAuthority(command) => {
+                required_scenarios.insert(activation_authority_scenario(&command.activation));
+                required_scenarios.insert(SchedulerScenarioClass::Settlement);
+            }
+            ProtocolCommand::AdmitActivation(command) => {
+                required_scenarios.insert(activation_authority_scenario(&command.activation));
+                required_scenarios.insert(SchedulerScenarioClass::Settlement);
+            }
+            ProtocolCommand::TriggerWait(_) => {
+                required_scenarios.insert(SchedulerScenarioClass::ExactWaitResume);
+            }
+            ProtocolCommand::SettleActivation(_) | ProtocolCommand::RecordMissingSettlement(_) => {
+                // Terminal commands drain authority granted when the activation was admitted.
+            }
+        }
+    }
+    for required_scenario in required_scenarios {
+        let mode = effective_scenario_mode_tx(tx, required_scenario.as_str())?;
+        if mode != ScenarioMode::Authoritative {
+            bail!(
+                "scheduler protocol production commands require authoritative scenario {}, got {:?}",
+                required_scenario.as_str(),
+                mode
+            );
+        }
+    }
+    Ok(())
+}
+
+fn activation_authority_scenario(
+    activation: &scheduler_protocol::AgentActivation,
+) -> SchedulerScenarioClass {
+    match &activation.cause {
+        ActivationCause::OperatorInput { .. } => match activation.binding {
+            scheduler_protocol::ActivationBinding::WorkItem { .. } => {
+                SchedulerScenarioClass::ExplicitlyBoundOperatorInput
+            }
+            _ => SchedulerScenarioClass::OrdinarySemanticOperatorBinding,
+        },
+        ActivationCause::OperatorInterjection { .. } => {
+            SchedulerScenarioClass::OperatorInterjection
+        }
+        ActivationCause::MessageIngress { .. } => SchedulerScenarioClass::ReducerOnlyCandidates,
+        ActivationCause::TaskRejoin { .. } => SchedulerScenarioClass::ExactTaskRejoin,
+        ActivationCause::WaitResume { .. } => SchedulerScenarioClass::ExactWaitResume,
+        ActivationCause::WorkItemRunnable { .. }
+        | ActivationCause::WorkItemRecheck { .. }
+        | ActivationCause::InternalFollowup { .. } => {
+            SchedulerScenarioClass::WorkItemAutonomousContinuation
+        }
+        ActivationCause::RuntimeRecovery { .. } | ActivationCause::SettlementRecovery { .. } => {
+            SchedulerScenarioClass::Settlement
+        }
+    }
+}
+
 pub(super) fn validate_protocol_commands_tx(
     tx: &Transaction<'_>,
     agent_id: &str,
@@ -572,6 +638,14 @@ fn scenario_mode_token(mode: ScenarioMode) -> &'static str {
 }
 
 impl RuntimeTransitionRepository<'_> {
+    pub(crate) fn scheduler_scenario_mode(
+        &self,
+        scenario_class: SchedulerScenarioClass,
+    ) -> Result<ScenarioMode> {
+        self.db
+            .transaction(|tx| effective_scenario_mode_tx(tx, scenario_class.as_str()))
+    }
+
     pub(crate) fn initialize_scheduler_protocol_partition(
         &self,
         agent_id: &str,
@@ -638,11 +712,34 @@ impl RuntimeTransitionRepository<'_> {
         command: &ProtocolCommand,
         fault: Option<TransitionFaultPoint>,
     ) -> Result<SchedulerProtocolTransitionCommit> {
+        self.commit_scheduler_protocol_command_inner(agent_id, command, fault, true)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn commit_scheduler_protocol_command_unchecked_for_test(
+        &self,
+        agent_id: &str,
+        command: &ProtocolCommand,
+        fault: Option<TransitionFaultPoint>,
+    ) -> Result<SchedulerProtocolTransitionCommit> {
+        self.commit_scheduler_protocol_command_inner(agent_id, command, fault, false)
+    }
+
+    fn commit_scheduler_protocol_command_inner(
+        &self,
+        agent_id: &str,
+        command: &ProtocolCommand,
+        fault: Option<TransitionFaultPoint>,
+        enforce_authority: bool,
+    ) -> Result<SchedulerProtocolTransitionCommit> {
         validate_command_agent(agent_id, command)?;
         let (command_kind, command_identity) = command_identity(command)?;
         let payload_hash = canonical_command_hash(command_kind, command)?;
 
         let outcome = self.db.transaction(|tx| {
+            if enforce_authority {
+                validate_protocol_command_authority_tx(tx, std::slice::from_ref(command))?;
+            }
             if let Some(stored) =
                 stored_command_result_tx(tx, agent_id, command_kind, &command_identity)?
             {


### PR DESCRIPTION
## 摘要

- 将顶层 runtime loop failure 写入 durable audit/health 状态，并在下一次 host access 时从 canonical storage 重建 Runtime
- 在 bootstrap/recovery 中诊断 canonical/legacy 跨模型 stuck invariants，并对 dequeued canonical activation 记录 missing settlement 后释放 claim
- 将 production command 环境开关限定为 capability ceiling；只有 rollout state 同时授权 autonomous continuation 与 settlement 时才允许 canonical admission
- 增加 deterministic regression tests，并同步 scheduler RFC 合同

## 为什么

P0 rollout 需要在 runtime loop 失败、canonical/legacy 状态断裂以及配置误用时保持故障可见、恢复有界，且不能让环境 capability 绕过正式 rollout authority。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`（2456 passed，0 failed，1 ignored）
