### PR TITLE
test: add scheduler rollout acceptance e2e

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -120,8 +120,20 @@ jobs:
           args=(
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
-            --suite core
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+          )
+          while IFS= read -r case_id; do
+            args+=(--case "${case_id}")
+          done < <(
+            python3 -c '
+            import json
+            from pathlib import Path
+            manifest = json.loads(Path("tests/e2e/docker/manifest.json").read_text())
+            print("\n".join(
+                case["id"] for case in manifest["cases"]
+                if case["tier"] == "core" or "scheduler" in case.get("tags", [])
+            ))
+            '
           )
           if [ -n "${HOLON_E2E_PREVIOUS_IMAGE}" ]; then
             args+=(--previous-image "${HOLON_E2E_PREVIOUS_IMAGE}")

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -48,7 +48,16 @@ deepseek/deepseek-v4-flash
 
 The suite requires network access and provider quota, so ordinary pull-request
 CI only validates its manifest and Python runner. Each release candidate runs
-the real suite through the protected `Release E2E` workflow.
+the core cases plus all scheduler-tagged rollout cases through the protected
+`Release E2E` workflow.
+
+The scheduler rollout cases use hidden offline fixtures guarded by both
+`HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS=true` and
+`HOLON_SCHEDULER_ACCEPTANCE_FIXTURES=true`. Their manifest is explicitly
+synthetic acceptance data: it exercises the production reducer, revision
+fences, atomic batch application, rejection of insufficient evidence, cutover,
+and rollback. It does not claim that one Docker run collected the production
+sample counts or the full fleet evidence corpus encoded by those gates.
 
 Run locally with a credential environment variable:
 
@@ -165,6 +174,19 @@ counts, cleanup status, and previous image when supplied.
 5. Assert the required tools succeeded and the durable completion result
    contains the generated completion marker.
 
