### PR TITLE
fix: add scenario mode guard to canonical queue settlement path

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1828,6 +1828,15 @@ impl RuntimeHandle {
         if !self.scheduler_protocol_production_commands_enabled() {
             return Ok(Vec::new());
         }
+        if self
+            .inner
+            .runtime_db
+            .transitions()
+            .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
+            != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+        {
+            return Ok(Vec::new());
+        }
         let Some(message) = self.inner.storage.read_message_by_id(&record.message_id)? else {
             return Ok(Vec::new());
         };


### PR DESCRIPTION
## 问题

`canonical_queue_settlement_commands` 缺少 scenario mode 守卫，与 dispatch/recovery 路径不一致。

当 `protocol_mode=legacy`（scenario mode=Off）且 `HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS=true` 时，dispatch 正确跳过 activation 创建，但 settlement 仍尝试查找 activation，导致 "canonical queue settlement has no matching activation" hard error 和 `bounded_restart` 循环。

## 修复

在 settlement 路径的 env var 检查之后增加与 dispatch 路径一致的 scenario mode 守卫：

```rust
if self.inner.runtime_db.transitions()
    .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
    != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
{
    return Ok(Vec::new());
}
```

## 验证

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- 本地测试通过

Closes #2394