### PR TITLE
feat: generalize scheduler activation admission

### DIFF
--- a/docs/implementation-decisions/098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md
+++ b/docs/implementation-decisions/098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md
@@ -14,6 +14,22 @@ boundaries (`AfterProviderRound`, `BeforeToolExecution`, `AfterToolResults`,
 `BeforeProviderContinuation`). A public `SchedulerDiagnosticAuditEvent`
 stream is emitted alongside the legacy audit for every decision.
 
+Model-reentry admission now derives one `canonical_activation_plan` for
+WorkItem autonomous continuation, exact task rejoin, exact wait resume, and
+explicitly bound operator input. The plan carries the typed cause, binding,
+provenance, expected WorkItem scheduling generation, expected agent dispatch
+revision, exact wait/task identity when applicable, and the legacy queue/Turn
+compatibility binding. Its optional demand registration and wait trigger,
+authority issuance, activation admission, legacy queue claim, and running
+projection commit in the same `QueueTransitionCommand`.
+
+Operator interjection is deliberately not a second admission. At a safe point
+the runtime commits a typed `ActivationInputAttachment`, the legacy
+`Queued -> Interjected` transition, transcript evidence, and audit evidence in
+one transaction. The attachment is fenced by the running activation, WorkItem
+scheduling generation, dispatch revision, message, Turn, boundary, and round;
+it does not reserve another slot or advance WorkItem scheduling state.
+
 The semantic decision plane returns `Ok(None)` when trusted ingress
 conditions are not met, rather than propagating the error. This prevents
 observation and audit mechanisms from blocking the run loop or causing test
@@ -56,3 +72,10 @@ validator retain all state-transition control. In `Authoritative` mode, legacy
 observation remains compatibility evidence, but Runtime-owned validation and
 transaction commit decide whether the transition is admitted. Semantic
 proposals cannot satisfy, bypass, or weaken the matched-evidence requirement.
+
+The generalized plan only covers structurally exact scenario classes. Ordinary
+unbound operator input and ambiguous reentry remain outside canonical
+admission. Legacy queue, AgentState, and Turn facts remain compatibility
+participants in the transaction rather than independent admission authority.
+This decision does not choose which scenario classes are promoted to
+`Authoritative`; rollout policy and promotion gates remain separate.

--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -452,6 +452,34 @@ Starting the activation changes `Admitted` to `Running` and claims the
 corresponding queue entry, Turn binding, or compatibility Run record in the
 same invariant-preserving transition.
 
+During migration, the runtime derives one `canonical_activation_plan` from the
+persisted message, scheduler projection, and continuation resolution. The
+implemented structural classes are:
+
+- WorkItem autonomous continuation;
+- exact task rejoin;
+- exact wait resume; and
+- explicitly bound operator input.
+
+Each plan preserves the source-specific cause and binding, message provenance
+and trust, correlation and causation, expected WorkItem scheduling generation,
+expected dispatch revision, exact task or wait generation where applicable,
+and the legacy queue/Turn compatibility identity. Demand registration, wait
+trigger, authority issuance, `AdmitActivation`, queue claim, and running
+projection either commit together or all roll back. Duplicate command identity
+returns the first canonical result; stale generations, wrong-agent bindings,
+ambiguous waits, and out-of-order source identities reject before execution
+ownership changes.
+
+Operator interjection follows a different path because a running activation
+already owns execution. A safe point attaches one typed
+`ActivationInputAttachment` to that activation and atomically commits the
+legacy `Interjected` queue state, incoming transcript evidence, and audit
+evidence. The attachment is unique per message and fenced by activation,
+WorkItem scheduling generation, dispatch revision, Turn, boundary, and round.
+It neither creates another activation nor changes slot, dispatch, or WorkItem
+generation.
+
 ## Activation Settlement
 
 Every normally terminal activation commits one settlement:

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -45,6 +45,15 @@ In that target:
 The Message/Turn/`SystemTick` descriptions below remain migration and current
 implementation context until the activation protocol becomes authoritative.
 
+The current migration path now constructs a unified
+`canonical_activation_plan` for WorkItem autonomous continuation, exact task
+rejoin, exact wait resume, and explicitly bound operator input. The canonical
+authority/admission commands and the legacy queue claim enter one transaction.
+Operator interjection instead attaches typed input to the existing running
+activation in the same transaction as the legacy `Interjected` state,
+transcript, and audit evidence. Queue, Turn, and `AgentState` records remain
+compatibility bindings while scenario rollout policy is handled separately.
+
 ## Problem
 
 Holon is headless, event-driven, and long-lived. Scheduler bugs therefore have

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -26,6 +26,8 @@ pub struct Snapshot {
     pub rollout: RolloutState,
     pub admitted_generations: BTreeSet<String>,
     pub continuation_admissions: BTreeMap<String, ContinuationAdmissionRecord>,
+    #[serde(default)]
+    pub activation_inputs: BTreeMap<String, ActivationInputAttachment>,
 }
 
 #[derive(Deserialize)]
