### PR TITLE
fix: avoid canonical wait head-of-line blocking

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -57,6 +57,23 @@ pub(crate) enum CanonicalActivationScenario {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CanonicalActivationCandidate {
+    WorkItemAutonomousContinuation {
+        work_item_id: String,
+    },
+    ExactTaskRejoin {
+        task_id: String,
+        work_item_id: String,
+    },
+    ExactWaitResume {
+        expected_work_item_id: Option<String>,
+    },
+    ExplicitlyBoundOperatorInput {
+        work_item_id: String,
+    },
+}
+
 #[derive(Debug)]
 pub(crate) struct AmbiguousCanonicalWaits {
     pub(crate) message_id: String,
@@ -84,7 +101,9 @@ impl CanonicalActivationScenario {
             | Self::ExplicitlyBoundOperatorInput { work_item_id, .. } => work_item_id,
         }
     }
+}
 
+impl CanonicalActivationCandidate {
     pub(crate) fn scenario_class(&self) -> SchedulerScenarioClass {
         match self {
             Self::WorkItemAutonomousContinuation { .. } => {
@@ -93,6 +112,17 @@ impl CanonicalActivationScenario {
             Self::ExactTaskRejoin { .. } => EXACT_TASK_REJOIN_SCENARIO,
             Self::ExactWaitResume { .. } => EXACT_WAIT_RESUME_SCENARIO,
             Self::ExplicitlyBoundOperatorInput { .. } => EXPLICITLY_BOUND_OPERATOR_INPUT_SCENARIO,
+        }
+    }
+
+    fn expected_work_item_id(&self) -> Option<&str> {
+        match self {
+            Self::WorkItemAutonomousContinuation { work_item_id }
+            | Self::ExactTaskRejoin { work_item_id, .. }
+            | Self::ExplicitlyBoundOperatorInput { work_item_id } => Some(work_item_id),
+            Self::ExactWaitResume {
+                expected_work_item_id,
+            } => expected_work_item_id.as_deref(),
         }
     }
 }
@@ -1318,33 +1348,23 @@ pub(crate) fn authority_scenarios_for_message_claim(
     scenarios
 }
 
-pub(crate) fn canonical_activation_scenario(
-    projection: &SchedulerProjection,
+pub(crate) fn canonical_activation_candidate(
     message: &MessageEnvelope,
     continuation_resolution: Option<&ContinuationResolution>,
     task: Option<&TaskRecord>,
-) -> Result<Option<CanonicalActivationScenario>> {
+) -> Result<Option<CanonicalActivationCandidate>> {
     if matches!(
         (&message.kind, &message.origin),
         (MessageKind::SystemTick, MessageOrigin::System { subsystem })
             if subsystem == "work_queue"
     ) {
         return Ok(message.work_item_id.clone().map(|work_item_id| {
-            CanonicalActivationScenario::WorkItemAutonomousContinuation { work_item_id }
+            CanonicalActivationCandidate::WorkItemAutonomousContinuation { work_item_id }
         }));
     }
     if !continuation_resolution.is_some_and(|resolution| resolution.model_reentry) {
         return Ok(None);
     }
-
-    let matching_waits = matching_wait_conditions(projection, message);
-    if matching_waits.len() > 1 {
-        return Err(anyhow::Error::new(AmbiguousCanonicalWaits {
-            message_id: message.id.clone(),
-            wait_condition_ids: matching_waits.iter().map(|wait| wait.id.clone()).collect(),
-        }));
-    }
-    let matching_wait = matching_waits.first().copied();
 
     if message.kind == MessageKind::TaskResult {
         let MessageOrigin::Task { task_id } = &message.origin else {
@@ -1372,22 +1392,9 @@ pub(crate) fn canonical_activation_scenario(
         if message.work_item_id.as_deref() != Some(work_item_id) {
             bail!("canonical task rejoin has inconsistent WorkItem binding");
         }
-        if matching_wait.is_some_and(|wait| wait.work_item_id.as_deref() != Some(work_item_id)) {
-            bail!("canonical task rejoin wait owner does not match task WorkItem");
-        }
-        if matching_wait.is_none()
-            && projection
-                .canonical_work_statuses
-                .as_ref()
-                .and_then(|statuses| statuses.get(work_item_id))
-                .is_some_and(|status| matches!(status, WorkStatus::Waiting { .. }))
-        {
-            return Ok(None);
-        }
-        return Ok(Some(CanonicalActivationScenario::ExactTaskRejoin {
+        return Ok(Some(CanonicalActivationCandidate::ExactTaskRejoin {
             task_id: task_id.clone(),
             work_item_id: work_item_id.to_string(),
-            wait_id: matching_wait.map(|wait| wait.id.clone()),
         }));
     }
 
@@ -1399,11 +1406,74 @@ pub(crate) fn canonical_activation_scenario(
             .work_item_id
             .clone()
             .ok_or_else(|| anyhow!("explicit operator input requires a WorkItem binding"))?;
-        if matching_wait
-            .is_some_and(|wait| wait.work_item_id.as_deref() != Some(work_item_id.as_str()))
+        return Ok(Some(
+            CanonicalActivationCandidate::ExplicitlyBoundOperatorInput { work_item_id },
+        ));
+    }
+
+    if matches!(
+        (&message.kind, &message.origin),
+        (
+            MessageKind::CallbackEvent | MessageKind::WebhookEvent | MessageKind::ChannelEvent,
+            _
+        ) | (MessageKind::TimerTick, MessageOrigin::Timer { .. })
+            | (MessageKind::SystemTick, MessageOrigin::System { .. })
+    ) {
+        return Ok(Some(CanonicalActivationCandidate::ExactWaitResume {
+            expected_work_item_id: message.work_item_id.clone(),
+        }));
+    }
+
+    Ok(None)
+}
+
+pub(crate) fn resolve_canonical_activation_scenario(
+    projection: &SchedulerProjection,
+    message: &MessageEnvelope,
+    candidate: CanonicalActivationCandidate,
+) -> Result<Option<CanonicalActivationScenario>> {
+    if let CanonicalActivationCandidate::WorkItemAutonomousContinuation { work_item_id } = candidate
+    {
+        return Ok(Some(
+            CanonicalActivationScenario::WorkItemAutonomousContinuation { work_item_id },
+        ));
+    }
+
+    let matching_waits = matching_wait_conditions_for_work_item(
+        projection,
+        message,
+        candidate.expected_work_item_id(),
+    );
+    if matching_waits.len() > 1 {
+        return Err(anyhow::Error::new(AmbiguousCanonicalWaits {
+            message_id: message.id.clone(),
+            wait_condition_ids: matching_waits.iter().map(|wait| wait.id.clone()).collect(),
+        }));
+    }
+    let matching_wait = matching_waits.first().copied();
+
+    if let CanonicalActivationCandidate::ExactTaskRejoin {
+        task_id,
+        work_item_id,
+    } = candidate
+    {
+        if matching_wait.is_none()
+            && projection
+                .canonical_work_statuses
+                .as_ref()
+                .and_then(|statuses| statuses.get(&work_item_id))
+                .is_some_and(|status| matches!(status, WorkStatus::Waiting { .. }))
         {
-            bail!("explicit operator input wait owner does not match WorkItem binding");
+            return Ok(None);
         }
+        return Ok(Some(CanonicalActivationScenario::ExactTaskRejoin {
+            task_id,
+            work_item_id,
+            wait_id: matching_wait.map(|wait| wait.id.clone()),
+        }));
+    }
+
+    if let CanonicalActivationCandidate::ExplicitlyBoundOperatorInput { work_item_id } = candidate {
         return Ok(Some(
             CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
                 work_item_id,
@@ -1419,13 +1489,6 @@ pub(crate) fn canonical_activation_scenario(
         .work_item_id
         .clone()
         .ok_or_else(|| anyhow!("canonical wait resume requires a WorkItem-owned wait"))?;
-    if message
-        .work_item_id
-        .as_ref()
-        .is_some_and(|binding| binding != &work_item_id)
-    {
-        bail!("canonical wait resume has inconsistent WorkItem binding");
-    }
     Ok(Some(CanonicalActivationScenario::ExactWaitResume {
         work_item_id,
         wait_id: wait.id.clone(),
@@ -1436,16 +1499,26 @@ fn matching_wait_conditions<'a>(
     projection: &'a SchedulerProjection,
     message: &MessageEnvelope,
 ) -> Vec<&'a WaitConditionRecord> {
+    matching_wait_conditions_for_work_item(projection, message, None)
+}
+
+fn matching_wait_conditions_for_work_item<'a>(
+    projection: &'a SchedulerProjection,
+    message: &MessageEnvelope,
+    expected_work_item_id: Option<&str>,
+) -> Vec<&'a WaitConditionRecord> {
     projection
         .activation_waits
         .iter()
         .filter(|condition| {
-            (condition.status == WaitConditionStatus::Active
-                || (message.kind == MessageKind::TaskResult
-                    && condition.status == WaitConditionStatus::Resolved
-                    && condition.kind == WaitConditionKind::Task
-                    && condition.work_item_id == message.work_item_id
-                    && resolved_task_wait_is_current(projection, condition)))
+            expected_work_item_id
+                .is_none_or(|work_item_id| condition.work_item_id.as_deref() == Some(work_item_id))
+                && (condition.status == WaitConditionStatus::Active
+                    || (message.kind == MessageKind::TaskResult
+                        && condition.status == WaitConditionStatus::Resolved
+                        && condition.kind == WaitConditionKind::Task
+                        && condition.work_item_id == message.work_item_id
+                        && resolved_task_wait_is_current(projection, condition)))
                 && message_matches_wait_condition(message, condition)
         })
         .collect()

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -574,8 +574,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             return Ok(None);
         }
         let task = dispatch_plan.task.as_ref().ok().and_then(Option::as_ref);
-        let Some(mut scenario) = scheduler::canonical_activation_scenario(
-            projection,
+        let Some(candidate) = scheduler::canonical_activation_candidate(
             message,
             dispatch_plan.continuation_resolution.as_ref(),
             task,
@@ -589,7 +588,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .runtime_db
             .transitions()
             .scheduler_rollout_expectations(
-                &[scenario.scenario_class(), scheduler::SETTLEMENT_SCENARIO],
+                &[candidate.scenario_class(), scheduler::SETTLEMENT_SCENARIO],
                 production_commands_enabled,
             )?;
         if rollout_expectations.iter().any(|expectation| {
@@ -597,6 +596,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         }) {
             return Ok(None);
         }
+        let Some(mut scenario) =
+            scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?
+        else {
+            return Ok(None);
+        };
 
         use crate::domain::scheduler_protocol::WorkStatus;
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -269,6 +269,50 @@ fn enable_production_protocol_authority_for(
     }
 }
 
+fn set_scheduler_scenario_mode(
+    runtime: &RuntimeHandle,
+    scenario: SchedulerScenarioClass,
+    mode: ScenarioMode,
+) {
+    let mode = match mode {
+        ScenarioMode::Off => "off",
+        ScenarioMode::Shadow => "shadow",
+        ScenarioMode::Authoritative => "authoritative",
+    };
+    runtime
+        .inner
+        .runtime_db
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE scheduler_scenario_authorities
+             SET mode = ?1,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE scenario_class = ?2",
+            rusqlite::params![mode, scenario.as_str()],
+        )
+        .unwrap();
+}
+
+fn trusted_operator_prompt(work_item_id: Option<&str>, text: &str) -> MessageEnvelope {
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text { text: text.into() },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
+    );
+    message.work_item_id = work_item_id.map(ToString::to_string);
+    message
+}
+
 struct OperatorInterjectionProbeProvider {
     calls: Mutex<usize>,
     requests: Mutex<Vec<ProviderTurnRequest>>,
@@ -2649,6 +2693,442 @@ async fn terminal_task_result_without_work_item_uses_ordinary_dispatch() {
         .load_scheduler_protocol_snapshot_if_initialized("default")
         .unwrap()
         .is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn restarted_interrupted_unbound_operator_prompt_uses_legacy_dispatch() {
+    let mut harness = LifecycleHarness::new();
+    let runtime = harness.runtime();
+    let first = runtime
+        .enqueue(trusted_operator_prompt(None, "first operator prompt"))
+        .await
+        .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("initial operator prompt should be claimable");
+    };
+    assert_eq!(scheduled.message.id, first.id);
+    assert_eq!(
+        runtime
+            .release_claimed_messages_for_runtime_restart()
+            .await
+            .unwrap(),
+        1
+    );
+    finish_claimed_test_run(runtime).await;
+
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(
+        runtime,
+        &[SchedulerScenarioClass::ExplicitlyBoundOperatorInput],
+    );
+    let work_item = runtime
+        .create_work_item("operator wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting on work item".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting on agent".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == first.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Interrupted)
+    );
+
+    harness.advance(std::time::Duration::from_millis(1)).await;
+    harness.restart();
+    let runtime = harness.runtime();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    let second = runtime
+        .enqueue(trusted_operator_prompt(None, "resent operator prompt"))
+        .await
+        .unwrap();
+
+    let first_poll = scheduler_executor::SchedulerDecisionExecutor::new(runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = first_poll else {
+        panic!("restarted interrupted operator prompt should use legacy dispatch");
+    };
+    assert_eq!(scheduled.message.id, first.id);
+    finish_claimed_test_run(runtime).await;
+
+    let second_poll = scheduler_executor::SchedulerDecisionExecutor::new(runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = second_poll else {
+        panic!("resent operator prompt should not remain behind the recovered queue head");
+    };
+    assert_eq!(scheduled.message.id, second.id);
+    assert!(!runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduling_advisory"
+                && event.data["kind"] == "ambiguous_canonical_wait_binding"
+        }));
+}
+
+#[tokio::test]
+async fn non_authoritative_explicit_operator_wait_ambiguity_uses_legacy_dispatch() {
+    for mode in [ScenarioMode::Off, ScenarioMode::Shadow] {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        runtime.set_scheduler_protocol_production_commands_enabled(true);
+        enable_production_protocol_authority_for(
+            &runtime,
+            &[SchedulerScenarioClass::ExplicitlyBoundOperatorInput],
+        );
+        set_scheduler_scenario_mode(
+            &runtime,
+            SchedulerScenarioClass::ExplicitlyBoundOperatorInput,
+            mode,
+        );
+        let work_item = runtime
+            .create_work_item(format!("{mode:?} operator wait"), None, None, Vec::new())
+            .await
+            .unwrap();
+        let registration = runtime
+            .register_wait_for(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::OperatorInput,
+                None,
+                "waiting for operator".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        let mut duplicate = registration.condition.clone();
+        duplicate.id = format!("{}-duplicate", registration.condition.id);
+        runtime.storage().append_wait_condition(&duplicate).unwrap();
+        let message = runtime
+            .enqueue(trusted_operator_prompt(
+                Some(&work_item.id),
+                "explicit operator input",
+            ))
+            .await
+            .unwrap();
+
+        let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap();
+        let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+            panic!("{mode:?} explicit operator input should use legacy dispatch");
+        };
+        assert_eq!(scheduled.message.id, message.id);
+        assert!(!runtime
+            .storage()
+            .read_recent_events(usize::MAX)
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event.kind == "scheduling_advisory"
+                    && event.data["kind"] == "ambiguous_canonical_wait_binding"
+            }));
+    }
+}
+
+#[tokio::test]
+async fn authoritative_explicit_operator_binding_ignores_unrelated_waits() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(
+        &runtime,
+        &[SchedulerScenarioClass::ExplicitlyBoundOperatorInput],
+    );
+    let target = runtime
+        .create_work_item("target operator wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let unrelated = runtime
+        .create_work_item("unrelated operator wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let target_wait = runtime
+        .register_wait_for(
+            "default",
+            Some(target.id.clone()),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting for target operator".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let unrelated_wait = runtime
+        .register_wait_for(
+            "default",
+            Some(unrelated.id.clone()),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting for unrelated operator".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let agent_wait = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting for any operator".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let target = runtime.latest_work_item(&target.id).await.unwrap().unwrap();
+    let unrelated = runtime
+        .latest_work_item(&unrelated.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut initial =
+        canonical_waiting_snapshot(&target, &target_wait.condition.id, target.revision);
+    initial.work.insert(
+        unrelated.id.clone(),
+        WorkDemand {
+            metadata_revision: unrelated.revision,
+            scheduling_generation: unrelated.revision,
+            status: WorkStatus::Waiting {
+                wait_id: unrelated_wait.condition.id.clone(),
+            },
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+    );
+    initial.waits.insert(
+        unrelated_wait.condition.id.clone(),
+        WaitRecord {
+            current_generation: unrelated.revision,
+            generations: std::collections::BTreeMap::from([(
+                unrelated.revision,
+                WaitGenerationRecord {
+                    owner_work_item_id: unrelated.id,
+                    state: WaitState::Active,
+                    trigger: None,
+                    consuming_activation_id: None,
+                },
+            )]),
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &initial)
+        .unwrap();
+    let message = runtime
+        .enqueue(trusted_operator_prompt(
+            Some(&target.id),
+            "resume target work item",
+        ))
+        .await
+        .unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("authoritative explicit operator input should be claimed");
+    };
+    assert_eq!(scheduled.message.id, message.id);
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let admission = &snapshot.activation_admissions[&activation_id].activation;
+    assert!(matches!(
+        &admission.cause,
+        ActivationCause::OperatorInput {
+            message_id,
+            resume: Some(resume),
+        } if message_id == &message.id && resume.wait_id == target_wait.condition.id
+    ));
+    let target_generation = snapshot.waits[&target_wait.condition.id].current_generation;
+    assert_eq!(
+        snapshot.waits[&target_wait.condition.id].generations[&target_generation].state,
+        WaitState::Consumed
+    );
+    let unrelated_generation = snapshot.waits[&unrelated_wait.condition.id].current_generation;
+    assert_eq!(
+        snapshot.waits[&unrelated_wait.condition.id].generations[&unrelated_generation].state,
+        WaitState::Active
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|wait| wait.id == agent_wait.condition.id)
+            .map(|wait| wait.status),
+        Some(WaitConditionStatus::Active)
+    );
+}
+
+#[tokio::test]
+async fn authoritative_explicit_operator_wait_ambiguity_remains_queued() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(
+        &runtime,
+        &[SchedulerScenarioClass::ExplicitlyBoundOperatorInput],
+    );
+    let work_item = runtime
+        .create_work_item("ambiguous operator wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting for operator".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let mut duplicate = registration.condition.clone();
+    duplicate.id = format!("{}-duplicate", registration.condition.id);
+    runtime.storage().append_wait_condition(&duplicate).unwrap();
+    let message = runtime
+        .enqueue(trusted_operator_prompt(
+            Some(&work_item.id),
+            "ambiguous explicit operator input",
+        ))
+        .await
+        .unwrap();
+
+    for _ in 0..2 {
+        assert!(matches!(
+            scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+                .poll()
+                .await
+                .unwrap(),
+            scheduler_executor::RunLoopPoll::Idle
+        ));
+    }
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+    let advisories = runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .into_iter()
+        .filter(|event| {
+            event.kind == "scheduling_advisory"
+                && event.data["kind"] == "ambiguous_canonical_wait_binding"
+                && event.data["evidence"].as_array().is_some_and(|evidence| {
+                    evidence
+                        .iter()
+                        .any(|item| item == &format!("message_id={}", message.id))
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(advisories.len(), 1);
+    assert!(advisories[0].data["evidence"]
+        .as_array()
+        .is_some_and(|evidence| {
+            evidence.iter().any(|item| {
+                item.as_str().is_some_and(|item| {
+                    item.contains(&registration.condition.id) && item.contains(&duplicate.id)
+                })
+            })
+        }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- classify canonical activation before resolving wait candidates, so unbound trusted `OperatorPrompt` messages continue through legacy dispatch
- require both the selected scenario and settlement rollout to be authoritative before canonical wait ambiguity can fail closed
- scope explicit operator bindings to waits for the same `work_item_id`, preventing unrelated waits from poisoning the queue head
- add lifecycle regressions for interrupted prompt recovery, off/shadow fallback, binding isolation, and authoritative ambiguity preservation

## Verification

- `cargo fmt --all -- --check`
- `cargo test restarted_interrupted_unbound_operator_prompt_uses_legacy_dispatch -- --nocapture`
- `cargo test non_authoritative_explicit_operator_wait_ambiguity_uses_legacy_dispatch -- --nocapture`
- `cargo test authoritative_explicit_operator_binding_ignores_unrelated_waits -- --nocapture`
- `cargo test authoritative_explicit_operator_wait_ambiguity_remains_queued -- --nocapture`
- `cargo test ambiguous_task_rejoin_waits_remain_queued_with_deduplicated_advisory -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Fixes #2415
