### PR TITLE
fix: bootstrap scheduler recovery reconciliation

### DIFF
--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -918,6 +918,32 @@ The decision is:
 This keeps replay simple and avoids introducing a premature side-effect
 classification system into the scheduler.
 
+### Bootstrap Recovery Reconciles Durable Claims Atomically
+
+Bootstrap recovery must reconcile a durable canonical activation and its
+legacy `Dequeued` queue entry in one runtime-database transaction. Recovery
+derives a typed settlement or missing-settlement command from persisted
+message, Turn, WorkItem, and scheduler-protocol facts; it must not synthesize
+terminal success when those facts are incomplete.
+
+The transaction is fenced twice:
+
+- the typed scheduler command validates the activation identity and admitted
+  scheduling generation;
+- the queue transition uses compare-and-set against the exact claim record
+  inspected by recovery.
+
+If either fence rejects, canonical protocol state, legacy queue state, and
+recovery audit provenance all remain unchanged. Replaying a successful
+reconciliation is idempotent. Automatic writes are allowed only while the
+settlement scenario is authoritative; other rollout modes may inspect the
+same candidates but remain read-only.
+
+The controlled diagnostic surface reports the original queue and canonical
+facts, the evidence used for classification, and any proposed typed commands.
+It does not provide a handwritten SQL repair path and does not overwrite or
+delete the source facts used to explain recovery.
+
 ### Task-To-WorkItem Association Becomes First-Class
 
 Task records should gain a first-class optional work-item association.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -576,6 +576,13 @@ pub enum DebugCommands {
         #[arg(long)]
         output: PathBuf,
     },