@@ -45,6 +47,8 @@ struct SnapshotWire {
     rollout: Option<RolloutState>,
     admitted_generations: Option<BTreeSet<String>>,
     continuation_admissions: Option<BTreeMap<String, ContinuationAdmissionRecord>>,
+    #[serde(default)]
+    activation_inputs: Option<BTreeMap<String, ActivationInputAttachment>>,
 }
 
 impl TryFrom<SnapshotWire> for Snapshot {
@@ -100,6 +104,7 @@ impl TryFrom<SnapshotWire> for Snapshot {
             rollout,
             admitted_generations,
             continuation_admissions,
+            activation_inputs: wire.activation_inputs.unwrap_or_default(),
         };
         assert_invariants(&snapshot)?;
         Ok(snapshot)
@@ -341,11 +346,12 @@ pub enum SchedulerScenarioClass {
 }
 
 impl SchedulerScenarioClass {
-    pub const PRODUCTION_AUTHORITY: [Self; 7] = [
+    pub const PRODUCTION_AUTHORITY: [Self; 8] = [
         Self::ReducerOnlyCandidates,
         Self::WorkItemAutonomousContinuation,
         Self::ExactTaskRejoin,
         Self::ExactWaitResume,
+        Self::ExplicitlyBoundOperatorInput,
         Self::OperatorInterjection,
         Self::Settlement,
         Self::Delivery,
@@ -561,6 +567,8 @@ pub fn activation_provenance_has_valid_authority(provenance: &ActivationProvenan
 pub enum ActivationCause {
     OperatorInput {
         message_id: String,
+        #[serde(default)]
+        resume: Option<WaitResumeClaim>,
     },
     OperatorInterjection {
         message_id: String,
@@ -571,6 +579,8 @@ pub enum ActivationCause {
     TaskRejoin {
         task_id: String,
         message_id: String,
+        #[serde(default)]
+        resume: Option<WaitResumeClaim>,
     },
     WaitResume {
         wait_id: String,
@@ -595,6 +605,14 @@ pub enum ActivationCause {
     SettlementRecovery {
         activation_id: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WaitResumeClaim {
+    pub wait_id: String,
+    pub wait_generation: u64,
+    pub trigger_id: String,
+    pub trigger_generation: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -791,6 +809,26 @@ pub struct TriggerWaitCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivationInputAttachment {
+    pub id: String,
+    pub activation_id: String,
+    pub work_item_id: String,
+    pub expected_scheduling_generation: u64,
+    pub expected_dispatch_revision: u64,
+    pub message_id: String,
+    pub turn_id: String,
+    pub boundary: String,
+    pub round: u64,
+    pub provenance: ActivationProvenance,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachActivationInputCommand {
+    pub attachment: ActivationInputAttachment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ProtocolCommand {
     RegisterWorkDemand(RegisterWorkDemandCommand),
@@ -799,6 +837,7 @@ pub enum ProtocolCommand {
     SettleActivation(SettleActivationCommand),
     RecordMissingSettlement(MissingSettlementRecord),
     TriggerWait(TriggerWaitCommand),
+    AttachActivationInput(AttachActivationInputCommand),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -921,6 +960,9 @@ pub enum Event {
     OperatorIntervention {
         input_id: String,
     },
+    AttachActivationInput {
+        attachment: ActivationInputAttachment,
+    },
     Settle {
         activation_id: String,
         settlement: Settlement,
@@ -931,6 +973,17 @@ pub enum Event {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AdmissionCause {
     Scheduling,
+    TaskRejoin {
+        task_id: String,
+        message_id: String,
+        #[serde(default)]
+        resume: Option<WaitResumeClaim>,
+    },
+    OperatorInput {
+        message_id: String,
+        #[serde(default)]
+        resume: Option<WaitResumeClaim>,
+    },
     WaitResume {
         wait_id: String,
         wait_generation: u64,
@@ -1103,6 +1156,7 @@ pub enum Decision {
     RollbackTripped,
     DuplicateIgnored,
     OperatorIntervention,
+    ActivationInputAttached,
     SettlementMissing,
     SettlementHeld,
     Rejected,
@@ -1224,6 +1278,29 @@ pub fn migrate_legacy_event(
                     ActivationCause::WorkItemRunnable {
                         work_item_id: work_item_id.clone(),
                         scheduling_generation: *expected_generation,
+                    },
+                    ActivationBinding::WorkItem {
+                        work_item_id: work_item_id.clone(),
+                    },
+                ),
+                AdmissionCause::TaskRejoin {
+                    task_id,
+                    message_id,
+                    resume,
+                } => (
+                    ActivationCause::TaskRejoin {
+                        task_id: task_id.clone(),
+                        message_id: message_id.clone(),
+                        resume: resume.clone(),
+                    },
+                    ActivationBinding::WorkItem {
+                        work_item_id: work_item_id.clone(),
+                    },
+                ),
+                AdmissionCause::OperatorInput { message_id, resume } => (
+                    ActivationCause::OperatorInput {
+                        message_id: message_id.clone(),
+                        resume: resume.clone(),
                     },
                     ActivationBinding::WorkItem {
                         work_item_id: work_item_id.clone(),
@@ -1500,6 +1577,9 @@ fn reduce_event(snapshot: &Snapshot, event: &Event) -> Outcome {
             diagnostics: vec![format!("operator_intervention:{input_id}")],
             snapshot: snapshot.clone(),
         },
+        Event::AttachActivationInput { attachment } => {
+            attach_activation_input(snapshot, attachment)
+        }
         Event::Settle {
             activation_id,
             settlement,
@@ -1572,6 +1652,12 @@ pub fn reduce_command(snapshot: &Snapshot, command: &ProtocolCommand) -> Protoco
                 .snapshot
                 .missing_settlements
                 .insert(record.id.clone(), record.clone());
+        }
+        (ProtocolCommand::AttachActivationInput(command), Decision::ActivationInputAttached) => {
+            outcome
+                .snapshot
+                .activation_inputs
+                .insert(command.attachment.id.clone(), command.attachment.clone());
         }
         _ => {}
     }
@@ -1705,6 +1791,34 @@ fn replay_or_conflict(
             }
         }
         ProtocolCommand::TriggerWait(_) => {}
+        ProtocolCommand::AttachActivationInput(command) => {
+            if let Some(existing) = snapshot.activation_inputs.get(&command.attachment.id) {
+                return Some(if existing == &command.attachment {
+                    duplicate_command(snapshot, "activation_input_already_attached")
+                } else {
+                    rejected_command(
+                        snapshot,
+                        command_conflict(
+                            ProtocolConflictKind::IdentityConflict,
+                            "activation_input_id_command_conflict",
+                        ),
+                    )
+                });
+            }
+            if snapshot
+                .activation_inputs
+                .values()
+                .any(|existing| existing.message_id == command.attachment.message_id)
+            {
+                return Some(rejected_command(
+                    snapshot,
+                    command_conflict(
+                        ProtocolConflictKind::IdempotencyConflict,
+                        "activation_input_message_conflict",
+                    ),
+                ));
+            }
+        }
     }
     None
 }
@@ -1802,6 +1916,29 @@ fn lower_command(
                 wait_generation: command.wait_generation,
                 trigger_id: command.trigger_id.clone(),
                 trigger_generation: command.trigger_generation,
+            })
+        }
+        ProtocolCommand::AttachActivationInput(command) => {
+            let attachment = &command.attachment;
+            if attachment.id.is_empty()
+                || attachment.activation_id.is_empty()
+                || attachment.work_item_id.is_empty()
+                || attachment.expected_scheduling_generation == 0
+                || attachment.message_id.is_empty()
+                || attachment.turn_id.is_empty()
+                || attachment.boundary.is_empty()
+                || attachment.created_at.is_empty()
+                || attachment.provenance.source_id != attachment.message_id
+                || attachment.provenance.origin != ActivationOrigin::Operator
+                || attachment.provenance.trust != ActivationTrust::OperatorInstruction
+            {
+                return Err(command_conflict(
+                    ProtocolConflictKind::InvalidCommand,
+                    "activation_input_identity_or_provenance_required",
+                ));
+            }
+            Ok(Event::AttachActivationInput {
+                attachment: attachment.clone(),
             })
         }
     }
@@ -1999,6 +2136,31 @@ fn lower_admit_activation(
             (work_item_id.clone(), AdmissionCause::Scheduling)
         }
         (
+            ActivationCause::TaskRejoin {
+                task_id,
+                message_id,
+                resume,
+            },
+            ActivationBinding::WorkItem { work_item_id },
+        ) => (
+            work_item_id.clone(),
+            AdmissionCause::TaskRejoin {
+                task_id: task_id.clone(),
+                message_id: message_id.clone(),
+                resume: resume.clone(),
+            },
+        ),
+        (
+            ActivationCause::OperatorInput { message_id, resume },
+            ActivationBinding::WorkItem { work_item_id },
+        ) => (
+            work_item_id.clone(),
+            AdmissionCause::OperatorInput {
+                message_id: message_id.clone(),
+                resume: resume.clone(),
+            },
+        ),
+        (
             ActivationCause::WaitResume {
                 wait_id,
                 wait_generation,
@@ -2029,6 +2191,8 @@ fn lower_admit_activation(
         ),
         (
             ActivationCause::WorkItemRunnable { .. }
+            | ActivationCause::TaskRejoin { .. }
+            | ActivationCause::OperatorInput { .. }
             | ActivationCause::WaitResume { .. }
             | ActivationCause::SettlementRecovery { .. },
             _,
@@ -2053,6 +2217,53 @@ fn lower_admit_activation(
         expected_dispatch_revision: command.expected_dispatch_revision,
         cause,
     })
+}
+
+fn attach_activation_input(snapshot: &Snapshot, attachment: &ActivationInputAttachment) -> Outcome {
+    let ActivationSlot::Running {
+        activation_id,
+        work_item_id,
+        admitted_generation,
+        ..
+    } = &snapshot.slot
+    else {
+        return rejected(snapshot, "activation_input_requires_running_slot");
+    };
+    if activation_id != &attachment.activation_id {
+        return rejected(snapshot, "activation_input_owner_mismatch");
+    }
+    if work_item_id != &attachment.work_item_id
+        || admitted_generation != &attachment.expected_scheduling_generation
+    {
+        return rejected(snapshot, "activation_input_work_item_binding_mismatch");
+    }
+    if snapshot.dispatch_revision != attachment.expected_dispatch_revision {
+        return rejected(snapshot, "stale_dispatch_revision");
+    }
+    let Some(activation) = snapshot.activations.get(activation_id) else {
+        return rejected(snapshot, "running_activation_record_missing");
+    };
+    if activation.state != ActivationState::Running {
+        return rejected(snapshot, "activation_input_owner_not_running");
+    }
+    let Some(admission) = snapshot.activation_admissions.get(activation_id) else {
+        return rejected(snapshot, "activation_has_no_canonical_admission");
+    };
+    if admission.activation.preemption != PreemptionPolicy::AllowOperatorInterjection {
+        return rejected(snapshot, "activation_disallows_operator_interjection");
+    }
+    let mut next = snapshot.clone();
+    next.activation_inputs
+        .insert(attachment.id.clone(), attachment.clone());
+    Outcome {
+        decision: Decision::ActivationInputAttached,
+        transitions: vec![format!(
+            "activation:{}:input_attached:{}:{}",
+            attachment.activation_id, attachment.message_id, attachment.boundary
+        )],
+        diagnostics: Vec::new(),
+        snapshot: next,
+    }
 }
 
 fn lower_activation_settlement(
@@ -2283,13 +2494,14 @@ fn reducer_conflict(code: &str) -> ProtocolConflict {
 
 fn activation_cause_has_identity(cause: &ActivationCause) -> bool {
     match cause {
-        ActivationCause::OperatorInput { message_id }
+        ActivationCause::OperatorInput { message_id, .. }
         | ActivationCause::OperatorInterjection { message_id }
         | ActivationCause::MessageIngress { message_id }
         | ActivationCause::InternalFollowup { message_id } => !message_id.is_empty(),
         ActivationCause::TaskRejoin {
             task_id,
             message_id,
+            ..
         } => !task_id.is_empty() && !message_id.is_empty(),
         ActivationCause::WaitResume {
             wait_id,
@@ -2341,11 +2553,12 @@ fn activation_provenance_matches_cause(
         ActivationCause::WaitResume { .. } => {
             matches!(
                 provenance.origin,
-                ActivationOrigin::Callback | ActivationOrigin::Timer | ActivationOrigin::System
-            ) && matches!(
-                provenance.trust,
-                ActivationTrust::RuntimeInstruction | ActivationTrust::IntegrationSignal
-            )
+                ActivationOrigin::Channel
+                    | ActivationOrigin::Webhook
+                    | ActivationOrigin::Callback
+                    | ActivationOrigin::Timer
+                    | ActivationOrigin::System
+            ) && activation_provenance_has_valid_authority(provenance)
         }
         ActivationCause::WorkItemRunnable { .. }
         | ActivationCause::WorkItemRecheck { .. }
@@ -2374,10 +2587,88 @@ fn admission_fence(work_item_id: &str, expected_generation: u64, cause: &Admissi
         AdmissionCause::SettlementRecovery {
             missing_activation_id,
         } => format!("{work_item_id}:{expected_generation}:recovery:{missing_activation_id}"),
+        AdmissionCause::TaskRejoin { task_id, .. } => format!("task:{task_id}"),
+        AdmissionCause::OperatorInput { message_id, .. } => {
+            format!("operator_message:{message_id}")
+        }
         AdmissionCause::Scheduling | AdmissionCause::WaitResume { .. } => {
             format!("{work_item_id}:{expected_generation}")
         }
     }
+}
+
+fn consume_wait_resume_claim(
+    snapshot: &Snapshot,
+    next: &mut Snapshot,
+    activation_id: &str,
+    work_item_id: &str,
+    claim: &WaitResumeClaim,
+    transitions: &mut Vec<String>,
+) -> Result<(), &'static str> {
+    let Some(wait) = snapshot.waits.get(&claim.wait_id) else {
+        return Err("unknown_wait");
+    };
+    if wait.current_generation != claim.wait_generation {
+        return Err("stale_wait_generation");
+    }
+    let generation = wait
+        .generations
+        .get(&claim.wait_generation)
+        .expect("current wait generation exists");
+    if generation.owner_work_item_id != work_item_id {
+        return Err("wait_owner_mismatch");
+    }
+    if generation.state != WaitState::Triggered {
+        return Err("wait_not_triggered");
+    }
+    if generation.trigger
+        != Some(WaitTrigger {
+            trigger_id: claim.trigger_id.clone(),
+            trigger_generation: claim.trigger_generation,
+        })
+    {
+        return Err("wait_trigger_identity_mismatch");
+    }
+    if snapshot.work[work_item_id]
+        != (WorkDemand {
+            status: WorkStatus::Waiting {
+                wait_id: claim.wait_id.clone(),
+            },
+            ..snapshot.work[work_item_id].clone()
+        })
+    {
+        return Err("work_item_not_waiting_for_wait");
+    }
+    if let AgentDispatchState::Awaiting {
+        wait: reserved_wait,
+    } = &snapshot.dispatch
+    {
+        if reserved_wait.id != claim.wait_id || reserved_wait.generation != claim.wait_generation {
+            return Err("agent_lane_reserved_for_other_wait");
+        }
+    }
+    let consumed = next
+        .waits
+        .get_mut(&claim.wait_id)
+        .expect("wait exists")
+        .generations
+        .get_mut(&claim.wait_generation)
+        .expect("current wait generation exists");
+    consumed.state = WaitState::Consumed;
+    consumed.consuming_activation_id = Some(activation_id.to_string());
+    transitions.push(format!(
+        "wait:{}:generation:{}:triggered->consumed:{}",
+        claim.wait_id, claim.wait_generation, activation_id
+    ));
+    if matches!(
+        snapshot.dispatch,
+        AgentDispatchState::Awaiting { wait: ref reserved_wait }
+            if reserved_wait.id == claim.wait_id
+                && reserved_wait.generation == claim.wait_generation
+    ) {
+        set_dispatch_state(next, AgentDispatchState::Open);
+    }
+    Ok(())
 }
 
 fn admit(
@@ -2430,71 +2721,79 @@ fn admit(
                 return rejected(snapshot, "agent_lane_reserved");
             }
         }
+        AdmissionCause::TaskRejoin {
+            task_id,
+            message_id,
+            resume,
+        } => {
+            if task_id.is_empty() || message_id.is_empty() {
+                return rejected(snapshot, "task_rejoin_identity_required");
+            }
+            if let Some(claim) = resume {
+                if let Err(code) = consume_wait_resume_claim(
+                    snapshot,
+                    &mut next,
+                    activation_id,
+                    work_item_id,
+                    claim,
+                    &mut transitions,
+                ) {
+                    return rejected(snapshot, code);
+                }
+            } else {
+                if work.status != WorkStatus::Runnable {
+                    return rejected(snapshot, "work_item_not_runnable");
+                }
+                if !matches!(snapshot.dispatch, AgentDispatchState::Open) {
+                    return rejected(snapshot, "agent_lane_reserved");
+                }
+            }
+        }
+        AdmissionCause::OperatorInput { message_id, resume } => {
+            if message_id.is_empty() {
+                return rejected(snapshot, "operator_input_identity_required");
+            }
+            if let Some(claim) = resume {
+                if let Err(code) = consume_wait_resume_claim(
+                    snapshot,
+                    &mut next,
+                    activation_id,
+                    work_item_id,
+                    claim,
+                    &mut transitions,
+                ) {
+                    return rejected(snapshot, code);
+                }
+            } else {
+                if work.status != WorkStatus::Runnable {
+                    return rejected(snapshot, "work_item_not_runnable");
+                }
+                if !matches!(snapshot.dispatch, AgentDispatchState::Open) {
+                    return rejected(snapshot, "agent_lane_reserved");
+                }
+            }
+        }
         AdmissionCause::WaitResume {
             wait_id,
             wait_generation,
             trigger_id,
             trigger_generation,
         } => {
-            let Some(wait) = snapshot.waits.get(wait_id) else {
-                return rejected(snapshot, "unknown_wait");
+            let claim = WaitResumeClaim {
+                wait_id: wait_id.clone(),
+                wait_generation: *wait_generation,
+                trigger_id: trigger_id.clone(),
+                trigger_generation: *trigger_generation,
             };
-            if wait.current_generation != *wait_generation {
-                return rejected(snapshot, "stale_wait_generation");
-            }
-            let wait_generation_record = wait
-                .generations
-                .get(wait_generation)
-                .expect("current wait generation exists");
-            if wait_generation_record.owner_work_item_id != work_item_id {
-                return rejected(snapshot, "wait_owner_mismatch");
-            }
-            if wait_generation_record.state != WaitState::Triggered {
-                return rejected(snapshot, "wait_not_triggered");
-            }
-            if wait_generation_record.trigger
-                != Some(WaitTrigger {
-                    trigger_id: trigger_id.clone(),
-                    trigger_generation: *trigger_generation,
-                })
-            {
-                return rejected(snapshot, "wait_trigger_identity_mismatch");
-            }
-            if work.status
-                != (WorkStatus::Waiting {
-                    wait_id: wait_id.clone(),
-                })
-            {
-                return rejected(snapshot, "work_item_not_waiting_for_wait");
-            }
-            if let AgentDispatchState::Awaiting {
-                wait: reserved_wait,
-            } = &snapshot.dispatch
-            {
-                if reserved_wait.id != *wait_id || reserved_wait.generation != *wait_generation {
-                    return rejected(snapshot, "agent_lane_reserved_for_other_wait");
-                }
-            }
-
-            let consumed = next
-                .waits
-                .get_mut(wait_id)
-                .expect("wait exists")
-                .generations
-                .get_mut(wait_generation)
-                .expect("current wait generation exists");
-            consumed.state = WaitState::Consumed;
-            consumed.consuming_activation_id = Some(activation_id.to_string());
-            transitions.push(format!(
-                "wait:{wait_id}:generation:{wait_generation}:triggered->consumed:{activation_id}"
-            ));
-            if matches!(
-                snapshot.dispatch,
-                AgentDispatchState::Awaiting { wait: ref reserved_wait }
-                    if reserved_wait.id == *wait_id
-                        && reserved_wait.generation == *wait_generation
+            if let Err(code) = consume_wait_resume_claim(
+                snapshot,
+                &mut next,
+                activation_id,
+                work_item_id,
+                &claim,
+                &mut transitions,
             ) {
-                set_dispatch_state(&mut next, AgentDispatchState::Open);
+                return rejected(snapshot, code);
             }
         }
         AdmissionCause::SettlementRecovery {
@@ -3562,7 +3861,10 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                 }
                 Some(missing_activation_id.clone())
             }
-            AdmissionCause::Scheduling | AdmissionCause::WaitResume { .. } => None,
+            AdmissionCause::Scheduling
+            | AdmissionCause::TaskRejoin { .. }
+            | AdmissionCause::OperatorInput { .. }
+            | AdmissionCause::WaitResume { .. } => None,
         };
         if !canonical_admission_fences.insert(admission_fence(
             &work_item_id,
@@ -3615,6 +3917,32 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
             {
                 return Err("consumed activation authority disagrees with admission".into());
             }
+        }
+    }
+    let mut activation_input_message_ids = BTreeSet::new();
+    for (attachment_id, attachment) in &snapshot.activation_inputs {
+        let Some(activation) = snapshot.activations.get(&attachment.activation_id) else {
+            return Err("activation input references unknown activation".into());
+        };
+        if attachment_id != &attachment.id
+            || activation.work_item_id != attachment.work_item_id
+            || activation.admitted_generation != attachment.expected_scheduling_generation
+            || attachment.expected_dispatch_revision > snapshot.dispatch_revision
+            || !activation_input_message_ids.insert(attachment.message_id.as_str())
+            || attachment.provenance.source_id != attachment.message_id
+            || attachment.provenance.origin != ActivationOrigin::Operator
+            || attachment.provenance.trust != ActivationTrust::OperatorInstruction
+        {
+            return Err("canonical activation input attachment is invalid".into());
+        }
+        let Some(admission) = snapshot
+            .activation_admissions
+            .get(&attachment.activation_id)
+        else {
+            return Err("activation input owner has no canonical admission".into());
+        };
+        if admission.activation.preemption != PreemptionPolicy::AllowOperatorInterjection {
+            return Err("activation input owner disallows operator interjection".into());
         }
     }
     let mut settled_activations = BTreeSet::new();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1714,21 +1714,18 @@ impl RuntimeHandle {
                             .flatten()
                     })
                     .map(|work_item| work_item.revision);
-                let activation_id = matches!(
-                    (&message.kind, &message.origin),
-                    (MessageKind::SystemTick, MessageOrigin::System { subsystem })
-                        if subsystem == "work_queue"
-                )
-                .then(|| scheduler_executor::canonical_activation_id(&message.id))
-                .filter(|activation_id| {
-                    self.inner
-                        .runtime_db
-                        .transitions()
-                        .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)
-                        .ok()
-                        .flatten()
-                        .is_some_and(|snapshot| snapshot.activations.contains_key(activation_id))
-                });
+                let activation_id = Some(scheduler_executor::canonical_activation_id(&message.id))
+                    .filter(|activation_id| {
+                        self.inner
+                            .runtime_db
+                            .transitions()
+                            .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)
+                            .ok()
+                            .flatten()
+                            .is_some_and(|snapshot| {
+                                snapshot.activations.contains_key(activation_id)
+                            })
+                    });
                 WorkItemExecutionBinding {
                     activation_id,
                     source_message_id: message.id.clone(),

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -9,14 +9,15 @@ use crate::domain::scheduler_semantic::{
 use crate::runtime::closure::runtime_error_active;
 use crate::storage::{AppStorage, WorkQueueReadModel};
 use crate::types::{
-    AgentPostureProjection, AgentSchedulingPosture, AgentStatus, AuthorityClass,
-    ExternalWaitRecoverability, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
-    Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus, TimerStatus,
-    TurnTerminalKind, WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
-    WorkItemRecord, WorkItemSchedulingState, WorkItemState, WorkReactivationMode,
-    WorkReactivationSignal,
+    AdmissionContext, AgentPostureProjection, AgentSchedulingPosture, AgentStatus, AuthorityClass,
+    ExternalWaitRecoverability, MessageDeliverySurface, MessageEnvelope, MessageKind,
+    MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
+    TaskStatus, TimerStatus, TurnTerminalKind, WaitConditionKind, WaitConditionRecord,
+    WaitConditionStatus, WakeSource, WorkItemRecord, WorkItemSchedulingState, WorkItemState,
+    WorkReactivationMode, WorkReactivationSignal,
 };
 use crate::work_item_scheduling::WorkItemSchedulingProjection;
+use anyhow::bail;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
@@ -28,10 +29,54 @@ pub(crate) const EXACT_TASK_REJOIN_SCENARIO: SchedulerScenarioClass =
     SchedulerScenarioClass::ExactTaskRejoin;
 pub(crate) const EXACT_WAIT_RESUME_SCENARIO: SchedulerScenarioClass =
     SchedulerScenarioClass::ExactWaitResume;
+pub(crate) const EXPLICITLY_BOUND_OPERATOR_INPUT_SCENARIO: SchedulerScenarioClass =
+    SchedulerScenarioClass::ExplicitlyBoundOperatorInput;
 pub(crate) const SETTLEMENT_SCENARIO: SchedulerScenarioClass = SchedulerScenarioClass::Settlement;
 pub(crate) const DELIVERY_SCENARIO: SchedulerScenarioClass = SchedulerScenarioClass::Delivery;
 pub(crate) const INTERJECTION_SCENARIO: SchedulerScenarioClass =
     SchedulerScenarioClass::OperatorInterjection;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CanonicalActivationScenario {
+    WorkItemAutonomousContinuation {
+        work_item_id: String,
+    },
+    ExactTaskRejoin {
+        task_id: String,
+        work_item_id: String,
+        wait_id: Option<String>,
+    },
+    ExactWaitResume {
+        work_item_id: String,
+        wait_id: String,
+    },
+    ExplicitlyBoundOperatorInput {
+        work_item_id: String,
+        wait_id: Option<String>,
+    },
+}
+
+impl CanonicalActivationScenario {
+    pub(crate) fn work_item_id(&self) -> &str {
+        match self {
+            Self::WorkItemAutonomousContinuation { work_item_id }
+            | Self::ExactTaskRejoin { work_item_id, .. }
+            | Self::ExactWaitResume { work_item_id, .. }
+            | Self::ExplicitlyBoundOperatorInput { work_item_id, .. } => work_item_id,
+        }
+    }
+
+    pub(crate) fn scenario_class(&self) -> SchedulerScenarioClass {
+        match self {
+            Self::WorkItemAutonomousContinuation { .. } => {
+                WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO
+            }
+            Self::ExactTaskRejoin { .. } => EXACT_TASK_REJOIN_SCENARIO,
+            Self::ExactWaitResume { .. } => EXACT_WAIT_RESUME_SCENARIO,
+            Self::ExplicitlyBoundOperatorInput { .. } => EXPLICITLY_BOUND_OPERATOR_INPUT_SCENARIO,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SchedulerProjection {
@@ -1187,6 +1232,147 @@ pub(crate) fn authority_scenarios_for_message_claim(
     scenarios
 }
 
+pub(crate) fn canonical_activation_scenario(
+    projection: &SchedulerProjection,
+    message: &MessageEnvelope,
+    continuation_resolution: Option<&ContinuationResolution>,
+    task: Option<&TaskRecord>,
+) -> Result<Option<CanonicalActivationScenario>> {
+    if matches!(
+        (&message.kind, &message.origin),
+        (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+            if subsystem == "work_queue"
+    ) {
+        return Ok(message.work_item_id.clone().map(|work_item_id| {
+            CanonicalActivationScenario::WorkItemAutonomousContinuation { work_item_id }
+        }));
+    }
+    if !continuation_resolution.is_some_and(|resolution| resolution.model_reentry) {
+        return Ok(None);
+    }
+
+    let matching_waits = matching_wait_conditions(projection, message);
+    if matching_waits.len() > 1 {
+        bail!(
+            "canonical activation message {} matches multiple active waits",
+            message.id
+        );
+    }
+    let matching_wait = matching_waits.first().copied();
+
+    if message.kind == MessageKind::TaskResult {
+        let MessageOrigin::Task { task_id } = &message.origin else {
+            bail!("canonical task rejoin requires task message origin");
+        };
+        if message.task_id.as_deref() != Some(task_id.as_str()) {
+            bail!("canonical task rejoin has inconsistent task identity");
+        }
+        let task = task.ok_or_else(|| anyhow!("canonical task rejoin is missing task record"))?;
+        if task.id != *task_id
+            || task.agent_id != message.agent_id
+            || !matches!(
+                task.status,
+                TaskStatus::Completed
+                    | TaskStatus::Failed
+                    | TaskStatus::Cancelled
+                    | TaskStatus::Interrupted
+            )
+        {
+            bail!("canonical task rejoin requires a terminal same-agent task");
+        }
+        let work_item_id = task
+            .effective_work_item_id()
+            .ok_or_else(|| anyhow!("canonical task rejoin requires a WorkItem binding"))?;
+        if message.work_item_id.as_deref() != Some(work_item_id) {
+            bail!("canonical task rejoin has inconsistent WorkItem binding");
+        }
+        if matching_wait.is_some_and(|wait| wait.work_item_id.as_deref() != Some(work_item_id)) {
+            bail!("canonical task rejoin wait owner does not match task WorkItem");
+        }
+        return Ok(Some(CanonicalActivationScenario::ExactTaskRejoin {
+            task_id: task_id.clone(),
+            work_item_id: work_item_id.to_string(),
+            wait_id: matching_wait.map(|wait| wait.id.clone()),
+        }));
+    }
+
+    if message.kind == MessageKind::OperatorPrompt {
+        if !trusted_explicit_operator_binding(message) {
+            return Ok(None);
+        }
+        let work_item_id = message
+            .work_item_id
+            .clone()
+            .ok_or_else(|| anyhow!("explicit operator input requires a WorkItem binding"))?;
+        if matching_wait
+            .is_some_and(|wait| wait.work_item_id.as_deref() != Some(work_item_id.as_str()))
+        {
+            bail!("explicit operator input wait owner does not match WorkItem binding");
+        }
+        return Ok(Some(
+            CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                work_item_id,
+                wait_id: matching_wait.map(|wait| wait.id.clone()),
+            },
+        ));
+    }
+
+    let Some(wait) = matching_wait else {
+        return Ok(None);
+    };
+    let work_item_id = wait
+        .work_item_id
+        .clone()
+        .ok_or_else(|| anyhow!("canonical wait resume requires a WorkItem-owned wait"))?;
+    if message
+        .work_item_id
+        .as_ref()
+        .is_some_and(|binding| binding != &work_item_id)
+    {
+        bail!("canonical wait resume has inconsistent WorkItem binding");
+    }
+    Ok(Some(CanonicalActivationScenario::ExactWaitResume {
+        work_item_id,
+        wait_id: wait.id.clone(),
+    }))
+}
+
+fn matching_wait_conditions<'a>(
+    projection: &'a SchedulerProjection,
+    message: &MessageEnvelope,
+) -> Vec<&'a WaitConditionRecord> {
+    projection
+        .semantic_waits
+        .iter()
+        .filter(|condition| {
+            condition.status == WaitConditionStatus::Active
+                && message_matches_wait_condition(message, condition)
+        })
+        .collect()
+}
+
+fn trusted_explicit_operator_binding(message: &MessageEnvelope) -> bool {
+    message
+        .message_seq
+        .is_some_and(|message_seq| message_seq > 0)
+        && message.work_item_id.is_some()
+        && message.authority_class == AuthorityClass::OperatorInstruction
+        && matches!(message.origin, MessageOrigin::Operator { .. })
+        && matches!(
+            (message.delivery_surface, message.admission_context),
+            (
+                Some(MessageDeliverySurface::CliPrompt | MessageDeliverySurface::RunOnce),
+                Some(AdmissionContext::LocalProcess)
+            ) | (
+                Some(MessageDeliverySurface::HttpControlPrompt),
+                Some(AdmissionContext::ControlAuthenticated)
+            ) | (
+                Some(MessageDeliverySurface::RemoteOperatorTransport),
+                Some(AdmissionContext::OperatorTransportAuthenticated)
+            )
+        )
+}
+
 fn message_admission_scenario_applies(
     message: &MessageEnvelope,
     continuation_resolution: Option<&ContinuationResolution>,
@@ -1313,6 +1499,32 @@ fn message_matches_wait_condition(
             condition.wake_sources.iter().any(
                 |source| matches!(source, WakeSource::TaskResult { task_id: id } if id == task_id),
             )
+        }
+        (MessageKind::OperatorPrompt, MessageOrigin::Operator { .. }) => condition
+            .wake_sources
+            .iter()
+            .any(|source| matches!(source, WakeSource::OperatorInput)),
+        (MessageKind::CallbackEvent | MessageKind::WebhookEvent | MessageKind::ChannelEvent, _) => {
+            let external_trigger_id = message.source_refs.get("external_trigger_id");
+            condition.wake_sources.iter().any(|source| {
+                matches!(
+                    source,
+                    WakeSource::ExternalIngress {
+                        external_trigger_id: expected,
+                    } if expected.as_ref().is_none_or(|expected| {
+                        external_trigger_id.is_some_and(|actual| actual == expected)
+                    })
+                )
+            })
+        }
+        (MessageKind::TimerTick, MessageOrigin::Timer { timer_id }) => {
+            condition.wake_sources.iter().any(|source| {
+                matches!(source, WakeSource::Timer { .. })
+                    && message
+                        .source_refs
+                        .get("timer_id")
+                        .is_none_or(|source_timer_id| source_timer_id == timer_id)
+            })
         }
         (MessageKind::SystemTick, MessageOrigin::System { subsystem }) => {
             if subsystem == "work_queue" {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -75,7 +75,7 @@ pub(super) struct ScheduledMessage {
 }
 
 struct CanonicalClaimPlan {
-    work_item: crate::types::WorkItemRecord,
+    scheduler_claim_work_item: Option<crate::types::WorkItemRecord>,
     bootstrap: Option<crate::domain::scheduler_protocol::Snapshot>,
     commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
 }
@@ -393,7 +393,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         )?
         .map(scheduler_semantic_shadow_command);
         let canonical_claim =
-            self.canonical_work_queue_claim_plan(&projection, &candidate.message)?;
+            self.canonical_activation_plan(&projection, &persisted_message, &dispatch_plan)?;
         scheduler::append_scheduling_advisories(
             &self.runtime.inner.storage,
             &candidate.prior_state,
@@ -439,7 +439,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     ),
                     scheduler_claim_work_item: canonical_claim
                         .as_ref()
-                        .map(|plan| plan.work_item.clone()),
+                        .and_then(|plan| plan.scheduler_claim_work_item.clone()),
                     scheduler_protocol_bootstrap: canonical_claim
                         .as_ref()
                         .and_then(|plan| plan.bootstrap.clone()),
@@ -508,10 +508,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         }))
     }
 
-    fn canonical_work_queue_claim_plan(
+    fn canonical_activation_plan(
         &self,
-        _projection: &scheduler::SchedulerProjection,
+        projection: &scheduler::SchedulerProjection,
         message: &MessageEnvelope,
+        dispatch_plan: &MessageDispatchPlan,
     ) -> Result<Option<CanonicalClaimPlan>> {
         if !self
             .runtime
@@ -519,12 +520,22 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         {
             return Ok(None);
         }
+        let task = dispatch_plan.task.as_ref().ok().and_then(Option::as_ref);
+        let Some(scenario) = scheduler::canonical_activation_scenario(
+            projection,
+            message,
+            dispatch_plan.continuation_resolution.as_ref(),
+            task,
+        )?
+        else {
+            return Ok(None);
+        };
         if self
             .runtime
             .inner
             .runtime_db
             .transitions()
-            .scheduler_scenario_mode(scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO)?
+            .scheduler_scenario_mode(scenario.scenario_class())?
             != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
             || self
                 .runtime
@@ -536,34 +547,34 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         {
             return Ok(None);
         }
-        if !matches!(
-            (&message.kind, &message.origin),
-            (MessageKind::SystemTick, MessageOrigin::System { subsystem })
-                if subsystem == "work_queue"
-        ) {
-            return Ok(None);
-        }
 
-        let work_item_id = message
-            .work_item_id
-            .as_deref()
-            .ok_or_else(|| anyhow!("canonical work queue claim requires a WorkItem binding"))?;
+        let work_item_id = scenario.work_item_id();
         let work_item = self
             .runtime
             .inner
             .storage
             .latest_work_item(work_item_id)?
-            .ok_or_else(|| anyhow!("canonical work queue claim references unknown WorkItem"))?;
+            .ok_or_else(|| anyhow!("canonical activation references unknown WorkItem"))?;
         let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
+        let work_projection = work_queue
+            .items
+            .iter()
+            .find(|candidate| candidate.id == work_item.id)
+            .ok_or_else(|| anyhow!("canonical activation has no WorkItem scheduling projection"))?;
         if work_item.agent_id != message.agent_id
             || work_item.state != crate::types::WorkItemState::Open
-            || !work_queue.items.iter().any(|candidate| {
-                candidate.id == work_item.id
-                    && candidate.scheduling_state == crate::types::WorkItemSchedulingState::Runnable
-            })
         {
             return Err(anyhow!(
-                "canonical work queue claim requires a runnable same-agent WorkItem"
+                "canonical activation requires an open same-agent WorkItem"
+            ));
+        }
+        if matches!(
+            scenario,
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+        ) && work_projection.scheduling_state != crate::types::WorkItemSchedulingState::Runnable
+        {
+            return Err(anyhow!(
+                "canonical autonomous activation requires a runnable WorkItem"
             ));
         }
         let activation_id = canonical_activation_id(&message.id);
@@ -573,7 +584,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             ActivationPriority, ActivationProvenance, ActivationSlot, ActivationTrust,
             AdmitActivationCommand, AgentActivation, AgentDispatchState,
             IssueActivationAuthorityCommand, PreemptionPolicy, ProtocolCommand,
-            RegisterWorkDemandCommand, RolloutState, Snapshot, WorkDemand, WorkStatus,
+            RegisterWorkDemandCommand, RolloutState, Snapshot, TriggerWaitCommand, WaitResumeClaim,
+            WorkDemand, WorkStatus,
         };
 
         let existing = self
@@ -596,9 +608,21 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 if activation.state == crate::domain::scheduler_protocol::ActivationState::Running
                     && activation.work_item_id == work_item_id
                     && slot_matches
+                    && snapshot
+                        .activation_admissions
+                        .get(&activation_id)
+                        .is_some_and(|admission| {
+                            canonical_admission_matches_scenario(admission, message, &scenario)
+                        })
                 {
                     return Ok(Some(CanonicalClaimPlan {
-                        work_item,
+                        scheduler_claim_work_item: matches!(
+                            scenario,
+                            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
+                                ..
+                            }
+                        )
+                        .then_some(work_item),
                         bootstrap: None,
                         commands: Vec::new(),
                     }));
@@ -617,12 +641,23 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             locality: "runtime".into(),
             cost_class: "default".into(),
         };
+        let wait_id = match &scenario {
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin { wait_id, .. }
+            | scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                wait_id,
+                ..
+            } => wait_id.as_deref(),
+            scheduler::CanonicalActivationScenario::ExactWaitResume { wait_id, .. } => {
+                Some(wait_id.as_str())
+            }
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. } => None,
+        };
         let (bootstrap, expected_dispatch_revision, scheduling_generation, register) =
             if let Some(snapshot) = existing.as_ref() {
                 if let Some(demand) = snapshot.work.get(work_item_id) {
-                    if demand.status != WorkStatus::Runnable {
+                    if wait_id.is_none() && demand.status != WorkStatus::Runnable {
                         return Err(anyhow!(
-                            "canonical WorkItem demand is not runnable for claim"
+                            "canonical WorkItem demand is not runnable for activation"
                         ));
                     }
                     (
@@ -632,6 +667,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         None,
                     )
                 } else {
+                    if wait_id.is_some() {
+                        return Err(anyhow!(
+                            "canonical wait resume requires an existing WorkItem demand"
+                        ));
+                    }
                     let demand = new_demand();
                     (
                         None,
@@ -646,6 +686,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     )
                 }
             } else {
+                if wait_id.is_some() {
+                    return Err(anyhow!(
+                        "canonical wait resume requires an initialized protocol partition"
+                    ));
+                }
                 let demand = new_demand();
                 (
                     Some(Snapshot {
@@ -663,6 +708,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         rollout: RolloutState::default(),
                         admitted_generations: Default::default(),
                         continuation_admissions: Default::default(),
+                        activation_inputs: Default::default(),
                     }),
                     0,
                     demand.scheduling_generation,
@@ -675,29 +721,113 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 )
             };
 
+        let resume = wait_id
+            .map(|wait_id| -> Result<WaitResumeClaim> {
+                let snapshot = existing.as_ref().ok_or_else(|| {
+                    anyhow!("canonical wait resume requires an initialized snapshot")
+                })?;
+                let wait = snapshot
+                    .waits
+                    .get(wait_id)
+                    .ok_or_else(|| anyhow!("canonical activation references unknown wait"))?;
+                let generation = wait
+                    .generations
+                    .get(&wait.current_generation)
+                    .ok_or_else(|| anyhow!("canonical wait has no current generation"))?;
+                if generation.owner_work_item_id != work_item_id {
+                    return Err(anyhow!(
+                        "canonical wait owner does not match WorkItem binding"
+                    ));
+                }
+                let trigger_generation = message.message_seq.ok_or_else(|| {
+                    anyhow!("canonical activation requires persisted message sequence")
+                })?;
+                Ok(WaitResumeClaim {
+                    wait_id: wait_id.to_string(),
+                    wait_generation: wait.current_generation,
+                    trigger_id: canonical_wait_trigger_id(message),
+                    trigger_generation,
+                })
+            })
+            .transpose()?;
+        let (cause, binding, provenance_origin, provenance_trust, idempotency_key) = match &scenario
+        {
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. } => (
+                ActivationCause::WorkItemRunnable {
+                    work_item_id: work_item.id.clone(),
+                    scheduling_generation,
+                },
+                ActivationBinding::WorkItem {
+                    work_item_id: work_item.id.clone(),
+                },
+                ActivationOrigin::System,
+                ActivationTrust::RuntimeInstruction,
+                format!("work-queue-message:{}", message.id),
+            ),
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => (
+                ActivationCause::TaskRejoin {
+                    task_id: task_id.clone(),
+                    message_id: message.id.clone(),
+                    resume: resume.clone(),
+                },
+                ActivationBinding::WorkItem {
+                    work_item_id: work_item.id.clone(),
+                },
+                ActivationOrigin::Task,
+                ActivationTrust::RuntimeInstruction,
+                format!("task-rejoin:{task_id}"),
+            ),
+            scheduler::CanonicalActivationScenario::ExactWaitResume { wait_id, .. } => {
+                let resume = resume
+                    .as_ref()
+                    .expect("exact wait resume has a canonical wait claim");
+                (
+                    ActivationCause::WaitResume {
+                        wait_id: wait_id.clone(),
+                        wait_generation: resume.wait_generation,
+                        trigger_id: resume.trigger_id.clone(),
+                        trigger_generation: resume.trigger_generation,
+                    },
+                    ActivationBinding::WaitOwner {
+                        wait_id: wait_id.clone(),
+                        owner_work_item_id: work_item.id.clone(),
+                    },
+                    canonical_activation_origin(message),
+                    canonical_activation_trust(message),
+                    format!("wait-resume:{}:{}", wait_id, resume.wait_generation),
+                )
+            }
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => (
+                ActivationCause::OperatorInput {
+                    message_id: message.id.clone(),
+                    resume: resume.clone(),
+                },
+                ActivationBinding::WorkItem {
+                    work_item_id: work_item.id.clone(),
+                },
+                ActivationOrigin::Operator,
+                ActivationTrust::OperatorInstruction,
+                format!("operator-message:{}", message.id),
+            ),
+        };
         let activation = AgentActivation {
             id: activation_id.clone(),
             agent_id: message.agent_id.clone(),
             state: ActivationLifecycleState::Admitted,
-            cause: ActivationCause::WorkItemRunnable {
-                work_item_id: work_item.id.clone(),
-                scheduling_generation,
-            },
-            binding: ActivationBinding::WorkItem {
-                work_item_id: work_item.id.clone(),
-            },
+            cause,
+            binding,
             priority: match message.priority {
                 Priority::Interject => ActivationPriority::Interject,
                 Priority::Next => ActivationPriority::Next,
                 Priority::Normal => ActivationPriority::Normal,
                 Priority::Background => ActivationPriority::Background,
             },
-            preemption: PreemptionPolicy::NonPreemptive,
+            preemption: PreemptionPolicy::AllowOperatorInterjection,
             source_revision: Some(work_item.revision),
-            idempotency_key: format!("work-queue-message:{}", message.id),
+            idempotency_key,
             provenance: ActivationProvenance {
-                origin: ActivationOrigin::System,
-                trust: ActivationTrust::RuntimeInstruction,
+                origin: provenance_origin,
+                trust: provenance_trust,
                 source_id: message.id.clone(),
                 correlation_id: message.correlation_id.clone(),
                 causation_id: message.causation_id.clone(),
@@ -716,13 +846,25 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             expected_scheduling_generation: scheduling_generation,
             expected_dispatch_revision,
         };
-        let mut commands = Vec::with_capacity(3);
+        let mut commands = Vec::with_capacity(4);
         commands.extend(register);
+        if let Some(resume) = resume {
+            commands.push(ProtocolCommand::TriggerWait(TriggerWaitCommand {
+                wait_id: resume.wait_id,
+                wait_generation: resume.wait_generation,
+                trigger_id: resume.trigger_id,
+                trigger_generation: resume.trigger_generation,
+            }));
+        }
         commands.push(ProtocolCommand::IssueActivationAuthority(authority));
         commands.push(ProtocolCommand::AdmitActivation(admission));
 
         Ok(Some(CanonicalClaimPlan {
-            work_item,
+            scheduler_claim_work_item: matches!(
+                scenario,
+                scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+            )
+            .then_some(work_item),
             bootstrap,
             commands,
         }))
@@ -751,6 +893,127 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
 pub(super) fn canonical_activation_id(message_id: &str) -> String {
     format!("activation:message:{message_id}")
+}
+
+fn canonical_wait_trigger_id(message: &MessageEnvelope) -> String {
+    for key in [
+        "task_result_id",
+        "callback_delivery_id",
+        "external_trigger_id",
+        "timer_id",
+    ] {
+        if let Some(value) = message.source_refs.get(key) {
+            return format!("{key}:{value}");
+        }
+    }
+    match &message.origin {
+        MessageOrigin::Task { task_id } => format!("task:{task_id}"),
+        MessageOrigin::Callback { descriptor_id, .. } => {
+            format!("callback:{descriptor_id}")
+        }
+        MessageOrigin::Timer { timer_id } => format!("timer:{timer_id}"),
+        _ => format!("message:{}", message.id),
+    }
+}
+
+fn canonical_activation_origin(
+    message: &MessageEnvelope,
+) -> crate::domain::scheduler_protocol::ActivationOrigin {
+    use crate::domain::scheduler_protocol::ActivationOrigin;
+    match message.origin {
+        MessageOrigin::Operator { .. } => ActivationOrigin::Operator,
+        MessageOrigin::Channel { .. } => ActivationOrigin::Channel,
+        MessageOrigin::Webhook { .. } => ActivationOrigin::Webhook,
+        MessageOrigin::Callback { .. } => ActivationOrigin::Callback,
+        MessageOrigin::Timer { .. } => ActivationOrigin::Timer,
+        MessageOrigin::System { .. } => ActivationOrigin::System,
+        MessageOrigin::Task { .. } => ActivationOrigin::Task,
+    }
+}
+
+fn canonical_activation_trust(
+    message: &MessageEnvelope,
+) -> crate::domain::scheduler_protocol::ActivationTrust {
+    use crate::domain::scheduler_protocol::ActivationTrust;
+    match message.authority_class {
+        crate::types::AuthorityClass::OperatorInstruction => ActivationTrust::OperatorInstruction,
+        crate::types::AuthorityClass::RuntimeInstruction => ActivationTrust::RuntimeInstruction,
+        crate::types::AuthorityClass::IntegrationSignal => ActivationTrust::IntegrationSignal,
+        crate::types::AuthorityClass::ExternalEvidence => ActivationTrust::ExternalEvidence,
+    }
+}
+
+fn canonical_admission_matches_scenario(
+    admission: &crate::domain::scheduler_protocol::AdmitActivationCommand,
+    message: &MessageEnvelope,
+    scenario: &scheduler::CanonicalActivationScenario,
+) -> bool {
+    use crate::domain::scheduler_protocol::{ActivationBinding, ActivationCause};
+    let activation = &admission.activation;
+    if activation.agent_id != message.agent_id
+        || activation.provenance.source_id != message.id
+        || activation.provenance.origin != canonical_activation_origin(message)
+        || activation.provenance.trust != canonical_activation_trust(message)
+    {
+        return false;
+    }
+    match (&activation.cause, &activation.binding, scenario) {
+        (
+            ActivationCause::WorkItemRunnable { work_item_id, .. },
+            ActivationBinding::WorkItem {
+                work_item_id: bound_work_item_id,
+            },
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
+                work_item_id: expected,
+            },
+        ) => work_item_id == expected && bound_work_item_id == expected,
+        (
+            ActivationCause::TaskRejoin {
+                task_id,
+                message_id,
+                resume,
+            },
+            ActivationBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin {
+                task_id: expected_task,
+                work_item_id: expected_work_item,
+                wait_id,
+            },
+        ) => {
+            task_id == expected_task
+                && message_id == &message.id
+                && work_item_id == expected_work_item
+                && resume.as_ref().map(|claim| claim.wait_id.as_str()) == wait_id.as_deref()
+        }
+        (
+            ActivationCause::WaitResume { wait_id, .. },
+            ActivationBinding::WaitOwner {
+                wait_id: bound_wait_id,
+                owner_work_item_id,
+            },
+            scheduler::CanonicalActivationScenario::ExactWaitResume {
+                work_item_id,
+                wait_id: expected_wait,
+            },
+        ) => {
+            wait_id == expected_wait
+                && bound_wait_id == expected_wait
+                && owner_work_item_id == work_item_id
+        }
+        (
+            ActivationCause::OperatorInput { message_id, resume },
+            ActivationBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                work_item_id: expected_work_item,
+                wait_id,
+            },
+        ) => {
+            message_id == &message.id
+                && work_item_id == expected_work_item
+                && resume.as_ref().map(|claim| claim.wait_id.as_str()) == wait_id.as_deref()
+        }
+        _ => false,
+    }
 }
 
 fn scheduler_semantic_shadow_command(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,9 +1,11 @@
 use super::super::*;
 use super::support::*;
 use crate::domain::scheduler_protocol::{
-    ActivationSlot, Decision, ObservationalDivergenceAllowance, ProtocolMode, RollbackAction,
-    RollbackPolicy, RollbackTrigger, RolloutClassEvidence, RolloutCommand, RolloutManifest,
-    ScenarioMode, SchedulerScenarioClass, WorkStatus,
+    ActivationCause, ActivationSlot, AgentDispatchState, Decision,
+    ObservationalDivergenceAllowance, ProtocolMode, RollbackAction, RollbackPolicy,
+    RollbackTrigger, RolloutClassEvidence, RolloutCommand, RolloutManifest, ScenarioMode,
+    SchedulerScenarioClass, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState,
+    WorkDemand, WorkStatus,
 };
 use crate::types::{
     ActiveSkillRecord, AuthorityClass, BriefKind, BriefRecord, CompletionReportState,
@@ -55,6 +57,13 @@ fn terminal_transition(
 }
 
 fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
+    enable_production_protocol_authority_for(runtime, &[]);
+}
+
+fn enable_production_protocol_authority_for(
+    runtime: &RuntimeHandle,
+    additional_scenarios: &[SchedulerScenarioClass],
+) {
     let evidence = |items: &[&str]| {
         ["restart", "fault_injection", "rollback_drill"]
             .into_iter()
@@ -62,9 +71,8 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
             .map(ToString::to_string)
             .collect::<std::collections::BTreeSet<_>>()
     };
-    let classes = [
-        (
-            SchedulerScenarioClass::WorkItemAutonomousContinuation,
+    let class_evidence = |scenario| match scenario {
+        SchedulerScenarioClass::WorkItemAutonomousContinuation => (
             2_000,
             14 * 24 * 60 * 60,
             evidence(&[
@@ -74,8 +82,36 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
                 "work_item_rollback",
             ]),
         ),
-        (
-            SchedulerScenarioClass::Settlement,
+        SchedulerScenarioClass::ExactTaskRejoin => (
+            1_000,
+            7 * 24 * 60 * 60,
+            evidence(&[
+                "duplicate_task_result",
+                "out_of_order_task_result",
+                "restart_before_rejoin_settlement",
+            ]),
+        ),
+        SchedulerScenarioClass::ExactWaitResume => (
+            1_000,
+            7 * 24 * 60 * 60,
+            evidence(&[
+                "duplicate_trigger",
+                "stale_generation",
+                "restart_after_consume",
+                "rearm",
+            ]),
+        ),
+        SchedulerScenarioClass::ExplicitlyBoundOperatorInput
+        | SchedulerScenarioClass::OperatorInterjection => (
+            1_000,
+            7 * 24 * 60 * 60,
+            evidence(&[
+                "duplicate_ingress",
+                "stale_binding_revision",
+                "wrong_agent_target",
+            ]),
+        ),
+        SchedulerScenarioClass::Settlement => (
             1_000,
             7 * 24 * 60 * 60,
             evidence(&[
@@ -84,35 +120,55 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
                 "restart_before_settlement_commit",
             ]),
         ),
+        scenario => panic!("unsupported runtime production authority scenario {scenario:?}"),
+    };
+    let scenarios = [
+        SchedulerScenarioClass::WorkItemAutonomousContinuation,
+        SchedulerScenarioClass::Settlement,
     ]
     .into_iter()
-    .map(
-        |(scenario, minimum_shadow_samples, minimum_shadow_duration_secs, evidence)| {
+    .chain(additional_scenarios.iter().copied())
+    .collect::<std::collections::BTreeSet<_>>();
+    let classes = scenarios
+        .iter()
+        .copied()
+        .map(|scenario| {
+            let (minimum_shadow_samples, minimum_shadow_duration_secs, evidence) =
+                class_evidence(scenario);
             (
-                scenario.as_str().to_string(),
-                RolloutClassEvidence {
-                    configured_mode: ScenarioMode::Authoritative,
-                    minimum_shadow_samples,
-                    minimum_shadow_duration_secs,
-                    observed_shadow_samples: minimum_shadow_samples,
-                    observed_shadow_duration_secs: minimum_shadow_duration_secs,
-                    maximum_p99_latency_regression_bps: 500,
-                    observed_p99_latency_regression_bps: 0,
-                    hard_blocker_count: 0,
-                    unresolved_divergence_count: 0,
-                    required_evidence: evidence.clone(),
-                    verified_evidence: evidence,
-                    rollback_policy: RollbackPolicy {
-                        trigger: RollbackTrigger::AnyHardBlocker,
-                        action: RollbackAction::StopAdmissionsAndRevert {
-                            target: ScenarioMode::Shadow,
+                scenario,
+                minimum_shadow_samples,
+                minimum_shadow_duration_secs,
+                evidence,
+            )
+        })
+        .map(
+            |(scenario, minimum_shadow_samples, minimum_shadow_duration_secs, evidence)| {
+                (
+                    scenario.as_str().to_string(),
+                    RolloutClassEvidence {
+                        configured_mode: ScenarioMode::Authoritative,
+                        minimum_shadow_samples,
+                        minimum_shadow_duration_secs,
+                        observed_shadow_samples: minimum_shadow_samples,
+                        observed_shadow_duration_secs: minimum_shadow_duration_secs,
+                        maximum_p99_latency_regression_bps: 500,
+                        observed_p99_latency_regression_bps: 0,
+                        hard_blocker_count: 0,
+                        unresolved_divergence_count: 0,
+                        required_evidence: evidence.clone(),
+                        verified_evidence: evidence,
+                        rollback_policy: RollbackPolicy {
+                            trigger: RollbackTrigger::AnyHardBlocker,
+                            action: RollbackAction::StopAdmissionsAndRevert {
+                                target: ScenarioMode::Shadow,
+                            },
                         },
                     },
-                },
-            )
-        },
-    )
-    .collect();
+                )
+            },
+        )
+        .collect();
     let manifest = RolloutManifest {
         revision: 1,
         preflight_revision: 1,
@@ -135,9 +191,9 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
         approver: "runtime-test".into(),
         approved_at: "2026-07-23T00:00:00Z".into(),
     };
-    let commands = [
+    let bootstrap_commands = [
         (
-            "open",
+            "open".to_string(),
             RolloutCommand::OpenPreflight {
                 expected_config_revision: 0,
                 manifest_revision: 1,
@@ -145,7 +201,7 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
             Decision::RolloutPreflightOpened,
         ),
         (
-            "complete",
+            "complete".to_string(),
             RolloutCommand::CompletePreflight {
                 expected_config_revision: 0,
                 expected_preflight_revision: 1,
@@ -154,7 +210,7 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
             Decision::RolloutPreflightCompleted,
         ),
         (
-            "install",
+            "install".to_string(),
             RolloutCommand::InstallManifest {
                 expected_config_revision: 0,
                 manifest,
@@ -162,70 +218,49 @@ fn enable_production_protocol_authority(runtime: &RuntimeHandle) {
             Decision::ManifestInstalled,
         ),
         (
-            "protocol",
+            "protocol".to_string(),
             RolloutCommand::ConfigureProtocol {
                 expected_config_revision: 1,
                 mode: ProtocolMode::Authoritative,
             },
             Decision::ProtocolConfigured,
         ),
-        (
-            "continuation-shadow",
-            RolloutCommand::ChangeScenarioAuthority {
-                scenario_class: SchedulerScenarioClass::WorkItemAutonomousContinuation
-                    .as_str()
-                    .into(),
-                expected_config_revision: 2,
-                expected_manifest_revision: 1,
-                expected_preflight_revision: 1,
-                mode: ScenarioMode::Shadow,
-            },
-            Decision::ScenarioAuthorityChanged,
-        ),
-        (
-            "continuation-authoritative",
-            RolloutCommand::ChangeScenarioAuthority {
-                scenario_class: SchedulerScenarioClass::WorkItemAutonomousContinuation
-                    .as_str()
-                    .into(),
-                expected_config_revision: 3,
-                expected_manifest_revision: 1,
-                expected_preflight_revision: 1,
-                mode: ScenarioMode::Authoritative,
-            },
-            Decision::ScenarioAuthorityChanged,
-        ),
-        (
-            "settlement-shadow",
-            RolloutCommand::ChangeScenarioAuthority {
-                scenario_class: SchedulerScenarioClass::Settlement.as_str().into(),
-                expected_config_revision: 4,
-                expected_manifest_revision: 1,
-                expected_preflight_revision: 1,
-                mode: ScenarioMode::Shadow,
-            },
-            Decision::ScenarioAuthorityChanged,
-        ),
-        (
-            "settlement-authoritative",
-            RolloutCommand::ChangeScenarioAuthority {
-                scenario_class: SchedulerScenarioClass::Settlement.as_str().into(),
-                expected_config_revision: 5,
-                expected_manifest_revision: 1,
-                expected_preflight_revision: 1,
-                mode: ScenarioMode::Authoritative,
-            },
-            Decision::ScenarioAuthorityChanged,
-        ),
     ];
-    for (identity, command, expected) in commands {
+    for (identity, command, expected) in bootstrap_commands {
         let committed = runtime
             .inner
             .runtime_db
             .transitions()
-            .commit_scheduler_rollout_command(identity, &command, None)
+            .commit_scheduler_rollout_command(&identity, &command, None)
             .unwrap();
         assert_eq!(committed.result.decision, expected);
+    }
+    let mut config_revision = 2;
+    for scenario in scenarios {
+        for mode in [ScenarioMode::Shadow, ScenarioMode::Authoritative] {
+            let identity = format!("{}-{mode:?}", scenario.as_str());
+            let committed = runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_scheduler_rollout_command(
+                    &identity,
+                    &RolloutCommand::ChangeScenarioAuthority {
+                        scenario_class: scenario.as_str().into(),
+                        expected_config_revision: config_revision,
+                        expected_manifest_revision: 1,
+                        expected_preflight_revision: 1,
+                        mode,
+                    },
+                    None,
+                )
+                .unwrap();
+            assert_eq!(
+                committed.result.decision,
+                Decision::ScenarioAuthorityChanged
+            );
+            config_revision += 1;
+        }
     }
 }
 
@@ -273,6 +308,62 @@ fn task_result_message(task_id: &str) -> MessageEnvelope {
             text: "task completed".into(),
         },
     )
+}
+
+fn canonical_waiting_snapshot(
+    work_item: &WorkItemRecord,
+    wait_id: &str,
+    wait_generation: u64,
+) -> Snapshot {
+    Snapshot {
+        slot: ActivationSlot::Idle,
+        dispatch: AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: wait_id.into(),
+                generation: wait_generation,
+            },
+        },
+        dispatch_revision: 1,
+        focus: Some(work_item.id.clone()),
+        work: std::collections::BTreeMap::from([(
+            work_item.id.clone(),
+            WorkDemand {
+                metadata_revision: work_item.revision,
+                scheduling_generation: work_item.revision,
+                status: WorkStatus::Waiting {
+                    wait_id: wait_id.into(),
+                },
+                capabilities: Default::default(),
+                locks: Default::default(),
+                locality: "runtime".into(),
+                cost_class: "default".into(),
+            },
+        )]),
+        waits: std::collections::BTreeMap::from([(
+            wait_id.into(),
+            WaitRecord {
+                current_generation: wait_generation,
+                generations: std::collections::BTreeMap::from([(
+                    wait_generation,
+                    WaitGenerationRecord {
+                        owner_work_item_id: work_item.id.clone(),
+                        state: WaitState::Active,
+                        trigger: None,
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        )]),
+        activations: Default::default(),
+        activation_authorities: Default::default(),
+        activation_admissions: Default::default(),
+        settlements: Default::default(),
+        missing_settlements: Default::default(),
+        rollout: Default::default(),
+        admitted_generations: Default::default(),
+        continuation_admissions: Default::default(),
+        activation_inputs: Default::default(),
+    }
 }
 
 #[test]
@@ -2015,6 +2106,199 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Processed)
     );
+}
+
+#[tokio::test]
+async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(
+        &runtime,
+        &[
+            SchedulerScenarioClass::ExactTaskRejoin,
+            SchedulerScenarioClass::ExactWaitResume,
+        ],
+    );
+    let work_item = runtime
+        .create_work_item("canonical task rejoin".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-rejoin".into()),
+            "waiting for task-rejoin".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let wait_generation = work_item.revision;
+    let initial_seed =
+        canonical_waiting_snapshot(&work_item, &registration.condition.id, wait_generation);
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &initial_seed)
+        .unwrap();
+    let initial = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+
+    let mut message = task_result_message("task-rejoin").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-rejoin",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-rejoin",
+        "work_item_id": work_item.id,
+    }));
+    let message = runtime.enqueue(message).await.unwrap();
+    let state_before_claim = runtime.agent_state().await.unwrap();
+    runtime.inject_next_transition_fault(
+        crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
+    );
+
+    let error = match scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+    {
+        Ok(_) => panic!("expected task rejoin claim fault"),
+        Err(error) => error,
+    };
+    assert_injected_transition_fault(&error);
+    assert_eq!(runtime.agent_state().await.unwrap(), state_before_claim);
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        initial
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("task rejoin should be claimed after fault retry");
+    };
+    assert_eq!(scheduled.message.id, message.id);
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(
+        claimed.slot,
+        ActivationSlot::Running {
+            activation_id: activation_id.clone(),
+            work_item_id: work_item.id.clone(),
+            admitted_generation: work_item.revision,
+            recovery_for: None,
+        }
+    );
+    assert_eq!(
+        claimed.waits[&registration.condition.id].generations[&wait_generation].state,
+        WaitState::Consumed
+    );
+    assert_eq!(
+        claimed.waits[&registration.condition.id].generations[&wait_generation]
+            .consuming_activation_id
+            .as_deref(),
+        Some(activation_id.as_str())
+    );
+    let admission = &claimed.activation_admissions[&activation_id].activation;
+    assert!(matches!(
+        &admission.cause,
+        ActivationCause::TaskRejoin {
+            task_id,
+            message_id,
+            resume: Some(resume),
+        } if task_id == "task-rejoin"
+            && message_id == &message.id
+            && resume.wait_id == registration.condition.id
+            && resume.wait_generation == wait_generation
+    ));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+
+    drop(runtime);
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let restarted = reopened
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(restarted, claimed);
 }
 
 #[tokio::test]
@@ -5554,6 +5838,194 @@ async fn operator_interjection_prompt_is_interjected_before_next_provider_round(
     }));
 
     runner.abort();
+}
+
+#[tokio::test]
+async fn operator_interjection_attachment_rolls_back_with_legacy_facts() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(
+        &runtime,
+        &[SchedulerScenarioClass::OperatorInterjection],
+    );
+    let work_item = runtime
+        .create_work_item("canonical interjection".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "start canonical turn".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("canonical work item should be claimed");
+    };
+    runtime
+        .begin_interactive_turn(Some(&scheduled.message), None, None)
+        .await
+        .unwrap();
+
+    let interjection = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("control".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Interject,
+            MessageBody::Text {
+                text: "use the smaller fix".into(),
+            },
+        ))
+        .await
+        .unwrap();
+    let snapshot_before = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let transcript_before = runtime.storage().read_all_transcript().unwrap();
+    let events_before = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    runtime.inject_next_transition_fault(
+        crate::runtime_db::transitions::TransitionFaultPoint::AfterAuditWrites,
+    );
+
+    let error = runtime
+        .drain_operator_interjections(
+            "default",
+            1,
+            crate::runtime::scheduler::InterjectionBoundary::BeforeToolExecution,
+        )
+        .await
+        .unwrap_err();
+    assert_injected_transition_fault(&error);
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap(),
+        snapshot_before
+    );
+    assert_eq!(
+        runtime.storage().read_all_transcript().unwrap(),
+        transcript_before
+    );
+    assert_eq!(
+        runtime.storage().read_recent_events(usize::MAX).unwrap(),
+        events_before
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == interjection.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+
+    let follow_ups = runtime
+        .drain_operator_interjections(
+            "default",
+            1,
+            crate::runtime::scheduler::InterjectionBoundary::BeforeToolExecution,
+        )
+        .await
+        .unwrap();
+    assert_eq!(follow_ups.len(), 1);
+    let attached = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(attached.slot, snapshot_before.slot);
+    assert_eq!(attached.dispatch, snapshot_before.dispatch);
+    assert_eq!(
+        attached.dispatch_revision,
+        snapshot_before.dispatch_revision
+    );
+    assert_eq!(attached.work, snapshot_before.work);
+    assert_eq!(attached.activations, snapshot_before.activations);
+    assert_eq!(
+        attached.activation_admissions,
+        snapshot_before.activation_admissions
+    );
+    let attachment = attached
+        .activation_inputs
+        .values()
+        .find(|attachment| attachment.message_id == interjection.id)
+        .expect("canonical activation input attachment");
+    assert_eq!(
+        attachment.activation_id,
+        scheduler_executor::canonical_activation_id(&message.id)
+    );
+    assert_eq!(attachment.work_item_id, work_item.id);
+    assert_eq!(attachment.boundary, "before_tool_execution");
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == interjection.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Interjected)
+    );
+    assert!(runtime
+        .storage()
+        .read_all_transcript()
+        .unwrap()
+        .iter()
+        .any(|entry| {
+            entry.kind == TranscriptEntryKind::IncomingMessage
+                && entry.related_message_id.as_deref() == Some(interjection.id.as_str())
+        }));
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "operator_interjection_admitted"
+                && event.data["message_id"] == interjection.id
+        }));
 }
 
 #[tokio::test]

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -360,6 +360,89 @@ impl RuntimeHandle {
                     break;
                 };
                 let expected_state = guard.state.clone();
+                let protocol_commands = if self.scheduler_protocol_production_commands_enabled()
+                    && self
+                        .inner
+                        .runtime_db
+                        .transitions()
+                        .scheduler_scenario_mode(scheduler::INTERJECTION_SCENARIO)?
+                        == crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+                {
+                    let execution_binding = expected_state
+                        .current_execution_binding
+                        .as_ref()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "operator interjection requires a current execution binding"
+                            )
+                        })?;
+                    let activation_id =
+                        execution_binding.activation_id.as_deref().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "operator interjection requires a canonical running activation"
+                            )
+                        })?;
+                    let work_item_id =
+                        execution_binding.work_item_id.as_deref().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "operator interjection requires a WorkItem execution binding"
+                            )
+                        })?;
+                    let snapshot = self
+                        .inner
+                        .runtime_db
+                        .transitions()
+                        .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "operator interjection requires an initialized protocol partition"
+                            )
+                        })?;
+                    let activation = snapshot.activations.get(activation_id).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "operator interjection references an unknown canonical activation"
+                        )
+                    })?;
+                    if activation.work_item_id != work_item_id {
+                        return Err(anyhow::anyhow!(
+                            "operator interjection WorkItem binding disagrees with activation"
+                        ));
+                    }
+                    vec![
+                        crate::domain::scheduler_protocol::ProtocolCommand::AttachActivationInput(
+                            crate::domain::scheduler_protocol::AttachActivationInputCommand {
+                                attachment:
+                                    crate::domain::scheduler_protocol::ActivationInputAttachment {
+                                        id: format!("activation-input:{}", message.id),
+                                        activation_id: activation_id.to_string(),
+                                        work_item_id: work_item_id.to_string(),
+                                        expected_scheduling_generation:
+                                            activation.admitted_generation,
+                                        expected_dispatch_revision: snapshot.dispatch_revision,
+                                        message_id: message.id.clone(),
+                                        turn_id: execution_binding.turn_id.clone(),
+                                        boundary: boundary_str.to_string(),
+                                        round: u64::try_from(round).map_err(|_| {
+                                            anyhow::anyhow!(
+                                                "operator interjection round exceeds u64"
+                                            )
+                                        })?,
+                                        provenance:
+                                            crate::domain::scheduler_protocol::ActivationProvenance {
+                                                origin: crate::domain::scheduler_protocol::ActivationOrigin::Operator,
+                                                trust: crate::domain::scheduler_protocol::ActivationTrust::OperatorInstruction,
+                                                source_id: message.id.clone(),
+                                                correlation_id: message.correlation_id.clone(),
+                                                causation_id: message.causation_id.clone(),
+                                            },
+                                        created_at: message.created_at.to_rfc3339(),
+                                    },
+                            },
+                        ),
+                    ]
+                } else {
+                    Vec::new()
+                };
                 let mut committed_state = expected_state.clone();
                 committed_state.pending = guard.queue.len().saturating_sub(1);
                 let text = render_operator_interjection_text(&message);
