### PR TITLE
fix(command-task): retry result enqueue after stale agent state

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -88,7 +88,7 @@ use crate::{
         transitions::{
             PostCommitWarning, TransitionApplyResult, TransitionCommit, TransitionFaultPoint,
         },
-        RuntimeDb,
+        RuntimeDb, RuntimeStateTransitionConflict,
     },
     runtime_error::describe_runtime_error,
     runtime_event::RuntimeEventKind,
@@ -128,6 +128,8 @@ use continuation::{resolve_continuation, ContinuationTrigger};
 #[cfg(test)]
 use subagent::sanitize_subagent_result;
 use turn::LoopControlOptions;
+
+const ENQUEUE_AGENT_STATE_MAX_ATTEMPTS: usize = 3;
 
 #[derive(Debug, Clone)]
 pub(super) struct WorkItemCompletionReportPromotion {
@@ -2109,6 +2111,33 @@ impl RuntimeHandle {
         if message.turn_id.is_none() {
             message.turn_id = Some(crate::ids::turn_id());
         }
+        for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+            match self.enqueue_attempt(&message).await {
+                Ok(mut commit) => {
+                    commit.effects.notify_scheduler = true;
+                    self.apply_transition_commit(commit).await;
+                    return Ok(message);
+                }
+                Err(error) => {
+                    let can_retry = attempt + 1 < ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                        && retryable_enqueue_agent_state_conflict(
+                            &error,
+                            message.agent_id.as_str(),
+                        );
+                    if !can_retry
+                        || !self
+                            .refresh_enqueue_agent_state_baseline(&message.agent_id)
+                            .await?
+                    {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+        unreachable!("enqueue attempts always return or retry")
+    }
+
+    async fn enqueue_attempt(&self, message: &MessageEnvelope) -> Result<TransitionCommit> {
         let message_is_new = self
             .inner
             .storage
@@ -2138,7 +2167,7 @@ impl RuntimeHandle {
                 &MessageLifecycleAuditEvent::from_message(&message),
             )?,
         ];
-        let mut commit = {
+        let commit = {
             let mut guard = self.inner.agent.lock().await;
             let expected_persisted_state = guard.last_persisted_state.clone();
             let mut committed_state = guard.state.clone();
@@ -2167,7 +2196,7 @@ impl RuntimeHandle {
                     }),
                 ));
             }
-            let commit = self.inner.runtime_db.transitions().commit_queue(
+            let mut commit = self.inner.runtime_db.transitions().commit_queue(
                 &crate::runtime_db::transitions::QueueTransitionCommand {
                     agent_id: message.agent_id.clone(),
                     operation: crate::runtime_db::transitions::QueueOperation::Admit,
@@ -2205,13 +2234,27 @@ impl RuntimeHandle {
             guard.queue.push(message.clone());
             guard.state = committed_state.clone();
             guard.last_persisted_state = committed_state;
-            let mut commit = commit;
             commit.effects.agent_state = None;
             commit
         };
-        commit.effects.notify_scheduler = true;
-        self.apply_transition_commit(commit).await;
-        Ok(message)
+        Ok(commit)
+    }
+
+    async fn refresh_enqueue_agent_state_baseline(&self, agent_id: &str) -> Result<bool> {
+        let mut guard = self.inner.agent.lock().await;
+        let Some(latest_persisted_state) = self.inner.runtime_db.agent_states().latest(agent_id)?
+        else {
+            return Ok(false);
+        };
+        if latest_persisted_state.id != agent_id
+            || guard.state != guard.last_persisted_state
+            || latest_persisted_state.pending != guard.queue.len()
+        {
+            return Ok(false);
+        }
+        guard.state = latest_persisted_state.clone();
+        guard.last_persisted_state = latest_persisted_state;
+        Ok(true)
     }
 
     pub(crate) fn append_audit_event(&self, kind: &str, data: serde_json::Value) -> Result<()> {
@@ -3363,6 +3406,18 @@ fn normalized_turn_id(turn_id: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|turn_id| !turn_id.is_empty())
         .map(ToString::to_string)
+}
+
+fn retryable_enqueue_agent_state_conflict(error: &anyhow::Error, agent_id: &str) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some_and(|conflict| {
+                conflict.retryable()
+                    && conflict.domain() == "agent_state"
+                    && conflict.record_id() == agent_id
+            })
+    })
 }
 
 #[cfg(test)]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -5525,6 +5525,216 @@ async fn sleep_wake_task_ignores_stale_sleeping_until() {
 }
 
 #[tokio::test]