+    #[command(about = "Inspect scheduler bootstrap recovery candidates without applying repairs")]
+    SchedulerRecovery {
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1457,6 +1457,26 @@ mod tests {
     }
 
     #[test]
+    fn debug_scheduler_recovery_command_parses_read_only_options() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "scheduler-recovery",
+            "--agent",
+            "pm",
+            "--json",
+        ]);
+        let Commands::Debug {
+            command: DebugCommands::SchedulerRecovery { agent, json },
+        } = cli.command
+        else {
+            panic!("expected debug scheduler-recovery command");
+        };
+        assert_eq!(agent.as_deref(), Some("pm"));
+        assert!(json);
+    }
+
+    #[test]
     fn debug_performance_command_parses_json_flag() {
         let cli = Cli::parse_from(["holon", "debug", "performance", "--json"]);
         let Commands::Debug {
@@ -2193,7 +2213,38 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
         DebugCommands::SchedulerFixture { agent, output } => {
             export_scheduler_fixture(&config, agent, &output)
         }
+        DebugCommands::SchedulerRecovery { agent, json } => {
+            print_scheduler_recovery_report(&config, agent, json)
+        }
     }
+}
+
+fn print_scheduler_recovery_report(
+    config: &AppConfig,
+    agent: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
+    let host = RuntimeHost::new(config.clone())?;
+    let storage = host.agent_storage(&agent_id)?;
+    let report = holon::runtime::scheduler_recovery_report(&storage, host.runtime_db(), &agent_id)?;
+    if json {
+        return print_json(&serde_json::to_value(report)?);
+    }
+    println!(
+        "Scheduler recovery candidates for {} (partition initialized: {})",
+        report.agent_id, report.partition_initialized
+    );
+    for candidate in report.candidates {
+        println!(
+            "- {}: eligible={} reason={} target={:?}",
+            candidate.message_id,
+            candidate.eligible,
+            candidate.reason,
+            candidate.target_queue_status
+        );
+    }
+    Ok(())
 }
 
 fn handle_runtime_db_debug_command(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -307,6 +307,315 @@ fn canonical_missing_settlement_id(message_id: &str) -> String {
     format!("missing-settlement:message:{message_id}")
 }
 
+fn canonical_queue_settlement_commands_from_facts(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    record: &QueueEntryRecord,
+) -> Result<Vec<crate::domain::scheduler_protocol::ProtocolCommand>> {
+    let Some(message) = storage.read_message_by_id(&record.message_id)? else {
+        return Ok(Vec::new());
+    };
+    if !matches!(
+        (&message.kind, &message.origin),
+        (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+            if subsystem == "work_queue"
+    ) {
+        return Ok(Vec::new());
+    }
+
+    use crate::domain::scheduler_protocol::{
+        ActivationDisposition, ActivationSettlement, AgentDispatchDisposition,
+        MissingSettlementRecord, ProtocolCommand, SettleActivationCommand,
+    };
+
+    let snapshot = runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized(&record.agent_id)?
+        .ok_or_else(|| anyhow!("canonical queue settlement has no scheduler partition"))?;
+    let activation_id = scheduler_executor::canonical_activation_id(&record.message_id);
+    let activation = snapshot
+        .activations
+        .get(&activation_id)
+        .ok_or_else(|| anyhow!("canonical queue settlement has no matching activation"))?;
+    let work_item_id = activation.work_item_id.clone();
+    let work_queue = storage.work_queue_prompt_projection()?;
+    let scheduling_state = work_queue
+        .items
+        .iter()
+        .find(|candidate| candidate.id == work_item_id)
+        .map(|candidate| candidate.scheduling_state);
+    let missing_settlement = || {
+        ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
+            id: canonical_missing_settlement_id(&record.message_id),
+            activation_id: activation_id.clone(),
+            created_at: record.updated_at.to_rfc3339(),
+        })
+    };
+
+    let command = if record.status == QueueEntryStatus::Processed {
+        match scheduling_state {
+            Some(crate::types::WorkItemSchedulingState::Runnable) => {
+                ProtocolCommand::SettleActivation(SettleActivationCommand {
+                    settlement: ActivationSettlement {
+                        id: canonical_settlement_id(&record.message_id),
+                        activation_id,
+                        turn_terminal: message.turn_id.clone(),
+                        disposition: ActivationDisposition::WorkContinues,
+                        agent_dispatch: AgentDispatchDisposition::Open,
+                        operator_delivery: None,
+                        evidence: vec![
+                            format!("message:{}", record.message_id),
+                            format!("work_item:{work_item_id}"),
+                        ],
+                        created_at: record.updated_at.to_rfc3339(),
+                    },
+                })
+            }
+            Some(crate::types::WorkItemSchedulingState::Completed) => {
+                let Some(work_item) = runtime_db.work_items().latest(&work_item_id)? else {
+                    return Ok(vec![missing_settlement()]);
+                };
+                let Some(turn_terminal) = message.turn_id.clone() else {
+                    return Ok(vec![missing_settlement()]);
+                };
+                let Some(completion_intent) = work_item.completion_intent.as_ref() else {
+                    return Ok(vec![missing_settlement()]);
+                };
+                if !(completion_intent.work_item_id == work_item_id
+                    && completion_intent.source_activation_id.as_deref()
+                        == Some(activation_id.as_str())
+                    && completion_intent.source_message_id.as_deref()
+                        == Some(record.message_id.as_str())
+                    && completion_intent.source_turn_id.as_deref() == Some(turn_terminal.as_str())
+                    && completion_intent.expected_work_revision == activation.admitted_generation)
+                {
+                    return Ok(vec![missing_settlement()]);
+                }
+                let Some(result_brief_id) =
+                    completion_intent
+                        .result_brief_id
+                        .as_deref()
+                        .filter(|result_brief_id| {
+                            work_item.result_brief_id.as_deref() == Some(*result_brief_id)
+                        })
+                else {
+                    return Ok(vec![missing_settlement()]);
+                };
+                let Some(brief) = storage.read_brief_by_id(result_brief_id)?.filter(|brief| {
+                    brief.kind.is_success()
+                        && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
+                        && brief.turn_id.as_deref() == Some(turn_terminal.as_str())
+                        && brief.related_message_id.as_deref() == Some(record.message_id.as_str())
+                        && !brief.text.trim().is_empty()
+                }) else {
+                    return Ok(vec![missing_settlement()]);
+                };
+                ProtocolCommand::SettleActivation(SettleActivationCommand {
+                    settlement: ActivationSettlement {
+                        id: canonical_settlement_id(&record.message_id),
+                        activation_id,
+                        turn_terminal: Some(turn_terminal.clone()),
+                        disposition: ActivationDisposition::WorkCompleted { continuation: None },
+                        agent_dispatch: AgentDispatchDisposition::Open,
+                        operator_delivery: Some(brief.id.clone()),
+                        evidence: vec![
+                            format!("message:{}", record.message_id),
+                            format!("work_item:{work_item_id}"),
+                            format!("turn:{turn_terminal}"),
+                            format!("brief:{}", brief.id),
+                        ],
+                        created_at: record.updated_at.to_rfc3339(),
+                    },
+                })
+            }
+            _ => missing_settlement(),
+        }
+    } else {
+        missing_settlement()
+    };
+    Ok(vec![command])
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerRecoveryReport {
+    pub agent_id: String,
+    pub partition_initialized: bool,
+    pub candidates: Vec<SchedulerRecoveryCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerRecoveryCandidate {
+    pub message_id: String,
+    pub activation_id: String,
+    pub work_item_id: Option<String>,
+    pub queue_status: QueueEntryStatus,
+    pub terminal_turn_id: Option<String>,
+    pub eligible: bool,
+    pub reason: String,
+    pub target_queue_status: Option<QueueEntryStatus>,
+    pub evidence: Vec<String>,
+    pub proposed_commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
+}
+
+pub fn scheduler_recovery_report(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+) -> Result<SchedulerRecoveryReport> {
+    let Some(snapshot) = runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+    else {
+        return Ok(SchedulerRecoveryReport {
+            agent_id: agent_id.to_string(),
+            partition_initialized: false,
+            candidates: Vec::new(),
+        });
+    };
+    let turns = runtime_db
+        .turn_records()
+        .recent_for_agent(agent_id, usize::MAX)?;
+    let mut entries = runtime_db
+        .queue_entries()
+        .recent(Some(agent_id), usize::MAX)?
+        .into_iter()
+        .filter(|entry| entry.status == QueueEntryStatus::Dequeued)
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.message_id.cmp(&right.message_id));
+    let mut candidates = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
+        let mut candidate = SchedulerRecoveryCandidate {
+            message_id: entry.message_id.clone(),
+            activation_id: activation_id.clone(),
+            work_item_id: None,
+            queue_status: entry.status.clone(),
+            terminal_turn_id: None,
+            eligible: false,
+            reason: "activation_missing".into(),
+            target_queue_status: None,
+            evidence: vec!["queue_status=dequeued".into()],
+            proposed_commands: Vec::new(),
+        };
+        let Some(activation) = snapshot.activations.get(&activation_id) else {
+            candidates.push(candidate);
+            continue;
+        };
+        candidate.work_item_id = Some(activation.work_item_id.clone());
+        candidate
+            .evidence
+            .push(format!("activation_state={:?}", activation.state));
+        candidate.evidence.push(format!(
+            "admitted_generation={}",
+            activation.admitted_generation
+        ));
+        let Some(message) = storage.read_message_by_id(&entry.message_id)? else {
+            candidate.reason = "message_missing".into();
+            candidates.push(candidate);
+            continue;
+        };
+        if !matches!(
+            (&message.kind, &message.origin),
+            (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                if subsystem == "work_queue"
+        ) {
+            candidate.reason = "message_not_work_queue_tick".into();
+            candidates.push(candidate);
+            continue;
+        }
+        if message.work_item_id.as_deref() != Some(activation.work_item_id.as_str()) {
+            candidate.reason = "work_item_binding_mismatch".into();
+            candidates.push(candidate);
+            continue;
+        }
+
+        let terminal_turn = turns.iter().find(|turn| {
+            turn.terminal.is_some()
+                && turn
+                    .trigger
+                    .as_ref()
+                    .and_then(|trigger| trigger.message_id.as_deref())
+                    == Some(entry.message_id.as_str())
+                && message.turn_id.as_deref() == Some(turn.turn_id.as_str())
+                && turn.current_work_item_id.as_deref() == Some(activation.work_item_id.as_str())
+        });
+        candidate.terminal_turn_id = terminal_turn.map(|turn| turn.turn_id.clone());
+        let terminal_is_completed = terminal_turn.is_some_and(|turn| {
+            turn.terminal
+                .as_ref()
+                .is_some_and(|terminal| terminal.kind == crate::types::TurnTerminalKind::Completed)
+        });
+        if activation.state == crate::domain::scheduler_protocol::ActivationState::Settled {
+            candidate.eligible = true;
+            candidate.reason = "canonical_settlement_legacy_queue_pending".into();
+            candidate.target_queue_status = Some(if terminal_is_completed {
+                QueueEntryStatus::Processed
+            } else {
+                QueueEntryStatus::Aborted
+            });
+            candidates.push(candidate);
+            continue;
+        }
+        if activation.state == crate::domain::scheduler_protocol::ActivationState::SettlementMissing
+        {
+            candidate.eligible = true;
+            candidate.reason = "canonical_missing_settlement_legacy_queue_pending".into();
+            candidate.target_queue_status = Some(QueueEntryStatus::Aborted);
+            candidates.push(candidate);
+            continue;
+        }
+        let mut proposed_entry = entry.clone();
+        proposed_entry.status = if terminal_is_completed {
+            QueueEntryStatus::Processed
+        } else {
+            QueueEntryStatus::Aborted
+        };
+        let mut commands =
+            canonical_queue_settlement_commands_from_facts(storage, runtime_db, &proposed_entry)?;
+        let settles_from_terminal = matches!(
+            commands.as_slice(),
+            [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
+        );
+        if !settles_from_terminal {
+            proposed_entry.status = QueueEntryStatus::Aborted;
+            commands = canonical_queue_settlement_commands_from_facts(
+                storage,
+                runtime_db,
+                &proposed_entry,
+            )?;
+        }
+        if let Some(diagnostics) = commands.iter().find_map(|command| {
+            let outcome = crate::domain::scheduler_protocol::reduce_command(&snapshot, command);
+            (outcome.outcome.decision == crate::domain::scheduler_protocol::Decision::Rejected)
+                .then(|| outcome.outcome.diagnostics)
+        }) {
+            candidate.reason = "typed_command_rejected".into();
+            candidate.evidence.extend(diagnostics);
+            candidate.proposed_commands = commands;
+            candidates.push(candidate);
+            continue;
+        }
+        candidate.eligible = true;
+        candidate.reason = if settles_from_terminal {
+            "terminal_turn_settlement".into()
+        } else if terminal_is_completed {
+            "terminal_evidence_incomplete".into()
+        } else {
+            "terminal_turn_missing".into()
+        };
+        candidate.target_queue_status = Some(proposed_entry.status);
+        candidate.proposed_commands = commands;
+        candidates.push(candidate);
+    }
+
+    Ok(SchedulerRecoveryReport {
+        agent_id: agent_id.to_string(),
+        partition_initialized: true,
+        candidates,
+    })
+}
+
 fn runtime_error_queue_settlement(
     message_kind: &MessageKind,
     error: &anyhow::Error,
@@ -1893,141 +2202,11 @@ impl RuntimeHandle {
         {
             return Ok(Vec::new());
         }
-        let Some(message) = self.inner.storage.read_message_by_id(&record.message_id)? else {
-            return Ok(Vec::new());
-        };
-        if !matches!(
-            (&message.kind, &message.origin),
-            (MessageKind::SystemTick, MessageOrigin::System { subsystem })
-                if subsystem == "work_queue"
-        ) {
-            return Ok(Vec::new());
-        }
-
-        use crate::domain::scheduler_protocol::{
-            ActivationDisposition, ActivationSettlement, AgentDispatchDisposition,
-            MissingSettlementRecord, ProtocolCommand, SettleActivationCommand,
-        };
-
-        let snapshot = self
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&record.agent_id)?
-            .ok_or_else(|| anyhow!("canonical queue settlement has no scheduler partition"))?;
-        let activation_id = scheduler_executor::canonical_activation_id(&record.message_id);
-        let activation = snapshot
-            .activations
-            .get(&activation_id)
-            .ok_or_else(|| anyhow!("canonical queue settlement has no matching activation"))?;
-        let work_item_id = activation.work_item_id.clone();
-        let work_queue = self.inner.storage.work_queue_prompt_projection()?;
-        let scheduling_state = work_queue
-            .items
-            .iter()
-            .find(|candidate| candidate.id == work_item_id)
-            .map(|candidate| candidate.scheduling_state);
-        let missing_settlement = || {
-            ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
-                id: canonical_missing_settlement_id(&record.message_id),
-                activation_id: activation_id.clone(),
-                created_at: record.updated_at.to_rfc3339(),
-            })
-        };
-
-        let command = if record.status == QueueEntryStatus::Processed {
-            match scheduling_state {
-                Some(crate::types::WorkItemSchedulingState::Runnable) => {
-                    ProtocolCommand::SettleActivation(SettleActivationCommand {
-                        settlement: ActivationSettlement {
-                            id: canonical_settlement_id(&record.message_id),
-                            activation_id,
-                            turn_terminal: message.turn_id.clone(),
-                            disposition: ActivationDisposition::WorkContinues,
-                            agent_dispatch: AgentDispatchDisposition::Open,
-                            operator_delivery: None,
-                            evidence: vec![
-                                format!("message:{}", record.message_id),
-                                format!("work_item:{work_item_id}"),
-                            ],
-                            created_at: record.updated_at.to_rfc3339(),
-                        },
-                    })
-                }
-                Some(crate::types::WorkItemSchedulingState::Completed) => {
-                    let Some(work_item) =
-                        self.inner.runtime_db.work_items().latest(&work_item_id)?
-                    else {
-                        return Ok(vec![missing_settlement()]);
-                    };
-                    let Some(turn_terminal) = message.turn_id.clone() else {
-                        return Ok(vec![missing_settlement()]);
-                    };
-                    let Some(completion_intent) = work_item.completion_intent.as_ref() else {
-                        return Ok(vec![missing_settlement()]);
-                    };
-                    if !(completion_intent.work_item_id == work_item_id
-                        && completion_intent.source_activation_id.as_deref()
-                            == Some(activation_id.as_str())
-                        && completion_intent.source_message_id.as_deref()
-                            == Some(record.message_id.as_str())
-                        && completion_intent.source_turn_id.as_deref()
-                            == Some(turn_terminal.as_str())
-                        && completion_intent.expected_work_revision
-                            == activation.admitted_generation)
-                    {
-                        return Ok(vec![missing_settlement()]);
-                    }
-                    let Some(result_brief_id) = completion_intent
-                        .result_brief_id
-                        .as_deref()
-                        .filter(|result_brief_id| {
-                            work_item.result_brief_id.as_deref() == Some(*result_brief_id)
-                        })
-                    else {
-                        return Ok(vec![missing_settlement()]);
-                    };
-                    let Some(brief) = self
-                        .inner
-                        .storage
-                        .read_brief_by_id(result_brief_id)?
-                        .filter(|brief| {
-                            brief.kind.is_success()
-                                && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
-                                && brief.turn_id.as_deref() == Some(turn_terminal.as_str())
-                                && brief.related_message_id.as_deref()
-                                    == Some(record.message_id.as_str())
-                                && !brief.text.trim().is_empty()
-                        })
-                    else {
-                        return Ok(vec![missing_settlement()]);
-                    };
-                    ProtocolCommand::SettleActivation(SettleActivationCommand {
-                        settlement: ActivationSettlement {
-                            id: canonical_settlement_id(&record.message_id),
-                            activation_id,
-                            turn_terminal: Some(turn_terminal.clone()),
-                            disposition: ActivationDisposition::WorkCompleted {
-                                continuation: None,
-                            },
-                            agent_dispatch: AgentDispatchDisposition::Open,
-                            operator_delivery: Some(brief.id.clone()),
-                            evidence: vec![
-                                format!("message:{}", record.message_id),
-                                format!("work_item:{work_item_id}"),
-                                format!("turn:{turn_terminal}"),
-                                format!("brief:{}", brief.id),
-                            ],
-                            created_at: record.updated_at.to_rfc3339(),
-                        },
-                    })
-                }
-                _ => missing_settlement(),
-            }
-        } else {
-            missing_settlement()
-        };
-        Ok(vec![command])
+        canonical_queue_settlement_commands_from_facts(
+            &self.inner.storage,
+            &self.inner.runtime_db,
+            record,
+        )
     }
 
     pub(crate) fn persist_transcript_evidence(&self, entry: &TranscriptEntry) -> Result<()> {
@@ -2493,16 +2672,19 @@ impl RuntimeHandle {
             .into_iter()
             .filter(|entry| entry.status == QueueEntryStatus::Dequeued)
             .collect::<Vec<_>>();
+        let turns = self
+            .inner
+            .runtime_db
+            .turn_records()
+            .recent_for_agent(&agent_id, usize::MAX)?;
         let mut recovered = 0;
 
         for mut entry in claimed {
+            let expected_entry = entry.clone();
             let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
             let Some(activation) = snapshot.activations.get(&activation_id) else {
                 continue;
             };
-            if activation.state != crate::domain::scheduler_protocol::ActivationState::Running {
-                continue;
-            }
             let Some(message) = self.inner.storage.read_message_by_id(&entry.message_id)? else {
                 continue;
             };
@@ -2515,47 +2697,200 @@ impl RuntimeHandle {
                 continue;
             }
 
-            let missing =
-                crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(
-                    crate::domain::scheduler_protocol::MissingSettlementRecord {
-                        id: canonical_missing_settlement_id(&entry.message_id),
-                        activation_id: activation_id.clone(),
-                        created_at: self.now().to_rfc3339(),
+            let terminal_turn = turns.iter().find(|turn| {
+                turn.terminal.is_some()
+                    && turn
+                        .trigger
+                        .as_ref()
+                        .and_then(|trigger| trigger.message_id.as_deref())
+                        == Some(entry.message_id.as_str())
+                    && message.turn_id.as_deref() == Some(turn.turn_id.as_str())
+                    && turn.current_work_item_id.as_deref()
+                        == Some(activation.work_item_id.as_str())
+            });
+            let terminal_is_completed = terminal_turn.is_some_and(|turn| {
+                turn.terminal.as_ref().is_some_and(|terminal| {
+                    terminal.kind == crate::types::TurnTerminalKind::Completed
+                })
+            });
+            if activation.state == crate::domain::scheduler_protocol::ActivationState::Settled {
+                entry.status = if terminal_is_completed {
+                    QueueEntryStatus::Processed
+                } else {
+                    QueueEntryStatus::Aborted
+                };
+                entry.updated_at = self.now();
+                let message_id = entry.message_id.clone();
+                let queue_status = entry.status.clone();
+                let commit = self.inner.runtime_db.transitions().commit_queue(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                        mutation:
+                            crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                                expected: expected_entry,
+                                record: entry,
+                            },
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        scheduler_authority_scenarios: Vec::new(),
+                        agent_state: None,
+                        message_evidence: Vec::new(),
+                        transcript_entries: Vec::new(),
+                        turn_record: terminal_turn.cloned(),
+                        audit_events: vec![AuditEvent::legacy(
+                            "scheduler_bootstrap_claim_recovered",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "message_id": message_id,
+                                "activation_id": activation_id,
+                                "work_item_id": activation.work_item_id,
+                                "queue_status": queue_status,
+                                "recovery_outcome": "legacy_queue_reconciled_from_canonical_settlement",
+                                "terminal_turn_id": terminal_turn.map(|turn| turn.turn_id.clone()),
+                                "provenance": "bootstrap_reconciliation",
+                            }),
+                        )],
+                        scheduler_shadow_comparison: None,
+                        scheduler_delivery_shadow_comparison: None,
+                        scheduler_semantic_shadow: None,
+                        notify_scheduler: true,
+                        fault: self.take_transition_fault(),
+                        brief_evidence: Vec::new(),
                     },
-                );
-            let protocol_commit = self
-                .inner
-                .runtime_db
-                .transitions()
-                .commit_scheduler_protocol_command(&agent_id, &missing, None)?;
-            if !matches!(
-                protocol_commit.result.decision,
-                crate::domain::scheduler_protocol::Decision::SettlementMissing
-                    | crate::domain::scheduler_protocol::Decision::DuplicateIgnored
-            ) {
-                return Err(anyhow!(
-                    "scheduler bootstrap claim recovery was rejected: {}",
-                    protocol_commit.result.diagnostics.join(", ")
-                ));
+                )?;
+                if commit.applied {
+                    recovered += 1;
+                }
+                self.apply_transition_commit(commit).await;
+                continue;
             }
-
-            entry.status = QueueEntryStatus::Aborted;
+            if activation.state
+                == crate::domain::scheduler_protocol::ActivationState::SettlementMissing
+            {
+                entry.status = QueueEntryStatus::Aborted;
+                entry.updated_at = self.now();
+                let message_id = entry.message_id.clone();
+                let commit = self.inner.runtime_db.transitions().commit_queue(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                        mutation:
+                            crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                                expected: expected_entry,
+                                record: entry,
+                            },
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        scheduler_authority_scenarios: Vec::new(),
+                        agent_state: None,
+                        message_evidence: Vec::new(),
+                        transcript_entries: Vec::new(),
+                        turn_record: terminal_turn.cloned(),
+                        audit_events: vec![AuditEvent::legacy(
+                            "scheduler_bootstrap_claim_recovered",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "message_id": message_id,
+                                "activation_id": activation_id,
+                                "work_item_id": activation.work_item_id,
+                                "queue_status": QueueEntryStatus::Aborted,
+                                "recovery_outcome": "legacy_queue_reconciled_from_canonical_missing_settlement",
+                                "terminal_turn_id": terminal_turn.map(|turn| turn.turn_id.clone()),
+                                "provenance": "bootstrap_reconciliation",
+                            }),
+                        )],
+                        scheduler_shadow_comparison: None,
+                        scheduler_delivery_shadow_comparison: None,
+                        scheduler_semantic_shadow: None,
+                        notify_scheduler: true,
+                        fault: self.take_transition_fault(),
+                        brief_evidence: Vec::new(),
+                    },
+                )?;
+                if commit.applied {
+                    recovered += 1;
+                }
+                self.apply_transition_commit(commit).await;
+                continue;
+            }
+            entry.status = if terminal_is_completed {
+                QueueEntryStatus::Processed
+            } else {
+                QueueEntryStatus::Aborted
+            };
             entry.updated_at = self.now();
