### PR TITLE
ci: run Docker job only on Docker-related changes in PRs, publish latest on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,6 @@ on:
       - "scripts/docker-e2e.py"
       - "scripts/docker-live-acceptance.py"
       - "scripts/docker_e2e/**"
-      - "scripts/docker-smoke.sh"
-      - "scripts/docker-e2e.py"
-      - "scripts/docker-live-acceptance.py"
-      - "scripts/docker_e2e/**"
   pull_request:
     branches: [main]
     paths:
@@ -43,19 +39,63 @@ on:
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
+      - "scripts/docker-smoke.sh"
+      - "scripts/docker-e2e.py"
+      - "scripts/docker-live-acceptance.py"
+      - "scripts/docker_e2e/**"
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker:
+              - '.github/workflows/ci.yml'
+              - '.dockerignore'
+              - 'Dockerfile'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile'
+              - 'build.rs'
+              - 'scripts/docker-smoke.sh'
+              - 'scripts/docker-e2e.py'
+              - 'scripts/docker-live-acceptance.py'
+              - 'scripts/docker_e2e/**'
+
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.docker == 'true'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
         uses: docker/build-push-action@v7
@@ -72,6 +112,14 @@ jobs:
 
       - name: Validate Docker E2E runner
         run: make docker-e2e-validate
+
+      - name: Publish latest image
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          repository="$(printf '%s' "ghcr.io/${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
+          docker tag holon:ci "${repository}:latest"
+          docker push "${repository}:latest"
 
   rust:
     name: Rust


### PR DESCRIPTION
## 动机

当前 CI 中 Docker job 在每个触及 `src/**`、`tests/**` 等路径的 PR 都会运行，导致大多数纯代码修改的 PR 需要等待完整的 Docker 镜像构建和测试，拖慢反馈速度。

Rust build 通过后，Docker 再完整编译一次的边际收益较低。Docker 构建失败通常只在 Dockerfile、构建依赖、容器脚本等文件变化时发生。

## 改动

- **PR 中按需运行 Docker**：添加 `changes` job（使用 `dorny/paths-filter@v3`），仅当 Dockerfile、`.dockerignore`、`Cargo.toml`、`Cargo.lock`、`Makefile`、`build.rs`、docker 脚本等文件变化时才运行 Docker job。
- **合并到 main 后始终运行 Docker 并发布 `latest` 镜像**：push to main 时 Docker job 无条件运行，smoke test 通过后自动 tag 并 push `ghcr.io/holon-run/holon:latest`。
- **修复触发路径遗漏**：`pull_request.paths` 补上缺失的 docker 脚本路径；移除 `push.paths` 中的重复条目。

## 效果

- 大多数纯代码 PR 不再等待 Docker 构建，CI 反馈时间显著缩短。
- 每次合并到 main 仍会验证 Docker 镜像并发布 `latest`，保留容器级别的最终验证。
- Release 流程（tag 触发）不受影响，仍通过 release-e2e 验证后发布版本镜像。