### PR TITLE
feat: add errorKind classification to agent.detail and events.catch_up trace spans

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   agentBriefPatchFromEvents,
+  agentDetailErrorKind,
   buildResumeRefreshes,
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
@@ -894,6 +895,36 @@ describe("bounded resume refresh scheduling", () => {
     );
 
     expect(started).toEqual([1]);
+  });
+});
+
+describe("agentDetailErrorKind", () => {
+  it("classifies AbortError as timeout", () => {
+    expect(agentDetailErrorKind(new DOMException("aborted", "AbortError"))).toBe("timeout");
+  });
+
+  it("classifies error with timeout message as timeout", () => {
+    const err = new Error("Request timed out after 8000ms");
+    expect(agentDetailErrorKind(err)).toBe("timeout");
+  });
+
+  it("classifies RuntimeHttpError name as http_error", () => {
+    const err = new Error("GET /agents/x failed with 500");
+    err.name = "RuntimeHttpError";
+    expect(agentDetailErrorKind(err)).toBe("http_error");
+  });
+
+  it("classifies TypeError as network_error", () => {
+    expect(agentDetailErrorKind(new TypeError("fetch failed"))).toBe("network_error");
+  });
+
+  it("classifies SyntaxError as parse_error", () => {
+    expect(agentDetailErrorKind(new SyntaxError("Unexpected token in JSON"))).toBe("parse_error");
+  });
+
+  it("returns unknown for unclassified errors", () => {
+    expect(agentDetailErrorKind(new Error("something broke"))).toBe("unknown");
+    expect(agentDetailErrorKind("string error")).toBe("unknown");
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -2455,7 +2455,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
             },
           },
         }));
-        span.end("error");
+        span.end("error", { errorKind: agentDetailErrorKind(error), phase: "fetch" });
       } finally {
         const current = agentDetailRefreshInFlight.get(key);
         if (current?.promise === promise) {
@@ -4155,7 +4155,7 @@ async function catchUpAgentEvents(
       eventCount: page.events?.length ?? 0,
     });
   })().catch((error) => {
-    span.end("error");
+    span.end("error", { errorKind: agentDetailErrorKind(error) });
     throw error;
   }).finally(() => {
     if (agentEventCatchUpInFlight.get(agentId) === request) {
@@ -4506,6 +4506,17 @@ function scheduleAutomaticBriefHydrationRetry(
     });
   }, delay);
   briefHydrationRetryTimers.set(key, timer);
+}
+
+export function agentDetailErrorKind(error: unknown): string {
+  if (error instanceof DOMException && error.name === "AbortError") return "timeout";
+  if (error instanceof Error) {
+    if (error.name === "RuntimeHttpError") return "http_error";
+    if (error.name === "SyntaxError") return "parse_error";
+    if (error.name === "TypeError") return "network_error";
+    if (/timeout|timed out|aborted/i.test(error.message)) return "timeout";
+  }
+  return "unknown";
 }
 
 function briefHydrationErrorKind(error: unknown): string {


### PR DESCRIPTION
## Summary

Add `agentDetailErrorKind` helper that classifies runtime errors into `timeout`, `http_error`, `parse_error`, `network_error`, or `unknown` categories, matching the existing `briefHydrationErrorKind` pattern.

Attach `errorKind` (and `phase: "fetch"` for `agent.detail`) to the error outcome of `agent.detail` and `events.catch_up` trace spans. Previously these spans only recorded `span.end("error")` with no error classification, making it impossible to distinguish timeouts from HTTP errors or parse failures in exported traces.

## Changes

- **`runtime-store.ts`**: Add exported `agentDetailErrorKind(error)` function; attach `errorKind` + `phase` to `agent.detail` error span; attach `errorKind` to `events.catch_up` error span
- **`runtime-store.test.ts`**: Add 6 unit tests covering each error classification path

## Context

Part of the agent detail timeout recovery path fix. This is PR 1 of 3 — the zero-risk observability improvement that should land first to help diagnose the remaining issues.
