### PR TITLE
feat: show recovering status when agent detail fails during active SSE

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -742,9 +742,9 @@ export function AgentPage({
               />
               ) : null
             ) : null}
-            {timeline.length > 0 && (syncStatus === "refreshing" || syncStatus === "stale") ? (
+            {timeline.length > 0 && (syncStatus === "refreshing" || syncStatus === "stale" || syncStatus === "recovering") ? (
               <div className="history-status" role="status">
-                {syncStatus === "refreshing" ? t("common.refreshing") : t("common.syncing")}
+                {syncStatus === "refreshing" ? t("common.refreshing") : syncStatus === "recovering" ? t("common.recovering") : t("common.syncing")}
               </div>
             ) : null}
           </div>

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -504,6 +504,8 @@ const agentStateRefreshInFlight = new Map<string, number>();
 const agentEventCatchUpInFlight = new Map<string, Promise<void>>();
 const agentDetailRefreshInFlight = new Map<string, { generation: number; promise: Promise<void> }>();
 const agentDetailRequestSequence = new Map<string, number>();
+const agentDetailRetryTimers = new Map<string, number>();
+const agentDetailRetryAttempts = new Map<string, number>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 let clientGeneration = 0;
@@ -518,6 +520,7 @@ const GLOBAL_BACKFILL_LIMIT = 100;
 const AGENT_VALIDATION_TTL_MS = 60_000;
 const RESUME_RECONCILIATION_THRESHOLD_MS = 60_000;
 const BRIEF_HYDRATION_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+const AGENT_DETAIL_RETRY_DELAYS_MS = [2_000, 5_000, 15_000] as const;
 
 function nextClientGeneration(): number {
   clientGeneration += 1;
@@ -561,6 +564,9 @@ function cancelClientGenerationWork(): void {
   agentEventCatchUpInFlight.clear();
   agentDetailRefreshInFlight.clear();
   agentDetailRequestSequence.clear();
+  for (const timer of agentDetailRetryTimers.values()) window.clearTimeout(timer);
+  agentDetailRetryTimers.clear();
+  agentDetailRetryAttempts.clear();
   inspectorDetailInFlight.clear();
   workItemRefreshInFlight.clear();
   workItemDetailInFlight.clear();
@@ -2419,6 +2425,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         scheduleTranscriptHydration(get, set, agentId, displayLevel);
         scheduleBriefHydration(get, set, agentId, displayLevel);
         scheduleCacheWrite(get, agentId);
+        clearAgentDetailRetry(agentId);
         span.end(detail.error ? "error" : "ok", {
           eventCount: detail.events?.length ?? 0,
         });
@@ -2440,6 +2447,30 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
             },
           }));
           span.end("skipped", { reason: "projection_busy" });
+          return;
+        }
+        const currentSession = get().sessionsByAgentId[agentId];
+        const canRecover =
+          get().globalStreamStatus === "streaming" &&
+          Boolean(currentSession?.eventSeqs.length);
+        if (canRecover) {
+          set((state) => ({
+            sessionsByAgentId: {
+              ...state.sessionsByAgentId,
+              [agentId]: {
+                ...emptyAgentSession(),
+                ...state.sessionsByAgentId[agentId],
+                loading: false,
+                syncStatus: "recovering",
+                contentStatus: state.sessionsByAgentId[agentId]?.eventSeqs.length
+                  ? "available"
+                  : "unknown",
+                error: error instanceof Error ? error.message : String(error),
+              },
+            },
+          }));
+          span.end("error", { recovery: true });
+          scheduleAgentDetailRetry(get, agentId, displayLevel);
           return;
         }
         set((state) => ({
@@ -3099,6 +3130,30 @@ function scheduleCacheWrite(get: () => RuntimeStoreState, agentId: string): void
   const session = get().sessionsByAgentId[agentId];
   if (!session) return;
   sessionCacheWriter.scheduleWrite(agentId, session);
+}
+
+function scheduleAgentDetailRetry(
+  get: () => RuntimeStoreState,
+  agentId: string,
+  displayLevel: DisplayLevel,
+): void {
+  if (agentDetailRetryTimers.has(agentId)) return;
+  const attempt = agentDetailRetryAttempts.get(agentId) ?? 0;
+  if (attempt >= AGENT_DETAIL_RETRY_DELAYS_MS.length) return;
+  const delay = AGENT_DETAIL_RETRY_DELAYS_MS[attempt];
+  agentDetailRetryAttempts.set(agentId, attempt + 1);
+  const timer = window.setTimeout(() => {
+    agentDetailRetryTimers.delete(agentId);
+    void get().refreshAgentDetail(agentId, displayLevel, { force: true });
+  }, delay);
+  agentDetailRetryTimers.set(agentId, timer);
+}
+
+function clearAgentDetailRetry(agentId: string): void {
+  const timer = agentDetailRetryTimers.get(agentId);
+  if (timer != null) window.clearTimeout(timer);
+  agentDetailRetryTimers.delete(agentId);
+  agentDetailRetryAttempts.delete(agentId);
 }
 
 // ─── Global event stream ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When `refreshAgentDetail` fails and the global event stream is active with cached event content, set `syncStatus` to `"recovering"` instead of `"error"` and schedule an automatic retry with exponential backoff (2s, 5s, 15s).

This prevents user-visible state oscillation where the page briefly shows an error state (~8s timeout) before SSE catch-up automatically recovers it ~0.6s later. With this change, the timeline remains visible during the retry, and a "Recovering" indicator is shown instead of an error.

## Changes

- **`runtime-store.ts`**:
  - Add `agentDetailRetryTimers` and `agentDetailRetryAttempts` maps with `AGENT_DETAIL_RETRY_DELAYS_MS = [2_000, 5_000, 15_000]`
  - Add `scheduleAgentDetailRetry()` and `clearAgentDetailRetry()` helpers
  - In `refreshAgentDetail` catch branch: check if SSE is streaming and session has cached event content; if so, set `syncStatus: "recovering"` with `contentStatus: "available"` and schedule a delayed retry
  - Clear retry state on successful detail load and in `cancelClientGenerationWork()`
- **`AgentPage.tsx`**: Show "Recovering" indicator for `syncStatus === "recovering"`

## Verification

- All 153 existing runtime tests pass
- TypeScript type check passes with no errors

## Context

Part of the agent detail timeout recovery path fix (WorkItem: `work_cccf132e8db57fe`). This is PR 3 of 3 — the UX improvement that prevents visible state oscillation on detail timeout. Builds conceptually on PR 2 (#2390) for the freshness field separation.
