### PR TITLE
feat: gate developer diagnostics UI

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -35,6 +35,7 @@ import { SettingsPage } from "../features/settings/SettingsPage";
 import { SkillDetailPage, SkillsPage } from "../features/skills/SkillsPage";
 import { TemplateDetailPage, TemplatesPage } from "../features/templates/TemplatesPage";
 import { deriveAgentDisplayStatus } from "../runtime/agent-status";
+import { availableDisplayLevels } from "../runtime/display-level";
 import {
   getRuntimeTraceRevision,
   isRuntimeTraceEnabled,
@@ -61,7 +62,7 @@ export function App() {
   const { bootstrap, loading, refresh } = useRuntimeDashboard();
   const { t } = useTranslation();
   useSyncExternalStore(subscribeRuntimeTrace, getRuntimeTraceRevision, getRuntimeTraceRevision);
-  const runtimeTraceEnabled = isRuntimeTraceEnabled();
+  const developerDiagnosticsEnabled = isRuntimeTraceEnabled();
   const [showCreateAgentModal, setShowCreateAgentModal] = useState(false);
   const [createAgentId, setCreateAgentId] = useState("");
   const [createAgentTemplate, setCreateAgentTemplate] = useState("");
@@ -83,6 +84,7 @@ export function App() {
   const openSkill = useRuntimeStore((state) => state.openSkill);
   const openTemplate = useRuntimeStore((state) => state.openTemplate);
   const setDisplayLevel = useRuntimeStore((state) => state.setDisplayLevel);
+  const disableDeveloperDiagnosticsUi = useRuntimeStore((state) => state.disableDeveloperDiagnosticsUi);
   const setRightPanelOpen = useRuntimeStore((state) => state.setRightPanelOpen);
   const inspectActivity = useRuntimeStore((state) => state.inspectActivity);
   const showAgentOverview = useRuntimeStore((state) => state.showAgentOverview);
@@ -191,13 +193,15 @@ export function App() {
   const loadOlderAgentEvents = useRuntimeStore((state) => state.loadOlderAgentEvents);
   const loadAgentWorkItemDetail = useRuntimeStore((state) => state.loadAgentWorkItemDetail);
   const loadAgentTaskDetail = useRuntimeStore((state) => state.loadAgentTaskDetail);
+  const effectiveDisplayLevel =
+    !developerDiagnosticsEnabled && displayLevel === "debug" ? "info" : displayLevel;
   const {
     detail: selectedAgentDetail,
     loading: agentDetailLoading,
     contentStatus: agentContentStatus,
     syncStatus: agentSyncStatus,
     refresh: refreshAgentDetail,
-  } = useAgentDetail(activeAgentId, displayLevel);
+  } = useAgentDetail(activeAgentId, effectiveDisplayLevel);
   const activeAgent = selectedAgent ?? selectedAgentDetail?.agent;
   const selectedAgentLiveStatus = selectedAgentSession?.liveStatus ?? "idle";
   const selectedAgentLiveTitle = liveStatusTitle(selectedAgentLiveStatus, t, selectedAgentSession?.lastStreamActivityAt, selectedAgentSession?.error);
@@ -238,7 +242,7 @@ export function App() {
           </Button>
         </div>
         <SegmentedControl className="display-level" label={t("app.displayLevel")}>
-          {(["info", "verbose", "debug"] as const).map((level) => (
+          {availableDisplayLevels(developerDiagnosticsEnabled).map((level) => (
             <SegmentedControlButton
               active={displayLevel === level}
               className={displayLevel === level ? "is-active" : ""}
@@ -250,7 +254,7 @@ export function App() {
             </SegmentedControlButton>
           ))}
         </SegmentedControl>
-        {activeAgentId ? (
+        {developerDiagnosticsEnabled && activeAgentId ? (
           <Button
             type="button"
             size="sm"
@@ -328,6 +332,12 @@ export function App() {
   useEffect(() => {
     document.title = browserWindowTitle(bootstrap.connection);
   }, [bootstrap.connection.baseUrl, bootstrap.connection.mode]);
+
+  useEffect(() => {
+    if (!developerDiagnosticsEnabled) {
+      disableDeveloperDiagnosticsUi(selectedAgentId);
+    }
+  }, [developerDiagnosticsEnabled, disableDeveloperDiagnosticsUi, selectedAgentId]);
 
   function navigateRoute(nextRoute: RouteKey) {
     setRoute(nextRoute);
@@ -576,7 +586,7 @@ export function App() {
               </div>
             </div>
             <div className="top-actions">
-              {runtimeTraceEnabled ? (
+              {developerDiagnosticsEnabled ? (
                 <button
                   className="runtime-trace-global-indicator"
                   type="button"
@@ -621,7 +631,7 @@ export function App() {
             detailLoading={agentDetailLoading}
             contentStatus={agentContentStatus}
             syncStatus={agentSyncStatus}
-            displayLevel={displayLevel}
+            displayLevel={effectiveDisplayLevel}
             sendingPrompt={selectedAgentSession?.sendingPrompt ?? false}
             promptError={selectedAgentSession?.promptError}
             modelCatalog={modelCatalog}
@@ -633,10 +643,10 @@ export function App() {
             targetEventSeq={selectedAgentSession?.targetEventSeq}
             resumeRevision={resumeRevision}
             onRefreshModels={refreshModelCatalog}
-            onSetModel={(model, reasoningEffort) => setAgentModel(activeAgent.id, model, displayLevel, reasoningEffort)}
-            onClearModel={() => clearAgentModel(activeAgent.id, displayLevel)}
-            onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, displayLevel)}
-            onSendPrompt={(text, attachments) => sendOperatorPrompt(activeAgent.id, text, displayLevel, attachments)}
+            onSetModel={(model, reasoningEffort) => setAgentModel(activeAgent.id, model, effectiveDisplayLevel, reasoningEffort)}
+            onClearModel={() => clearAgentModel(activeAgent.id, effectiveDisplayLevel)}
+            onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, effectiveDisplayLevel)}
+            onSendPrompt={(text, attachments) => sendOperatorPrompt(activeAgent.id, text, effectiveDisplayLevel, attachments)}
             onOpenInspector={() => {
               showAgentOverview(activeAgent.id);
             }}

--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -11,6 +11,7 @@ import {
   timelineLayoutRevision,
   writeStoredComposerDraft,
 } from "./AgentPage";
+import { availableDisplayLevels } from "../../runtime/display-level";
 import type { TimelineTurn } from "./timeline-utils";
 
 class MemoryStorage implements Storage {
@@ -150,6 +151,11 @@ describe("timeline virtual layout reconciliation", () => {
 });
 
 describe("timeline display levels", () => {
+  it("only exposes Debug while developer diagnostics are enabled", () => {
+    expect(availableDisplayLevels(false)).toEqual(["info", "verbose"]);
+    expect(availableDisplayLevels(true)).toEqual(["info", "verbose", "debug"]);
+  });
+
   it("keeps debug on the semantic timeline instead of replacing it with raw events", () => {
     const semanticItem = timelineTurn("turn:assistant", "Semantic result").items[0];
     const debugItem = {

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -1563,23 +1563,23 @@ export function SettingsPage({
         <Card className="settings-card" hidden={activeTab !== "advanced"}>
           <div className="settings-card-head">
             <div>
-              <span className="eyebrow">{t("runtimeTrace.diagnostics")}</span>
-              <h2>{t("runtimeTrace.title")}</h2>
+              <span className="eyebrow">{t("developerDiagnostics.eyebrow")}</span>
+              <h2>{t("developerDiagnostics.title")}</h2>
             </div>
             <StatusChip
               className={`settings-status ${runtimeTraceEnabled ? "available" : "unavailable"}`}
               tone={runtimeTraceEnabled ? "success" : "error"}
-              title={t(runtimeTraceEnabled ? "runtimeTrace.recording" : "runtimeTrace.off")}
+              title={t(runtimeTraceEnabled ? "developerDiagnostics.enabled" : "developerDiagnostics.disabled")}
             />
           </div>
-          <p className="settings-muted">{t("runtimeTrace.settingsDescription")}</p>
+          <p className="settings-muted">{t("developerDiagnostics.description")}</p>
           <label className="settings-checkbox runtime-trace-setting">
             <input
               checked={runtimeTraceEnabled}
               type="checkbox"
               onChange={(event) => setRuntimeTraceEnabled(event.target.checked)}
             />
-            <span>{t("runtimeTrace.enableProduction")}</span>
+            <span>{t("developerDiagnostics.enable")}</span>
           </label>
           <div className="settings-callout">
             <strong>{t("runtimeTrace.privacyTitle")}</strong>

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -972,6 +972,15 @@ const en = {
     attributes: "Attributes",
   },
 
+  developerDiagnostics: {
+    eyebrow: "Developer tools",
+    title: "Developer diagnostics",
+    enabled: "Developer diagnostics enabled",
+    disabled: "Developer diagnostics disabled",
+    description: "Show Debug and Timeline Events for agents and collect bounded runtime traces in this browser.",
+    enable: "Enable developer diagnostics in this browser",
+  },
+
   timelineEvents: {
     title: "Timeline Events",
     shortTitle: "Timeline Events",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -974,6 +974,15 @@ const zh: Record<string, any> = {
     attributes: "属性",
   },
 
+  developerDiagnostics: {
+    eyebrow: "开发者工具",
+    title: "开发者诊断",
+    enabled: "开发者诊断已开启",
+    disabled: "开发者诊断已关闭",
+    description: "显示 Agent 的调试与 Timeline Events，并在此浏览器中采集有界运行时追踪。",
+    enable: "在此浏览器中开启开发者诊断",
+  },
+
   timelineEvents: {
     title: "Timeline Events",
     shortTitle: "Timeline Events",

--- a/web-gui/app/src/runtime/display-level.ts
+++ b/web-gui/app/src/runtime/display-level.ts
@@ -2,6 +2,10 @@ import type { DisplayLevel } from "./types";
 
 export const displayLevels: DisplayLevel[] = ["info", "verbose", "debug"];
 
+export function availableDisplayLevels(developerDiagnosticsEnabled: boolean): readonly DisplayLevel[] {
+  return developerDiagnosticsEnabled ? displayLevels : displayLevels.slice(0, 2);
+}
+
 export function isVerboseLevel(level: DisplayLevel): boolean {
   return level === "verbose" || level === "debug";
 }

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -270,6 +270,36 @@ describe("timeline events state", () => {
     });
   });
 
+  it("returns developer-only UI to a non-debug closed state when diagnostics are disabled", () => {
+    useRuntimeStore.setState({
+      selectedAgentId: "agent-a",
+      displayLevel: "debug",
+      displayLevelsByAgentId: {
+        "agent-a": "debug",
+        "agent-b": "verbose",
+      },
+      rightPanelOpen: true,
+      rightPanelView: { kind: "timeline_events", agentId: "agent-a" },
+      rightPanelViewStack: [
+        { kind: "agent_overview", agentId: "agent-a" },
+        { kind: "timeline_events", agentId: "agent-b" },
+      ],
+    });
+
+    useRuntimeStore.getState().disableDeveloperDiagnosticsUi("agent-a");
+
+    expect(useRuntimeStore.getState()).toMatchObject({
+      displayLevel: "info",
+      displayLevelsByAgentId: {
+        "agent-a": "info",
+        "agent-b": "verbose",
+      },
+      rightPanelOpen: false,
+      rightPanelView: { kind: "agent_overview", agentId: "agent-a" },
+      rightPanelViewStack: [{ kind: "agent_overview", agentId: "agent-a" }],
+    });
+  });
+
   it("appends older pages in sequence order and resets on epoch changes", () => {
     const initial = mergeTimelineEventPage(
       {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -315,6 +315,7 @@ export interface RuntimeStoreState {
   openSkill: (skillId: string) => void;
   openTemplate: (catalogId: string) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
+  disableDeveloperDiagnosticsUi: (agentId?: string) => void;
   setRightPanelOpen: (open: boolean) => void;
   showAgentOverview: (agentId?: string) => void;
   showTimelineEvents: (agentId: string) => void;
@@ -1202,6 +1203,32 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       };
       writeStoredDisplayLevels(displayLevelsByAgentId);
       return { displayLevel, displayLevelsByAgentId };
+    }),
+  disableDeveloperDiagnosticsUi: (agentId) =>
+    set((state) => {
+      const targetAgentId = agentId ?? state.selectedAgentId;
+      const resetStoredDisplayLevel =
+        Boolean(targetAgentId) && state.displayLevelsByAgentId[targetAgentId] === "debug";
+      const resetCurrentDisplayLevel =
+        (!targetAgentId || targetAgentId === state.selectedAgentId) && state.displayLevel === "debug";
+      const displayLevelsByAgentId = resetStoredDisplayLevel && targetAgentId
+        ? { ...state.displayLevelsByAgentId, [targetAgentId]: "info" as const }
+        : state.displayLevelsByAgentId;
+      if (displayLevelsByAgentId !== state.displayLevelsByAgentId) {
+        writeStoredDisplayLevels(displayLevelsByAgentId);
+      }
+
+      const timelineEventsView =
+        state.rightPanelView?.kind === "timeline_events" ? state.rightPanelView : undefined;
+      return {
+        displayLevel: resetCurrentDisplayLevel ? "info" : state.displayLevel,
+        displayLevelsByAgentId,
+        rightPanelOpen: timelineEventsView ? false : state.rightPanelOpen,
+        rightPanelView: timelineEventsView
+          ? { kind: "agent_overview", agentId: timelineEventsView.agentId }
+          : state.rightPanelView,
+        rightPanelViewStack: state.rightPanelViewStack.filter((view) => view.kind !== "timeline_events"),
+      };
     }),
   setRightPanelOpen: (open) => set({ rightPanelOpen: open }),
   showAgentOverview: (agentId) =>


### PR DESCRIPTION
## Summary
- rename the existing browser diagnostic recording setting to a unified developer diagnostics setting while preserving its stored preference
- hide `Debug` and `Timeline Events` unless developer diagnostics are enabled
- when disabling developer diagnostics, persistently fall back an active `Debug` agent to `Info` and close/clear the Timeline Events view
- add regression coverage for display-level availability and runtime-store state convergence

## Verification
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
