### PR TITLE
fix: fail closed on ambiguous scheduler waits

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -20,6 +20,7 @@ use crate::work_item_scheduling::WorkItemSchedulingProjection;
 use anyhow::bail;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use std::fmt;
 
 pub(crate) const REDUCER_ONLY_CANDIDATES_SCENARIO: SchedulerScenarioClass =
     SchedulerScenarioClass::ReducerOnlyCandidates;
@@ -55,6 +56,24 @@ pub(crate) enum CanonicalActivationScenario {
         wait_id: Option<String>,
     },
 }
+
+#[derive(Debug)]
+pub(crate) struct AmbiguousCanonicalWaits {
+    pub(crate) message_id: String,
+    pub(crate) wait_condition_ids: Vec<String>,
+}
+
+impl fmt::Display for AmbiguousCanonicalWaits {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "canonical activation message {} matches multiple active waits",
+            self.message_id
+        )
+    }
+}
+
+impl std::error::Error for AmbiguousCanonicalWaits {}
 
 impl CanonicalActivationScenario {
     pub(crate) fn work_item_id(&self) -> &str {
@@ -511,6 +530,32 @@ pub(crate) fn append_scheduling_advisories(
     }
 
     Ok(appended)
+}
+
+pub(crate) fn append_ambiguous_wait_advisory(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+    wait_condition_ids: &[String],
+) -> Result<()> {
+    let diagnostic = SchedulingAdvisory::warning(
+        "ambiguous_canonical_wait_binding",
+        "canonical activation input matches multiple active waits and remains queued",
+    )
+    .maybe_work_item_id(message.work_item_id.clone())
+    .evidence(format!("message_id={}", message.id))
+    .evidence(format!(
+        "wait_condition_ids={}",
+        wait_condition_ids.join(",")
+    ));
+    let event = scheduling_advisory_event(&diagnostic);
+    let duplicate = storage
+        .read_recent_events(64)?
+        .iter()
+        .any(|latest| latest.kind == event.kind && latest.data == event.data);
+    if !duplicate {
+        storage.append_event(&event)?;
+    }
+    Ok(())
 }
 
 trait SchedulingAdvisoryExt {
@@ -1253,10 +1298,10 @@ pub(crate) fn canonical_activation_scenario(
 
     let matching_waits = matching_wait_conditions(projection, message);
     if matching_waits.len() > 1 {
-        bail!(
-            "canonical activation message {} matches multiple active waits",
-            message.id
-        );
+        return Err(anyhow::Error::new(AmbiguousCanonicalWaits {
+            message_id: message.id.clone(),
+            wait_condition_ids: matching_waits.iter().map(|wait| wait.id.clone()).collect(),
+        }));
     }
     let matching_wait = matching_waits.first().copied();
 

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -393,7 +393,27 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         )?
         .map(scheduler_semantic_shadow_command);
         let canonical_claim =
-            self.canonical_activation_plan(&projection, &persisted_message, &dispatch_plan)?;
+            match self.canonical_activation_plan(&projection, &persisted_message, &dispatch_plan) {
+                Ok(plan) => plan,
+                Err(error) => {
+                    if let Some(ambiguous) =
+                        error.downcast_ref::<scheduler::AmbiguousCanonicalWaits>()
+                    {
+                        scheduler::append_ambiguous_wait_advisory(
+                            &self.runtime.inner.storage,
+                            &persisted_message,
+                            &ambiguous.wait_condition_ids,
+                        )?;
+                        scheduler::append_scheduling_advisories(
+                            &self.runtime.inner.storage,
+                            &candidate.prior_state,
+                            candidate.queue_len,
+                        )?;
+                        return Ok(RunLoopPoll::Idle);
+                    }
+                    return Err(error);
+                }
+            };
         scheduler::append_scheduling_advisories(
             &self.runtime.inner.storage,
             &candidate.prior_state,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2302,6 +2302,110 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
 }
 
 #[tokio::test]
+async fn ambiguous_task_rejoin_waits_remain_queued_with_deduplicated_advisory() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(&runtime, &[SchedulerScenarioClass::ExactTaskRejoin]);
+    let work_item = runtime
+        .create_work_item("ambiguous task rejoin".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-ambiguous".into()),
+            "waiting for task-ambiguous".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let mut duplicate_wait = registration.condition.clone();
+    duplicate_wait.id = "wait-task-ambiguous-duplicate".into();
+    runtime
+        .storage()
+        .append_wait_condition(&duplicate_wait)
+        .unwrap();
+
+    let mut message = task_result_message("task-ambiguous").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-ambiguous",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-ambiguous",
+        "work_item_id": work_item.id,
+    }));
+    let message = runtime.enqueue(message).await.unwrap();
+
+    for _ in 0..2 {
+        let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap();
+        assert!(matches!(poll, scheduler_executor::RunLoopPoll::Idle));
+    }
+
+    assert_eq!(runtime.inner.agent.lock().await.queue.len(), 1);
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+    let advisories = runtime
+        .storage()
+        .read_recent_events(64)
+        .unwrap()
+        .into_iter()
+        .filter(|event| {
+            event.kind == "scheduling_advisory"
+                && event.data["kind"] == "ambiguous_canonical_wait_binding"
+                && event.data["evidence"].as_array().is_some_and(|evidence| {
+                    evidence
+                        .iter()
+                        .any(|item| item == &format!("message_id={}", message.id))
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(advisories.len(), 1);
+    assert!(advisories[0].data["evidence"]
+        .as_array()
+        .is_some_and(|evidence| {
+            evidence.iter().any(|item| {
+                item.as_str().is_some_and(|item| {
+                    item.contains(&registration.condition.id) && item.contains(&duplicate_wait.id)
+                })
+            })
+        }));
+}
+
+#[tokio::test]
 async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent() {
     for fault in PRE_COMMIT_FAULTS {
         let dir = tempdir().unwrap();

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -360,89 +360,13 @@ impl RuntimeHandle {
                     break;
                 };
                 let expected_state = guard.state.clone();
-                let protocol_commands = if self.scheduler_protocol_production_commands_enabled()
-                    && self
-                        .inner
-                        .runtime_db
-                        .transitions()
-                        .scheduler_scenario_mode(scheduler::INTERJECTION_SCENARIO)?
-                        == crate::domain::scheduler_protocol::ScenarioMode::Authoritative
-                {
-                    let execution_binding = expected_state
-                        .current_execution_binding
-                        .as_ref()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "operator interjection requires a current execution binding"
-                            )
-                        })?;
-                    let activation_id =
-                        execution_binding.activation_id.as_deref().ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "operator interjection requires a canonical running activation"
-                            )
-                        })?;
-                    let work_item_id =
-                        execution_binding.work_item_id.as_deref().ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "operator interjection requires a WorkItem execution binding"
-                            )
-                        })?;
-                    let snapshot = self
-                        .inner
-                        .runtime_db
-                        .transitions()
-                        .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "operator interjection requires an initialized protocol partition"
-                            )
-                        })?;
-                    let activation = snapshot.activations.get(activation_id).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "operator interjection references an unknown canonical activation"
-                        )
-                    })?;
-                    if activation.work_item_id != work_item_id {
-                        return Err(anyhow::anyhow!(
-                            "operator interjection WorkItem binding disagrees with activation"
-                        ));
-                    }
-                    vec![
-                        crate::domain::scheduler_protocol::ProtocolCommand::AttachActivationInput(
-                            crate::domain::scheduler_protocol::AttachActivationInputCommand {
-                                attachment:
-                                    crate::domain::scheduler_protocol::ActivationInputAttachment {
-                                        id: format!("activation-input:{}", message.id),
-                                        activation_id: activation_id.to_string(),
-                                        work_item_id: work_item_id.to_string(),
-                                        expected_scheduling_generation:
-                                            activation.admitted_generation,
-                                        expected_dispatch_revision: snapshot.dispatch_revision,
-                                        message_id: message.id.clone(),
-                                        turn_id: execution_binding.turn_id.clone(),
-                                        boundary: boundary_str.to_string(),
-                                        round: u64::try_from(round).map_err(|_| {
-                                            anyhow::anyhow!(
-                                                "operator interjection round exceeds u64"
-                                            )
-                                        })?,
-                                        provenance:
-                                            crate::domain::scheduler_protocol::ActivationProvenance {
-                                                origin: crate::domain::scheduler_protocol::ActivationOrigin::Operator,
-                                                trust: crate::domain::scheduler_protocol::ActivationTrust::OperatorInstruction,
-                                                source_id: message.id.clone(),
-                                                correlation_id: message.correlation_id.clone(),
-                                                causation_id: message.causation_id.clone(),
-                                            },
-                                        created_at: message.created_at.to_rfc3339(),
-                                    },
-                            },
-                        ),
-                    ]
-                } else {
-                    Vec::new()
-                };
+                let protocol_commands = self.operator_interjection_protocol_commands(
+                    agent_id,
+                    &expected_state,
+                    &message,
+                    round,
+                    boundary_str,
+                )?;
                 let mut committed_state = expected_state.clone();
                 committed_state.pending = guard.queue.len().saturating_sub(1);
                 let text = render_operator_interjection_text(&message);
