### PR TITLE
fix: enforce scheduler rollout authority

### DIFF
--- a/docs/implementation-decisions/098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md
+++ b/docs/implementation-decisions/098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md
@@ -38,15 +38,17 @@ deadlock.
 The `Authoritative` rollout mode is scenario-local and fail-closed. A queue
 transition is accepted only when the same transaction carries matched
 canonical comparison evidence for the authoritative scenario. Missing or
-divergent evidence rejects the whole transaction without leaving partial
-queue, projection, audit, or comparison writes. A reported hard blocker is a
-fenced command that records the blocker and atomically returns that scenario
-to its configured `Shadow` or `Off` rollback target.
+divergent evidence rejects the queue, projection, audit, comparison, and
+protocol writes, while the same transaction records a revision-fenced hard
+blocker and atomically returns that scenario to its configured `Shadow` or
+`Off` rollback target.
 
 `QueueTransitionCommand` declares its authority scenario requirements
-separately from the optional comparison payloads. This lets the repository
-reject an omitted payload before any queue mutation instead of treating
-absence as an unscoped legacy transition.
+separately from the optional comparison payloads and carries the exact rollout
+configuration, manifest, preflight, and production-capability expectation read
+before the boundary. This lets the repository reject stale authority or an
+omitted payload before any queue mutation instead of treating absence as an
+unscoped legacy transition.
 
 ## Reason
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2038,6 +2038,7 @@ impl RuntimeHandle {
                     scheduler_protocol_bootstrap: None,
                     scheduler_protocol_commands: Vec::new(),
                     scheduler_authority_scenarios: Vec::new(),
+                    scheduler_rollout_expectations: Vec::new(),
                     agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                         expected: Some(Box::new(expected_persisted_state)),
                         record: Box::new(committed_state.clone()),
@@ -2113,6 +2114,14 @@ impl RuntimeHandle {
         brief_evidence: Vec<BriefRecord>,
     ) -> Result<bool> {
         let scheduler_protocol_commands = self.canonical_queue_settlement_commands(&record).await?;
+        let scheduler_rollout_expectations = self
+            .inner
+            .runtime_db
+            .transitions()
+            .scheduler_rollout_expectations(
+                &[scheduler::SETTLEMENT_SCENARIO, scheduler::DELIVERY_SCENARIO],
+                self.scheduler_protocol_production_commands_enabled(),
+            )?;
         let (projection_state, queue_len, agent_state) = {
             let guard = self.inner.agent.lock().await;
             let mut state = committed_agent_state.unwrap_or_else(|| guard.state.clone());
@@ -2169,6 +2178,7 @@ impl RuntimeHandle {
                     scheduler::SETTLEMENT_SCENARIO,
                     scheduler::DELIVERY_SCENARIO,
                 ],
+                scheduler_rollout_expectations,
                 agent_state,
                 message_evidence: Vec::new(),
                 transcript_entries,
@@ -2189,18 +2199,6 @@ impl RuntimeHandle {
         &self,
         record: &QueueEntryRecord,
     ) -> Result<Vec<crate::domain::scheduler_protocol::ProtocolCommand>> {
-        if !self.scheduler_protocol_production_commands_enabled() {
-            return Ok(Vec::new());
-        }
-        if self
-            .inner
-            .runtime_db
-            .transitions()
-            .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
-            != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
-        {
-            return Ok(Vec::new());
-        }
         canonical_queue_settlement_commands_from_facts(
             &self.inner.storage,
             &self.inner.runtime_db,
@@ -2614,6 +2612,7 @@ impl RuntimeHandle {
                     scheduler_protocol_bootstrap: None,
                     scheduler_protocol_commands: Vec::new(),
                     scheduler_authority_scenarios: Vec::new(),
+                    scheduler_rollout_expectations: Vec::new(),
                     agent_state: None,
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),
@@ -2643,17 +2642,19 @@ impl RuntimeHandle {
     }
 
     async fn recover_scheduler_bootstrap_claims(&self) -> Result<usize> {
-        if !self.scheduler_protocol_production_commands_enabled()
-            || self
-                .inner
-                .runtime_db
-                .transitions()
-                .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
-                != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
-        {
+        let scheduler_rollout_expectations = self
+            .inner
+            .runtime_db
+            .transitions()
+            .scheduler_rollout_expectations(
+                &[scheduler::SETTLEMENT_SCENARIO],
+                self.scheduler_protocol_production_commands_enabled(),
+            )?;
+        if scheduler_rollout_expectations.iter().any(|expectation| {
+            expectation.mode != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+        }) {
             return Ok(0);
         }
-
         let agent_id = self.inner.agent.lock().await.state.id.clone();
         let Some(snapshot) = self
             .inner
@@ -2736,6 +2737,7 @@ impl RuntimeHandle {
                         scheduler_protocol_bootstrap: None,
                         scheduler_protocol_commands: Vec::new(),
                         scheduler_authority_scenarios: Vec::new(),
+                        scheduler_rollout_expectations: Vec::new(),
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),
@@ -2786,6 +2788,7 @@ impl RuntimeHandle {
                         scheduler_protocol_bootstrap: None,
                         scheduler_protocol_commands: Vec::new(),
                         scheduler_authority_scenarios: Vec::new(),
+                        scheduler_rollout_expectations: Vec::new(),
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),
@@ -2888,6 +2891,7 @@ impl RuntimeHandle {
                     scheduler_protocol_bootstrap: None,
                     scheduler_protocol_commands,
                     scheduler_authority_scenarios: Vec::new(),
+                    scheduler_rollout_expectations: scheduler_rollout_expectations.clone(),
                     agent_state: None,
                     message_evidence: Vec::new(),
                     transcript_entries: Vec::new(),

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -797,6 +797,14 @@ impl RuntimeHandle {
                 created_at: message.created_at,
                 updated_at: Utc::now(),
             };
+            let scheduler_rollout_expectations = self
+                .inner
+                .runtime_db
+                .transitions()
+                .scheduler_rollout_expectations(
+                    &[scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO],
+                    self.scheduler_protocol_production_commands_enabled(),
+                )?;
             let mut commit = self.inner.runtime_db.transitions().commit_queue(
                 &crate::runtime_db::transitions::QueueTransitionCommand {
                     agent_id: message.agent_id.clone(),
@@ -808,6 +816,7 @@ impl RuntimeHandle {
                     scheduler_authority_scenarios: vec![
                         scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
                     ],
+                    scheduler_rollout_expectations,
                     agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                         expected: Some(Box::new(expected_persisted_state)),
                         record: Box::new(committed_state.clone()),

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -78,6 +78,9 @@ struct CanonicalClaimPlan {
     scheduler_claim_work_item: Option<crate::types::WorkItemRecord>,
     bootstrap: Option<crate::domain::scheduler_protocol::Snapshot>,
     commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
+    rollout_expectations: Vec<
+        crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRolloutExpectation,
+    >,
 }
 
 pub(super) struct SchedulerDecisionExecutor<'a> {
@@ -353,6 +356,18 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &candidate.message,
             dispatch_plan.continuation_resolution.as_ref(),
         );
+        let production_commands_enabled = self
+            .runtime
+            .scheduler_protocol_production_commands_enabled();
+        let mut scheduler_rollout_expectations = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .scheduler_rollout_expectations(
+                &scheduler_authority_scenarios,
+                production_commands_enabled,
+            )?;
         let shadow_comparison = scheduler::shadow_comparison_for_message_admission(
             &projection,
             &candidate.message,
@@ -392,28 +407,41 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &persisted_message,
         )?
         .map(scheduler_semantic_shadow_command);
-        let canonical_claim =
-            match self.canonical_activation_plan(&projection, &persisted_message, &dispatch_plan) {
-                Ok(plan) => plan,
-                Err(error) => {
-                    if let Some(ambiguous) =
-                        error.downcast_ref::<scheduler::AmbiguousCanonicalWaits>()
-                    {
-                        scheduler::append_ambiguous_wait_advisory(
-                            &self.runtime.inner.storage,
-                            &persisted_message,
-                            &ambiguous.wait_condition_ids,
-                        )?;
-                        scheduler::append_scheduling_advisories(
-                            &self.runtime.inner.storage,
-                            &candidate.prior_state,
-                            candidate.queue_len,
-                        )?;
-                        return Ok(RunLoopPoll::Idle);
-                    }
-                    return Err(error);
+        let canonical_claim = match self.canonical_activation_plan(
+            &projection,
+            &persisted_message,
+            &dispatch_plan,
+            production_commands_enabled,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => {
+                if let Some(ambiguous) = error.downcast_ref::<scheduler::AmbiguousCanonicalWaits>()
+                {
+                    scheduler::append_ambiguous_wait_advisory(
+                        &self.runtime.inner.storage,
+                        &persisted_message,
+                        &ambiguous.wait_condition_ids,
+                    )?;
+                    scheduler::append_scheduling_advisories(
+                        &self.runtime.inner.storage,
+                        &candidate.prior_state,
+                        candidate.queue_len,
+                    )?;
+                    return Ok(RunLoopPoll::Idle);
                 }
-            };
+                return Err(error);
+            }
+        };
+        if let Some(plan) = canonical_claim.as_ref() {
+            for expectation in &plan.rollout_expectations {
+                if !scheduler_rollout_expectations
+                    .iter()
+                    .any(|candidate| candidate.scenario_class == expectation.scenario_class)
+                {
+                    scheduler_rollout_expectations.push(expectation.clone());
+                }
+            }
+        }
         scheduler::append_scheduling_advisories(
             &self.runtime.inner.storage,
             &candidate.prior_state,
@@ -468,6 +496,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         .map(|plan| plan.commands.clone())
                         .unwrap_or_default(),
                     scheduler_authority_scenarios,
+                    scheduler_rollout_expectations,
                     agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                         expected: Some(Box::new(guard.state.clone())),
                         record: Box::new(running_state.clone()),
@@ -496,6 +525,12 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     brief_evidence: Vec::new(),
                 },
             )?;
+            if commit.scheduler_authority_blocked {
+                commit.effects.agent_state = None;
+                drop(guard);
+                self.runtime.apply_transition_commit(commit).await;
+                return Ok(RunLoopPoll::Idle);
+            }
             if !commit.applied {
                 let _ = guard.queue.pop_if_next(&candidate.message.id);
                 guard.state.pending = guard.queue.len();
@@ -533,11 +568,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         projection: &scheduler::SchedulerProjection,
         message: &MessageEnvelope,
         dispatch_plan: &MessageDispatchPlan,
+        production_commands_enabled: bool,
     ) -> Result<Option<CanonicalClaimPlan>> {
-        if !self
-            .runtime
-            .scheduler_protocol_production_commands_enabled()
-        {
+        if !production_commands_enabled {
             return Ok(None);
         }
         let task = dispatch_plan.task.as_ref().ok().and_then(Option::as_ref);
@@ -550,21 +583,18 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         else {
             return Ok(None);
         };
-        if self
+        let rollout_expectations = self
             .runtime
             .inner
             .runtime_db
             .transitions()
-            .scheduler_scenario_mode(scenario.scenario_class())?
-            != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
-            || self
-                .runtime
-                .inner
-                .runtime_db
-                .transitions()
-                .scheduler_scenario_mode(scheduler::SETTLEMENT_SCENARIO)?
-                != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
-        {
+            .scheduler_rollout_expectations(
+                &[scenario.scenario_class(), scheduler::SETTLEMENT_SCENARIO],
+                production_commands_enabled,
+            )?;
+        if rollout_expectations.iter().any(|expectation| {
+            expectation.mode != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
+        }) {
             return Ok(None);
         }
 
@@ -645,6 +675,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         .then_some(work_item),
                         bootstrap: None,
                         commands: Vec::new(),
+                        rollout_expectations,
                     }));
                 }
                 return Err(anyhow!(
@@ -887,6 +918,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .then_some(work_item),
             bootstrap,
             commands,
+            rollout_expectations,
         }))
     }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -120,6 +120,11 @@ fn enable_production_protocol_authority_for(
                 "restart_before_settlement_commit",
             ]),
         ),
+        SchedulerScenarioClass::ReducerOnlyCandidates => (
+            10_000,
+            72 * 60 * 60,
+            evidence(&["deterministic_replay", "duplicate_command_idempotency"]),
+        ),
         scenario => panic!("unsupported runtime production authority scenario {scenario:?}"),
     };
     let scenarios = [
@@ -1818,6 +1823,7 @@ async fn stale_bootstrap_recovery_command_cannot_settle_successor_generation() {
             scheduler_protocol_bootstrap: None,
             scheduler_protocol_commands: vec![stale_command],
             scheduler_authority_scenarios: Vec::new(),
+            scheduler_rollout_expectations: Vec::new(),
             agent_state: None,
             message_evidence: Vec::new(),
             transcript_entries: Vec::new(),
@@ -3836,12 +3842,14 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
                 ))
                 .unwrap();
         }
+        runtime.set_scheduler_protocol_production_commands_enabled(true);
+        enable_production_protocol_authority_for(&runtime, &[scenario_class]);
         let connection = runtime.inner.runtime_db.connection().unwrap();
         connection
             .execute(
                 "UPDATE scheduler_protocol_config
                  SET protocol_mode = 'shadow',
-                     config_revision = 1,
+                     config_revision = config_revision + 1,
                      updated_at = CURRENT_TIMESTAMP
                  WHERE config_id = 1",
                 [],
@@ -3849,10 +3857,10 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
             .unwrap();
         connection
             .execute(
-                "INSERT INTO scheduler_scenario_authorities (
-                   scenario_class, mode, rollback_target,
-                   manifest_revision, preflight_revision, updated_at
-                 ) VALUES (?1, 'shadow', 'off', NULL, NULL, CURRENT_TIMESTAMP)",
+                "UPDATE scheduler_scenario_authorities
+                 SET mode = 'shadow',
+                     updated_at = CURRENT_TIMESTAMP
+                 WHERE scenario_class = ?1",
                 [scenario_class.as_str()],
             )
             .unwrap();
@@ -3863,7 +3871,7 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
             .execute(
                 "UPDATE scheduler_protocol_config
                  SET protocol_mode = 'authoritative',
-                     config_revision = 2,
+                     config_revision = config_revision + 1,
                      updated_at = CURRENT_TIMESTAMP
                  WHERE config_id = 1",
                 [],
@@ -3879,26 +3887,43 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
                 [scenario_class.as_str()],
             )
             .unwrap();
+        let authority_revision: i64 = connection
+            .query_row(
+                "SELECT config_revision
+                 FROM scheduler_protocol_config
+                 WHERE config_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         runtime.omit_next_scheduler_claim_shadow_comparison();
 
-        let error = match scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
             .poll()
             .await
-        {
-            Ok(_) => panic!(
-                "expected missing authoritative evidence to reject {}",
-                scenario_class.as_str()
-            ),
-            Err(error) => error,
-        };
-
-        assert!(
-            error
-                .to_string()
-                .contains("requires matched canonical evidence"),
-            "unexpected {} error: {error:#}",
-            scenario_class.as_str()
-        );
+            .unwrap();
+        match poll {
+            scheduler_executor::RunLoopPoll::Idle => {}
+            scheduler_executor::RunLoopPoll::Message(scheduled) => {
+                panic!(
+                    "missing authoritative executor evidence for {} unexpectedly claimed {}",
+                    scenario_class.as_str(),
+                    scheduled.message.id
+                )
+            }
+            scheduler_executor::RunLoopPoll::Shutdown => {
+                panic!(
+                    "missing authoritative executor evidence for {} unexpectedly shut down",
+                    scenario_class.as_str()
+                )
+            }
+            scheduler_executor::RunLoopPoll::Stopped(_, queue_len) => {
+                panic!(
+                    "missing authoritative executor evidence for {} unexpectedly stopped with {queue_len} queued messages",
+                    scenario_class.as_str()
+                )
+            }
+        }
         assert_eq!(runtime.agent_state().await.unwrap(), state_before_claim);
         assert_eq!(runtime.inner.agent.lock().await.queue.len(), 1);
         let entries = runtime
@@ -3918,6 +3943,31 @@ async fn authoritative_claim_scope_rejects_missing_executor_evidence_without_par
             )
             .unwrap();
         assert_eq!(comparison_count, 0);
+        let (
+            scenario_mode,
+            blocker_config_revision,
+            blocker_manifest_revision,
+            blocker_preflight_revision,
+        ): (String, i64, i64, i64) = connection
+            .query_row(
+                "SELECT
+                   scheduler_scenario_authorities.mode,
+                   scheduler_scenario_hard_blockers.config_revision,
+                   scheduler_scenario_hard_blockers.manifest_revision,
+                   scheduler_scenario_hard_blockers.preflight_revision
+                 FROM scheduler_scenario_authorities
+                 JOIN scheduler_scenario_hard_blockers
+                   USING (scenario_class)
+                 WHERE scenario_class = ?1
+                   AND blocker_code = 'canonical_evidence_missing'",
+                [scenario_class.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(scenario_mode, "shadow");
+        assert_eq!(blocker_config_revision, authority_revision);
+        assert_eq!(blocker_manifest_revision, 1);
+        assert_eq!(blocker_preflight_revision, 1);
         let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
         assert!(!events.iter().any(|event| {
             event.kind == "scheduler_decision"
@@ -3947,12 +3997,16 @@ async fn run_loop_stale_head_noops_before_authoritative_fence() {
         context_config(),
     )
     .unwrap();
+    enable_production_protocol_authority_for(
+        &runtime,
+        &[SchedulerScenarioClass::ReducerOnlyCandidates],
+    );
     let connection = runtime.inner.runtime_db.connection().unwrap();
     connection
         .execute(
             "UPDATE scheduler_protocol_config
              SET protocol_mode = 'shadow',
-                 config_revision = 1,
+                 config_revision = config_revision + 1,
                  updated_at = CURRENT_TIMESTAMP
              WHERE config_id = 1",
             [],
@@ -3960,13 +4014,10 @@ async fn run_loop_stale_head_noops_before_authoritative_fence() {
         .unwrap();
     connection
         .execute(
-            "INSERT INTO scheduler_scenario_authorities (
-               scenario_class, mode, rollback_target,
-               manifest_revision, preflight_revision, updated_at
-             ) VALUES (
-               'reducer_only_candidates', 'shadow', 'off',
-               NULL, NULL, CURRENT_TIMESTAMP
-             )",
+            "UPDATE scheduler_scenario_authorities
+             SET mode = 'shadow',
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE scenario_class = 'reducer_only_candidates'",
             [],
         )
         .unwrap();
@@ -4006,7 +4057,7 @@ async fn run_loop_stale_head_noops_before_authoritative_fence() {
         .execute(
             "UPDATE scheduler_protocol_config
              SET protocol_mode = 'authoritative',
-                 config_revision = 2,
+                 config_revision = config_revision + 1,
                  updated_at = CURRENT_TIMESTAMP
              WHERE config_id = 1",
             [],
@@ -4354,29 +4405,8 @@ async fn lifecycle_sleep_work_queue_override_allows_matched_authoritative_eviden
         guard.state.current_work_item_id = Some(work_item_id.clone());
         guard.persist_state(&runtime.inner.storage).unwrap();
     }
+    enable_production_protocol_authority(&runtime);
     let connection = runtime.inner.runtime_db.connection().unwrap();
-    connection
-        .execute(
-            "UPDATE scheduler_protocol_config
-             SET protocol_mode = 'authoritative',
-                 config_revision = 1,
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE config_id = 1",
-            [],
-        )
-        .unwrap();
-    connection
-        .execute(
-            "INSERT INTO scheduler_scenario_authorities (
-               scenario_class, mode, rollback_target,
-               manifest_revision, preflight_revision, updated_at
-             ) VALUES (
-               'work_item_autonomous_continuation', 'authoritative', 'shadow',
-               NULL, NULL, CURRENT_TIMESTAMP
-             )",
-            [],
-        )
-        .unwrap();
 
     runtime.transition_to_sleep(None).await.unwrap();
 
@@ -7695,6 +7725,7 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
             scheduler_protocol_bootstrap: None,
             scheduler_protocol_commands: Vec::new(),
             scheduler_authority_scenarios: Vec::new(),
+            scheduler_rollout_expectations: Vec::new(),
             agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                 expected: Some(Box::new(expected)),
                 record: Box::new(committed),

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -360,12 +360,15 @@ impl RuntimeHandle {
                     break;
                 };
                 let expected_state = guard.state.clone();
+                let production_commands_enabled =
+                    self.scheduler_protocol_production_commands_enabled();
                 let protocol_commands = self.operator_interjection_protocol_commands(
                     agent_id,
                     &expected_state,
                     &message,
                     round,
                     boundary_str,
+                    production_commands_enabled,
                 )?;
                 let mut committed_state = expected_state.clone();
                 committed_state.pending = guard.queue.len().saturating_sub(1);
@@ -430,6 +433,14 @@ impl RuntimeHandle {
                         ),
                     }),
                 );
+                let scheduler_rollout_expectations = self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .scheduler_rollout_expectations(
+                        &[scheduler::INTERJECTION_SCENARIO],
+                        production_commands_enabled,
+                    )?;
                 let mut commit = self.inner.runtime_db.transitions().commit_queue(
                     &crate::runtime_db::transitions::QueueTransitionCommand {
                         agent_id: message.agent_id.clone(),
@@ -441,6 +452,7 @@ impl RuntimeHandle {
                         scheduler_protocol_bootstrap: None,
                         scheduler_protocol_commands: protocol_commands,
                         scheduler_authority_scenarios: vec![scheduler::INTERJECTION_SCENARIO],
+                        scheduler_rollout_expectations,
                         agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                             expected: Some(Box::new(expected_state)),
                             record: Box::new(committed_state.clone()),
@@ -457,6 +469,11 @@ impl RuntimeHandle {
                         brief_evidence: Vec::new(),
                     },
                 )?;
+                if commit.scheduler_authority_blocked {
+                    drop(guard);
+                    self.apply_transition_commit(commit).await;
+                    break;
+                }
                 if !commit.applied {
                     return Err(anyhow::anyhow!(
                         "interjection settlement made no durable progress"
@@ -484,13 +501,14 @@ impl RuntimeHandle {
         message: &MessageEnvelope,
         round: usize,
         boundary: &str,
+        production_commands_enabled: bool,
     ) -> Result<Vec<crate::domain::scheduler_protocol::ProtocolCommand>> {
         use crate::domain::scheduler_protocol::{
             ActivationInputAttachment, ActivationOrigin, ActivationProvenance, ActivationTrust,
             AttachActivationInputCommand, ProtocolCommand, ScenarioMode,
         };
 
-        if !self.scheduler_protocol_production_commands_enabled()
+        if !production_commands_enabled
             || self
                 .inner
                 .runtime_db

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3477,6 +3477,29 @@ pub(crate) fn try_claim_queued_message_tx(
     try_transition_claimable_message_tx(tx, record, QueueEntryStatus::Dequeued, true)
 }
 
+pub(crate) fn queue_entry_is_claimable_tx(
+    tx: &Transaction<'_>,
+    record: &QueueEntryRecord,
+    include_interrupted: bool,
+) -> Result<bool> {
+    let status = tx
+        .query_row(
+            "SELECT status
+             FROM queue_entries
+             WHERE message_id = ?1 AND agent_id = ?2",
+            params![record.message_id, record.agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(status.is_some_and(|status| {
+        status == enum_string(&QueueEntryStatus::Queued).expect("queue status serializes")
+            || (include_interrupted
+                && status
+                    == enum_string(&QueueEntryStatus::Interrupted)
+                        .expect("queue status serializes"))
+    }))
+}
+
 pub(crate) fn try_interject_queued_message_tx(
     tx: &Transaction<'_>,
     record: &QueueEntryRecord,

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -2638,6 +2638,9 @@ mod tests {
                     .commit_scheduler_rollout_command(&identity, &command, None)?;
                 assert_eq!(committed.result.decision, expected_decision);
             }
+            let authoritative_expectations = db
+                .transitions()
+                .scheduler_rollout_expectations(&[scenario], true)?;
 
             let now = Utc::now();
             let matched_queue_record = QueueEntryRecord {
@@ -2656,6 +2659,7 @@ mod tests {
                 scheduler_protocol_bootstrap: None,
                 scheduler_protocol_commands: Vec::new(),
                 scheduler_authority_scenarios: vec![scenario],
+                scheduler_rollout_expectations: authoritative_expectations,
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),
@@ -2696,17 +2700,46 @@ mod tests {
                 scheduler_shadow_comparison: None,
                 ..matched_queue_command.clone()
             };
-            let error = db
-                .transitions()
-                .commit_queue(&missing_queue_command)
-                .unwrap_err();
-            assert!(error
-                .to_string()
-                .contains("requires matched canonical evidence"));
+            let blocked = db.transitions().commit_queue(&missing_queue_command)?;
+            assert!(blocked.applied);
+            assert!(blocked.scheduler_authority_blocked);
             assert_eq!(
                 db.queue_entries().latest_all()?,
                 vec![matched_queue_record.clone()]
             );
+            let after_missing = db
+                .transitions()
+                .load_scheduler_protocol_snapshot("agent-a")?;
+            assert_eq!(
+                after_missing.rollout.scenarios[scenario_class].mode,
+                ScenarioMode::Shadow
+            );
+            assert!(after_missing.rollout.hard_blockers.iter().any(|blocker| {
+                blocker.scenario_class == scenario_class
+                    && blocker.blocker_code == "canonical_evidence_missing"
+                    && blocker.config_revision == 4
+                    && blocker.manifest_revision == 1
+                    && blocker.preflight_revision == 1
+            }));
+
+            let reauthorized = db.transitions().commit_scheduler_rollout_command(
+                &format!("{scenario_class}-reauthorize-after-missing"),
+                &RolloutCommand::ChangeScenarioAuthority {
+                    scenario_class: scenario_class.into(),
+                    expected_config_revision: 5,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                    mode: ScenarioMode::Authoritative,
+                },
+                None,
+            )?;
+            assert_eq!(
+                reauthorized.result.decision,
+                Decision::ScenarioAuthorityChanged
+            );
+            let authoritative_expectations = db
+                .transitions()
+                .scheduler_rollout_expectations(&[scenario], true)?;
 
             let divergent_queue_record = QueueEntryRecord {
                 message_id: format!("message-divergent-{scenario_class}"),
@@ -2714,6 +2747,7 @@ mod tests {
             };
             let divergent_queue_command = QueueTransitionCommand {
                 mutation: QueueMutation::Upsert(divergent_queue_record.clone()),
+                scheduler_rollout_expectations: authoritative_expectations,
                 scheduler_shadow_comparison: Some(SchedulerShadowComparisonCommand {
                     scenario_class: scenario_class.into(),
                     comparison_identity: format!("comparison-divergent-{scenario_class}"),
@@ -2726,13 +2760,9 @@ mod tests {
                 }),
                 ..matched_queue_command.clone()
             };
-            let error = db
-                .transitions()
-                .commit_queue(&divergent_queue_command)
-                .unwrap_err();
-            assert!(error
-                .to_string()
-                .contains("rejected divergent canonical evidence"));
+            let blocked = db.transitions().commit_queue(&divergent_queue_command)?;
+            assert!(blocked.applied);
+            assert!(blocked.scheduler_authority_blocked);
             assert_eq!(
                 db.queue_entries().latest_all()?,
                 vec![matched_queue_record.clone()]
@@ -2744,24 +2774,34 @@ mod tests {
                 |row| row.get(0),
             )?;
             assert_eq!(comparison_count, 1);
-
-            let rolled_back = db.transitions().commit_scheduler_rollout_command(
-                &format!("{scenario_class}-hard-blocker"),
-                &RolloutCommand::ReportScenarioHardBlocker {
-                    scenario_class: scenario_class.into(),
-                    blocker_code: "canonical_evidence_diverged".into(),
-                    expected_config_revision: 4,
-                    expected_manifest_revision: 1,
-                    expected_preflight_revision: 1,
-                },
-                None,
-            )?;
-            assert_eq!(rolled_back.result.decision, Decision::RollbackTripped);
-            assert!(
-                db.transitions()
-                    .commit_queue(&divergent_queue_command)?
-                    .applied
+            let after_divergence = db
+                .transitions()
+                .load_scheduler_protocol_snapshot("agent-a")?;
+            assert_eq!(
+                after_divergence.rollout.scenarios[scenario_class].mode,
+                ScenarioMode::Shadow
             );
+            assert!(after_divergence
+                .rollout
+                .hard_blockers
+                .iter()
+                .any(|blocker| {
+                    blocker.scenario_class == scenario_class
+                        && blocker.blocker_code == "phase5h_cutover_mismatch"
+                        && blocker.config_revision == 6
+                        && blocker.manifest_revision == 1
+                        && blocker.preflight_revision == 1
+                }));
+            let fallback_expectations = db
+                .transitions()
+                .scheduler_rollout_expectations(&[scenario], true)?;
+            let fallback_queue_command = QueueTransitionCommand {
+                scheduler_rollout_expectations: fallback_expectations,
+                ..divergent_queue_command
+            };
+            let fallback = db.transitions().commit_queue(&fallback_queue_command)?;
+            assert!(fallback.applied);
+            assert!(!fallback.scheduler_authority_blocked);
             drop(db);
 
             let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -2868,10 +2908,17 @@ mod tests {
                 .commit_scheduler_rollout_command(identity, &command, None)?;
             assert!(committed.applied);
         }
+        let authoritative_expectations = db.transitions().scheduler_rollout_expectations(
+            &[SCENARIO_CLASS
+                .parse::<SchedulerScenarioClass>()
+                .expect("registered scheduler scenario class")],
+            true,
+        )?;
 
         let mut handles = Vec::new();
         for writer_index in 0..WRITERS {
             let writer = db.clone();
+            let authoritative_expectations = authoritative_expectations.clone();
             handles.push(std::thread::spawn(move || -> Result<()> {
                 for commit_index in 0..COMMITS_PER_WRITER {
                     let identity = format!("{writer_index}-{commit_index}");
@@ -2894,6 +2941,7 @@ mod tests {
                         scheduler_authority_scenarios: vec![SCENARIO_CLASS
                             .parse::<SchedulerScenarioClass>()
                             .expect("registered scheduler scenario class")],
+                        scheduler_rollout_expectations: authoritative_expectations.clone(),
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -118,6 +118,7 @@ pub(crate) struct AgentStateMutation {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct TransitionCommit {
     pub applied: bool,
+    pub scheduler_authority_blocked: bool,
     pub effects: PostCommitEffects,
 }
 
@@ -174,6 +175,8 @@ pub(crate) struct QueueTransitionCommand {
     pub scheduler_protocol_commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
     pub scheduler_authority_scenarios:
         Vec<crate::domain::scheduler_protocol::SchedulerScenarioClass>,
+    pub scheduler_rollout_expectations:
+        Vec<scheduler_protocol_repository::SchedulerRolloutExpectation>,
     pub agent_state: Option<AgentStateMutation>,
     pub message_evidence: Vec<MessageEnvelope>,
     pub transcript_entries: Vec<TranscriptEntry>,
@@ -365,6 +368,22 @@ impl RuntimeTransitionRepository<'_> {
         self.db.transaction(|tx| {
             validate_queue_operation(command)?;
             validate_queue_mutation_tx(tx, &command.mutation)?;
+            if let QueueMutation::Consume(record) = &command.mutation {
+                let include_interrupted = match command.operation {
+                    QueueOperation::Claim => true,
+                    QueueOperation::Interject => false,
+                    QueueOperation::Admit | QueueOperation::Release | QueueOperation::Settle => {
+                        unreachable!("queue operation validation rejects this combination")
+                    }
+                };
+                if !crate::runtime_db::repositories::queue_entry_is_claimable_tx(
+                    tx,
+                    record,
+                    include_interrupted,
+                )? {
+                    return Ok(TransitionCommit::default());
+                }
+            }
             validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             validate_scheduler_claim_work_item_tx(
                 tx,
@@ -375,6 +394,7 @@ impl RuntimeTransitionRepository<'_> {
             scheduler_protocol_repository::validate_protocol_command_authority_tx(
                 tx,
                 &command.scheduler_protocol_commands,
+                &command.scheduler_rollout_expectations,
             )?;
             let scheduler_protocol = scheduler_protocol_repository::validate_protocol_commands_tx(
                 tx,
@@ -382,14 +402,27 @@ impl RuntimeTransitionRepository<'_> {
                 command.scheduler_protocol_bootstrap.as_ref(),
                 &command.scheduler_protocol_commands,
             )?;
-            scheduler_protocol_repository::validate_required_shadow_comparisons_tx(
-                tx,
-                &command.scheduler_authority_scenarios,
-                [
-                    command.scheduler_shadow_comparison.as_ref(),
-                    command.scheduler_delivery_shadow_comparison.as_ref(),
-                ],
-            )?;
+            if let Some(blocker) =
+                scheduler_protocol_repository::validate_required_shadow_comparisons_tx(
+                    tx,
+                    &command.scheduler_authority_scenarios,
+                    &command.scheduler_rollout_expectations,
+                    [
+                        command.scheduler_shadow_comparison.as_ref(),
+                        command.scheduler_delivery_shadow_comparison.as_ref(),
+                    ],
+                )?
+            {
+                scheduler_protocol_repository::persist_authority_hard_blocker_tx(tx, &blocker)?;
+                return Ok(TransitionCommit {
+                    applied: true,
+                    scheduler_authority_blocked: true,
+                    effects: PostCommitEffects {
+                        notify_scheduler: true,
+                        ..PostCommitEffects::default()
+                    },
+                });
+            }
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
             let mutation_applied = match &command.mutation {
                 QueueMutation::Consume(record) => match command.operation {
@@ -571,6 +604,7 @@ fn finish_transition_tx(
     effects.fault = fault.filter(|point| point.is_post_commit());
     Ok(TransitionCommit {
         applied: true,
+        scheduler_authority_blocked: false,
         effects,
     })
 }
@@ -977,6 +1011,11 @@ fn inject_fault(
 mod tests {
     use super::*;
     use crate::{
+        domain::scheduler_protocol::{
+            Decision, ObservationalDivergenceAllowance, ProtocolMode, RollbackAction,
+            RollbackPolicy, RollbackTrigger, RolloutClassEvidence, RolloutCommand, RolloutManifest,
+            ScenarioMode, SchedulerScenarioClass,
+        },
         runtime_db::{RuntimeIndexChange, RuntimeIndexOperation},
         types::{
             Priority, QueueEntryStatus, TaskKind, TaskStatus, WaitConditionKind,
@@ -984,6 +1023,7 @@ mod tests {
         },
     };
     use chrono::Utc;
+    use std::collections::{BTreeMap, BTreeSet};
     use tempfile::TempDir;
 
     fn runtime_db() -> Result<(TempDir, RuntimeDb)> {
@@ -993,6 +1033,134 @@ mod tests {
             dir.path().join("state/runtime.lock"),
         )?;
         Ok((dir, db))
+    }
+
+    fn enable_authoritative_reducer(
+        db: &RuntimeDb,
+    ) -> Result<Vec<scheduler_protocol_repository::SchedulerRolloutExpectation>> {
+        let evidence: BTreeSet<String> = [
+            "restart",
+            "fault_injection",
+            "rollback_drill",
+            "deterministic_replay",
+            "duplicate_command_idempotency",
+        ]
+        .into_iter()
+        .map(Into::into)
+        .collect();
+        let manifest = RolloutManifest {
+            revision: 1,
+            preflight_revision: 1,
+            preflight_for_manifest_revision: 1,
+            preflight_succeeded: true,
+            protocol_build: "holon-transition-test".into(),
+            schema_build: "scheduler-protocol-schema-v1".into(),
+            schema_revision: 1,
+            fixture_corpus_revision: "transition-authority-v1".into(),
+            classes: BTreeMap::from([(
+                SchedulerScenarioClass::ReducerOnlyCandidates
+                    .as_str()
+                    .to_string(),
+                RolloutClassEvidence {
+                    configured_mode: ScenarioMode::Authoritative,
+                    minimum_shadow_samples: 10_000,
+                    minimum_shadow_duration_secs: 72 * 60 * 60,
+                    observed_shadow_samples: 10_000,
+                    observed_shadow_duration_secs: 72 * 60 * 60,
+                    maximum_p99_latency_regression_bps: 500,
+                    observed_p99_latency_regression_bps: 0,
+                    hard_blocker_count: 0,
+                    unresolved_divergence_count: 0,
+                    required_evidence: evidence.clone(),
+                    verified_evidence: evidence,
+                    rollback_policy: RollbackPolicy {
+                        trigger: RollbackTrigger::AnyHardBlocker,
+                        action: RollbackAction::StopAdmissionsAndRevert {
+                            target: ScenarioMode::Shadow,
+                        },
+                    },
+                },
+            )]),
+            safety_divergence_bps: 0,
+            canonical_state_divergence_bps: 0,
+            allowed_observational_divergence: BTreeMap::from([(
+                "diagnostic_order".into(),
+                ObservationalDivergenceAllowance {
+                    maximum_rate_bps: 0,
+                    reviewed_by: "transition-test".into(),
+                },
+            )]),
+            approver: "transition-test".into(),
+            approved_at: "2026-07-23T00:00:00Z".into(),
+        };
+        for (identity, command, expected) in [
+            (
+                "transition-authority-open",
+                RolloutCommand::OpenPreflight {
+                    expected_config_revision: 0,
+                    manifest_revision: 1,
+                },
+                Decision::RolloutPreflightOpened,
+            ),
+            (
+                "transition-authority-complete",
+                RolloutCommand::CompletePreflight {
+                    expected_config_revision: 0,
+                    expected_preflight_revision: 1,
+                    manifest: manifest.clone(),
+                },
+                Decision::RolloutPreflightCompleted,
+            ),
+            (
+                "transition-authority-install",
+                RolloutCommand::InstallManifest {
+                    expected_config_revision: 0,
+                    manifest,
+                },
+                Decision::ManifestInstalled,
+            ),
+            (
+                "transition-authority-protocol",
+                RolloutCommand::ConfigureProtocol {
+                    expected_config_revision: 1,
+                    mode: ProtocolMode::Authoritative,
+                },
+                Decision::ProtocolConfigured,
+            ),
+            (
+                "transition-authority-shadow",
+                RolloutCommand::ChangeScenarioAuthority {
+                    scenario_class: SchedulerScenarioClass::ReducerOnlyCandidates
+                        .as_str()
+                        .into(),
+                    expected_config_revision: 2,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                    mode: ScenarioMode::Shadow,
+                },
+                Decision::ScenarioAuthorityChanged,
+            ),
+            (
+                "transition-authority-authoritative",
+                RolloutCommand::ChangeScenarioAuthority {
+                    scenario_class: SchedulerScenarioClass::ReducerOnlyCandidates
+                        .as_str()
+                        .into(),
+                    expected_config_revision: 3,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                    mode: ScenarioMode::Authoritative,
+                },
+                Decision::ScenarioAuthorityChanged,
+            ),
+        ] {
+            let committed = db
+                .transitions()
+                .commit_scheduler_rollout_command(identity, &command, None)?;
+            assert_eq!(committed.result.decision, expected);
+        }
+        db.transitions()
+            .scheduler_rollout_expectations(&[SchedulerScenarioClass::ReducerOnlyCandidates], true)
     }
 
     fn index_change(kind: &str, id: &str) -> RuntimeIndexChange {
@@ -1363,6 +1531,7 @@ mod tests {
                     scheduler_protocol_bootstrap: None,
                     scheduler_protocol_commands: Vec::new(),
                     scheduler_authority_scenarios: Vec::new(),
+                    scheduler_rollout_expectations: Vec::new(),
                     agent_state: Some(AgentStateMutation {
                         expected: Some(Box::new(initial_state.clone())),
                         record: Box::new(settled_state),
@@ -1421,6 +1590,7 @@ mod tests {
             scheduler_protocol_bootstrap: None,
             scheduler_protocol_commands: Vec::new(),
             scheduler_authority_scenarios: Vec::new(),
+            scheduler_rollout_expectations: Vec::new(),
             agent_state: None,
             message_evidence: Vec::new(),
             transcript_entries: Vec::new(),
@@ -1477,6 +1647,7 @@ mod tests {
                 scheduler_protocol_bootstrap: None,
                 scheduler_protocol_commands: Vec::new(),
                 scheduler_authority_scenarios: Vec::new(),
+                scheduler_rollout_expectations: Vec::new(),
                 agent_state: None,
                 message_evidence: Vec::new(),
                 transcript_entries: Vec::new(),
@@ -1570,6 +1741,7 @@ mod tests {
                     scheduler_authority_scenarios: vec![
                         crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
                     ],
+                    scheduler_rollout_expectations: Vec::new(),
                     agent_state: Some(AgentStateMutation {
                         expected: Some(Box::new(initial_state.clone())),
                         record: Box::new(running_state),
@@ -1621,25 +1793,7 @@ mod tests {
     #[test]
     fn authoritative_queue_claim_commits_only_with_matched_canonical_evidence() -> Result<()> {
         let (_dir, db) = runtime_db()?;
-        let connection = db.connection()?;
-        connection.execute(
-            "UPDATE scheduler_protocol_config
-             SET protocol_mode = 'authoritative',
-                 config_revision = 1,
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE config_id = 1",
-            [],
-        )?;
-        connection.execute(
-            "INSERT INTO scheduler_scenario_authorities (
-               scenario_class, mode, rollback_target,
-               manifest_revision, preflight_revision, updated_at
-             ) VALUES (
-               'reducer_only_candidates', 'authoritative', 'shadow',
-               NULL, NULL, CURRENT_TIMESTAMP
-             )",
-            [],
-        )?;
+        let rollout_expectations = enable_authoritative_reducer(&db)?;
 
         let now = Utc::now();
         let queued = QueueEntryRecord {
@@ -1665,6 +1819,7 @@ mod tests {
             scheduler_authority_scenarios: vec![
                 crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
             ],
+            scheduler_rollout_expectations: rollout_expectations,
             agent_state: None,
             message_evidence: Vec::new(),
             transcript_entries: Vec::new(),
@@ -1711,27 +1866,9 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_queue_claim_rejects_divergence_without_partial_writes() -> Result<()> {
+    fn authoritative_queue_claim_rolls_back_on_divergence_without_partial_writes() -> Result<()> {
         let (_dir, db) = runtime_db()?;
-        let connection = db.connection()?;
-        connection.execute(
-            "UPDATE scheduler_protocol_config
-             SET protocol_mode = 'authoritative',
-                 config_revision = 1,
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE config_id = 1",
-            [],
-        )?;
-        connection.execute(
-            "INSERT INTO scheduler_scenario_authorities (
-               scenario_class, mode, rollback_target,
-               manifest_revision, preflight_revision, updated_at
-             ) VALUES (
-               'reducer_only_candidates', 'authoritative', 'shadow',
-               NULL, NULL, CURRENT_TIMESTAMP
-             )",
-            [],
-        )?;
+        let rollout_expectations = enable_authoritative_reducer(&db)?;
 
         let now = Utc::now();
         let queued = QueueEntryRecord {
@@ -1747,54 +1884,51 @@ mod tests {
         claimed.status = QueueEntryStatus::Dequeued;
         claimed.updated_at += chrono::Duration::seconds(1);
 
-        let error = db
-            .transitions()
-            .commit_queue(&QueueTransitionCommand {
-                agent_id: "agent-a".into(),
-                operation: QueueOperation::Claim,
-                mutation: QueueMutation::Consume(claimed),
-                scheduler_claim_work_item: None,
-                scheduler_protocol_bootstrap: None,
-                scheduler_protocol_commands: Vec::new(),
-                scheduler_authority_scenarios: vec![
-                    crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
-                ],
-                agent_state: None,
-                message_evidence: Vec::new(),
-                transcript_entries: Vec::new(),
-                turn_record: None,
-                audit_events: vec![AuditEvent::legacy(
-                    "authoritative_claim",
-                    serde_json::json!({}),
-                )],
-                scheduler_semantic_shadow: None,
-                scheduler_shadow_comparison: Some(
-                    scheduler_protocol_repository::SchedulerShadowComparisonCommand {
-                        scenario_class: "reducer_only_candidates".into(),
-                        comparison_identity: "message_admission:message-authoritative-divergence"
-                            .into(),
-                        boundary: "run_loop".into(),
-                        input_identity: "message:message-authoritative-divergence".into(),
-                        legacy_observation: serde_json::json!({
-                            "legacy_decision": "start_model_turn"
-                        }),
-                        shadow_candidate: serde_json::json!({
-                            "action": "reduce_message_only"
-                        }),
-                        matched: false,
-                        divergence_code: Some("message_admission_outcome_mismatch".into()),
-                    },
-                ),
-                scheduler_delivery_shadow_comparison: None,
-                notify_scheduler: false,
-                fault: None,
-                brief_evidence: Vec::new(),
-            })
-            .unwrap_err();
+        let committed = db.transitions().commit_queue(&QueueTransitionCommand {
+            agent_id: "agent-a".into(),
+            operation: QueueOperation::Claim,
+            mutation: QueueMutation::Consume(claimed),
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: Vec::new(),
+            scheduler_authority_scenarios: vec![
+                crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
+            ],
+            scheduler_rollout_expectations: rollout_expectations,
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: vec![AuditEvent::legacy(
+                "authoritative_claim",
+                serde_json::json!({}),
+            )],
+            scheduler_semantic_shadow: None,
+            scheduler_shadow_comparison: Some(
+                scheduler_protocol_repository::SchedulerShadowComparisonCommand {
+                    scenario_class: "reducer_only_candidates".into(),
+                    comparison_identity: "message_admission:message-authoritative-divergence"
+                        .into(),
+                    boundary: "run_loop".into(),
+                    input_identity: "message:message-authoritative-divergence".into(),
+                    legacy_observation: serde_json::json!({
+                        "legacy_decision": "start_model_turn"
+                    }),
+                    shadow_candidate: serde_json::json!({
+                        "action": "reduce_message_only"
+                    }),
+                    matched: false,
+                    divergence_code: Some("message_admission_outcome_mismatch".into()),
+                },
+            ),
+            scheduler_delivery_shadow_comparison: None,
+            notify_scheduler: false,
+            fault: None,
+            brief_evidence: Vec::new(),
+        })?;
 
-        assert!(error
-            .to_string()
-            .contains("rejected divergent canonical evidence"));
+        assert!(committed.applied);
+        assert!(committed.scheduler_authority_blocked);
         assert_eq!(db.queue_entries().latest_all()?, vec![queued]);
         assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
         let comparison_count: i64 = db.connection()?.query_row(
@@ -1803,6 +1937,27 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(comparison_count, 0);
+        let connection = db.connection()?;
+        let scenario_mode: String = connection.query_row(
+            "SELECT mode
+             FROM scheduler_scenario_authorities
+             WHERE scenario_class = ?1",
+            [SchedulerScenarioClass::ReducerOnlyCandidates.as_str()],
+            |row| row.get(0),
+        )?;
+        assert_eq!(scenario_mode, "shadow");
+        let blocker_count: i64 = connection.query_row(
+            "SELECT COUNT(*)
+             FROM scheduler_scenario_hard_blockers
+             WHERE scenario_class = ?1
+               AND blocker_code = 'message_admission_outcome_mismatch'
+               AND config_revision = 4
+               AND manifest_revision = 1
+               AND preflight_revision = 1",
+            [SchedulerScenarioClass::ReducerOnlyCandidates.as_str()],
+            |row| row.get(0),
+        )?;
+        assert_eq!(blocker_count, 1);
         Ok(())
     }
 

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -53,6 +53,25 @@ pub(crate) struct SchedulerSemanticShadowCommand {
     pub policy: SemanticValidationPolicy,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SchedulerRolloutExpectation {
+    pub scenario_class: SchedulerScenarioClass,
+    pub production_commands_enabled: bool,
+    pub mode: ScenarioMode,
+    pub config_revision: u64,
+    pub manifest_revision: Option<u64>,
+    pub preflight_revision: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SchedulerAuthorityHardBlocker {
+    pub scenario_class: SchedulerScenarioClass,
+    pub blocker_code: String,
+    pub expected_config_revision: u64,
+    pub expected_manifest_revision: u64,
+    pub expected_preflight_revision: u64,
+}
+
 pub(super) struct PreparedShadowComparison {
     command: SchedulerShadowComparisonCommand,
     payload_hash: String,
@@ -174,30 +193,118 @@ enum CommandTransactionOutcome<T> {
 pub(super) fn validate_required_shadow_comparisons_tx(
     tx: &Transaction<'_>,
     required_scenarios: &[SchedulerScenarioClass],
+    expectations: &[SchedulerRolloutExpectation],
     commands: [Option<&SchedulerShadowComparisonCommand>; 2],
-) -> Result<()> {
+) -> Result<Option<SchedulerAuthorityHardBlocker>> {
+    let rollout = load_rollout(tx)?;
+    validate_rollout_expectations(&rollout, expectations)?;
     for scenario_class in required_scenarios {
-        if effective_scenario_mode_tx(tx, scenario_class.as_str())? != ScenarioMode::Authoritative {
+        let expectation = expectations
+            .iter()
+            .find(|expectation| expectation.scenario_class == *scenario_class)
+            .ok_or_else(|| {
+                anyhow!(
+                    "scheduler authority boundary is missing rollout expectation for {}",
+                    scenario_class.as_str()
+                )
+            })?;
+        if expectation.mode != ScenarioMode::Authoritative {
             continue;
         }
-        let has_evidence = commands
+        let evidence = commands
             .iter()
             .flatten()
-            .any(|command| command.scenario_class == scenario_class.as_str());
-        if !has_evidence {
+            .find(|command| command.scenario_class == expectation.scenario_class.as_str());
+        let blocker_code = match evidence {
+            None => Some("canonical_evidence_missing".to_string()),
+            Some(command) if !command.matched => Some(
+                command
+                    .divergence_code
+                    .clone()
+                    .unwrap_or_else(|| "canonical_evidence_diverged".to_string()),
+            ),
+            Some(_) => None,
+        };
+        if let Some(blocker_code) = blocker_code {
+            return Ok(Some(SchedulerAuthorityHardBlocker {
+                scenario_class: expectation.scenario_class,
+                blocker_code,
+                expected_config_revision: expectation.config_revision,
+                expected_manifest_revision: expectation.manifest_revision.ok_or_else(|| {
+                    anyhow!(
+                        "authoritative scheduler scenario {} is missing a manifest revision",
+                        expectation.scenario_class.as_str()
+                    )
+                })?,
+                expected_preflight_revision: expectation.preflight_revision.ok_or_else(|| {
+                    anyhow!(
+                        "authoritative scheduler scenario {} is missing a preflight revision",
+                        expectation.scenario_class.as_str()
+                    )
+                })?,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn persist_authority_hard_blocker_tx(
+    tx: &Transaction<'_>,
+    blocker: &SchedulerAuthorityHardBlocker,
+) -> Result<()> {
+    let previous = load_rollout(tx)?;
+    let command = RolloutCommand::ReportScenarioHardBlocker {
+        scenario_class: blocker.scenario_class.as_str().to_string(),
+        blocker_code: blocker.blocker_code.clone(),
+        expected_config_revision: blocker.expected_config_revision,
+        expected_manifest_revision: blocker.expected_manifest_revision,
+        expected_preflight_revision: blocker.expected_preflight_revision,
+    };
+    let outcome =
+        scheduler_protocol::reduce_rollout_command(&rollout_snapshot(previous.clone()), &command);
+    if outcome.outcome.decision != Decision::RollbackTripped {
+        bail!(
+            "scheduler authority hard blocker was rejected: {:?}",
+            outcome.outcome.diagnostics
+        );
+    }
+    scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
+        anyhow!("scheduler hard blocker produced invalid rollout state: {error}")
+    })?;
+    persist_rollout_tx(tx, &previous, &outcome.outcome.snapshot.rollout)
+}
+
+pub(super) fn validate_protocol_command_authority_tx(
+    tx: &Transaction<'_>,
+    commands: &[ProtocolCommand],
+    expectations: &[SchedulerRolloutExpectation],
+) -> Result<()> {
+    let rollout = load_rollout(tx)?;
+    validate_rollout_expectations(&rollout, expectations)?;
+    for required_scenario in required_protocol_command_scenarios(commands) {
+        let expectation = expectations
+            .iter()
+            .find(|expectation| expectation.scenario_class == required_scenario)
+            .ok_or_else(|| {
+                anyhow!(
+                    "scheduler protocol production command is missing rollout expectation for {}",
+                    required_scenario.as_str()
+                )
+            })?;
+        if expectation.mode != ScenarioMode::Authoritative {
             bail!(
-                "scheduler scenario {} requires matched canonical evidence",
-                scenario_class.as_str()
+                "scheduler protocol production commands require authoritative scenario {}, got {:?}",
+                required_scenario.as_str(),
+                expectation.mode
             );
         }
     }
     Ok(())
 }
 
-pub(super) fn validate_protocol_command_authority_tx(
-    tx: &Transaction<'_>,
+fn required_protocol_command_scenarios(
     commands: &[ProtocolCommand],
-) -> Result<()> {
+) -> BTreeSet<SchedulerScenarioClass> {
     let mut required_scenarios = BTreeSet::new();
     for command in commands {
         match command {
@@ -212,9 +319,7 @@ pub(super) fn validate_protocol_command_authority_tx(
                 required_scenarios.insert(activation_authority_scenario(&command.activation));
                 required_scenarios.insert(SchedulerScenarioClass::Settlement);
             }
-            ProtocolCommand::TriggerWait(_) => {
-                required_scenarios.insert(SchedulerScenarioClass::ExactWaitResume);
-            }
+            ProtocolCommand::TriggerWait(_) => {}
             ProtocolCommand::AttachActivationInput(_) => {
                 required_scenarios.insert(SchedulerScenarioClass::OperatorInterjection);
             }
@@ -223,17 +328,7 @@ pub(super) fn validate_protocol_command_authority_tx(
             }
         }
     }
-    for required_scenario in required_scenarios {
-        let mode = effective_scenario_mode_tx(tx, required_scenario.as_str())?;
-        if mode != ScenarioMode::Authoritative {
-            bail!(
-                "scheduler protocol production commands require authoritative scenario {}, got {:?}",
-                required_scenario.as_str(),
-                mode
-            );
-        }
-    }
-    Ok(())
+    required_scenarios
 }
 
 fn activation_authority_scenario(
@@ -589,37 +684,124 @@ pub(super) fn persist_semantic_shadow_decision_tx(
     Ok(())
 }
 
-fn effective_scenario_mode_tx(tx: &Transaction<'_>, scenario_class: &str) -> Result<ScenarioMode> {
-    let protocol_mode = tx.query_row(
-        "SELECT protocol_mode
-         FROM scheduler_protocol_config
-         WHERE config_id = 1",
-        [],
-        |row| row.get::<_, String>(0),
-    )?;
-    let scenario_mode = tx
-        .query_row(
-            "SELECT mode
-             FROM scheduler_scenario_authorities
-             WHERE scenario_class = ?1",
-            [scenario_class],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()?;
-
-    match (protocol_mode.as_str(), scenario_mode.as_deref()) {
-        ("legacy", _) | (_, None | Some("off")) => Ok(ScenarioMode::Off),
-        ("shadow", Some("shadow")) | ("authoritative", Some("shadow")) => {
-            Ok(ScenarioMode::Shadow)
+fn effective_scenario_mode(
+    rollout: &RolloutState,
+    scenario_class: SchedulerScenarioClass,
+) -> Result<ScenarioMode> {
+    let scenario_mode = rollout
+        .scenarios
+        .get(scenario_class.as_str())
+        .map(|scenario| scenario.mode)
+        .unwrap_or(ScenarioMode::Off);
+    match (rollout.protocol_mode, scenario_mode) {
+        (ProtocolMode::Legacy, _) | (_, ScenarioMode::Off) => Ok(ScenarioMode::Off),
+        (ProtocolMode::Shadow, ScenarioMode::Shadow)
+        | (ProtocolMode::Authoritative, ScenarioMode::Shadow) => Ok(ScenarioMode::Shadow),
+        (ProtocolMode::Authoritative, ScenarioMode::Authoritative) => {
+            Ok(ScenarioMode::Authoritative)
         }
-        ("authoritative", Some("authoritative")) => Ok(ScenarioMode::Authoritative),
-        ("shadow", Some("authoritative")) => {
+        (ProtocolMode::Shadow, ScenarioMode::Authoritative) => {
             bail!("scheduler scenario authority exceeds the protocol mode ceiling")
         }
-        (mode, scenario) => bail!(
-            "invalid scheduler rollout authority state: protocol_mode={mode}, scenario_mode={scenario:?}"
-        ),
     }
+}
+
+fn rollout_expectation(
+    rollout: &RolloutState,
+    scenario_class: SchedulerScenarioClass,
+    production_commands_enabled: bool,
+) -> Result<SchedulerRolloutExpectation> {
+    let configured_mode = effective_scenario_mode(rollout, scenario_class)?;
+    let mode = if !production_commands_enabled && configured_mode == ScenarioMode::Authoritative {
+        ScenarioMode::Shadow
+    } else {
+        configured_mode
+    };
+    let manifest_revision = rollout.manifest.as_ref().map(|manifest| manifest.revision);
+    let preflight_revision = rollout
+        .manifest
+        .as_ref()
+        .map(|manifest| manifest.preflight_revision);
+    if configured_mode == ScenarioMode::Authoritative {
+        let scenario = rollout
+            .scenarios
+            .get(scenario_class.as_str())
+            .ok_or_else(|| {
+                anyhow!(
+                    "authoritative scheduler scenario {} is missing authority state",
+                    scenario_class.as_str()
+                )
+            })?;
+        if scenario.manifest_revision != manifest_revision
+            || scenario.preflight_revision != preflight_revision
+        {
+            bail!(
+                "authoritative scheduler scenario {} disagrees with the installed rollout manifest",
+                scenario_class.as_str()
+            );
+        }
+        let preflight_revision = preflight_revision.ok_or_else(|| {
+            anyhow!(
+                "authoritative scheduler scenario {} is missing preflight authority",
+                scenario_class.as_str()
+            )
+        })?;
+        if !rollout
+            .preflights
+            .get(&preflight_revision)
+            .is_some_and(|preflight| {
+                preflight.state == RolloutPreflightState::Consumed
+                    && preflight.manifest.as_ref() == rollout.manifest.as_ref()
+            })
+        {
+            bail!(
+                "authoritative scheduler scenario {} lacks a consumed matching preflight",
+                scenario_class.as_str()
+            );
+        }
+    }
+    Ok(SchedulerRolloutExpectation {
+        scenario_class,
+        production_commands_enabled,
+        mode,
+        config_revision: rollout.config_revision,
+        manifest_revision,
+        preflight_revision,
+    })
+}
+
+fn validate_rollout_expectations(
+    rollout: &RolloutState,
+    expectations: &[SchedulerRolloutExpectation],
+) -> Result<()> {
+    let mut scenario_classes = BTreeSet::new();
+    for expectation in expectations {
+        if !scenario_classes.insert(expectation.scenario_class) {
+            bail!(
+                "duplicate scheduler rollout expectation for {}",
+                expectation.scenario_class.as_str()
+            );
+        }
+        let current = rollout_expectation(
+            rollout,
+            expectation.scenario_class,
+            expectation.production_commands_enabled,
+        )?;
+        if &current != expectation {
+            bail!(
+                "stale scheduler rollout expectation for {}",
+                expectation.scenario_class.as_str()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn effective_scenario_mode_tx(tx: &Transaction<'_>, scenario_class: &str) -> Result<ScenarioMode> {
+    let scenario_class = scenario_class
+        .parse::<SchedulerScenarioClass>()
+        .map_err(|_| anyhow!("unknown scheduler scenario class {scenario_class}"))?;
+    effective_scenario_mode(&load_rollout(tx)?, scenario_class)
 }
 
 fn canonical_shadow_comparison_hash(command: &SchedulerShadowComparisonCommand) -> Result<String> {
@@ -647,6 +829,25 @@ fn scenario_mode_token(mode: ScenarioMode) -> &'static str {
 }
 
 impl RuntimeTransitionRepository<'_> {
+    pub(crate) fn scheduler_rollout_expectations(
+        &self,
+        scenario_classes: &[SchedulerScenarioClass],
+        production_commands_enabled: bool,
+    ) -> Result<Vec<SchedulerRolloutExpectation>> {
+        self.db.transaction(|tx| {
+            let rollout = load_rollout(tx)?;
+            let mut unique = BTreeSet::new();
+            scenario_classes
+                .iter()
+                .copied()
+                .filter(|scenario_class| unique.insert(*scenario_class))
+                .map(|scenario_class| {
+                    rollout_expectation(&rollout, scenario_class, production_commands_enabled)
+                })
+                .collect()
+        })
+    }
+
     pub(crate) fn scheduler_scenario_mode(
         &self,
         scenario_class: SchedulerScenarioClass,
@@ -747,7 +948,17 @@ impl RuntimeTransitionRepository<'_> {
 
         let outcome = self.db.transaction(|tx| {
             if enforce_authority {
-                validate_protocol_command_authority_tx(tx, std::slice::from_ref(command))?;
+                let rollout = load_rollout(tx)?;
+                let expectations =
+                    required_protocol_command_scenarios(std::slice::from_ref(command))
+                        .into_iter()
+                        .map(|scenario_class| rollout_expectation(&rollout, scenario_class, true))
+                        .collect::<Result<Vec<_>>>()?;
+                validate_protocol_command_authority_tx(
+                    tx,
+                    std::slice::from_ref(command),
+                    &expectations,
+                )?;
             }
             if let Some(stored) =
                 stored_command_result_tx(tx, agent_id, command_kind, &command_identity)?

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -88,23 +88,28 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
         .await?;
     assert!(second.status().is_success());
 
-    let runtime_for_wait = runtime.clone();
+    let host_for_wait = host.clone();
+    let external_trigger_id_for_wait = capability.external_trigger_id.clone();
     wait_until_async(move || {
-        let runtime = runtime_for_wait.clone();
+        let host = host_for_wait.clone();
+        let external_trigger_id = external_trigger_id_for_wait.clone();
         async move {
+            let runtime = host.default_runtime().await?;
             let messages = runtime.storage().read_recent_messages(20)?;
             let descriptors = runtime.latest_external_triggers().await?;
             Ok(messages
                 .iter()
                 .all(|message| message.kind != MessageKind::CallbackEvent)
                 && descriptors
-                    .first()
+                    .iter()
+                    .find(|item| item.external_trigger_id == external_trigger_id)
                     .map(|item| item.delivery_count == 2)
                     .unwrap_or(false))
         }
     })
     .await?;
 
+    let runtime = host.default_runtime().await?;
     let messages = runtime.storage().read_recent_messages(20)?;
     assert!(messages
         .iter()
@@ -140,10 +145,12 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
         .await?;
     assert_eq!(revoked.status(), reqwest::StatusCode::FORBIDDEN);
 
-    let waiting: Vec<()> = vec![];
     let descriptors = runtime.latest_external_triggers().await?;
-    assert!(waiting.is_empty());
-    assert_eq!(descriptors[0].status, ExternalTriggerStatus::Revoked);
+    let descriptor = descriptors
+        .iter()
+        .find(|item| item.external_trigger_id == capability.external_trigger_id)
+        .expect("revoked external trigger descriptor");
+    assert_eq!(descriptor.status, ExternalTriggerStatus::Revoked);
 
     server.abort();
     Ok(())
@@ -443,12 +450,20 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
     assert!(first.status().is_success());
     let first_payload: serde_json::Value = first.json().await?;
     assert_eq!(first_payload["delivery_mode"], "wake_hint");
-    assert_eq!(first_payload["disposition"], "triggered");
+    assert!(
+        matches!(
+            first_payload["disposition"].as_str(),
+            Some("triggered" | "coalesced")
+        ),
+        "unexpected wake disposition: {}",
+        first_payload["disposition"]
+    );
 
-    let runtime_for_wait = runtime.clone();
+    let host_for_wait = host.clone();
     wait_until_async(move || {
-        let runtime = runtime_for_wait.clone();
+        let host = host_for_wait.clone();
         async move {
+            let runtime = host.default_runtime().await?;
             let descriptors = runtime.latest_external_triggers().await?;
             Ok(descriptors
                 .first()
@@ -458,6 +473,7 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
     })
     .await?;
 
+    let runtime = host.default_runtime().await?;
     server.abort();
     runtime.control(holon::types::ControlAction::Stop).await?;
     wait_until(|| {
@@ -476,11 +492,16 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
     let runtime2 = host2.default_runtime().await?;
     let (base2, server2) = spawn_server_for_host(host2.clone()).await?;
 
-    let waiting: Vec<()> = vec![];
     let descriptors = runtime2.latest_external_triggers().await?;
-    assert!(waiting.is_empty());
     assert_eq!(descriptors.len(), 1);
     assert_eq!(descriptors[0].delivery_count, 1);
+    assert_eq!(descriptors[0].status, ExternalTriggerStatus::Revoked);
+    let callback_events_before = runtime2
+        .storage()
+        .read_recent_messages(20)?
+        .into_iter()
+        .filter(|message| message.kind == MessageKind::CallbackEvent)
+        .count();
 
     let second = client
         .post(format!("{base2}{callback_path}"))
@@ -491,22 +512,16 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
     // longer valid and the callback is rejected at the token level.
     assert_eq!(second.status(), reqwest::StatusCode::FORBIDDEN);
 
-    let runtime_for_wait = runtime2.clone();
-    wait_until_async(move || {
-        let runtime = runtime_for_wait.clone();
-        async move {
-            let messages = runtime.storage().read_recent_messages(20)?;
-            let descriptors = runtime.latest_external_triggers().await?;
-            Ok(messages
-                .iter()
-                .all(|message| message.kind != MessageKind::CallbackEvent)
-                && descriptors
-                    .first()
-                    .map(|item| item.delivery_count == 1)
-                    .unwrap_or(false))
-        }
-    })
-    .await?;
+    let descriptors = runtime2.latest_external_triggers().await?;
+    assert_eq!(descriptors[0].delivery_count, 1);
+    assert_eq!(descriptors[0].status, ExternalTriggerStatus::Revoked);
+    let callback_events_after = runtime2
+        .storage()
+        .read_recent_messages(20)?
+        .into_iter()
+        .filter(|message| message.kind == MessageKind::CallbackEvent)
+        .count();
+    assert_eq!(callback_events_after, callback_events_before);
 
     server2.abort();
     Ok(())


### PR DESCRIPTION
## 概要

收口 scheduler protocol 的 production rollout authority：`HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS` 仅作为 capability ceiling，不能单独授予 canonical execution ownership。

## 变更

- 在每个 scheduler authority boundary 携带并事务内复核 config / manifest / consumed preflight / scenario mode / capability expectation，阻止 stale authority admission。
- legacy 或 shadow 有效模式不创建 canonical activation/slot；只有具备完整 rollout authority 的 scenario 才生成 production protocol commands。
- authoritative comparison 缺失或分歧时，拒绝队列、projection、audit、comparison 与 protocol 业务写入，同时原子持久化 revision-fenced hard blocker，并按 manifest rollback target 停止后续 admission、回退到 `shadow` 或 `off`。
- 保持已 admission activation 的 terminal settlement 可按原 authority drain；bootstrap recovery 与 settlement 同样使用 rollout expectation fence。
- 更新 runtime/repository 测试夹具与 callback 回归中的 host-handle 时序假设，并同步 implementation decision。

## 验证

- `cargo test --test runtime_waiting_and_delivery_regressions -- --nocapture`（26/26）
- `cargo test --all-targets`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
