### PR TITLE
fix: 允许无 WorkItem 的 task result 走普通 dispatch

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1366,9 +1366,9 @@ pub(crate) fn canonical_activation_scenario(
         {
             bail!("canonical task rejoin requires a terminal same-agent task");
         }
-        let work_item_id = task
-            .effective_work_item_id()
-            .ok_or_else(|| anyhow!("canonical task rejoin requires a WorkItem binding"))?;
+        let Some(work_item_id) = task.effective_work_item_id() else {
+            return Ok(None);
+        };
         if message.work_item_id.as_deref() != Some(work_item_id) {
             bail!("canonical task rejoin has inconsistent WorkItem binding");
         }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2562,6 +2562,96 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
 }
 
 #[tokio::test]
+async fn terminal_task_result_without_work_item_uses_ordinary_dispatch() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(&runtime, &[SchedulerScenarioClass::ExactTaskRejoin]);
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: "task-without-work-item".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Completed,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("task completed".into()),
+            detail: None,
+            recovery: None,
+        })
+        .unwrap();
+
+    let mut message = task_result_message("task-without-work-item").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-without-work-item",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-without-work-item",
+    }));
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(message.work_item_id.is_none());
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("task result without a WorkItem should use ordinary dispatch");
+    };
+    assert_eq!(scheduled.message.id, message.id);
+    assert!(scheduled
+        .dispatch_plan
+        .continuation_resolution
+        .as_ref()
+        .is_some_and(|resolution| resolution.model_reentry));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
+    );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
 async fn ambiguous_task_rejoin_waits_remain_queued_with_deduplicated_advisory() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();


### PR DESCRIPTION
## 概要

修复 authoritative scheduler 对合法无 `WorkItem` binding 的 terminal `command_task` result 构造 canonical task rejoin 时硬失败的问题。

- 保留 `task_id`、agent identity 与 terminal 状态校验
- 当 `effective_work_item_id()` 为 `None` 时退出 canonical activation 分类，让消息继续走普通 queue claim + dispatch
- 有 `WorkItem` binding 的 exact task rejoin 仍执行既有 binding、wait owner 与 canonical waiting status 校验
- 新增 runtime boundary 回归测试，覆盖真实 executor claim 与 dispatch 路径

## 验证

- `cargo fmt --all -- --check`
- `cargo test terminal_task_result_without_work_item_uses_ordinary_dispatch -- --nocapture`
- `cargo test exact_task_rejoin_claim_is_atomic_and_restart_safe -- --nocapture`
- `cargo test ambiguous_task_rejoin_waits_reconcile_without_claiming_message -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2407