+#### Scheduler rollout cases
+
+The protected release run also selects every case tagged `scheduler`:
+
+1. `scheduler-autonomous-legacy` preserves the legacy comparison baseline.
+2. `scheduler-rollout-authoritative-autonomous` validates shadow evidence,
+   per-scenario authoritative cutover, task-result and external-wait
+   continuations, exact completion delivery binding, restart persistence, and
+   rollback.
+3. `scheduler-terminal-before-settlement-restart` uses a checked-in offline
+   fault fixture to validate bootstrap reconciliation and second-restart
+   idempotence without issuing a model prompt.
+
 These cases validate the complete boundary:
 
 ```text
@@ -183,7 +205,8 @@ jobs:
 1. Build and push `candidate-<git-sha>` with OCI version, revision, and source
    labels.
 2. Pull and test the resulting immutable digest in the `release-e2e`
-   environment using `DEEPSEEK_API_KEY`.
+   environment using `DEEPSEEK_API_KEY`, selecting all core and
+   scheduler-tagged cases in one attested runner invocation.
 
 The E2E job has read-only repository/package permissions and cannot publish a
 GitHub release, promote `latest`, or update Homebrew. Evidence is retained as a

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -27,6 +27,8 @@ from xml.etree import ElementTree
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "tests/e2e/docker/manifest.json"
 DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
+OFFLINE_MODEL_CREDENTIAL_ENV = "DEEPSEEK_API_KEY"
+OFFLINE_MODEL_CREDENTIAL = "docker-e2e-offline-provider-unused"
 EVIDENCE_SCHEMA_VERSION = 1
 TERMINAL_STATUSES = {"awake_idle", "asleep", "awaiting_task"}
 
@@ -63,7 +65,7 @@ CALLBACK_CAPABILITY_PATTERN = re.compile(
     r"(/api/callbacks/(?:wake|enqueue)/)[A-Za-z0-9_-]+"
 )
 CALLBACK_CAPABILITY_SCAN_PATTERN = re.compile(
-    r"/api/callbacks/(?:wake|enqueue)/([^\s\"'`),}\]]+)"
+    r"/api/callbacks/(?:wake|enqueue)/(?!<redacted>)[A-Za-z0-9_-]+"
 )
 BEARER_SECRET_PATTERN = re.compile(
     r"(?:Authorization:\s*Bearer\s+|\"authorization\"\s*:\s*\"Bearer\s+)"
@@ -125,6 +127,7 @@ class CaseHarness:
         case_id: str,
         image: str,
         model: str,
+        requires_model: bool = True,
         credential_envs: list[str],
         env_file: Path | None,
         runtime_env: dict[str, str],
@@ -135,10 +138,15 @@ class CaseHarness:
         suffix = secrets.token_hex(4)
         self.case_id = case_id
         self.image = image
-        self.model = model
-        self.credential_envs = credential_envs
-        self.env_file = env_file
-        self.runtime_env = runtime_env
+        self.model = model if requires_model else DEFAULT_MODEL
+        self.credential_envs = credential_envs if requires_model else []
+        self.env_file = env_file if requires_model else None
+        self.runtime_env = dict(runtime_env)
+        if not requires_model:
+            self.runtime_env.setdefault(
+                OFFLINE_MODEL_CREDENTIAL_ENV,
+                OFFLINE_MODEL_CREDENTIAL,
+            )
         self.evidence = evidence_root / case_id
         self.timeout_seconds = timeout_seconds
         self.keep = keep
@@ -154,6 +162,76 @@ class CaseHarness:
 
     def docker(self, *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         return run(["docker", *args], **kwargs)
+
+    def offline_debug(
+        self, label: str, *args: str, expect_success: bool = True
+    ) -> dict[str, Any]:
+        self.docker("volume", "create", self.volume)
+        command = [
+            "run",
+            "--rm",
+            "--volume",
+            f"{self.volume}:/var/lib/holon",
+            "--volume",
+            f"{self.evidence}:/acceptance-evidence:ro",
+        ]
+        for name, value in sorted(self.runtime_env.items()):
+            command.extend(["--env", f"{name}={value}"])
+        command.extend([self.image, "debug", *args, "--json"])
+        result = self.docker(*command, check=False)
+        (self.evidence / f"{label}-stdout.json").write_text(result.stdout)
+        (self.evidence / f"{label}-stderr.log").write_text(result.stderr)
+        if not expect_success:
+            require(
+                result.returncode != 0,
+                f"offline debug command unexpectedly succeeded for {label}",
+            )
+            return {
+                "returncode": result.returncode,
+                "stderr": result.stderr.strip(),
+            }
+        require(
+            result.returncode == 0,
+            f"offline debug command failed for {label}: {result.stderr.strip()}",
+        )
+        value = json.loads(result.stdout)
+        write_json(self.evidence / f"{label}.json", value)
+        return value
+
+    def apply_scheduler_rollout(
+        self, label: str, commands: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        path = self.evidence / f"{label}-input.json"
+        write_json(path, {"commands": commands})
+        return self.offline_debug(
+            label,
+            "scheduler-rollout-apply",
+            "--input",
+            f"/acceptance-evidence/{path.name}",
+        )
+
+    def reject_scheduler_rollout(
+        self, label: str, commands: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        path = self.evidence / f"{label}-input.json"
+        write_json(path, {"commands": commands})
+        return self.offline_debug(
+            label,
+            "scheduler-rollout-apply",
+            "--input",
+            f"/acceptance-evidence/{path.name}",
+            expect_success=False,
+        )
+
+    def seed_scheduler_recovery_fixture(
+        self, label: str, objective: str
+    ) -> dict[str, Any]:
+        return self.offline_debug(
+            label,
+            "scheduler-recovery-fixture",
+            "--objective",
+            objective,
+        )
 
     def initialize_workspace(self) -> None:
         self.workspace_parent.mkdir(parents=True, exist_ok=True)
@@ -176,7 +254,7 @@ class CaseHarness:
             "git add README.md; git commit -m 'acceptance fixture'",
         )
 
-    def start(self) -> None:
+    def start(self, *, wait_idle: bool = True) -> None:
         self.docker("volume", "create", self.volume)
         if self.docker("network", "inspect", self.network, check=False).returncode != 0:
             self.docker("network", "create", self.network)
@@ -236,7 +314,8 @@ class CaseHarness:
         require(bool(port), "failed to resolve the container's published port")
         self.base_url = f"http://127.0.0.1:{port}"
         self.wait_readiness()
-        self.wait_agent_idle()
+        if wait_idle:
+            self.wait_agent_idle()
 
     def stop(self) -> None:
         shutdown_error = ""
@@ -275,9 +354,31 @@ class CaseHarness:
         self.docker("rm", "-f", self.container, check=False)
         self.base_url = ""
 
-    def restart(self) -> None:
+    def restart(self, *, wait_idle: bool = True) -> None:
         self.stop()
-        self.start()
+        self.start(wait_idle=wait_idle)
+
+    def reset_callback(self, label: str) -> dict[str, Any]:
+        value = self.request(
+            "POST",
+            self.agent_path("reset-callback", control=True),
+        )
+        write_json(self.evidence / f"{label}.json", value)
+        return value
+
+    def fire_callback(
+        self, label: str, trigger_url: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        path = urllib.parse.urlparse(trigger_url).path
+        require(path.startswith("/api/callbacks/wake/"), "unexpected callback path")
+        value = self.request(
+            "POST",
+            path,
+            body,
+            authenticated=False,
+        )
+        write_json(self.evidence / f"{label}.json", value)
+        return value
 
     def cleanup(self) -> dict[str, Any]:
         if self.keep:
@@ -317,7 +418,7 @@ class CaseHarness:
         result = self.docker("logs", self.container, check=False)
         self.log_index += 1
         path = self.evidence / f"container-{self.log_index}.log"
-        path.write_text(result.stdout + result.stderr)
+        path.write_text(redact_evidence(result.stdout + result.stderr))
 
     def request(
         self,
@@ -443,6 +544,36 @@ class CaseHarness:
         self.capture_context(f"{label}-timeout")
         raise TimeoutError(
             f"timed out waiting for WorkItem {objective_marker} to reach {expected_state}"
+        )
+
+    def wait_work_item_scheduling_state(
+        self,
+        *,
+        objective_marker: str,
+        expected_scheduling_state: str,
+        label: str,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_seconds
+        matches: list[dict[str, Any]] = []
+        while time.monotonic() < deadline:
+            items = self.request("GET", self.agent_path("work-items?limit=50"))
+            matches = [
+                item for item in items if objective_marker in item.get("objective", "")
+            ]
+            if (
+                len(matches) == 1
+                and matches[0].get("scheduling_state")
+                == expected_scheduling_state
+            ):
+                write_json(self.evidence / f"{label}-work-items.json", items)
+                self.wait_agent_idle()
+                return matches[0]
+            time.sleep(1)
+        write_json(self.evidence / f"{label}-timeout-work-items.json", matches)
+        self.capture_context(f"{label}-timeout")
+        raise TimeoutError(
+            f"timed out waiting for WorkItem {objective_marker} to reach "
+            f"{expected_scheduling_state}"
         )
 
     def brief(self, brief_id: str, label: str) -> dict[str, Any]:
@@ -614,10 +745,57 @@ class CaseHarness:
                     "updated_at, payload_json FROM queue_entries "
                     "ORDER BY created_at, updated_at",
                 ),
+                "turn_records": sqlite_rows(
+                    connection,
+                    "SELECT turn_id, turn_index, agent_id, run_id, "
+                    "current_work_item_id, trigger_message_id, terminal_kind, "
+                    "created_at, completed_at, payload_json "
+                    "FROM turn_records ORDER BY turn_index, created_at",
+                ),
+                "audit_events": sqlite_rows(
+                    connection,
+                    "SELECT audit_event_id, event_seq, agent_id, kind, created_at, "
+                    "data_json FROM audit_events ORDER BY event_seq",
+                ),
+                "briefs": sqlite_rows(
+                    connection,
+                    "SELECT evidence_id, agent_id, turn_id, message_id, task_id, "
+                    "work_item_id, kind, preview, payload_json "
+                    "FROM briefs ORDER BY created_at",
+                ),
+                "wait_conditions": sqlite_rows(
+                    connection,
+                    "SELECT wait_condition_id, agent_id, work_item_id, status, kind, "
+                    "subject_ref, waiting_for, last_turn_id, payload_json "
+                    "FROM wait_conditions ORDER BY created_at",
+                ),
                 "scheduler_protocol_config": sqlite_rows(
                     connection,
                     "SELECT protocol_mode, config_revision, latest_preflight_revision "
                     "FROM scheduler_protocol_config",
+                ),
+                "scheduler_rollout_preflights": sqlite_rows(
+                    connection,
+                    "SELECT preflight_revision, manifest_revision, state, manifest_json "
+                    "FROM scheduler_rollout_preflights ORDER BY preflight_revision",
+                ),
+                "scheduler_rollout_manifests": sqlite_rows(
+                    connection,
+                    "SELECT manifest_revision, preflight_revision, payload_json "
+                    "FROM scheduler_rollout_manifests ORDER BY manifest_revision",
+                ),
+                "scheduler_scenario_authorities": sqlite_rows(
+                    connection,
+                    "SELECT scenario_class, mode, rollback_target, manifest_revision, "
+                    "preflight_revision FROM scheduler_scenario_authorities "
+                    "ORDER BY scenario_class",
+                ),
+                "scheduler_rollout_command_results": sqlite_rows(
+                    connection,
+                    "SELECT command_kind, command_identity, decision, conflict_kind, "
+                    "conflict_code, result_references_json, pre_state_fence_json, "
+                    "post_state_fence_json FROM scheduler_rollout_command_results "
+                    "ORDER BY created_at",
                 ),
                 "scheduler_work_demands": sqlite_rows(
                     connection,
@@ -639,6 +817,18 @@ class CaseHarness:
                     connection,
                     "SELECT agent_id, settlement_id, activation_id, payload_json "
                     "FROM scheduler_activation_settlements",
+                ),
+                "scheduler_wait_generations": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, wait_id, generation, owner_work_item_id, "
+                    "lifecycle_state, trigger_id, trigger_generation, "
+                    "consuming_activation_id, payload_json "
+                    "FROM scheduler_wait_generations ORDER BY wait_id, generation",
+                ),
+                "scheduler_missing_settlements": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, missing_settlement_id, activation_id, payload_json "
+                    "FROM scheduler_missing_settlements",
                 ),
                 "scheduler_protocol_command_results": sqlite_rows(
                     connection,
@@ -680,6 +870,398 @@ def require_processed_queue_entries(
         and all(row.get("status") == "processed" for row in matching),
         f"work_queue messages did not reach processed current state: {matching}",
     )
+
+
+SCHEDULER_ROLLOUT_GATES = {
+    "reducer_only_candidates": (
+        10_000,
+        72 * 60 * 60,
+        ["deterministic_replay", "duplicate_command_idempotency"],
+    ),
+    "exact_task_rejoin": (
+        1_000,
+        7 * 24 * 60 * 60,
+        [
+            "duplicate_task_result",
+            "out_of_order_task_result",
+            "restart_before_rejoin_settlement",
+        ],
+    ),
+    "exact_wait_resume": (
+        1_000,
+        7 * 24 * 60 * 60,
+        ["duplicate_trigger", "stale_generation", "restart_after_consume", "rearm"],
+    ),
+    "work_item_autonomous_continuation": (
+        2_000,
+        14 * 24 * 60 * 60,
+        [
+            "concurrent_claim",
+            "reservation_conflict",
+            "yield_return",
+            "work_item_rollback",
+        ],
+    ),
+    "settlement": (
+        1_000,
+        7 * 24 * 60 * 60,
+        [
+            "duplicate_settlement",
+            "missing_settlement_recovery",
+            "restart_before_settlement_commit",
+        ],
+    ),
+    "delivery": (
+        1_000,
+        7 * 24 * 60 * 60,
+        ["duplicate_delivery", "delivery_retry", "restart_before_delivery_commit"],
+    ),
+}
+
+
+def scheduler_rollout_manifest(
+    scenario_modes: dict[str, str],
+    *,
+    revision: int = 1,
+    preflight_revision: int = 1,
+) -> dict[str, Any]:
+    # Explicit acceptance-only synthetic data: exercise the production reducer
+    # and revision fences without claiming fleet shadow evidence collection.
+    universal = {"restart", "fault_injection", "rollback_drill"}
+    classes = {}
+    for scenario_class, configured_mode in scenario_modes.items():
+        minimum_samples, minimum_duration, class_evidence = SCHEDULER_ROLLOUT_GATES[
+            scenario_class
+        ]
+        evidence = sorted(universal.union(class_evidence))
+        classes[scenario_class] = {
+            "configured_mode": configured_mode,
+            "minimum_shadow_samples": minimum_samples,
+            "minimum_shadow_duration_secs": minimum_duration,
+            "observed_shadow_samples": minimum_samples,
+            "observed_shadow_duration_secs": minimum_duration,
+            "maximum_p99_latency_regression_bps": 500,
+            "observed_p99_latency_regression_bps": 0,
+            "hard_blocker_count": 0,
+            "unresolved_divergence_count": 0,
+            "required_evidence": evidence,
+            "verified_evidence": evidence,
+            "rollback_policy": {
+                "trigger": "any_hard_blocker",
+                "action": {
+                    "kind": "stop_admissions_and_revert",
+                    "target": "shadow",
+                },
+            },
+        }
+    return {
+        "revision": revision,
+        "preflight_revision": preflight_revision,
+        "preflight_for_manifest_revision": revision,
+        "preflight_succeeded": True,
+        "protocol_build": "holon-docker-e2e-synthetic-acceptance",
+        "schema_build": "scheduler-protocol-schema-v1",
+        "schema_revision": 1,
+        "fixture_corpus_revision": "scheduler-pr-g-synthetic-acceptance-v1",
+        "classes": classes,
+        "safety_divergence_bps": 0,
+        "canonical_state_divergence_bps": 0,
+        "allowed_observational_divergence": {
+            "diagnostic_order": {
+                "maximum_rate_bps": 0,
+                "reviewed_by": "docker-e2e",
+            }
+        },
+        "approver": "docker-e2e-synthetic-acceptance",
+        "approved_at": "2026-07-23T00:00:00Z",
+    }
+
+
+def scheduler_incomplete_rollout_commands(
+    scenario_modes: dict[str, str],
+) -> list[dict[str, Any]]:
+    manifest = scheduler_rollout_manifest(scenario_modes)
+    for evidence in manifest["classes"].values():
+        evidence["observed_shadow_samples"] = 0
+        evidence["observed_shadow_duration_secs"] = 0
+        evidence["verified_evidence"] = []
+    return [
+        {
+            "command_identity": "docker-e2e-rejected-rollout-open",
+            "command": {
+                "kind": "open_preflight",
+                "expected_config_revision": 0,
+                "manifest_revision": 1,
+            },
+        },
+        {
+            "command_identity": "docker-e2e-rejected-rollout-complete",
+            "command": {
+                "kind": "complete_preflight",
+                "expected_config_revision": 0,
+                "expected_preflight_revision": 1,
+                "manifest": manifest,
+            },
+        },
+    ]
+
+
+def scheduler_rollout_commands(
+    scenario_modes: dict[str, str],
+    *,
+    approved_scenario_modes: dict[str, str] | None = None,
+    rollback_scenario: str | None = None,
+) -> list[dict[str, Any]]:
+    manifest = scheduler_rollout_manifest(
+        approved_scenario_modes or scenario_modes
+    )
+    commands = [
+        {
+            "command_identity": "docker-e2e-rollout-open",
+            "command": {
+                "kind": "open_preflight",
+                "expected_config_revision": 0,
+                "manifest_revision": 1,
+            },
+        },
+        {
+            "command_identity": "docker-e2e-rollout-complete",
+            "command": {
+                "kind": "complete_preflight",
+                "expected_config_revision": 0,
+                "expected_preflight_revision": 1,
+                "manifest": manifest,
+            },
+        },
+        {
+            "command_identity": "docker-e2e-rollout-install",
+            "command": {
+                "kind": "install_manifest",
+                "expected_config_revision": 0,
+                "manifest": manifest,
+            },
+        },
+        {
+            "command_identity": "docker-e2e-rollout-configure",
+            "command": {
+                "kind": "configure_protocol",
+                "expected_config_revision": 1,
+                "mode": "authoritative",
+            },
+        },
+    ]
+    revision = 2
+    for scenario_class, target_mode in scenario_modes.items():
+        if target_mode == "off":
+            continue
+        commands.append(
+            {
+                "command_identity": f"docker-e2e-{scenario_class}-shadow",
+                "command": {
+                    "kind": "change_scenario_authority",
+                    "scenario_class": scenario_class,
+                    "expected_config_revision": revision,
+                    "expected_manifest_revision": 1,
+                    "expected_preflight_revision": 1,
+                    "mode": "shadow",
+                },
+            }
+        )
+        revision += 1
+        if target_mode == "authoritative":
+            commands.append(
+                {
+                    "command_identity": f"docker-e2e-{scenario_class}-authoritative",
+                    "command": {
+                        "kind": "change_scenario_authority",
+                        "scenario_class": scenario_class,
+                        "expected_config_revision": revision,
+                        "expected_manifest_revision": 1,
+                        "expected_preflight_revision": 1,
+                        "mode": "authoritative",
+                    },
+                }
+            )
+            revision += 1
+    if rollback_scenario is not None:
+        commands.append(
+            {
+                "command_identity": f"docker-e2e-{rollback_scenario}-rollback",
+                "command": {
+                    "kind": "change_scenario_authority",
+                    "scenario_class": rollback_scenario,
+                    "expected_config_revision": revision,
+                    "expected_manifest_revision": 1,
+                    "expected_preflight_revision": 1,
+                    "mode": "shadow",
+                },
+            }
+        )
+    return commands
+
+
+def scheduler_scenario_mode_commands(
+    scenario_modes: dict[str, str],
+    *,
+    expected_config_revision: int,
+    identity_suffix: str,
+) -> list[dict[str, Any]]:
+    commands = []
+    revision = expected_config_revision
+    for scenario_class, mode in scenario_modes.items():
+        commands.append(
+            {
+                "command_identity": (
+                    f"docker-e2e-{scenario_class}-{mode}-{identity_suffix}"
+                ),
+                "command": {
+                    "kind": "change_scenario_authority",
+                    "scenario_class": scenario_class,
+                    "expected_config_revision": revision,
+                    "expected_manifest_revision": 1,
+                    "expected_preflight_revision": 1,
+                    "mode": mode,
+                },
+            }
+        )
+        revision += 1
+    return commands
+
+
+def require_rollout_state(
+    snapshot: dict[str, Any],
+    expected_modes: dict[str, str],
+) -> None:
+    require(
+        snapshot["scheduler_protocol_config"]
+        and snapshot["scheduler_protocol_config"][0]["protocol_mode"]
+        == "authoritative",
+        f"scheduler protocol ceiling is not authoritative: "
+        f"{snapshot['scheduler_protocol_config']}",
+    )
+    preflights = snapshot["scheduler_rollout_preflights"]
+    require(
+        len(preflights) == 1
+        and preflights[0]["preflight_revision"] == 1
+        and preflights[0]["manifest_revision"] == 1
+        and preflights[0]["state"] == "consumed",
+        f"rollout preflight was not consumed exactly once: {preflights}",
+    )
+    require(
+        len(snapshot["scheduler_rollout_manifests"]) == 1
+        and snapshot["scheduler_rollout_manifests"][0]["manifest_revision"] == 1,
+        f"rollout manifest is missing or duplicated: "
+        f"{snapshot['scheduler_rollout_manifests']}",
+    )
+    authorities = {
+        row["scenario_class"]: row for row in snapshot["scheduler_scenario_authorities"]
+    }
+    for scenario_class, mode in expected_modes.items():
+        require(
+            authorities.get(scenario_class, {}).get("mode") == mode,
+            f"scenario {scenario_class} did not reach {mode}: {authorities}",
+        )
+        row = authorities[scenario_class]
+        if mode == "authoritative":
+            require(
+                row["manifest_revision"] == 1 and row["preflight_revision"] == 1,
+                f"authoritative scenario lacks rollout fence: {row}",
+            )
+        else:
+            require(
+                row["manifest_revision"] is None
+                and row["preflight_revision"] is None,
+                f"non-authoritative scenario retained authority fence: {row}",
+            )
+    require(
+        all(
+            row["conflict_kind"] is None
+            for row in snapshot["scheduler_rollout_command_results"]
+        ),
+        f"rollout command chain contains conflicts: "
+        f"{snapshot['scheduler_rollout_command_results']}",
+    )
+
+
+def require_turns_terminal(
+    snapshot: dict[str, Any], message_ids: set[str]
+) -> list[dict[str, Any]]:
+    turns = [
+        row
+        for row in snapshot["turn_records"]
+        if row.get("trigger_message_id") in message_ids
+    ]
+    require(
+        len(turns) == len(message_ids)
+        and all(row.get("terminal_kind") == "completed" for row in turns),
+        f"scheduler turns did not reach completed terminal state: {turns}",
+    )
+    return turns
+
+
+def require_scheduler_activation_chain(
+    snapshot: dict[str, Any],
+    *,
+    agent_id: str,
+    work_item_id: str,
+    expected_activation_count: int,
+) -> list[dict[str, Any]]:
+    activations = [
+        row
+        for row in snapshot["scheduler_activations"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(activations) == expected_activation_count
+        and all(row["lifecycle_state"] == "settled" for row in activations),
+        f"canonical activations did not settle exactly once: {activations}",
+    )
+    activation_ids = {row["activation_id"] for row in activations}
+    settlements = [
+        row
+        for row in snapshot["scheduler_activation_settlements"]
+        if row["activation_id"] in activation_ids
+    ]
+    require(
+        len(settlements) == expected_activation_count,
+        f"canonical settlements are missing or duplicated: {settlements}",
+    )
+    require(
+        not [
+            row
+            for row in snapshot["scheduler_missing_settlements"]
+            if row["activation_id"] in activation_ids
+        ],
+        "canonical activation chain retained missing settlement evidence",
+    )
+    slots = [
+        row for row in snapshot["scheduler_agent_slots"] if row["agent_id"] == agent_id
+    ]
+    require(
+        len(slots) == 1
+        and slots[0]["slot_kind"] == "idle"
+        and slots[0]["activation_id"] is None,
+        f"canonical activation slot was not released: {slots}",
+    )
+    return activations
+
+
+def require_scheduler_comparisons(
+    snapshot: dict[str, Any],
+    expected: dict[str, int],
+) -> None:
+    for scenario_class, minimum_count in expected.items():
+        rows = [
+            row
+            for row in snapshot["scheduler_shadow_comparisons"]
+            if row["scenario_class"] == scenario_class
+        ]
+        require(
+            len(rows) >= minimum_count
+            and all(row["comparison_outcome"] == "matched" for row in rows),
+            f"scheduler comparison evidence missing or divergent for "
+            f"{scenario_class}: {rows}",
+        )
 
 
 def find_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
@@ -1226,6 +1808,397 @@ def run_scheduler_protocol_case(harness: CaseHarness, case: dict[str, Any]) -> N
     )
 
 
+def run_scheduler_rollout_authoritative_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    harness.initialize_workspace()
+    scenario_modes = {
+        "work_item_autonomous_continuation": "shadow",
+        "exact_task_rejoin": "shadow",
+        "exact_wait_resume": "shadow",
+        "settlement": "shadow",
+        "delivery": "shadow",
+    }
+    authoritative_modes = {
+        scenario_class: "authoritative" for scenario_class in scenario_modes
+    }
+    rejected = harness.reject_scheduler_rollout(
+        "scheduler-rollout-insufficient-evidence",
+        scheduler_incomplete_rollout_commands(authoritative_modes),
+    )
+    require(
+        "rejected" in rejected["stderr"].lower(),
+        f"insufficient rollout evidence did not report rejection: {rejected}",
+    )
+    rejected_snapshot = harness.runtime_db_snapshot(
+        "scheduler-rollout-insufficient-evidence"
+    )
+    require(
+        not rejected_snapshot["scheduler_rollout_preflights"]
+        and not rejected_snapshot["scheduler_rollout_manifests"]
+        and not rejected_snapshot["scheduler_rollout_command_results"],
+        "rejected rollout batch left partial canonical state",
+    )
+    harness.apply_scheduler_rollout(
+        "scheduler-rollout-shadow",
+        scheduler_rollout_commands(
+            scenario_modes,
+            approved_scenario_modes=authoritative_modes,
+        ),
+    )
+    harness.start()
+
+    shadow_marker = secrets.token_hex(4)
+    shadow_objective = f"SCHEDULER-SHADOW-WAIT-{shadow_marker}"
+    shadow_completion = f"SCHEDULER-SHADOW-COMPLETE-{shadow_marker}"
+    callback = harness.reset_callback("scheduler-shadow-callback")
+    shadow_phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "scheduler-shadow-wait",
+        shadow_phase["prompt"].format(
+            case_id=case["id"],
+            objective=shadow_objective,
+            completion_marker=shadow_completion,
+        ),
+    )
+    waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=shadow_objective,
+        expected_scheduling_state="waiting_external",
+        label="scheduler-shadow-waiting",
+    )
+    harness.fire_callback(
+        "scheduler-shadow-wake",
+        callback["trigger_url"],
+        {"case_id": case["id"], "marker": shadow_marker},
+    )
+    shadow_item = harness.wait_work_item(
+        objective_marker=shadow_objective,
+        expected_state="completed",
+        label="scheduler-shadow-completed",
+    )
+    required, forbidden = phase_tools(shadow_phase)
+    harness.assert_tools("scheduler-shadow-wait", baseline, required, forbidden)
+    require(
+        shadow_item["id"] == waiting["id"],
+        "shadow wait-resume changed WorkItem identity",
+    )
+    shadow_snapshot = harness.runtime_db_snapshot("scheduler-shadow")
+    shadow_comparisons = [
+        row
+        for row in shadow_snapshot["scheduler_shadow_comparisons"]
+        if row["scenario_class"] == "exact_wait_resume"
+    ]
+    require(
+        len(shadow_comparisons) == 1
+        and shadow_comparisons[0]["authority_mode"] == "shadow"
+        and shadow_comparisons[0]["comparison_outcome"] == "matched",
+        f"shadow wait-resume evidence is incomplete: {shadow_comparisons}",
+    )
+    require(
+        not shadow_snapshot["scheduler_activations"],
+        f"shadow mode unexpectedly acquired canonical execution ownership: "
+        f"{shadow_snapshot['scheduler_activations']}",
+    )
+
+    harness.stop()
+    first_authoritative_revision = 2 + len(scenario_modes)
+    harness.apply_scheduler_rollout(
+        "scheduler-rollout-authoritative",
+        scheduler_scenario_mode_commands(
+            authoritative_modes,
+            expected_config_revision=first_authoritative_revision,
+            identity_suffix="cutover",
+        ),
+    )
+    harness.start()
+
+    marker = secrets.token_hex(4)
+    objective_marker = f"SCHEDULER-AUTHORITATIVE-CONTINUATIONS-{marker}"
+    task_marker = f"SCHEDULER-TASK-RESULT-{marker}"
+    completion_marker = f"SCHEDULER-AUTHORITATIVE-COMPLETE-{marker}"
+    objective = (
+        f"{objective_marker}. This WorkItem must exercise two continuation boundaries. "
+        f"On the first autonomous work_queue turn, call ExecCommand with command "
+        f"`sleep 15; printf {task_marker}`, yield_time_ms=50, and a bounded output limit. "
+        "Use the returned promoted command task_id to call WaitFor with wake=task_result. "
+        "Do not poll the task and do not complete the WorkItem. On the task-result rejoin, "
+        "call GetWorkItem for the current WorkItem, then call WaitFor with wake=external, "
+        f"resource=docker-e2e:{marker}, and a concrete reason. Do not complete it yet. "
+        "On the later external wake, call GetWorkItem, update both existing todos to "
+        "completed, then emit a concise operator-facing completion report containing "
+        f"{completion_marker} immediately followed by CompleteWorkItem for the exact "
+        "current item. Do not create another WorkItem."
+    )
+    authoritative_phase = case["phases"][1]
+    baseline, _ = harness.prompt(
+        "scheduler-authoritative-seed",
+        authoritative_phase["prompt"].format(
+            case_id=case["id"],
+            objective=json.dumps(objective, ensure_ascii=False),
+            completion_marker=completion_marker,
+        ),
+    )
+    task_waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=objective_marker,
+        expected_scheduling_state="waiting_task",
+        label="scheduler-authoritative-task-wait",
+    )
+    external_waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=objective_marker,
+        expected_scheduling_state="waiting_external",
+        label="scheduler-authoritative-external-wait",
+    )
+    require(
+        external_waiting["id"] == task_waiting["id"],
+        "task-result rejoin changed WorkItem identity",
+    )
+    callback = harness.reset_callback("scheduler-authoritative-callback")
+    harness.fire_callback(
+        "scheduler-authoritative-wake",
+        callback["trigger_url"],
+        {"case_id": case["id"], "marker": marker},
+    )
+    item = harness.wait_work_item(
+        objective_marker=objective_marker,
+        expected_state="completed",
+        label="scheduler-authoritative-completed",
+    )
+    required, forbidden = phase_tools(authoritative_phase)
+    harness.assert_tools(
+        "scheduler-authoritative-seed", baseline, required, forbidden
+    )
+    work_item_id = item["id"]
+    result_brief_id = item.get("result_brief_id")
+    require(
+        isinstance(result_brief_id, str) and result_brief_id,
+        f"authoritative WorkItem omitted result brief: {item}",
+    )
+    result_brief = harness.brief(result_brief_id, "scheduler-authoritative-result")
+    require(
+        result_brief.get("work_item_id") == work_item_id
+        and completion_marker in (result_brief.get("text") or ""),
+        f"authoritative completion brief mismatch: {result_brief}",
+    )
+
+    snapshot = harness.runtime_db_snapshot("scheduler-authoritative")
+    require_rollout_state(snapshot, authoritative_modes)
+    activation_rows = [
+        row
+        for row in snapshot["scheduler_activations"]
+        if row["work_item_id"] == work_item_id
+    ]
+    message_ids = {
+        json.loads(row["payload_json"])["activation"]["provenance"]["source_id"]
+        for row in activation_rows
+    }
+    scheduler_messages = [
+        row for row in snapshot["messages"] if row["message_id"] in message_ids
+    ]
+    require(
+        len(activation_rows) == 3
+        and len(message_ids) == 3
+        and len(scheduler_messages) == 3,
+        f"expected autonomous, task-result, and wait-resume messages: {scheduler_messages}",
+    )
+    require_processed_queue_entries(snapshot["queue_entries"], message_ids)
+    turns = require_turns_terminal(snapshot, message_ids)
+    activations = require_scheduler_activation_chain(
+        snapshot,
+        agent_id=harness.agent_id,
+        work_item_id=work_item_id,
+        expected_activation_count=3,
+    )
+    demand = [
+        row
+        for row in snapshot["scheduler_work_demands"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(demand) == 1
+        and demand[0]["status"] == "terminal"
+        and demand[0]["scheduling_generation"]
+        == max(row["admitted_generation"] for row in activations) + 1,
+        f"canonical WorkItem demand did not converge at the final generation: {demand}",
+    )
+    final_turn_id = result_brief.get("turn_id")
+    final_message_id = result_brief.get("related_message_id")
+    require(
+        any(
+            row["turn_id"] == final_turn_id
+            and row["trigger_message_id"] == final_message_id
+            for row in turns
+        ),
+        f"result brief was not bound to the terminal continuation turn: {result_brief}",
+    )
+    brief_rows = [
+        row for row in snapshot["briefs"] if row["evidence_id"] == result_brief_id
+    ]
+    require(
+        len(brief_rows) == 1
+        and brief_rows[0]["work_item_id"] == work_item_id
+        and brief_rows[0]["turn_id"] == final_turn_id
+        and brief_rows[0]["message_id"] == final_message_id,
+        f"database result brief binding is not exact: {brief_rows}",
+    )
+    waits = [
+        row
+        for row in snapshot["wait_conditions"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(waits) == 2
+        and {row["kind"] for row in waits} == {"task", "external"}
+        and {
+            row["kind"]: row["status"]
+            for row in waits
+        }
+        == {"task": "resolved", "external": "cancelled"},
+        f"legacy task/external waits did not reach their terminal states: {waits}",
+    )
+    canonical_waits = [
+        row
+        for row in snapshot["scheduler_wait_generations"]
+        if row["owner_work_item_id"] == work_item_id
+    ]
+    require(
+        len(canonical_waits) == 2
+        and all(row["lifecycle_state"] == "resolved" for row in canonical_waits)
+        and all(row["consuming_activation_id"] is None for row in canonical_waits),
+        f"canonical task/external waits did not resolve exactly once: {canonical_waits}",
+    )
+    require_scheduler_comparisons(
+        snapshot,
+        {
+            "work_item_autonomous_continuation": 1,
+            "exact_task_rejoin": 1,
+            "exact_wait_resume": 1,
+            "settlement": 3,
+            "delivery": 3,
+        },
+    )
+
+    harness.stop()
+    rollback_revision = first_authoritative_revision + len(authoritative_modes)
+    harness.apply_scheduler_rollout(
+        "scheduler-rollout-rollback",
+        scheduler_scenario_mode_commands(
+            {"work_item_autonomous_continuation": "shadow"},
+            expected_config_revision=rollback_revision,
+            identity_suffix="rollback",
+        ),
+    )
+    harness.start()
+    restarted = harness.work_items("scheduler-authoritative-after-rollback")
+    restored = next(candidate for candidate in restarted if candidate["id"] == work_item_id)
+    require(
+        restored["state"] == "completed"
+        and restored.get("result_brief_id") == result_brief_id,
+        f"rollback/restart changed completed WorkItem identity: {restored}",
+    )
+    rollback_snapshot = harness.runtime_db_snapshot("scheduler-rollback")
+    expected_after_rollback = dict(authoritative_modes)
+    expected_after_rollback["work_item_autonomous_continuation"] = "shadow"
+    require_rollout_state(rollback_snapshot, expected_after_rollback)
+    require_scheduler_activation_chain(
+        rollback_snapshot,
+        agent_id=harness.agent_id,
+        work_item_id=work_item_id,
+        expected_activation_count=3,
+    )
+
+
+def run_scheduler_terminal_recovery_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    scenario_modes = {
+        "work_item_autonomous_continuation": "authoritative",
+        "settlement": "authoritative",
+    }
+    harness.apply_scheduler_rollout(
+        "scheduler-recovery-rollout",
+        scheduler_rollout_commands(scenario_modes),
+    )
+    objective = f"SCHEDULER-TERMINAL-RECOVERY-{secrets.token_hex(4)}"
+    fixture = harness.seed_scheduler_recovery_fixture(
+        "scheduler-terminal-recovery-fixture",
+        objective,
+    )
+    harness.start(wait_idle=False)
+    deadline = time.monotonic() + harness.timeout_seconds
+    recovered = False
+    while time.monotonic() < deadline:
+        recovered = any(
+            event["type"] == "scheduler_bootstrap_claim_recovered"
+            and event["payload"].get("message_id") == fixture["message_id"]
+            for event in harness.events("scheduler-recovery-poll")
+        )
+        if recovered:
+            break
+        time.sleep(1)
+    require(recovered, "serve bootstrap did not reconcile the recovery fixture")
+    first = harness.runtime_db_snapshot("scheduler-recovery-first")
+    require_rollout_state(first, scenario_modes)
+    require_processed_queue_entries(first["queue_entries"], {fixture["message_id"]})
+    require_turns_terminal(first, {fixture["message_id"]})
+    activations = require_scheduler_activation_chain(
+        first,
+        agent_id=fixture["agent_id"],
+        work_item_id=fixture["work_item_id"],
+        expected_activation_count=1,
+    )
+    require(
+        activations[0]["activation_id"] == fixture["activation_id"]
+        and activations[0]["admitted_generation"] == fixture["admitted_generation"],
+        f"recovery changed activation identity or generation: {activations}",
+    )
+    work_items = [
+        row
+        for row in first["work_items"]
+        if row["work_item_id"] == fixture["work_item_id"]
+    ]
+    require(
+        len(work_items) == 1 and work_items[0]["state"] == "open",
+        f"recovery fixture WorkItem disposition changed unexpectedly: {work_items}",
+    )
+    demands = [
+        row
+        for row in first["scheduler_work_demands"]
+        if row["work_item_id"] == fixture["work_item_id"]
+    ]
+    require(
+        len(demands) == 1
+        and demands[0]["status"] == "runnable"
+        and demands[0]["scheduling_generation"]
+        == fixture["admitted_generation"] + 1,
+        f"terminal recovery did not advance the successor WorkItem generation: {demands}",
+    )
+    require(
+        not first["scheduler_missing_settlements"],
+        f"terminal recovery produced missing-settlement evidence: "
+        f"{first['scheduler_missing_settlements']}",
+    )
+
+    harness.restart(wait_idle=False)
+    second = harness.runtime_db_snapshot("scheduler-recovery-second")
+    require(
+        second["queue_entries"] == first["queue_entries"]
+        and second["scheduler_activations"] == first["scheduler_activations"]
+        and second["scheduler_activation_settlements"]
+        == first["scheduler_activation_settlements"]
+        and second["scheduler_missing_settlements"]
+        == first["scheduler_missing_settlements"]
+        and second["scheduler_work_demands"] == first["scheduler_work_demands"]
+        and second["scheduler_agent_slots"] == first["scheduler_agent_slots"]
+        and second["scheduler_wait_generations"]
+        == first["scheduler_wait_generations"]
+        and second["scheduler_protocol_command_results"]
+        == first["scheduler_protocol_command_results"]
+        and second["turn_records"] == first["turn_records"]
+        and second["audit_events"] == first["audit_events"],
+        "second restart changed reconciled scheduler state",
+    )
+
+
 CASE_RUNNERS = {
     "runtime-auth-model-delivery": run_runtime_case,
     "memory-agent-home-persistence": run_memory_case,
@@ -1233,6 +2206,12 @@ CASE_RUNNERS = {
     "workitem-wait-restart-complete": run_workitem_case,
     "scheduler-autonomous-legacy": run_scheduler_protocol_case,
     "scheduler-autonomous-authoritative": run_scheduler_protocol_case,
+    "scheduler-rollout-authoritative-autonomous": (
+        run_scheduler_rollout_authoritative_case
+    ),
+    "scheduler-terminal-before-settlement-restart": (
+        run_scheduler_terminal_recovery_case
+    ),
 }
 
 
@@ -1260,6 +2239,11 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             and case["timeout_seconds"] > 0,
             f"{case_id} timeout_seconds must be positive",
         )
+        if "requires_model" in case:
+            require(
+                isinstance(case["requires_model"], bool),
+                f"{case_id} requires_model must be boolean",
+            )
         runtime_env = case.get("runtime_env", {})
         require(isinstance(runtime_env, dict), f"{case_id} runtime_env must be an object")
         require(
@@ -1353,9 +2337,8 @@ def secret_scan(evidence_root: Path, secrets_to_find: list[str]) -> dict[str, An
                 findings.append({"path": relative, "kind": f"secret-value-{index + 1}"})
         if BEARER_SECRET_PATTERN.search(text):
             findings.append({"path": relative, "kind": "bearer-header"})
-        for match in CALLBACK_CAPABILITY_SCAN_PATTERN.finditer(text):
-            if match.group(1) != "<redacted>":
-                findings.append({"path": relative, "kind": "callback-capability"})
+        if CALLBACK_CAPABILITY_SCAN_PATTERN.search(text):
+            findings.append({"path": relative, "kind": "callback-capability"})
     result = {
         "schema_version": EVIDENCE_SCHEMA_VERSION,
         "status": "pass" if not findings else "fail",
@@ -1494,6 +2477,13 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     require(shutil.which("docker") is not None, "docker is required")
+    selected = select_cases(
+        manifest,
+        requested=args.cases,
+        suite=args.suite,
+        tags=args.tag,
+    )
+    requires_model = any(case.get("requires_model", True) for case in selected)
     model = args.model or first_env(
         "HOLON_E2E_MODEL", "HOLON_LIVE_MODEL", default=DEFAULT_MODEL
     )
@@ -1505,7 +2495,7 @@ def main(argv: list[str] | None = None) -> int:
         "HOLON_E2E_DOCKER_ENV_FILE", "HOLON_LIVE_DOCKER_ENV_FILE"
     )
     env_file = Path(env_file_value).resolve() if env_file_value else None
-    if not credential_envs and env_file is None:
+    if requires_model and not credential_envs and env_file is None:
         inferred = inferred_credential_env(model)
         require(
             inferred is not None,
@@ -1513,8 +2503,12 @@ def main(argv: list[str] | None = None) -> int:
             f"for model {model}",
         )
         credential_envs = [inferred]
-    for name in credential_envs:
-        require(name in os.environ, f"required credential environment {name} is unset")
+    if requires_model:
+        for name in credential_envs:
+            require(name in os.environ, f"required credential environment {name} is unset")
+    else:
+        credential_envs = []
+        env_file = None
 
     secret_values = [os.environ[name] for name in credential_envs]
     if env_file is not None:
@@ -1533,12 +2527,6 @@ def main(argv: list[str] | None = None) -> int:
         require(not args.image_digest, "cannot build when --image-digest is supplied")
         run(["docker", "build", "--tag", image, str(ROOT)], capture=False)
 
-    selected = select_cases(
-        manifest,
-        requested=args.cases,
-        suite=args.suite,
-        tags=args.tag,
-    )
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     evidence_root = (
         args.evidence_dir.resolve()
@@ -1581,6 +2569,7 @@ def main(argv: list[str] | None = None) -> int:
             case_id=case_id,
             image=image,
             model=model,
+            requires_model=case.get("requires_model", True),
             credential_envs=credential_envs,
             env_file=env_file,
             runtime_env=dict(case.get("runtime_env", {})),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -583,6 +583,22 @@ pub enum DebugCommands {
         #[arg(long)]
         json: bool,
     },
+    #[command(hide = true)]
+    SchedulerRolloutApply {
+        #[arg(long)]
+        input: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    #[command(hide = true)]
+    SchedulerRecoveryFixture {
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long)]
+        objective: String,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -3122,6 +3122,7 @@ fn settle(snapshot: &Snapshot, activation_id: &str, settlement: &Settlement) -> 
                     .expect("current wait generation exists");
                 if previous.state == WaitState::Consumed {
                     previous.state = WaitState::Resolved;
+                    previous.consuming_activation_id = None;
                     transitions.push(format!(
                         "wait:{}:generation:{}:consumed->resolved",
                         wait.id, record.current_generation
@@ -3247,6 +3248,7 @@ fn resolve_consumed_wait(
         .get_mut(&wait.current_generation)
         .expect("current wait generation exists");
     generation.state = WaitState::Resolved;
+    generation.consuming_activation_id = None;
     transitions.push(format!(
         "wait:{wait_id}:generation:{}:consumed->resolved",
         wait.current_generation

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use clap::ValueEnum;
+use serde::Deserialize;
 
 use holon::{
     client::{normalize_control_base_url, LocalClient, LocalHttpError},
@@ -41,7 +42,7 @@ use holon::{
     onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
-    runtime::maybe_enqueue_first_run_intro,
+    runtime::{maybe_enqueue_first_run_intro, seed_scheduler_terminal_recovery_fixture},
     runtime_db::{RuntimeDb, RuntimeDbLock},
     solve::{run_solve, SolveRequest},
     storage::AppStorage,
@@ -177,7 +178,11 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         return run_tui(config, *no_alt_screen, Some(client)).await;
     }
 
-    let config = AppConfig::load()?;
+    let config = if runtime_command_uses_config_inspection(&command) {
+        AppConfig::load_for_config_inspection()?
+    } else {
+        AppConfig::load()?
+    };
     match command {
         Commands::Serve { options } => serve(config, options).await,
         Commands::Daemon { command } => handle_daemon_command(config, command).await,
@@ -267,6 +272,16 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         Commands::Onboard { .. } => unreachable!("onboard command is handled before runtime load"),
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
     }
+}
+
+fn runtime_command_uses_config_inspection(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Debug {
+            command: DebugCommands::SchedulerRolloutApply { .. }
+                | DebugCommands::SchedulerRecoveryFixture { .. }
+        }
+    )
 }
 
 async fn handle_memory_index_command(
@@ -1477,6 +1492,80 @@ mod tests {
     }
 
     #[test]
+    fn hidden_scheduler_rollout_apply_parses_input_and_json() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "scheduler-rollout-apply",
+            "--input",
+            "/tmp/rollout.json",
+            "--json",
+        ]);
+        let Commands::Debug {
+            command: DebugCommands::SchedulerRolloutApply { input, json },
+        } = cli.command
+        else {
+            panic!("expected hidden scheduler-rollout-apply command");
+        };
+        assert_eq!(input, PathBuf::from("/tmp/rollout.json"));
+        assert!(json);
+    }
+
+    #[test]
+    fn hidden_scheduler_recovery_fixture_parses_objective() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "scheduler-recovery-fixture",
+            "--agent",
+            "runner",
+            "--objective",
+            "terminal before settlement",
+            "--json",
+        ]);
+        let Commands::Debug {
+            command:
+                DebugCommands::SchedulerRecoveryFixture {
+                    agent,
+                    objective,
+                    json,
+                },
+        } = cli.command
+        else {
+            panic!("expected hidden scheduler-recovery-fixture command");
+        };
+        assert_eq!(agent.as_deref(), Some("runner"));
+        assert_eq!(objective, "terminal before settlement");
+        assert!(json);
+    }
+
+    #[test]
+    fn hidden_offline_scheduler_commands_skip_runtime_model_resolution() {
+        for args in [
+            vec![
+                "holon",
+                "debug",
+                "scheduler-rollout-apply",
+                "--input",
+                "/tmp/rollout.json",
+            ],
+            vec![
+                "holon",
+                "debug",
+                "scheduler-recovery-fixture",
+                "--objective",
+                "terminal before settlement",
+            ],
+        ] {
+            let cli = Cli::parse_from(args);
+            assert!(runtime_command_uses_config_inspection(&cli.command));
+        }
+
+        let cli = Cli::parse_from(["holon", "debug", "scheduler-recovery"]);
+        assert!(!runtime_command_uses_config_inspection(&cli.command));
+    }
+
+    #[test]
     fn debug_performance_command_parses_json_flag() {
         let cli = Cli::parse_from(["holon", "debug", "performance", "--json"]);
         let Commands::Debug {
@@ -2216,6 +2305,70 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
         DebugCommands::SchedulerRecovery { agent, json } => {
             print_scheduler_recovery_report(&config, agent, json)
         }
+        DebugCommands::SchedulerRolloutApply { input, json } => {
+            apply_scheduler_rollout_command(&config, &input, json)
+        }
+        DebugCommands::SchedulerRecoveryFixture {
+            agent,
+            objective,
+            json,
+        } => seed_scheduler_recovery_fixture(&config, agent, objective, json).await,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SchedulerRolloutApplyInput {
+    commands: Vec<SchedulerRolloutApplyCommand>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SchedulerRolloutApplyCommand {
+    command_identity: String,
+    command: holon::domain::scheduler_protocol::RolloutCommand,
+}
+
+fn apply_scheduler_rollout_command(config: &AppConfig, input: &Path, json: bool) -> Result<()> {
+    holon::runtime::require_scheduler_acceptance_fixtures_enabled()?;
+    let _maintenance_lock = RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path())
+        .context("scheduler rollout apply requires holon serve to be stopped")?;
+    let request: SchedulerRolloutApplyInput = serde_json::from_slice(
+        &fs::read(input).with_context(|| format!("reading {}", input.display()))?,
+    )
+    .with_context(|| format!("parsing scheduler rollout command {}", input.display()))?;
+    let db = RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+    if request.commands.is_empty() {
+        return Err(anyhow!("scheduler rollout command list must not be empty"));
+    }
+    let commands = request
+        .commands
+        .into_iter()
+        .map(|request| (request.command_identity, request.command))
+        .collect::<Vec<_>>();
+    let receipts = db.apply_scheduler_rollout_commands(&commands)?;
+    if json {
+        print_json(&serde_json::json!({ "receipts": receipts }))
+    } else {
+        println!("{}", serde_json::to_string_pretty(&receipts)?);
+        Ok(())
+    }
+}
+
+async fn seed_scheduler_recovery_fixture(
+    config: &AppConfig,
+    agent: Option<String>,
+    objective: String,
+    json: bool,
+) -> Result<()> {
+    holon::runtime::require_scheduler_acceptance_fixtures_enabled()?;
+    let _maintenance_lock = RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path())
+        .context("scheduler recovery fixture requires holon serve to be stopped")?;
+    let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
+    let fixture = seed_scheduler_terminal_recovery_fixture(config, &agent_id, objective).await?;
+    if json {
+        print_json(&serde_json::to_value(fixture)?)
+    } else {
+        println!("{}", serde_json::to_string_pretty(&fixture)?);
+        Ok(())
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,6 +14,7 @@ mod operator;
 mod operator_dispatch;
 mod provider_turn;
 mod scheduler;
+mod scheduler_acceptance;
 mod scheduler_executor;
 mod subagent;
 mod task_state_reducer;
@@ -29,6 +30,9 @@ mod worktree;
 
 pub use first_run_intro::maybe_enqueue_first_run_intro;
 pub(crate) use lifecycle::LightweightAgentStateProjection;
+pub use scheduler_acceptance::{
+    seed_scheduler_terminal_recovery_fixture, SchedulerTerminalRecoveryFixture,
+};
 pub use tasks::{
     PickedWorkItem, WorkItemContinuationSummary, WorkItemFocusTransition,
     WorkItemFocusTransitionWarning,
@@ -285,17 +289,85 @@ struct RuntimeInner {
 
 const SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV: &str =
     "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS";
+const SCHEDULER_ACCEPTANCE_FIXTURES_ENV: &str = "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES";
 
 fn scheduler_protocol_production_commands_enabled_from_env() -> Result<bool> {
-    let Some(value) = std::env::var_os(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV) else {
-        return Ok(false);
+    boolean_env(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV).map(|value| value.unwrap_or(false))
+}
+
+fn boolean_env(name: &str) -> Result<Option<bool>> {
+    let Some(value) = std::env::var_os(name) else {
+        return Ok(None);
     };
-    match value.to_string_lossy().trim().to_ascii_lowercase().as_str() {
-        "1" | "true" | "yes" | "on" => Ok(true),
-        "0" | "false" | "no" | "off" => Ok(false),
-        _ => Err(anyhow!(
-            "{SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV} expects a boolean"
-        )),
+    let value = match value.to_string_lossy().trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        _ => return Err(anyhow!("{name} expects a boolean")),
+    };
+    Ok(Some(value))
+}
+
+pub fn require_scheduler_acceptance_fixtures_enabled() -> Result<()> {
+    if boolean_env(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV)? != Some(true) {
+        return Err(anyhow!(
+            "scheduler acceptance fixtures require {SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV}=true"
+        ));
+    }
+    if boolean_env(SCHEDULER_ACCEPTANCE_FIXTURES_ENV)? != Some(true) {
+        return Err(anyhow!(
+            "scheduler acceptance fixtures require {SCHEDULER_ACCEPTANCE_FIXTURES_ENV}=true"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn scheduler_acceptance_fixtures_enabled_from_values(
+    production_commands: Option<&str>,
+    acceptance_fixtures: Option<&str>,
+) -> Result<bool> {
+    fn parse(name: &str, value: Option<&str>) -> Result<Option<bool>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(Some(true)),
+            "0" | "false" | "no" | "off" => Ok(Some(false)),
+            _ => Err(anyhow!("{name} expects a boolean")),
+        }
+    }
+    Ok(parse(
+        SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV,
+        production_commands,
+    )? == Some(true)
+        && parse(SCHEDULER_ACCEPTANCE_FIXTURES_ENV, acceptance_fixtures)? == Some(true))
+}
+
+#[cfg(test)]
+mod scheduler_acceptance_gate_tests {
+    use super::*;
+
+    #[test]
+    fn scheduler_acceptance_gate_requires_both_explicit_flags() {
+        assert!(
+            scheduler_acceptance_fixtures_enabled_from_values(Some("true"), Some("true")).unwrap()
+        );
+        assert!(!scheduler_acceptance_fixtures_enabled_from_values(Some("true"), None).unwrap());
+        assert!(!scheduler_acceptance_fixtures_enabled_from_values(None, Some("true")).unwrap());
+        assert!(
+            !scheduler_acceptance_fixtures_enabled_from_values(Some("false"), Some("true"))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn scheduler_acceptance_gate_rejects_invalid_boolean() {
+        assert!(
+            scheduler_acceptance_fixtures_enabled_from_values(Some("sometimes"), Some("true"))
+                .unwrap_err()
+                .to_string()
+                .contains(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV)
+        );
     }
 }
 
@@ -315,28 +387,21 @@ fn canonical_queue_settlement_commands_from_facts(
     let Some(message) = storage.read_message_by_id(&record.message_id)? else {
         return Ok(Vec::new());
     };
-    if !matches!(
-        (&message.kind, &message.origin),
-        (MessageKind::SystemTick, MessageOrigin::System { subsystem })
-            if subsystem == "work_queue"
-    ) {
-        return Ok(Vec::new());
-    }
-
     use crate::domain::scheduler_protocol::{
         ActivationDisposition, ActivationSettlement, AgentDispatchDisposition,
-        MissingSettlementRecord, ProtocolCommand, SettleActivationCommand,
+        MissingSettlementRecord, ProtocolCommand, SettleActivationCommand, WaitIdentity,
     };
 
-    let snapshot = runtime_db
+    let Some(snapshot) = runtime_db
         .transitions()
         .load_scheduler_protocol_snapshot_if_initialized(&record.agent_id)?
-        .ok_or_else(|| anyhow!("canonical queue settlement has no scheduler partition"))?;
+    else {
+        return Ok(Vec::new());
+    };
     let activation_id = scheduler_executor::canonical_activation_id(&record.message_id);
-    let activation = snapshot
-        .activations
-        .get(&activation_id)
-        .ok_or_else(|| anyhow!("canonical queue settlement has no matching activation"))?;
+    let Some(activation) = snapshot.activations.get(&activation_id) else {
+        return Ok(Vec::new());
+    };
     let work_item_id = activation.work_item_id.clone();
     let work_queue = storage.work_queue_prompt_projection()?;
     let scheduling_state = work_queue
@@ -381,13 +446,17 @@ fn canonical_queue_settlement_commands_from_facts(
                 let Some(completion_intent) = work_item.completion_intent.as_ref() else {
                     return Ok(vec![missing_settlement()]);
                 };
+                let Some(admission) = snapshot.activation_admissions.get(&activation_id) else {
+                    return Ok(vec![missing_settlement()]);
+                };
                 if !(completion_intent.work_item_id == work_item_id
                     && completion_intent.source_activation_id.as_deref()
                         == Some(activation_id.as_str())
                     && completion_intent.source_message_id.as_deref()
                         == Some(record.message_id.as_str())
                     && completion_intent.source_turn_id.as_deref() == Some(turn_terminal.as_str())
-                    && completion_intent.expected_work_revision == activation.admitted_generation)
+                    && admission.activation.source_revision
+                        == Some(completion_intent.expected_work_revision))
                 {
                     return Ok(vec![missing_settlement()]);
                 }
@@ -423,6 +492,44 @@ fn canonical_queue_settlement_commands_from_facts(
                             format!("work_item:{work_item_id}"),
                             format!("turn:{turn_terminal}"),
                             format!("brief:{}", brief.id),
+                        ],
+                        created_at: record.updated_at.to_rfc3339(),
+                    },
+                })
+            }
+            Some(
+                crate::types::WorkItemSchedulingState::WaitingOperator
+                | crate::types::WorkItemSchedulingState::WaitingTask
+                | crate::types::WorkItemSchedulingState::WaitingExternal
+                | crate::types::WorkItemSchedulingState::WaitingTimer
+                | crate::types::WorkItemSchedulingState::WaitingSystem,
+            ) => {
+                let active_waits = storage
+                    .active_wait_conditions_for_work_item(&record.agent_id, &work_item_id)?;
+                let [active_wait] = active_waits.as_slice() else {
+                    return Ok(vec![missing_settlement()]);
+                };
+                let generation = activation
+                    .admitted_generation
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow!("canonical wait generation overflow"))?;
+                ProtocolCommand::SettleActivation(SettleActivationCommand {
+                    settlement: ActivationSettlement {
+                        id: canonical_settlement_id(&record.message_id),
+                        activation_id,
+                        turn_terminal: message.turn_id.clone(),
+                        disposition: ActivationDisposition::WorkWaits {
+                            wait: WaitIdentity {
+                                id: active_wait.id.clone(),
+                                generation,
+                            },
+                        },
+                        agent_dispatch: AgentDispatchDisposition::Open,
+                        operator_delivery: None,
+                        evidence: vec![
+                            format!("message:{}", record.message_id),
+                            format!("work_item:{work_item_id}"),
+                            format!("wait:{}", active_wait.id),
                         ],
                         created_at: record.updated_at.to_rfc3339(),
                     },

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -140,6 +140,34 @@ impl RuntimeHandle {
         )
     }
 
+    pub(super) fn new_offline_with_runtime_db(
+        agent_id: impl Into<String>,
+        data_dir: PathBuf,
+        initial_workspace: impl Into<InitialWorkspaceBinding>,
+        runtime_db: RuntimeDb,
+    ) -> Result<Self> {
+        Self::new_internal(
+            agent_id,
+            data_dir,
+            initial_workspace,
+            String::new(),
+            Arc::new(crate::provider::StubProvider::new("unused")),
+            String::new(),
+            ContextConfig::default(),
+            ContextConfig::default(),
+            RuntimeModelCatalog::default(),
+            Vec::new(),
+            crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
+            crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS,
+            crate::web::WebConfig::default(),
+            None,
+            Some(runtime_db),
+            None,
+            None,
+            Arc::new(SystemClock),
+        )
+    }
+
     #[cfg(test)]
     pub(crate) fn new_with_clock(
         agent_id: impl Into<String>,

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -24,12 +24,26 @@ impl RuntimeHandle {
         };
         let continuation_trigger =
             ContinuationTrigger::from_message(message, task.as_ref().ok().and_then(Option::as_ref));
+        let matching_wait_work_item_id = if continuation_trigger.is_some() {
+            let matching_waits = self
+                .inner
+                .storage
+                .active_wait_conditions_for_agent(&message.agent_id)?
+                .into_iter()
+                .filter(|condition| scheduler::message_matches_wait_condition(message, condition))
+                .collect::<Vec<_>>();
+            (matching_waits.len() == 1)
+                .then(|| matching_waits[0].work_item_id.clone())
+                .flatten()
+        } else {
+            None
+        };
+        let continuation_work_item_id = matching_wait_work_item_id
+            .as_deref()
+            .or(scheduler_state.current_turn_work_item_id.as_deref())
+            .or(scheduler_state.current_work_item_id.as_deref());
         let continuation_resolution = continuation_trigger.as_ref().map(|trigger| {
-            resolve_continuation(
-                &prior_closure,
-                trigger,
-                scheduler_state.current_work_item_id.as_deref(),
-            )
+            resolve_continuation(&prior_closure, trigger, continuation_work_item_id)
         });
         let model_turn_allowed = !matches!(scheduler_state.status, AgentStatus::Stopped);
         Ok(MessageDispatchPlan {

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::domain::scheduler_protocol::SchedulerScenarioClass;
+use crate::domain::scheduler_protocol::{SchedulerScenarioClass, WorkStatus};
 use crate::domain::scheduler_semantic::{
     structural_semantic_proposal, SemanticProposalProviderConfig, SemanticProposalProviderIdentity,
     SemanticProposalResponse, SemanticValidationPolicy, SemanticWaitCandidate,
@@ -20,7 +20,7 @@ use crate::work_item_scheduling::WorkItemSchedulingProjection;
 use anyhow::bail;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 pub(crate) const REDUCER_ONLY_CANDIDATES_SCENARIO: SchedulerScenarioClass =
     SchedulerScenarioClass::ReducerOnlyCandidates;
@@ -121,6 +121,8 @@ pub(crate) struct SchedulerProjection {
     pub turn_in_progress: bool,
     pub runtime_error: bool,
     semantic_waits: Vec<WaitConditionRecord>,
+    activation_waits: Vec<WaitConditionRecord>,
+    canonical_work_statuses: Option<HashMap<String, WorkStatus>>,
     semantic_work_items: Vec<WorkItemSchedulingProjection>,
 }
 
@@ -237,6 +239,32 @@ impl SchedulerProjection {
         let waiting_work_item_scheduling_state =
             waiting_work_item_projection.map(|item| item.scheduling_state);
         let active_wait_conditions = storage.active_wait_conditions_for_agent(&snapshot.id)?;
+        let activation_waits = storage
+            .latest_wait_conditions()?
+            .into_iter()
+            .filter(|condition| condition.agent_id == snapshot.id)
+            .filter(|condition| {
+                condition.status == WaitConditionStatus::Active
+                    || (condition.status == WaitConditionStatus::Resolved
+                        && condition.kind == WaitConditionKind::Task)
+            })
+            .collect();
+        let canonical_work_statuses = storage
+            .runtime_db()?
+            .map(|runtime_db| {
+                runtime_db
+                    .transitions()
+                    .load_scheduler_protocol_snapshot_if_initialized(&snapshot.id)
+            })
+            .transpose()?
+            .flatten()
+            .map(|snapshot| {
+                snapshot
+                    .work
+                    .into_iter()
+                    .map(|(work_item_id, demand)| (work_item_id, demand.status))
+                    .collect()
+            });
         let active_work_item_waiting_intents = active_wait_conditions
             .iter()
             .filter(|condition| condition.work_item_id.is_some())
@@ -284,6 +312,8 @@ impl SchedulerProjection {
                 &storage.read_recent_briefs(64)?,
             ),
             semantic_waits: active_wait_conditions,
+            activation_waits,
+            canonical_work_statuses,
             semantic_work_items: work_queue.items,
         })
     }
@@ -933,10 +963,21 @@ pub(crate) fn decide_next_action(
             message,
             model_turn_allowed,
             continuation_resolution,
-        } => message_processing_decision(message, model_turn_allowed, continuation_resolution)
-            .boundary(boundary_label)
-            .evidence(format!("queue_len={}", projection.queue_len))
-            .evidence(format!("turn_in_progress={}", projection.turn_in_progress)),
+        } => {
+            let matching_wait_work_item_id = matching_wait_conditions(projection, message)
+                .into_iter()
+                .filter_map(|condition| condition.work_item_id.clone())
+                .next();
+            let mut decision =
+                message_processing_decision(message, model_turn_allowed, continuation_resolution)
+                    .boundary(boundary_label)
+                    .evidence(format!("queue_len={}", projection.queue_len))
+                    .evidence(format!("turn_in_progress={}", projection.turn_in_progress));
+            if decision.work_item_id.is_none() {
+                decision.work_item_id = matching_wait_work_item_id;
+            }
+            decision
+        }
         SchedulerInput::IdleSignal(signal) => {
             decide_idle_signal_action(projection, boundary_label, signal)
         }
@@ -1334,6 +1375,15 @@ pub(crate) fn canonical_activation_scenario(
         if matching_wait.is_some_and(|wait| wait.work_item_id.as_deref() != Some(work_item_id)) {
             bail!("canonical task rejoin wait owner does not match task WorkItem");
         }
+        if matching_wait.is_none()
+            && projection
+                .canonical_work_statuses
+                .as_ref()
+                .and_then(|statuses| statuses.get(work_item_id))
+                .is_some_and(|status| matches!(status, WorkStatus::Waiting { .. }))
+        {
+            return Ok(None);
+        }
         return Ok(Some(CanonicalActivationScenario::ExactTaskRejoin {
             task_id: task_id.clone(),
             work_item_id: work_item_id.to_string(),
@@ -1387,13 +1437,34 @@ fn matching_wait_conditions<'a>(
     message: &MessageEnvelope,
 ) -> Vec<&'a WaitConditionRecord> {
     projection
-        .semantic_waits
+        .activation_waits
         .iter()
         .filter(|condition| {
-            condition.status == WaitConditionStatus::Active
+            (condition.status == WaitConditionStatus::Active
+                || (message.kind == MessageKind::TaskResult
+                    && condition.status == WaitConditionStatus::Resolved
+                    && condition.kind == WaitConditionKind::Task
+                    && condition.work_item_id == message.work_item_id
+                    && resolved_task_wait_is_current(projection, condition)))
                 && message_matches_wait_condition(message, condition)
         })
         .collect()
+}
+
+fn resolved_task_wait_is_current(
+    projection: &SchedulerProjection,
+    condition: &WaitConditionRecord,
+) -> bool {
+    let Some(statuses) = &projection.canonical_work_statuses else {
+        return true;
+    };
+    let Some(work_item_id) = condition.work_item_id.as_deref() else {
+        return false;
+    };
+    matches!(
+        statuses.get(work_item_id),
+        Some(WorkStatus::Waiting { wait_id }) if wait_id == &condition.id
+    )
 }
 
 fn trusted_explicit_operator_binding(message: &MessageEnvelope) -> bool {
@@ -1442,14 +1513,7 @@ pub(crate) fn shadow_comparison_for_wait_resume(
     if !wait_resume_scenario_applies(projection, message) {
         return None;
     }
-    let matching_waits: Vec<&WaitConditionRecord> = projection
-        .semantic_waits
-        .iter()
-        .filter(|condition| {
-            condition.status == WaitConditionStatus::Active
-                && message_matches_wait_condition(message, condition)
-        })
-        .collect();
+    let matching_waits = matching_wait_conditions(projection, message);
     if matching_waits.is_empty() {
         return None;
     }
@@ -1529,13 +1593,10 @@ fn wait_resume_scenario_applies(
     matches!(
         message.kind,
         MessageKind::TaskResult | MessageKind::SystemTick
-    ) && projection.semantic_waits.iter().any(|condition| {
-        condition.status == WaitConditionStatus::Active
-            && message_matches_wait_condition(message, condition)
-    })
+    ) && !matching_wait_conditions(projection, message).is_empty()
 }
 
-fn message_matches_wait_condition(
+pub(super) fn message_matches_wait_condition(
     message: &MessageEnvelope,
     condition: &WaitConditionRecord,
 ) -> bool {
@@ -1574,6 +1635,18 @@ fn message_matches_wait_condition(
         (MessageKind::SystemTick, MessageOrigin::System { subsystem }) => {
             if subsystem == "work_queue" {
                 return false;
+            }
+            if let Some(external_trigger_id) = message.source_refs.get("external_trigger_id") {
+                return condition.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        WakeSource::ExternalIngress {
+                            external_trigger_id: expected,
+                        } if expected.as_ref().is_none_or(|expected| {
+                            expected == external_trigger_id
+                        })
+                    )
+                });
             }
             condition
                 .wake_sources

--- a/src/runtime/scheduler_acceptance.rs
+++ b/src/runtime/scheduler_acceptance.rs
@@ -1,0 +1,180 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use serde::Serialize;
+
+use crate::{
+    config::AppConfig,
+    domain::scheduler_protocol::{ActivationSlot, ActivationState},
+    runtime_db::RuntimeDb,
+    types::{
+        AgentStatus, TurnRecord, TurnTerminalKind, TurnTerminalRecord, TurnTerminalSummary,
+        TurnTriggerSummary, WorkItemPlanStatus,
+    },
+};
+
+use super::{scheduler, scheduler_executor, InitialWorkspaceBinding, RuntimeHandle};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerTerminalRecoveryFixture {
+    pub agent_id: String,
+    pub work_item_id: String,
+    pub message_id: String,
+    pub turn_id: String,
+    pub activation_id: String,
+    pub admitted_generation: u64,
+    pub queue_status: String,
+    pub activation_state: String,
+    pub slot_state: String,
+}
+
+pub async fn seed_scheduler_terminal_recovery_fixture(
+    config: &AppConfig,
+    agent_id: &str,
+    objective: String,
+) -> Result<SchedulerTerminalRecoveryFixture> {
+    super::require_scheduler_acceptance_fixtures_enabled()?;
+    let runtime_db =
+        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+    let agent_home = config.agent_root_dir().join(agent_id);
+    std::fs::create_dir_all(&agent_home)
+        .with_context(|| format!("creating agent home {}", agent_home.display()))?;
+    let runtime = RuntimeHandle::new_offline_with_runtime_db(
+        agent_id,
+        agent_home,
+        InitialWorkspaceBinding::Detached,
+        runtime_db,
+    )?;
+    if !runtime.scheduler_protocol_production_commands_enabled() {
+        return Err(anyhow!(
+            "scheduler recovery fixture requires HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS=true"
+        ));
+    }
+
+    let work_item = runtime
+        .create_work_item(objective, Some(WorkItemPlanStatus::Ready), None, Vec::new())
+        .await?;
+    let agent_state = runtime.agent_state().await?;
+    let projection = scheduler::SchedulerProjection::from_state_with_queue_len(
+        &runtime.inner.storage,
+        &agent_state,
+        agent_state.pending,
+    )?;
+    let decision = scheduler::decide_next_action(
+        &projection,
+        scheduler::SchedulerBoundary::IdleTick,
+        scheduler::SchedulerInput::IdleSignal(scheduler::SchedulerIdleSignal::QueuedAvailable {
+            work_item: &work_item,
+            duplicate: None,
+        }),
+    );
+    if !matches!(
+        decision.kind,
+        scheduler::SchedulerDecisionKind::EmitSystemTick
+    ) {
+        return Err(anyhow!(
+            "scheduler recovery fixture could not emit queued work item: {}",
+            decision.reason
+        ));
+    }
+    let shadow_comparison = scheduler::shadow_comparison_for_work_queue_tick(
+        &projection,
+        &work_item,
+        "queued_available",
+        &decision,
+        scheduler::SchedulerBoundary::IdleTick,
+    );
+    runtime
+        .emit_system_tick_from_work_queue(
+            &work_item,
+            "queued_available",
+            shadow_comparison,
+            Some(&decision),
+        )
+        .await?;
+    let scheduled = match scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await?
+    {
+        scheduler_executor::RunLoopPoll::Message(scheduled) => scheduled,
+        scheduler_executor::RunLoopPoll::Idle => {
+            return Err(anyhow!(
+                "scheduler recovery fixture did not claim the work queue message"
+            ));
+        }
+        scheduler_executor::RunLoopPoll::Stopped(_, _) => {
+            return Err(anyhow!(
+                "scheduler recovery fixture agent was stopped before the claim"
+            ));
+        }
+        scheduler_executor::RunLoopPoll::Shutdown => {
+            return Err(anyhow!(
+                "scheduler recovery fixture runtime shut down before the claim"
+            ));
+        }
+    };
+    let message = scheduled.message;
+    let turn_id = message
+        .turn_id
+        .clone()
+        .ok_or_else(|| anyhow!("claimed scheduler fixture message has no turn id"))?;
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot(agent_id)?;
+    let activation = snapshot
+        .activations
+        .get(&activation_id)
+        .ok_or_else(|| anyhow!("scheduler fixture claim did not create canonical activation"))?;
+    if activation.state != ActivationState::Running
+        || !matches!(
+            snapshot.slot,
+            ActivationSlot::Running {
+                activation_id: ref slot_activation_id,
+                ..
+            } if slot_activation_id == &activation_id
+        )
+    {
+        return Err(anyhow!(
+            "scheduler fixture claim did not retain a running canonical activation"
+        ));
+    }
+
+    let turn_index = runtime.agent_state().await?.turn_index.saturating_add(1);
+    let terminal = TurnTerminalRecord {
+        turn_id: turn_id.clone(),
+        turn_index,
+        kind: TurnTerminalKind::Completed,
+        reason: None,
+        last_assistant_message: Some("scheduler recovery fixture terminal".into()),
+        checkpoint: None,
+        completed_at: Utc::now(),
+        duration_ms: 1,
+    };
+    let mut turn = TurnRecord::new(agent_id, &turn_id, turn_index);
+    turn.run_id = scheduled.running_state.current_run_id.clone();
+    turn.current_work_item_id = Some(work_item.id.clone());
+    turn.trigger = Some(TurnTriggerSummary::from_message(&message));
+    turn.input_message_ids = vec![message.id.clone()];
+    turn.terminal = Some(TurnTerminalSummary::from_terminal(&terminal));
+    runtime.inner.storage.append_turn(&turn)?;
+
+    let mut stopped = runtime.agent_state().await?;
+    stopped.status = AgentStatus::Stopped;
+    stopped.current_run_id = None;
+    stopped.pending = 0;
+    runtime.inner.storage.write_agent(&stopped)?;
+
+    Ok(SchedulerTerminalRecoveryFixture {
+        agent_id: agent_id.to_string(),
+        work_item_id: work_item.id,
+        message_id: message.id,
+        turn_id,
+        activation_id,
+        admitted_generation: activation.admitted_generation,
+        queue_status: "dequeued".into(),
+        activation_state: "running".into(),
+        slot_state: "running".into(),
+    })
+}

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -574,7 +574,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             return Ok(None);
         }
         let task = dispatch_plan.task.as_ref().ok().and_then(Option::as_ref);
-        let Some(scenario) = scheduler::canonical_activation_scenario(
+        let Some(mut scenario) = scheduler::canonical_activation_scenario(
             projection,
             message,
             dispatch_plan.continuation_resolution.as_ref(),
@@ -596,6 +596,50 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             expectation.mode != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
         }) {
             return Ok(None);
+        }
+
+        use crate::domain::scheduler_protocol::WorkStatus;
+
+        let existing = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
+        if let scheduler::CanonicalActivationScenario::ExactTaskRejoin {
+            work_item_id,
+            wait_id,
+            ..
+        } = &mut scenario
+        {
+            if wait_id.is_none() {
+                let authoritative_wait_id = existing
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.work.get(work_item_id))
+                    .and_then(|demand| match &demand.status {
+                        WorkStatus::Waiting { wait_id } => Some(wait_id),
+                        _ => None,
+                    });
+                if let Some(authoritative_wait_id) = authoritative_wait_id {
+                    let resolved_legacy_wait_matches = self
+                        .runtime
+                        .inner
+                        .storage
+                        .latest_wait_conditions()?
+                        .into_iter()
+                        .any(|condition| {
+                            condition.id == *authoritative_wait_id
+                                && condition.agent_id == message.agent_id
+                                && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
+                                && condition.status == crate::types::WaitConditionStatus::Resolved
+                                && condition.kind == crate::types::WaitConditionKind::Task
+                                && scheduler::message_matches_wait_condition(message, &condition)
+                        });
+                    if resolved_legacy_wait_matches {
+                        *wait_id = Some(authoritative_wait_id.clone());
+                    }
+                }
+            }
         }
 
         let work_item_id = scenario.work_item_id();
@@ -635,15 +679,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             AdmitActivationCommand, AgentActivation, AgentDispatchState,
             IssueActivationAuthorityCommand, PreemptionPolicy, ProtocolCommand,
             RegisterWorkDemandCommand, RolloutState, Snapshot, TriggerWaitCommand, WaitResumeClaim,
-            WorkDemand, WorkStatus,
+            WorkDemand,
         };
 
-        let existing = self
-            .runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
         if let Some(snapshot) = existing.as_ref() {
             if let Some(activation) = snapshot.activations.get(&activation_id) {
                 let slot_matches = matches!(

--- a/src/runtime/tests/contracts/queue.rs
+++ b/src/runtime/tests/contracts/queue.rs
@@ -1,5 +1,55 @@
 use super::super::support::*;
-use crate::types::{MessageEnvelope, QueueEntryRecord};
+use crate::types::{AdmissionContext, MessageDeliverySurface, MessageEnvelope, QueueEntryRecord};
+
+#[tokio::test]
+async fn legacy_work_queue_settlement_does_not_require_scheduler_partition() {
+    let harness = LifecycleHarness::new();
+    let message = harness
+        .runtime()
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::SystemTick,
+                MessageOrigin::System {
+                    subsystem: "work_queue".into(),
+                },
+                AuthorityClass::RuntimeInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "legacy work queue tick".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::RuntimeSystem,
+                AdmissionContext::RuntimeOwned,
+            ),
+        )
+        .await
+        .unwrap();
+    let mut processed = harness
+        .snapshot()
+        .queue_entries
+        .into_iter()
+        .find(|entry| entry.message_id == message.id)
+        .unwrap();
+    processed.status = QueueEntryStatus::Processed;
+    processed.updated_at = Utc::now();
+
+    assert!(harness
+        .runtime()
+        .commit_queue_settlement(processed.clone(), Vec::new(), true)
+        .await
+        .unwrap());
+    assert_eq!(
+        harness
+            .snapshot()
+            .queue_entries
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .unwrap(),
+        processed
+    );
+}
 
 #[tokio::test]
 async fn queue_runtime_path_rolls_back_each_pre_commit_fault() {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2115,6 +2115,226 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
 }
 
 #[tokio::test]
+async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(
+        &runtime,
+        &[
+            SchedulerScenarioClass::ExactTaskRejoin,
+            SchedulerScenarioClass::ExactWaitResume,
+        ],
+    );
+    let work_item = runtime
+        .create_work_item("canonical wait settlement".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "wait for task".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-rejoin".into()),
+            "waiting for task-rejoin".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    finish_claimed_test_run(&runtime).await;
+    runtime
+        .commit_queue_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let wait_generation = work_item.revision + 1;
+    assert_eq!(settled.slot, ActivationSlot::Idle);
+    assert_eq!(settled.dispatch, AgentDispatchState::Open);
+    assert_eq!(
+        settled.work.get(&work_item.id).map(|demand| &demand.status),
+        Some(&WorkStatus::Waiting {
+            wait_id: registration.condition.id.clone(),
+        })
+    );
+    assert_eq!(
+        settled
+            .waits
+            .get(&registration.condition.id)
+            .map(|wait| wait.current_generation),
+        Some(wait_generation)
+    );
+    assert!(settled
+        .settlements
+        .contains_key(&canonical_settlement_id(&message.id)));
+    assert!(settled.missing_settlements.is_empty());
+
+    let mut rejoin = task_result_message("task-rejoin").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    rejoin.work_item_id = Some(work_item.id.clone());
+    rejoin.metadata = Some(serde_json::json!({
+        "task_id": "task-rejoin",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-rejoin",
+        "work_item_id": work_item.id,
+    }));
+    let rejoin = runtime.enqueue(rejoin).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let rejoined = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(matches!(
+        rejoined.slot,
+        ActivationSlot::Running {
+            ref work_item_id,
+            admitted_generation,
+            ..
+        } if work_item_id == &work_item.id && admitted_generation == wait_generation
+    ));
+    assert_eq!(
+        rejoined.waits[&registration.condition.id].generations[&wait_generation].state,
+        WaitState::Consumed
+    );
+    assert_eq!(
+        rejoined.waits[&registration.condition.id].generations[&wait_generation]
+            .consuming_activation_id,
+        Some(scheduler_executor::canonical_activation_id(&rejoin.id))
+    );
+
+    let external_wait = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::External,
+            Some("external-rejoin".into()),
+            "waiting for external-rejoin".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    finish_claimed_test_run(&runtime).await;
+    runtime
+        .commit_queue_settlement(
+            QueueEntryRecord {
+                message_id: rejoin.id.clone(),
+                agent_id: rejoin.agent_id.clone(),
+                priority: rejoin.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: rejoin.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let settled_rejoin = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let external_wait_generation = wait_generation + 1;
+    assert_eq!(settled_rejoin.slot, ActivationSlot::Idle);
+    assert_eq!(
+        settled_rejoin
+            .work
+            .get(&work_item.id)
+            .map(|demand| &demand.status),
+        Some(&WorkStatus::Waiting {
+            wait_id: external_wait.condition.id.clone(),
+        })
+    );
+    assert_eq!(
+        settled_rejoin
+            .waits
+            .get(&external_wait.condition.id)
+            .map(|wait| wait.current_generation),
+        Some(external_wait_generation)
+    );
+    assert_eq!(
+        settled_rejoin.waits[&registration.condition.id].generations[&wait_generation].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        settled_rejoin.waits[&registration.condition.id].generations[&wait_generation]
+            .consuming_activation_id,
+        None
+    );
+    assert!(settled_rejoin
+        .settlements
+        .contains_key(&canonical_settlement_id(&rejoin.id)));
+}
+
+#[tokio::test]
 async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -2175,6 +2395,40 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         .transitions()
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
+    runtime
+        .persist_task_transition(
+            &TaskRecord {
+                id: "task-rejoin".into(),
+                agent_id: "default".into(),
+                kind: TaskKind::CommandTask,
+                status: TaskStatus::Completed,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                parent_message_id: None,
+                work_item_id: Some(work_item.id.clone()),
+                summary: Some("task-rejoin".into()),
+                detail: None,
+                recovery: None,
+            },
+            "task_completed",
+        )
+        .await
+        .unwrap();
+    assert!(runtime
+        .storage()
+        .active_wait_conditions_for_work_item("default", &work_item.id)
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Resolved)
+    );
 
     let mut message = task_result_message("task-rejoin").with_admission(
         MessageDeliverySurface::TaskRejoin,
@@ -3002,6 +3256,54 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         )
         .await
         .unwrap();
+    let work_item = runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            Some("settle exact completion brief after metadata update".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let scheduling_generation = work_item.revision.saturating_sub(1);
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition(
+            "default",
+            &Snapshot {
+                slot: ActivationSlot::Idle,
+                dispatch: AgentDispatchState::Open,
+                dispatch_revision: 0,
+                focus: None,
+                work: std::collections::BTreeMap::from([(
+                    work_item.id.clone(),
+                    WorkDemand {
+                        metadata_revision: work_item.revision,
+                        scheduling_generation,
+                        status: WorkStatus::Runnable,
+                        capabilities: Default::default(),
+                        locks: Default::default(),
+                        locality: "runtime".into(),
+                        cost_class: "default".into(),
+                    },
+                )]),
+                waits: Default::default(),
+                activations: Default::default(),
+                activation_authorities: Default::default(),
+                activation_admissions: Default::default(),
+                settlements: Default::default(),
+                missing_settlements: Default::default(),
+                rollout: Default::default(),
+                admitted_generations: Default::default(),
+                continuation_admissions: Default::default(),
+                activation_inputs: Default::default(),
+            },
+        )
+        .unwrap();
     let mut message = MessageEnvelope::new(
         "default",
         MessageKind::SystemTick,
@@ -3028,6 +3330,21 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         .unwrap();
     assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let activation = &claimed.activations[&activation_id];
+    assert_eq!(activation.admitted_generation, scheduling_generation);
+    assert_eq!(
+        claimed.activation_admissions[&activation_id]
+            .activation
+            .source_revision,
+        Some(work_item.revision)
+    );
+    assert_ne!(activation.admitted_generation, work_item.revision);
 
     runtime
         .begin_interactive_turn(Some(&message), None, None)

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1,5 +1,9 @@
 use super::super::*;
 use super::support::*;
+use crate::domain::scheduler_protocol::{
+    ActivationSlot, AgentDispatchState, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord,
+    WaitState, WorkDemand, WorkStatus,
+};
 use crate::types::{
     AgentPostureProjection, AgentSchedulingPosture, ToolExecutionStatus, WaitConditionKind,
     WaitConditionRecord, WaitConditionStatus, WakeSource, WorkItemPlanStatus,
@@ -8,6 +12,7 @@ use crate::types::{
 use chrono::DateTime;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Deserialize)]
@@ -1357,6 +1362,190 @@ fn wait_resume_shadow_comparison_records_task_result_matching_active_wait() {
 }
 
 #[test]
+fn task_rejoin_comparison_retains_resolved_legacy_wait_identity() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    append_open_work_item(&storage, "wi-1", "default");
+    append_task_wait_condition(&storage, "wait-1", "default", Some("wi-1"), "task-1");
+    let mut resolved = storage
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == "wait-1")
+        .unwrap();
+    resolved.status = WaitConditionStatus::Resolved;
+    resolved.resolved_at = Some(Utc::now());
+    resolved.updated_at = Utc::now();
+    storage.append_wait_condition(&resolved).unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-1".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: String::new(),
+        },
+    );
+    message.work_item_id = Some("wi-1".into());
+    let decision = scheduler::SchedulerDecision::new(
+        scheduler::SchedulerDecisionKind::StartModelTurn,
+        "task_result_wait_resume",
+    )
+    .message(&message)
+    .model_reentry(true)
+    .work_item_id("wi-1");
+
+    assert_eq!(
+        scheduler::authority_scenarios_for_message_claim(&projection, &message, None),
+        vec![scheduler::EXACT_TASK_REJOIN_SCENARIO]
+    );
+    let comparison = scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision)
+        .expect("resolved task wait should retain exact task rejoin evidence");
+    assert_eq!(comparison.scenario_class.as_str(), "exact_task_rejoin");
+    assert!(comparison.matched);
+    let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
+    assert_eq!(
+        candidate["consumed_wait_condition_ids"],
+        serde_json::json!(["wait-1"])
+    );
+    assert_eq!(candidate["binding_work_item_id"], "wi-1");
+}
+
+#[test]
+fn stale_resolved_task_wait_is_not_reused_after_work_item_moves_to_external_wait() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    append_open_work_item(&storage, "wi-1", "default");
+    append_task_wait_condition(&storage, "wait-task", "default", Some("wi-1"), "task-1");
+    let mut resolved = storage
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == "wait-task")
+        .unwrap();
+    resolved.status = WaitConditionStatus::Resolved;
+    resolved.resolved_at = Some(Utc::now());
+    resolved.updated_at = Utc::now();
+    storage.append_wait_condition(&resolved).unwrap();
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-external".into(),
+            agent_id: "default".into(),
+            work_item_id: Some("wi-1".into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("test".into()),
+            subject_ref: Some("external:next".into()),
+            waiting_for: "next external wake".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-next".into()),
+            }],
+            continuation: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        })
+        .unwrap();
+    let work_item = storage.latest_work_item("wi-1").unwrap().unwrap();
+    let canonical = Snapshot {
+        slot: ActivationSlot::Idle,
+        dispatch: AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: "wait-external".into(),
+                generation: 2,
+            },
+        },
+        dispatch_revision: 1,
+        focus: Some(work_item.id.clone()),
+        work: BTreeMap::from([(
+            work_item.id.clone(),
+            WorkDemand {
+                metadata_revision: work_item.revision,
+                scheduling_generation: 2,
+                status: WorkStatus::Waiting {
+                    wait_id: "wait-external".into(),
+                },
+                capabilities: Default::default(),
+                locks: Default::default(),
+                locality: "runtime".into(),
+                cost_class: "default".into(),
+            },
+        )]),
+        waits: BTreeMap::from([(
+            "wait-external".into(),
+            WaitRecord {
+                current_generation: 2,
+                generations: BTreeMap::from([(
+                    2,
+                    WaitGenerationRecord {
+                        owner_work_item_id: work_item.id,
+                        state: WaitState::Active,
+                        trigger: None,
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        )]),
+        activations: Default::default(),
+        activation_authorities: Default::default(),
+        activation_admissions: Default::default(),
+        settlements: Default::default(),
+        missing_settlements: Default::default(),
+        rollout: Default::default(),
+        admitted_generations: Default::default(),
+        continuation_admissions: Default::default(),
+        activation_inputs: Default::default(),
+    };
+    storage
+        .runtime_db()
+        .unwrap()
+        .unwrap()
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &canonical)
+        .unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-1".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: String::new(),
+        },
+    );
+    message.work_item_id = Some("wi-1".into());
+    let decision = scheduler::SchedulerDecision::new(
+        scheduler::SchedulerDecisionKind::StartModelTurn,
+        "duplicate_task_result",
+    )
+    .message(&message)
+    .model_reentry(true)
+    .work_item_id("wi-1");
+
+    assert_eq!(
+        scheduler::authority_scenarios_for_message_claim(&projection, &message, None),
+        Vec::<crate::domain::scheduler_protocol::SchedulerScenarioClass>::new()
+    );
+    assert!(
+        scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision).is_none()
+    );
+}
+
+#[test]
 fn message_claim_authority_scope_is_derived_without_shadow_evidence() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
@@ -1464,6 +1653,140 @@ fn system_wait_resume_uses_exact_wait_resume_authority_class() {
     let comparison = scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision)
         .expect("system tick matching an active wait should produce a comparison");
     assert_eq!(comparison.scenario_class.as_str(), "exact_wait_resume");
+}
+
+#[test]
+fn wake_hint_system_tick_matches_external_ingress_wait() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    append_open_work_item(&storage, "work-external", "default");
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-external".into(),
+            agent_id: "default".into(),
+            work_item_id: Some("work-external".into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("test".into()),
+            subject_ref: None,
+            waiting_for: "external callback".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-external".into()),
+            }],
+            continuation: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        })
+        .unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "wake_hint".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: String::new(),
+        },
+    );
+    message
+        .source_refs
+        .insert("external_trigger_id".into(), "trigger-external".into());
+    let decision = scheduler::SchedulerDecision::new(
+        scheduler::SchedulerDecisionKind::StartModelTurn,
+        "external_wait_resume",
+    )
+    .message(&message)
+    .work_item_id("work-external")
+    .model_reentry(true);
+
+    let comparison = scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision)
+        .expect("wake hint matching an external wait should produce a comparison");
+    assert_eq!(comparison.scenario_class.as_str(), "exact_wait_resume");
+    assert!(comparison.matched);
+}
+
+#[test]
+fn message_decision_inherits_work_item_from_matching_wait() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    append_open_work_item(&storage, "work-external", "default");
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-external".into(),
+            agent_id: "default".into(),
+            work_item_id: Some("work-external".into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("test".into()),
+            subject_ref: None,
+            waiting_for: "external callback".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-external".into()),
+            }],
+            continuation: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        })
+        .unwrap();
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "wake_hint".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: String::new(),
+        },
+    );
+    message
+        .source_refs
+        .insert("external_trigger_id".into(), "trigger-external".into());
+    let continuation = ContinuationResolution {
+        trigger_kind: ContinuationTriggerKind::SystemTick,
+        class: ContinuationClass::LocalContinuation,
+        model_reentry: true,
+        prior_closure_outcome: ClosureOutcome::Waiting,
+        prior_waiting_reason: Some(WaitingReason::AwaitingExternalChange),
+        matched_waiting_reason: true,
+        evidence: Vec::new(),
+    };
+
+    let decision = scheduler::decide_next_action(
+        &projection,
+        scheduler::SchedulerBoundary::RunLoop,
+        scheduler::SchedulerInput::Message {
+            message: &message,
+            model_turn_allowed: true,
+            continuation_resolution: Some(&continuation),
+        },
+    );
+
+    assert_eq!(
+        decision.kind,
+        scheduler::SchedulerDecisionKind::StartModelTurn
+    );
+    assert_eq!(decision.work_item_id.as_deref(), Some("work-external"));
+    let comparison = scheduler::shadow_comparison_for_wait_resume(&projection, &message, &decision)
+        .expect("matching wait should produce a comparison");
+    assert!(comparison.matched);
 }
 
 #[test]

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -344,6 +344,49 @@ mod tests {
         }
     }
 