+async fn enqueue_retries_stale_agent_state_from_safe_persisted_baseline() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.control(ControlAction::Stop).await.unwrap();
+
+    let mut concurrent_state = runtime.storage().read_agent().unwrap().unwrap();
+    concurrent_state.total_input_tokens = 41;
+    runtime.storage().write_agent(&concurrent_state).unwrap();
+
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-enqueue-retry".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "task completed".into(),
+        },
+    );
+    let message_id = message.id.clone();
+
+    runtime.enqueue(message).await.unwrap();
+
+    let committed_state = runtime.storage().read_agent().unwrap().unwrap();
+    assert_eq!(committed_state.total_input_tokens, 41);
+    assert_eq!(committed_state.pending, 1);
+    assert_eq!(committed_state.total_message_count, 1);
+    assert!(runtime
+        .storage()
+        .read_message_by_id(&message_id)
+        .unwrap()
+        .is_some());
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .filter(|entry| entry.message_id == message_id)
+            .count(),
+        1
+    );
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    for kind in ["message_admitted", "message_enqueued"] {
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.kind == kind && event.data["message_id"] == message_id.as_str()
+                })
+                .count(),
+            1,
+            "{kind} should be committed exactly once"
+        );
+    }
+}
+
+#[tokio::test]
+async fn enqueue_stale_agent_state_fails_closed_when_local_state_is_dirty() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.control(ControlAction::Stop).await.unwrap();
+
+    let mut concurrent_state = runtime.storage().read_agent().unwrap().unwrap();
+    concurrent_state.total_input_tokens = 17;
+    runtime.storage().write_agent(&concurrent_state).unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.last_wake_reason = Some("unpersisted-local-change".into());
+    }
+
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-dirty-state".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "task completed".into(),
+        },
+    );
+    let message_id = message.id.clone();
+
+    let error = runtime.enqueue(message).await.unwrap_err();
+
+    let conflict = error
+        .downcast_ref::<crate::runtime_db::RuntimeStateTransitionConflict>()
+        .expect("stale state should remain an OCC conflict");
+    assert_eq!(conflict.domain(), "agent_state");
+    assert!(runtime
+        .storage()
+        .read_message_by_id(&message_id)
+        .unwrap()
+        .is_none());
+    assert!(runtime
+        .storage()
+        .latest_queue_entries()
+        .unwrap()
+        .into_iter()
+        .all(|entry| entry.message_id != message_id));
+    assert_eq!(
+        runtime
+            .inner
+            .agent
+            .lock()
+            .await
+            .state
+            .last_wake_reason
+            .as_deref(),
+        Some("unpersisted-local-change")
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .read_agent()
+            .unwrap()
+            .unwrap()
+            .total_input_tokens,
+        17
+    );
+}
+
+#[tokio::test]
+async fn enqueue_stale_agent_state_fails_closed_when_pending_diverges_from_queue() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.control(ControlAction::Stop).await.unwrap();
+
+    let mut concurrent_state = runtime.storage().read_agent().unwrap().unwrap();
+    concurrent_state.pending = 1;
+    runtime.storage().write_agent(&concurrent_state).unwrap();
+
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-divergent-queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "task completed".into(),
+        },
+    );
+    let message_id = message.id.clone();
+
+    let error = runtime.enqueue(message).await.unwrap_err();
+
+    let conflict = error
+        .downcast_ref::<crate::runtime_db::RuntimeStateTransitionConflict>()
+        .expect("divergent queue should preserve the OCC conflict");
+    assert_eq!(conflict.domain(), "agent_state");
+    assert!(runtime
+        .storage()
+        .read_message_by_id(&message_id)
+        .unwrap()
+        .is_none());
+    assert!(runtime
+        .storage()
+        .latest_queue_entries()
+        .unwrap()
+        .into_iter()
+        .all(|entry| entry.message_id != message_id));
+    assert_eq!(runtime.storage().read_agent().unwrap().unwrap().pending, 1);
+}
+
+#[tokio::test]
 async fn enqueue_normalizes_operator_admission_fields() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -47,6 +47,7 @@ runtime_async_tests!(
     command_task_output_truncation_preserves_path_artifact_reference,
     command_task_stop_cancels_running_command,
     background_command_task_persists_terminal_state_while_runtime_stopped,
+    command_task_result_enqueue_retries_stale_agent_state,
     blocking_command_task_clears_active_state_while_runtime_stopped,
     command_task_result_is_canonical_follow_up_on_completion,
     task_result_rejoin_preserves_runtime_provenance_not_operator_authority,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -2076,6 +2076,106 @@ pub async fn background_command_task_persists_terminal_state_while_runtime_stopp
     Ok(())
 }
 