@@ -432,7 +515,7 @@ impl RuntimeHandle {
                         ),
                         scheduler_claim_work_item: None,
                         scheduler_protocol_bootstrap: None,
-                        scheduler_protocol_commands: Vec::new(),
+                        scheduler_protocol_commands: protocol_commands,
                         scheduler_authority_scenarios: vec![scheduler::INTERJECTION_SCENARIO],
                         agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                             expected: Some(Box::new(expected_state)),
@@ -446,7 +529,7 @@ impl RuntimeHandle {
                         scheduler_delivery_shadow_comparison: None,
                         scheduler_semantic_shadow: None,
                         notify_scheduler: false,
-                        fault: None,
+                        fault: self.take_transition_fault(),
                         brief_evidence: Vec::new(),
                     },
                 )?;

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -1709,6 +1709,61 @@ CREATE INDEX IF NOT EXISTS idx_scheduler_semantic_shadow_decisions_created
   ON scheduler_semantic_shadow_decisions(agent_id, created_at);
 "#,
     },
+    Migration {
+        version: 34,
+        name: "scheduler_activation_source_fences_and_inputs",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS scheduler_activation_sources (
+  agent_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  source_kind TEXT NOT NULL CHECK (
+    source_kind IN ('task_rejoin', 'operator_input')
+  ),
+  source_identity TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, activation_id),
+  UNIQUE (agent_id, source_kind, source_identity),
+  FOREIGN KEY (agent_id, activation_id)
+    REFERENCES scheduler_activations(agent_id, activation_id)
+);
+
+CREATE TABLE IF NOT EXISTS scheduler_activation_inputs (
+  agent_id TEXT NOT NULL,
+  attachment_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  work_item_id TEXT NOT NULL,
+  expected_scheduling_generation INTEGER NOT NULL CHECK (
+    expected_scheduling_generation > 0
+  ),
+  expected_dispatch_revision INTEGER NOT NULL CHECK (
+    expected_dispatch_revision >= 0
+  ),
+  message_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  boundary TEXT NOT NULL,
+  round INTEGER NOT NULL CHECK (round >= 0),
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, attachment_id),
+  UNIQUE (agent_id, message_id),
+  FOREIGN KEY (
+    agent_id,
+    activation_id,
+    work_item_id,
+    expected_scheduling_generation
+  ) REFERENCES scheduler_activations(
+    agent_id,
+    activation_id,
+    work_item_id,
+    admitted_generation
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduler_activation_inputs_activation
+  ON scheduler_activation_inputs(agent_id, activation_id, round);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -78,15 +78,16 @@ mod tests {
     use crate::{
         domain::scheduler_protocol::{
             self, ActivationBinding, ActivationCause, ActivationDisposition,
-            ActivationLifecycleState, ActivationOrigin, ActivationPriority, ActivationProvenance,
-            ActivationSettlement, ActivationSlot, ActivationTrust, AdmitActivationCommand,
-            AgentActivation, AgentDispatchDisposition, AgentDispatchState, Continuation, Decision,
+            ActivationInputAttachment, ActivationLifecycleState, ActivationOrigin,
+            ActivationPriority, ActivationProvenance, ActivationSettlement, ActivationSlot,
+            ActivationTrust, AdmitActivationCommand, AgentActivation, AgentDispatchDisposition,
+            AgentDispatchState, AttachActivationInputCommand, Continuation, Decision,
             IssueActivationAuthorityCommand, ObservationalDivergenceAllowance, PreemptionPolicy,
             ProtocolCommand, ProtocolMode, RollbackAction, RollbackPolicy, RollbackTrigger,
             RolloutClassEvidence, RolloutCommand, RolloutManifest, RolloutPreflightState,
             ScenarioMode, SchedulerScenarioClass, SettleActivationCommand, Snapshot,
-            WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WaitTrigger, WorkDemand,
-            WorkStatus,
+            TriggerWaitCommand, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitResumeClaim,
+            WaitState, WaitTrigger, WorkDemand, WorkStatus,
         },
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
@@ -339,6 +340,7 @@ mod tests {
             rollout: Default::default(),
             admitted_generations: BTreeSet::new(),
             continuation_admissions: BTreeMap::new(),
+            activation_inputs: BTreeMap::new(),
         }
     }
 
@@ -510,7 +512,7 @@ mod tests {
                         "rearm",
                     ],
                 ),
-                "operator_interjection" => (
+                "explicitly_bound_operator_input" | "operator_interjection" => (
                     1_000,
                     7 * 24 * 60 * 60,
                     vec![
@@ -810,6 +812,8 @@ mod tests {
             "scheduler_activation_settlements",
             "scheduler_missing_settlements",
             "scheduler_continuation_admissions",
+            "scheduler_activation_sources",
+            "scheduler_activation_inputs",
             "scheduler_protocol_command_results",
             "scheduler_protocol_command_conflict_attempts",
             "scheduler_protocol_migrations",
@@ -1619,6 +1623,302 @@ mod tests {
                 .consuming_activation_id
                 .as_deref(),
             Some("activation-wait-resume")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_task_rejoin_persists_source_fence_and_wait_consumption() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let wait_id = "wait-task";
+        let wait_generation = 2;
+        let trigger_id = "task:task-a";
+        let trigger_generation = 7;
+        let scheduling_generation = 2;
+        let dispatch_revision = 1;
+        let resume = WaitResumeClaim {
+            wait_id: wait_id.into(),
+            wait_generation,
+            trigger_id: trigger_id.into(),
+            trigger_generation,
+        };
+        let activation = AgentActivation {
+            id: "activation-task-rejoin".into(),
+            agent_id: agent_id.into(),
+            state: ActivationLifecycleState::Admitted,
+            cause: ActivationCause::TaskRejoin {
+                task_id: "task-a".into(),
+                message_id: "message-task-result".into(),
+                resume: Some(resume.clone()),
+            },
+            binding: ActivationBinding::WorkItem {
+                work_item_id: "work-a".into(),
+            },
+            priority: ActivationPriority::Normal,
+            preemption: PreemptionPolicy::AllowOperatorInterjection,
+            source_revision: Some(7),
+            idempotency_key: "task-rejoin:task-a".into(),
+            provenance: ActivationProvenance {
+                origin: ActivationOrigin::Task,
+                trust: ActivationTrust::RuntimeInstruction,
+                source_id: "message-task-result".into(),
+                correlation_id: Some("task-a".into()),
+                causation_id: Some("parent-message".into()),
+            },
+        };
+        let authority_id = "authority-task-rejoin";
+        let authority =
+            ProtocolCommand::IssueActivationAuthority(IssueActivationAuthorityCommand {
+                authority_id: authority_id.into(),
+                activation: activation.clone(),
+                expected_scheduling_generation: scheduling_generation,
+                expected_dispatch_revision: dispatch_revision,
+            });
+        let trigger = ProtocolCommand::TriggerWait(TriggerWaitCommand {
+            wait_id: wait_id.into(),
+            wait_generation,
+            trigger_id: trigger_id.into(),
+            trigger_generation,
+        });
+        let admission = ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: authority_id.into(),
+            activation,
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision: dispatch_revision,
+        });
+        let mut initial = scheduler_protocol_snapshot(scheduling_generation);
+        initial.work.get_mut("work-a").expect("work").status = WorkStatus::Waiting {
+            wait_id: wait_id.into(),
+        };
+        initial.dispatch = AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: wait_id.into(),
+                generation: wait_generation,
+            },
+        };
+        initial.dispatch_revision = dispatch_revision;
+        initial.waits.insert(
+            wait_id.into(),
+            WaitRecord {
+                current_generation: wait_generation,
+                generations: BTreeMap::from([(
+                    wait_generation,
+                    WaitGenerationRecord {
+                        owner_work_item_id: "work-a".into(),
+                        state: WaitState::Active,
+                        trigger: None,
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        );
+
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &initial)?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &authority, None)?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &trigger, None)?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
+        drop(db);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let snapshot = reopened
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        assert_eq!(
+            snapshot.waits[wait_id].generations[&wait_generation].state,
+            WaitState::Consumed
+        );
+        assert_eq!(
+            snapshot.admitted_generations,
+            BTreeSet::from(["task:task-a".into()])
+        );
+        let source: (String, String) = reopened.connection()?.query_row(
+            "SELECT source_kind, source_identity
+             FROM scheduler_activation_sources
+             WHERE agent_id = ?1 AND activation_id = 'activation-task-rejoin'",
+            [agent_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(source, ("task_rejoin".into(), "task-a".into()));
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_operator_input_uses_message_source_fence() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let scheduling_generation = 1;
+        let activation = AgentActivation {
+            id: "activation-operator-input".into(),
+            agent_id: agent_id.into(),
+            state: ActivationLifecycleState::Admitted,
+            cause: ActivationCause::OperatorInput {
+                message_id: "message-operator".into(),
+                resume: None,
+            },
+            binding: ActivationBinding::WorkItem {
+                work_item_id: "work-a".into(),
+            },
+            priority: ActivationPriority::Normal,
+            preemption: PreemptionPolicy::AllowOperatorInterjection,
+            source_revision: Some(9),
+            idempotency_key: "operator-message:message-operator".into(),
+            provenance: ActivationProvenance {
+                origin: ActivationOrigin::Operator,
+                trust: ActivationTrust::OperatorInstruction,
+                source_id: "message-operator".into(),
+                correlation_id: None,
+                causation_id: None,
+            },
+        };
+        let authority_id = "authority-operator-input";
+        let authority =
+            ProtocolCommand::IssueActivationAuthority(IssueActivationAuthorityCommand {
+                authority_id: authority_id.into(),
+                activation: activation.clone(),
+                expected_scheduling_generation: scheduling_generation,
+                expected_dispatch_revision: 0,
+            });
+        let admission = ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: authority_id.into(),
+            activation,
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision: 0,
+        });
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions().initialize_scheduler_protocol_partition(
+            agent_id,
+            &scheduler_protocol_snapshot(scheduling_generation),
+        )?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &authority, None)?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
+        drop(db);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let snapshot = reopened
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        assert_eq!(
+            snapshot.admitted_generations,
+            BTreeSet::from(["operator_message:message-operator".into()])
+        );
+        let source: (String, String) = reopened.connection()?.query_row(
+            "SELECT source_kind, source_identity
+             FROM scheduler_activation_sources
+             WHERE agent_id = ?1 AND activation_id = 'activation-operator-input'",
+            [agent_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(source, ("operator_input".into(), "message-operator".into()));
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_activation_input_attachment_is_restart_safe_and_message_unique() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let initial = scheduler_protocol_snapshot(1);
+        let authority = scheduler_protocol_authority_command(agent_id, 1);
+        let ProtocolCommand::IssueActivationAuthority(authority_payload) = &authority else {
+            unreachable!()
+        };
+        let mut admission_payload = AdmitActivationCommand {
+            authority_id: authority_payload.authority_id.clone(),
+            activation: authority_payload.activation.clone(),
+            expected_scheduling_generation: 1,
+            expected_dispatch_revision: 0,
+        };
+        admission_payload.activation.preemption = PreemptionPolicy::AllowOperatorInterjection;
+        let authority =
+            ProtocolCommand::IssueActivationAuthority(IssueActivationAuthorityCommand {
+                authority_id: admission_payload.authority_id.clone(),
+                activation: admission_payload.activation.clone(),
+                expected_scheduling_generation: 1,
+                expected_dispatch_revision: 0,
+            });
+        let admission = ProtocolCommand::AdmitActivation(admission_payload);
+        let attachment = ActivationInputAttachment {
+            id: "attachment-a".into(),
+            activation_id: "activation-a".into(),
+            work_item_id: "work-a".into(),
+            expected_scheduling_generation: 1,
+            expected_dispatch_revision: 0,
+            message_id: "interjection-message".into(),
+            turn_id: "turn-a".into(),
+            boundary: "after_provider_round".into(),
+            round: 1,
+            provenance: ActivationProvenance {
+                origin: ActivationOrigin::Operator,
+                trust: ActivationTrust::OperatorInstruction,
+                source_id: "interjection-message".into(),
+                correlation_id: Some("activation-a".into()),
+                causation_id: None,
+            },
+            created_at: "2026-07-23T00:00:00Z".into(),
+        };
+        let command = ProtocolCommand::AttachActivationInput(AttachActivationInputCommand {
+            attachment: attachment.clone(),
+        });
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &initial)?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &authority, None)?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
+        let committed = db
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &command, None)?;
+        assert_eq!(committed.result.decision, Decision::ActivationInputAttached);
+        let replayed = db
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &command, None)?;
+        assert!(replayed.replayed);
+
+        let conflicting = ProtocolCommand::AttachActivationInput(AttachActivationInputCommand {
+            attachment: ActivationInputAttachment {
+                id: "attachment-b".into(),
+                boundary: "before_tool_execution".into(),
+                ..attachment.clone()
+            },
+        });
+        let before_conflict = db
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        let conflict = db
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &conflicting, None)?;
+        assert_eq!(conflict.result.decision, Decision::Rejected);
+        assert!(conflict.result.fact_references.is_empty());
+        assert_eq!(
+            conflict
+                .result
+                .conflict
+                .as_ref()
+                .map(|conflict| conflict.code.as_str()),
+            Some("activation_input_message_conflict")
+        );
+        assert_eq!(
+            db.transitions()
+                .load_scheduler_protocol_snapshot(agent_id)?,
+            before_conflict
+        );
+        drop(db);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(
+            reopened
+                .transitions()
+                .load_scheduler_protocol_snapshot(agent_id)?
+                .activation_inputs,
+            BTreeMap::from([("attachment-a".into(), attachment)])
         );
         Ok(())
     }

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -12,12 +12,12 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::domain::scheduler_protocol::{
-    self, ActivationAdmissionAuthority, ActivationCause, ActivationRecord, ActivationSlot,
-    ActivationState, AdmitActivationCommand, AgentDispatchState, ContinuationAdmissionRecord,
-    Decision, MissingSettlementRecord, ProtocolCommand, ProtocolConflict, ProtocolConflictKind,
-    ProtocolMode, RollbackAction, RollbackTrigger, RolloutCommand, RolloutManifest,
-    RolloutPreflightRecord, RolloutPreflightState, RolloutState, ScenarioAuthority,
-    ScenarioHardBlockerRecord, ScenarioMode, SchedulerScenarioClass, Snapshot,
+    self, ActivationAdmissionAuthority, ActivationCause, ActivationInputAttachment,
+    ActivationRecord, ActivationSlot, ActivationState, AdmitActivationCommand, AgentDispatchState,
+    ContinuationAdmissionRecord, Decision, MissingSettlementRecord, ProtocolCommand,
+    ProtocolConflict, ProtocolConflictKind, ProtocolMode, RollbackAction, RollbackTrigger,
+    RolloutCommand, RolloutManifest, RolloutPreflightRecord, RolloutPreflightState, RolloutState,
+    ScenarioAuthority, ScenarioHardBlockerRecord, ScenarioMode, SchedulerScenarioClass, Snapshot,
     WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
 use crate::domain::scheduler_semantic::{
@@ -214,6 +214,9 @@ pub(super) fn validate_protocol_command_authority_tx(
             }
             ProtocolCommand::TriggerWait(_) => {
                 required_scenarios.insert(SchedulerScenarioClass::ExactWaitResume);
+            }
+            ProtocolCommand::AttachActivationInput(_) => {
+                required_scenarios.insert(SchedulerScenarioClass::OperatorInterjection);
             }
             ProtocolCommand::SettleActivation(_) | ProtocolCommand::RecordMissingSettlement(_) => {
                 // Terminal commands drain authority granted when the activation was admitted.
@@ -928,6 +931,7 @@ fn rollout_snapshot(rollout: RolloutState) -> Snapshot {
         rollout,
         admitted_generations: BTreeSet::new(),
         continuation_admissions: BTreeMap::new(),
+        activation_inputs: BTreeMap::new(),
     }
 }
 
@@ -1030,6 +1034,9 @@ fn command_identity(command: &ProtocolCommand) -> Result<(&'static str, String)>
             "trigger_wait",
             serde_json::to_string(&(command.wait_id.as_str(), command.wait_generation))?,
         ),
+        ProtocolCommand::AttachActivationInput(command) => {
+            ("attach_activation_input", command.attachment.id.clone())
+        }
     })
 }
 