+    #[test]
+    fn scheduler_rollout_batch_rejection_rolls_back_prior_commands() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("runtime.sqlite"),
+            dir.path().join("runtime.lock"),
+        )?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition("agent-a", &scheduler_protocol_snapshot(1))?;
+        let commands = vec![
+            (
+                "batch-open".to_string(),
+                RolloutCommand::OpenPreflight {
+                    expected_config_revision: 0,
+                    manifest_revision: 1,
+                },
+            ),
+            (
+                "batch-conflict".to_string(),
+                RolloutCommand::OpenPreflight {
+                    expected_config_revision: 0,
+                    manifest_revision: 2,
+                },
+            ),
+        ];
+
+        let error = db
+            .apply_scheduler_rollout_commands(&commands)
+            .expect_err("second command should reject the whole batch");
+        assert!(error.to_string().contains("batch-conflict"));
+        let snapshot = db
+            .transitions()
+            .load_scheduler_protocol_snapshot("agent-a")?;
+        assert!(snapshot.rollout.preflights.is_empty());
+        let stored_results: i64 = db.connection()?.query_row(
+            "SELECT COUNT(*) FROM scheduler_rollout_command_results",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(stored_results, 0);
+        Ok(())
+    }
+
     fn scheduler_protocol_authority_command(
         agent_id: &str,
         scheduling_generation: u64,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -215,6 +215,65 @@ impl RuntimeDb {
     pub(crate) fn transitions(&self) -> RuntimeTransitionRepository<'_> {
         RuntimeTransitionRepository { db: self }
     }
+
+    pub fn apply_scheduler_rollout_command(
+        &self,
+        command_identity: &str,
+        command: &crate::domain::scheduler_protocol::RolloutCommand,
+    ) -> Result<SchedulerRolloutCommandReceipt> {
+        let committed =
+            self.transitions()
+                .commit_scheduler_rollout_command(command_identity, command, None)?;
+        Ok(SchedulerRolloutCommandReceipt {
+            command_identity: command_identity.to_string(),
+            applied: committed.applied,
+            replayed: committed.replayed,
+            decision: committed.result.decision,
+            conflict: committed.result.conflict,
+            diagnostics: committed.result.diagnostics,
+            fact_references: committed.result.fact_references,
+            pre_state_fence: committed.result.pre_state_fence,
+            post_state_fence: committed.result.post_state_fence,
+        })
+    }
+
+    pub fn apply_scheduler_rollout_commands(
+        &self,
+        commands: &[(String, crate::domain::scheduler_protocol::RolloutCommand)],
+    ) -> Result<Vec<SchedulerRolloutCommandReceipt>> {
+        self.transitions()
+            .commit_scheduler_rollout_commands(commands, None)?
+            .into_iter()
+            .zip(commands)
+            .map(|(committed, (command_identity, _))| {
+                Ok(SchedulerRolloutCommandReceipt {
+                    command_identity: command_identity.clone(),
+                    applied: committed.applied,
+                    replayed: committed.replayed,
+                    decision: committed.result.decision,
+                    conflict: committed.result.conflict,
+                    diagnostics: committed.result.diagnostics,
+                    fact_references: committed.result.fact_references,
+                    pre_state_fence: committed.result.pre_state_fence,
+                    post_state_fence: committed.result.post_state_fence,
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SchedulerRolloutCommandReceipt {
+    pub command_identity: String,
+    pub applied: bool,
+    pub replayed: bool,
+    pub decision: crate::domain::scheduler_protocol::Decision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conflict: Option<crate::domain::scheduler_protocol::ProtocolConflict>,
+    pub diagnostics: Vec<String>,
+    pub fact_references: Vec<String>,
+    pub pre_state_fence: serde_json::Value,
+    pub post_state_fence: serde_json::Value,
 }
 
 impl RuntimeTransitionRepository<'_> {

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -1037,85 +1037,123 @@ impl RuntimeTransitionRepository<'_> {
         command: &RolloutCommand,
         fault: Option<TransitionFaultPoint>,
     ) -> Result<SchedulerRolloutTransitionCommit> {
-        if command_identity.is_empty() {
-            bail!("scheduler rollout command requires a non-empty identity");
-        }
-        let command_kind = rollout_command_kind(command);
-        let payload_hash = canonical_rollout_command_hash(command_kind, command)?;
-
         let outcome = self.db.transaction(|tx| {
-            if let Some(stored) =
-                stored_rollout_command_result_tx(tx, command_kind, command_identity)?
-            {
-                if stored.payload_hash != payload_hash {
-                    let conflict = insert_command_identity_conflict_attempt_tx(
-                        tx,
-                        "global_rollout",
-                        "global",
-                        command_kind,
-                        command_identity,
-                        &stored.payload_hash,
-                        &payload_hash,
-                    )?;
-                    return Ok(CommandTransactionOutcome::Conflict(conflict));
-                }
-                return Ok(CommandTransactionOutcome::Commit(
-                    SchedulerRolloutTransitionCommit {
-                        applied: false,
-                        replayed: true,
-                        result: stored.result,
-                    },
-                ));
-            }
-
-            let rollout = load_rollout(tx)?;
-            let snapshot = rollout_snapshot(rollout.clone());
-            let outcome = scheduler_protocol::reduce_rollout_command(&snapshot, command);
-            scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
-                anyhow!("scheduler rollout reducer produced invalid state: {error}")
-            })?;
-            inject_fault(fault, TransitionFaultPoint::AfterValidation)?;
-
-            if outcome.outcome.decision != Decision::Rejected {
-                persist_rollout_tx(tx, &rollout, &outcome.outcome.snapshot.rollout)?;
-            }
-            inject_fault(fault, TransitionFaultPoint::AfterCanonicalWrites)?;
-
-            let decision = outcome.outcome.decision.clone();
-            let result = SchedulerProtocolCommandResult {
-                decision: decision.clone(),
-                conflict: outcome.conflict,
-                transitions: outcome.outcome.transitions,
-                diagnostics: outcome.outcome.diagnostics,
-                fact_references: decision_fact_references(
-                    &decision,
-                    rollout_command_fact_references(command, &outcome.outcome.snapshot.rollout),
-                ),
-                pre_state_fence: rollout_fence(&rollout),
-                post_state_fence: rollout_fence(&outcome.outcome.snapshot.rollout),
-            };
-            insert_rollout_command_result_tx(
-                tx,
-                command_kind,
-                command_identity,
-                &payload_hash,
-                &result,
-            )?;
-            inject_fault(fault, TransitionFaultPoint::BeforeCommit)?;
-
-            Ok(CommandTransactionOutcome::Commit(
-                SchedulerRolloutTransitionCommit {
-                    applied: true,
-                    replayed: false,
-                    result,
-                },
-            ))
+            apply_scheduler_rollout_command_tx(tx, command_identity, command, fault)
         })?;
         match outcome {
             CommandTransactionOutcome::Commit(commit) => Ok(commit),
             CommandTransactionOutcome::Conflict(conflict) => Err(conflict.into()),
         }
     }
+
+    pub(crate) fn commit_scheduler_rollout_commands(
+        &self,
+        commands: &[(String, RolloutCommand)],
+        fault: Option<TransitionFaultPoint>,
+    ) -> Result<Vec<SchedulerRolloutTransitionCommit>> {
+        if commands.is_empty() {
+            bail!("scheduler rollout command list must not be empty");
+        }
+        self.db.transaction(|tx| {
+            let mut commits = Vec::with_capacity(commands.len());
+            for (command_identity, command) in commands {
+                let commit =
+                    match apply_scheduler_rollout_command_tx(tx, command_identity, command, fault)?
+                    {
+                        CommandTransactionOutcome::Commit(commit) => commit,
+                        CommandTransactionOutcome::Conflict(conflict) => {
+                            return Err(conflict.into());
+                        }
+                    };
+                if commit.result.decision == Decision::Rejected {
+                    let detail = commit
+                        .result
+                        .conflict
+                        .as_ref()
+                        .map(|conflict| format!("{:?}: {}", conflict.kind, conflict.code))
+                        .unwrap_or_else(|| "reducer rejected command".to_string());
+                    bail!(
+                        "scheduler rollout command {} was rejected: {}",
+                        command_identity,
+                        detail
+                    );
+                }
+                commits.push(commit);
+            }
+            Ok(commits)
+        })
+    }
+}
+
+fn apply_scheduler_rollout_command_tx(
+    tx: &Transaction<'_>,
+    command_identity: &str,
+    command: &RolloutCommand,
+    fault: Option<TransitionFaultPoint>,
+) -> Result<CommandTransactionOutcome<SchedulerRolloutTransitionCommit>> {
+    if command_identity.is_empty() {
+        bail!("scheduler rollout command requires a non-empty identity");
+    }
+    let command_kind = rollout_command_kind(command);
+    let payload_hash = canonical_rollout_command_hash(command_kind, command)?;
+
+    if let Some(stored) = stored_rollout_command_result_tx(tx, command_kind, command_identity)? {
+        if stored.payload_hash != payload_hash {
+            let conflict = insert_command_identity_conflict_attempt_tx(
+                tx,
+                "global_rollout",
+                "global",
+                command_kind,
+                command_identity,
+                &stored.payload_hash,
+                &payload_hash,
+            )?;
+            return Ok(CommandTransactionOutcome::Conflict(conflict));
+        }
+        return Ok(CommandTransactionOutcome::Commit(
+            SchedulerRolloutTransitionCommit {
+                applied: false,
+                replayed: true,
+                result: stored.result,
+            },
+        ));
+    }
+
+    let rollout = load_rollout(tx)?;
+    let snapshot = rollout_snapshot(rollout.clone());
+    let outcome = scheduler_protocol::reduce_rollout_command(&snapshot, command);
+    scheduler_protocol::assert_invariants(&outcome.outcome.snapshot)
+        .map_err(|error| anyhow!("scheduler rollout reducer produced invalid state: {error}"))?;
+    inject_fault(fault, TransitionFaultPoint::AfterValidation)?;
+
+    if outcome.outcome.decision != Decision::Rejected {
+        persist_rollout_tx(tx, &rollout, &outcome.outcome.snapshot.rollout)?;
+    }
+    inject_fault(fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+
+    let decision = outcome.outcome.decision.clone();
+    let result = SchedulerProtocolCommandResult {
+        decision: decision.clone(),
+        conflict: outcome.conflict,
+        transitions: outcome.outcome.transitions,
+        diagnostics: outcome.outcome.diagnostics,
+        fact_references: decision_fact_references(
+            &decision,
+            rollout_command_fact_references(command, &outcome.outcome.snapshot.rollout),
+        ),
+        pre_state_fence: rollout_fence(&rollout),
+        post_state_fence: rollout_fence(&outcome.outcome.snapshot.rollout),
+    };
+    insert_rollout_command_result_tx(tx, command_kind, command_identity, &payload_hash, &result)?;
+    inject_fault(fault, TransitionFaultPoint::BeforeCommit)?;
+
+    Ok(CommandTransactionOutcome::Commit(
+        SchedulerRolloutTransitionCommit {
+            applied: true,
+            replayed: false,
+            result,
+        },
+    ))
 }
 
 fn decision_fact_references(decision: &Decision, references: Vec<String>) -> Vec<String> {

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -146,30 +146,68 @@
       ]
     },
     {
-      "id": "scheduler-autonomous-authoritative",
+      "id": "scheduler-rollout-authoritative-autonomous",
       "tier": "extended",
-      "tags": ["scheduler", "workitem", "authoritative", "restart", "persistence"],
-      "timeout_seconds": 600,
-      "description": "Verify the feature-flagged canonical production claim and settlement chain through a real-LLM autonomous WorkItem turn.",
-      "scheduler_protocol_commands_enabled": true,
+      "tags": ["scheduler", "workitem", "rollout", "shadow", "authoritative", "task-result", "wait", "restart", "rollback", "delivery"],
+      "timeout_seconds": 900,
+      "description": "Verify shadow evidence, per-scenario authoritative cutover, autonomous/task-result/external-wait continuation settlements, exact completion delivery binding, restart persistence, and rollback.",
       "runtime_env": {
-        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true"
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true",
+        "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES": "true"
       },
       "phases": [
         {
-          "id": "autonomous-complete",
+          "id": "shadow-wait-resume",
           "required_tools": [
             "CreateWorkItem",
-            "ListWorkItems",
+            "PickWorkItem",
+            "WaitFor",
+            "GetWorkItem",
             "UpdateWorkItem",
             "CompleteWorkItem"
           ],
           "forbidden_tools": [
             "ApplyPatch",
-            "ExecCommand",
-            "WaitFor"
+            "ExecCommand"
           ],
-          "prompt": "Scheduler Docker E2E case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: scheduler-seed completed, autonomous-completion pending. Do not PickWorkItem, UpdateWorkItem, CompleteWorkItem, or WaitFor in this operator-triggered turn. After CreateWorkItem succeeds, end this response with a concise acknowledgement. The objective governs the later autonomous work_queue turn. Do not modify files. The expected completion marker is {completion_marker}."
+          "prompt": "Scheduler rollout Docker E2E case {case_id}, shadow phase. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: shadow-wait pending, shadow-complete pending. Pick that WorkItem, then call WaitFor with wake=external, resource=docker-e2e-shadow, and a concrete reason. Do not complete it in this turn. When the external wake later resumes this exact WorkItem, call GetWorkItem, update both todos to completed, then emit a concise completion result containing {completion_marker} immediately followed by CompleteWorkItem for the exact current item. Do not create another WorkItem and do not modify files."
+        },
+        {
+          "id": "authoritative-continuations",
+          "required_tools": [
+            "CreateWorkItem",
+            "ExecCommand",
+            "WaitFor",
+            "GetWorkItem",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "forbidden_tools": [
+            "ApplyPatch",
+            "TaskStatus",
+            "TaskOutput"
+          ],
+          "prompt": "Scheduler rollout Docker E2E case {case_id}, authoritative phase. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: task-continuation pending, external-continuation pending. Do not PickWorkItem, ExecCommand, WaitFor, UpdateWorkItem, or CompleteWorkItem in this operator-triggered turn. After CreateWorkItem succeeds, end this response with a concise acknowledgement. The objective governs all later autonomous continuation turns. Do not create another WorkItem and do not modify files. The expected final completion marker is {completion_marker}."
+        }
+      ]
+    },
+    {
+      "id": "scheduler-terminal-before-settlement-restart",
+      "tier": "extended",
+      "tags": ["scheduler", "rollout", "authoritative", "fault", "restart", "recovery", "settlement"],
+      "timeout_seconds": 600,
+      "requires_model": false,
+      "description": "Construct a controlled terminal-before-settlement crash cut through the hidden acceptance fixture and verify real serve bootstrap reconciliation plus second-restart idempotence.",
+      "runtime_env": {
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true",
+        "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES": "true"
+      },
+      "phases": [
+        {
+          "id": "offline-fixture-and-restart-recovery",
+          "required_tools": [],
+          "forbidden_tools": [],
+          "prompt": "This phase is driven by the checked-in offline acceptance fixture and real holon serve restart path; no model prompt is issued."
         }
       ]
     }

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -807,6 +807,61 @@
     "aliases": []
   },
   {
+    "path": "debug.scheduler-recovery-fixture",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "objective",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": true
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "debug.scheduler-rollout-apply",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "input",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": true
+      },
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "events",
     "positionals": [],
     "flags": [],

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -213,7 +213,7 @@ pub async fn subagent_task_updates_parent_state_and_child_summary_during_lifecyc
         "expected child agent summary while delegated task runs"
     );
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(30), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -95,6 +95,16 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 [{"path": "evidence.txt", "kind": "callback-capability"}],
             )
 