@@ -551,6 +475,85 @@ impl RuntimeHandle {
             follow_up_texts.push(committed.0);
         }
         Ok(follow_up_texts)
+    }
+
+    fn operator_interjection_protocol_commands(
+        &self,
+        agent_id: &str,
+        expected_state: &crate::types::AgentState,
+        message: &MessageEnvelope,
+        round: usize,
+        boundary: &str,
+    ) -> Result<Vec<crate::domain::scheduler_protocol::ProtocolCommand>> {
+        use crate::domain::scheduler_protocol::{
+            ActivationInputAttachment, ActivationOrigin, ActivationProvenance, ActivationTrust,
+            AttachActivationInputCommand, ProtocolCommand, ScenarioMode,
+        };
+
+        if !self.scheduler_protocol_production_commands_enabled()
+            || self
+                .inner
+                .runtime_db
+                .transitions()
+                .scheduler_scenario_mode(scheduler::INTERJECTION_SCENARIO)?
+                != ScenarioMode::Authoritative
+        {
+            return Ok(Vec::new());
+        }
+
+        let execution_binding = expected_state
+            .current_execution_binding
+            .as_ref()
+            .ok_or_else(|| {
+                anyhow::anyhow!("operator interjection requires a current execution binding")
+            })?;
+        let activation_id = execution_binding.activation_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("operator interjection requires a canonical running activation")
+        })?;
+        let work_item_id = execution_binding.work_item_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("operator interjection requires a WorkItem execution binding")
+        })?;
+        let snapshot = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+            .ok_or_else(|| {
+                anyhow::anyhow!("operator interjection requires an initialized protocol partition")
+            })?;
+        let activation = snapshot.activations.get(activation_id).ok_or_else(|| {
+            anyhow::anyhow!("operator interjection references an unknown canonical activation")
+        })?;
+        if activation.work_item_id != work_item_id {
+            return Err(anyhow::anyhow!(
+                "operator interjection WorkItem binding disagrees with activation"
+            ));
+        }
+
+        Ok(vec![ProtocolCommand::AttachActivationInput(
+            AttachActivationInputCommand {
+                attachment: ActivationInputAttachment {
+                    id: format!("activation-input:{}", message.id),
+                    activation_id: activation_id.to_string(),
+                    work_item_id: work_item_id.to_string(),
+                    expected_scheduling_generation: activation.admitted_generation,
+                    expected_dispatch_revision: snapshot.dispatch_revision,
+                    message_id: message.id.clone(),
+                    turn_id: execution_binding.turn_id.clone(),
+                    boundary: boundary.to_string(),
+                    round: u64::try_from(round)
+                        .map_err(|_| anyhow::anyhow!("operator interjection round exceeds u64"))?,
+                    provenance: ActivationProvenance {
+                        origin: ActivationOrigin::Operator,
+                        trust: ActivationTrust::OperatorInstruction,
+                        source_id: message.id.clone(),
+                        correlation_id: message.correlation_id.clone(),
+                        causation_id: message.causation_id.clone(),
+                    },
+                    created_at: message.created_at.to_rfc3339(),
+                },
+            },
+        )])
     }
 
     pub(super) async fn append_operator_interjections_to_last_round(


### PR DESCRIPTION
## 概要

这是已合并 #2398 的窄范围 review follow-up：

- 当 canonical input 同时匹配多个 active wait 时 fail closed，消息保持 queued，不取得 execution ownership
- 写入可去重的 `ambiguous_canonical_wait_binding` scheduling advisory，记录 message/wait 证据
- 提取 interjection activation-input attachment helper，保持 attachment、legacy queue/transcript/audit facts 的单事务原子性
- 补充 ambiguous wait 与 interjection rollback 的确定性回归测试，并同步 Phase 3 scenario evidence manifest

## 验证

- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