+            let mut scheduler_protocol_commands = if terminal_is_completed {
+                self.canonical_queue_settlement_commands(&entry).await?
+            } else {
+                vec![
+                    crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(
+                        crate::domain::scheduler_protocol::MissingSettlementRecord {
+                            id: canonical_missing_settlement_id(&entry.message_id),
+                            activation_id: activation_id.clone(),
+                            created_at: entry.updated_at.to_rfc3339(),
+                        },
+                    ),
+                ]
+            };
+            let settles_from_terminal = matches!(
+                scheduler_protocol_commands.as_slice(),
+                [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
+            );
+            if !settles_from_terminal {
+                entry.status = QueueEntryStatus::Aborted;
+                if terminal_is_completed {
+                    scheduler_protocol_commands = canonical_queue_settlement_commands_from_facts(
+                        &self.inner.storage,
+                        &self.inner.runtime_db,
+                        &entry,
+                    )?;
+                }
+            }
+            let rejected = scheduler_protocol_commands.iter().find_map(|command| {
+                let outcome = crate::domain::scheduler_protocol::reduce_command(&snapshot, command);
+                (outcome.outcome.decision == crate::domain::scheduler_protocol::Decision::Rejected)
+                    .then(|| outcome.outcome.diagnostics)
+            });
+            if let Some(diagnostics) = rejected {
+                self.inner.storage.append_event(
+                    &scheduler::scheduler_invariant_diagnostic_event(
+                        &agent_id,
+                        "bootstrap_recovery_command_rejected",
+                        Some(activation.work_item_id.clone()),
+                        Some(entry.message_id.clone()),
+                        diagnostics,
+                    )?,
+                )?;
+                continue;
+            }
             let message_id = entry.message_id.clone();
             let work_item_id = activation.work_item_id.clone();
+            let queue_status = entry.status.clone();
+            let terminal_turn_id = terminal_turn.map(|turn| turn.turn_id.clone());
+            let recovery_outcome = if settles_from_terminal {
+                "settled_from_terminal_turn"
+            } else {
+                "settlement_missing"
+            };
             let commit = self.inner.runtime_db.transitions().commit_queue(
                 &crate::runtime_db::transitions::QueueTransitionCommand {
                     agent_id: agent_id.clone(),
                     operation: crate::runtime_db::transitions::QueueOperation::Settle,
-                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
+                    mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                        expected: expected_entry,
+                        record: entry,
+                    },
                     scheduler_claim_work_item: None,
                     scheduler_protocol_bootstrap: None,
-                    scheduler_protocol_commands: Vec::new(),
+                    scheduler_protocol_commands,
                     scheduler_authority_scenarios: Vec::new(),
                     agent_state: None,
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
-                    turn_record: None,
+                    turn_record: terminal_turn.cloned(),
                     audit_events: vec![AuditEvent::legacy(
                         "scheduler_bootstrap_claim_recovered",
                         serde_json::json!({
@@ -2563,15 +2898,17 @@ impl RuntimeHandle {
                             "message_id": message_id,
                             "activation_id": activation_id,
                             "work_item_id": work_item_id,
-                            "queue_status": QueueEntryStatus::Aborted,
-                            "activation_status": "settlement_missing",
+                            "queue_status": queue_status,
+                            "recovery_outcome": recovery_outcome,
+                            "terminal_turn_id": terminal_turn_id,
+                            "provenance": "bootstrap_reconciliation",
                         }),
                     )],
                     scheduler_shadow_comparison: None,
                     scheduler_delivery_shadow_comparison: None,
                     scheduler_semantic_shadow: None,
                     notify_scheduler: true,
-                    fault: None,
+                    fault: self.take_transition_fault(),
                     brief_evidence: Vec::new(),
                 },
             )?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -472,6 +472,8 @@ pub fn scheduler_recovery_report(
             candidates: Vec::new(),
         });
     };