@@ -1066,6 +1073,10 @@ fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
             "wait:{}:generation:{}",
             command.wait_id, command.wait_generation
         )],
+        ProtocolCommand::AttachActivationInput(command) => vec![
+            format!("activation:{}", command.attachment.activation_id),
+            format!("activation_input:{}", command.attachment.id),
+        ],
     }
 }
 
@@ -1076,7 +1087,8 @@ fn validate_command_agent(agent_id: &str, command: &ProtocolCommand) -> Result<(
         ProtocolCommand::AdmitActivation(command) => Some(&command.activation.agent_id),
         ProtocolCommand::SettleActivation(_)
         | ProtocolCommand::RecordMissingSettlement(_)
-        | ProtocolCommand::TriggerWait(_) => None,
+        | ProtocolCommand::TriggerWait(_)
+        | ProtocolCommand::AttachActivationInput(_) => None,
     };
     if command_agent_id.is_some_and(|command_agent_id| command_agent_id != agent_id) {
         bail!("scheduler protocol command crosses agent partition {agent_id}");
@@ -1675,6 +1687,30 @@ fn persist_agent_snapshot_tx(
                 &now,
             ],
         )?;
+        if let Some((source_kind, source_identity)) = activation_source_columns(admission) {
+            tx.execute(
+                "INSERT INTO scheduler_activation_sources (
+                   agent_id,
+                   activation_id,
+                   source_kind,
+                   source_identity,
+                   payload_json,
+                   created_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(agent_id, activation_id) DO UPDATE SET
+                   source_kind = excluded.source_kind,
+                   source_identity = excluded.source_identity,
+                   payload_json = excluded.payload_json",
+                params![
+                    agent_id,
+                    activation_id,
+                    source_kind,
+                    source_identity,
+                    serde_json::to_string(&admission.activation.cause)?,
+                    &now,
+                ],
+            )?;
+        }
     }
 
     for (authority_id, authority) in &snapshot.activation_authorities {
@@ -1819,6 +1855,54 @@ fn persist_agent_snapshot_tx(
                 )?,
                 serde_json::to_string(admission)?,
                 &now,
+            ],
+        )?;
+    }
+    for (attachment_id, attachment) in &snapshot.activation_inputs {
+        tx.execute(
+            "INSERT INTO scheduler_activation_inputs (
+               agent_id,
+               attachment_id,
+               activation_id,
+               work_item_id,
+               expected_scheduling_generation,
+               expected_dispatch_revision,
+               message_id,
+               turn_id,
+               boundary,
+               round,
+               payload_json,
+               created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             ON CONFLICT(agent_id, attachment_id) DO UPDATE SET
+               activation_id = excluded.activation_id,
+               work_item_id = excluded.work_item_id,
+               expected_scheduling_generation = excluded.expected_scheduling_generation,
+               expected_dispatch_revision = excluded.expected_dispatch_revision,
+               message_id = excluded.message_id,
+               turn_id = excluded.turn_id,
+               boundary = excluded.boundary,
+               round = excluded.round,
+               payload_json = excluded.payload_json",
+            params![
+                agent_id,
+                attachment_id,
+                &attachment.activation_id,
+                &attachment.work_item_id,
+                to_i64(
+                    attachment.expected_scheduling_generation,
+                    "activation input scheduling generation",
+                )?,
+                to_i64(
+                    attachment.expected_dispatch_revision,
+                    "activation input dispatch revision",
+                )?,
+                &attachment.message_id,
+                &attachment.turn_id,
+                &attachment.boundary,
+                to_i64(attachment.round, "activation input round")?,
+                serde_json::to_string(attachment)?,
+                &attachment.created_at,
             ],
         )?;
     }