+    def test_secret_scan_accepts_redacted_callback_with_log_punctuation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "evidence.txt").write_text(
+                "callback=/api/callbacks/wake/<redacted>.\n"
+                'callback="/api/callbacks/enqueue/<redacted>\\u001b[0m"\n'
+            )
+            result = runner.secret_scan(root, [])
+            self.assertEqual(result["status"], "pass")
+
     def test_secret_scan_quarantines_files_with_findings(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -120,6 +130,32 @@ class DockerE2ERunnerTests(unittest.TestCase):
             redacted["url"],
             "http://localhost/api/callbacks/wake/<redacted>",
         )
+
+    def test_capture_logs_redacts_callback_capability(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            harness = runner.CaseHarness(
+                case_id="log-redaction-test",
+                image="holon:test",
+                model="deepseek/deepseek-v4-flash",
+                credential_envs=[],
+                env_file=None,
+                runtime_env={},
+                evidence_root=Path(directory),
+                timeout_seconds=1,
+                keep=False,
+            )
+            harness.docker = lambda *args, **kwargs: subprocess.CompletedProcess(
+                ["docker", *args],
+                0,
+                "callback=/api/callbacks/wake/cb_secret-capability\n",
+                "",
+            )
+
+            harness.capture_logs()
+
+            captured = (harness.evidence / "container-1.log").read_text()
+            self.assertNotIn("cb_secret-capability", captured)
+            self.assertIn("/api/callbacks/wake/<redacted>", captured)
 
     def test_cleanup_fails_when_resource_still_exists(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -180,7 +216,31 @@ class DockerE2ERunnerTests(unittest.TestCase):
             ):
                 harness.assert_tools("complete", 3, ["CompleteWorkItem"])
 
-    def test_scheduler_extended_cases_declare_explicit_feature_flag(self) -> None:
+    def test_no_model_harness_uses_inert_provider_bootstrap(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            harness = runner.CaseHarness(
+                case_id="offline-test",
+                image="holon:test",
+                model="openai/gpt-test",
+                requires_model=False,
+                credential_envs=["OPENAI_API_KEY"],
+                env_file=Path(directory) / "credentials.env",
+                runtime_env={"HOLON_TEST_MARKER": "true"},
+                evidence_root=Path(directory),
+                timeout_seconds=1,
+                keep=False,
+            )
+
+            self.assertEqual(harness.model, runner.DEFAULT_MODEL)
+            self.assertEqual(harness.credential_envs, [])
+            self.assertIsNone(harness.env_file)
+            self.assertEqual(
+                harness.runtime_env[runner.OFFLINE_MODEL_CREDENTIAL_ENV],
+                runner.OFFLINE_MODEL_CREDENTIAL,
+            )
+            self.assertEqual(harness.runtime_env["HOLON_TEST_MARKER"], "true")
+
+    def test_scheduler_extended_cases_declare_rollout_modes(self) -> None:
         selected = runner.select_cases(
             self.manifest, requested=None, suite="extended", tags=["scheduler"]
         )
@@ -188,34 +248,167 @@ class DockerE2ERunnerTests(unittest.TestCase):
             [case["id"] for case in selected],
             [
                 "scheduler-autonomous-legacy",
-                "scheduler-autonomous-authoritative",
+                "scheduler-rollout-authoritative-autonomous",
+                "scheduler-terminal-before-settlement-restart",
             ],
         )
         self.assertEqual(
             [
-                (
-                    case["scheduler_protocol_commands_enabled"],
-                    case["runtime_env"][
-                        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS"
-                    ],
-                )
+                case["runtime_env"][
+                    "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS"
+                ]
                 for case in selected
             ],
-            [(False, "false"), (True, "true")],
+            ["false", "true", "true"],
         )
-        for case in selected:
-            phase = case["phases"][0]
-            self.assertEqual(
-                phase["required_tools"],
-                [
-                    "CreateWorkItem",
-                    "ListWorkItems",
-                    "UpdateWorkItem",
-                    "CompleteWorkItem",
-                ],
+        self.assertNotIn(
+            "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES", selected[0]["runtime_env"]
+        )
+        self.assertEqual(
+            [
+                case["runtime_env"]["HOLON_SCHEDULER_ACCEPTANCE_FIXTURES"]
+                for case in selected[1:]
+            ],
+            ["true", "true"],
+        )
+        authoritative = selected[1]
+        recovery = selected[2]
+        self.assertEqual(len(authoritative["phases"]), 2)
+        self.assertIn(
+            "WaitFor", authoritative["phases"][0]["required_tools"]
+        )
+        self.assertIn(
+            "ExecCommand", authoritative["phases"][1]["required_tools"]
+        )
+        self.assertNotIn(
+            "PickWorkItem", authoritative["phases"][1]["required_tools"]
+        )
+        self.assertFalse(recovery["requires_model"])
+
+    def test_manifest_rejects_non_boolean_requires_model(self) -> None:
+        invalid = json.loads(json.dumps(self.manifest))
+        invalid["cases"][-1]["requires_model"] = "false"
+        with self.assertRaisesRegex(AssertionError, "requires_model must be boolean"):
+            runner.validate_manifest(invalid)
+
+    def test_scheduler_rollout_commands_are_revision_fenced(self) -> None:
+        commands = runner.scheduler_rollout_commands(
+            {
+                "work_item_autonomous_continuation": "authoritative",
+                "settlement": "shadow",
+            }
+        )
+        self.assertEqual(
+            [entry["command"]["kind"] for entry in commands],
+            [
+                "open_preflight",
+                "complete_preflight",
+                "install_manifest",
+                "configure_protocol",
+                "change_scenario_authority",
+                "change_scenario_authority",
+                "change_scenario_authority",
+            ],
+        )
+        self.assertEqual(
+            [
+                entry["command"]["expected_config_revision"]
+                for entry in commands[4:]
+            ],
+            [2, 3, 4],
+        )
+        manifest = commands[1]["command"]["manifest"]
+        self.assertEqual(
+            manifest["classes"]["work_item_autonomous_continuation"][
+                "configured_mode"
+            ],
+            "authoritative",
+        )
+        self.assertIn(
+            "work_item_rollback",
+            manifest["classes"]["work_item_autonomous_continuation"][
+                "verified_evidence"
+            ],
+        )
+
+    def test_scheduler_rollout_commands_can_stage_shadow_under_authoritative_approval(
+        self,
+    ) -> None:
+        commands = runner.scheduler_rollout_commands(
+            {"exact_wait_resume": "shadow"},
+            approved_scenario_modes={"exact_wait_resume": "authoritative"},
+        )
+        manifest = commands[1]["command"]["manifest"]
+        self.assertEqual(
+            manifest["classes"]["exact_wait_resume"]["configured_mode"],
+            "authoritative",
+        )
+        self.assertEqual(
+            [
+                entry["command"]["mode"]
+                for entry in commands
+                if entry["command"]["kind"] == "change_scenario_authority"
+            ],
+            ["shadow"],
+        )
+
+    def test_incomplete_scheduler_rollout_fixture_fails_after_open_command(self) -> None:
+        commands = runner.scheduler_incomplete_rollout_commands(
+            {"exact_wait_resume": "authoritative"}
+        )
+        self.assertEqual(
+            [entry["command"]["kind"] for entry in commands],
+            ["open_preflight", "complete_preflight"],
+        )
+        evidence = commands[1]["command"]["manifest"]["classes"][
+            "exact_wait_resume"
+        ]
+        self.assertEqual(evidence["observed_shadow_samples"], 0)
+        self.assertEqual(evidence["verified_evidence"], [])
+
+    def test_scheduler_rollout_oracle_requires_consumed_preflight(self) -> None:
+        snapshot = {
+            "scheduler_protocol_config": [
+                {
+                    "protocol_mode": "authoritative",
+                    "config_revision": 5,
+                    "latest_preflight_revision": 1,
+                }
+            ],
+            "scheduler_rollout_preflights": [
+                {
+                    "preflight_revision": 1,
+                    "manifest_revision": 1,
+                    "state": "consumed",
+                    "manifest_json": "{}",
+                }
+            ],
+            "scheduler_rollout_manifests": [
+                {
+                    "manifest_revision": 1,
+                    "preflight_revision": 1,
+                    "payload_json": "{}",
+                }
+            ],
+            "scheduler_scenario_authorities": [
+                {
+                    "scenario_class": "settlement",
+                    "mode": "authoritative",
+                    "rollback_target": "shadow",
+                    "manifest_revision": 1,
+                    "preflight_revision": 1,
+                }
+            ],
+            "scheduler_rollout_command_results": [
+                {"conflict_kind": None}
+            ],
+        }
+        runner.require_rollout_state(snapshot, {"settlement": "authoritative"})
+        snapshot["scheduler_rollout_preflights"][0]["state"] = "completed"
+        with self.assertRaisesRegex(AssertionError, "not consumed"):
+            runner.require_rollout_state(
+                snapshot, {"settlement": "authoritative"}
             )
-            self.assertNotIn("GetWorkItem", phase["required_tools"])
-            self.assertNotIn("PickWorkItem", phase["forbidden_tools"])
 
     def test_scheduler_queue_oracle_uses_current_processed_state(self) -> None:
         runner.require_processed_queue_entries(


### PR DESCRIPTION
## Summary
- add the PR-G scheduler rollout acceptance matrix on the real Docker/LLM execution path
- cover CompleteWorkItem final-report delivery, task-result rejoin, wait resume, terminal-before-settlement recovery, restart reconciliation, shadow evidence, and authoritative cutover/rollback
- add database oracles for queue, Turn, activation, settlement, slot, WorkItem generation/disposition, result brief binding, and rollout comparison evidence
- add a fail-closed acceptance gate and atomic rollout fixture batches; tighten stale task-result wait matching and recovery idempotency coverage

## Runtime contract
This validates the scheduler protocol introduced by PR-A through PR-F through production-shaped paths. Hidden rollout/recovery fixture commands remain guarded by the existing shutdown lock plus explicit test-only environment gates.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- `python3 -m unittest scripts.docker_e2e.test_runner`
- Docker E2E manifest validation for the supported `published` suite
- complete release Docker E2E matrix, including authoritative real-LLM coverage
- focused scheduler acceptance, stale wait, rollout atomicity, recovery, shadow, legacy, and secret-scan checks
