### PR TITLE
fix: resolve brief permanent loading with pending status and retry limits

### DIFF
--- a/web-gui/app/src/features/agent/AgentTimeline.tsx
+++ b/web-gui/app/src/features/agent/AgentTimeline.tsx
@@ -221,17 +221,18 @@ export function BriefHydrationStatus({
   onRetry: () => void;
 }) {
   const { t } = useTranslation();
-  const isLoading = hydration.status === "loading";
-  const label = isLoading
-    ? t("agentPage.briefLoading")
-    : hydration.status === "not_found"
-      ? t("agentPage.briefNotFound")
-      : t("agentPage.briefLoadFailed");
+  const showSpinner = hydration.status === "loading";
+  const showError = hydration.status === "failed" || hydration.status === "not_found";
+  const label = hydration.status === "not_found"
+    ? t("agentPage.briefNotFound")
+    : hydration.status === "failed"
+      ? t("agentPage.briefLoadFailed")
+      : t("agentPage.briefLoading");
   return (
     <div className={`brief-hydration-status is-${hydration.status}`} role="status">
-      {isLoading ? <LoaderCircle className="is-spinning" size={14} /> : <CircleAlert size={14} />}
+      {showSpinner ? <LoaderCircle className="is-spinning" size={14} /> : showError ? <CircleAlert size={14} /> : null}
       <span>{label}</span>
-      {!isLoading ? (
+      {showError ? (
         <button type="button" onClick={onRetry}>
           <RefreshCw size={13} />
           {t("agentPage.retryBrief")}

--- a/web-gui/app/src/runtime/object-renderers.ts
+++ b/web-gui/app/src/runtime/object-renderers.ts
@@ -80,7 +80,7 @@ function briefHydrationForEvent(
   if (!briefId || stringField(payload, "text") || ctx.briefRecordsById?.[briefId]?.text) return undefined;
   return ctx.briefHydrationById?.[briefId] ?? {
     briefId,
-    status: "loading",
+    status: "pending",
     attempt: 0,
   };
 }

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -518,6 +518,7 @@ const GLOBAL_BACKFILL_LIMIT = 100;
 const AGENT_VALIDATION_TTL_MS = 60_000;
 const RESUME_RECONCILIATION_THRESHOLD_MS = 60_000;
 const BRIEF_HYDRATION_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+const BRIEF_HYDRATION_MAX_ATTEMPTS = 5;
 
 function nextClientGeneration(): number {
   clientGeneration += 1;
@@ -549,6 +550,28 @@ function clearInFlightHydration(): void {
   briefHydrationInFlight.clear();
   for (const timer of briefHydrationRetryTimers.values()) window.clearTimeout(timer);
   briefHydrationRetryTimers.clear();
+}
+
+function resetBriefHydrationLoading(set: StoreSet): void {
+  set((state) => {
+    let changed = false;
+    const sessionsByAgentId = { ...state.sessionsByAgentId };
+    for (const [agentId, session] of Object.entries(sessionsByAgentId)) {
+      const briefHydrationById = { ...session.briefHydrationById };
+      let modified = false;
+      for (const [briefId, view] of Object.entries(briefHydrationById)) {
+        if (view.status === "loading") {
+          briefHydrationById[briefId] = { ...view, status: "pending" };
+          modified = true;
+        }
+      }
+      if (modified) {
+        sessionsByAgentId[agentId] = { ...session, briefHydrationById };
+        changed = true;
+      }
+    }
+    return changed ? { sessionsByAgentId } : {};
+  });
 }
 
 function cancelClientGenerationWork(): void {
@@ -1297,6 +1320,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   setRuntimeConnection: async (config) => {
     nextClientGeneration();
     cancelClientGenerationWork();
+    resetBriefHydrationLoading(set);
     const normalizedBaseUrl = config.mode === "remote" ? normalizeConnectionBaseUrl(config.baseUrl) : "";
     const retainedToken =
       config.mode === "remote" &&
@@ -1490,6 +1514,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
     const generation = nextClientGeneration();
     cancelClientGenerationWork();
+    resetBriefHydrationLoading(set);
     closeEventStreamsForResume(set);
     // First invalidate transient layout/loading state before fresh projections arrive.
     set((state) => ({
@@ -2310,6 +2335,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       session.lastValidatedAt != null &&
       Date.now() - session.lastValidatedAt < AGENT_VALIDATION_TTL_MS;
     if (hasCachedContent && fresh && get().globalStreamStatus === "streaming") {
+      if (session && missingBriefIdsForHydration(session).length > 0) {
+        scheduleBriefHydration(get, set, agentId, displayLevel);
+      }
       startRuntimeSpan(trace, "agent.validate", { reason: "fresh_stream" }).end("skipped");
       return;
     }
@@ -4418,7 +4446,13 @@ function scheduleBriefHydration(
     inFlight = new Set<string>();
     briefHydrationInFlight.set(agentId, inFlight);
   }
-  const requestIds = briefIds.filter((briefId) => !inFlight.has(briefId));
+  const isForced = Boolean(options.forceIds);
+  const requestIds = briefIds.filter((briefId) => {
+    if (inFlight.has(briefId)) return false;
+    if (isForced) return true;
+    const attempt = session?.briefHydrationById[briefId]?.attempt ?? 0;
+    return attempt < BRIEF_HYDRATION_MAX_ATTEMPTS;
+  });
   if (!requestIds.length) return;
   requestIds.forEach((briefId) => inFlight.add(briefId));
   set((state) => updateBriefHydrationState(state, agentId, {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1343,7 +1343,7 @@ describe("reduceAgentSessionTimeline", () => {
         body: "Preview remains visible.",
         briefHydration: {
           briefId: "brief_123",
-          status: "loading",
+          status: "pending",
           attempt: 0,
         },
       }),

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -780,7 +780,7 @@ export interface AgentTimelineItem {
   briefHydration?: BriefHydrationViewState;
 }
 
-export type BriefHydrationStatus = "loading" | "resolved" | "not_found" | "failed";
+export type BriefHydrationStatus = "pending" | "loading" | "resolved" | "not_found" | "failed";
 
 export interface BriefHydrationViewState {
   briefId: string;


### PR DESCRIPTION
## Summary

Fix the brief permanent loading problem where `brief_created` event text stays stuck on a loading spinner forever. Four complementary fixes address the six identified root causes.

## Changes

**Plan A — Pending status** (root causes 1, 4): Add `"pending"` to `BriefHydrationStatus` type. Change the `briefHydrationForEvent` fallback from `"loading"` to `"pending"` so briefs that have not yet been requested do not show a spinner. Update `BriefHydrationStatus` component to only show spinner for `"loading"` and error icons for `"failed"`/`"not_found"`.

**Plan B — fresh_stream hydration** (root cause 3): In `ensureAgentSession`, before the `fresh_stream` early return, check for unresolved brief IDs and trigger `scheduleBriefHydration` so SSE-delivered briefs are hydrated even when the session is considered fresh.

**Plan E — Max retry limit** (root cause 5): Add `BRIEF_HYDRATION_MAX_ATTEMPTS=5` constant. In `scheduleBriefHydration`, filter out briefs that have exceeded the max attempt count for automatic requests. Manual retries via `forceIds` bypass this limit, preventing infinite loading/failed oscillation.

**Plan D — Generation reset** (root cause 4): Add `resetBriefHydrationLoading` helper that resets `"loading"` entries in `briefHydrationById` to `"pending"` when client generation changes. Call it at both `cancelClientGenerationWork` call sites.

## Files Changed

- `types.ts`: Add `"pending"` to `BriefHydrationStatus`
- `object-renderers.ts`: Change fallback to `"pending"`
- `AgentTimeline.tsx`: Update `BriefHydrationStatus` component rendering
- `runtime-store.ts`: fresh_stream check, max retry filter, generation reset
- `session-reducer.test.ts`: Update expected fallback status

## Verification

- All 153 existing runtime tests pass
- TypeScript type check passes with no errors