@@ -2102,6 +2186,11 @@ fn load_snapshot_connection_with_hook(
         "SELECT admission_id, payload_json FROM scheduler_continuation_admissions WHERE agent_id = ?1",
         agent_id,
     )?;
+    let activation_inputs = load_payload_map::<ActivationInputAttachment>(
+        connection,
+        "SELECT attachment_id, payload_json FROM scheduler_activation_inputs WHERE agent_id = ?1",
+        agent_id,
+    )?;
     let rollout = load_rollout(connection)?;
     let admitted_generations = activation_admissions
         .values()
@@ -2122,6 +2211,7 @@ fn load_snapshot_connection_with_hook(
         rollout,
         admitted_generations,
         continuation_admissions,
+        activation_inputs,
     };
     validate_agent_partition(agent_id, &snapshot)?;
     scheduler_protocol::assert_invariants(&snapshot)
@@ -2351,6 +2441,19 @@ fn activation_admission_columns(
 ) -> Result<(&'static str, Option<&str>, Option<&str>, Option<i64>)> {
     match &admission.activation.cause {
         ActivationCause::WorkItemRunnable { .. } => Ok(("scheduling", None, None, None)),
+        ActivationCause::TaskRejoin { resume, .. }
+        | ActivationCause::OperatorInput { resume, .. } => match resume {
+            Some(resume) => Ok((
+                "wait_resume",
+                None,
+                Some(&resume.wait_id),
+                Some(to_i64(
+                    resume.wait_generation,
+                    "embedded wait resume generation",
+                )?),
+            )),
+            None => Ok(("scheduling", None, None, None)),
+        },
         ActivationCause::WaitResume {
             wait_id,
             wait_generation,
@@ -2381,6 +2484,14 @@ fn persisted_admission_fence(admission: &AdmitActivationCommand) -> Result<Strin
             },
         ) if work_item_id == bound_work_item_id => work_item_id,
         (
+            ActivationCause::TaskRejoin { task_id, .. },
+            scheduler_protocol::ActivationBinding::WorkItem { .. },
+        ) => return Ok(format!("task:{task_id}")),
+        (
+            ActivationCause::OperatorInput { message_id, .. },
+            scheduler_protocol::ActivationBinding::WorkItem { .. },
+        ) => return Ok(format!("operator_message:{message_id}")),
+        (
             ActivationCause::WaitResume { wait_id, .. },
             scheduler_protocol::ActivationBinding::WaitOwner {
                 wait_id: bound_wait_id,
@@ -2405,6 +2516,14 @@ fn persisted_admission_fence(admission: &AdmitActivationCommand) -> Result<Strin
         "{work_item_id}:{}",
         admission.expected_scheduling_generation
     ))
+}
+
+fn activation_source_columns(admission: &AdmitActivationCommand) -> Option<(&'static str, &str)> {
+    match &admission.activation.cause {
+        ActivationCause::TaskRejoin { task_id, .. } => Some(("task_rejoin", task_id)),
+        ActivationCause::OperatorInput { message_id, .. } => Some(("operator_input", message_id)),
+        _ => None,
+    }
 }
 
 fn activation_state_token(state: &ActivationState) -> &'static str {

