### PR TITLE
fix: tolerate nonstandard visual observations

### DIFF
--- a/docs/rfcs/visual-observation-and-image-view.md
+++ b/docs/rfcs/visual-observation-and-image-view.md
@@ -580,6 +580,15 @@ The adapter prompt should instruct the model to:
 
 The primary model remains the agent brain. The vision adapter is a sensor.
 
+Provider response validation must keep the observation identity fields
+(`type`, `schema`, and non-empty `summary`) strict. Auxiliary observation fields
+are best-effort sensor data and must not invalidate an otherwise usable
+observation solely because a provider ignored its strict response schema.
+Holon normalizes arrays directly, wraps single objects, converts meaningful
+strings into text-bearing entries, and ignores null, boolean, numeric, or
+otherwise unusable auxiliary values. `uncertainties` similarly accepts a
+string, a text-bearing object, or an array containing either form.
+
 ### External UI Structure
 
 Holon core should not collect DOM, Android hierarchy, macOS accessibility tree,

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -326,6 +326,7 @@ fn optional_value_array(value: Option<&Value>, field: &str) -> Vec<Value> {
         Some(Value::Array(values)) => values.clone(),
         Some(Value::Object(object)) => vec![Value::Object(object.clone())],
         Some(Value::String(text)) if !text.trim().is_empty() => {
+            // OCR entries expose text; every other current observation array describes an item.
             let text_field = if field == "ocr" {
                 "text"
             } else {

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -282,12 +282,12 @@ fn parse_visual_observation(
             selection_reason: Some(selection.selection_reason.clone()),
         },
         summary,
-        ocr: optional_value_array(object.get("ocr"), "ocr")?,
-        elements: optional_value_array(object.get("elements"), "elements")?,
-        relations: optional_value_array(object.get("relations"), "relations")?,
-        issues: optional_value_array(object.get("issues"), "issues")?,
-        uncertainties: optional_uncertainties(object.get("uncertainties"))?,
-        external_sources: optional_value_array(object.get("external_sources"), "external_sources")?,
+        ocr: optional_value_array(object.get("ocr"), "ocr"),
+        elements: optional_value_array(object.get("elements"), "elements"),
+        relations: optional_value_array(object.get("relations"), "relations"),
+        issues: optional_value_array(object.get("issues"), "issues"),
+        uncertainties: optional_uncertainties(object.get("uncertainties")),
+        external_sources: optional_value_array(object.get("external_sources"), "external_sources"),
     })
 }
 
@@ -321,50 +321,42 @@ fn parse_observation_json(raw: &str) -> Result<Value> {
         .map_err(|error| anyhow!("vision adapter returned invalid observation JSON: {error}"))
 }
 
-fn optional_value_array(value: Option<&Value>, field: &str) -> Result<Vec<Value>> {
+fn optional_value_array(value: Option<&Value>, field: &str) -> Vec<Value> {
     match value {
-        Some(Value::Array(values)) => Ok(values.clone()),
-        Some(_) => Err(anyhow!(
-            "vision adapter response field `{field}` must be an array when present"
-        )),
-        None => Ok(Vec::new()),
+        Some(Value::Array(values)) => values.clone(),
+        Some(Value::Object(object)) => vec![Value::Object(object.clone())],
+        Some(Value::String(text)) if !text.trim().is_empty() => {
+            let text_field = if field == "ocr" {
+                "text"
+            } else {
+                "description"
+            };
+            vec![json!({ text_field: text.trim() })]
+        }
+        Some(Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)) | None => {
+            Vec::new()
+        }
     }
 }
 