+    // This debug-only report intentionally scans retained history so it cannot
+    // omit an old recovery candidate; its cost scales with agent history.
     let turns = runtime_db
         .turn_records()
         .recent_for_agent(agent_id, usize::MAX)?;
@@ -2713,6 +2715,8 @@ impl RuntimeHandle {
                     terminal.kind == crate::types::TurnTerminalKind::Completed
                 })
             });
+            // Canonical terminal states need no new protocol command; these
+            // branches only reconcile the legacy queue claim that remains.
             if activation.state == crate::domain::scheduler_protocol::ActivationState::Settled {
                 entry.status = if terminal_is_completed {
                     QueueEntryStatus::Processed

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1008,6 +1008,44 @@ async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settl
     assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
     finish_claimed_test_run(&runtime).await;
 
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert_eq!(report.candidates.len(), 1);
+    assert!(report.candidates[0].eligible);
+    assert_eq!(report.candidates[0].reason, "terminal_turn_missing");
+    assert!(matches!(
+        report.candidates[0].proposed_commands.as_slice(),
+        [crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(_)]
+    ));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        claimed
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+
     assert_eq!(
         runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
         1
@@ -1063,6 +1101,796 @@ async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settl
                 && event.data["message_id"] == message.id
                 && event.data["activation_id"] == activation_id
         }));
