### PR TITLE
fix: make brief hydration retryable

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1640,6 +1640,40 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "BatchGetBriefsRequest": {
+        "properties": {
+          "brief_ids": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "title": "BatchGetBriefsRequest",
+        "type": "object"
+      },
+      "BatchGetBriefsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "briefs": {
+            "items": {
+              "$ref": "#/components/schemas/BriefRecord"
+            },
+            "type": "array"
+          },
+          "missing_brief_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "briefs"
+        ],
+        "type": "object"
+      },
       "BatchGetMessagesRequest": {
         "properties": {
           "message_ids": {
@@ -7825,6 +7859,74 @@
           }
         ],
         "summary": "Brief detail",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/api/agents/{agent_id}/briefs:batchGet": {
+      "post": {
+        "description": "Return persisted briefs for the selected agent. Missing or cross-agent ids are reported in missing_brief_ids.",
+        "operationId": "agentBriefsBatchGet",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchGetBriefsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchGetBriefsResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Batch get briefs",
         "tags": [
           "agents"
         ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,12 +11,12 @@ use crate::{
     daemon::{RuntimeShutdownResponse, RuntimeStatusResponse},
     diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
-        AttachWorkspaceRequest, BatchGetMessagesRequest, BatchGetMessagesResponse,
-        BatchGetTranscriptEntriesRequest, BatchGetTranscriptEntriesResponse,
-        ClearAgentModelRequest, ControlPromptRequest, CreateAgentRequest, DebugPromptRequest,
-        DetachWorkspaceRequest, ExitWorkspaceRequest, ModelConfigMigrationRequest,
-        RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
-        SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
+        AttachWorkspaceRequest, BatchGetBriefsRequest, BatchGetBriefsResponse,
+        BatchGetMessagesRequest, BatchGetMessagesResponse, BatchGetTranscriptEntriesRequest,
+        BatchGetTranscriptEntriesResponse, ClearAgentModelRequest, ControlPromptRequest,
+        CreateAgentRequest, DebugPromptRequest, DetachWorkspaceRequest, ExitWorkspaceRequest,
+        ModelConfigMigrationRequest, RuntimeConfigReadResponse, RuntimeConfigUpdateRequest,
+        RuntimeConfigUpdateResponse, SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
     },
     http_dto::AgentStateSnapshotDto,
     model_catalog::BuiltInModelMetadata,
@@ -473,6 +473,18 @@ impl LocalClient {
     pub async fn agent_brief(&self, agent_id: &str, brief_id: &str) -> Result<BriefRecord> {
         self.get_json(&format!("/agents/{agent_id}/briefs/{brief_id}"))
             .await
+    }
+
+    pub async fn agent_briefs_batch_get(
+        &self,
+        agent_id: &str,
+        brief_ids: Vec<String>,
+    ) -> Result<BatchGetBriefsResponse> {
+        self.post_json(
+            &format!("/agents/{agent_id}/briefs:batchGet"),
+            &BatchGetBriefsRequest { brief_ids },
+        )
+        .await
     }
 
     pub async fn agent_transcript(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -82,13 +82,13 @@ pub(crate) use crate::{
     system::{ExecutionScopeKind, HostLocalBoundary},
     types::{
         AdmissionContext, AgentRegistryStatus, AgentState, AgentVisibility, AuditEvent,
-        AuthorityClass, CallbackDeliveryPayload, CallbackDeliveryResult, ControlAction,
-        ExternalTriggerStateSnapshot, MessageBody, MessageDeliverySurface, MessageEnvelope,
-        MessageKind, MessageOrigin, OperatorTransportBinding, OperatorTransportBindingStatus,
-        OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TaskStatusSnapshot,
-        TaskStopResult, TodoItem, TranscriptEntry, TurnTerminalRecord, WaitingReason,
-        WorkItemPlanStatus, WorkItemRecord, WorkItemState,
+        AuthorityClass, BriefRecord, CallbackDeliveryPayload, CallbackDeliveryResult,
+        ControlAction, ExternalTriggerStateSnapshot, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, OperatorTransportBinding,
+        OperatorTransportBindingStatus, OperatorTransportCapabilities,
+        OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskStatus,
+        TaskStatusSnapshot, TaskStopResult, TodoItem, TranscriptEntry, TurnTerminalRecord,
+        WaitingReason, WorkItemPlanStatus, WorkItemRecord, WorkItemState,
     },
 };
 mod agents;
@@ -126,9 +126,9 @@ pub use skills::{
     remove_skill_from_catalog, skills_catalog, uninstall_skill,
 };
 pub use state::{
-    agent_state, brief, briefs, briefs_default, enqueue, enqueue_default, state_default, status,
-    status_default, transcript, transcript_batch_get, transcript_default, transcript_entry,
-    worktree_summary, worktree_summary_default,
+    agent_state, brief, briefs, briefs_batch_get, briefs_default, enqueue, enqueue_default,
+    state_default, status, status_default, transcript, transcript_batch_get, transcript_default,
+    transcript_entry, worktree_summary, worktree_summary_default,
 };
 pub use tasks::{
     cancel_timer, complete_work_item, create_command_task, create_timer, create_work_item,
@@ -349,6 +349,10 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/enqueue", post(state::enqueue))
         .route("/agents/{agent_id}/status", get(state::status))
         .route("/agents/{agent_id}/briefs", get(state::briefs))
+        .route(
+            "/agents/{agent_id}/briefs:batchGet",
+            post(state::briefs_batch_get),
+        )
         .route("/agents/{agent_id}/briefs/{brief_id}", get(state::brief))
         .route("/agents/{agent_id}/state", get(state::agent_state))
         .route("/events/stream", get(events::global_events_stream))

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -1052,6 +1052,50 @@ pub async fn brief(
     Ok(Json(brief))
 }
 
+pub async fn briefs_batch_get(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<BatchGetBriefsRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let brief_ids = request
+        .brief_ids
+        .into_iter()
+        .filter(|brief_id| !brief_id.is_empty())
+        .fold(Vec::new(), |mut brief_ids, brief_id| {
+            if !brief_ids.contains(&brief_id) {
+                brief_ids.push(brief_id);
+            }
+            brief_ids
+        });
+    let briefs_by_id = runtime
+        .briefs_by_ids(&brief_ids)
+        .await
+        .map_err(error_response)?
+        .into_iter()
+        .filter(|brief| brief.agent_id == agent_id)
+        .map(|brief| (brief.id.clone(), brief))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut briefs = Vec::new();
+    let mut missing_brief_ids = Vec::new();
+    for brief_id in brief_ids {
+        match briefs_by_id.get(&brief_id) {
+            Some(brief) => briefs.push(brief.clone()),
+            None => missing_brief_ids.push(brief_id),
+        }
+    }
+    Ok(Json(BatchGetBriefsResponse {
+        briefs,
+        missing_brief_ids,
+    }))
+}
+
 pub async fn transcript_default(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -243,6 +243,19 @@ pub struct BatchGetMessagesResponse {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct BatchGetBriefsRequest {
+    #[serde(default)]
+    pub brief_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BatchGetBriefsResponse {
+    pub briefs: Vec<BriefRecord>,
+    #[serde(default)]
+    pub missing_brief_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct BatchGetTranscriptEntriesRequest {
     #[serde(default)]
     pub entry_ids: Vec<String>,

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -8,11 +8,11 @@ use serde_json::{json, Value};
 use crate::{
     diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
-        BatchGetMessagesRequest, BatchGetTranscriptEntriesRequest, CancelTimerRequest,
-        CompleteWorkItemRequest, CreateTimerRequest, MemoryGetRequest, ModelConfigMigrationRequest,
-        PickWorkItemRequest, PickWorkItemResponse, RuntimeConfigReadResponse,
-        RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse, SearchRequest, SearchResponse,
-        UpdateWorkItemRequest,
+        BatchGetBriefsRequest, BatchGetMessagesRequest, BatchGetTranscriptEntriesRequest,
+        CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest, MemoryGetRequest,
+        ModelConfigMigrationRequest, PickWorkItemRequest, PickWorkItemResponse,
+        RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
+        SearchRequest, SearchResponse, UpdateWorkItemRequest,
     },
     http_dto::{AgentStateSnapshotDto, SlimTaskDto, SlimWorkItemDto},
     memory::MemoryGetResult,
@@ -73,6 +73,7 @@ const ROUTES: &[RouteSpec] = &[
     aide_route("get", "/agents/list", "listAgents", "agents", "List agents", "Return lightweight public agent entries.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/status", "agentStatus", "agents", "Agent status", "Return the public AgentSummary read model.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/briefs", "agentBriefs", "agents", "Recent briefs", "Return recent user-facing delivery briefs. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route_with_response("post", "/agents/{agent_id}/briefs:batchGet", "agentBriefsBatchGet", "agents", "Batch get briefs", "Return persisted briefs for the selected agent. Missing or cross-agent ids are reported in missing_brief_ids.", Some("BatchGetBriefsRequest"), "BatchGetBriefsResponse", AuthKind::RemoteAccess),
     route_with_response("get", "/agents/{agent_id}/briefs/{brief_id}", "agentBrief", "agents", "Brief detail", "Return a persisted user-facing delivery brief by id.", None, "BriefRecord", AuthKind::RemoteAccess),
     route_with_response("get", "/agents/{agent_id}/state", "agentState", "agents", "Agent state snapshot", "Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.", None, "AgentStateSnapshotDto", AuthKind::RemoteAccess),
     event_stream_route("get", "/events/stream", "eventsStream", "events", "Global event stream", "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor. If the receiver lags, the server closes the stream; clients must backfill each agent from its last contiguous event_seq before reconnecting.", None, AuthKind::RemoteAccess),
@@ -694,12 +695,34 @@ fn component_schemas() -> Value {
         component_schema::<AddSkillRequest>(),
     );
     schemas.insert(
+        "BatchGetBriefsRequest".into(),
+        component_schema::<BatchGetBriefsRequest>(),
+    );
+    schemas.insert(
         "BatchGetMessagesRequest".into(),
         component_schema::<BatchGetMessagesRequest>(),
     );
     schemas.insert(
         "BatchGetTranscriptEntriesRequest".into(),
         component_schema::<BatchGetTranscriptEntriesRequest>(),
+    );
+    schemas.insert(
+        "BatchGetBriefsResponse".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "briefs": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/BriefRecord" }
+                },
+                "missing_brief_ids": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["briefs"],
+            "additionalProperties": false
+        }),
     );
     schemas.insert(
         "BatchGetMessagesResponse".into(),

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -19,6 +19,10 @@ impl RuntimeHandle {
         self.inner.storage.read_brief_by_id(brief_id)
     }
 
+    pub async fn briefs_by_ids(&self, brief_ids: &[String]) -> Result<Vec<BriefRecord>> {
+        self.inner.storage.read_briefs_by_ids(brief_ids)
+    }
+
     pub async fn recent_operator_messages(
         &self,
         limit: usize,

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -2228,6 +2228,13 @@ impl EvidenceRepository<'_> {
             .transpose()
     }
 
+    pub fn briefs_by_ids(&self, agent_id: &str, brief_ids: &[String]) -> Result<Vec<BriefRecord>> {
+        self.payloads_by_ids(EvidenceKind::Brief, agent_id, brief_ids)?
+            .into_iter()
+            .map(|row| serde_json::from_str(&row.payload_json).map_err(Into::into))
+            .collect()
+    }
+
     pub fn recent_tool_executions(
         &self,
         agent_id: &str,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -550,6 +550,13 @@ impl AppStorage {
             .brief_by_id(&self.storage_agent_id()?, brief_id);
     }
 
+    pub fn read_briefs_by_ids(&self, brief_ids: &[String]) -> Result<Vec<BriefRecord>> {
+        let runtime_db = self.runtime_db.clone();
+        runtime_db
+            .evidence()
+            .briefs_by_ids(&self.storage_agent_id()?, brief_ids)
+    }
+
     pub fn read_recent_messages(&self, limit: usize) -> Result<Vec<MessageEnvelope>> {
         let runtime_db = self.runtime_db.clone();
         return runtime_db

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -18,6 +18,7 @@ http_async_tests!(
     runtime_search_route_returns_memory_search_results,
     runtime_search_route_filters_memory_results_by_agent_ids,
     agent_brief_route_returns_full_brief_by_id,
+    agent_briefs_batch_get_returns_found_missing_and_scoped_briefs,
     agent_state_route_scopes_work_items_to_requested_agent,
     agent_state_route_does_not_prune_stale_workspaces,
     agent_state_route_includes_bootstrap_projection_fields_when_present,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -86,7 +86,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 96, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 97, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -905,6 +905,28 @@
   },
   {
     "method": "post",
+    "path": "/api/agents/{agent_id}/briefs:batchGet",
+    "handler": "briefs_batch_get",
+    "operation_id": "agentBriefsBatchGet",
+    "tag": "agents",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "BatchGetBriefsRequest",
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/api/agents/{agent_id}/enqueue",
     "handler": "enqueue",
     "operation_id": "enqueueAgent",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -346,6 +346,39 @@ pub async fn agent_brief_route_returns_full_brief_by_id() -> Result<()> {
     Ok(())
 }
 
+pub async fn agent_briefs_batch_get_returns_found_missing_and_scoped_briefs() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+    let first = BriefRecord::new("default", BriefKind::Result, "first brief", None, None);
+    let second = BriefRecord::new("default", BriefKind::Failure, "second brief", None, None);
+    let other_agent = BriefRecord::new("other-agent", BriefKind::Result, "scoped out", None, None);
+    runtime.storage().append_brief(&first)?;
+    runtime.storage().append_brief(&second)?;
+    runtime.storage().append_brief(&other_agent)?;
+
+    let response = client
+        .post(format!("{base}/api/agents/default/briefs:batchGet"))
+        .json(&serde_json::json!({
+            "brief_ids": [second.id, "missing-brief", other_agent.id, first.id, second.id, ""]
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = response.json().await?;
+    let briefs = body["briefs"].as_array().expect("briefs array");
+    assert_eq!(briefs.len(), 2);
+    assert_eq!(briefs[0]["id"], second.id);
+    assert_eq!(briefs[1]["id"], first.id);
+    assert_eq!(
+        body["missing_brief_ids"],
+        serde_json::json!(["missing-brief", other_agent.id])
+    );
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn unloaded_agent_state_route_uses_storage_without_starting_runtime() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let agent_id = host.config().default_agent_id.clone();

--- a/web-gui/app/src/features/agent/AgentTimeline.test.tsx
+++ b/web-gui/app/src/features/agent/AgentTimeline.test.tsx
@@ -1,9 +1,10 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import i18next from "i18next";
 
 import "../../i18n";
 import type { AgentTimelineActivity } from "../../runtime/types";
-import { ActivityTrail } from "./AgentTimeline";
+import { ActivityTrail, BriefHydrationStatus } from "./AgentTimeline";
 
 function activity(overrides: Partial<AgentTimelineActivity> = {}): AgentTimelineActivity {
   return {
@@ -68,5 +69,42 @@ describe("ActivityTrail", () => {
     expect(markup).toContain('data-status="running"');
     expect(markup).toContain("is-spinning");
     expect(markup).not.toContain("Task queued");
+  });
+});
+
+describe("BriefHydrationStatus", () => {
+  it("renders a localized loading state without a retry button", async () => {
+    await i18next.changeLanguage("en");
+    const markup = renderToStaticMarkup(
+      <BriefHydrationStatus
+        hydration={{ briefId: "brief-1", status: "loading", attempt: 1 }}
+        onRetry={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Loading full result");
+    expect(markup).not.toContain("<button");
+  });
+
+  it("renders localized retry actions for failed and not found states", async () => {
+    await i18next.changeLanguage("zh-CN");
+    const failed = renderToStaticMarkup(
+      <BriefHydrationStatus
+        hydration={{ briefId: "brief-1", status: "failed", attempt: 3 }}
+        onRetry={() => undefined}
+      />,
+    );
+    const notFound = renderToStaticMarkup(
+      <BriefHydrationStatus
+        hydration={{ briefId: "brief-2", status: "not_found", attempt: 1 }}
+        onRetry={() => undefined}
+      />,
+    );
+
+    expect(failed).toContain("完整结果加载失败");
+    expect(failed).toContain("重试");
+    expect(notFound).toContain("未找到完整结果");
+    expect(notFound).toContain("重试");
+    await i18next.changeLanguage("en");
   });
 });

--- a/web-gui/app/src/features/agent/AgentTimeline.tsx
+++ b/web-gui/app/src/features/agent/AgentTimeline.tsx
@@ -112,6 +112,7 @@ const TimelineMessage = memo(function TimelineMessage({
   const isRuntimeItem = isRuntimeActivityItem(item);
   const selectedAgentId = useRuntimeStore((s) => s.selectedAgentId);
   const showFileBrowser = useRuntimeStore((s) => s.showFileBrowser);
+  const retryBriefHydration = useRuntimeStore((s) => s.retryBriefHydration);
   const activities =
     isRuntimeItem && item.meta === "activity"
       ? (item.activities ?? [])
@@ -156,6 +157,12 @@ const TimelineMessage = memo(function TimelineMessage({
       <div className="bubble">
         <TimelineItemContent item={item} />
         <TimelineItemDetail detail={item.detail} />
+        {item.briefHydration ? (
+          <BriefHydrationStatus
+            hydration={item.briefHydration}
+            onRetry={() => selectedAgentId && retryBriefHydration(selectedAgentId, item.briefHydration!.briefId)}
+          />
+        ) : null}
       </div>
       <div className="message-actions" aria-label={t("agent.messageActions")}>
         <button className="message-action" type="button" title={t("agent.copyMessage")} onClick={() => copyMessageText(item.body)}>
@@ -204,6 +211,34 @@ function extractWorkspaceImageRefs(text: string): WorkspaceImageRef[] {
 }
 function TimelineItemContent({ item }: { item: AgentTimelineItem }) {
   return <MarkdownContent text={item.body} compact={false} />;
+}
+
+export function BriefHydrationStatus({
+  hydration,
+  onRetry,
+}: {
+  hydration: NonNullable<AgentTimelineItem["briefHydration"]>;
+  onRetry: () => void;
+}) {
+  const { t } = useTranslation();
+  const isLoading = hydration.status === "loading";
+  const label = isLoading
+    ? t("agentPage.briefLoading")
+    : hydration.status === "not_found"
+      ? t("agentPage.briefNotFound")
+      : t("agentPage.briefLoadFailed");
+  return (
+    <div className={`brief-hydration-status is-${hydration.status}`} role="status">
+      {isLoading ? <LoaderCircle className="is-spinning" size={14} /> : <CircleAlert size={14} />}
+      <span>{label}</span>
+      {!isLoading ? (
+        <button type="button" onClick={onRetry}>
+          <RefreshCw size={13} />
+          {t("agentPage.retryBrief")}
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 function TimelineItemDetail({ detail, compact = false }: { detail?: AgentTimelineItem["detail"]; compact?: boolean }) {

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -352,6 +352,10 @@ const en = {
     },
     assistantMessage: "Assistant message",
     action: "Action",
+    briefLoading: "Loading full result…",
+    briefLoadFailed: "Could not load the full result.",
+    briefNotFound: "The full result was not found.",
+    retryBrief: "Retry",
   },
   settings: {
     title: "Settings",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -354,6 +354,10 @@ const zh: Record<string, any> = {
     },
     assistantMessage: "助手消息",
     action: "操作",
+    briefLoading: "正在加载完整结果…",
+    briefLoadFailed: "完整结果加载失败。",
+    briefNotFound: "未找到完整结果。",
+    retryBrief: "重试",
   },
   settings: {
     title: "设置",

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -929,12 +929,15 @@ describe("createRuntimeClient", () => {
           missing_entry_ids: [],
         });
       }
-      if (url.endsWith("/agents/agent-one/briefs/brief-123")) {
+      if (url.endsWith("/agents/agent-one/briefs:batchGet")) {
         return Response.json({
-          id: "brief-123",
-          text: "Canonical persisted brief.",
-          kind: "result",
-          created_at: "2026-07-10T00:00:00Z",
+          briefs: [{
+            id: "brief-123",
+            text: "Canonical persisted brief.",
+            kind: "result",
+            created_at: "2026-07-10T00:00:00Z",
+          }],
+          missing_brief_ids: [],
         });
       }
       return new Response("not found", { status: 404 });
@@ -971,6 +974,6 @@ describe("createRuntimeClient", () => {
         body: "Canonical persisted brief.",
       }),
     );
-    expect(seen).toContain("http://example.test:7878/api/agents/agent-one/briefs/brief-123");
+    expect(seen).toContain("http://example.test:7878/api/agents/agent-one/briefs:batchGet");
   });
 });

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -494,6 +494,11 @@ interface AgentTranscriptEntriesBatchGetResponseDto {
   missing_entry_ids?: string[];
 }
 
+interface AgentBriefsBatchGetResponseDto {
+  briefs?: RuntimeBriefRecord[];
+  missing_brief_ids?: string[];
+}
+
 interface SkillCatalogEntryDto {
   skill_id?: string;
   root_id?: string;
@@ -1282,7 +1287,9 @@ async function fetchBriefRecordsForEvents(
     ),
   );
   if (!briefIds.length) return {};
-  return fetchBriefRecordsById(baseUrl, fetchImpl, headers, agentId, briefIds).then((r) => r.recordsById);
+  return fetchBriefRecordsById(baseUrl, fetchImpl, headers, agentId, briefIds)
+    .then((r) => r.recordsById)
+    .catch(() => ({}));
 }
 
 interface BriefFetchResult {
@@ -1297,29 +1304,17 @@ async function fetchBriefRecordsById(
   agentId: string,
   briefIds: string[],
 ): Promise<BriefFetchResult> {
-  const results = await Promise.all(
-    briefIds.map(async (briefId): Promise<{ briefId: string; record?: RuntimeBriefRecord; notFound?: boolean }> => {
-      const path = `/agents/${encodeURIComponent(agentId)}/briefs/${encodeURIComponent(briefId)}`;
-      try {
-        const record = await getJson<RuntimeBriefRecord>(fetchImpl, baseUrl, path, { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers });
-        return { briefId, record };
-      } catch (error) {
-        if (error instanceof RuntimeHttpError && error.status === 404) return { briefId, notFound: true };
-        // Transient failure (timeout, network, 5xx): leave absent for retry.
-        return { briefId };
-      }
-    }),
+  const response = await postJson<AgentBriefsBatchGetResponseDto>(
+    fetchImpl,
+    baseUrl,
+    `/agents/${encodeURIComponent(agentId)}/briefs:batchGet`,
+    { brief_ids: Array.from(new Set(briefIds)) },
+    headers,
   );
-  const recordsById: Record<string, RuntimeBriefRecord> = {};
-  const notFoundIds: string[] = [];
-  for (const result of results) {
-    if (result.notFound) {
-      notFoundIds.push(result.briefId);
-    } else if (result.record?.id) {
-      recordsById[result.record.id] = result.record;
-    }
-  }
-  return { recordsById, notFoundIds };
+  return {
+    recordsById: Object.fromEntries((response.briefs ?? []).flatMap((brief) => brief.id ? [[brief.id, brief]] : [])),
+    notFoundIds: response.missing_brief_ids ?? [],
+  };
 }
 
 function streamAgentEvents(

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -81,6 +81,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agents/{agent_id}/briefs:batchGet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch get briefs
+         * @description Return persisted briefs for the selected agent. Missing or cross-agent ids are reported in missing_brief_ids.
+         */
+        post: operations["agentBriefsBatchGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/agents/{agent_id}/enqueue": {
         parameters: {
             query?: never;
@@ -2311,6 +2331,15 @@ export interface components {
         AttachWorkspaceRequest: {
             [key: string]: unknown;
         };
+        /** BatchGetBriefsRequest */
+        BatchGetBriefsRequest: {
+            /** @default [] */
+            brief_ids: string[];
+        };
+        BatchGetBriefsResponse: {
+            briefs: components["schemas"]["BriefRecord"][];
+            missing_brief_ids?: string[];
+        };
         /** BatchGetMessagesRequest */
         BatchGetMessagesRequest: {
             /** @default [] */
@@ -4045,6 +4074,51 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BriefRecord"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentBriefsBatchGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchGetBriefsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchGetBriefsResponse"];
                 };
             };
             /** @description Client error JSON response. */

--- a/web-gui/app/src/runtime/object-renderers.ts
+++ b/web-gui/app/src/runtime/object-renderers.ts
@@ -66,6 +66,22 @@ export function renderDomainObject(
     detail: projection.detail,
     rawEvent: event,
     debug: ctx.includeDebug ? JSON.stringify(event, null, 2) : undefined,
+    briefHydration: briefHydrationForEvent(eventType, payload, ctx),
+  };
+}
+
+function briefHydrationForEvent(
+  eventType: string,
+  payload: Record<string, unknown> | undefined,
+  ctx: RenderContext,
+): AgentTimelineItem["briefHydration"] {
+  if (eventType !== "brief_created") return undefined;
+  const briefId = stringField(payload, "brief_id") ?? stringField(payload, "id");
+  if (!briefId || stringField(payload, "text") || ctx.briefRecordsById?.[briefId]?.text) return undefined;
+  return ctx.briefHydrationById?.[briefId] ?? {
+    briefId,
+    status: "loading",
+    attempt: 0,
   };
 }
 
@@ -277,4 +293,12 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : undefined;
+}
+
+function stringField(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -624,6 +624,47 @@ describe("brief projection and hydration", () => {
 
     expect(missingBriefIdsForHydration(session)).toEqual(["brief-123"]);
   });
+
+  it("tracks loading, transient failure, manual retry, and not found brief states", () => {
+    let projection = reduceSessionProjection(createSessionProjectionState(), {
+      type: "briefs_hydration_started",
+      briefIds: ["brief-123"],
+    });
+    expect(projection.briefHydrationById["brief-123"]).toEqual({
+      briefId: "brief-123",
+      status: "loading",
+      attempt: 1,
+    });
+
+    projection = reduceSessionProjection(projection, {
+      type: "briefs_hydration_failed",
+      briefIds: ["brief-123"],
+      errorKind: "request_failed",
+    });
+    expect(projection.briefHydrationById["brief-123"]).toEqual({
+      briefId: "brief-123",
+      status: "failed",
+      attempt: 1,
+      errorKind: "request_failed",
+    });
+
+    projection = reduceSessionProjection(projection, {
+      type: "briefs_hydration_started",
+      briefIds: ["brief-123"],
+    });
+    expect(projection.briefHydrationById["brief-123"]?.attempt).toBe(2);
+
+    projection = reduceSessionProjection(projection, {
+      type: "briefs_hydrated",
+      recordsById: {},
+      missingIds: ["brief-123"],
+    });
+    expect(projection.briefHydrationById["brief-123"]).toEqual({
+      briefId: "brief-123",
+      status: "not_found",
+      attempt: 2,
+    });
+  });
 });
 
 describe("optimistic operator prompt reconciliation", () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -376,6 +376,7 @@ export interface RuntimeStoreState {
   ) => Promise<void>;
   refreshAgentWorkItems: (agentId: string | undefined) => Promise<void>;
   refreshAgentState: (agentId: string | undefined) => Promise<void>;
+  retryBriefHydration: (agentId: string, briefId: string) => void;
   loadAgentWorkItemDetail: (agentId: string | undefined, workItemId: string | undefined) => Promise<void>;
   loadAgentTaskDetail: (agentId: string | undefined, taskId: string | undefined, force?: boolean) => Promise<void>;
   loadAgentToolExecutionDetail: (agentId: string | undefined, toolExecutionId: string | undefined, fallbackActivity?: AgentTimelineActivity) => Promise<void>;
@@ -493,6 +494,7 @@ const globalEventRecovery = new EventGapRecoveryTracker();
 const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
+const briefHydrationRetryTimers = new Map<string, number>();
 const inspectorDetailInFlight = new Set<string>();
 const workItemRefreshInFlight = new Set<string>();
 const workItemDetailInFlight = new Set<string>();
@@ -515,6 +517,7 @@ const GLOBAL_STREAM_STALE_TIMEOUT_MS = 45_000;
 const GLOBAL_BACKFILL_LIMIT = 100;
 const AGENT_VALIDATION_TTL_MS = 60_000;
 const RESUME_RECONCILIATION_THRESHOLD_MS = 60_000;
+const BRIEF_HYDRATION_RETRY_DELAYS_MS = [1_000, 2_000] as const;
 
 function nextClientGeneration(): number {
   clientGeneration += 1;
@@ -544,6 +547,8 @@ function clearInFlightHydration(): void {
   messageHydrationInFlight.clear();
   transcriptHydrationInFlight.clear();
   briefHydrationInFlight.clear();
+  for (const timer of briefHydrationRetryTimers.values()) window.clearTimeout(timer);
+  briefHydrationRetryTimers.clear();
 }
 
 function cancelClientGenerationWork(): void {
@@ -2509,6 +2514,24 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }
   },
 
+  retryBriefHydration: (agentId, briefId) => {
+    const displayLevel = get().displayLevelsByAgentId[agentId] ?? get().displayLevel;
+    const trace = createRuntimeTrace("object.hydration", {
+      agentId,
+      trigger: "brief.hydration.manual_retry",
+    });
+    startRuntimeSpan(trace, "object.hydration", {
+      resource: "brief",
+      retry: "manual",
+      idCount: 1,
+    }).end("ok");
+    scheduleBriefHydration(get, set, agentId, displayLevel, {
+      forceIds: [briefId],
+      trace,
+      trigger: "manual",
+    });
+  },
+
   loadAgentWorkItemDetail: async (agentId, workItemId) => {
     if (!agentId || !workItemId) return;
     const request = captureClientRequest();
@@ -4380,9 +4403,14 @@ function scheduleBriefHydration(
   set: StoreSet,
   agentId: string,
   displayLevel: DisplayLevel,
+  options: {
+    forceIds?: string[];
+    trace?: RuntimeTraceContext;
+    trigger?: "automatic" | "manual" | "scheduled";
+  } = {},
 ): void {
   const session = get().sessionsByAgentId[agentId];
-  const briefIds = missingBriefIdsForHydration(session);
+  const briefIds = options.forceIds ?? missingBriefIdsForHydration(session);
   if (!briefIds.length) return;
 
   let inFlight = briefHydrationInFlight.get(agentId);
@@ -4393,11 +4421,18 @@ function scheduleBriefHydration(
   const requestIds = briefIds.filter((briefId) => !inFlight.has(briefId));
   if (!requestIds.length) return;
   requestIds.forEach((briefId) => inFlight.add(briefId));
+  set((state) => updateBriefHydrationState(state, agentId, {
+    type: "briefs_hydration_started",
+    briefIds: requestIds,
+  }, displayLevel));
 
   const hydrationSpan = startRuntimeSpan(
-    createRuntimeTrace("object.hydration", { agentId, trigger: "brief.hydration" }),
+    options.trace ?? createRuntimeTrace("object.hydration", {
+      agentId,
+      trigger: `brief.hydration.${options.trigger ?? "automatic"}`,
+    }),
     "object.hydration",
-    { resource: "brief", idCount: requestIds.length },
+    { resource: "brief", idCount: requestIds.length, retry: options.trigger ?? "automatic" },
   );
   const generation = clientGeneration;
   void runtimeClient
@@ -4405,19 +4440,21 @@ function scheduleBriefHydration(
     .then(({ recordsById, notFoundIds }) => {
       if (!isCurrentClientGeneration(generation)) return;
       set((state) => mergeHydratedBriefRecordsIntoSession(state, agentId, recordsById, notFoundIds, displayLevel));
-      hydrationSpan.end("ok", { returnedCount: Object.keys(recordsById).length });
+      hydrationSpan.end("ok", {
+        returnedCount: Object.keys(recordsById).length,
+        notFoundCount: notFoundIds.length,
+      });
     })
     .catch((error) => {
       if (!isCurrentClientGeneration(generation)) return;
-      set((state) => ({
-        sessionsByAgentId: {
-          ...state.sessionsByAgentId,
-          [agentId]: {
-            ...(state.sessionsByAgentId[agentId] ?? emptyAgentSession()),
-            historyError: error instanceof Error ? error.message : String(error),
-          },
-        },
-      }));
+      const errorKind = briefHydrationErrorKind(error);
+      set((state) => updateBriefHydrationState(state, agentId, {
+        type: "briefs_hydration_failed",
+        briefIds: requestIds,
+        errorKind,
+      }, displayLevel));
+      hydrationSpan.end("error", { errorKind });
+      scheduleAutomaticBriefHydrationRetry(get, set, agentId, requestIds, displayLevel);
     })
     .finally(() => {
       if (!isCurrentClientGeneration(generation)) return;
@@ -4426,6 +4463,55 @@ function scheduleBriefHydration(
       requestIds.forEach((briefId) => current.delete(briefId));
       if (!current.size) briefHydrationInFlight.delete(agentId);
     });
+}
+
+function updateBriefHydrationState(
+  state: RuntimeStoreState,
+  agentId: string,
+  action: Extract<SessionProjectionAction, { type: "briefs_hydration_started" | "briefs_hydration_failed" }>,
+  displayLevel: DisplayLevel,
+): Partial<RuntimeStoreState> {
+  const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+  return {
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: applyProjectionAction(current, action, displayLevel),
+    },
+  };
+}
+
+function scheduleAutomaticBriefHydrationRetry(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  briefIds: string[],
+  displayLevel: DisplayLevel,
+): void {
+  const retryIds = briefIds.filter((briefId) => {
+    const attempt = get().sessionsByAgentId[agentId]?.briefHydrationById[briefId]?.attempt ?? 1;
+    return attempt <= BRIEF_HYDRATION_RETRY_DELAYS_MS.length;
+  });
+  if (!retryIds.length) return;
+  const key = `${agentId}:${retryIds.join(",")}`;
+  if (briefHydrationRetryTimers.has(key)) return;
+  const attempt = Math.max(...retryIds.map((briefId) =>
+    get().sessionsByAgentId[agentId]?.briefHydrationById[briefId]?.attempt ?? 1
+  ));
+  const delay = BRIEF_HYDRATION_RETRY_DELAYS_MS[Math.max(0, attempt - 1)];
+  const timer = window.setTimeout(() => {
+    briefHydrationRetryTimers.delete(key);
+    scheduleBriefHydration(get, set, agentId, displayLevel, {
+      forceIds: retryIds,
+      trigger: "scheduled",
+    });
+  }, delay);
+  briefHydrationRetryTimers.set(key, timer);
+}
+
+function briefHydrationErrorKind(error: unknown): string {
+  if (error instanceof DOMException && error.name === "AbortError") return "timeout";
+  if (error instanceof Error && /timeout|aborted/i.test(error.message)) return "timeout";
+  return "request_failed";
 }
 
 export function agentBriefPatchFromEvents(

--- a/web-gui/app/src/runtime/session-projection.ts
+++ b/web-gui/app/src/runtime/session-projection.ts
@@ -9,6 +9,7 @@ import { cloneSessionState, createSessionState, type SessionState } from "./sess
 import { deriveTimelineView } from "./timeline-view-model";
 import type {
   AgentTimelineItem,
+  BriefHydrationViewState,
   DisplayLevel,
   RuntimeBriefRecord,
   RuntimeMessageEnvelope,
@@ -39,6 +40,7 @@ export interface SessionProjectionState {
   missingTranscriptEntryIds: Record<string, true>;
   briefRecordsById: Record<string, RuntimeBriefRecord>;
   missingBriefIds: Record<string, true>;
+  briefHydrationById: Record<string, BriefHydrationViewState>;
   referencedMessageIds: Record<string, true>;
   referencedTranscriptEntryIds: Record<string, true>;
   referencedBriefIds: Record<string, true>;
@@ -81,6 +83,15 @@ export type SessionProjectionAction =
       missingIds: string[];
     }
   | {
+      type: "briefs_hydration_started";
+      briefIds: string[];
+    }
+  | {
+      type: "briefs_hydration_failed";
+      briefIds: string[];
+      errorKind: string;
+    }
+  | {
       type: "reset";
       eventLogEpoch?: string;
       reason?: SessionProjectionState["invalidatedReason"];
@@ -102,6 +113,7 @@ export function createSessionProjectionState(eventLogEpoch?: string): SessionPro
     missingTranscriptEntryIds: {},
     briefRecordsById: {},
     missingBriefIds: {},
+    briefHydrationById: {},
     referencedMessageIds: {},
     referencedTranscriptEntryIds: {},
     referencedBriefIds: {},
@@ -171,11 +183,53 @@ export function reduceSessionProjection(
     }
     case "briefs_hydrated": {
       const briefRecordsById = { ...current.briefRecordsById, ...action.recordsById };
+      const briefHydrationById = { ...current.briefHydrationById };
+      for (const briefId of Object.keys(action.recordsById)) {
+        briefHydrationById[briefId] = {
+          briefId,
+          status: "resolved",
+          attempt: briefHydrationById[briefId]?.attempt ?? 1,
+        };
+      }
+      for (const briefId of action.missingIds) {
+        briefHydrationById[briefId] = {
+          briefId,
+          status: "not_found",
+          attempt: briefHydrationById[briefId]?.attempt ?? 1,
+        };
+      }
       return {
         ...current,
         briefRecordsById,
+        briefHydrationById,
         missingBriefIds: mergeMissingIds(current.missingBriefIds, action.missingIds, Object.keys(briefRecordsById)),
       };
+    }
+    case "briefs_hydration_started": {
+      const briefHydrationById = { ...current.briefHydrationById };
+      const missingBriefIds = { ...current.missingBriefIds };
+      for (const briefId of action.briefIds) {
+        const previous = briefHydrationById[briefId];
+        briefHydrationById[briefId] = {
+          briefId,
+          status: "loading",
+          attempt: (previous?.attempt ?? 0) + 1,
+        };
+        delete missingBriefIds[briefId];
+      }
+      return { ...current, briefHydrationById, missingBriefIds };
+    }
+    case "briefs_hydration_failed": {
+      const briefHydrationById = { ...current.briefHydrationById };
+      for (const briefId of action.briefIds) {
+        briefHydrationById[briefId] = {
+          briefId,
+          status: "failed",
+          attempt: briefHydrationById[briefId]?.attempt ?? 1,
+          errorKind: action.errorKind,
+        };
+      }
+      return { ...current, briefHydrationById };
     }
   }
 }
@@ -193,6 +247,7 @@ export function deriveSessionTimeline(
     messagesById: projection.messagesById,
     transcriptEntriesById: projection.transcriptEntriesById,
     briefRecordsById: projection.briefRecordsById,
+    briefHydrationById: projection.briefHydrationById,
   });
 }
 

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -415,8 +415,7 @@ export function projectRuntimeEvent(
       label: stringField(payload, "kind") === "result" ? "Result" : "Brief Created",
       body:
         briefTextForPayload(payload, briefRecordsById) ||
-        readableTextWithoutSummary(payload) ||
-        "Brief text unavailable.",
+        readableTextWithoutSummary(payload),
       timestamp: stringField(payload, "created_at"),
       minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1320,6 +1320,36 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("keeps the brief preview while full text hydration is pending", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "brief-event",
+            event_seq: 22,
+            type: "brief_created",
+            payload: {
+              brief_id: "brief_123",
+              kind: "result",
+              text_preview: "Preview remains visible.",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        body: "Preview remains visible.",
+        briefHydration: {
+          briefId: "brief_123",
+          status: "loading",
+          attempt: 0,
+        },
+      }),
+    );
+  });
+
   it("uses the persisted brief instead of associated transcript thinking", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/timeline-view-model.ts
+++ b/web-gui/app/src/runtime/timeline-view-model.ts
@@ -1,4 +1,11 @@
-import type { AgentTimelineItem, DisplayLevel, RuntimeMessageEnvelope, RuntimeBriefRecord, RuntimeTranscriptEntry } from "./types";
+import type {
+  AgentTimelineItem,
+  BriefHydrationViewState,
+  DisplayLevel,
+  RuntimeMessageEnvelope,
+  RuntimeBriefRecord,
+  RuntimeTranscriptEntry,
+} from "./types";
 import type { SessionEventEnvelope } from "./session-events";
 import type { SessionState } from "./session-state-reducer";
 import type { DomainObject, InsertionEntry, SessionObjectType } from "./session-object-types";
@@ -18,6 +25,7 @@ export interface RenderContext {
   messagesById?: Record<string, RuntimeMessageEnvelope>;
   transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>;
   briefRecordsById?: Record<string, RuntimeBriefRecord>;
+  briefHydrationById?: Record<string, BriefHydrationViewState>;
 }
 
 /**

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -774,6 +774,16 @@ export interface AgentTimelineItem {
   activities?: AgentTimelineActivity[];
   rawEvent?: unknown;
   debug?: string;
+  briefHydration?: BriefHydrationViewState;
+}
+
+export type BriefHydrationStatus = "loading" | "resolved" | "not_found" | "failed";
+
+export interface BriefHydrationViewState {
+  briefId: string;
+  status: BriefHydrationStatus;
+  attempt: number;
+  errorKind?: string;
 }
 
 export interface AgentDetail {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1989,6 +1989,38 @@ code {
   background: transparent;
 }
 
+.brief-hydration-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.brief-hydration-status.is-failed,
+.brief-hydration-status.is-not_found {
+  color: var(--danger);
+}
+
+.brief-hydration-status button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.brief-hydration-status .is-spinning {
+  animation: spin 1s linear infinite;
+}
+
 .operator .bubble::before,
 .assistant .bubble::before {
   content: none;


### PR DESCRIPTION
## Summary

- add `POST /agents/{agent_id}/briefs:batchGet` backed by one scoped multi-ID evidence query
- keep available brief previews visible while full text hydrates, with explicit loading / failed / not-found state
- add localized English and Simplified Chinese status text plus manual retry for failed and not-found briefs
- distinguish transient batch failures from confirmed missing IDs, add bounded automatic retry, and enrich hydration trace fields
- refresh OpenAPI, generated TypeScript transport types, and HTTP route snapshots

## Runtime concept

Brief content hydration is now an explicit session projection state instead of treating absent full text as a completed empty result. The batch response is the authority for confirmed missing IDs; transport failures remain retryable.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test http_control agent_briefs_batch_get_returns_found_missing_and_scoped_briefs`
- `cargo test --test openapi_snapshot --test http_route_snapshot`
- Web GUI full suite: 240 tests passed
- Web GUI hydration/i18n focused suite: 112 tests passed
- `npm run typecheck`
- `npm run build`