-fn optional_uncertainties(value: Option<&Value>) -> Result<Vec<String>> {
-    let Some(value) = value else {
-        return Ok(Vec::new());
+fn optional_uncertainties(value: Option<&Value>) -> Vec<String> {
+    let values = match value {
+        Some(Value::Array(values)) => values.as_slice(),
+        Some(value) => std::slice::from_ref(value),
+        None => return Vec::new(),
     };
-    let values = value.as_array().ok_or_else(|| {
-        anyhow!("vision adapter response field `uncertainties` must be an array when present")
+    values.iter().filter_map(uncertainty_text).collect()
+}
+
+fn uncertainty_text(value: &Value) -> Option<String> {
+    let text = value.as_str().or_else(|| {
+        let object = value.as_object()?;
+        ["text", "description", "summary", "message"]
+            .iter()
+            .find_map(|field| object.get(*field).and_then(Value::as_str))
     })?;
-    values
-        .iter()
-        .map(|value| {
-            if let Some(text) = value.as_str() {
-                return Ok(text.to_string());
-            }
-            let Some(object) = value.as_object() else {
-                return Err(anyhow!(
-                    "vision adapter response field `uncertainties` must contain strings or objects with text"
-                ));
-            };
-            ["text", "description", "summary", "message"]
-                .iter()
-                .find_map(|field| object.get(*field).and_then(Value::as_str))
-                .map(ToString::to_string)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "vision adapter response field `uncertainties` object entries must include text"
-                    )
-                })
-        })
-        .filter_map(|result| match result {
-            Ok(text) if text.trim().is_empty() => None,
-            Ok(text) => Some(Ok(text)),
-            Err(error) => Some(Err(error)),
-        })
-        .collect()
+    let text = text.trim();
+    (!text.is_empty()).then(|| text.to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -733,6 +725,75 @@ mod tests {
                 "Small text is hard to read.".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn normalizes_non_array_optional_fields_from_vision_adapter() {
+        let observation = parse_visual_observation(
+            r#"{
+                "type": "visual_observation",
+                "schema": "visual_observation.v1",
+                "summary": "A logo is visible.",
+                "ocr": "HOLON",
+                "elements": {"type": "logo"},
+                "relations": "The logo is above the wordmark.",
+                "issues": null,
+                "uncertainties": {"message": "Small details may be unclear."},
+                "external_sources": 42
+            }"#,
+            &test_visual_reference(),
+            "Describe the image.",
+            &test_vision_selection(),
+        )
+        .unwrap();
+
+        assert_eq!(observation.ocr, vec![json!({"text": "HOLON"})]);
+        assert_eq!(observation.elements, vec![json!({"type": "logo"})]);
+        assert_eq!(
+            observation.relations,
+            vec![json!({"description": "The logo is above the wordmark."})]
+        );
+        assert!(observation.issues.is_empty());
+        assert_eq!(
+            observation.uncertainties,
+            vec!["Small details may be unclear.".to_string()]
+        );
+        assert!(observation.external_sources.is_empty());
+    }
+
+    #[test]
+    fn ignores_unusable_optional_entries_without_hiding_invalid_core_fields() {
+        let observation = parse_visual_observation(
+            r#"{
+                "type": "visual_observation",
+                "schema": "visual_observation.v1",
+                "summary": "A logo is visible.",
+                "ocr": false,
+                "uncertainties": [null, 12, {}, "", {"text": "  "}]
+            }"#,
+            &test_visual_reference(),
+            "Describe the image.",
+            &test_vision_selection(),
+        )
+        .unwrap();
+
+        assert!(observation.ocr.is_empty());
+        assert!(observation.uncertainties.is_empty());
+
+        let error = parse_visual_observation(
+            r#"{
+                "type": "visual_observation",
+                "schema": "visual_observation.v1",
+                "summary": "",
+                "ocr": "HOLON"
+            }"#,
+            &test_visual_reference(),
+            "Describe the image.",
+            &test_vision_selection(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("non-empty `summary`"));
     }
 
     #[test]

--- a/tests/live_view_image.rs
+++ b/tests/live_view_image.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use holon::{
-    config::{AppConfig, ProviderId},
+    config::{AppConfig, ModelRouteRef, ProviderId},
     provider::{
         build_provider_from_model_chain, ConversationMessage, ModelBlock, ProviderTurnRequest,
     },
@@ -62,16 +62,27 @@ fn accepted_uncertainty_text(value: &Value) -> Option<&str> {
 #[ignore = "requires configured live vision provider credentials and network access"]
 async fn live_view_image_vision_adapter_returns_visual_observation_json() -> Result<()> {
     let config = AppConfig::load()?;
-    let model_ref = config
-        .provider_chain()
-        .into_iter()
-        .find(|model| {
-            matches!(
-                model.provider.as_str(),
-                ProviderId::OPENAI | ProviderId::OPENAI_CODEX
-            )
-        })
-        .context("live ViewImage needs a configured OpenAI-compatible vision provider")?;
+    let model_override = std::env::var("HOLON_LIVE_VIEW_IMAGE_MODEL")
+        .ok()
+        .map(|value| ModelRouteRef::parse_compatible(&value))
+        .transpose()
+        .context("HOLON_LIVE_VIEW_IMAGE_MODEL must be a valid model route")?;
+    let model_ref = match model_override {
+        Some(model_ref) => model_ref,
+        None => config
+            .provider_chain()
+            .into_iter()
+            .find(|model| {
+                matches!(
+                    model.provider.as_str(),
+                    ProviderId::OPENAI | ProviderId::OPENAI_CODEX
+                )
+            })
+            .context(
+                "live ViewImage needs a configured OpenAI-compatible vision provider or \
+                 HOLON_LIVE_VIEW_IMAGE_MODEL",
+            )?,
+    };
     let provider = build_provider_from_model_chain(&config, &[model_ref.clone()])?;
     let image = std::fs::read("docs/website/assets/logo.png")?;
     let output = provider
@@ -109,15 +120,16 @@ async fn live_view_image_vision_adapter_returns_visual_observation_json() -> Res
             .is_some_and(|summary| !summary.trim().is_empty()),
         "raw={text:?}"
     );
-    let uncertainties = value
-        .get("uncertainties")
-        .and_then(Value::as_array)
-        .context("raw live response must include uncertainties as an array")?;
+    let uncertainties = match value.get("uncertainties") {
+        Some(Value::Array(values)) => values.as_slice(),
+        Some(value) => std::slice::from_ref(value),
+        None => &[],
+    };
     assert!(
         uncertainties
             .iter()
             .all(|entry| accepted_uncertainty_text(entry).is_some()),
-        "uncertainties must be strings or text-bearing objects so ViewImage can normalize them; raw={text:?}"
+        "uncertainties must have readable entries when present; raw={text:?}"
     );
     println!(
         "live_view_image ref={} input_tokens={} output_tokens={} text={text}",


### PR DESCRIPTION
## Summary
- tolerate semantically useful nonstandard `visual_observation` JSON from vision-capable LLM providers
- keep `type`, `schema`, and non-empty `summary` strict while normalizing readable auxiliary fields from arrays, objects, or strings
- document the compatibility boundary and make the ignored live ViewImage test assert semantic output instead of provider-specific exact structure

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib tool::tools::view_image -- --nocapture` (19 passed)
- `cargo test --test live_view_image live_view_image_vision_adapter_returns_visual_observation_json -- --exact --ignored --nocapture` (passed with a real configured vision LLM)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2406
