### PR TITLE
fix: skip duplicate terminal audit event emission on repeated task transitions

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -906,6 +906,11 @@ impl RuntimeHandle {
         &self.inner.storage
     }
 
+    #[cfg(test)]
+    pub(crate) fn runtime_db(&self) -> &crate::runtime_db::RuntimeDb {
+        &self.inner.runtime_db
+    }
+
     pub fn object_query_cache(&self) -> Arc<crate::object_query_cache::ObjectQueryCache> {
         self.inner.object_query_cache.clone()
     }

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -156,6 +156,7 @@ impl RuntimeHandle {
         }
         if emit_event {
             let payload = TaskLifecycleAuditEvent::from_task(&persisted_task);
+            let mut skip_event = false;
             let mut event =
                 if let Some(kind) = RuntimeEventKind::from_wire_name(transition.event_kind) {
                     AuditEvent::typed(kind, &payload)?
@@ -165,8 +166,21 @@ impl RuntimeHandle {
             if is_terminal_task_status(&persisted_task.status) {
                 event.id = stable_terminal_task_event_id(transition.event_kind, &persisted_task);
                 event.created_at = persisted_task.updated_at;
+                // When a terminal transition is repeated (e.g. duplicate
+                // task_result delivery after a concurrent writer modified the
+                // stored task), the stable event id collides with the original
+                // emission but the payload may differ.  Skip re-emission when
+                // the event already exists to avoid a content conflict.
+                skip_event = repeated_terminal
+                    && self
+                        .inner
+                        .runtime_db
+                        .audit_events()
+                        .has_event_by_id(&event.id)?;
             }
-            audit_events.push(event);
+            if !skip_event {
+                audit_events.push(event);
+            }
         }
         if is_terminal_task_status(&task.status) {
             let matching = self
@@ -873,6 +887,62 @@ mod tests {
             brief.kind == crate::types::BriefKind::Result
                 && brief.text.contains("Task task-1 completed")
         }));
+    }
+
+    #[tokio::test]
+    async fn repeated_terminal_after_concurrent_update_does_not_emit_conflicting_event() {
+        let runtime = runtime();
+        let mut original = task("task-1", TaskStatus::Completed, false);
+        original.parent_message_id = Some("parent-1".into());
+        original.detail = Some(json!({"version": 1}));
+        runtime
+            .reduce_task_result_message(
+                &task_result_message("task-1"),
+                original.clone(),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Simulate a concurrent writer updating the task in the runtime_db
+        // with different content while keeping the same terminal status.
+        // Use raw SQL to bypass the transition validation that would reject
+        // a completed -> completed update with a different payload.
+        runtime
+            .runtime_db()
+            .connection()
+            .unwrap()
+            .execute(
+                "UPDATE tasks SET payload_json = json_set(payload_json, '$.detail', json('{\"version\": 2}')) WHERE task_id = 'task-1'",
+                [],
+            )
+            .unwrap();
+
+        // Re-dispatch the same task result.  Before the fix this emitted an
+        // audit event with the same stable ID but content derived from the
+        // concurrently-updated DB record, causing a conflict error.
+        runtime
+            .reduce_task_result_message(
+                &task_result_message("task-1"),
+                original.clone(),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let events = runtime.recent_events(20).await.unwrap();
+        let result_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.kind == "task_result_received")
+            .collect();
+        // Only the original emission should exist.
+        assert_eq!(result_events.len(), 1);
+        let payload =
+            serde_json::from_value::<TaskLifecycleAuditEvent>(result_events[0].data.clone())
+                .unwrap();
+        assert_eq!(payload, TaskLifecycleAuditEvent::from_task(&original));
     }
 
     #[tokio::test]

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -2308,6 +2308,19 @@ impl AuditEventSink<'_> {
         )
     }
 
+    /// Check whether an audit event with the given id already exists.
+    pub fn has_event_by_id(&self, event_id: &str) -> Result<bool> {
+        let connection = self.db.connection()?;
+        Ok(connection
+            .query_row(
+                "SELECT 1 FROM audit_events WHERE audit_event_id = ?1",
+                [event_id],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some())
+    }
+
     pub fn append_many(
         &self,
         agent_id: Option<&str>,


### PR DESCRIPTION
## 问题

PR #2379 修复了 task_result 重派发时稳定 audit_event_id 搭配非确定性事件内容的问题，但 holon-dev 再次遇到相同错误：

```
Turn failed while processing task_result: conflicting audit event content for audit_event_id event_f302159154606ab
```

## 根因

当一个终态 task transition 被重复处理（例如 task_result 重复投递），且并发写入者在此期间修改了 DB 中的 task 记录时：

1. 首次发射 audit event，内容基于原始 task 状态
2. 并发写入修改了 DB 中的 task（如 detail 字段）
3. 重复投递触发 `repeated_terminal` 路径，`persisted_task` 取自 DB（已被修改）
4. `stable_terminal_task_event_id` 生成相同 ID（基于 event_kind + task.id + parent_message_id + status）
5. 但 event 内容不同（基于修改后的 DB 记录）→ `append_audit_event_tx` 报 conflicting content 错误

PR #2383 的 retry 机制无法处理此错误，因为 conflicting audit event content 不是 `RuntimeStateTransitionConflict`，不可重试。

## 修复

在发射终态 audit event 前，检查该 stable ID 是否已存在于 audit store。若已存在则跳过发射（原始事件为权威记录）。不同 event kind（如 `task_status_updated` vs `task_result_received`）有不同 stable ID，首次发射不受影响。

## 变更

- `src/runtime_db/repositories.rs`: 新增 `AuditEventSink::has_event_by_id` 查询方法
- `src/runtime/task_state_reducer.rs`: 终态事件发射前检查存在性，跳过重复；新增回归测试
- `src/runtime.rs`: 新增 `#[cfg(test)]` 的 `runtime_db()` 访问器

## 测试

- 新增 `repeated_terminal_after_concurrent_update_does_not_emit_conflicting_event` 回归测试
- 全部 18 个 task_state_reducer 测试通过
- `cargo fmt --all -- --check` 通过
- `RUSTFLAGS="-D warnings" cargo check --all-targets` 通过