### PR TITLE
fix: paginate agent event catch-up

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -1090,6 +1090,86 @@ describe("agent event catch-up", () => {
       syncStatus: "idle",
     });
   });
+
+  it("does not advance the consumed cursor from an empty newer page", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const event = {
+      id: "event-1",
+      event_seq: 1,
+      event_log_epoch: "epoch-1",
+      contract_version: 1,
+      ts: "2026-07-24T00:00:00Z",
+      agent_id: "agent-a",
+      type: "legacy_event",
+      payload_schema: "holon.runtime_event.legacy",
+      payload_schema_version: 1,
+      provenance: {},
+      payload: {},
+    };
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        return Promise.resolve(jsonResponse({
+          events: [],
+          event_log_epoch: "epoch-1",
+          cursor_seq: 1428,
+          newest_seq: 1428,
+          oldest_seq: null,
+          has_older: false,
+          has_newer: true,
+          order: "asc",
+          limit: 100,
+        }));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+    const now = Date.now();
+    useRuntimeStore.setState({
+      globalStreamStatus: "idle",
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          cacheStatus: "hit",
+          contentStatus: "available",
+          syncStatus: "stale",
+          detailValidatedAt: now,
+          eventsValidatedAt: now,
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          eventsBySeq: { 1: event },
+          eventSeqs: [1],
+          newestSeq: 1,
+          oldestSeq: 1,
+          eventLogEpoch: "epoch-1",
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().ensureAgentSession("agent-a", "info");
+
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      eventSeqs: [1],
+      newestSeq: 1,
+      syncStatus: "error",
+      error: "Agent event catch-up page did not advance its consumed cursor.",
+    });
+  });
 });
 
 describe("brief hydration retry limits", () => {

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -982,6 +982,116 @@ describe("runtime client generation", () => {
   });
 });
 