--- a/tests/scheduler_intent_mvp.rs
+++ b/tests/scheduler_intent_mvp.rs
@@ -580,5 +580,6 @@ fn semantic_authority_snapshot() -> Snapshot {
         rollout: Default::default(),
         admitted_generations: Default::default(),
         continuation_admissions: BTreeMap::new(),
+        activation_inputs: BTreeMap::new(),
     }
 }

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -122,7 +122,7 @@ fn apply_event(snapshot: &Snapshot, event: &Event) -> model::Outcome {
             expected_dispatch_revision,
             cause,
         } => {
-            let (typed_cause, binding, origin) = match cause {
+            let (typed_cause, binding, origin, trust) = match cause {
                 AdmissionCause::Scheduling => (
                     ActivationCause::WorkItemRunnable {
                         work_item_id: work_item_id.clone(),
@@ -132,6 +132,34 @@ fn apply_event(snapshot: &Snapshot, event: &Event) -> model::Outcome {
                         work_item_id: work_item_id.clone(),
                     },
                     ActivationOrigin::System,
+                    ActivationTrust::RuntimeInstruction,
+                ),
+                AdmissionCause::TaskRejoin {
+                    task_id,
+                    message_id,
+                    resume,
+                } => (
+                    ActivationCause::TaskRejoin {
+                        task_id: task_id.clone(),
+                        message_id: message_id.clone(),
+                        resume: resume.clone(),
+                    },
+                    ActivationBinding::WorkItem {
+                        work_item_id: work_item_id.clone(),
+                    },
+                    ActivationOrigin::Task,
+                    ActivationTrust::RuntimeInstruction,
+                ),
+                AdmissionCause::OperatorInput { message_id, resume } => (
+                    ActivationCause::OperatorInput {
+                        message_id: message_id.clone(),
+                        resume: resume.clone(),
+                    },
+                    ActivationBinding::WorkItem {
+                        work_item_id: work_item_id.clone(),
+                    },
+                    ActivationOrigin::Operator,
+                    ActivationTrust::OperatorInstruction,
                 ),
                 AdmissionCause::WaitResume {
                     wait_id,
@@ -150,6 +178,7 @@ fn apply_event(snapshot: &Snapshot, event: &Event) -> model::Outcome {
                         owner_work_item_id: work_item_id.clone(),
                     },
                     ActivationOrigin::System,
+                    ActivationTrust::RuntimeInstruction,
                 ),
                 AdmissionCause::SettlementRecovery {
                     missing_activation_id,
@@ -161,6 +190,7 @@ fn apply_event(snapshot: &Snapshot, event: &Event) -> model::Outcome {
                         work_item_id: work_item_id.clone(),
                     },
                     ActivationOrigin::RuntimeRecovery,
+                    ActivationTrust::RuntimeInstruction,
                 ),
             };
             let command = AdmitActivationCommand {
@@ -177,7 +207,7 @@ fn apply_event(snapshot: &Snapshot, event: &Event) -> model::Outcome {
                     idempotency_key: format!("activation-{activation_id}"),
                     provenance: ActivationProvenance {
                         origin,
-                        trust: ActivationTrust::RuntimeInstruction,
+                        trust,
                         source_id: "legacy-test-adapter".into(),
                         correlation_id: None,
                         causation_id: None,
@@ -3069,5 +3099,6 @@ fn minimal_snapshot(scheduling_generation: u64) -> Snapshot {
         rollout: Default::default(),
         admitted_generations: Default::default(),
         continuation_admissions: Default::default(),
+        activation_inputs: Default::default(),
     }
 }


### PR DESCRIPTION
## Summary

- replace the work-queue-only canonical claim path with a unified typed activation plan for WorkItem continuation, exact task rejoin, exact wait resume, and explicitly bound operator input
- carry activation cause/binding, provenance and trust, WorkItem scheduling generation, dispatch revision, exact source identity, and legacy queue/Turn compatibility identity through canonical admission
- attach operator interjections to the existing running activation instead of creating a second activation, committing the attachment, legacy transition, transcript, and audit evidence atomically
- preserve duplicate idempotency while rejecting stale, wrong-agent, out-of-order, and inexactly bound commands; document the migration boundary and leave rollout authority gating to PR-F

## Tests

- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`

Coverage includes deterministic and restart-safe admission for task rejoin, wait resume, explicitly bound operator input, atomic interjection attachment, stale/source-specific fences, duplicate commands, and transaction fault rollback.
