### PR TITLE
fix: 原子提交 terminal settlement

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1731,6 +1731,7 @@ impl RuntimeHandle {
                     }),
                     message_evidence: vec![message.clone()],
                     transcript_entries: Vec::new(),
+                    turn_record: None,
                     audit_events,
                     scheduler_shadow_comparison: None,
                     scheduler_delivery_shadow_comparison: None,
@@ -1758,19 +1759,67 @@ impl RuntimeHandle {
             .append_event(&AuditEvent::legacy(kind, data))
     }
 
+    #[cfg(test)]
     pub(crate) async fn commit_queue_settlement(
         &self,
         record: QueueEntryRecord,
         audit_events: Vec<AuditEvent>,
         notify_scheduler: bool,
     ) -> Result<bool> {
+        self.commit_queue_terminal_settlement(record, audit_events, notify_scheduler, None)
+            .await
+    }
+
+    async fn commit_queue_terminal_settlement(
+        &self,
+        record: QueueEntryRecord,
+        audit_events: Vec<AuditEvent>,
+        notify_scheduler: bool,
+        terminal_transition: Option<&turn::TurnTerminalTransition>,
+    ) -> Result<bool> {
+        self.commit_queue_terminal_settlement_with_evidence(
+            record,
+            audit_events,
+            notify_scheduler,
+            terminal_transition,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .await
+    }
+
+    async fn commit_queue_terminal_settlement_with_evidence(
+        &self,
+        record: QueueEntryRecord,
+        mut audit_events: Vec<AuditEvent>,
+        notify_scheduler: bool,
+        terminal_transition: Option<&turn::TurnTerminalTransition>,
+        committed_agent_state: Option<AgentState>,
+        transcript_entries: Vec<TranscriptEntry>,
+        brief_evidence: Vec<BriefRecord>,
+    ) -> Result<bool> {
         let scheduler_protocol_commands = self.canonical_queue_settlement_commands(&record).await?;
-        let shadow_comparison = {
+        let (projection_state, queue_len, agent_state) = {
             let guard = self.inner.agent.lock().await;
+            let mut state = committed_agent_state.unwrap_or_else(|| guard.state.clone());
+            let agent_state = if let Some(transition) = terminal_transition {
+                state.current_turn_id = Some(transition.terminal.turn_id.clone());
+                state.last_turn_terminal = Some(transition.terminal.clone());
+                Some(crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(guard.last_persisted_state.clone())),
+                    record: Box::new(state.clone()),
+                })
+            } else {
+                None
+            };
+            (state, guard.queue.len(), agent_state)
+        };
+        let shadow_comparison = {
             let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
                 &self.inner.storage,
-                &guard.state,
-                guard.queue.len(),
+                &projection_state,
+                queue_len,
                 self.now(),
             )?;
             scheduler::shadow_comparison_for_settlement(&projection, &record)
@@ -1778,17 +1827,23 @@ impl RuntimeHandle {
                 .transpose()?
         };
         let delivery_shadow_comparison = {
-            let guard = self.inner.agent.lock().await;
             let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
                 &self.inner.storage,
-                &guard.state,
-                guard.queue.len(),
+                &projection_state,
+                queue_len,
                 self.now(),
             )?;
             scheduler::shadow_comparison_for_delivery(&projection, &record)
                 .map(scheduler_executor::scheduler_shadow_comparison_command)
                 .transpose()?
         };
+        if let Some(transition) = terminal_transition {
+            audit_events.push(AuditEvent::legacy(
+                "turn_terminal",
+                serde_json::to_value(&transition.terminal)?,
+            ));
+            audit_events.push(Self::turn_record_audit_event(&transition.turn_record));
+        }
         let commit = self.inner.runtime_db.transitions().commit_queue(
             &crate::runtime_db::transitions::QueueTransitionCommand {
                 agent_id: record.agent_id.clone(),
@@ -1801,16 +1856,17 @@ impl RuntimeHandle {
                     scheduler::SETTLEMENT_SCENARIO,
                     scheduler::DELIVERY_SCENARIO,
                 ],
-                agent_state: None,
+                agent_state,
                 message_evidence: Vec::new(),
-                transcript_entries: Vec::new(),
+                transcript_entries,
+                turn_record: terminal_transition.map(|transition| transition.turn_record.clone()),
                 audit_events,
                 scheduler_shadow_comparison: shadow_comparison,
                 scheduler_delivery_shadow_comparison: delivery_shadow_comparison,
                 scheduler_semantic_shadow: None,
                 notify_scheduler,
                 fault: self.take_transition_fault(),
-                brief_evidence: Vec::new(),
+                brief_evidence,
             },
         )?;
         Ok(self.apply_transition_commit(commit).await.applied)
@@ -1857,6 +1913,13 @@ impl RuntimeHandle {
             .iter()
             .find(|candidate| candidate.id == work_item_id)
             .map(|candidate| candidate.scheduling_state);
+        let missing_settlement = || {
+            ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
+                id: canonical_missing_settlement_id(&record.message_id),
+                activation_id: activation_id.clone(),
+                created_at: record.updated_at.to_rfc3339(),
+            })
+        };
 
         let command = if record.status == QueueEntryStatus::Processed {
             match scheduling_state {
@@ -1878,45 +1941,39 @@ impl RuntimeHandle {
                     })
                 }
                 Some(crate::types::WorkItemSchedulingState::Completed) => {
-                    let work_item = self
-                        .inner
-                        .runtime_db
-                        .work_items()
-                        .latest(&work_item_id)?
-                        .ok_or_else(|| {
-                            anyhow!("canonical WorkItem completion references missing WorkItem")
-                        })?;
-                    let turn_terminal = message.turn_id.clone().ok_or_else(|| {
-                        anyhow!("canonical WorkItem completion requires a turn identity")
-                    })?;
-                    let completion_intent =
-                        work_item.completion_intent.as_ref().ok_or_else(|| {
-                            anyhow!(
-                                "canonical WorkItem completion requires a completion intent binding"
-                            )
-                        })?;
-                    anyhow::ensure!(
-                        completion_intent.work_item_id == work_item_id
-                            && completion_intent.source_activation_id.as_deref()
-                                == Some(activation_id.as_str())
-                            && completion_intent.source_message_id.as_deref()
-                                == Some(record.message_id.as_str())
-                            && completion_intent.source_turn_id.as_deref()
-                                == Some(turn_terminal.as_str())
-                            && completion_intent.expected_work_revision
-                                == activation.admitted_generation,
-                        "canonical WorkItem completion intent does not match the settling execution"
-                    );
-                    let result_brief_id = completion_intent
+                    let Some(work_item) =
+                        self.inner.runtime_db.work_items().latest(&work_item_id)?
+                    else {
+                        return Ok(vec![missing_settlement()]);
+                    };
+                    let Some(turn_terminal) = message.turn_id.clone() else {
+                        return Ok(vec![missing_settlement()]);
+                    };
+                    let Some(completion_intent) = work_item.completion_intent.as_ref() else {
+                        return Ok(vec![missing_settlement()]);
+                    };
+                    if !(completion_intent.work_item_id == work_item_id
+                        && completion_intent.source_activation_id.as_deref()
+                            == Some(activation_id.as_str())
+                        && completion_intent.source_message_id.as_deref()
+                            == Some(record.message_id.as_str())
+                        && completion_intent.source_turn_id.as_deref()
+                            == Some(turn_terminal.as_str())
+                        && completion_intent.expected_work_revision
+                            == activation.admitted_generation)
+                    {
+                        return Ok(vec![missing_settlement()]);
+                    }
+                    let Some(result_brief_id) = completion_intent
                         .result_brief_id
                         .as_deref()
                         .filter(|result_brief_id| {
                             work_item.result_brief_id.as_deref() == Some(*result_brief_id)
                         })
-                        .ok_or_else(|| {
-                            anyhow!("canonical WorkItem completion requires a result brief binding")
-                        })?;
-                    let brief = self
+                    else {
+                        return Ok(vec![missing_settlement()]);
+                    };
+                    let Some(brief) = self
                         .inner
                         .storage
                         .read_brief_by_id(result_brief_id)?
@@ -1928,9 +1985,9 @@ impl RuntimeHandle {
                                     == Some(record.message_id.as_str())
                                 && !brief.text.trim().is_empty()
                         })
-                        .ok_or_else(|| {
-                            anyhow!("canonical WorkItem completion result brief binding is invalid")
-                        })?;
+                    else {
+                        return Ok(vec![missing_settlement()]);
+                    };
                     ProtocolCommand::SettleActivation(SettleActivationCommand {
                         settlement: ActivationSettlement {
                             id: canonical_settlement_id(&record.message_id),
@@ -1951,18 +2008,10 @@ impl RuntimeHandle {
                         },
                     })
                 }
-                _ => ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
-                    id: canonical_missing_settlement_id(&record.message_id),
-                    activation_id,
-                    created_at: record.updated_at.to_rfc3339(),
-                }),
+                _ => missing_settlement(),
             }
         } else {
-            ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
-                id: canonical_missing_settlement_id(&record.message_id),
-                activation_id,
-                created_at: record.updated_at.to_rfc3339(),
-            })
+            missing_settlement()
         };
         Ok(vec![command])
     }
@@ -2087,126 +2136,179 @@ impl RuntimeHandle {
             }
             self.append_state_changed_events(&scheduled.running_state)?;
 