+describe("agent event catch-up", () => {
+  afterEach(() => {
+    useRuntimeStore.setState({
+      sessionsByAgentId: {},
+      globalStreamStatus: "idle",
+      selectedAgentId: "",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("loads every newer page without treating the server high watermark as consumed", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const event = (eventSeq: number) => ({
+      id: `event-${eventSeq}`,
+      event_seq: eventSeq,
+      event_log_epoch: "epoch-1",
+      contract_version: 1,
+      ts: "2026-07-24T00:00:00Z",
+      agent_id: "agent-a",
+      type: "legacy_event",
+      payload_schema: "holon.runtime_event.legacy",
+      payload_schema_version: 1,
+      provenance: {},
+      payload: {},
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        const afterSeq = Number(url.searchParams.get("after_seq"));
+        if (afterSeq === 1) {
+          return Promise.resolve(jsonResponse({
+            events: Array.from({ length: 100 }, (_, index) => event(index + 2)),
+            event_log_epoch: "epoch-1",
+            cursor_seq: 1428,
+            newest_seq: 101,
+            oldest_seq: 2,
+            has_older: false,
+            has_newer: true,
+            order: "asc",
+            limit: 100,
+          }));
+        }
+        if (afterSeq === 101) {
+          return Promise.resolve(jsonResponse({
+            events: Array.from({ length: 49 }, (_, index) => event(index + 102)),
+            event_log_epoch: "epoch-1",
+            cursor_seq: 1428,
+            newest_seq: 150,
+            oldest_seq: 102,
+            has_older: false,
+            has_newer: false,
+            order: "asc",
+            limit: 100,
+          }));
+        }
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+    const now = Date.now();
+    useRuntimeStore.setState({
+      globalStreamStatus: "idle",
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          cacheStatus: "hit",
+          contentStatus: "available",
+          syncStatus: "stale",
+          detailValidatedAt: now,
+          eventsValidatedAt: now,
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          eventsBySeq: { 1: event(1) },
+          eventSeqs: [1],
+          newestSeq: 1,
+          oldestSeq: 1,
+          eventLogEpoch: "epoch-1",
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().ensureAgentSession("agent-a", "info");
+
+    const eventRequests = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), "http://localhost"))
+      .filter((url) => url.pathname.endsWith("/agents/agent-a/events"));
+    expect(eventRequests.map((url) => url.searchParams.get("after_seq"))).toEqual(["1", "101"]);
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      eventSeqs: Array.from({ length: 150 }, (_, index) => index + 1),
+      newestSeq: 150,
+      syncStatus: "idle",
+    });
+  });
+});
+
 describe("brief hydration retry limits", () => {
   afterEach(() => {
     useRuntimeStore.setState({

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4411,27 +4411,48 @@ async function catchUpAgentEvents(
   const span = startRuntimeSpan(trace, "events.catch_up");
   const request = (async () => {
     const generation = clientGeneration;
-    const afterSeq = get().sessionsByAgentId[agentId]?.newestSeq;
-    const page = await runtimeClient.getAgentEvents(agentId, {
-      afterSeq,
-      limit: 100,
-      order: "asc",
-    });
-    if (!isCurrentClientGeneration(generation)) {
-      span.end("cancelled");
-      return;
+    const initialAfterSeq = get().sessionsByAgentId[agentId]?.newestSeq;
+    let afterSeq = initialAfterSeq;
+    let eventCount = 0;
+    let pageCount = 0;
+    let refreshWorkItems = false;
+    let refreshAgentState = false;
+    while (true) {
+      const page = await runtimeClient.getAgentEvents(agentId, {
+        afterSeq,
+        limit: 100,
+        order: "asc",
+      });
+      if (!isCurrentClientGeneration(generation)) {
+        span.end("cancelled");
+        return;
+      }
+      const pageEvents = page.events ?? [];
+      const consumedSeq = Math.max(
+        page.newest_seq ?? 0,
+        ...pageEvents.map((event) => event.event_seq ?? 0),
+      ) || undefined;
+      set((state) =>
+        mergeEventPageIntoSession(state, agentId, pageEvents, page.oldest_seq ?? undefined, page.has_older, "debug", {
+          newestSeq: consumedSeq,
+          append: true,
+          eventLogEpoch: page.event_log_epoch,
+        }),
+      );
+      eventCount += pageEvents.length;
+      pageCount += 1;
+      refreshWorkItems ||= pageEvents.some(isWorkItemCacheInvalidationEvent);
+      refreshAgentState ||= pageEvents.some(isAgentStateCacheInvalidationEvent);
+      if (!page.has_newer) break;
+      if (consumedSeq == null || (afterSeq != null && consumedSeq <= afterSeq)) {
+        throw new Error("Agent event catch-up page did not advance its consumed cursor.");
+      }
+      afterSeq = consumedSeq;
     }
-    set((state) =>
-      mergeEventPageIntoSession(state, agentId, page.events ?? [], page.oldest_seq ?? undefined, page.has_older, "debug", {
-        newestSeq: page.cursor_seq ?? page.newest_seq ?? undefined,
-        append: true,
-        eventLogEpoch: page.event_log_epoch,
-      }),
-    );
-    if ((page.events ?? []).some(isWorkItemCacheInvalidationEvent)) {
+    if (refreshWorkItems) {
       void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
     }
-    if ((page.events ?? []).some(isAgentStateCacheInvalidationEvent)) {
+    if (refreshAgentState) {
       void useRuntimeStore.getState().refreshAgentState(agentId);
     }
     if (get().selectedAgentId === agentId) {
@@ -4441,8 +4462,9 @@ async function catchUpAgentEvents(
     }
     scheduleCacheWrite(get, agentId);
     span.end("ok", {
-      afterSeq,
-      eventCount: page.events?.length ?? 0,
+      afterSeq: initialAfterSeq,
+      eventCount,
+      pageCount,
     });
   })().catch((error) => {
     span.end("error", { errorKind: agentDetailErrorKind(error) });

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4428,10 +4428,7 @@ async function catchUpAgentEvents(
         return;
       }
       const pageEvents = page.events ?? [];
-      const consumedSeq = Math.max(
-        page.newest_seq ?? 0,
-        ...pageEvents.map((event) => event.event_seq ?? 0),
-      ) || undefined;
+      const consumedSeq = Math.max(...pageEvents.map((event) => event.event_seq ?? 0)) || undefined;
       set((state) =>
         mergeEventPageIntoSession(state, agentId, pageEvents, page.oldest_seq ?? undefined, page.has_older, "debug", {
           newestSeq: consumedSeq,


### PR DESCRIPTION
## Summary
- paginate Agent event catch-up until the server reports no newer events
- advance the client cursor from the newest event actually consumed instead of the server high-water `cursor_seq`
- add regression coverage for more than 100 queued events and empty intermediate pages

## Verification
- `npm test` (88 tests passed)
- `npm run build`
- `git diff --check`

## Context
Fixes the deterministic partial-sync behavior seen when an Agent accumulates more than one page of events while inactive: opening the Agent previously loaded only the first 100 events and could incorrectly mark the server high-water sequence as consumed.