+}
+
+#[tokio::test]
+async fn bootstrap_recovery_settles_dequeued_activation_from_terminal_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "recover terminal canonical claim".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "claim completed before restart".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.turn_id = Some("turn-bootstrap-terminal".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&work_item.id));
+    runtime
+        .storage()
+        .append_turn(&terminal.turn_record)
+        .unwrap();
+
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert_eq!(report.candidates.len(), 1);
+    assert!(report.candidates[0].eligible);
+    assert_eq!(report.candidates[0].reason, "terminal_turn_settlement");
+    assert_eq!(
+        report.candidates[0].target_queue_status,
+        Some(QueueEntryStatus::Processed)
+    );
+    assert!(matches!(
+        report.candidates[0].proposed_commands.as_slice(),
+        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
+    ));
+
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    assert_eq!(
+        snapshot
+            .activations
+            .get(&activation_id)
+            .map(|activation| activation.state.clone()),
+        Some(crate::domain::scheduler_protocol::ActivationState::Settled)
+    );
+    assert!(snapshot
+        .settlements
+        .contains_key(&canonical_settlement_id(&message.id)));
+    assert!(!snapshot
+        .missing_settlements
+        .contains_key(&canonical_missing_settlement_id(&message.id)));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
+    let mut harness = LifecycleHarness::new();
+    let (message_id, activation_id, settled_snapshot) = {
+        let runtime = harness.runtime();
+        runtime.set_scheduler_protocol_production_commands_enabled(true);
+        enable_production_protocol_authority(runtime);
+        let work_item = runtime
+            .create_work_item(
+                "repair canonical legacy split after restart".into(),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_queue".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "canonical settlement committed before restart".into(),
+            },
+        );
+        message.work_item_id = Some(work_item.id.clone());
+        message.turn_id = Some("turn-bootstrap-split-restart".into());
+        let message = runtime.enqueue(message).await.unwrap();
+        assert!(matches!(
+            scheduler_executor::SchedulerDecisionExecutor::new(runtime)
+                .poll()
+                .await
+                .unwrap(),
+            scheduler_executor::RunLoopPoll::Message(_)
+        ));
+        finish_claimed_test_run(runtime).await;
+        let terminal = terminal_transition(&message, Some(&work_item.id));
+        runtime
+            .storage()
+            .append_turn(&terminal.turn_record)
+            .unwrap();
+        let report =
+            scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+                .unwrap();
+        let command = report.candidates[0].proposed_commands[0].clone();
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test("default", &command, None)
+            .unwrap();
+        let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+        let snapshot = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap();
+        assert_eq!(
+            snapshot.activations[&activation_id].state,
+            crate::domain::scheduler_protocol::ActivationState::Settled
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .queue_entries()
+                .latest_all()
+                .unwrap()
+                .into_iter()
+                .find(|entry| entry.message_id == message.id)
+                .map(|entry| entry.status),
+            Some(QueueEntryStatus::Dequeued)
+        );
+        (message.id, activation_id, snapshot)
+    };
+
+    harness.restart();
+    let runtime = harness.runtime();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        settled_snapshot
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message_id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(64)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_bootstrap_claim_recovered"
+                && event.data["message_id"] == message_id
+                && event.data["activation_id"] == activation_id
+                && event.data["recovery_outcome"]
+                    == "legacy_queue_reconciled_from_canonical_settlement"
+                && event.data["provenance"] == "bootstrap_reconciliation"
+        }));
+}
+
+#[tokio::test]
+async fn non_authoritative_bootstrap_recovery_is_read_only() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "non authoritative recovery remains read only".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "claimed before settlement authority rollback".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    finish_claimed_test_run(&runtime).await;
+    runtime
+        .inner
+        .runtime_db
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE scheduler_scenario_authorities
+             SET mode = 'shadow',
+                 manifest_revision = NULL,
+                 preflight_revision = NULL
+             WHERE scenario_class = 'settlement'",
+            [],
+        )
+        .unwrap();
+    let before = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert_eq!(report.candidates.len(), 1);
+    assert!(report.candidates[0].eligible);
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        before
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_recovery_settles_completed_work_item_from_bound_terminal_evidence() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "recover completed canonical claim".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete before settlement commit".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.turn_id = Some("turn-bootstrap-completed".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+    runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let completed = runtime
+        .promote_work_item_completion_report(
+            work_item.id.clone(),
+            "recovered completion report".into(),
+            Some(1),
+            Some(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let result_brief_id = completed
+        .result_brief_id
+        .clone()
+        .expect("completed work item has bound result brief");
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&work_item.id));
+    runtime
+        .storage()
+        .append_turn(&terminal.turn_record)
+        .unwrap();
+
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert_eq!(report.candidates.len(), 1);
+    assert!(report.candidates[0].eligible);
+    assert_eq!(report.candidates[0].reason, "terminal_turn_settlement");
+    assert!(matches!(
+        report.candidates[0].proposed_commands.as_slice(),
+        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
+    ));
+
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    assert_eq!(
+        snapshot
+            .activations
+            .get(&activation_id)
+            .map(|activation| activation.state.clone()),
+        Some(crate::domain::scheduler_protocol::ActivationState::Settled)
+    );
+    let settlement = snapshot
+        .settlements
+        .get(&canonical_settlement_id(&message.id))
+        .expect("completed activation settlement");
+    assert_eq!(
+        settlement.operator_delivery.as_deref(),
+        Some(result_brief_id.as_str())
+    );
+    assert!(settlement
+        .evidence
+        .iter()
+        .any(|evidence| evidence == &format!("turn:{}", terminal.terminal.turn_id)));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
+    );
+}
+
+#[tokio::test]
+async fn stale_bootstrap_recovery_command_cannot_settle_successor_generation() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority(&runtime);
+    let work_item = runtime
+        .create_work_item(
+            "fence stale bootstrap recovery".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut first_message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "first claimed generation".into(),
+        },
+    );
+    first_message.work_item_id = Some(work_item.id.clone());
+    first_message.turn_id = Some("turn-bootstrap-stale-first".into());
+    let first_message = runtime.enqueue(first_message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&first_message, Some(&work_item.id));
+    runtime
+        .storage()
+        .append_turn(&terminal.turn_record)
+        .unwrap();
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    let mut stale_command = report.candidates[0].proposed_commands[0].clone();
+    let crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command) =
+        &mut stale_command
+    else {
+        panic!("terminal recovery should propose settlement");
+    };
+    command.settlement.id = "settlement:stale-bootstrap-proposal".into();
+
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    let mut successor_message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "successor claimed generation".into(),
+        },
+    );
+    successor_message.work_item_id = Some(work_item.id.clone());
+    let successor_message = runtime.enqueue(successor_message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    finish_claimed_test_run(&runtime).await;
+    let before = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(
+        before.work[&work_item.id].scheduling_generation,
+        claimed.work[&work_item.id].scheduling_generation + 1
+    );
+
+    let expected_entry = runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest_all()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.message_id == successor_message.id)
+        .unwrap();
+    let mut processed_entry = expected_entry.clone();
+    processed_entry.status = QueueEntryStatus::Processed;
+    processed_entry.updated_at = runtime.now();
+    let error = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .commit_queue(&crate::runtime_db::transitions::QueueTransitionCommand {
+            agent_id: "default".into(),
+            operation: crate::runtime_db::transitions::QueueOperation::Settle,
+            mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                expected: expected_entry,
+                record: processed_entry,
+            },
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: vec![stale_command],
+            scheduler_authority_scenarios: Vec::new(),
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: vec![AuditEvent::legacy(
+                "stale_bootstrap_recovery_attempt",
+                serde_json::json!({"message_id": first_message.id}),
+            )],
+            scheduler_shadow_comparison: None,
+            scheduler_delivery_shadow_comparison: None,
+            scheduler_semantic_shadow: None,
+            notify_scheduler: true,
+            fault: None,
+            brief_evidence: Vec::new(),
+        })
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("activation_terminal_settlement_already_recorded"),
+        "unexpected stale recovery error: {error:#}"
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        before
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == successor_message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(64)
+        .unwrap()
+        .iter()
+        .all(|event| event.kind != "stale_bootstrap_recovery_attempt"));
+}
+
+#[tokio::test]
+async fn bootstrap_recovery_fault_rolls_back_queue_canonical_and_audit() {
+    for terminal_evidence in [false, true] {
+        for fault in PRE_COMMIT_FAULTS {
+            let dir = tempdir().unwrap();
+            let workspace = tempdir().unwrap();
+            let runtime = RuntimeHandle::new(
+                "default",
+                dir.path().to_path_buf(),
+                workspace.path().to_path_buf(),
+                "http://127.0.0.1:7878".into(),
+                Arc::new(CountingProvider {
+                    calls: Mutex::new(0),
+                    reply: "unused",
+                }),
+                "default".into(),
+                context_config(),
+            )
+            .unwrap();
+            runtime.set_scheduler_protocol_production_commands_enabled(true);
+            enable_production_protocol_authority(&runtime);
+            let work_item = runtime
+                .create_work_item(
+                    format!("atomic bootstrap recovery {terminal_evidence} {fault:?}"),
+                    None,
+                    None,
+                    Vec::new(),
+                )
+                .await
+                .unwrap();
+            let mut message = MessageEnvelope::new(
+                "default",
+                MessageKind::SystemTick,
+                MessageOrigin::System {
+                    subsystem: "work_queue".into(),
+                },
+                AuthorityClass::RuntimeInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "claim before recovery fault".into(),
+                },
+            );
+            message.work_item_id = Some(work_item.id.clone());
+            message.turn_id = terminal_evidence
+                .then(|| format!("turn-bootstrap-fault-{terminal_evidence}-{fault:?}"));
+            let message = runtime.enqueue(message).await.unwrap();
+            let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+                .poll()
+                .await
+                .unwrap();
+            assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+            finish_claimed_test_run(&runtime).await;
+            if terminal_evidence {
+                let terminal = terminal_transition(&message, Some(&work_item.id));
+                runtime
+                    .storage()
+                    .append_turn(&terminal.turn_record)
+                    .unwrap();
+            }
+            let claimed = runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .load_scheduler_protocol_snapshot("default")
+                .unwrap();
+
+            runtime.inject_next_transition_fault(fault);
+            let error = runtime
+                .recover_scheduler_bootstrap_claims()
+                .await
+                .unwrap_err();
+            assert_injected_transition_fault(&error);
+            assert_eq!(
+                runtime
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .load_scheduler_protocol_snapshot("default")
+                    .unwrap(),
+                claimed
+            );
+            assert_eq!(
+                runtime
+                    .inner
+                    .runtime_db
+                    .queue_entries()
+                    .latest_all()
+                    .unwrap()
+                    .into_iter()
+                    .find(|entry| entry.message_id == message.id)
+                    .map(|entry| entry.status),
+                Some(QueueEntryStatus::Dequeued)
+            );
+            assert!(runtime
+                .storage()
+                .read_recent_events(64)
+                .unwrap()
+                .iter()
+                .all(|event| {
+                    event.kind != "scheduler_bootstrap_claim_recovered"
+                        || event.data["message_id"] != message.id
+                }));
+
+            assert_eq!(
+                runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+                1
+            );
+            assert_eq!(
+                runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+                0
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3258,6 +3258,46 @@ pub(crate) fn upsert_queue_entry_tx(
     Ok(true)
 }
 
+pub(crate) fn compare_and_set_queue_entry_tx(
+    tx: &Transaction<'_>,
+    expected: &QueueEntryRecord,
+    record: &QueueEntryRecord,
+) -> Result<bool> {
+    if expected.message_id != record.message_id || expected.agent_id != record.agent_id {
+        return Err(anyhow!(
+            "queue compare-and-set identity must remain unchanged"
+        ));
+    }
+    queue_entry_transition(expected, record)?;
+
+    let expected_payload_json = serde_json::to_string(expected)?;
+    let payload_json = serde_json::to_string(record)?;
+    let priority = enum_string(&record.priority)?;
+    let status = enum_string(&record.status)?;
+    let changed = tx.execute(
+        "UPDATE queue_entries
+         SET priority = ?3,
+             status = ?4,
+             created_at = ?5,
+             updated_at = ?6,
+             payload_json = ?7
+         WHERE message_id = ?1
+           AND agent_id = ?2
+           AND payload_json = ?8",
+        params![
+            record.message_id,
+            record.agent_id,
+            priority,
+            status,
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            payload_json,
+            expected_payload_json,
+        ],
+    )?;
+    Ok(changed == 1)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StateTransitionOutcome {
     Applied,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -16,8 +16,8 @@ use crate::{
             insert_brief_evidence_tx, insert_runtime_index_changes_tx, upsert_agent_state_tx,
         },
         repositories::{
-            insert_new_work_item_tx, queue_entry_transition, task_transition,
-            try_claim_queued_message_tx, try_interject_queued_message_tx,
+            compare_and_set_queue_entry_tx, insert_new_work_item_tx, queue_entry_transition,
+            task_transition, try_claim_queued_message_tx, try_interject_queued_message_tx,
             update_expected_work_item_tx, upsert_queue_entry_tx, upsert_task_tx,
             upsert_turn_record_tx, upsert_wait_condition_tx, upsert_work_item_continuation_tx,
             wait_condition_transition,
@@ -83,6 +83,10 @@ impl WorkItemMutation {
 pub(crate) enum QueueMutation {
     Consume(QueueEntryRecord),
     Upsert(QueueEntryRecord),
+    CompareAndSet {
+        expected: QueueEntryRecord,
+        record: QueueEntryRecord,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -396,8 +400,11 @@ impl RuntimeTransitionRepository<'_> {
                     }
                 },
                 QueueMutation::Upsert(record) => upsert_queue_entry_tx(tx, record)?,
+                QueueMutation::CompareAndSet { expected, record } => {
+                    compare_and_set_queue_entry_tx(tx, expected, record)?
+                }
             };
-            if matches!(&command.mutation, QueueMutation::Consume(_)) && !mutation_applied {
+            if !matches!(&command.mutation, QueueMutation::Upsert(_)) && !mutation_applied {
                 return Ok(TransitionCommit::default());
             }
             let shadow_comparison = scheduler_protocol_repository::validate_shadow_comparison_tx(
@@ -419,7 +426,10 @@ impl RuntimeTransitionRepository<'_> {
                 )?;
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
-            let applied = mutation_applied || agent_state_applied;
+            let protocol_applied = scheduler_protocol
+                .as_ref()
+                .is_some_and(|prepared| prepared.has_writes());
+            let applied = mutation_applied || agent_state_applied || protocol_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
@@ -868,6 +878,7 @@ fn validate_wait_condition_tx(tx: &Transaction<'_>, incoming: &WaitConditionReco
 fn validate_queue_mutation_tx(tx: &Transaction<'_>, mutation: &QueueMutation) -> Result<()> {
     let incoming = match mutation {
         QueueMutation::Consume(record) | QueueMutation::Upsert(record) => record,
+        QueueMutation::CompareAndSet { record, .. } => record,
     };
     let existing = tx
         .query_row(
@@ -878,8 +889,14 @@ fn validate_queue_mutation_tx(tx: &Transaction<'_>, mutation: &QueueMutation) ->
         .optional()?
         .map(|payload| serde_json::from_str::<QueueEntryRecord>(&payload))
         .transpose()?;
-    if let (QueueMutation::Upsert(_), Some(existing)) = (mutation, existing.as_ref()) {
-        queue_entry_transition(existing, incoming)?;
+    match (mutation, existing.as_ref()) {
+        (QueueMutation::Upsert(_), Some(existing)) => {
+            queue_entry_transition(existing, incoming)?;
+        }
+        (QueueMutation::CompareAndSet { expected, record }, _) => {
+            queue_entry_transition(expected, record)?;
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -920,6 +937,21 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
                     | QueueEntryStatus::Dropped,
                 ..
             })
+        ) | (
+            QueueOperation::Settle,
+            QueueMutation::CompareAndSet {
+                expected: QueueEntryRecord {
+                    status: QueueEntryStatus::Dequeued,
+                    ..
+                },
+                record: QueueEntryRecord {
+                    status: QueueEntryStatus::Processed
+                        | QueueEntryStatus::Interrupted
+                        | QueueEntryStatus::Aborted
+                        | QueueEntryStatus::Dropped,
+                    ..
+                },
+            }
         )
     );
     if !valid {
@@ -1355,6 +1387,59 @@ mod tests {
             assert!(db.transcript_entries().all(Some("agent-a"))?.is_empty());
             assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_compare_and_set_rejects_changed_claim_without_side_effects() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let now = Utc::now();
+        let expected = QueueEntryRecord {
+            message_id: "message-recovery-cas".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Dequeued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&expected)?;
+        let mut refreshed = expected.clone();
+        refreshed.updated_at += chrono::Duration::seconds(1);
+        db.queue_entries().upsert(&refreshed)?;
+        let mut processed = expected.clone();
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at += chrono::Duration::seconds(2);
+
+        let commit = db.transitions().commit_queue(&QueueTransitionCommand {
+            agent_id: "agent-a".into(),
+            operation: QueueOperation::Settle,
+            mutation: QueueMutation::CompareAndSet {
+                expected,
+                record: processed,
+            },
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: Vec::new(),
+            scheduler_authority_scenarios: Vec::new(),
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: vec![AuditEvent::legacy(
+                "stale_recovery_claim_settled",
+                serde_json::json!({}),
+            )],
+            scheduler_semantic_shadow: None,
+            scheduler_shadow_comparison: None,
+            scheduler_delivery_shadow_comparison: None,
+            notify_scheduler: true,
+            fault: None,
+            brief_evidence: Vec::new(),
+        })?;
+
+        assert!(!commit.applied);
+        assert_eq!(db.queue_entries().latest_all()?, vec![refreshed]);
+        assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
         Ok(())
     }
 

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -74,6 +74,12 @@ pub(super) struct PreparedProtocolCommands {
     results: Vec<PreparedProtocolCommandResult>,
 }
 
+impl PreparedProtocolCommands {
+    pub(super) fn has_writes(&self) -> bool {
+        self.initialized_partition || !self.results.is_empty()
+    }
+}
+
 struct PreparedProtocolCommandResult {
     command_kind: &'static str,
     command_identity: String,

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -783,6 +783,30 @@
     "aliases": []
   },
   {
+    "path": "debug.scheduler-recovery",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "events",
     "positionals": [],
     "flags": [],


### PR DESCRIPTION
## Summary

- reconcile canonical scheduler activations and legacy queue claims atomically during bootstrap
- fence recovery with both scheduler generation/activation validation and queue claim compare-and-set
- derive typed terminal or missing-settlement commands from durable evidence, preserving recovery provenance
- add a read-only `holon debug scheduler-recovery` diagnostic surface and document the recovery contract

## Tests

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`

Coverage includes real runtime reopen, canonical/legacy duplicate splits, stale generations, concurrent claim changes, terminal and missing-settlement rollback faults, authority modes, idempotency, and provenance.
