### PR TITLE
fix: bind work item completion to exact execution

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3023,6 +3023,76 @@
                   "null"
                 ]
               },
+              "completion_intent": {
+                "properties": {
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "expected_work_revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "report_requirement": {
+                    "enum": [
+                      "required"
+                    ],
+                    "type": "string"
+                  },
+                  "report_state": {
+                    "enum": [
+                      "pending",
+                      "bound",
+                      "missing"
+                    ],
+                    "type": "string"
+                  },
+                  "result_brief_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_activation_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_message_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_turn_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "updated_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "work_item_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "work_item_id",
+                  "expected_work_revision",
+                  "report_requirement",
+                  "report_state",
+                  "created_at",
+                  "updated_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
               "created_at": {
                 "format": "date-time",
                 "type": "string"
@@ -3260,6 +3330,76 @@
               "blocked_by": {
                 "type": [
                   "string",
+                  "null"
+                ]
+              },
+              "completion_intent": {
+                "properties": {
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "expected_work_revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "report_requirement": {
+                    "enum": [
+                      "required"
+                    ],
+                    "type": "string"
+                  },
+                  "report_state": {
+                    "enum": [
+                      "pending",
+                      "bound",
+                      "missing"
+                    ],
+                    "type": "string"
+                  },
+                  "result_brief_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_activation_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_message_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_turn_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "updated_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "work_item_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "work_item_id",
+                  "expected_work_revision",
+                  "report_requirement",
+                  "report_state",
+                  "created_at",
+                  "updated_at"
+                ],
+                "type": [
+                  "object",
                   "null"
                 ]
               },
@@ -7390,6 +7530,76 @@
           "blocked_by": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "completion_intent": {
+            "properties": {
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "expected_work_revision": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "report_requirement": {
+                "enum": [
+                  "required"
+                ],
+                "type": "string"
+              },
+              "report_state": {
+                "enum": [
+                  "pending",
+                  "bound",
+                  "missing"
+                ],
+                "type": "string"
+              },
+              "result_brief_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_activation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_message_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_turn_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "work_item_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "work_item_id",
+              "expected_work_revision",
+              "report_requirement",
+              "report_state",
+              "created_at",
+              "updated_at"
+            ],
+            "type": [
+              "object",
               "null"
             ]
           },

--- a/src/domain/work_item.rs
+++ b/src/domain/work_item.rs
@@ -133,6 +133,38 @@ pub enum TodoItemState {
     Completed,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionReportRequirement {
+    Required,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionReportState {
+    Pending,
+    Bound,
+    Missing,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkItemCompletionIntent {
+    pub work_item_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_activation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_turn_id: Option<String>,
+    pub expected_work_revision: u64,
+    pub report_requirement: CompletionReportRequirement,
+    pub report_state: CompletionReportState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_brief_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct WorkItemRecord {
     pub id: String,
@@ -161,6 +193,8 @@ pub struct WorkItemRecord {
     pub result_brief_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_intent: Option<WorkItemCompletionIntent>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,6 +225,7 @@ impl WorkItemRecord {
             recheck_consumed_at: None,
             result_brief_id: None,
             result_summary: None,
+            completion_intent: None,
             created_at: now,
             updated_at: now,
             turn_id: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -114,8 +114,8 @@ use crate::{
         SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
         TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord,
         TimerStatus, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind,
-        ViewImageObservation, WaitingReason, WorkItemLifecycleAuditEvent, WorkspaceEntry,
-        AGENT_HOME_WORKSPACE_ID,
+        ViewImageObservation, WaitingReason, WorkItemExecutionBinding, WorkItemLifecycleAuditEvent,
+        WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::{WebConfig, WebProviderKind},
 };
@@ -1374,13 +1374,53 @@ impl RuntimeHandle {
         let state = {
             let mut guard = self.inner.agent.lock().await;
             guard.state.turn_index += 1;
-            guard.state.current_turn_id = message
+            let turn_id = message
                 .and_then(|message| normalized_turn_id(message.turn_id.as_deref()))
-                .or_else(|| Some(crate::ids::turn_id()));
+                .unwrap_or_else(crate::ids::turn_id);
+            guard.state.current_turn_id = Some(turn_id.clone());
             guard.state.last_turn_terminal = None;
             if guard.state.current_turn_work_item_id.is_none() {
                 guard.state.current_turn_work_item_id = guard.state.current_work_item_id.clone();
             }
+            guard.state.current_execution_binding = message.map(|message| {
+                let work_item_id = message
+                    .work_item_id
+                    .clone()
+                    .or_else(|| guard.state.current_turn_work_item_id.clone());
+                let claimed_work_revision = work_item_id
+                    .as_deref()
+                    .and_then(|work_item_id| {
+                        self.inner
+                            .runtime_db
+                            .work_items()
+                            .latest(work_item_id)
+                            .ok()
+                            .flatten()
+                    })
+                    .map(|work_item| work_item.revision);
+                let activation_id = matches!(
+                    (&message.kind, &message.origin),
+                    (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                        if subsystem == "work_queue"
+                )
+                .then(|| scheduler_executor::canonical_activation_id(&message.id))
+                .filter(|activation_id| {
+                    self.inner
+                        .runtime_db
+                        .transitions()
+                        .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)
+                        .ok()
+                        .flatten()
+                        .is_some_and(|snapshot| snapshot.activations.contains_key(activation_id))
+                });
+                WorkItemExecutionBinding {
+                    activation_id,
+                    source_message_id: message.id.clone(),
+                    turn_id,
+                    work_item_id,
+                    claimed_work_revision,
+                }
+            });
             guard.state.current_turn_operator_binding_id =
                 operator_binding_id.and_then(|binding_id| {
                     let binding_id = binding_id.trim();
@@ -1838,23 +1878,59 @@ impl RuntimeHandle {
                     })
                 }
                 Some(crate::types::WorkItemSchedulingState::Completed) => {
-                    let brief = self
+                    let work_item = self
                         .inner
-                        .storage
-                        .read_recent_briefs(usize::MAX)?
-                        .into_iter()
-                        .filter(|brief| {
-                            brief.kind.is_success()
-                                && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
-                                && !brief.text.trim().is_empty()
-                        })
-                        .max_by_key(|brief| brief.created_at)
+                        .runtime_db
+                        .work_items()
+                        .latest(&work_item_id)?
                         .ok_or_else(|| {
-                            anyhow!("canonical WorkItem completion requires a result brief binding")
+                            anyhow!("canonical WorkItem completion references missing WorkItem")
                         })?;
                     let turn_terminal = message.turn_id.clone().ok_or_else(|| {
                         anyhow!("canonical WorkItem completion requires a turn identity")
                     })?;
+                    let completion_intent =
+                        work_item.completion_intent.as_ref().ok_or_else(|| {
+                            anyhow!(
+                                "canonical WorkItem completion requires a completion intent binding"
+                            )
+                        })?;
+                    anyhow::ensure!(
+                        completion_intent.work_item_id == work_item_id
+                            && completion_intent.source_activation_id.as_deref()
+                                == Some(activation_id.as_str())
+                            && completion_intent.source_message_id.as_deref()
+                                == Some(record.message_id.as_str())
+                            && completion_intent.source_turn_id.as_deref()
+                                == Some(turn_terminal.as_str())
+                            && completion_intent.expected_work_revision
+                                == activation.admitted_generation,
+                        "canonical WorkItem completion intent does not match the settling execution"
+                    );
+                    let result_brief_id = completion_intent
+                        .result_brief_id
+                        .as_deref()
+                        .filter(|result_brief_id| {
+                            work_item.result_brief_id.as_deref() == Some(*result_brief_id)
+                        })
+                        .ok_or_else(|| {
+                            anyhow!("canonical WorkItem completion requires a result brief binding")
+                        })?;
+                    let brief = self
+                        .inner
+                        .storage
+                        .read_brief_by_id(result_brief_id)?
+                        .filter(|brief| {
+                            brief.kind.is_success()
+                                && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
+                                && brief.turn_id.as_deref() == Some(turn_terminal.as_str())
+                                && brief.related_message_id.as_deref()
+                                    == Some(record.message_id.as_str())
+                                && !brief.text.trim().is_empty()
+                        })
+                        .ok_or_else(|| {
+                            anyhow!("canonical WorkItem completion result brief binding is invalid")
+                        })?;
                     ProtocolCommand::SettleActivation(SettleActivationCommand {
                         settlement: ActivationSettlement {
                             id: canonical_settlement_id(&record.message_id),

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -3,8 +3,8 @@ use super::*;
 use std::collections::BTreeMap;
 
 use crate::types::{
-    BriefAttachment, GenerateImageResult, OperatorMessageRecord, OperatorMessageStatus,
-    ToolExecutionStatus,
+    BriefAttachment, BriefKind, CompletionReportState, GenerateImageResult, OperatorMessageRecord,
+    OperatorMessageStatus, ToolExecutionStatus, WorkItemRecord,
 };
 
 const OPERATOR_MESSAGE_SCAN_MIN: usize = 256;
@@ -80,7 +80,7 @@ impl RuntimeHandle {
 
     pub(super) async fn persist_brief(&self, brief: &BriefRecord) -> Result<()> {
         let mut bound_brief = brief.clone();
-        {
+        let default_turn_work_item_id = {
             let guard = self.inner.agent.lock().await;
             bound_brief.workspace_id = guard
                 .state
@@ -88,12 +88,21 @@ impl RuntimeHandle {
                 .as_ref()
                 .map(|entry| entry.workspace_id.clone())
                 .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
-            if bound_brief.work_item_id.is_none() {
-                bound_brief.work_item_id = guard.state.current_turn_work_item_id.clone();
-            }
             if bound_brief.turn_id.is_none() {
                 bound_brief.turn_id = guard.state.current_turn_id.clone();
             }
+            guard.state.current_turn_work_item_id.clone()
+        };
+        if bound_brief.work_item_id.is_none() && bound_brief.kind == BriefKind::Result {
+            if let Some(work_item) = self.pending_completion_intent_for_brief(&bound_brief)? {
+                bound_brief.work_item_id = Some(work_item.id.clone());
+                self.persist_completion_brief_binding(work_item, &bound_brief)
+                    .await?;
+                return Ok(());
+            }
+        }
+        if bound_brief.work_item_id.is_none() {
+            bound_brief.work_item_id = default_turn_work_item_id;
         }
         self.attach_generated_image_brief_attachments(&mut bound_brief)?;
         let event_payload = BriefCreatedAuditEvent::from_brief(&bound_brief);
@@ -105,6 +114,86 @@ impl RuntimeHandle {
         )?)?;
         let mut guard = self.inner.agent.lock().await;
         guard.state.last_brief_at = Some(bound_brief.created_at);
+        guard.persist_state(&self.inner.storage)?;
+        Ok(())
+    }
+
+    fn pending_completion_intent_for_brief(
+        &self,
+        brief: &BriefRecord,
+    ) -> Result<Option<WorkItemRecord>> {
+        let Some(turn_id) = brief.turn_id.as_deref() else {
+            return Ok(None);
+        };
+        let candidates = self
+            .inner
+            .runtime_db
+            .work_items()
+            .latest_for_agent(&brief.agent_id, usize::MAX)?
+            .into_iter()
+            .filter(|work_item| {
+                work_item.result_brief_id.is_none()
+                    && work_item.completion_intent.as_ref().is_some_and(|intent| {
+                        intent.report_state == CompletionReportState::Pending
+                            && intent.source_turn_id.as_deref() == Some(turn_id)
+                            && intent.source_message_id.as_deref()
+                                == brief.related_message_id.as_deref()
+                    })
+            })
+            .collect::<Vec<_>>();
+        Ok((candidates.len() == 1).then(|| candidates[0].clone()))
+    }
+
+    async fn persist_completion_brief_binding(
+        &self,
+        existing: WorkItemRecord,
+        brief: &BriefRecord,
+    ) -> Result<()> {
+        let mut completion_intent = existing
+            .completion_intent
+            .clone()
+            .ok_or_else(|| anyhow!("completion brief binding requires a completion intent"))?;
+        completion_intent.report_state = CompletionReportState::Bound;
+        completion_intent.result_brief_id = Some(brief.id.clone());
+        completion_intent.updated_at = Utc::now();
+        let record = WorkItemRecord {
+            revision: existing.revision + 1,
+            result_brief_id: Some(brief.id.clone()),
+            completion_intent: Some(completion_intent),
+            updated_at: Utc::now(),
+            ..existing
+        };
+        let event_payload = BriefCreatedAuditEvent::from_brief(brief);
+        let commit = self.inner.runtime_db.transitions().commit_work_item(
+            &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                agent_id: record.agent_id.clone(),
+                mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                    record: record.clone(),
+                    expected_revision: record.revision - 1,
+                },
+                agent_state: None,
+                brief_evidence: vec![brief.clone()],
+                audit_events: vec![
+                    AuditEvent::typed(RuntimeEventKind::BriefCreated, &event_payload)?,
+                    AuditEvent::legacy(
+                        "work_item_completion_report_bound_from_final",
+                        serde_json::json!({
+                            "agent_id": record.agent_id,
+                            "work_item_id": record.id,
+                            "brief_id": brief.id,
+                            "turn_id": brief.turn_id,
+                            "source_message_id": brief.related_message_id,
+                        }),
+                    ),
+                ],
+                index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                notify_scheduler: false,
+                fault: self.take_transition_fault(),
+            },
+        )?;
+        self.apply_transition_commit(commit).await;
+        let mut guard = self.inner.agent.lock().await;
+        guard.state.last_brief_at = Some(brief.created_at);
         guard.persist_state(&self.inner.storage)?;
         Ok(())
     }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -6,9 +6,9 @@ use crate::storage::AppStorage;
 use crate::types::{
     AgentLifecycleHint, AgentListEntry, AgentModelState, AgentPostureProjection,
     AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason, ChildAgentObservabilitySnapshot,
-    ChildAgentPhase, ChildAgentSummary, ExecutionRootEntry, TaskRecord, TaskStatus, TokenUsage,
-    WaitingReason, WorkItemState, WorkspaceOccupancyRecord, WorkspaceProjectionMetadata,
-    WorktreeSession,
+    ChildAgentPhase, ChildAgentSummary, CompletionReportState, ExecutionRootEntry, TaskRecord,
+    TaskStatus, TokenUsage, WaitingReason, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
+    WorkspaceProjectionMetadata, WorktreeSession,
 };
 use crate::work_item_scheduling::WorkQueueReadModel;
 
@@ -72,6 +72,10 @@ impl RuntimeHandle {
             let guard = self.inner.agent.lock().await;
             guard.state.current_turn_id.clone()
         };
+        if let Some(turn_id) = current_turn_id.as_deref() {
+            self.mark_pending_completion_reports_missing(turn_id)
+                .await?;
+        }
 
         let Some(work_item_id) = work_item_id else {
             return Ok(None);
@@ -135,6 +139,7 @@ impl RuntimeHandle {
                         expected_revision: latest.revision,
                     },
                     agent_state: None,
+                    brief_evidence: Vec::new(),
                     audit_events,
                     index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                     notify_scheduler: true,
@@ -161,6 +166,61 @@ impl RuntimeHandle {
             }),
         ))?;
         Ok(Some(committed))
+    }
+
+    async fn mark_pending_completion_reports_missing(&self, turn_id: &str) -> Result<()> {
+        let candidates = self
+            .inner
+            .runtime_db
+            .work_items()
+            .latest_for_agent(&self.agent_id().await?, usize::MAX)?
+            .into_iter()
+            .filter(|work_item| {
+                work_item.result_brief_id.is_none()
+                    && work_item.completion_intent.as_ref().is_some_and(|intent| {
+                        intent.report_state == CompletionReportState::Pending
+                            && intent.source_turn_id.as_deref() == Some(turn_id)
+                    })
+            })
+            .collect::<Vec<_>>();
+        for existing in candidates {
+            let mut completion_intent = existing
+                .completion_intent
+                .clone()
+                .ok_or_else(|| anyhow!("missing completion intent disappeared"))?;
+            completion_intent.report_state = CompletionReportState::Missing;
+            completion_intent.updated_at = Utc::now();
+            let record = WorkItemRecord {
+                revision: existing.revision + 1,
+                completion_intent: Some(completion_intent),
+                updated_at: Utc::now(),
+                ..existing
+            };
+            let commit = self.inner.runtime_db.transitions().commit_work_item(
+                &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                    agent_id: record.agent_id.clone(),
+                    mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                        record: record.clone(),
+                        expected_revision: record.revision - 1,
+                    },
+                    agent_state: None,
+                    brief_evidence: Vec::new(),
+                    audit_events: vec![AuditEvent::legacy(
+                        "work_item_completion_report_missing",
+                        serde_json::json!({
+                            "agent_id": record.agent_id.clone(),
+                            "work_item_id": record.id.clone(),
+                            "turn_id": turn_id,
+                        }),
+                    )],
+                    index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                    notify_scheduler: false,
+                    fault: self.take_transition_fault(),
+                },
+            )?;
+            self.apply_transition_commit(commit).await;
+        }
+        Ok(())
     }
 
     pub(crate) async fn closure_decision_for_state(

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -261,6 +261,7 @@ impl RuntimeHandle {
                     expected_revision: record.revision - 1,
                 },
                 agent_state: None,
+                brief_evidence: Vec::new(),
                 audit_events: vec![AuditEvent::legacy(
                     "work_item_refs_updated",
                     serde_json::json!({

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -10,10 +10,11 @@ use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
     AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
-    FailureArtifact, FailureArtifactCategory, SpawnAgentModelRequest, SpawnAgentModelResolution,
-    SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind,
-    TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot,
-    TaskStatusSnapshot, TodoItem, ToolArtifactRef, WaitConditionStatus, WorkItemContinuationFrame,
+    CompletionReportRequirement, CompletionReportState, FailureArtifact, FailureArtifactCategory,
+    SpawnAgentModelRequest, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
+    SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult,
+    TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef,
+    WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
     WorkItemContinuationReturnPolicy, WorkItemDelegationRecord, WorkItemDelegationState,
     WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
 };
@@ -2253,6 +2254,7 @@ impl RuntimeHandle {
                     record: record.clone(),
                 },
                 agent_state: None,
+                brief_evidence: Vec::new(),
                 audit_events: vec![self.work_item_written_event("created", &record, Value::Null)],
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,
@@ -2667,6 +2669,7 @@ impl RuntimeHandle {
                         expected_revision: existing.revision,
                     },
                     agent_state,
+                    brief_evidence: Vec::new(),
                     audit_events,
                     index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                     notify_scheduler: true,
@@ -2734,6 +2737,7 @@ impl RuntimeHandle {
                     expected_revision: existing.revision,
                 },
                 agent_state: None,
+                brief_evidence: Vec::new(),
                 audit_events,
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: true,
@@ -2768,6 +2772,33 @@ impl RuntimeHandle {
                 continuation_resumed: None,
             });
         }
+        let mut state = self.agent_state().await?;
+        let expected_state = state.clone();
+        let now = Utc::now();
+        let execution_binding = state.current_execution_binding.clone();
+        let matching_execution_binding = execution_binding
+            .as_ref()
+            .filter(|binding| binding.work_item_id.as_deref() == Some(existing.id.as_str()));
+        let completion_intent = WorkItemCompletionIntent {
+            work_item_id: existing.id.clone(),
+            source_activation_id: matching_execution_binding
+                .and_then(|binding| binding.activation_id.clone()),
+            source_message_id: matching_execution_binding
+                .map(|binding| binding.source_message_id.clone()),
+            source_turn_id: matching_execution_binding.map(|binding| binding.turn_id.clone()),
+            expected_work_revision: matching_execution_binding
+                .and_then(|binding| binding.claimed_work_revision)
+                .unwrap_or(existing.revision),
+            report_requirement: CompletionReportRequirement::Required,
+            report_state: if existing.result_brief_id.is_some() {
+                CompletionReportState::Bound
+            } else {
+                CompletionReportState::Pending
+            },
+            result_brief_id: existing.result_brief_id.clone(),
+            created_at: now,
+            updated_at: now,
+        };
         let mut record = WorkItemRecord {
             revision: existing.revision + 1,
             state: WorkItemState::Completed,
@@ -2776,14 +2807,14 @@ impl RuntimeHandle {
             recheck_consumed_at: None,
             result_brief_id: existing.result_brief_id.clone(),
             result_summary: existing.result_summary.clone(),
-            updated_at: Utc::now(),
+            completion_intent: Some(completion_intent),
+            updated_at: now,
             ..existing
         };
         let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
             self.agent_home().as_path(),
             &mut record,
         )?;
-        let now = Utc::now();
         let active_waits = self
             .inner
             .storage
@@ -2807,8 +2838,6 @@ impl RuntimeHandle {
                 audit_events.push(event);
             }
         }
-        let mut state = self.agent_state().await?;
-        let expected_state = state.clone();
         let release_current = state.current_work_item_id.as_deref() == Some(record.id.as_str());
         let release_turn = state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
         let mut continuation_records = Vec::new();
@@ -2909,6 +2938,7 @@ impl RuntimeHandle {
             serde_json::json!({
                 "warning_count": warnings.len(),
                 "continuation_resumed": continuation_resumed,
+                "completion_intent": record.completion_intent,
             }),
         ));
         let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
@@ -2979,30 +3009,54 @@ impl RuntimeHandle {
                 existing,
             ));
         }
-        if let Some(result_brief_id) = existing.result_brief_id.as_deref() {
-            if let Some(brief) = self.inner.storage.read_brief_by_id(result_brief_id)? {
-                if brief.text.trim() == report_text {
-                    return Ok(WorkItemCompletionReportPromotionOutcome::Unchanged(
-                        existing,
-                    ));
-                }
-            }
+        if existing.result_brief_id.is_some()
+            || existing
+                .completion_intent
+                .as_ref()
+                .is_some_and(|intent| intent.report_state == CompletionReportState::Bound)
+        {
+            return Ok(WorkItemCompletionReportPromotionOutcome::Unchanged(
+                existing,
+            ));
         }
-        let current_turn_id = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.current_turn_id.clone()
-        };
         let mut brief =
             BriefRecord::new(agent_id.clone(), BriefKind::Result, report_text, None, None);
         brief.work_item_id = Some(existing.id.clone());
         brief.workspace_id = existing.workspace_id.clone();
         brief.turn_index = source_turn_index;
-        brief.turn_id = current_turn_id;
-        self.persist_brief(&brief).await?;
+        brief.turn_id = existing
+            .completion_intent
+            .as_ref()
+            .and_then(|intent| intent.source_turn_id.clone());
+        brief.related_message_id = existing
+            .completion_intent
+            .as_ref()
+            .and_then(|intent| intent.source_message_id.clone());
+        let now = Utc::now();
+        let mut completion_intent =
+            existing
+                .completion_intent
+                .clone()
+                .unwrap_or(WorkItemCompletionIntent {
+                    work_item_id: existing.id.clone(),
+                    source_activation_id: None,
+                    source_message_id: brief.related_message_id.clone(),
+                    source_turn_id: brief.turn_id.clone(),
+                    expected_work_revision: existing.revision.saturating_sub(1),
+                    report_requirement: CompletionReportRequirement::Required,
+                    report_state: CompletionReportState::Pending,
+                    result_brief_id: None,
+                    created_at: now,
+                    updated_at: now,
+                });
+        completion_intent.report_state = CompletionReportState::Bound;
+        completion_intent.result_brief_id = Some(brief.id.clone());
+        completion_intent.updated_at = now;
         let record = WorkItemRecord {
             revision: existing.revision + 1,
             result_brief_id: Some(brief.id.clone()),
-            updated_at: Utc::now(),
+            completion_intent: Some(completion_intent),
+            updated_at: now,
             ..existing
         };
         let commit = self.inner.runtime_db.transitions().commit_work_item(
@@ -3013,26 +3067,38 @@ impl RuntimeHandle {
                     expected_revision: record.revision - 1,
                 },
                 agent_state: None,
-                audit_events: vec![AuditEvent::legacy(
-                    "work_item_completion_report_promoted",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "work_item_id": record.id.clone(),
-                        "revision": record.revision,
-                        "source_turn_index": source_turn_index,
-                        "source_round": source_round,
-                        "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
-                        "warnings": warnings.clone(),
-                        "warning_count": warnings.len(),
-                        "brief_id": brief.id.clone(),
-                    }),
-                )],
+                brief_evidence: vec![brief.clone()],
+                audit_events: vec![
+                    AuditEvent::typed(
+                        RuntimeEventKind::BriefCreated,
+                        &BriefCreatedAuditEvent::from_brief(&brief),
+                    )?,
+                    AuditEvent::legacy(
+                        "work_item_completion_report_promoted",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "work_item_id": record.id.clone(),
+                            "revision": record.revision,
+                            "source_turn_index": source_turn_index,
+                            "source_round": source_round,
+                            "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
+                            "warnings": warnings.clone(),
+                            "warning_count": warnings.len(),
+                            "brief_id": brief.id.clone(),
+                        }),
+                    ),
+                ],
                 index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
                 notify_scheduler: false,
                 fault: self.take_transition_fault(),
             },
         )?;
         self.apply_transition_commit(commit).await;
+        {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.last_brief_at = Some(brief.created_at);
+            guard.persist_state(&self.inner.storage)?;
+        }
         Ok(WorkItemCompletionReportPromotionOutcome::Promoted(
             WorkItemCompletionReportPromotion {
                 record,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -6,10 +6,10 @@ use crate::domain::scheduler_protocol::{
     ScenarioMode, SchedulerScenarioClass, WorkStatus,
 };
 use crate::types::{
-    ActiveSkillRecord, AuthorityClass, QueueEntryStatus, SkillActivationSource,
-    SkillActivationState, SkillLoadReason, SkillScope, WaitConditionKind, WaitConditionRecord,
-    WaitConditionStatus, WakeSource, WorkItemPlanStatus, WorkItemRecord, WorkItemSchedulingState,
-    WorkItemState,
+    ActiveSkillRecord, AuthorityClass, BriefKind, BriefRecord, CompletionReportState,
+    QueueEntryStatus, SkillActivationSource, SkillActivationState, SkillLoadReason, SkillScope,
+    WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource, WorkItemPlanStatus,
+    WorkItemRecord, WorkItemSchedulingState, WorkItemState,
 };
 
 struct BlockingProvider {
@@ -1146,6 +1146,322 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
             .find(|entry| entry.message_id == message.id)
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Processed)
+    );
+}
+
+#[tokio::test]
+async fn completed_production_settlement_uses_exact_bound_result_brief() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "settle exact completion brief".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete canonical work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.turn_id = Some("turn-exact-completion".into());
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+    let completed = runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let intent = completed
+        .completion_intent
+        .as_ref()
+        .expect("completion should persist an execution-bound intent");
+    assert_eq!(
+        intent.source_activation_id.as_deref(),
+        Some(activation_id.as_str())
+    );
+    assert_eq!(
+        intent.source_message_id.as_deref(),
+        Some(message.id.as_str())
+    );
+    assert_eq!(intent.source_turn_id.as_deref(), message.turn_id.as_deref());
+    assert_eq!(intent.expected_work_revision, work_item.revision);
+    assert_eq!(intent.report_state, CompletionReportState::Pending);
+
+    let completed = runtime
+        .promote_work_item_completion_report(
+            work_item.id.clone(),
+            "canonical completion report".into(),
+            Some(1),
+            Some(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let result_brief_id = completed
+        .result_brief_id
+        .clone()
+        .expect("completion report should have an exact brief binding");
+    let canonical_brief = runtime
+        .storage()
+        .read_brief_by_id(&result_brief_id)
+        .unwrap()
+        .expect("canonical completion brief");
+    let mut conflicting_brief = canonical_brief.clone();
+    conflicting_brief.text = "rewritten completion report".into();
+    let conflict = runtime
+        .storage()
+        .append_brief(&conflicting_brief)
+        .expect_err("a bound brief identity must reject content replacement");
+    assert!(conflict
+        .to_string()
+        .contains("conflicting brief content for evidence_id"));
+    assert_eq!(
+        runtime
+            .storage()
+            .read_brief_by_id(&result_brief_id)
+            .unwrap(),
+        Some(canonical_brief)
+    );
+    let mut decoy = BriefRecord::new(
+        "default",
+        BriefKind::Result,
+        "newer decoy result that must not settle the activation",
+        Some(work_item.id.clone()),
+        None,
+    );
+    decoy.created_at = completed.updated_at + chrono::Duration::seconds(1);
+    runtime.storage().append_brief(&decoy).unwrap();
+
+    finish_claimed_test_run(&runtime).await;
+    runtime
+        .commit_queue_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            vec![AuditEvent::legacy(
+                "queue_entry_settled",
+                serde_json::json!({
+                    "message_id": message.id,
+                    "status": QueueEntryStatus::Processed,
+                }),
+            )],
+            true,
+        )
+        .await
+        .unwrap();
+
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let settlement = settled
+        .settlements
+        .get(&canonical_settlement_id(&message.id))
+        .expect("completed activation should have an exact settlement");
+    assert_eq!(
+        settlement.operator_delivery.as_deref(),
+        Some(result_brief_id.as_str())
+    );
+    assert_ne!(
+        settlement.operator_delivery.as_deref(),
+        Some(decoy.id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn completed_production_settlement_rejects_mismatched_completion_execution() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "reject mismatched completion execution".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete canonical work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.turn_id = Some("turn-mismatched-completion".into());
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+    runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let completed = runtime
+        .promote_work_item_completion_report(
+            work_item.id.clone(),
+            "completion report from the claimed execution".into(),
+            Some(1),
+            Some(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut mismatched = completed.clone();
+    mismatched.revision += 1;
+    mismatched.updated_at = Utc::now();
+    mismatched
+        .completion_intent
+        .as_mut()
+        .expect("completion intent")
+        .source_activation_id = Some("activation:message:foreign-execution".into());
+    let commit = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .commit_work_item(&crate::runtime_db::transitions::WorkItemTransitionCommand {
+            agent_id: mismatched.agent_id.clone(),
+            mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                record: mismatched,
+                expected_revision: completed.revision,
+            },
+            agent_state: None,
+            brief_evidence: Vec::new(),
+            audit_events: Vec::new(),
+            index_changes: Vec::new(),
+            notify_scheduler: false,
+            fault: None,
+        })
+        .unwrap();
+    runtime.apply_transition_commit(commit).await;
+
+    finish_claimed_test_run(&runtime).await;
+    let error = runtime
+        .commit_queue_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            vec![AuditEvent::legacy(
+                "queue_entry_settled",
+                serde_json::json!({
+                    "message_id": message.id,
+                    "status": QueueEntryStatus::Processed,
+                }),
+            )],
+            true,
+        )
+        .await
+        .expect_err("settlement must reject a completion intent from another execution");
+    assert!(error
+        .to_string()
+        .contains("completion intent does not match the settling execution"));
+
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(!snapshot
+        .settlements
+        .contains_key(&canonical_settlement_id(&message.id)));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
     );
 }
 
@@ -5186,6 +5502,7 @@ async fn post_commit_cache_fault_preserves_durable_transition_and_returns_warnin
                     record: record.clone(),
                 },
                 agent_state: None,
+                brief_evidence: Vec::new(),
                 audit_events: vec![AuditEvent::legacy(
                     "post_commit_fault_test",
                     serde_json::json!({}),

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::support::*;
 use crate::types::{
-    WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
+    CompletionReportState, WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
     WorkItemContinuationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState,
     AGENT_HOME_WORKSPACE_ID,
 };
@@ -1929,6 +1929,12 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         .unwrap();
 
     let report_text = "Implemented completion report promotion and verified focused tests.";
+    let expected_work_revision = seed_runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .revision;
     let provider = Arc::new(CompleteWorkItemReportProvider {
         work_item_id: work_item.id.clone(),
         report_text: Some(report_text.into()),
@@ -1996,6 +2002,27 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         completed.result_brief_id.as_deref(),
         Some(result_briefs[0].id.as_str())
     );
+    let completion_intent = completed
+        .completion_intent
+        .as_ref()
+        .expect("completed work item should retain completion intent");
+    assert_eq!(
+        completion_intent.source_message_id.as_deref(),
+        Some(message.id.as_str())
+    );
+    assert_eq!(
+        completion_intent.source_turn_id.as_deref(),
+        result_briefs[0].turn_id.as_deref()
+    );
+    assert_eq!(
+        completion_intent.expected_work_revision,
+        expected_work_revision
+    );
+    assert_eq!(completion_intent.report_state, CompletionReportState::Bound);
+    assert_eq!(
+        completion_intent.result_brief_id.as_deref(),
+        Some(result_briefs[0].id.as_str())
+    );
     assert_eq!(result_briefs[0].turn_index, Some(1));
     assert!(runtime
         .storage()
@@ -2048,6 +2075,326 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
     assert_eq!(
         tool_result["result"]["completion_report_promoted"].as_bool(),
         Some(true)
+    );
+}
+
+#[tokio::test]
+async fn later_final_report_binds_completed_work_item_after_continuation_resume() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let caller = seed_runtime
+        .create_work_item(
+            "resume caller after child completion".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(caller.id.clone())
+        .await
+        .unwrap();
+    let completed_work = seed_runtime
+        .create_work_item(
+            "complete child without preceding report".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(completed_work.id.clone())
+        .await
+        .unwrap();
+
+    let provider = Arc::new(CompleteWorkItemReportProvider {
+        work_item_id: completed_work.id.clone(),
+        report_text: None,
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete the child and return to the caller".into(),
+        },
+    );
+
+    runtime
+        .process_interactive_message(
+            &message,
+            None,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let completed = runtime
+        .latest_work_item(&completed_work.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let result_brief_id = completed
+        .result_brief_id
+        .as_deref()
+        .expect("later final report should bind the completed work item");
+    let result_brief = runtime
+        .storage()
+        .read_brief_by_id(result_brief_id)
+        .unwrap()
+        .expect("bound later final report should exist");
+    assert_eq!(result_brief.text, "done");
+    assert_eq!(
+        result_brief.work_item_id.as_deref(),
+        Some(completed_work.id.as_str())
+    );
+    assert_eq!(
+        result_brief.related_message_id.as_deref(),
+        Some(message.id.as_str())
+    );
+    let completion_intent = completed
+        .completion_intent
+        .as_ref()
+        .expect("completion intent should remain durable");
+    assert_eq!(completion_intent.report_state, CompletionReportState::Bound);
+    assert_eq!(
+        completion_intent.result_brief_id.as_deref(),
+        Some(result_brief_id)
+    );
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(caller.id.as_str())
+    );
+    assert_eq!(
+        state.current_turn_work_item_id.as_deref(),
+        Some(caller.id.as_str())
+    );
+    assert!(
+        runtime
+            .recent_briefs(10)
+            .await
+            .unwrap()
+            .iter()
+            .all(|brief| brief.work_item_id.as_deref() != Some(caller.id.as_str())),
+        "completed child final report must not be rebound to resumed caller"
+    );
+
+    let restarted = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let restarted_completed = restarted
+        .latest_work_item(&completed_work.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        restarted_completed.result_brief_id,
+        completed.result_brief_id
+    );
+    assert_eq!(
+        restarted_completed.completion_intent,
+        completed.completion_intent
+    );
+}
+
+#[tokio::test]
+async fn completion_intent_does_not_borrow_mismatched_execution_identity() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let active = runtime
+        .create_work_item("active execution".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let unrelated = runtime
+        .create_work_item(
+            "completed outside active execution".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(active.id.clone()).await.unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "continue active execution".into(),
+        },
+    );
+    message.turn_id = Some("turn-active-execution".into());
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+
+    let completed = runtime
+        .complete_work_item(unrelated.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let intent = completed
+        .completion_intent
+        .as_ref()
+        .expect("completion intent");
+    assert_eq!(intent.source_activation_id, None);
+    assert_eq!(intent.source_message_id, None);
+    assert_eq!(intent.source_turn_id, None);
+    assert_eq!(intent.expected_work_revision, unrelated.revision);
+}
+
+#[tokio::test]
+async fn turn_end_marks_unbound_completion_report_missing_and_persists_restart() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "complete without a final report".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete without reporting".into(),
+        },
+    );
+    message.turn_id = Some("turn-missing-completion-report".into());
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+
+    let completed = runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        completed
+            .completion_intent
+            .as_ref()
+            .expect("completion intent")
+            .report_state,
+        CompletionReportState::Pending
+    );
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.last_turn_terminal = Some(TurnTerminalRecord {
+            turn_id: message.turn_id.clone().unwrap(),
+            turn_index: guard.state.turn_index,
+            kind: TurnTerminalKind::Completed,
+            reason: None,
+            last_assistant_message: None,
+            checkpoint: None,
+            completed_at: Utc::now(),
+            duration_ms: 10,
+        });
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    assert!(runtime
+        .maybe_commit_turn_end_work_item_transition()
+        .await
+        .unwrap()
+        .is_none());
+    let missing = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(missing.result_brief_id, None);
+    assert_eq!(
+        missing
+            .completion_intent
+            .as_ref()
+            .expect("completion intent")
+            .report_state,
+        CompletionReportState::Missing
+    );
+
+    let restarted = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    assert_eq!(
+        restarted
+            .latest_work_item(&work_item.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .completion_intent,
+        missing.completion_intent
     );
 }
 
@@ -2640,6 +2987,84 @@ async fn repeated_complete_work_item_does_not_overwrite_existing_report() {
         tool_result["result"]["completion_report_promoted"].as_bool(),
         Some(true)
     );
+}
+
+#[tokio::test]
+async fn conflicting_completion_report_promotion_keeps_first_canonical_brief() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("bind one canonical report".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let completed = runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let first = runtime
+        .promote_work_item_completion_report(
+            completed.id.clone(),
+            "First canonical completion report".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let first_brief_id = first
+        .result_brief_id
+        .clone()
+        .expect("first promotion should bind a brief");
+
+    let repeated = runtime
+        .promote_work_item_completion_report(
+            completed.id.clone(),
+            "Conflicting replacement report".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        repeated.result_brief_id.as_deref(),
+        Some(first_brief_id.as_str())
+    );
+    assert_eq!(
+        repeated
+            .completion_intent
+            .as_ref()
+            .expect("completion intent")
+            .result_brief_id
+            .as_deref(),
+        Some(first_brief_id.as_str())
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .read_brief_by_id(&first_brief_id)
+            .unwrap()
+            .expect("first canonical brief")
+            .text,
+        "First canonical completion report"
+    );
+    assert!(runtime
+        .recent_briefs(10)
+        .await
+        .unwrap()
+        .iter()
+        .all(|brief| brief.text != "Conflicting replacement report"));
 }
 
 #[tokio::test]

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -582,6 +582,22 @@ pub(crate) fn insert_tool_evidence_tx(
 }
 
 pub(crate) fn insert_brief_evidence_tx(tx: &Transaction<'_>, brief: &BriefRecord) -> Result<()> {
+    if let Some(payload_json) = tx
+        .query_row(
+            "SELECT payload_json FROM briefs WHERE evidence_id = ?1",
+            [&brief.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        let existing: BriefRecord = serde_json::from_str(&payload_json)?;
+        anyhow::ensure!(
+            existing == *brief,
+            "conflicting brief content for evidence_id {}",
+            brief.id
+        );
+        return Ok(());
+    }
     insert_evidence_tx(
         tx,
         EvidenceInsert {

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -127,6 +127,7 @@ pub(crate) struct WorkItemTransitionCommand {
     pub agent_id: String,
     pub mutation: WorkItemMutation,
     pub agent_state: Option<AgentStateMutation>,
+    pub brief_evidence: Vec<BriefRecord>,
     pub audit_events: Vec<AuditEvent>,
     pub index_changes: Vec<RuntimeIndexChange>,
     pub notify_scheduler: bool,
@@ -280,6 +281,9 @@ impl RuntimeTransitionRepository<'_> {
             applied |= agent_state_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
+            }
+            for brief in &command.brief_evidence {
+                insert_brief_evidence_tx(tx, brief)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
             finish_transition_tx(
@@ -1031,6 +1035,7 @@ mod tests {
                         record: record.clone(),
                     },
                     agent_state: None,
+                    brief_evidence: Vec::new(),
                     audit_events: vec![AuditEvent::legacy("work_item_test", serde_json::json!({}))],
                     index_changes: vec![index_change("work_item", &record.id)],
                     notify_scheduler: true,
@@ -1061,6 +1066,7 @@ mod tests {
                 record: record.clone(),
             },
             agent_state: None,
+            brief_evidence: Vec::new(),
             audit_events: vec![AuditEvent::legacy("work_item_test", serde_json::json!({}))],
             index_changes: vec![index_change("work_item", &record.id)],
             notify_scheduler: true,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1492,6 +1492,7 @@ fn tui_work_item_from_dto(item: SlimWorkItemDto) -> WorkItemSchedulingProjection
             recheck_consumed_at: None,
             result_brief_id: item.result_brief_id,
             result_summary: item.result_summary,
+            completion_intent: None,
             created_at: item.created_at,
             updated_at: item.updated_at,
             turn_id: item.turn_id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1884,6 +1884,18 @@ pub struct WorkingMemoryState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkItemExecutionBinding {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activation_id: Option<String>,
+    pub source_message_id: String,
+    pub turn_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_work_revision: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentState {
     pub id: String,
     pub status: AgentStatus,
@@ -1921,6 +1933,8 @@ pub struct AgentState {
     pub current_turn_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_turn_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_execution_binding: Option<WorkItemExecutionBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2072,6 +2086,7 @@ impl AgentState {
             turn_index: 0,
             current_turn_id: None,
             current_turn_work_item_id: None,
+            current_execution_binding: None,
             current_work_item_id: None,
             current_turn_operator_binding_id: None,
             current_turn_operator_reply_route_id: None,

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2783,6 +2783,23 @@ export interface components {
             current_work_item: {
                 agent_id: string;
                 blocked_by?: string | null;
+                completion_intent?: {
+                    /** Format: date-time */
+                    created_at: string;
+                    /** Format: uint64 */
+                    expected_work_revision: number;
+                    /** @enum {string} */
+                    report_requirement: "required";
+                    /** @enum {string} */
+                    report_state: "pending" | "bound" | "missing";
+                    result_brief_id?: string | null;
+                    source_activation_id?: string | null;
+                    source_message_id?: string | null;
+                    source_turn_id?: string | null;
+                    /** Format: date-time */
+                    updated_at: string;
+                    work_item_id: string;
+                } | null;
                 /** Format: date-time */
                 created_at: string;
                 id: string;
@@ -2849,6 +2866,23 @@ export interface components {
             previous_work_item?: {
                 agent_id: string;
                 blocked_by?: string | null;
+                completion_intent?: {
+                    /** Format: date-time */
+                    created_at: string;
+                    /** Format: uint64 */
+                    expected_work_revision: number;
+                    /** @enum {string} */
+                    report_requirement: "required";
+                    /** @enum {string} */
+                    report_state: "pending" | "bound" | "missing";
+                    result_brief_id?: string | null;
+                    source_activation_id?: string | null;
+                    source_message_id?: string | null;
+                    source_turn_id?: string | null;
+                    /** Format: date-time */
+                    updated_at: string;
+                    work_item_id: string;
+                } | null;
                 /** Format: date-time */
                 created_at: string;
                 id: string;
@@ -3865,6 +3899,23 @@ export interface components {
         WorkItemRecord: {
             agent_id: string;
             blocked_by?: string | null;
+            completion_intent?: {
+                /** Format: date-time */
+                created_at: string;
+                /** Format: uint64 */
+                expected_work_revision: number;
+                /** @enum {string} */
+                report_requirement: "required";
+                /** @enum {string} */
+                report_state: "pending" | "bound" | "missing";
+                result_brief_id?: string | null;
+                source_activation_id?: string | null;
+                source_message_id?: string | null;
+                source_turn_id?: string | null;
+                /** Format: date-time */
+                updated_at: string;
+                work_item_id: string;
+            } | null;
             /** Format: date-time */
             created_at: string;
             id: string;


### PR DESCRIPTION
## 概要

- 为当前 canonical execution 增加持久、不可变的 activation/message/work item/revision 绑定
- 为 `CompleteWorkItem` 持久化 exact `CompletionIntent`，使 completion report 无论先于还是后于完成调用，都绑定到同一目标 WorkItem
- settlement 只读取并校验 exact `result_brief_id`，移除 recent brief 扫描与 mutable focus 推断
- 保持 terminal transaction 原子化在后续 PR-C 的边界内
- 同步 OpenAPI 快照与 Web 生成类型

## 正确性约束

- settlement 校验 intent 与当前 activation、source message、claimed revision 一致
- 已持久化的 brief ID 不允许以不同内容改写
- continuation 恢复 caller 后，later final report 仍归属于被完成的 WorkItem

## 验证

- `cargo fmt --all -- --check`
- `make transport-types`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`

运行 Cargo 验证时清除了宿主 Holon 实例继承的 `HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS`，避免现有测试环境污染。
