### PR TITLE
feat: reconcile scheduler rollout from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ docker run --rm \
 
 Replace the model and credential environment variable when using another
 provider. Holon validates that the configured model provider is available
-before the service starts.
+before the service starts. `HOLON_SCHEDULER` accepts `legacy` (the default),
+`shadow`, or `authoritative`; authoritative scenario ownership remains gated
+by installed rollout evidence and hard-blocker checks. See the
+[Configuration Reference](docs/website/reference/configuration.md#scheduler-rollout).
 
 The base image includes Git and common shell/network utilities. Mount a
 writable workspace at `/workspace`, or derive a project-specific image when

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -101,6 +101,33 @@ holon config set api.cors.max_age_seconds 600
 Do not combine `api.cors.allow_credentials=true` with
 `api.cors.allowed_origins=["*"]`; Holon rejects that unsafe combination.
 
+### Scheduler Rollout
+
+Use one environment variable to select the desired scheduler mode:
+
+```bash
+HOLON_SCHEDULER=legacy        # explicitly request legacy scheduler ownership
+HOLON_SCHEDULER=shadow        # new scheduler compares decisions without ownership
+HOLON_SCHEDULER=authoritative # request production ownership after safety gates pass
+```
+
+Holon reconciles this desired state before starting agent runtimes. `shadow`
+installs a runtime-managed shadow manifest when no rollout manifest exists and
+enables the production scenario classes for comparison. `authoritative` does
+the same, but a scenario takes ownership only when its installed manifest
+contains complete approved evidence and no matching hard blocker. The
+environment variable never fabricates authoritative evidence or bypasses the
+rollout reducer's revision, preflight, and rollback fences.
+
+Changing the value to `legacy` and restarting lowers authoritative scenarios
+through `shadow` to `off` before lowering the protocol ceiling. Invalid values
+fail startup. The older
+`HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS` switch remains temporarily
+supported for existing rollout tooling when `HOLON_SCHEDULER` is unset; new
+deployments should use only `HOLON_SCHEDULER`. When neither variable is set,
+Holon preserves the persisted rollout state; a fresh database is already
+legacy by default.
+
 ## Credential Management
 
 Credentials are stored securely in `~/.holon/credentials.json`. Use `config credentials` subcommands — **never edit this file directly**.

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -126,7 +126,15 @@ fail startup. The older
 supported for existing rollout tooling when `HOLON_SCHEDULER` is unset; new
 deployments should use only `HOLON_SCHEDULER`. When neither variable is set,
 Holon preserves the persisted rollout state; a fresh database is already
-legacy by default.
+legacy by default. When both variables are set, `HOLON_SCHEDULER` also takes
+precedence for production-command and acceptance-fixture capability checks, so
+`legacy` or `shadow` cannot be overridden by the older boolean switch.
+
+If startup finds an open rollout preflight without an installed manifest, it
+fails closed and reports that preflight revision instead of fabricating a
+completion for a potentially operator-managed maintenance window. A completed
+preflight with its manifest intact is resumed by installing that exact
+manifest.
 
 ## Credential Management
 

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -3397,7 +3397,7 @@ fn complete_rollout_preflight(
     if !manifest.preflight_succeeded {
         return rejected(snapshot, "rollout_preflight_failed");
     }
-    if !rollout_manifest_is_complete(manifest) {
+    if !rollout_manifest_is_installable(manifest) {
         return rejected(snapshot, "rollout_manifest_incomplete");
     }
 
@@ -3439,7 +3439,7 @@ fn install_rollout_manifest(
     if !manifest.preflight_succeeded {
         return rejected(snapshot, "rollout_preflight_failed");
     }
-    if !rollout_manifest_is_complete(manifest) {
+    if !rollout_manifest_is_installable(manifest) {
         return rejected(snapshot, "rollout_manifest_incomplete");
     }
     let Some(preflight) = snapshot
@@ -3546,6 +3546,16 @@ fn change_scenario_authority(
         };
         if class.configured_mode != ScenarioMode::Authoritative {
             return rejected(snapshot, "scenario_not_approved_for_authority");
+        }
+        if !rollout_class_evidence_is_complete(scenario_class, class) {
+            return rejected(snapshot, "rollout_class_evidence_incomplete");
+        }
+        if snapshot.rollout.hard_blockers.iter().any(|blocker| {
+            blocker.scenario_class == scenario_class
+                && blocker.manifest_revision == manifest.revision
+                && blocker.preflight_revision == manifest.preflight_revision
+        }) {
+            return rejected(snapshot, "scenario_has_unresolved_hard_blocker");
         }
     }
     let rollback_target = manifest
@@ -3757,7 +3767,43 @@ fn rollout_class_gate(scenario_class: &str) -> Option<RolloutClassGate> {
     Some(gate)
 }
 
-fn rollout_class_evidence_is_complete(scenario_class: &str, class: &RolloutClassEvidence) -> bool {
+fn rollout_class_evidence_is_installable(
+    scenario_class: &str,
+    class: &RolloutClassEvidence,
+) -> bool {
+    let Some(gate) = rollout_class_gate(scenario_class) else {
+        return false;
+    };
+    let mandatory_evidence: BTreeSet<&str> = UNIVERSAL_ROLLOUT_EVIDENCE
+        .iter()
+        .chain(gate.required_evidence.iter())
+        .copied()
+        .collect();
+
+    matches!(
+        class.configured_mode,
+        ScenarioMode::Shadow | ScenarioMode::Authoritative
+    ) && class.minimum_shadow_samples >= gate.minimum_shadow_samples
+        && class.minimum_shadow_duration_secs >= gate.minimum_shadow_duration_secs
+        && class.maximum_p99_latency_regression_bps <= MAXIMUM_P99_LATENCY_REGRESSION_BPS
+        && class.observed_p99_latency_regression_bps <= class.maximum_p99_latency_regression_bps
+        && mandatory_evidence
+            .iter()
+            .all(|evidence| class.required_evidence.contains(*evidence))
+        && class
+            .verified_evidence
+            .iter()
+            .all(|evidence| class.required_evidence.contains(evidence))
+        && class.rollback_policy.trigger == RollbackTrigger::AnyHardBlocker
+        && rollback_target(&class.rollback_policy) != ScenarioMode::Authoritative
+        && (class.configured_mode == ScenarioMode::Shadow
+            || rollout_class_evidence_is_complete(scenario_class, class))
+}
+
+pub(crate) fn rollout_class_evidence_is_complete(
+    scenario_class: &str,
+    class: &RolloutClassEvidence,
+) -> bool {
     let Some(gate) = rollout_class_gate(scenario_class) else {
         return false;
     };
@@ -3789,7 +3835,7 @@ fn rollout_class_evidence_is_complete(scenario_class: &str, class: &RolloutClass
         && rollback_target(&class.rollback_policy) != ScenarioMode::Authoritative
 }
 
-fn rollout_manifest_is_complete(manifest: &RolloutManifest) -> bool {
+fn rollout_manifest_is_installable(manifest: &RolloutManifest) -> bool {
     manifest.preflight_for_manifest_revision == manifest.revision
         && manifest.preflight_succeeded
         && !manifest.protocol_build.is_empty()
@@ -3798,7 +3844,7 @@ fn rollout_manifest_is_complete(manifest: &RolloutManifest) -> bool {
         && !manifest.fixture_corpus_revision.is_empty()
         && !manifest.classes.is_empty()
         && manifest.classes.iter().all(|(scenario_class, class)| {
-            rollout_class_evidence_is_complete(scenario_class, class)
+            rollout_class_evidence_is_installable(scenario_class, class)
         })
         && manifest.safety_divergence_bps == 0
         && manifest.canonical_state_divergence_bps == 0
@@ -3812,6 +3858,65 @@ fn rollout_manifest_is_complete(manifest: &RolloutManifest) -> bool {
             })
         && !manifest.approver.is_empty()
         && !manifest.approved_at.is_empty()
+}
+
+pub(crate) fn managed_shadow_rollout_manifest(
+    revision: u64,
+    preflight_revision: u64,
+    protocol_build: String,
+    schema_build: String,
+    schema_revision: u64,
+) -> RolloutManifest {
+    let classes = SchedulerScenarioClass::PRODUCTION_AUTHORITY
+        .into_iter()
+        .map(|scenario_class| {
+            let gate = rollout_class_gate(scenario_class.as_str())
+                .expect("production scheduler scenario has a rollout gate");
+            let required_evidence = UNIVERSAL_ROLLOUT_EVIDENCE
+                .iter()
+                .chain(gate.required_evidence.iter())
+                .map(|evidence| (*evidence).to_string())
+                .collect();
+            (
+                scenario_class.as_str().to_string(),
+                RolloutClassEvidence {
+                    configured_mode: ScenarioMode::Shadow,
+                    minimum_shadow_samples: gate.minimum_shadow_samples,
+                    minimum_shadow_duration_secs: gate.minimum_shadow_duration_secs,
+                    observed_shadow_samples: 0,
+                    observed_shadow_duration_secs: 0,
+                    maximum_p99_latency_regression_bps: MAXIMUM_P99_LATENCY_REGRESSION_BPS,
+                    observed_p99_latency_regression_bps: 0,
+                    hard_blocker_count: 0,
+                    unresolved_divergence_count: 0,
+                    required_evidence,
+                    verified_evidence: BTreeSet::new(),
+                    rollback_policy: RollbackPolicy {
+                        trigger: RollbackTrigger::AnyHardBlocker,
+                        action: RollbackAction::StopAdmissionsAndRevert {
+                            target: ScenarioMode::Shadow,
+                        },
+                    },
+                },
+            )
+        })
+        .collect();
+    RolloutManifest {
+        revision,
+        preflight_revision,
+        preflight_for_manifest_revision: revision,
+        preflight_succeeded: true,
+        protocol_build,
+        schema_build,
+        schema_revision,
+        fixture_corpus_revision: "runtime-managed-shadow-v1".into(),
+        classes,
+        safety_divergence_bps: 0,
+        canonical_state_divergence_bps: 0,
+        allowed_observational_divergence: BTreeMap::new(),
+        approver: "operator:HOLON_SCHEDULER".into(),
+        approved_at: "runtime-managed-shadow".into(),
+    }
 }
 
 fn rejected(snapshot: &Snapshot, diagnostic: &str) -> Outcome {
@@ -4253,7 +4358,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
         return Err("non-legacy protocol has no rollout manifest".into());
     }
     if let Some(manifest) = &snapshot.rollout.manifest {
-        if !rollout_manifest_is_complete(manifest) {
+        if !rollout_manifest_is_installable(manifest) {
             return Err("rollout manifest is incomplete".into());
         }
         let preflight = snapshot
@@ -4321,6 +4426,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                     .ok_or_else(|| "authoritative scenario has no class evidence".to_string())?;
                 if !manifest.preflight_succeeded
                     || class.configured_mode != ScenarioMode::Authoritative
+                    || !rollout_class_evidence_is_complete(scenario_class, class)
                     || scenario.manifest_revision != Some(manifest.revision)
                     || scenario.preflight_revision != Some(manifest.preflight_revision)
                     || scenario.rollback_target != rollback_target(&class.rollback_policy)

--- a/src/host.rs
+++ b/src/host.rs
@@ -35,6 +35,7 @@ use crate::{
     provider::{build_provider_from_config, AgentProvider},
     runtime::{InitialWorkspaceBinding, LightweightAgentStateProjection, RuntimeHandle},
     runtime_db::RuntimeDb,
+    scheduler_rollout,
     skills::{
         effective_skill_root_registrations, skills_runtime_view_from_catalog, SkillVisibility,
         SkillsRegistry,
@@ -244,6 +245,7 @@ impl RuntimeHost {
     ) -> Result<Self> {
         let runtime_db =
             RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+        scheduler_rollout::reconcile_from_env(&runtime_db)?;
         let registry = RuntimeRegistry::new(config, runtime_db.clone())?;
         let host = Self {
             inner: Arc::new(HostInner {

--- a/src/host.rs
+++ b/src/host.rs
@@ -2503,12 +2503,13 @@ fn child_has_active_lifecycle_blockers(storage: &AppStorage, child_agent_id: &st
 #[cfg(test)]
 mod tests {
     use std::{
+        ffi::OsString,
         fs,
         path::Path,
         path::PathBuf,
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc,
+            Arc, MutexGuard,
         },
     };
 
@@ -2519,6 +2520,9 @@ mod tests {
 
     use crate::{
         config::{provider_registry_for_tests, ControlAuthMode, ModelRouteRef},
+        domain::scheduler_protocol::{
+            managed_shadow_rollout_manifest, ProtocolMode, RolloutCommand,
+        },
         provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
         runtime::RuntimeHandle,
         runtime_db::RuntimeDb,
@@ -2540,6 +2544,43 @@ mod tests {
             r#"{"model":{"default":"openai/gpt-5.4"}}"#,
         )
         .unwrap();
+    }
+
+    struct SchedulerEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        scheduler: Option<OsString>,
+        legacy_production_commands: Option<OsString>,
+    }
+
+    impl SchedulerEnvGuard {
+        fn unset() -> Self {
+            let lock = crate::test_env::lock_env();
+            let scheduler = std::env::var_os(crate::scheduler_rollout::SCHEDULER_ENV);
+            let legacy_production_commands =
+                std::env::var_os("HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS");
+            std::env::remove_var(crate::scheduler_rollout::SCHEDULER_ENV);
+            std::env::remove_var("HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS");
+            Self {
+                _lock: lock,
+                scheduler,
+                legacy_production_commands,
+            }
+        }
+    }
+
+    impl Drop for SchedulerEnvGuard {
+        fn drop(&mut self) {
+            match &self.scheduler {
+                Some(value) => std::env::set_var(crate::scheduler_rollout::SCHEDULER_ENV, value),
+                None => std::env::remove_var(crate::scheduler_rollout::SCHEDULER_ENV),
+            }
+            match &self.legacy_production_commands {
+                Some(value) => {
+                    std::env::set_var("HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS", value)
+                }
+                None => std::env::remove_var("HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS"),
+            }
+        }
     }
 
     struct ProviderConfigFixture {
@@ -4867,6 +4908,74 @@ mod tests {
         let fixture = provider_test_config(Some("anthropic-token"));
         let host = RuntimeHost::new(fixture.config);
         assert!(host.is_ok());
+    }
+
+    #[test]
+    fn runtime_host_without_scheduler_env_preserves_persisted_rollout_state() {
+        let _env = SchedulerEnvGuard::unset();
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        let schema_revision = u64::try_from(runtime_db.current_schema_version().unwrap()).unwrap();
+        let manifest = managed_shadow_rollout_manifest(
+            1,
+            1,
+            "persisted-build".into(),
+            "persisted-schema".into(),
+            schema_revision,
+        );
+        runtime_db
+            .apply_scheduler_rollout_commands(&[
+                (
+                    "test:preflight:open".into(),
+                    RolloutCommand::OpenPreflight {
+                        expected_config_revision: 0,
+                        manifest_revision: manifest.revision,
+                    },
+                ),
+                (
+                    "test:preflight:complete".into(),
+                    RolloutCommand::CompletePreflight {
+                        expected_config_revision: 0,
+                        expected_preflight_revision: manifest.preflight_revision,
+                        manifest: manifest.clone(),
+                    },
+                ),
+                (
+                    "test:manifest:install".into(),
+                    RolloutCommand::InstallManifest {
+                        expected_config_revision: 0,
+                        manifest,
+                    },
+                ),
+                (
+                    "test:protocol:shadow".into(),
+                    RolloutCommand::ConfigureProtocol {
+                        expected_config_revision: 1,
+                        mode: ProtocolMode::Shadow,
+                    },
+                ),
+            ])
+            .unwrap();
+        let before = runtime_db
+            .transitions()
+            .load_scheduler_rollout_state()
+            .unwrap();
+        drop(runtime_db);
+
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("ok"))).unwrap();
+        let after = host
+            .runtime_db()
+            .transitions()
+            .load_scheduler_rollout_state()
+            .unwrap();
+
+        assert_eq!(after, before);
+        assert_eq!(after.protocol_mode, ProtocolMode::Shadow);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod runtime;
 pub mod runtime_db;
 pub mod runtime_error;
 pub mod runtime_event;
+mod scheduler_rollout;
 pub mod skills;
 pub mod solve;
 pub mod storage;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -324,6 +324,7 @@ pub fn require_scheduler_acceptance_fixtures_enabled() -> Result<()> {
 
 #[cfg(test)]
 fn scheduler_acceptance_fixtures_enabled_from_values(
+    desired: Option<&str>,
     production_commands: Option<&str>,
     acceptance_fixtures: Option<&str>,
 ) -> Result<bool> {
@@ -337,11 +338,12 @@ fn scheduler_acceptance_fixtures_enabled_from_values(
             _ => Err(anyhow!("{name} expects a boolean")),
         }
     }
-    Ok(parse(
-        SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV,
-        production_commands,
-    )? == Some(true)
-        && parse(SCHEDULER_ACCEPTANCE_FIXTURES_ENV, acceptance_fixtures)? == Some(true))
+    Ok(
+        crate::scheduler_rollout::production_commands_enabled_from_values(
+            desired.map(std::ffi::OsStr::new),
+            production_commands.map(std::ffi::OsStr::new),
+        )? && parse(SCHEDULER_ACCEPTANCE_FIXTURES_ENV, acceptance_fixtures)? == Some(true),
+    )
 }
 
 #[cfg(test)]
@@ -349,26 +351,63 @@ mod scheduler_acceptance_gate_tests {
     use super::*;
 
     #[test]
-    fn scheduler_acceptance_gate_requires_both_explicit_flags() {
-        assert!(
-            scheduler_acceptance_fixtures_enabled_from_values(Some("true"), Some("true")).unwrap()
-        );
-        assert!(!scheduler_acceptance_fixtures_enabled_from_values(Some("true"), None).unwrap());
-        assert!(!scheduler_acceptance_fixtures_enabled_from_values(None, Some("true")).unwrap());
-        assert!(
-            !scheduler_acceptance_fixtures_enabled_from_values(Some("false"), Some("true"))
-                .unwrap()
-        );
+    fn scheduler_acceptance_gate_uses_scheduler_mode_precedence() {
+        assert!(scheduler_acceptance_fixtures_enabled_from_values(
+            Some("authoritative"),
+            None,
+            Some("true")
+        )
+        .unwrap());
+        assert!(scheduler_acceptance_fixtures_enabled_from_values(
+            Some("authoritative"),
+            Some("false"),
+            Some("true")
+        )
+        .unwrap());
+        assert!(!scheduler_acceptance_fixtures_enabled_from_values(
+            Some("shadow"),
+            Some("true"),
+            Some("true")
+        )
+        .unwrap());
+        assert!(!scheduler_acceptance_fixtures_enabled_from_values(
+            Some("legacy"),
+            Some("true"),
+            Some("true")
+        )
+        .unwrap());
+        assert!(scheduler_acceptance_fixtures_enabled_from_values(
+            None,
+            Some("true"),
+            Some("true")
+        )
+        .unwrap());
+        assert!(!scheduler_acceptance_fixtures_enabled_from_values(
+            Some("authoritative"),
+            None,
+            None
+        )
+        .unwrap());
     }
 
     #[test]
-    fn scheduler_acceptance_gate_rejects_invalid_boolean() {
-        assert!(
-            scheduler_acceptance_fixtures_enabled_from_values(Some("sometimes"), Some("true"))
-                .unwrap_err()
-                .to_string()
-                .contains(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV)
-        );
+    fn scheduler_acceptance_gate_rejects_invalid_scheduler_configuration() {
+        assert!(scheduler_acceptance_fixtures_enabled_from_values(
+            Some("enabled"),
+            Some("true"),
+            Some("true")
+        )
+        .unwrap_err()
+        .to_string()
+        .contains(crate::scheduler_rollout::SCHEDULER_ENV));
+        assert!(scheduler_acceptance_fixtures_enabled_from_values(
+            None,
+            Some("sometimes"),
+            Some("true")
+        )
+        .unwrap_err()
+        .to_string()
+        .contains(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV));
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -292,7 +292,7 @@ const SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV: &str =
 const SCHEDULER_ACCEPTANCE_FIXTURES_ENV: &str = "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES";
 
 fn scheduler_protocol_production_commands_enabled_from_env() -> Result<bool> {
-    boolean_env(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV).map(|value| value.unwrap_or(false))
+    crate::scheduler_rollout::production_commands_enabled_from_env()
 }
 
 fn boolean_env(name: &str) -> Result<Option<bool>> {
@@ -308,9 +308,10 @@ fn boolean_env(name: &str) -> Result<Option<bool>> {
 }
 
 pub fn require_scheduler_acceptance_fixtures_enabled() -> Result<()> {
-    if boolean_env(SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV)? != Some(true) {
+    if !scheduler_protocol_production_commands_enabled_from_env()? {
         return Err(anyhow!(
-            "scheduler acceptance fixtures require {SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV}=true"
+            "scheduler acceptance fixtures require HOLON_SCHEDULER=authoritative or \
+             {SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS_ENV}=true"
         ));
     }
     if boolean_env(SCHEDULER_ACCEPTANCE_FIXTURES_ENV)? != Some(true) {

--- a/src/runtime/scheduler_acceptance.rs
+++ b/src/runtime/scheduler_acceptance.rs
@@ -46,7 +46,8 @@ pub async fn seed_scheduler_terminal_recovery_fixture(
     )?;
     if !runtime.scheduler_protocol_production_commands_enabled() {
         return Err(anyhow!(
-            "scheduler recovery fixture requires HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS=true"
+            "scheduler recovery fixture requires HOLON_SCHEDULER=authoritative or \
+             HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS=true"
         ));
     }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -2765,21 +2765,50 @@ mod tests {
                     && blocker.preflight_revision == 1
             }));
 
-            let reauthorized = db.transitions().commit_scheduler_rollout_command(
-                &format!("{scenario_class}-reauthorize-after-missing"),
-                &RolloutCommand::ChangeScenarioAuthority {
-                    scenario_class: scenario_class.into(),
-                    expected_config_revision: 5,
-                    expected_manifest_revision: 1,
-                    expected_preflight_revision: 1,
-                    mode: ScenarioMode::Authoritative,
-                },
-                None,
-            )?;
-            assert_eq!(
-                reauthorized.result.decision,
-                Decision::ScenarioAuthorityChanged
-            );
+            let replacement_manifest = scheduler_phase3_rollout_manifest(scenario_class, 2, 2);
+            for (identity, command, expected_decision) in [
+                (
+                    format!("{scenario_class}-replacement-open"),
+                    RolloutCommand::OpenPreflight {
+                        expected_config_revision: 5,
+                        manifest_revision: 2,
+                    },
+                    Decision::RolloutPreflightOpened,
+                ),
+                (
+                    format!("{scenario_class}-replacement-complete"),
+                    RolloutCommand::CompletePreflight {
+                        expected_config_revision: 5,
+                        expected_preflight_revision: 2,
+                        manifest: replacement_manifest.clone(),
+                    },
+                    Decision::RolloutPreflightCompleted,
+                ),
+                (
+                    format!("{scenario_class}-replacement-install"),
+                    RolloutCommand::InstallManifest {
+                        expected_config_revision: 5,
+                        manifest: replacement_manifest.clone(),
+                    },
+                    Decision::ManifestInstalled,
+                ),
+                (
+                    format!("{scenario_class}-reauthorize-after-missing"),
+                    RolloutCommand::ChangeScenarioAuthority {
+                        scenario_class: scenario_class.into(),
+                        expected_config_revision: 6,
+                        expected_manifest_revision: 2,
+                        expected_preflight_revision: 2,
+                        mode: ScenarioMode::Authoritative,
+                    },
+                    Decision::ScenarioAuthorityChanged,
+                ),
+            ] {
+                let committed = db
+                    .transitions()
+                    .commit_scheduler_rollout_command(&identity, &command, None)?;
+                assert_eq!(committed.result.decision, expected_decision);
+            }
             let authoritative_expectations = db
                 .transitions()
                 .scheduler_rollout_expectations(&[scenario], true)?;
@@ -2831,9 +2860,9 @@ mod tests {
                 .any(|blocker| {
                     blocker.scenario_class == scenario_class
                         && blocker.blocker_code == "phase5h_cutover_mismatch"
-                        && blocker.config_revision == 6
-                        && blocker.manifest_revision == 1
-                        && blocker.preflight_revision == 1
+                        && blocker.config_revision == 7
+                        && blocker.manifest_revision == 2
+                        && blocker.preflight_revision == 2
                 }));
             let fallback_expectations = db
                 .transitions()

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -894,6 +894,11 @@ impl RuntimeTransitionRepository<'_> {
         Ok(Some(snapshot))
     }
 
+    pub(crate) fn load_scheduler_rollout_state(&self) -> Result<RolloutState> {
+        let connection = self.db.connection()?;
+        load_rollout(&connection)
+    }
+
     fn load_scheduler_protocol_snapshot_with_hook(
         &self,
         agent_id: &str,

--- a/src/scheduler_rollout.rs
+++ b/src/scheduler_rollout.rs
@@ -1,0 +1,748 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsStr,
+};
+
+use anyhow::{anyhow, bail, Result};
+
+use crate::{
+    domain::scheduler_protocol::{
+        managed_shadow_rollout_manifest, rollout_class_evidence_is_complete, ProtocolMode,
+        RolloutCommand, RolloutManifest, RolloutPreflightState, RolloutState,
+        ScenarioHardBlockerRecord, ScenarioMode,
+    },
+    runtime_db::RuntimeDb,
+};
+
+pub(crate) const SCHEDULER_ENV: &str = "HOLON_SCHEDULER";
+const LEGACY_PRODUCTION_COMMANDS_ENV: &str = "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchedulerDesiredMode {
+    Legacy,
+    Shadow,
+    Authoritative,
+}
+
+impl SchedulerDesiredMode {
+    fn token(self) -> &'static str {
+        match self {
+            Self::Legacy => "legacy",
+            Self::Shadow => "shadow",
+            Self::Authoritative => "authoritative",
+        }
+    }
+}
+
+fn desired_mode_from_value(value: Option<&OsStr>) -> Result<Option<SchedulerDesiredMode>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .ok_or_else(|| anyhow!("{SCHEDULER_ENV} must be valid UTF-8"))?
+        .trim()
+        .to_ascii_lowercase();
+    match value.as_str() {
+        "legacy" => Ok(Some(SchedulerDesiredMode::Legacy)),
+        "shadow" => Ok(Some(SchedulerDesiredMode::Shadow)),
+        "authoritative" => Ok(Some(SchedulerDesiredMode::Authoritative)),
+        _ => Err(anyhow!(
+            "{SCHEDULER_ENV} expects legacy, shadow, or authoritative"
+        )),
+    }
+}
+
+pub(crate) fn production_commands_enabled_from_env() -> Result<bool> {
+    production_commands_enabled_from_values(
+        std::env::var_os(SCHEDULER_ENV).as_deref(),
+        std::env::var_os(LEGACY_PRODUCTION_COMMANDS_ENV).as_deref(),
+    )
+}
+
+pub(crate) fn reconcile_from_env(runtime_db: &RuntimeDb) -> Result<()> {
+    let Some(desired) = desired_mode_for_values(
+        std::env::var_os(SCHEDULER_ENV).as_deref(),
+        std::env::var_os(LEGACY_PRODUCTION_COMMANDS_ENV).as_deref(),
+    )?
+    else {
+        return Ok(());
+    };
+    let rollout = runtime_db.transitions().load_scheduler_rollout_state()?;
+    let commands = reconciliation_commands(runtime_db, desired, &rollout)?;
+    if !commands.is_empty() {
+        runtime_db.apply_scheduler_rollout_commands(&commands)?;
+    }
+    Ok(())
+}
+
+fn desired_mode_for_values(
+    desired: Option<&OsStr>,
+    legacy_production_commands: Option<&OsStr>,
+) -> Result<Option<SchedulerDesiredMode>> {
+    if let Some(desired) = desired_mode_from_value(desired)? {
+        return Ok(Some(desired));
+    }
+    boolean_from_value(LEGACY_PRODUCTION_COMMANDS_ENV, legacy_production_commands)?;
+    Ok(None)
+}
+
+fn boolean_from_value(name: &str, value: Option<&OsStr>) -> Result<Option<bool>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .ok_or_else(|| anyhow!("{name} must be valid UTF-8"))?
+        .trim()
+        .to_ascii_lowercase();
+    match value.as_str() {
+        "1" | "true" | "yes" | "on" => Ok(Some(true)),
+        "0" | "false" | "no" | "off" => Ok(Some(false)),
+        _ => Err(anyhow!("{name} expects a boolean")),
+    }
+}
+
+fn production_commands_enabled_from_values(
+    desired: Option<&OsStr>,
+    legacy_production_commands: Option<&OsStr>,
+) -> Result<bool> {
+    if let Some(desired) = desired_mode_from_value(desired)? {
+        return Ok(desired == SchedulerDesiredMode::Authoritative);
+    }
+    Ok(
+        boolean_from_value(LEGACY_PRODUCTION_COMMANDS_ENV, legacy_production_commands)?
+            .unwrap_or(false),
+    )
+}
+
+fn reconciliation_commands(
+    runtime_db: &RuntimeDb,
+    desired: SchedulerDesiredMode,
+    rollout: &RolloutState,
+) -> Result<Vec<(String, RolloutCommand)>> {
+    let schema_revision = u64::try_from(runtime_db.current_schema_version()?)
+        .map_err(|_| anyhow!("runtime schema revision is negative"))?;
+    reconciliation_commands_for_state(desired, rollout, schema_revision)
+}
+
+fn reconciliation_commands_for_state(
+    desired: SchedulerDesiredMode,
+    rollout: &RolloutState,
+    schema_revision: u64,
+) -> Result<Vec<(String, RolloutCommand)>> {
+    let mut planner = ReconciliationPlanner::new(desired, rollout);
+    if desired != SchedulerDesiredMode::Legacy && planner.manifest.is_none() {
+        if let Some((revision, _)) = rollout
+            .preflights
+            .iter()
+            .rev()
+            .find(|(_, preflight)| preflight.state == RolloutPreflightState::Open)
+        {
+            bail!(
+                "cannot reconcile {SCHEDULER_ENV}={} while rollout preflight {revision} is open",
+                desired.token()
+            );
+        }
+        if let Some((revision, preflight)) = rollout
+            .preflights
+            .iter()
+            .rev()
+            .find(|(_, preflight)| preflight.state == RolloutPreflightState::Completed)
+        {
+            let manifest = preflight
+                .manifest
+                .clone()
+                .ok_or_else(|| anyhow!("completed rollout preflight {revision} has no manifest"))?;
+            planner.install_completed_manifest(manifest);
+        } else {
+            planner.install_managed_shadow_manifest(
+                rollout.latest_preflight_revision + 1,
+                schema_revision,
+            );
+        }
+    }
+    match desired {
+        SchedulerDesiredMode::Legacy => planner.plan_legacy(),
+        SchedulerDesiredMode::Shadow => planner.plan_shadow(),
+        SchedulerDesiredMode::Authoritative => planner.plan_authoritative(),
+    }
+    Ok(planner.finish())
+}
+
+struct ReconciliationPlanner {
+    desired: SchedulerDesiredMode,
+    initial_config_revision: u64,
+    config_revision: u64,
+    protocol_mode: ProtocolMode,
+    manifest: Option<RolloutManifest>,
+    scenario_modes: BTreeMap<String, ScenarioMode>,
+    hard_blockers: BTreeSet<ScenarioHardBlockerRecord>,
+    commands: Vec<RolloutCommand>,
+}
+
+impl ReconciliationPlanner {
+    fn new(desired: SchedulerDesiredMode, rollout: &RolloutState) -> Self {
+        Self {
+            desired,
+            initial_config_revision: rollout.config_revision,
+            config_revision: rollout.config_revision,
+            protocol_mode: rollout.protocol_mode,
+            manifest: rollout.manifest.clone(),
+            scenario_modes: rollout
+                .scenarios
+                .iter()
+                .map(|(scenario, authority)| (scenario.clone(), authority.mode))
+                .collect(),
+            hard_blockers: rollout.hard_blockers.clone(),
+            commands: Vec::new(),
+        }
+    }
+
+    fn install_managed_shadow_manifest(&mut self, preflight_revision: u64, schema_revision: u64) {
+        let manifest_revision = self
+            .manifest
+            .as_ref()
+            .map_or(1, |manifest| manifest.revision + 1);
+        let manifest = managed_shadow_rollout_manifest(
+            manifest_revision,
+            preflight_revision,
+            format!("holon-{}", env!("CARGO_PKG_VERSION")),
+            format!("runtime-db-schema-{schema_revision}"),
+            schema_revision,
+        );
+        self.commands.push(RolloutCommand::OpenPreflight {
+            expected_config_revision: self.config_revision,
+            manifest_revision,
+        });
+        self.commands.push(RolloutCommand::CompletePreflight {
+            expected_config_revision: self.config_revision,
+            expected_preflight_revision: preflight_revision,
+            manifest: manifest.clone(),
+        });
+        self.commands.push(RolloutCommand::InstallManifest {
+            expected_config_revision: self.config_revision,
+            manifest: manifest.clone(),
+        });
+        self.config_revision += 1;
+        self.manifest = Some(manifest);
+    }
+
+    fn install_completed_manifest(&mut self, manifest: RolloutManifest) {
+        self.commands.push(RolloutCommand::InstallManifest {
+            expected_config_revision: self.config_revision,
+            manifest: manifest.clone(),
+        });
+        self.config_revision += 1;
+        self.manifest = Some(manifest);
+    }
+
+    fn plan_legacy(&mut self) {
+        self.lower_authoritative_scenarios();
+        self.lower_shadow_scenarios();
+        self.configure_protocol(ProtocolMode::Legacy);
+    }
+
+    fn plan_shadow(&mut self) {
+        self.lower_authoritative_scenarios();
+        self.configure_protocol(ProtocolMode::Shadow);
+        self.converge_manifest_scenarios(false);
+    }
+
+    fn plan_authoritative(&mut self) {
+        self.configure_protocol(ProtocolMode::Authoritative);
+        self.converge_manifest_scenarios(true);
+    }
+
+    fn lower_authoritative_scenarios(&mut self) {
+        for scenario in self.known_scenarios() {
+            if self.scenario_mode(&scenario) == ScenarioMode::Authoritative {
+                self.change_scenario(&scenario, ScenarioMode::Shadow);
+            }
+        }
+    }
+
+    fn lower_shadow_scenarios(&mut self) {
+        for scenario in self.known_scenarios() {
+            if self.scenario_mode(&scenario) == ScenarioMode::Shadow {
+                self.change_scenario(&scenario, ScenarioMode::Off);
+            }
+        }
+    }
+
+    fn converge_manifest_scenarios(&mut self, allow_authoritative: bool) {
+        let manifest_classes = self
+            .manifest
+            .as_ref()
+            .map(|manifest| manifest.classes.clone())
+            .unwrap_or_default();
+        for scenario in self.known_scenarios() {
+            let configured = manifest_classes
+                .get(&scenario)
+                .map(|class| class.configured_mode);
+            if configured.is_none() {
+                if self.scenario_mode(&scenario) == ScenarioMode::Authoritative {
+                    self.change_scenario(&scenario, ScenarioMode::Shadow);
+                }
+                if self.scenario_mode(&scenario) == ScenarioMode::Shadow {
+                    self.change_scenario(&scenario, ScenarioMode::Off);
+                }
+                continue;
+            }
+            if self.scenario_mode(&scenario) == ScenarioMode::Off {
+                self.change_scenario(&scenario, ScenarioMode::Shadow);
+            }
+            if allow_authoritative
+                && configured == Some(ScenarioMode::Authoritative)
+                && self.scenario_mode(&scenario) == ScenarioMode::Shadow
+                && manifest_classes
+                    .get(&scenario)
+                    .is_some_and(|class| rollout_class_evidence_is_complete(&scenario, class))
+                && !self.has_hard_blocker(&scenario)
+            {
+                self.change_scenario(&scenario, ScenarioMode::Authoritative);
+            } else if !allow_authoritative
+                && self.scenario_mode(&scenario) == ScenarioMode::Authoritative
+            {
+                self.change_scenario(&scenario, ScenarioMode::Shadow);
+            }
+        }
+    }
+
+    fn configure_protocol(&mut self, mode: ProtocolMode) {
+        if self.protocol_mode == mode {
+            return;
+        }
+        self.commands.push(RolloutCommand::ConfigureProtocol {
+            expected_config_revision: self.config_revision,
+            mode,
+        });
+        self.config_revision += 1;
+        self.protocol_mode = mode;
+    }
+
+    fn change_scenario(&mut self, scenario: &str, mode: ScenarioMode) {
+        if self.scenario_mode(scenario) == mode {
+            return;
+        }
+        let manifest = self
+            .manifest
+            .as_ref()
+            .expect("non-legacy scenario transition requires a manifest");
+        self.commands.push(RolloutCommand::ChangeScenarioAuthority {
+            scenario_class: scenario.to_string(),
+            expected_config_revision: self.config_revision,
+            expected_manifest_revision: manifest.revision,
+            expected_preflight_revision: manifest.preflight_revision,
+            mode,
+        });
+        self.config_revision += 1;
+        self.scenario_modes.insert(scenario.to_string(), mode);
+    }
+
+    fn scenario_mode(&self, scenario: &str) -> ScenarioMode {
+        self.scenario_modes
+            .get(scenario)
+            .copied()
+            .unwrap_or(ScenarioMode::Off)
+    }
+
+    fn has_hard_blocker(&self, scenario: &str) -> bool {
+        let Some(manifest) = &self.manifest else {
+            return false;
+        };
+        self.hard_blockers.iter().any(|blocker| {
+            blocker.scenario_class == scenario
+                && blocker.manifest_revision == manifest.revision
+                && blocker.preflight_revision == manifest.preflight_revision
+        })
+    }
+
+    fn known_scenarios(&self) -> Vec<String> {
+        let mut scenarios = self.scenario_modes.keys().cloned().collect::<Vec<_>>();
+        if let Some(manifest) = &self.manifest {
+            scenarios.extend(manifest.classes.keys().cloned());
+        }
+        scenarios.sort();
+        scenarios.dedup();
+        scenarios
+    }
+
+    fn finish(self) -> Vec<(String, RolloutCommand)> {
+        self.commands
+            .into_iter()
+            .enumerate()
+            .map(|(index, command)| {
+                (
+                    format!(
+                        "scheduler-env:{}:{}:{}",
+                        self.desired.token(),
+                        self.initial_config_revision,
+                        index
+                    ),
+                    command,
+                )
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use crate::domain::scheduler_protocol::{
+        RollbackAction, RollbackTrigger, RolloutPreflightRecord, RolloutPreflightState,
+        ScenarioAuthority, ScenarioHardBlockerRecord, SchedulerScenarioClass,
+    };
+
+    #[test]
+    fn desired_mode_parser_is_strict() {
+        assert_eq!(desired_mode_from_value(None).unwrap(), None);
+        assert_eq!(
+            desired_mode_from_value(Some(OsStr::new(" shadow "))).unwrap(),
+            Some(SchedulerDesiredMode::Shadow)
+        );
+        assert!(desired_mode_from_value(Some(OsStr::new("enabled"))).is_err());
+    }
+
+    #[test]
+    fn unset_desired_mode_preserves_legacy_rollout_control() {
+        assert_eq!(desired_mode_for_values(None, None).unwrap(), None);
+        assert_eq!(
+            desired_mode_for_values(None, Some(OsStr::new("false"))).unwrap(),
+            None
+        );
+        assert_eq!(
+            desired_mode_for_values(None, Some(OsStr::new("true"))).unwrap(),
+            None
+        );
+        assert_eq!(
+            desired_mode_for_values(Some(OsStr::new("shadow")), Some(OsStr::new("true"))).unwrap(),
+            Some(SchedulerDesiredMode::Shadow)
+        );
+    }
+
+    #[test]
+    fn desired_mode_overrides_the_legacy_production_capability() {
+        assert!(production_commands_enabled_from_values(
+            Some(OsStr::new("authoritative")),
+            Some(OsStr::new("false"))
+        )
+        .unwrap());
+        assert!(!production_commands_enabled_from_values(
+            Some(OsStr::new("shadow")),
+            Some(OsStr::new("true"))
+        )
+        .unwrap());
+        assert!(production_commands_enabled_from_values(None, Some(OsStr::new("true"))).unwrap());
+    }
+
+    #[test]
+    fn fresh_shadow_bootstraps_only_shadow_authority() {
+        let commands = reconciliation_commands_for_state(
+            SchedulerDesiredMode::Shadow,
+            &RolloutState::default(),
+            7,
+        )
+        .unwrap();
+
+        assert!(commands.iter().any(|(_, command)| matches!(
+            command,
+            RolloutCommand::InstallManifest { manifest, .. }
+                if manifest.classes.values().all(|class| {
+                    class.configured_mode == ScenarioMode::Shadow
+                        && class.verified_evidence.is_empty()
+                })
+        )));
+        assert!(commands.iter().any(|(_, command)| matches!(
+            command,
+            RolloutCommand::ConfigureProtocol {
+                mode: ProtocolMode::Shadow,
+                ..
+            }
+        )));
+        assert_eq!(
+            scenario_transitions(&commands, ScenarioMode::Shadow),
+            SchedulerScenarioClass::PRODUCTION_AUTHORITY.len()
+        );
+        assert_eq!(
+            scenario_transitions(&commands, ScenarioMode::Authoritative),
+            0
+        );
+    }
+
+    #[test]
+    fn fresh_authoritative_stays_shadow_without_approved_evidence() {
+        let commands = reconciliation_commands_for_state(
+            SchedulerDesiredMode::Authoritative,
+            &RolloutState::default(),
+            7,
+        )
+        .unwrap();
+
+        assert!(commands.iter().any(|(_, command)| matches!(
+            command,
+            RolloutCommand::ConfigureProtocol {
+                mode: ProtocolMode::Authoritative,
+                ..
+            }
+        )));
+        assert_eq!(
+            scenario_transitions(&commands, ScenarioMode::Shadow),
+            SchedulerScenarioClass::PRODUCTION_AUTHORITY.len()
+        );
+        assert_eq!(
+            scenario_transitions(&commands, ScenarioMode::Authoritative),
+            0
+        );
+    }
+
+    #[test]
+    fn authoritative_promotes_only_manifest_approved_classes() {
+        let mut rollout = approved_authoritative_rollout();
+        let excluded = SchedulerScenarioClass::Delivery.as_str();
+        rollout
+            .manifest
+            .as_mut()
+            .expect("manifest")
+            .classes
+            .get_mut(excluded)
+            .expect("class")
+            .configured_mode = ScenarioMode::Shadow;
+
+        let commands =
+            reconciliation_commands_for_state(SchedulerDesiredMode::Authoritative, &rollout, 7)
+                .unwrap();
+
+        assert_eq!(
+            scenario_transitions(&commands, ScenarioMode::Authoritative),
+            SchedulerScenarioClass::PRODUCTION_AUTHORITY.len() - 1
+        );
+        assert!(!commands.iter().any(|(_, command)| matches!(
+            command,
+            RolloutCommand::ChangeScenarioAuthority {
+                scenario_class,
+                mode: ScenarioMode::Authoritative,
+                ..
+            } if scenario_class == excluded
+        )));
+    }
+
+    #[test]
+    fn authoritative_does_not_promote_a_hard_blocked_class() {
+        let mut rollout = approved_authoritative_rollout();
+        let blocked = SchedulerScenarioClass::ExactWaitResume.as_str();
+        rollout.hard_blockers.insert(ScenarioHardBlockerRecord {
+            scenario_class: blocked.to_string(),
+            blocker_code: "stale_wait_generation_accepted".into(),
+            config_revision: 0,
+            manifest_revision: 1,
+            preflight_revision: 1,
+            trigger: RollbackTrigger::AnyHardBlocker,
+            action: RollbackAction::StopAdmissionsAndRevert {
+                target: ScenarioMode::Shadow,
+            },
+        });
+
+        let commands =
+            reconciliation_commands_for_state(SchedulerDesiredMode::Authoritative, &rollout, 7)
+                .unwrap();
+
+        assert!(!commands.iter().any(|(_, command)| matches!(
+            command,
+            RolloutCommand::ChangeScenarioAuthority {
+                scenario_class,
+                mode: ScenarioMode::Authoritative,
+                ..
+            } if scenario_class == blocked
+        )));
+    }
+
+    #[test]
+    fn legacy_downgrade_is_ordered_and_idempotent() {
+        let mut rollout = approved_authoritative_rollout();
+        rollout.protocol_mode = ProtocolMode::Authoritative;
+        let manifest = rollout.manifest.as_ref().expect("manifest");
+        for scenario in SchedulerScenarioClass::PRODUCTION_AUTHORITY {
+            rollout.scenarios.insert(
+                scenario.as_str().to_string(),
+                ScenarioAuthority {
+                    mode: ScenarioMode::Authoritative,
+                    rollback_target: ScenarioMode::Shadow,
+                    manifest_revision: Some(manifest.revision),
+                    preflight_revision: Some(manifest.preflight_revision),
+                },
+            );
+        }
+
+        let commands =
+            reconciliation_commands_for_state(SchedulerDesiredMode::Legacy, &rollout, 7).unwrap();
+        let modes = commands
+            .iter()
+            .filter_map(|(_, command)| match command {
+                RolloutCommand::ChangeScenarioAuthority { mode, .. } => Some(*mode),
+                RolloutCommand::ConfigureProtocol { mode, .. } => {
+                    assert_eq!(*mode, ProtocolMode::Legacy);
+                    None
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            modes,
+            [ScenarioMode::Shadow, ScenarioMode::Off]
+                .into_iter()
+                .flat_map(|mode| {
+                    std::iter::repeat_n(mode, SchedulerScenarioClass::PRODUCTION_AUTHORITY.len())
+                })
+                .collect::<Vec<_>>()
+        );
+
+        rollout.protocol_mode = ProtocolMode::Legacy;
+        for authority in rollout.scenarios.values_mut() {
+            authority.mode = ScenarioMode::Off;
+            authority.manifest_revision = None;
+            authority.preflight_revision = None;
+        }
+        assert!(
+            reconciliation_commands_for_state(SchedulerDesiredMode::Legacy, &rollout, 7)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn open_preflight_fails_with_actionable_diagnostic() {
+        let mut rollout = RolloutState {
+            latest_preflight_revision: 1,
+            ..RolloutState::default()
+        };
+        rollout.preflights.insert(
+            1,
+            RolloutPreflightRecord {
+                revision: 1,
+                manifest_revision: 1,
+                state: RolloutPreflightState::Open,
+                manifest: None,
+            },
+        );
+
+        let error = reconciliation_commands_for_state(SchedulerDesiredMode::Shadow, &rollout, 7)
+            .unwrap_err();
+        assert!(error.to_string().contains("rollout preflight 1 is open"));
+    }
+
+    #[test]
+    fn completed_preflight_is_installed_without_reopening() {
+        let manifest = managed_shadow_rollout_manifest(1, 1, "build".into(), "schema".into(), 7);
+        let rollout = RolloutState {
+            latest_preflight_revision: 1,
+            preflights: BTreeMap::from([(
+                1,
+                RolloutPreflightRecord {
+                    revision: 1,
+                    manifest_revision: 1,
+                    state: RolloutPreflightState::Completed,
+                    manifest: Some(manifest.clone()),
+                },
+            )]),
+            ..RolloutState::default()
+        };
+
+        let commands =
+            reconciliation_commands_for_state(SchedulerDesiredMode::Shadow, &rollout, 7).unwrap();
+        assert!(matches!(
+            commands.first(),
+            Some((
+                _,
+                RolloutCommand::InstallManifest {
+                    manifest: installed,
+                    ..
+                }
+            )) if installed == &manifest
+        ));
+        assert!(!commands.iter().any(|(_, command)| matches!(
+            command,
+            RolloutCommand::OpenPreflight { .. } | RolloutCommand::CompletePreflight { .. }
+        )));
+    }
+
+    #[test]
+    fn runtime_db_reconciliation_is_restart_idempotent() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )?;
+        let schema_revision = u64::try_from(db.current_schema_version()?)?;
+
+        let rollout = db.transitions().load_scheduler_rollout_state()?;
+        let commands = reconciliation_commands_for_state(
+            SchedulerDesiredMode::Authoritative,
+            &rollout,
+            schema_revision,
+        )?;
+        db.apply_scheduler_rollout_commands(&commands)?;
+
+        let restarted = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )?;
+        let rollout = restarted.transitions().load_scheduler_rollout_state()?;
+        assert_eq!(rollout.protocol_mode, ProtocolMode::Authoritative);
+        assert!(rollout
+            .scenarios
+            .values()
+            .all(|authority| authority.mode == ScenarioMode::Shadow));
+        assert!(reconciliation_commands_for_state(
+            SchedulerDesiredMode::Authoritative,
+            &rollout,
+            schema_revision
+        )?
+        .is_empty());
+        Ok(())
+    }
+
+    fn scenario_transitions(
+        commands: &[(String, RolloutCommand)],
+        expected: ScenarioMode,
+    ) -> usize {
+        commands
+            .iter()
+            .filter(|(_, command)| {
+                matches!(
+                    command,
+                    RolloutCommand::ChangeScenarioAuthority { mode, .. } if *mode == expected
+                )
+            })
+            .count()
+    }
+
+    fn approved_authoritative_rollout() -> RolloutState {
+        let mut manifest =
+            managed_shadow_rollout_manifest(1, 1, "build".into(), "schema".into(), 7);
+        for class in manifest.classes.values_mut() {
+            class.configured_mode = ScenarioMode::Authoritative;
+            class.observed_shadow_samples = class.minimum_shadow_samples;
+            class.observed_shadow_duration_secs = class.minimum_shadow_duration_secs;
+            class.verified_evidence = class.required_evidence.clone();
+        }
+        RolloutState {
+            latest_preflight_revision: 1,
+            preflights: BTreeMap::from([(
+                1,
+                RolloutPreflightRecord {
+                    revision: 1,
+                    manifest_revision: 1,
+                    state: RolloutPreflightState::Consumed,
+                    manifest: Some(manifest.clone()),
+                },
+            )]),
+            manifest: Some(manifest),
+            hard_blockers: BTreeSet::new(),
+            ..RolloutState::default()
+        }
+    }
+}

--- a/src/scheduler_rollout.rs
+++ b/src/scheduler_rollout.rs
@@ -103,7 +103,7 @@ fn boolean_from_value(name: &str, value: Option<&OsStr>) -> Result<Option<bool>>
     }
 }
 
-fn production_commands_enabled_from_values(
+pub(crate) fn production_commands_enabled_from_values(
     desired: Option<&OsStr>,
     legacy_production_commands: Option<&OsStr>,
 ) -> Result<bool> {
@@ -163,9 +163,9 @@ fn reconciliation_commands_for_state(
         }
     }
     match desired {
-        SchedulerDesiredMode::Legacy => planner.plan_legacy(),
-        SchedulerDesiredMode::Shadow => planner.plan_shadow(),
-        SchedulerDesiredMode::Authoritative => planner.plan_authoritative(),
+        SchedulerDesiredMode::Legacy => planner.plan_legacy()?,
+        SchedulerDesiredMode::Shadow => planner.plan_shadow()?,
+        SchedulerDesiredMode::Authoritative => planner.plan_authoritative()?,
     }
     Ok(planner.finish())
 }
@@ -224,6 +224,8 @@ impl ReconciliationPlanner {
             expected_config_revision: self.config_revision,
             manifest: manifest.clone(),
         });
+        // Opening and completing preserve the config fence; installation advances
+        // it once for the whole bootstrap sequence.
         self.config_revision += 1;
         self.manifest = Some(manifest);
     }
@@ -237,40 +239,43 @@ impl ReconciliationPlanner {
         self.manifest = Some(manifest);
     }
 
-    fn plan_legacy(&mut self) {
-        self.lower_authoritative_scenarios();
-        self.lower_shadow_scenarios();
+    fn plan_legacy(&mut self) -> Result<()> {
+        self.lower_authoritative_scenarios()?;
+        self.lower_shadow_scenarios()?;
         self.configure_protocol(ProtocolMode::Legacy);
+        Ok(())
     }
 
-    fn plan_shadow(&mut self) {
-        self.lower_authoritative_scenarios();
+    fn plan_shadow(&mut self) -> Result<()> {
+        self.lower_authoritative_scenarios()?;
         self.configure_protocol(ProtocolMode::Shadow);
-        self.converge_manifest_scenarios(false);
+        self.converge_manifest_scenarios(false)
     }
 
-    fn plan_authoritative(&mut self) {
+    fn plan_authoritative(&mut self) -> Result<()> {
         self.configure_protocol(ProtocolMode::Authoritative);
-        self.converge_manifest_scenarios(true);
+        self.converge_manifest_scenarios(true)
     }
 
-    fn lower_authoritative_scenarios(&mut self) {
+    fn lower_authoritative_scenarios(&mut self) -> Result<()> {
         for scenario in self.known_scenarios() {
             if self.scenario_mode(&scenario) == ScenarioMode::Authoritative {
-                self.change_scenario(&scenario, ScenarioMode::Shadow);
+                self.change_scenario(&scenario, ScenarioMode::Shadow)?;
             }
         }
+        Ok(())
     }
 
-    fn lower_shadow_scenarios(&mut self) {
+    fn lower_shadow_scenarios(&mut self) -> Result<()> {
         for scenario in self.known_scenarios() {
             if self.scenario_mode(&scenario) == ScenarioMode::Shadow {
-                self.change_scenario(&scenario, ScenarioMode::Off);
+                self.change_scenario(&scenario, ScenarioMode::Off)?;
             }
         }
+        Ok(())
     }
 
-    fn converge_manifest_scenarios(&mut self, allow_authoritative: bool) {
+    fn converge_manifest_scenarios(&mut self, allow_authoritative: bool) -> Result<()> {
         let manifest_classes = self
             .manifest
             .as_ref()
@@ -282,15 +287,15 @@ impl ReconciliationPlanner {
                 .map(|class| class.configured_mode);
             if configured.is_none() {
                 if self.scenario_mode(&scenario) == ScenarioMode::Authoritative {
-                    self.change_scenario(&scenario, ScenarioMode::Shadow);
+                    self.change_scenario(&scenario, ScenarioMode::Shadow)?;
                 }
                 if self.scenario_mode(&scenario) == ScenarioMode::Shadow {
-                    self.change_scenario(&scenario, ScenarioMode::Off);
+                    self.change_scenario(&scenario, ScenarioMode::Off)?;
                 }
                 continue;
             }
             if self.scenario_mode(&scenario) == ScenarioMode::Off {
-                self.change_scenario(&scenario, ScenarioMode::Shadow);
+                self.change_scenario(&scenario, ScenarioMode::Shadow)?;
             }
             if allow_authoritative
                 && configured == Some(ScenarioMode::Authoritative)
@@ -300,13 +305,14 @@ impl ReconciliationPlanner {
                     .is_some_and(|class| rollout_class_evidence_is_complete(&scenario, class))
                 && !self.has_hard_blocker(&scenario)
             {
-                self.change_scenario(&scenario, ScenarioMode::Authoritative);
+                self.change_scenario(&scenario, ScenarioMode::Authoritative)?;
             } else if !allow_authoritative
                 && self.scenario_mode(&scenario) == ScenarioMode::Authoritative
             {
-                self.change_scenario(&scenario, ScenarioMode::Shadow);
+                self.change_scenario(&scenario, ScenarioMode::Shadow)?;
             }
         }
+        Ok(())
     }
 
     fn configure_protocol(&mut self, mode: ProtocolMode) {
@@ -321,14 +327,20 @@ impl ReconciliationPlanner {
         self.protocol_mode = mode;
     }
 
-    fn change_scenario(&mut self, scenario: &str, mode: ScenarioMode) {
+    fn change_scenario(&mut self, scenario: &str, mode: ScenarioMode) -> Result<()> {
         if self.scenario_mode(scenario) == mode {
-            return;
+            return Ok(());
         }
         let manifest = self
             .manifest
             .as_ref()
-            .expect("non-legacy scenario transition requires a manifest");
+            .ok_or_else(|| {
+                anyhow!(
+                    "cannot reconcile {SCHEDULER_ENV}={} because scenario {scenario} is {:?} without an installed manifest",
+                    self.desired.token(),
+                    self.scenario_mode(scenario)
+                )
+            })?;
         self.commands.push(RolloutCommand::ChangeScenarioAuthority {
             scenario_class: scenario.to_string(),
             expected_config_revision: self.config_revision,
@@ -338,6 +350,7 @@ impl ReconciliationPlanner {
         });
         self.config_revision += 1;
         self.scenario_modes.insert(scenario.to_string(), mode);
+        Ok(())
     }
 
     fn scenario_mode(&self, scenario: &str) -> ScenarioMode {
@@ -611,6 +624,26 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn legacy_downgrade_reports_missing_manifest_without_panicking() {
+        let rollout = RolloutState {
+            scenarios: BTreeMap::from([(
+                SchedulerScenarioClass::ExactWaitResume.as_str().to_string(),
+                ScenarioAuthority {
+                    mode: ScenarioMode::Shadow,
+                    rollback_target: ScenarioMode::Off,
+                    manifest_revision: None,
+                    preflight_revision: None,
+                },
+            )]),
+            ..RolloutState::default()
+        };
+
+        let error = reconciliation_commands_for_state(SchedulerDesiredMode::Legacy, &rollout, 7)
+            .unwrap_err();
+        assert!(error.to_string().contains("without an installed manifest"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

- 增加单一 `HOLON_SCHEDULER=legacy|shadow|authoritative` 期望状态，并在 `RuntimeHost` 启动 agent runtime 前协调持久化 rollout
- `shadow` 可安全安装 runtime-managed shadow manifest；`authoritative` 仅对具备完整 evidence、已消费 preflight 且无匹配 hard blocker 的 scenario 晋级
- 保留未设置新变量时的现有 rollout 状态，并兼容 `HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS`
- 支持逐级降级、completed preflight 恢复、非法值/open preflight fail-closed，并更新配置文档

## 运行时边界

- 环境变量只表达期望模式，不生成 authoritative evidence，也不绕过 revision、manifest、preflight 或 rollback fence
- fresh `authoritative` 请求会先进入 protocol authoritative + scenario shadow；证据不足时不会取得 canonical ownership
- `legacy` 按 authoritative → shadow → off 的顺序降低 scenario，再降低 protocol ceiling

## 验证

- `cargo fmt --all -- --check`
- `cargo test scheduler_rollout::tests --lib`
- `cargo test scheduler_acceptance_gate_tests --lib`
- `cargo test --test scheduler_workitem_mvp rollout_authority_requires_complete_evidence_and_fenced_rollback -- --nocapture`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `git diff --check`
