### PR TITLE
fix: restore brief hydration retry guards

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -151,6 +151,10 @@ describe("resume session reset", () => {
         sendingPrompt: true,
         liveStatus: "recovering",
         reconnectAttempt: 4,
+        briefHydrationById: {
+          loading: { briefId: "loading", status: "loading", attempt: 2 },
+          failed: { briefId: "failed", status: "failed", attempt: 5, errorKind: "timeout" },
+        },
         workItemDetailsById: { "work-1": { loading: true } },
         taskDetailsById: { "task-1": { loading: true } },
         toolExecutionDetailsById: { "tool-1": { loading: true } },
@@ -163,6 +167,10 @@ describe("resume session reset", () => {
       sendingPrompt: false,
       liveStatus: "stale",
       reconnectAttempt: 0,
+      briefHydrationById: {
+        loading: { briefId: "loading", status: "pending", attempt: 2 },
+        failed: { briefId: "failed", status: "failed", attempt: 5, errorKind: "timeout" },
+      },
       workItemDetailsById: { "work-1": { loading: false } },
       taskDetailsById: { "task-1": { loading: false } },
       toolExecutionDetailsById: { "tool-1": { loading: false } },
@@ -781,6 +789,92 @@ describe("runtime client generation", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe("brief hydration retry limits", () => {
+  afterEach(() => {
+    useRuntimeStore.setState({
+      sessionsByAgentId: {},
+      globalStreamStatus: "idle",
+      selectedAgentId: "",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("stops automatic hydration after five attempts but still allows manual retry", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/agents/agent-a/briefs:batchGet")) {
+        return Promise.resolve(jsonResponse({
+          briefs: [{ id: "brief-123", text: "Hydrated after manual retry." }],
+          missing_brief_ids: [],
+        }));
+      }
+      if (url.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+
+    const now = Date.now();
+    useRuntimeStore.setState({
+      globalStreamStatus: "streaming",
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          cacheStatus: "hit",
+          contentStatus: "available",
+          syncStatus: "streaming",
+          detailValidatedAt: now,
+          eventsValidatedAt: now,
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          eventsBySeq: {
+            1: {
+              agent_id: "agent-a",
+              event_seq: 1,
+              ts: "2026-07-23T00:00:00Z",
+              type: "brief_created",
+              payload: { brief_id: "brief-123" },
+            },
+          },
+          eventSeqs: [1],
+          referencedBriefIds: { "brief-123": true },
+          briefHydrationById: {
+            "brief-123": {
+              briefId: "brief-123",
+              status: "failed",
+              attempt: 5,
+              errorKind: "request_failed",
+            },
+          },
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().ensureAgentSession("agent-a", "info");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    useRuntimeStore.getState().retryBriefHydration("agent-a", "brief-123");
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]?.briefRecordsById["brief-123"]?.text)
+        .toBe("Hydrated after manual retry.");
+    });
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4502,6 +4502,7 @@ function scheduleBriefHydration(
   const isForced = Boolean(options.forceIds);
   const requestIds = briefIds.filter((briefId) => {
     if (inFlight.has(briefId)) return false;
+    // Forced IDs cover manual retry and scheduled retry, which has its own attempt cap.
     if (isForced) return true;
     const attempt = session?.briefHydrationById[briefId]?.attempt ?? 0;
     return attempt < BRIEF_HYDRATION_MAX_ATTEMPTS;

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -521,6 +521,7 @@ const GLOBAL_BACKFILL_LIMIT = 100;
 const AGENT_VALIDATION_TTL_MS = 60_000;
 const RESUME_RECONCILIATION_THRESHOLD_MS = 60_000;
 const BRIEF_HYDRATION_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+const BRIEF_HYDRATION_MAX_ATTEMPTS = 5;
 const AGENT_DETAIL_RETRY_DELAYS_MS = [2_000, 5_000, 15_000] as const;
 
 function nextClientGeneration(): number {
@@ -634,6 +635,12 @@ export function resetSessionsForResume(
         sendingPrompt: false,
         liveStatus: "stale" as const,
         reconnectAttempt: 0,
+        briefHydrationById: Object.fromEntries(
+          Object.entries(session.briefHydrationById).map(([briefId, hydration]) => [
+            briefId,
+            hydration.status === "loading" ? { ...hydration, status: "pending" as const } : hydration,
+          ]),
+        ),
         workItemDetailsById: resetDetailLoading(session.workItemDetailsById),
         taskDetailsById: resetDetailLoading(session.taskDetailsById),
         toolExecutionDetailsById: resetDetailLoading(session.toolExecutionDetailsById),
@@ -4492,7 +4499,13 @@ function scheduleBriefHydration(
     inFlight = new Set<string>();
     briefHydrationInFlight.set(agentId, inFlight);
   }
-  const requestIds = briefIds.filter((briefId) => !inFlight.has(briefId));
+  const isForced = Boolean(options.forceIds);
+  const requestIds = briefIds.filter((briefId) => {
+    if (inFlight.has(briefId)) return false;
+    if (isForced) return true;
+    const attempt = session?.briefHydrationById[briefId]?.attempt ?? 0;
+    return attempt < BRIEF_HYDRATION_MAX_ATTEMPTS;
+  });
   if (!requestIds.length) return;
   requestIds.forEach((briefId) => inFlight.add(briefId));
   set((state) => updateBriefHydrationState(state, agentId, {


### PR DESCRIPTION
## Summary

- restore `loading` to `pending` reset for brief hydration when runtime sessions resume
- stop automatic brief hydration scheduling after five attempts while preserving explicit manual retry
- add regression coverage for resume recovery and retry-limit behavior

## Regression

PR #2390 was based on code predating the brief hydration safeguards merged in #2393 and unintentionally removed both the resume reset and maximum-attempt guard.

## Verification

- `npm test` (279 tests)
- `npm run build`
- `npm run typecheck`
- `git diff --check`