+pub async fn command_task_result_enqueue_retries_stale_agent_state() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    let runtime = host.default_runtime().await?;
+    runtime.control(ControlAction::Stop).await?;
+    let gate = tempfile::tempdir()?;
+    let release_path = gate.path().join("release");
+    let command = format!(
+        "while [ ! -f '{}' ]; do sleep 0.01; done; printf stale_snapshot_ok",
+        release_path.display()
+    );
+
+    let task = runtime
+        .schedule_command_task(
+            "retry stale result enqueue".into(),
+            holon::types::CommandTaskSpec {
+                cmd: command,
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: Some(256),
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            AuthorityClass::OperatorInstruction,
+        )
+        .await?;
+    assert!(task.work_item_id.is_none());
+
+    eventually_for(Duration::from_secs(10), || {
+        let tasks = runtime.storage().latest_task_records()?;
+        Ok(tasks.iter().any(|record| {
+            record.id == task.id && record.status == holon::types::TaskStatus::Running
+        }))
+    })
+    .await?;
+
+    let mut concurrent_state = runtime
+        .storage()
+        .read_agent()?
+        .expect("agent state should exist");
+    concurrent_state.total_input_tokens = 73;
+    runtime.storage().write_agent(&concurrent_state)?;
+    std::fs::write(&release_path, b"release")?;
+
+    eventually_for(Duration::from_secs(10), || {
+        let tasks = runtime.storage().latest_task_records()?;
+        let messages = runtime.storage().read_recent_messages(20)?;
+        Ok(tasks.iter().any(|record| {
+            record.id == task.id && record.status == holon::types::TaskStatus::Completed
+        }) && messages.iter().any(|message| {
+            message.kind == MessageKind::TaskResult
+                && message.task_id.as_deref() == Some(task.id.as_str())
+        }))
+    })
+    .await?;
+
+    let messages = runtime.storage().read_recent_messages(20)?;
+    let task_results = messages
+        .iter()
+        .filter(|message| {
+            message.kind == MessageKind::TaskResult
+                && message.task_id.as_deref() == Some(task.id.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(task_results.len(), 1);
+    assert!(task_results[0].work_item_id.is_none());
+    let result_message_id = task_results[0].id.as_str();
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()?
+            .into_iter()
+            .filter(|entry| entry.message_id == result_message_id)
+            .count(),
+        1
+    );
+    assert_eq!(runtime.agent_state().await?.total_input_tokens, 73);
+    let events = runtime.storage().read_recent_events(usize::MAX)?;
+    assert!(!events.iter().any(|event| {
+        event.kind == "command_task_result_enqueue_failed"
+            && event.data["task_id"] == task.id.as_str()
+    }));
+    for kind in ["message_admitted", "message_enqueued"] {
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.kind == kind && event.data["message_id"] == result_message_id
+                })
+                .count(),
+            1,
+            "{kind} should be committed exactly once"
+        );
+    }
+    Ok(())
+}
+
 pub async fn blocking_command_task_clears_active_state_while_runtime_stopped() -> Result<()> {
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;


### PR DESCRIPTION
## 概要

- 在 `RuntimeHandle::enqueue()` 中仅对当前 agent 的 retryable `agent_state` OCC 冲突执行最多 3 次有界重试。
- 冲突后只有在本地 `AgentState` 无未提交差异，且持久化 `pending_message_count` 与内存 queue 对齐时，才刷新 durable baseline 并重算 admission 投影；其他情况继续 fail closed。
- 复用已规范化的 message identity，保持 message、queue entry、AgentState 与 admission audit event 的单事务原子性，避免重试产生重复记录。
- 增加 state dirty、pending/queue 不一致的 fail-closed 回归，以及真实 gated shell command 的 task result enqueue 回归。

## 验证

- `cargo fmt --all -- --check`
- `cargo test enqueue_retries_stale_agent_state_from_safe_persisted_baseline -- --nocapture`
- `cargo test enqueue_stale_agent_state_fails_closed_when_local_state_is_dirty -- --nocapture`
- `cargo test enqueue_stale_agent_state_fails_closed_when_pending_diverges_from_queue -- --nocapture`
- `cargo test command_task_result_enqueue_retries_stale_agent_state -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2409
