### PR TITLE
fix: prefetch briefs for inactive agents

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agentBriefPatchFromEvents,
   agentDetailErrorKind,
+  applyStreamEvents,
   buildResumeRefreshes,
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
@@ -680,6 +681,76 @@ describe("roster activity unread state", () => {
 });
 
 describe("brief projection and hydration", () => {
+  afterEach(() => {
+    useRuntimeStore.setState({
+      sessionsByAgentId: {},
+      globalStreamStatus: "idle",
+      selectedAgentId: "",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("prefetches a brief for a non-selected agent without hydrating its messages or transcripts", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/agents/agent-b/briefs:batchGet")) {
+        return Promise.resolve(jsonResponse({
+          briefs: [{ id: "brief-b", text: "Background hydrated brief." }],
+          missing_brief_ids: [],
+        }));
+      }
+      if (url.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+    useRuntimeStore.setState({
+      selectedAgentId: "agent-a",
+      sessionsByAgentId: {
+        "agent-a": sessionState(),
+        "agent-b": sessionState(),
+      },
+    });
+
+    const briefEvent: StreamEventEnvelopeDto = {
+      id: "event-brief-b",
+      event_seq: 1,
+      event_log_epoch: "epoch-b",
+      contract_version: 1,
+      ts: "2026-07-24T00:00:00Z",
+      agent_id: "agent-b",
+      type: "brief_created",
+      payload_schema: "holon.runtime_event.brief_created",
+      payload_schema_version: 1,
+      provenance: {},
+      payload: { brief_id: "brief-b" },
+    };
+
+    applyStreamEvents(useRuntimeStore.setState, "agent-b", [briefEvent]);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/agents/agent-b/briefs:batchGet");
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().sessionsByAgentId["agent-b"]?.briefRecordsById["brief-b"]?.text)
+        .toBe("Background hydrated brief.");
+    });
+
+    applyStreamEvents(useRuntimeStore.setState, "agent-b", [briefEvent]);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses persisted brief text for roster patches", () => {
     const patch = agentBriefPatchFromEvents(
       [

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4456,7 +4456,7 @@ async function catchUpAgentEvents(
   return request;
 }
 
-function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEnvelopeDto[]): void {
+export function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEnvelopeDto[]): void {
   const incomingEpoch = eventLogEpochFromEvents(events);
   const incomingEvents = events.filter(
     (event) =>
@@ -4551,8 +4551,8 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
   if (useRuntimeStore.getState().selectedAgentId === agentId) {
     scheduleMessageHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
     scheduleTranscriptHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
-    scheduleBriefHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   }
+  scheduleBriefHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   scheduleCacheWrite(useRuntimeStore.getState, agentId);
   if (events.some((event) => canApplySessionEvent(event) && isWorkItemCacheInvalidationEvent(event))) {
     void useRuntimeStore.getState().refreshAgentWorkItems(agentId);

--- a/web-gui/app/src/runtime/useAgentDetail.ts
+++ b/web-gui/app/src/runtime/useAgentDetail.ts
@@ -38,13 +38,12 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
     const prevLevel = prevDisplayLevelRef.current;
     const levelRank: Record<DisplayLevel, number> = { info: 0, verbose: 1, debug: 2 };
     const levelIncreased = prevLevel != null && levelRank[displayLevel] > levelRank[prevLevel];
-    if (!detail || detail.error) {
-      void ensureAgentSession(agentId, displayLevel);
-    } else if (levelIncreased) {
+    void ensureAgentSession(agentId, displayLevel);
+    if (detail && !detail.error && levelIncreased) {
       void refreshAgentDetail(agentId, displayLevel, { trigger: "display_level.increased" });
     }
     prevDisplayLevelRef.current = displayLevel;
-  }, [agentId, displayLevel, ensureAgentSession, refreshAgentDetail, detail]);
+  }, [agentId, displayLevel, ensureAgentSession, refreshAgentDetail]);
 
   return { detail, loading, contentStatus, syncStatus, refresh };
 }


### PR DESCRIPTION
## Summary

- prefetch missing brief bodies as soon as `brief_created` events are projected, including for non-selected agents
- keep message and transcript hydration limited to the selected agent
- always ensure the selected agent session on mount/switch so cached or missed-event states converge
- add regression coverage for background brief hydration, cache availability, request deduplication, and avoiding unrelated hydration

## Verification

- `cd web-gui/app && npm test` (290 tests passed)
- `cd web-gui/app && npm test -- --run src/runtime/runtime-store.test.ts` (39 tests passed)
- `cd web-gui/app && npm run typecheck`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