-            if let Err(err) = self
-                .process_message_with_plan(
+            let terminal_transition = match self
+                .process_message_with_plan_deferred(
                     scheduled.message,
                     scheduled.dispatch_plan,
                     &scheduled.scheduler_decision,
                 )
                 .await
             {
-                let aborted = err.downcast_ref::<CurrentRunAborted>().cloned();
-                if let Some(aborted) = aborted.as_ref() {
-                    self.commit_queue_settlement(
-                        QueueEntryRecord {
-                            message_id: message.id.clone(),
-                            agent_id: message.agent_id.clone(),
-                            priority: message.priority.clone(),
-                            status: QueueEntryStatus::Interrupted,
-                            created_at: message.created_at,
-                            updated_at: Utc::now(),
-                        },
-                        vec![AuditEvent::legacy(
-                            "message_processing_aborted",
+                Ok(transition) => transition,
+                Err(err) => {
+                    let aborted = err.downcast_ref::<CurrentRunAborted>().cloned();
+                    let (terminal, queue_status, mut audit_events, failure_artifacts) =
+                        if let Some(aborted) = aborted.as_ref() {
+                            (
+                                self.build_turn_aborted_record(&aborted.reason, None, 0)
+                                    .await,
+                                QueueEntryStatus::Interrupted,
+                                vec![AuditEvent::legacy(
+                                    "message_processing_aborted",
+                                    serde_json::json!({
+                                        "message_id": message.id.clone(),
+                                        "message_kind": message.kind.clone(),
+                                        "run_id": aborted.run_id.clone(),
+                                        "reason": aborted.reason.clone(),
+                                    }),
+                                )],
+                                None,
+                            )
+                        } else {
+                            let descriptor = describe_runtime_error(&err);
+                            let terminal = self
+                                .build_turn_aborted_record("runtime_error", None, 0)
+                                .await;
+                            error!(
+                                message_id = %message.id,
+                                turn_id = %terminal.turn_id,
+                                domain = ?descriptor.domain,
+                                code = %descriptor.code,
+                                retryable = descriptor.retryable,
+                                error = %descriptor.operator_message,
+                                "failed to process message"
+                            );
+                            let (queue_status, settlement_reason) =
+                                runtime_error_queue_settlement(&message.kind, &err);
+                            let artifacts = self
+                                .build_runtime_failure_artifacts(&message, &err, &terminal)
+                                .await?;
+                            let terminal_turn_id = terminal.turn_id.clone();
+                            (
+                                terminal,
+                                queue_status.clone(),
+                                vec![
+                                    AuditEvent::legacy(
+                                        "runtime_error",
+                                        serde_json::json!({
+                                            "message_id": message.id.clone(),
+                                            "turn_id": terminal_turn_id,
+                                            "message_kind": message.kind.clone(),
+                                            "domain": descriptor.domain,
+                                            "code": descriptor.code,
+                                            "retryable": descriptor.retryable,
+                                            "error": descriptor.operator_message,
+                                            "recovery_hint": descriptor.recovery_hint,
+                                            "safe_context": descriptor.safe_context,
+                                            "source_chain": descriptor.source_chain,
+                                            "token_usage": provider_attempt_timeline(&err)
+                                                .and_then(|timeline| timeline.aggregated_token_usage.clone()),
+                                            "provider_attempt_timeline": provider_attempt_timeline(&err),
+                                        }),
+                                    ),
+                                    AuditEvent::legacy(
+                                        "queue_entry_settled",
+                                        serde_json::json!({
+                                            "message_id": message.id.clone(),
+                                            "message_kind": message.kind.clone(),
+                                            "status": queue_status,
+                                            "reason": settlement_reason,
+                                        }),
+                                    ),
+                                ],
+                                Some(artifacts),
+                            )
+                        };
+                    if let Some(aborted) = aborted.as_ref() {
+                        audit_events.push(AuditEvent::legacy(
+                            "turn_terminal_aborted",
                             serde_json::json!({
-                                "message_id": message.id,
-                                "message_kind": message.kind,
                                 "run_id": aborted.run_id,
                                 "reason": aborted.reason,
+                                "turn_id": terminal.turn_id,
+                                "turn_index": terminal.turn_index,
+                                "kind": terminal.kind,
+                                "completed_at": terminal.completed_at,
+                                "duration_ms": terminal.duration_ms,
                             }),
-                        )],
-                        true,
-                    )
-                    .await?;
-                } else {
-                    let descriptor = describe_runtime_error(&err);
-                    let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
-                    error!(
-                        message_id = %message.id,
-                        turn_id = %terminal.turn_id,
-                        domain = ?descriptor.domain,
-                        code = %descriptor.code,
-                        retryable = descriptor.retryable,
-                        error = %descriptor.operator_message,
-                        "failed to process message"
-                    );
-                    self.inner.storage.append_event(&AuditEvent::legacy(
-                        "runtime_error",
-                        serde_json::json!({
-                            "message_id": message.id,
-                            "turn_id": terminal.turn_id,
-                            "message_kind": message.kind,
-                            "domain": descriptor.domain,
-                            "code": descriptor.code,
-                            "retryable": descriptor.retryable,
-                            "error": descriptor.operator_message,
-                            "recovery_hint": descriptor.recovery_hint,
-                            "safe_context": descriptor.safe_context,
-                            "source_chain": descriptor.source_chain,
-                            "token_usage": provider_attempt_timeline(&err)
-                                .and_then(|timeline| timeline.aggregated_token_usage.clone()),
-                            "provider_attempt_timeline": provider_attempt_timeline(&err),
-                        }),
-                    ))?;
-                    self.persist_runtime_failure_artifacts(&message, &err)
-                        .await?;
-                    let (queue_status, settlement_reason) =
-                        runtime_error_queue_settlement(&message.kind, &err);
-                    self.commit_queue_settlement(
+                        ));
+                    }
+                    let mut turn_record = self.build_turn_record(&terminal).await?;
+                    if let Some(artifacts) = failure_artifacts.as_ref() {
+                        if !turn_record.produced_brief_ids.contains(&artifacts.brief.id) {
+                            turn_record
+                                .produced_brief_ids
+                                .push(artifacts.brief.id.clone());
+                        }
+                    }
+                    let terminal_transition = turn::TurnTerminalTransition {
+                        terminal,
+                        turn_record,
+                    };
+                    let committed_state = {
+                        let guard = self.inner.agent.lock().await;
+                        let mut state = guard.state.clone();
+                        if !matches!(state.status, AgentStatus::Stopped) {
+                            if state.pending_fallback_model.is_some() {
+                                let has_fallback = provider_attempt_timeline(&err)
+                                    .and_then(|timeline| {
+                                        timeline.pending_fallback_model_ref.as_deref()
+                                    })
+                                    .is_some();
+                                if !has_fallback {
+                                    state.pending_fallback_model = None;
+                                }
+                            }
+                            scheduler::apply_idle_projection(&mut state, &self.inner.storage)?;
+                        }
+                        if let Some(artifacts) = failure_artifacts.as_ref() {
+                            state.last_runtime_failure = Some(artifacts.failure_summary.clone());
+                        }
+                        state
+                    };
+                    self.commit_queue_terminal_settlement_with_evidence(
                         QueueEntryRecord {
                             message_id: message.id.clone(),
                             agent_id: message.agent_id.clone(),
                             priority: message.priority.clone(),
-                            status: queue_status.clone(),
+                            status: queue_status,
                             created_at: message.created_at,
                             updated_at: Utc::now(),
                         },
-                        vec![AuditEvent::legacy(
-                            "queue_entry_settled",
-                            serde_json::json!({
-                                "message_id": message.id,
-                                "message_kind": message.kind,
-                                "status": queue_status,
-                                "reason": settlement_reason,
-                            }),
-                        )],
+                        audit_events,
                         true,
+                        Some(&terminal_transition),
+                        Some(committed_state),
+                        failure_artifacts
+                            .as_ref()
+                            .map(|artifacts| vec![artifacts.transcript.clone()])
+                            .unwrap_or_default(),
+                        failure_artifacts
+                            .as_ref()
+                            .map(|artifacts| vec![artifacts.brief.clone()])
+                            .unwrap_or_default(),
                     )
                     .await?;
+                    let failed_state = {
+                        let mut guard = self.inner.agent.lock().await;
+                        guard.current_run_abort = None;
+                        guard.state.clone()
+                    };
+                    self.append_state_changed_events(&failed_state)?;
+                    self.maybe_commit_turn_end_work_item_transition().await?;
+                    self.record_closure_decision_event(Some(true)).await?;
+                    self.maybe_emit_pending_system_tick(None).await?;
+                    continue;
                 }
-                let failed_state = {
-                    let mut guard = self.inner.agent.lock().await;
-                    if !matches!(guard.state.status, AgentStatus::Stopped) {
-                        // Defense-in-depth: clear a stale pending_fallback_model when
-                        // the current error has no further fallback to delegate to.
-                        // This prevents the agent from becoming permanently stuck on
-                        // a fallback model that is unsupported or unavailable.
-                        if guard.state.pending_fallback_model.is_some() {
-                            let has_fallback = provider_attempt_timeline(&err)
-                                .and_then(|t| t.pending_fallback_model_ref.as_deref())
-                                .is_some();
-                            if !has_fallback {
-                                guard.state.pending_fallback_model = None;
-                            }
-                        }
-                        scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
-                    }
-                    guard.current_run_abort = None;
-                    guard.persist_state(&self.inner.storage)?;
-                    guard.state.clone()
-                };
-                self.append_state_changed_events(&failed_state)?;
-                self.maybe_commit_turn_end_work_item_transition().await?;
-                self.record_closure_decision_event(Some(true)).await?;
-                self.maybe_emit_pending_system_tick(None).await?;
-            } else {
+            };
+            {
                 let processed_state = {
                     let mut guard = self.inner.agent.lock().await;
                     guard.current_run_abort = None;
                     guard.state.clone()
                 };
                 self.append_state_changed_events(&processed_state)?;
-                self.commit_queue_settlement(
+                self.commit_queue_terminal_settlement(
                     QueueEntryRecord {
                         message_id: message.id.clone(),
                         agent_id: message.agent_id.clone(),
@@ -2224,6 +2326,7 @@ impl RuntimeHandle {
                         }),
                     )],
                     true,
+                    terminal_transition.as_ref(),
                 )
                 .await?;
             }
@@ -2322,6 +2425,7 @@ impl RuntimeHandle {
                     agent_state: None,
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
+                    turn_record: None,
                     audit_events: vec![AuditEvent::legacy(
                         "queue_claim_released_for_runtime_restart",
                         serde_json::json!({
@@ -2437,6 +2541,7 @@ impl RuntimeHandle {
                     agent_state: None,
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
+                    turn_record: None,
                     audit_events: vec![AuditEvent::legacy(
                         "scheduler_bootstrap_claim_recovered",
                         serde_json::json!({

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -1,9 +1,19 @@
 use super::*;
 use crate::provider::ProviderAttemptTimeline;
 use crate::runtime_error::{describe_runtime_error, RuntimeErrorContext, RuntimeErrorDescriptor};
-use crate::types::{FailureArtifact, FailureArtifactCategory, TurnTerminalRecord};
+use crate::types::{
+    BriefRecord, FailureArtifact, FailureArtifactCategory, RuntimeFailureSummary, TranscriptEntry,
+    TurnTerminalRecord,
+};
+
+pub(super) struct RuntimeFailureArtifacts {
+    pub(super) brief: BriefRecord,
+    pub(super) transcript: TranscriptEntry,
+    pub(super) failure_summary: RuntimeFailureSummary,
+}
 
 impl RuntimeHandle {
+    #[cfg(test)]
     pub(super) async fn ensure_runtime_failure_terminal(
         &self,
         last_assistant_message: Option<String>,
@@ -20,8 +30,14 @@ impl RuntimeHandle {
         if let Some(terminal) = existing {
             return Ok(terminal);
         }
-        self.persist_turn_aborted_record("", "runtime_error", last_assistant_message, duration_ms)
-            .await
+        self.persist_turn_aborted_record(
+            "",
+            "runtime_error",
+            last_assistant_message,
+            duration_ms,
+            true,
+        )
+        .await
     }
 
     fn sanitize_failure_artifact_url(raw: &str) -> String {
@@ -317,14 +333,35 @@ impl RuntimeHandle {
         )
     }
 
+    #[cfg(test)]
     pub(super) async fn persist_runtime_failure_artifacts(
         &self,
         message: &MessageEnvelope,
         error: &anyhow::Error,
     ) -> Result<()> {
+        let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
+        let artifacts = self
+            .build_runtime_failure_artifacts(message, error, &terminal)
+            .await?;
+        self.persist_brief(&artifacts.brief).await?;
+        self.persist_turn_record(&terminal).await?;
+        self.persist_transcript_evidence(&artifacts.transcript)?;
+        {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.last_runtime_failure = Some(artifacts.failure_summary);
+            guard.persist_state(&self.inner.storage)?;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn build_runtime_failure_artifacts(
+        &self,
+        message: &MessageEnvelope,
+        error: &anyhow::Error,
+        terminal: &TurnTerminalRecord,
+    ) -> Result<RuntimeFailureArtifacts> {
         let failure_text = Self::concise_runtime_failure_text(message, error);
         let attempt_timeline = provider_attempt_timeline(error);
-        let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
         let (run_id, current_work_item_id) = {
             let guard = self.inner.agent.lock().await;
             (
@@ -355,9 +392,7 @@ impl RuntimeHandle {
         let mut brief = brief::make_failure(&message.agent_id, message, failure_text.clone());
         brief.turn_id = Some(terminal.turn_id.clone());
         brief.turn_index = Some(terminal.turn_index);
-        self.persist_brief(&brief).await?;
-        self.persist_turn_record(&terminal).await?;
-        self.persist_transcript_evidence(&TranscriptEntry::new(
+        let transcript = TranscriptEntry::new(
             message.agent_id.clone(),
             TranscriptEntryKind::RuntimeFailure,
             None,
@@ -375,18 +410,17 @@ impl RuntimeHandle {
                 "token_usage": token_usage,
                 "provider_attempt_timeline": attempt_timeline,
             }),
-        ))?;
-        {
-            let mut guard = self.inner.agent.lock().await;
-            guard.state.last_runtime_failure = Some(RuntimeFailureSummary {
+        );
+        Ok(RuntimeFailureArtifacts {
+            brief,
+            transcript,
+            failure_summary: RuntimeFailureSummary {
                 occurred_at: Utc::now(),
                 summary: failure_text,
                 phase: RuntimeFailurePhase::RuntimeTurn,
                 detail_hint: Some("run `holon daemon logs` for details".into()),
                 failure_artifact: Some(failure_artifact),
-            });
-            guard.persist_state(&self.inner.storage)?;
-        }
-        Ok(())
+            },
+        })
     }
 }

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -814,6 +814,7 @@ impl RuntimeHandle {
                     }),
                     message_evidence: vec![message.clone()],
                     transcript_entries: Vec::new(),
+                    turn_record: None,
                     audit_events,
                     scheduler_shadow_comparison,
                     scheduler_delivery_shadow_comparison: None,

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -79,10 +79,25 @@ impl RuntimeHandle {
 
     pub(super) async fn process_message_with_plan(
         &self,
-        mut message: MessageEnvelope,
+        message: MessageEnvelope,
         plan: MessageDispatchPlan,
         scheduler_decision: &scheduler::SchedulerDecision,
     ) -> Result<()> {
+        if let Some(transition) = self
+            .process_message_with_plan_deferred(message, plan, scheduler_decision)
+            .await?
+        {
+            self.persist_terminal_transition(&transition).await?;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn process_message_with_plan_deferred(
+        &self,
+        mut message: MessageEnvelope,
+        plan: MessageDispatchPlan,
+        scheduler_decision: &scheduler::SchedulerDecision,
+    ) -> Result<Option<turn::TurnTerminalTransition>> {
         message.normalize_admission_fields();
         self.inner.storage.append_event(&AuditEvent::typed(
             RuntimeEventKind::MessageProcessingStarted,
@@ -97,6 +112,7 @@ impl RuntimeHandle {
         } = plan;
         let model_reentry = scheduler_decision.model_reentry;
         let task = task?;
+        let mut terminal_transition = None;
         if let Some(trigger) = continuation_trigger.as_ref() {
             self.record_continuation_trigger_received(&message, trigger, &prior_closure)
                 .await?;
@@ -116,14 +132,16 @@ impl RuntimeHandle {
                         guard.state.current_turn_work_item_id = Some(work_item_id.to_string());
                         guard.persist_state(&self.inner.storage)?;
                     }
-                    self.process_interactive_message(
-                        &message,
-                        continuation_resolution.as_ref(),
-                        LoopControlOptions {
-                            max_tool_rounds: None,
-                        },
-                    )
-                    .await?;
+                    terminal_transition = Some(
+                        self.process_interactive_message_deferred(
+                            &message,
+                            continuation_resolution.as_ref(),
+                            LoopControlOptions {
+                                max_tool_rounds: None,
+                            },
+                        )
+                        .await?,
+                    );
                 }
             }
             MessageKind::TaskStatus => {
@@ -132,13 +150,14 @@ impl RuntimeHandle {
             }
             MessageKind::TaskResult => {
                 let task = task.ok_or_else(|| anyhow!("task result message should parse task"))?;
-                self.reduce_task_result_message(
-                    &message,
-                    task,
-                    model_reentry,
-                    continuation_resolution.as_ref(),
-                )
-                .await?;
+                terminal_transition = self
+                    .reduce_task_result_message_deferred(
+                        &message,
+                        task,
+                        model_reentry,
+                        continuation_resolution.as_ref(),
+                    )
+                    .await?;
             }
             MessageKind::Control => {
                 let action = match &message.body {
@@ -211,7 +230,7 @@ impl RuntimeHandle {
         ))?;
 
         info!("processed message {}", message.id);
-        Ok(())
+        Ok(terminal_transition)
     }
 
     async fn refresh_current_work_item_refs(

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -1,13 +1,29 @@
 use super::*;
+use crate::runtime::turn::TurnTerminalTransition;
 use crate::tool::{ApplyPatchSurface, ToolSpec};
 
 impl RuntimeHandle {
+    #[cfg(test)]
     pub(super) async fn process_interactive_message(
         &self,
         message: &MessageEnvelope,
         continuation_resolution: Option<&ContinuationResolution>,
         loop_control: LoopControlOptions,
     ) -> Result<()> {
+        let terminal_transition = self
+            .process_interactive_message_deferred(message, continuation_resolution, loop_control)
+            .await?;
+        self.persist_terminal_transition(&terminal_transition)
+            .await?;
+        Ok(())
+    }
+
+    pub(super) async fn process_interactive_message_deferred(
+        &self,
+        message: &MessageEnvelope,
+        continuation_resolution: Option<&ContinuationResolution>,
+        loop_control: LoopControlOptions,
+    ) -> Result<TurnTerminalTransition> {
         let (operator_binding_id, operator_reply_route_id) =
             Self::operator_transport_from_message(message);
         self.begin_interactive_turn(
@@ -91,7 +107,7 @@ impl RuntimeHandle {
             }),
         ))?;
         let outcome = self
-            .run_agent_loop(
+            .run_agent_loop_deferred(
                 &message.agent_id,
                 message.authority_class.clone(),
                 built,
@@ -126,7 +142,7 @@ impl RuntimeHandle {
             );
             self.persist_brief(&brief).await?;
         }
-        self.persist_turn_record(&outcome.terminal).await?;
+        let turn_record = self.build_turn_record(&outcome.terminal).await?;
         self.promote_turn_active_skills().await?;
 
         if outcome.should_sleep {
@@ -139,7 +155,10 @@ impl RuntimeHandle {
         }
 
         crate::diagnostics::record_turn_cleanup(cleanup_started.elapsed());
-        Ok(())
+        Ok(TurnTerminalTransition {
+            terminal: outcome.terminal,
+            turn_record,
+        })
     }
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1346,7 +1346,7 @@ pub(crate) fn shadow_comparison_for_settlement(
         QueueEntryStatus::Dropped => "dropped",
         QueueEntryStatus::Queued | QueueEntryStatus::Dequeued => return None,
     };
-    let candidate_disposition = restricted_settlement_disposition(projection);
+    let candidate_disposition = restricted_settlement_disposition(projection, record);
     let input_identity = format!("message:{}", record.message_id);
     let observation = LegacySchedulerObservation::Settlement(LegacySettlementObservation {
         schema_version: 1,
@@ -1376,14 +1376,25 @@ pub(crate) fn shadow_comparison_for_settlement(
     })
 }
 
-fn restricted_settlement_disposition(projection: &SchedulerProjection) -> &'static str {
-    if matches!(projection.status, AgentStatus::Stopped) {
-        return "failed";
+fn restricted_settlement_disposition(
+    projection: &SchedulerProjection,
+    record: &QueueEntryRecord,
+) -> &'static str {
+    match record.status {
+        QueueEntryStatus::Aborted | QueueEntryStatus::Dropped => "failed",
+        QueueEntryStatus::Interrupted => "interrupted",
+        QueueEntryStatus::Interjected => "interjected",
+        QueueEntryStatus::Processed => {
+            if matches!(projection.status, AgentStatus::Stopped) {
+                "failed"
+            } else if projection.turn_in_progress {
+                "pending"
+            } else {
+                "complete"
+            }
+        }
+        QueueEntryStatus::Queued | QueueEntryStatus::Dequeued => "pending",
     }
-    if projection.turn_in_progress {
-        return "pending";
-    }
-    "complete"
 }
 
 pub(crate) fn shadow_comparison_for_delivery(
@@ -1428,7 +1439,8 @@ pub(crate) fn shadow_comparison_for_delivery(
         delivery_disposition: candidate_disposition,
         resulting_posture: "open",
     });
-    let legacy_category = turn_terminal_delivery_category(projection.last_turn_terminal);
+    let legacy_category =
+        turn_terminal_delivery_category(projection.last_turn_terminal, &record.status);
     let matched = legacy_category == candidate_disposition;
     Some(SchedulerShadowComparison {
         scenario_class: DELIVERY_SCENARIO,
@@ -1442,16 +1454,38 @@ pub(crate) fn shadow_comparison_for_delivery(
     })
 }
 
-fn turn_terminal_delivery_category(kind: Option<TurnTerminalKind>) -> &'static str {
-    match kind {
-        Some(TurnTerminalKind::Completed) => "completed",
-        Some(
-            TurnTerminalKind::Aborted
-            | TurnTerminalKind::ProviderFailedNeedsRecovery
-            | TurnTerminalKind::BaselineOverBudget,
+fn turn_terminal_delivery_category(
+    kind: Option<TurnTerminalKind>,
+    queue_status: &QueueEntryStatus,
+) -> &'static str {
+    match (kind, queue_status) {
+        (
+            Some(
+                TurnTerminalKind::Aborted
+                | TurnTerminalKind::ProviderFailedNeedsRecovery
+                | TurnTerminalKind::BaselineOverBudget,
+            ),
+            QueueEntryStatus::Interrupted | QueueEntryStatus::Interjected,
+        ) => "interrupted",
+        (
+            Some(
+                TurnTerminalKind::Aborted
+                | TurnTerminalKind::ProviderFailedNeedsRecovery
+                | TurnTerminalKind::BaselineOverBudget,
+            ),
+            QueueEntryStatus::Aborted | QueueEntryStatus::Dropped,
         ) => "failed",
-        Some(TurnTerminalKind::DeferredToFallback) => "pending",
-        None => "none",
+        (Some(TurnTerminalKind::Completed), _) => "completed",
+        (
+            Some(
+                TurnTerminalKind::Aborted
+                | TurnTerminalKind::ProviderFailedNeedsRecovery
+                | TurnTerminalKind::BaselineOverBudget,
+            ),
+            _,
+        ) => "failed",
+        (Some(TurnTerminalKind::DeferredToFallback), _) => "pending",
+        (None, _) => "none",
     }
 }
 

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -454,6 +454,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     }),
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
+                    turn_record: None,
                     audit_events: vec![
                         scheduler_decision_events[0].clone(),
                         scheduler_decision_events[1].clone(),

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -331,6 +331,7 @@ impl RuntimeHandle {
             .await
     }
 
+    #[cfg(test)]
     pub(super) async fn reduce_task_result_message(
         &self,
         message: &MessageEnvelope,
@@ -338,8 +339,29 @@ impl RuntimeHandle {
         model_reentry: bool,
         continuation_resolution: Option<&ContinuationResolution>,
     ) -> Result<()> {
+        if let Some(transition) = self
+            .reduce_task_result_message_deferred(
+                message,
+                task,
+                model_reentry,
+                continuation_resolution,
+            )
+            .await?
+        {
+            self.persist_terminal_transition(&transition).await?;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn reduce_task_result_message_deferred(
+        &self,
+        message: &MessageEnvelope,
+        task: TaskRecord,
+        model_reentry: bool,
+        continuation_resolution: Option<&ContinuationResolution>,
+    ) -> Result<Option<turn::TurnTerminalTransition>> {
         if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, &task) {
-            return Ok(());
+            return Ok(None);
         }
         self.persist_task_transition(&task, "task_result_received")
             .await?;
@@ -379,21 +401,23 @@ impl RuntimeHandle {
                 guard.state.current_turn_work_item_id = Some(work_item_id);
                 guard.persist_state(&self.inner.storage)?;
             }
-            self.process_interactive_message(
-                message,
-                continuation_resolution,
-                LoopControlOptions {
-                    max_tool_rounds: None,
-                },
-            )
-            .await?;
+            let transition = self
+                .process_interactive_message_deferred(
+                    message,
+                    continuation_resolution,
+                    LoopControlOptions {
+                        max_tool_rounds: None,
+                    },
+                )
+                .await?;
+            return Ok(Some(transition));
         } else {
             if emit_result_brief {
                 let brief = brief::make_result(&message.agent_id, message, result_text);
                 self.persist_brief(&brief).await?;
             }
         }
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -16,11 +16,42 @@ struct BlockingProvider {
     started: Arc<tokio::sync::Notify>,
 }
 
+struct GatedFailingProvider {
+    started: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
 async fn finish_claimed_test_run(runtime: &RuntimeHandle) {
     let mut guard = runtime.inner.agent.lock().await;
     scheduler::apply_idle_projection(&mut guard.state, &runtime.inner.storage).unwrap();
     guard.current_run_abort = None;
     guard.persist_state(&runtime.inner.storage).unwrap();
+}
+
+fn terminal_transition(
+    message: &MessageEnvelope,
+    work_item_id: Option<&str>,
+) -> super::super::turn::TurnTerminalTransition {
+    let turn_id = message.turn_id.clone().expect("test message turn id");
+    let terminal = crate::types::TurnTerminalRecord {
+        turn_id: turn_id.clone(),
+        turn_index: 1,
+        kind: crate::types::TurnTerminalKind::Completed,
+        reason: None,
+        last_assistant_message: Some("terminal transition committed".into()),
+        checkpoint: None,
+        completed_at: Utc::now(),
+        duration_ms: 1,
+    };
+    let mut turn_record = crate::types::TurnRecord::new(&message.agent_id, turn_id, 1);
+    turn_record.current_work_item_id = work_item_id.map(ToString::to_string);
+    turn_record.trigger = Some(crate::types::TurnTriggerSummary::from_message(message));
+    turn_record.input_message_ids = vec![message.id.clone()];
+    turn_record.terminal = Some(crate::types::TurnTerminalSummary::from_terminal(&terminal));
+    super::super::turn::TurnTerminalTransition {
+        terminal,
+        turn_record,
+    }
 }
 
 fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
@@ -403,6 +434,15 @@ impl AgentProvider for BlockingProvider {
     async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
         self.started.notify_waiters();
         std::future::pending::<Result<ProviderTurnResponse>>().await
+    }
+}
+
+#[async_trait]
+impl AgentProvider for GatedFailingProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        self.started.notify_one();
+        self.release.notified().await;
+        Err(anyhow!("injected gated provider failure"))
     }
 }
 
@@ -1150,6 +1190,569 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
 }
 
 #[tokio::test]
+async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent() {
+    for fault in PRE_COMMIT_FAULTS {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        runtime.set_scheduler_protocol_production_commands_enabled(true);
+        enable_production_protocol_authority(&runtime);
+        let work_item = runtime
+            .create_work_item("atomic terminal settlement".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_queue".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "commit terminal atomically".into(),
+            },
+        );
+        message.work_item_id = Some(work_item.id.clone());
+        message.turn_id = Some(format!("turn-terminal-fault-{fault:?}"));
+        let message = runtime.enqueue(message).await.unwrap();
+        let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap();
+        assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+        let claimed = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap();
+        finish_claimed_test_run(&runtime).await;
+
+        let processed = QueueEntryRecord {
+            message_id: message.id.clone(),
+            agent_id: message.agent_id.clone(),
+            priority: message.priority.clone(),
+            status: QueueEntryStatus::Processed,
+            created_at: message.created_at,
+            updated_at: Utc::now(),
+        };
+        let transition = terminal_transition(&message, Some(&work_item.id));
+        runtime.inject_next_transition_fault(fault);
+
+        let error = runtime
+            .commit_queue_terminal_settlement(
+                processed.clone(),
+                Vec::new(),
+                true,
+                Some(&transition),
+            )
+            .await
+            .unwrap_err();
+        assert_injected_transition_fault(&error);
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .load_scheduler_protocol_snapshot("default")
+                .unwrap(),
+            claimed
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .queue_entries()
+                .latest_all()
+                .unwrap()
+                .into_iter()
+                .find(|entry| entry.message_id == message.id)
+                .map(|entry| entry.status),
+            Some(QueueEntryStatus::Dequeued)
+        );
+        assert!(runtime
+            .inner
+            .runtime_db
+            .agent_states()
+            .latest("default")
+            .unwrap()
+            .unwrap()
+            .last_turn_terminal
+            .is_none());
+        assert!(runtime
+            .storage()
+            .read_recent_turns(16)
+            .unwrap()
+            .iter()
+            .all(|turn| turn.turn_id != transition.terminal.turn_id));
+        assert!(runtime
+            .storage()
+            .read_recent_events(64)
+            .unwrap()
+            .iter()
+            .all(|event| {
+                !(event.kind == "turn_terminal"
+                    && event.data["turn_id"] == transition.terminal.turn_id)
+            }));
+
+        assert!(runtime
+            .commit_queue_terminal_settlement(
+                processed.clone(),
+                Vec::new(),
+                true,
+                Some(&transition),
+            )
+            .await
+            .unwrap());
+        let committed_events = runtime.storage().read_recent_events(128).unwrap();
+        let terminal_event_count = committed_events
+            .iter()
+            .filter(|event| {
+                event.kind == "turn_terminal"
+                    && event.data["turn_id"] == transition.terminal.turn_id
+            })
+            .count();
+        assert_eq!(terminal_event_count, 1);
+        assert_eq!(
+            runtime
+                .storage()
+                .read_recent_turns(16)
+                .unwrap()
+                .iter()
+                .filter(|turn| turn.turn_id == transition.terminal.turn_id)
+                .count(),
+            1
+        );
+        let settled = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap();
+        assert_eq!(settled.slot, ActivationSlot::Idle);
+        assert!(settled
+            .settlements
+            .contains_key(&canonical_settlement_id(&message.id)));
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .agent_states()
+                .latest("default")
+                .unwrap()
+                .unwrap()
+                .last_turn_terminal,
+            Some(transition.terminal.clone())
+        );
+
+        assert!(!runtime
+            .commit_queue_terminal_settlement(processed, Vec::new(), true, Some(&transition),)
+            .await
+            .unwrap());
+        assert_eq!(
+            runtime
+                .storage()
+                .read_recent_events(128)
+                .unwrap()
+                .iter()
+                .filter(|event| {
+                    event.kind == "turn_terminal"
+                        && event.data["turn_id"] == transition.terminal.turn_id
+                })
+                .count(),
+            1
+        );
+    }
+}
+
+#[tokio::test]
+async fn terminal_settlement_survives_post_commit_effect_faults() {
+    for (fault, expected_effect) in POST_COMMIT_FAULTS {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        runtime.set_scheduler_protocol_production_commands_enabled(true);
+        enable_production_protocol_authority(&runtime);
+        let work_item = runtime
+            .create_work_item(
+                "post-commit terminal settlement".into(),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_queue".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "retain committed terminal".into(),
+            },
+        );
+        message.work_item_id = Some(work_item.id.clone());
+        message.turn_id = Some(format!("turn-terminal-post-commit-{fault:?}"));
+        let message = runtime.enqueue(message).await.unwrap();
+        let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap();
+        assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+        finish_claimed_test_run(&runtime).await;
+
+        let transition = terminal_transition(&message, Some(&work_item.id));
+        runtime.inject_next_transition_fault(fault);
+        assert!(runtime
+            .commit_queue_terminal_settlement(
+                QueueEntryRecord {
+                    message_id: message.id.clone(),
+                    agent_id: message.agent_id.clone(),
+                    priority: message.priority,
+                    status: QueueEntryStatus::Processed,
+                    created_at: message.created_at,
+                    updated_at: Utc::now(),
+                },
+                Vec::new(),
+                true,
+                Some(&transition),
+            )
+            .await
+            .unwrap());
+        let warnings = runtime.take_transition_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].effect, expected_effect);
+
+        let snapshot = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap();
+        assert_eq!(snapshot.slot, ActivationSlot::Idle);
+        assert!(snapshot
+            .settlements
+            .contains_key(&canonical_settlement_id(&message.id)));
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .queue_entries()
+                .latest_all()
+                .unwrap()
+                .into_iter()
+                .find(|entry| entry.message_id == message.id)
+                .map(|entry| entry.status),
+            Some(QueueEntryStatus::Processed)
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .agent_states()
+                .latest("default")
+                .unwrap()
+                .unwrap()
+                .last_turn_terminal,
+            Some(transition.terminal.clone())
+        );
+        assert!(runtime
+            .storage()
+            .read_recent_turns(16)
+            .unwrap()
+            .iter()
+            .any(|turn| turn.turn_id == transition.terminal.turn_id));
+    }
+}
+
+#[tokio::test]
+async fn runtime_failure_terminal_fault_rolls_back_queue_canonical_and_failure_evidence() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(GatedFailingProvider {
+            started: started.clone(),
+            release: release.clone(),
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "runtime failure terminal rollback".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "fail after canonical claim".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id);
+    let message = runtime.enqueue(message).await.unwrap();
+    let turn_id = message.turn_id.clone().expect("enqueued turn id");
+
+    let runner = tokio::spawn(runtime.clone().run());
+    tokio::time::timeout(std::time::Duration::from_secs(2), started.notified())
+        .await
+        .expect("provider should start");
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    runtime.inject_next_transition_fault(
+        crate::runtime_db::transitions::TransitionFaultPoint::AfterAuditWrites,
+    );
+    release.notify_one();
+
+    let error = tokio::time::timeout(std::time::Duration::from_secs(2), runner)
+        .await
+        .expect("runtime should exit after terminal settlement fault")
+        .unwrap()
+        .unwrap_err();
+    assert_injected_transition_fault(&error);
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        claimed
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .agent_states()
+        .latest("default")
+        .unwrap()
+        .unwrap()
+        .last_turn_terminal
+        .is_none());
+    assert!(runtime
+        .storage()
+        .read_recent_turns(16)
+        .unwrap()
+        .iter()
+        .all(|turn| turn.turn_id != turn_id));
+    assert!(runtime
+        .storage()
+        .read_recent_briefs(16)
+        .unwrap()
+        .iter()
+        .all(|brief| brief.related_message_id.as_deref() != Some(message.id.as_str())));
+    assert!(runtime
+        .storage()
+        .read_recent_transcript(32)
+        .unwrap()
+        .iter()
+        .all(|entry| {
+            entry.kind != TranscriptEntryKind::RuntimeFailure
+                || entry.related_message_id.as_deref() != Some(message.id.as_str())
+        }));
+    assert!(runtime
+        .storage()
+        .read_recent_events(128)
+        .unwrap()
+        .iter()
+        .all(|event| {
+            event.data["message_id"] != message.id
+                || !matches!(
+                    event.kind.as_str(),
+                    "runtime_error" | "queue_entry_settled" | "turn_terminal"
+                )
+        }));
+}
+
+#[tokio::test]
+async fn interrupted_terminal_fault_rolls_back_queue_canonical_and_turn_facts() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(BlockingProvider {
+            started: started.clone(),
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "interrupted terminal rollback".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "abort after canonical claim".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id);
+    let message = runtime.enqueue(message).await.unwrap();
+    let turn_id = message.turn_id.clone().expect("enqueued turn id");
+
+    let runner = tokio::spawn(runtime.clone().run());
+    tokio::time::timeout(std::time::Duration::from_secs(2), started.notified())
+        .await
+        .expect("provider should start");
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let run_id = runtime
+        .agent_state()
+        .await
+        .unwrap()
+        .current_run_id
+        .expect("active run id");
+    runtime.inject_next_transition_fault(
+        crate::runtime_db::transitions::TransitionFaultPoint::AfterAuditWrites,
+    );
+    runtime
+        .abort_current_run(CurrentRunAbortRequest {
+            run_id: Some(run_id),
+            mode: CurrentRunAbortMode::StopAfterAbort,
+        })
+        .await
+        .unwrap();
+
+    let error = tokio::time::timeout(std::time::Duration::from_secs(2), runner)
+        .await
+        .expect("runtime should exit after interrupted terminal settlement fault")
+        .unwrap()
+        .unwrap_err();
+    assert_injected_transition_fault(&error);
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        claimed
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .agent_states()
+        .latest("default")
+        .unwrap()
+        .unwrap()
+        .last_turn_terminal
+        .is_none());
+    assert!(runtime
+        .storage()
+        .read_recent_turns(16)
+        .unwrap()
+        .iter()
+        .all(|turn| turn.turn_id != turn_id));
+    assert!(runtime
+        .storage()
+        .read_recent_events(128)
+        .unwrap()
+        .iter()
+        .all(|event| {
+            event.data["message_id"] != message.id
+                || !matches!(
+                    event.kind.as_str(),
+                    "message_processing_aborted" | "turn_terminal_aborted" | "turn_terminal"
+                )
+        }));
+}
+
+#[tokio::test]
 async fn completed_production_settlement_uses_exact_bound_result_brief() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -1317,7 +1920,7 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
 }
 
 #[tokio::test]
-async fn completed_production_settlement_rejects_mismatched_completion_execution() {
+async fn completed_production_settlement_records_missing_for_mismatched_completion_execution() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -1417,7 +2020,7 @@ async fn completed_production_settlement_rejects_mismatched_completion_execution
     runtime.apply_transition_commit(commit).await;
 
     finish_claimed_test_run(&runtime).await;
-    let error = runtime
+    assert!(runtime
         .commit_queue_settlement(
             QueueEntryRecord {
                 message_id: message.id.clone(),
@@ -1437,10 +2040,7 @@ async fn completed_production_settlement_rejects_mismatched_completion_execution
             true,
         )
         .await
-        .expect_err("settlement must reject a completion intent from another execution");
-    assert!(error
-        .to_string()
-        .contains("completion intent does not match the settling execution"));
+        .unwrap());
 
     let snapshot = runtime
         .inner
@@ -1448,9 +2048,18 @@ async fn completed_production_settlement_rejects_mismatched_completion_execution
         .transitions()
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
-    assert!(!snapshot
-        .settlements
-        .contains_key(&canonical_settlement_id(&message.id)));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    assert!(snapshot
+        .missing_settlements
+        .contains_key(&canonical_missing_settlement_id(&message.id)));
+    assert_eq!(
+        snapshot
+            .activations
+            .get(&activation_id)
+            .map(|activation| activation.state.clone()),
+        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing)
+    );
     assert_eq!(
         runtime
             .inner
@@ -1461,7 +2070,113 @@ async fn completed_production_settlement_rejects_mismatched_completion_execution
             .into_iter()
             .find(|entry| entry.message_id == message.id)
             .map(|entry| entry.status),
-        Some(QueueEntryStatus::Dequeued)
+        Some(QueueEntryStatus::Processed)
+    );
+}
+
+#[tokio::test]
+async fn completed_production_settlement_records_missing_without_result_report() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "complete without result report".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete without delivery evidence".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.turn_id = Some("turn-missing-completion-report".into());
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+    runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    finish_claimed_test_run(&runtime).await;
+
+    assert!(runtime
+        .commit_queue_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+        )
+        .await
+        .unwrap());
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    assert!(snapshot
+        .missing_settlements
+        .contains_key(&canonical_missing_settlement_id(&message.id)));
+    assert_eq!(
+        snapshot
+            .activations
+            .get(&activation_id)
+            .map(|activation| activation.state.clone()),
+        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing)
+    );
+    assert_eq!(
+        snapshot
+            .work
+            .get(&work_item.id)
+            .map(|demand| &demand.status),
+        Some(&WorkStatus::NeedsSettlement { activation_id })
     );
 }
 
@@ -5582,6 +6297,7 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
             }),
             message_evidence: Vec::new(),
             transcript_entries: Vec::new(),
+            turn_record: None,
             audit_events: Vec::new(),
             scheduler_semantic_shadow: None,
             scheduler_shadow_comparison: None,

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1741,6 +1741,22 @@ fn settlement_shadow_comparison_matches_aborted_with_stopped_agent() {
     assert_eq!(candidate["settlement_disposition"], "failed");
 }
 
+#[test]
+fn settlement_shadow_comparison_matches_aborted_with_idle_agent() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let record = make_settlement_record("msg-1", QueueEntryStatus::Aborted);
+    let comparison = scheduler::shadow_comparison_for_settlement(&projection, &record)
+        .expect("aborted settlement should produce comparison");
+    assert!(comparison.matched);
+    assert_eq!(comparison.divergence_code, None);
+    let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
+    assert_eq!(candidate["settlement_disposition"], "failed");
+}
+
 // --- delivery shadow comparison ---
 
 #[test]
@@ -1862,6 +1878,34 @@ fn delivery_shadow_comparison_matches_interrupted_settlement() {
     assert!(!comparison.matched);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
     assert_eq!(observation["turn_terminal"], "none");
+    let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
+    assert_eq!(candidate["delivery_disposition"], "interrupted");
+}
+
+#[test]
+fn delivery_shadow_comparison_matches_interrupted_with_aborted_terminal() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.last_turn_terminal = Some(TurnTerminalRecord {
+        turn_id: "turn-1".into(),
+        turn_index: 1,
+        kind: TurnTerminalKind::Aborted,
+        reason: Some("operator_abort".into()),
+        last_assistant_message: None,
+        checkpoint: None,
+        completed_at: Utc::now(),
+        duration_ms: 100,
+    });
+    storage.write_agent(&agent).unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let record = make_settlement_record("msg-1", QueueEntryStatus::Interrupted);
+    let comparison = scheduler::shadow_comparison_for_delivery(&projection, &record)
+        .expect("interrupted delivery should produce comparison");
+    assert!(comparison.matched);
+    assert_eq!(comparison.divergence_code, None);
+    let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
+    assert_eq!(observation["turn_terminal"], "aborted");
     let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
     assert_eq!(candidate["delivery_disposition"], "interrupted");
 }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -66,6 +66,7 @@ impl RuntimeHandle {
         round: usize,
         error: &anyhow::Error,
         duration_ms: u64,
+        persist_terminal: bool,
     ) -> Result<Option<AgentLoopOutcome>> {
         if !provider_error_is_context_length_exceeded(error) {
             return Ok(None);
@@ -89,6 +90,7 @@ impl RuntimeHandle {
                 Some(final_text.clone()),
                 duration_ms,
                 None,
+                persist_terminal,
             )
             .await?;
         Ok(Some(AgentLoopOutcome {
@@ -109,6 +111,7 @@ impl RuntimeHandle {
         last_assistant_message: Option<String>,
         duration_ms: u64,
         checkpoint_state: Option<&TurnLocalCheckpointState>,
+        persist: bool,
     ) -> Result<TurnTerminalRecord> {
         let record = {
             let mut guard = self.inner.agent.lock().await;
@@ -135,14 +138,18 @@ impl RuntimeHandle {
                 completed_at: chrono::Utc::now(),
                 duration_ms,
             };
-            guard.state.last_turn_terminal = Some(record.clone());
-            guard.persist_state(&self.inner.storage)?;
+            if persist {
+                guard.state.last_turn_terminal = Some(record.clone());
+                guard.persist_state(&self.inner.storage)?;
+            }
             record
         };
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "turn_terminal",
-            serde_json::to_value(&record)?,
-        ))?;
+        if persist {
+            self.inner.storage.append_event(&AuditEvent::legacy(
+                "turn_terminal",
+                serde_json::to_value(&record)?,
+            ))?;
+        }
         Ok(record)
     }
     pub(super) async fn maybe_defer_provider_lineage_failure(
@@ -153,6 +160,7 @@ impl RuntimeHandle {
         last_assistant_message: Option<String>,
         duration_ms: u64,
         side_effect_boundary_crossed: bool,
+        persist_terminal: bool,
     ) -> Result<Option<AgentLoopOutcome>> {
         let Some(timeline) = provider_attempt_timeline(error).cloned() else {
             return Ok(None);
@@ -203,6 +211,7 @@ impl RuntimeHandle {
                     .or_else(|| Some(final_text.clone())),
                 duration_ms,
                 None,
+                persist_terminal,
             )
             .await?;
         let event_kind = if side_effect_boundary_crossed {
@@ -431,6 +440,7 @@ impl RuntimeHandle {
                         }),
                         message_evidence: Vec::new(),
                         transcript_entries: vec![transcript],
+                        turn_record: None,
                         audit_events: vec![audit_event],
                         scheduler_shadow_comparison: shadow_comparison,
                         scheduler_delivery_shadow_comparison: None,
@@ -477,6 +487,7 @@ impl RuntimeHandle {
         Ok(admitted)
     }
 
+    #[cfg(test)]
     pub(crate) async fn run_agent_loop(
         &self,
         agent_id: &str,
@@ -490,6 +501,26 @@ impl RuntimeHandle {
             authority_class,
             effective_prompt,
             loop_control,
+            persist_terminal: true,
+        }
+        .run()
+        .await
+    }
+
+    pub(crate) async fn run_agent_loop_deferred(
+        &self,
+        agent_id: &str,
+        authority_class: AuthorityClass,
+        effective_prompt: EffectivePrompt,
+        loop_control: LoopControlOptions,
+    ) -> Result<AgentLoopOutcome> {
+        TurnExecution {
+            runtime: self,
+            agent_id,
+            authority_class,
+            effective_prompt,
+            loop_control,
+            persist_terminal: false,
         }
         .run()
         .await
@@ -615,6 +646,7 @@ pub(super) struct TurnExecution<'a> {
     pub(super) authority_class: AuthorityClass,
     pub(super) effective_prompt: EffectivePrompt,
     pub(super) loop_control: LoopControlOptions,
+    pub(super) persist_terminal: bool,
 }
 
 impl TurnExecution<'_> {
@@ -625,6 +657,7 @@ impl TurnExecution<'_> {
             authority_class,
             mut effective_prompt,
             loop_control,
+            persist_terminal,
         } = self;
         let mut completed_rounds = Vec::<TurnRoundRecord>::new();
         let turn_started_at = Instant::now();
@@ -691,6 +724,7 @@ impl TurnExecution<'_> {
                             &aborted.reason,
                             last_assistant_message.clone(),
                             turn_started_at.elapsed().as_millis() as u64,
+                            persist_terminal,
                         )
                         .await?;
                 }
@@ -708,6 +742,7 @@ impl TurnExecution<'_> {
                             Some(final_text.clone()),
                             turn_started_at.elapsed().as_millis() as u64,
                             None,
+                            persist_terminal,
                         )
                         .await?;
                     return Ok(AgentLoopOutcome {
@@ -777,6 +812,7 @@ impl TurnExecution<'_> {
                                     &aborted.reason,
                                     last_assistant_message.clone(),
                                     turn_started_at.elapsed().as_millis() as u64,
+                                    persist_terminal,
                                 )
                                 .await?;
                             return Err(err);
@@ -787,6 +823,7 @@ impl TurnExecution<'_> {
                                 round,
                                 &err,
                                 turn_started_at.elapsed().as_millis() as u64,
+                                persist_terminal,
                             )
                             .await?
                         {
@@ -800,6 +837,7 @@ impl TurnExecution<'_> {
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                                 !completed_rounds.is_empty() || last_assistant_message.is_some(),
+                                persist_terminal,
                             )
                             .await?
                         {
@@ -818,6 +856,7 @@ impl TurnExecution<'_> {
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                                 None,
+                                persist_terminal,
                             )
                             .await?;
                         return Err(err);
@@ -1028,6 +1067,7 @@ impl TurnExecution<'_> {
                                     Some(final_text.clone()),
                                     turn_started_at.elapsed().as_millis() as u64,
                                     None,
+                                    persist_terminal,
                                 )
                                 .await?;
                             return Ok(AgentLoopOutcome {
@@ -1121,6 +1161,7 @@ impl TurnExecution<'_> {
                                     &aborted.reason,
                                     last_assistant_message.clone(),
                                     turn_started_at.elapsed().as_millis() as u64,
+                                    persist_terminal,
                                 )
                                 .await?;
                             return Err(err);
@@ -1131,6 +1172,7 @@ impl TurnExecution<'_> {
                                 round,
                                 &err,
                                 turn_started_at.elapsed().as_millis() as u64,
+                                persist_terminal,
                             )
                             .await?
                         {
@@ -1144,6 +1186,7 @@ impl TurnExecution<'_> {
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                                 !completed_rounds.is_empty() || last_assistant_message.is_some(),
+                                persist_terminal,
                             )
                             .await?
                         {
@@ -1162,6 +1205,7 @@ impl TurnExecution<'_> {
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                                 None,
+                                persist_terminal,
                             )
                             .await?;
                         return Err(err);
@@ -1650,6 +1694,7 @@ impl TurnExecution<'_> {
                         last_assistant_message.clone(),
                         turn_started_at.elapsed().as_millis() as u64,
                         Some(&checkpoint_state),
+                        persist_terminal,
                     )
                     .await?;
                 return Ok(AgentLoopOutcome {
@@ -1678,6 +1723,7 @@ impl TurnExecution<'_> {
                                 &aborted.reason,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
+                                persist_terminal,
                             )
                             .await?;
                     }
@@ -1958,6 +2004,7 @@ impl TurnExecution<'_> {
                                     &aborted.reason,
                                     last_assistant_message.clone(),
                                     turn_started_at.elapsed().as_millis() as u64,
+                                    persist_terminal,
                                 )
                                 .await?;
                             return Err(err);
@@ -2145,6 +2192,7 @@ impl TurnExecution<'_> {
                         last_assistant_message.clone(),
                         turn_started_at.elapsed().as_millis() as u64,
                         Some(&checkpoint_state),
+                        persist_terminal,
                     )
                     .await?;
                 return Ok(AgentLoopOutcome {

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -45,6 +45,12 @@ pub(crate) struct AgentLoopOutcome {
     pub(super) terminal_kind: TurnTerminalKind,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct TurnTerminalTransition {
+    pub(super) terminal: TurnTerminalRecord,
+    pub(super) turn_record: TurnRecord,
+}
+
 pub(crate) struct LoopControlOptions {
     pub(super) max_tool_rounds: Option<usize>,
 }
@@ -144,7 +150,10 @@ fn render_operator_interjection_text(message: &MessageEnvelope) -> String {
 }
 
 impl RuntimeHandle {
-    pub(super) async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
+    pub(super) async fn build_turn_record(
+        &self,
+        terminal: &TurnTerminalRecord,
+    ) -> Result<TurnRecord> {
         let (agent_id, run_id, current_work_item_id) = {
             let guard = self.inner.agent.lock().await;
             (
@@ -159,7 +168,9 @@ impl RuntimeHandle {
         };
         let turn_id = terminal.turn_id.trim();
         if turn_id.is_empty() {
-            return Ok(());
+            return Err(anyhow::anyhow!(
+                "cannot build turn record for terminal without turn_id"
+            ));
         }
 
         let messages = self.inner.storage.read_all_messages()?;
@@ -218,8 +229,41 @@ impl RuntimeHandle {
             .collect();
         record.terminal = Some(TurnTerminalSummary::from_terminal(terminal));
 
-        self.inner.storage.append_turn(&record)?;
+        Ok(record)
+    }
+
+    pub(super) async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
+        let record = self.build_turn_record(terminal).await?;
+        self.persist_built_turn_record(&record)
+    }
+
+    pub(super) async fn persist_terminal_transition(
+        &self,
+        transition: &TurnTerminalTransition,
+    ) -> Result<()> {
+        {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.current_turn_id = Some(transition.terminal.turn_id.clone());
+            guard.state.last_turn_terminal = Some(transition.terminal.clone());
+            guard.persist_state(&self.inner.storage)?;
+        }
         self.inner.storage.append_event(&AuditEvent::legacy(
+            "turn_terminal",
+            serde_json::to_value(&transition.terminal)?,
+        ))?;
+        self.persist_built_turn_record(&transition.turn_record)
+    }
+
+    pub(super) fn persist_built_turn_record(&self, record: &TurnRecord) -> Result<()> {
+        self.inner.storage.append_turn(&record)?;
+        self.inner
+            .storage
+            .append_event(&Self::turn_record_audit_event(record))?;
+        Ok(())
+    }
+
+    pub(super) fn turn_record_audit_event(record: &TurnRecord) -> AuditEvent {
+        AuditEvent::legacy(
             "turn_record",
             serde_json::json!({
                 "turn_id": record.turn_id,
@@ -234,8 +278,7 @@ impl RuntimeHandle {
                 "terminal": record.terminal,
                 "created_at": record.created_at,
             }),
-        ))?;
-        Ok(())
+        )
     }
 
     pub(super) async fn persist_turn_aborted_record(
@@ -244,47 +287,61 @@ impl RuntimeHandle {
         reason: &str,
         last_assistant_message: Option<String>,
         duration_ms: u64,
+        persist: bool,
     ) -> Result<TurnTerminalRecord> {
-        let record = {
-            let mut guard = self.inner.agent.lock().await;
-            let turn_id = guard
-                .state
-                .current_turn_id
-                .clone()
-                .filter(|turn_id| !turn_id.trim().is_empty())
-                .unwrap_or_else(crate::ids::turn_id);
-            guard.state.current_turn_id = Some(turn_id.clone());
-            let record = TurnTerminalRecord {
-                turn_id,
-                turn_index: guard.state.turn_index,
-                kind: TurnTerminalKind::Aborted,
-                reason: Some(reason.to_string()),
-                last_assistant_message,
-                checkpoint: None,
-                completed_at: chrono::Utc::now(),
-                duration_ms,
-            };
-            guard.state.last_turn_terminal = Some(record.clone());
-            guard.persist_state(&self.inner.storage)?;
-            record
-        };
-        self.persist_turn_record(&record).await?;
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "turn_terminal",
-            serde_json::to_value(&record)?,
-        ))?;
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "turn_terminal_aborted",
-            serde_json::json!({
-                "run_id": run_id,
-                "reason": reason,
-                "turn_id": record.turn_id.clone(),
-                "turn_index": record.turn_index,
-                "kind": record.kind,
-                "completed_at": record.completed_at,
-                "duration_ms": record.duration_ms,
-            }),
-        ))?;
+        let record = self
+            .build_turn_aborted_record(reason, last_assistant_message, duration_ms)
+            .await;
+        if persist {
+            {
+                let mut guard = self.inner.agent.lock().await;
+                guard.state.current_turn_id = Some(record.turn_id.clone());
+                guard.state.last_turn_terminal = Some(record.clone());
+                guard.persist_state(&self.inner.storage)?;
+            }
+            self.persist_turn_record(&record).await?;
+            self.inner.storage.append_event(&AuditEvent::legacy(
+                "turn_terminal",
+                serde_json::to_value(&record)?,
+            ))?;
+            self.inner.storage.append_event(&AuditEvent::legacy(
+                "turn_terminal_aborted",
+                serde_json::json!({
+                    "run_id": run_id,
+                    "reason": reason,
+                    "turn_id": record.turn_id.clone(),
+                    "turn_index": record.turn_index,
+                    "kind": record.kind,
+                    "completed_at": record.completed_at,
+                    "duration_ms": record.duration_ms,
+                }),
+            ))?;
+        }
         Ok(record)
+    }
+
+    pub(super) async fn build_turn_aborted_record(
+        &self,
+        reason: &str,
+        last_assistant_message: Option<String>,
+        duration_ms: u64,
+    ) -> TurnTerminalRecord {
+        let guard = self.inner.agent.lock().await;
+        let turn_id = guard
+            .state
+            .current_turn_id
+            .clone()
+            .filter(|turn_id| !turn_id.trim().is_empty())
+            .unwrap_or_else(crate::ids::turn_id);
+        TurnTerminalRecord {
+            turn_id,
+            turn_index: guard.state.turn_index,
+            kind: TurnTerminalKind::Aborted,
+            reason: Some(reason.to_string()),
+            last_assistant_message,
+            checkpoint: None,
+            completed_at: chrono::Utc::now(),
+            duration_ms,
+        }
     }
 }

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3537,7 +3537,7 @@ fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
     Ok(())
 }
 
-fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -> Result<()> {
+pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -> Result<()> {
     let payload_json = serde_json::to_string(record)?;
     let terminal_kind = record
         .terminal

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -2359,6 +2359,7 @@ mod tests {
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),
+                turn_record: None,
                 audit_events: Vec::new(),
                 scheduler_semantic_shadow: None,
                 scheduler_shadow_comparison: Some(SchedulerShadowComparisonCommand {
@@ -2596,6 +2597,7 @@ mod tests {
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),
+                        turn_record: None,
                         audit_events: Vec::new(),
                         scheduler_semantic_shadow: None,
                         scheduler_shadow_comparison: Some(SchedulerShadowComparisonCommand {

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -19,14 +19,15 @@ use crate::{
             insert_new_work_item_tx, queue_entry_transition, task_transition,
             try_claim_queued_message_tx, try_interject_queued_message_tx,
             update_expected_work_item_tx, upsert_queue_entry_tx, upsert_task_tx,
-            upsert_wait_condition_tx, upsert_work_item_continuation_tx, wait_condition_transition,
+            upsert_turn_record_tx, upsert_wait_condition_tx, upsert_work_item_continuation_tx,
+            wait_condition_transition,
         },
         RuntimeDb, RuntimeIndexChange, RuntimeStateTransitionConflict,
     },
     runtime_error::RuntimeError,
     types::{
         AgentState, AuditEvent, BriefRecord, MessageEnvelope, QueueEntryRecord, QueueEntryStatus,
-        TaskRecord, TranscriptEntry, WaitConditionRecord, WorkItemContinuationFrame,
+        TaskRecord, TranscriptEntry, TurnRecord, WaitConditionRecord, WorkItemContinuationFrame,
         WorkItemRecord, WorkItemSchedulingState, WorkItemState,
     },
 };
@@ -172,6 +173,7 @@ pub(crate) struct QueueTransitionCommand {
     pub agent_state: Option<AgentStateMutation>,
     pub message_evidence: Vec<MessageEnvelope>,
     pub transcript_entries: Vec<TranscriptEntry>,
+    pub turn_record: Option<TurnRecord>,
     pub audit_events: Vec<AuditEvent>,
     pub scheduler_shadow_comparison:
         Option<scheduler_protocol_repository::SchedulerShadowComparisonCommand>,
@@ -446,6 +448,9 @@ impl RuntimeTransitionRepository<'_> {
             }
             for entry in &command.transcript_entries {
                 append_transcript_entry_tx(tx, entry)?;
+            }
+            if let Some(turn_record) = command.turn_record.as_ref() {
+                upsert_turn_record_tx(tx, turn_record)?;
             }
             for brief in &command.brief_evidence {
                 insert_brief_evidence_tx(tx, brief)?;
@@ -1332,6 +1337,7 @@ mod tests {
                     }),
                     message_evidence: Vec::new(),
                     transcript_entries: vec![transcript],
+                    turn_record: None,
                     audit_events: vec![AuditEvent::legacy("queue_settled", serde_json::json!({}))],
                     scheduler_semantic_shadow: None,
                     scheduler_shadow_comparison: None,
@@ -1389,6 +1395,7 @@ mod tests {
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),
+                turn_record: None,
                 audit_events: vec![AuditEvent::legacy(
                     "queue_entry_claimed",
                     serde_json::json!({}),
@@ -1484,6 +1491,7 @@ mod tests {
                     }),
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
+                    turn_record: None,
                     audit_events: vec![AuditEvent::legacy(
                         "queue_entry_claimed",
                         serde_json::json!({}),
@@ -1575,6 +1583,7 @@ mod tests {
             agent_state: None,
             message_evidence: Vec::new(),
             transcript_entries: Vec::new(),
+            turn_record: None,
             audit_events: vec![AuditEvent::legacy(
                 "authoritative_claim",
                 serde_json::json!({}),
@@ -1668,6 +1677,7 @@ mod tests {
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),
+                turn_record: None,
                 audit_events: vec![AuditEvent::legacy(
                     "authoritative_claim",
                     serde_json::json!({}),

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -38,6 +38,27 @@ fn run_request(text: impl Into<String>) -> RunOnceRequest {
         wait_for_tasks: true,
         workspace_root: None,
         cwd: None,
+    }
+}
+
+fn run_on_large_stack<F, Fut>(name: &str, test: F) -> Result<()>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<()>> + 'static,
+{
+    let test_thread = std::thread::Builder::new()
+        .name(name.into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?
+                .block_on(test())
+        })?;
+
+    match test_thread.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
     }
 }
 
@@ -1064,8 +1085,7 @@ async fn run_once_no_wait_allows_short_command_tasks_to_finish_during_quiescence
     Ok(())
 }
 
-#[tokio::test]
-async fn run_once_prefers_parent_final_result_over_delegated_task_briefs() -> Result<()> {
+async fn assert_run_once_prefers_parent_final_result_over_delegated_task_briefs() -> Result<()> {
     let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
         test_config.config().clone(),
@@ -1084,6 +1104,14 @@ async fn run_once_prefers_parent_final_result_over_delegated_task_briefs() -> Re
         "parent-facing final_text should not be selected from child task output"
     );
     Ok(())
+}
+
+#[test]
+fn run_once_prefers_parent_final_result_over_delegated_task_briefs() -> Result<()> {
+    run_on_large_stack(
+        "run-once-parent-final-result",
+        assert_run_once_prefers_parent_final_result_over_delegated_task_briefs,
+    )
 }
 
 struct TwoRoundProvider {
@@ -1510,20 +1538,10 @@ async fn assert_run_once_includes_worktree_task_metadata() -> Result<()> {
 
 #[test]
 fn run_once_includes_worktree_task_metadata() -> Result<()> {
-    let test_thread = std::thread::Builder::new()
-        .name("run-once-worktree-metadata".into())
-        .stack_size(8 * 1024 * 1024)
-        .spawn(|| {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()?
-                .block_on(assert_run_once_includes_worktree_task_metadata())
-        })?;
-
-    match test_thread.join() {
-        Ok(result) => result,
-        Err(panic) => std::panic::resume_unwind(panic),
-    }
+    run_on_large_stack(
+        "run-once-worktree-metadata",
+        assert_run_once_includes_worktree_task_metadata,
+    )
 }
 
 #[tokio::test]

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1483,8 +1483,7 @@ impl AgentProvider for WorktreeTaskProvider {
     }
 }
 
-#[tokio::test]
-async fn run_once_includes_worktree_task_metadata() -> Result<()> {
+async fn assert_run_once_includes_worktree_task_metadata() -> Result<()> {
     let test_config = test_config();
     let workspace_dir = test_config.workspace_dir().to_path_buf();
     init_git_repo(&workspace_dir)?;
@@ -1507,6 +1506,24 @@ async fn run_once_includes_worktree_task_metadata() -> Result<()> {
         format!("task-{}", response.tasks[0].task.task_id)
     );
     Ok(())
+}
+
+#[test]
+fn run_once_includes_worktree_task_metadata() -> Result<()> {
+    let test_thread = std::thread::Builder::new()
+        .name("run-once-worktree-metadata".into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?
+                .block_on(assert_run_once_includes_worktree_task_metadata())
+        })?;
+
+    match test_thread.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 概要

- 将 Turn terminal、legacy queue terminal、canonical activation settlement / typed missing settlement、slot release 收拢到同一个 `QueueTransitionCommand` 事务边界
- 让 runtime failure 与 operator abort/interruption 路径先构造 terminal/failure evidence，再与 queue/canonical 状态原子提交
- 对完成态 WorkItem 仅使用精确绑定的 result brief；证据缺失或 execution 不匹配时记录 typed missing settlement
- 保留 post-commit 通知/审计副作用，不让其失败回滚已提交的 terminal facts

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- deterministic fault tests 覆盖成功、runtime failure、interruption 的事务回滚、重试幂等与 post-commit fault
