### PR TITLE
feat: agent deletion lifecycle phase 0-1 (#2418)

### DIFF
--- a/docs/rfcs/agent-deletion-lifecycle.md
+++ b/docs/rfcs/agent-deletion-lifecycle.md
@@ -1,0 +1,68 @@
+---
+title: RFC: Agent Deletion Lifecycle
+date: 2026-07-24
+status: draft
+---
+
+# RFC: Agent Deletion Lifecycle
+
+## Summary
+
+Holon separates reversible execution control from irreversible identity
+deletion:
+
+- `stop` / `start` change `AgentStatus` and remain reversible;
+- `delete` transitions identity `Active -> Deleting -> Deleted`;
+- `purge` is a future evidence-erasure contract and is not part of delete.
+
+Deletion is an authenticated operator control-plane operation. It creates a
+durable, idempotent deletion job before cleanup begins.
+
+## Phase 0–1 Contract
+
+Agent identity is canonical in `agent_identities.payload_json`, with projected
+columns for queries. Legacy `archived` identity payloads decode as `Deleted`;
+the historical SQLite `archived_at` column remains a compatibility projection
+for the Rust `deleted_at` field.
+
+The first deletion transaction:
+
+1. verifies that the identity exists and its revision is current;
+2. rejects the configured default agent and identities that are not public and
+   self-owned;
+3. changes identity status from `Active` to `Deleting`;
+4. inserts one durable `agent_deletion_jobs` record;
+5. returns the existing job for repeated delete requests.
+
+After the fence commits, runtime bootstrap, ingress, wake, prompt, enqueue, and
+control paths must not return or create a runnable runtime for that identity.
+An already loaded runtime is unloaded when the deletion request is admitted.
+
+## HTTP Contract
+
+The authenticated operator control plane exposes:
+
+- `DELETE /api/control/agents/{agent_id}` to create or return the deletion job;
+- `GET /api/control/agents/{agent_id}/delete-status` to read identity and job.
+
+Status semantics are:
+
+- unknown identity: `404 Not Found`;
+- `Deleting`: `409 Conflict` on ordinary agent surfaces;
+- `Deleted`: `410 Gone` on ordinary agent surfaces;
+- forbidden delete target, including the configured default agent: `409
+  Conflict`.
+
+Normal public lists include only `Active` identities. Agent IDs are not reused.
+
+## Cleanup Boundary
+
+Phase 0–1 establishes the fence, durable job, status API, and restart-safe
+record. Later phases advance the job through runtime, ingress, scheduler,
+workspace, index, AgentHome, and finalization cleanup. Cleanup must be
+reentrant and fail closed on dirty, locked, or occupied managed worktrees.
+
+Private-child cleanup remains on the existing parent-supervised path until it
+is migrated to the unified cleanup engine. Public named descendants never
+cascade automatically; private children cascade only when explicitly
+requested.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -97,6 +97,350 @@
         "title": "AddSkillRequest",
         "type": "object"
       },
+      "AgentDeletionResponse": {
+        "properties": {
+          "created": {
+            "type": "boolean"
+          },
+          "identity": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "delegated_from_task_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_default_agent": {
+                "type": "boolean"
+              },
+              "kind": {
+                "enum": [
+                  "default",
+                  "named",
+                  "child"
+                ],
+                "type": "string"
+              },
+              "lineage_parent_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ownership": {
+                "enum": [
+                  "parent_supervised",
+                  "self_owned"
+                ],
+                "type": "string"
+              },
+              "parent_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "profile_preset": {
+                "enum": [
+                  "private_child",
+                  "public_named"
+                ],
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "active",
+                  "deleting",
+                  "deleted"
+                ],
+                "type": "string"
+              },
+              "visibility": {
+                "enum": [
+                  "public",
+                  "private"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "agent_id",
+              "kind",
+              "visibility",
+              "ownership",
+              "profile_preset",
+              "status",
+              "is_default_agent"
+            ],
+            "type": "object"
+          },
+          "job": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "attempts": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cascade_private_children": {
+                "type": "boolean"
+              },
+              "completed_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "deletion_id": {
+                "type": "string"
+              },
+              "expected_identity_revision": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_error": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "phase": {
+                "enum": [
+                  "fence",
+                  "quiesce",
+                  "ingress",
+                  "scheduler",
+                  "workspace",
+                  "index",
+                  "home",
+                  "finalize"
+                ],
+                "type": "string"
+              },
+              "requested_by": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "pending",
+                  "running",
+                  "retryable_failed",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "required": [
+              "deletion_id",
+              "agent_id",
+              "status",
+              "phase",
+              "requested_by",
+              "expected_identity_revision",
+              "cascade_private_children",
+              "attempts",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "object"
+          },
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok",
+          "created",
+          "identity",
+          "job"
+        ],
+        "title": "AgentDeletionResponse",
+        "type": "object"
+      },
+      "AgentDeletionStatusResponse": {
+        "properties": {
+          "identity": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "delegated_from_task_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_default_agent": {
+                "type": "boolean"
+              },
+              "kind": {
+                "enum": [
+                  "default",
+                  "named",
+                  "child"
+                ],
+                "type": "string"
+              },
+              "lineage_parent_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ownership": {
+                "enum": [
+                  "parent_supervised",
+                  "self_owned"
+                ],
+                "type": "string"
+              },
+              "parent_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "profile_preset": {
+                "enum": [
+                  "private_child",
+                  "public_named"
+                ],
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "active",
+                  "deleting",
+                  "deleted"
+                ],
+                "type": "string"
+              },
+              "visibility": {
+                "enum": [
+                  "public",
+                  "private"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "agent_id",
+              "kind",
+              "visibility",
+              "ownership",
+              "profile_preset",
+              "status",
+              "is_default_agent"
+            ],
+            "type": "object"
+          },
+          "job": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "attempts": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cascade_private_children": {
+                "type": "boolean"
+              },
+              "completed_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "deletion_id": {
+                "type": "string"
+              },
+              "expected_identity_revision": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_error": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "phase": {
+                "enum": [
+                  "fence",
+                  "quiesce",
+                  "ingress",
+                  "scheduler",
+                  "workspace",
+                  "index",
+                  "home",
+                  "finalize"
+                ],
+                "type": "string"
+              },
+              "requested_by": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "pending",
+                  "running",
+                  "retryable_failed",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "required": [
+              "deletion_id",
+              "agent_id",
+              "status",
+              "phase",
+              "requested_by",
+              "expected_identity_revision",
+              "cascade_private_children",
+              "attempts",
+              "created_at",
+              "updated_at"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "identity"
+        ],
+        "title": "AgentDeletionStatusResponse",
+        "type": "object"
+      },
       "AgentStateSnapshotDto": {
         "properties": {
           "agent": {
@@ -166,7 +510,8 @@
                         "status": {
                           "enum": [
                             "active",
-                            "archived"
+                            "deleting",
+                            "deleted"
                           ],
                           "type": "string"
                         },
@@ -823,7 +1168,8 @@
                   "status": {
                     "enum": [
                       "active",
-                      "archived"
+                      "deleting",
+                      "deleted"
                     ],
                     "type": "string"
                   },
@@ -932,7 +1278,7 @@
                   "posture": {
                     "enum": [
                       "unknown",
-                      "archived",
+                      "stopped",
                       "active_turn",
                       "has_queued_input",
                       "has_runnable_work",
@@ -2050,6 +2396,17 @@
       "DebugPromptRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "DeleteAgentRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "cascade_private_children": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "title": "DeleteAgentRequest",
         "type": "object"
       },
       "DetachWorkspaceRequest": {
@@ -9739,6 +10096,74 @@
         ]
       }
     },
+    "/api/control/agents/{agent_id}": {
+      "delete": {
+        "description": "Fence a public self-owned agent and create or return its durable deletion job.",
+        "operationId": "deleteAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDeletionResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete agent",
+        "tags": [
+          "control"
+        ]
+      }
+    },
     "/api/control/agents/{agent_id}/control": {
       "post": {
         "description": "Submit a lifecycle control action.",
@@ -10006,6 +10431,64 @@
           }
         ],
         "summary": "Debug prompt",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/delete-status": {
+      "get": {
+        "description": "Return the identity tombstone and current or completed deletion job.",
+        "operationId": "agentDeleteStatus",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDeletionStatusResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent deletion status",
         "tags": [
           "control"
         ]

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -10,7 +10,7 @@ This page defines the current contract for agent state, lifecycle, and
 runtime projection in Holon. It is verified against implementation and tests
 as of the last review date noted below.
 
-> **Last verified:** 2026-05-27 against `src/types.rs` `AgentState`,
+> **Last verified:** 2026-07-24 against `src/types.rs` `AgentState`,
 > `AgentStatus`, `AgentIdentityView`, `AgentSchedulingPosture`,
 > `AgentPostureProjection`, `ClosureDecision`, `ContinuationResolution`,
 > `RuntimePosture`, and `AgentSummary`; `src/storage/mod.rs`
@@ -24,6 +24,7 @@ as of the last review date noted below.
 - [Agent Control Plane Model](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-control-plane-model.md)
 - [Agent Profile Model](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-profile-model.md)
 - [Agent Initialization and Template](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-initialization-and-template.md)
+- [Agent Deletion Lifecycle](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-deletion-lifecycle.md)
 
 ## Authoritative records vs projections
 
@@ -33,6 +34,7 @@ single opaque status field. The key distinction is:
 | Layer | What | Authority |
 |-------|------|-----------|
 | **Identity** | `agent_id`, kind, visibility, ownership, profile preset | Agent registry record |
+| **Identity lifecycle** | `AgentRegistryStatus` — Active, Deleting, Deleted | Agent identity repository |
 | **Lifecycle status** | `AgentStatus` — Booting, AwakeIdle, AwakeRunning, AwaitingTask, Asleep, Stopped | Scheduler executor (single writer) |
 | **Scheduling posture** | `AgentSchedulingPosture` — derived from queue, WorkItems, tasks, wait state | Scheduler `derive_posture` projection |
 | **Runtime posture** | `RuntimePosture` — Awake or Sleeping | Closure decision at turn end |
@@ -125,7 +127,7 @@ uses this precedence:
 
 | Posture | Condition |
 |---------|-----------|
-| `Archived` | Agent lifecycle is stopped (`AgentStatus::Stopped`) |
+| `Stopped` | Agent lifecycle is stopped (`AgentStatus::Stopped`) |
 | `ActiveTurn` | `AgentState.current_run_id` is set |
 | `HasQueuedInput` | Queue contains a pending queued entry for the agent |
 | `HasRunnableWork` | Current or queued WorkItem is runnable |
@@ -141,7 +143,7 @@ uses this precedence:
 - Posture is derived from queue depth, WorkItem readiness, waiting state,
   task blocking state, and external triggers.
 - Posture is snapshot-derived; it is not persisted as durable state.
-- Stopped lifecycle wins the exposed projection (`Archived`) before transient
+- Stopped lifecycle wins the exposed projection (`Stopped`) before transient
   run, queue, work, or wait facts.
 - Queue and runnable work outrank passive sleep posture. An `Asleep` agent with
   queued input or runnable WorkItems is projected as `HasQueuedInput` or
@@ -212,7 +214,7 @@ projection facts and current turn facts to choose a `ClosureOutcome`,
 
 ## Lifecycle control
 
-Agent lifecycle control is `Start` / `Stop`:
+Agent execution lifecycle control is `Start` / `Stop`:
 
 - `Start` hands the agent to the scheduler. It does **not** directly start a
   model turn; the scheduler decides whether the agent should be idle or

--- a/src/host.rs
+++ b/src/host.rs
@@ -44,14 +44,14 @@ use crate::{
     system::{ExecutionScopeKind, HostLocalBoundary, WorkspaceAccessMode},
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
-        AdmissionContext, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
-        AgentListEntry, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
-        AgentStatus, AgentSummary, AgentVisibility, AuthorityClass, ChildAgentSummary,
-        ClosureOutcome, ExternalTriggerRecord, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
-        RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-        TaskKind, TaskRecord, TaskStatus, TimerRecord, TranscriptEntry, TranscriptEntryKind,
-        WorkspaceEntry, WorkspaceOccupancyRecord,
+        AdmissionContext, AgentDeletionJob, AgentIdentityRecord, AgentIdentityView, AgentKind,
+        AgentLifecycleHint, AgentListEntry, AgentOwnership, AgentProfilePreset,
+        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentVisibility,
+        AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        OperatorNotificationRecord, Priority, RuntimeFailureSummary, SpawnAgentModelResolution,
+        SpawnAgentModelResolutionStatus, TaskKind, TaskRecord, TaskStatus, TimerRecord,
+        TranscriptEntry, TranscriptEntryKind, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -103,7 +103,9 @@ const HOST_SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 #[derive(Debug)]
 pub enum PublicAgentError {
     NotFound { agent_id: String },
-    Archived { agent_id: String },
+    Deleting { agent_id: String },
+    Deleted { agent_id: String },
+    DeleteForbidden { agent_id: String, reason: String },
     Private { agent_id: String },
     Stopped { agent_id: String },
     Runtime(anyhow::Error),
@@ -112,8 +114,15 @@ pub enum PublicAgentError {
 impl std::fmt::Display for PublicAgentError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotFound { agent_id } => write!(f, "agent {} not found", agent_id),
-            Self::Archived { agent_id } => write!(f, "agent {} is archived", agent_id),
+            Self::NotFound { agent_id } => write!(
+                f,
+                "agent {agent_id} not found; create it first with 'holon agent create {agent_id}'"
+            ),
+            Self::Deleting { agent_id } => write!(f, "agent {} is being deleted", agent_id),
+            Self::Deleted { agent_id } => write!(f, "agent {} was deleted", agent_id),
+            Self::DeleteForbidden { agent_id, reason } => {
+                write!(f, "agent {} cannot be deleted: {}", agent_id, reason)
+            }
             Self::Private { agent_id } => write!(f, "agent {} is private", agent_id),
             Self::Stopped { agent_id } => {
                 write!(f, "agent {} is stopped; start first", agent_id)
@@ -610,13 +619,11 @@ impl RuntimeHost {
     }
 
     pub async fn default_runtime(&self) -> Result<RuntimeHandle> {
-        self.ensure_default_agent_identity()?;
-        self.ensure_default_agent_home_initialized().await?;
         self.get_or_create_agent(&self.config().default_agent_id)
             .await
     }
 
-    fn public_agent_identity(
+    fn active_agent_identity(
         &self,
         agent_id: &str,
     ) -> std::result::Result<AgentIdentityRecord, PublicAgentError> {
@@ -626,11 +633,22 @@ impl RuntimeHost {
             .ok_or_else(|| PublicAgentError::NotFound {
                 agent_id: agent_id.to_string(),
             })?;
-        if identity.status != AgentRegistryStatus::Active {
-            return Err(PublicAgentError::Archived {
+        match identity.status {
+            AgentRegistryStatus::Active => Ok(identity),
+            AgentRegistryStatus::Deleting => Err(PublicAgentError::Deleting {
                 agent_id: agent_id.to_string(),
-            });
+            }),
+            AgentRegistryStatus::Deleted => Err(PublicAgentError::Deleted {
+                agent_id: agent_id.to_string(),
+            }),
         }
+    }
+
+    fn public_agent_identity(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<AgentIdentityRecord, PublicAgentError> {
+        let identity = self.active_agent_identity(agent_id)?;
         if identity.visibility != AgentVisibility::Public {
             return Err(PublicAgentError::Private {
                 agent_id: agent_id.to_string(),
@@ -647,6 +665,78 @@ impl RuntimeHost {
         self.get_or_create_agent(agent_id)
             .await
             .map_err(PublicAgentError::Runtime)
+    }
+
+    pub async fn begin_public_agent_deletion(
+        &self,
+        agent_id: &str,
+        cascade_private_children: bool,
+        requested_by: &str,
+    ) -> std::result::Result<(AgentIdentityRecord, AgentDeletionJob, bool), PublicAgentError> {
+        self.validate_agent_id(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let identity = self
+            .agent_identity_record(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .ok_or_else(|| PublicAgentError::NotFound {
+                agent_id: agent_id.to_string(),
+            })?;
+        if agent_id == self.config().default_agent_id {
+            return Err(PublicAgentError::DeleteForbidden {
+                agent_id: agent_id.to_string(),
+                reason: "the configured default agent cannot be deleted".into(),
+            });
+        }
+        if identity.visibility != AgentVisibility::Public
+            || identity.ownership() != AgentOwnership::SelfOwned
+        {
+            return Err(PublicAgentError::DeleteForbidden {
+                agent_id: agent_id.to_string(),
+                reason: "only public self-owned agents have an operator delete surface".into(),
+            });
+        }
+        let (updated_identity, job, created) = self
+            .runtime_db()
+            .agent_deletions()
+            .begin(
+                agent_id,
+                identity.revision,
+                requested_by,
+                cascade_private_children,
+            )
+            .map_err(PublicAgentError::Runtime)?;
+        self.append_agent_identity(&updated_identity)
+            .map_err(PublicAgentError::Runtime)?;
+        self.unload_runtime(agent_id).await;
+        Ok((updated_identity, job, created))
+    }
+
+    pub fn public_agent_deletion_status(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<(AgentIdentityRecord, Option<AgentDeletionJob>), PublicAgentError>
+    {
+        self.validate_agent_id(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let identity = self
+            .agent_identity_record(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .ok_or_else(|| PublicAgentError::NotFound {
+                agent_id: agent_id.to_string(),
+            })?;
+        if identity.visibility != AgentVisibility::Public
+            || identity.ownership() != AgentOwnership::SelfOwned
+        {
+            return Err(PublicAgentError::Private {
+                agent_id: agent_id.to_string(),
+            });
+        }
+        let job = self
+            .runtime_db()
+            .agent_deletions()
+            .latest_for_agent(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        Ok((identity, job))
     }
 
     pub(crate) async fn public_agent_state_projection(
@@ -791,17 +881,7 @@ impl RuntimeHost {
         &self,
         agent_id: &str,
     ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
-        let identity = self
-            .agent_identity_record(agent_id)
-            .map_err(PublicAgentError::Runtime)?
-            .ok_or_else(|| PublicAgentError::NotFound {
-                agent_id: agent_id.to_string(),
-            })?;
-        if identity.status != AgentRegistryStatus::Active {
-            return Err(PublicAgentError::Archived {
-                agent_id: agent_id.to_string(),
-            });
-        }
+        self.active_agent_identity(agent_id)?;
         // Allow both Public and Private agents through the local status API.
         self.get_or_create_agent(agent_id)
             .await
@@ -918,8 +998,10 @@ impl RuntimeHost {
         }
         let existing = self.agent_identity_record(agent_id)?;
         if let Some(existing) = existing {
-            if existing.status == AgentRegistryStatus::Archived {
-                return Err(anyhow!("agent {} is archived", agent_id));
+            if existing.status != AgentRegistryStatus::Active {
+                return Err(anyhow!(self
+                    .active_agent_identity(agent_id)
+                    .expect_err("non-active identity must be fenced")));
             }
             if existing.kind != AgentKind::Named
                 || existing.visibility != AgentVisibility::Public
@@ -983,6 +1065,14 @@ impl RuntimeHost {
     ) -> Pin<Box<dyn Future<Output = Result<RuntimeHandle>> + Send + 'a>> {
         Box::pin(async move {
             self.validate_agent_id(agent_id)?;
+            if agent_id == self.config().default_agent_id {
+                self.ensure_default_agent_identity()?;
+            }
+            self.active_agent_identity(agent_id)
+                .map_err(anyhow::Error::new)?;
+            if agent_id == self.config().default_agent_id {
+                self.ensure_default_agent_home_initialized().await?;
+            }
             {
                 let agents = self.inner.agents.read().await;
                 if let Some(entry) = agents.get(agent_id) {
@@ -1007,29 +1097,14 @@ impl RuntimeHost {
                 let _ = entry.task.await;
             }
 
-            if agent_id == self.config().default_agent_id {
-                self.ensure_default_agent_identity()?;
-                self.ensure_default_agent_home_initialized().await?;
-            } else {
-                match self.agent_identity_record(agent_id)? {
-                    Some(identity) if identity.status == AgentRegistryStatus::Archived => {
-                        return Err(anyhow!("agent {} is archived", agent_id));
-                    }
-                    Some(_) => {}
-                    None => {
-                        return Err(anyhow!(
-                            "agent {} not found; create it first with 'holon agent create {}'",
-                            agent_id,
-                            agent_id
-                        ));
-                    }
-                }
-            }
-
             let (runtime, runtime_task) = self.spawn_runtime(agent_id)?;
 
             let mut stale_entry = None;
             let mut agents = self.inner.agents.write().await;
+            if let Err(error) = self.active_agent_identity(agent_id) {
+                runtime_task.abort();
+                return Err(anyhow::Error::new(error));
+            }
             if let Some(entry) = agents.get(agent_id) {
                 if !entry.task.is_finished() {
                     runtime_task.abort();
@@ -1313,9 +1388,8 @@ impl RuntimeHost {
                 )
             })?
         };
-        if identity.status == AgentRegistryStatus::Archived {
-            return Err(anyhow!("agent {} is archived", agent_id));
-        }
+        self.active_agent_identity(agent_id)
+            .map_err(anyhow::Error::new)?;
         self.preview_agent_prompt_from_storage(&identity, text, authority_class)
             .await
     }
@@ -1608,9 +1682,9 @@ impl RuntimeHost {
 
     async fn archive_private_agent(&self, agent_id: &str) -> Result<()> {
         if let Some(mut identity) = self.agent_identity_record(agent_id)? {
-            if identity.status != AgentRegistryStatus::Archived {
-                identity.status = AgentRegistryStatus::Archived;
-                identity.archived_at = Some(chrono::Utc::now());
+            if identity.status != AgentRegistryStatus::Deleted {
+                identity.status = AgentRegistryStatus::Deleted;
+                identity.deleted_at = Some(chrono::Utc::now());
                 identity.updated_at = chrono::Utc::now();
                 self.append_agent_identity(&identity)?;
             }
@@ -1715,9 +1789,9 @@ impl RuntimeHost {
 
     fn archive_private_agent_identity_record(&self, agent_id: &str) -> Result<()> {
         if let Some(mut identity) = self.agent_identity_record(agent_id)? {
-            if identity.status != AgentRegistryStatus::Archived {
-                identity.status = AgentRegistryStatus::Archived;
-                identity.archived_at = Some(chrono::Utc::now());
+            if identity.status != AgentRegistryStatus::Deleted {
+                identity.status = AgentRegistryStatus::Deleted;
+                identity.deleted_at = Some(chrono::Utc::now());
                 identity.updated_at = chrono::Utc::now();
                 self.append_agent_identity(&identity)?;
             }
@@ -4061,7 +4135,7 @@ mod tests {
             .agent_identity_record("child_recover")
             .unwrap()
             .expect("child identity should remain recorded");
-        assert_eq!(child_identity.status, AgentRegistryStatus::Archived);
+        assert_eq!(child_identity.status, AgentRegistryStatus::Deleted);
 
         runtime_task.abort();
     }
@@ -4329,7 +4403,7 @@ mod tests {
             .agent_identity_record("child_orphan")
             .unwrap()
             .expect("child identity should still be recorded after archive");
-        assert_eq!(identity.status, AgentRegistryStatus::Archived);
+        assert_eq!(identity.status, AgentRegistryStatus::Deleted);
         assert!(!restarted.agent_data_dir("child_orphan").exists());
     }
 
@@ -4406,7 +4480,7 @@ mod tests {
             .agent_identity_record("child_parent_missing")
             .unwrap()
             .expect("child identity should remain recorded after archive");
-        assert_eq!(identity.status, AgentRegistryStatus::Archived);
+        assert_eq!(identity.status, AgentRegistryStatus::Deleted);
         assert!(!restarted.agent_data_dir("child_parent_missing").exists());
         assert!(!restarted.agent_data_dir("parent_missing").exists());
     }
@@ -4475,7 +4549,7 @@ mod tests {
             .agent_identity_record("child_stop")
             .unwrap()
             .expect("child identity should remain recorded after archive");
-        assert_eq!(identity.status, AgentRegistryStatus::Archived);
+        assert_eq!(identity.status, AgentRegistryStatus::Deleted);
         assert!(!restarted.agent_data_dir("child_stop").exists());
     }
 
@@ -5063,7 +5137,7 @@ mod tests {
             Some(host.config().default_agent_id.clone()),
             Some("task-1".into()),
         );
-        child.status = AgentRegistryStatus::Archived;
+        child.status = AgentRegistryStatus::Deleted;
         host.append_agent_identity(&child).unwrap();
 
         let err = host
@@ -5072,7 +5146,7 @@ mod tests {
             .err()
             .expect("archived agent should be rejected");
         match err {
-            PublicAgentError::Archived { agent_id } => {
+            PublicAgentError::Deleted { agent_id } => {
                 assert_eq!(agent_id, "child_archived_1");
             }
             other => panic!("expected Archived error, got: {other}"),

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -455,6 +455,52 @@ pub async fn create_agent(
     Ok(Json(agent))
 }
 
+pub async fn delete_agent(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<DeleteAgentRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let (identity, job, created) = state
+        .host
+        .begin_public_agent_deletion(
+            &agent_id,
+            request.cascade_private_children,
+            "authenticated_operator_control",
+        )
+        .await
+        .map_err(agent_access_error)?;
+    Ok(Json(AgentDeletionResponse {
+        ok: true,
+        created,
+        identity: crate::types::AgentIdentityView::from_record(
+            &identity,
+            &state.host.config().default_agent_id,
+        ),
+        job,
+    }))
+}
+
+pub async fn agent_deletion_status(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let (identity, job) = state
+        .host
+        .public_agent_deletion_status(&agent_id)
+        .map_err(agent_access_error)?;
+    Ok(Json(AgentDeletionStatusResponse {
+        identity: crate::types::AgentIdentityView::from_record(
+            &identity,
+            &state.host.config().default_agent_id,
+        ),
+        job,
+    }))
+}
+
 pub async fn control(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -448,6 +448,11 @@ pub fn router(state: AppState) -> Router {
             "/control/agents/{agent_id}/create",
             post(control::create_agent),
         )
+        .route("/control/agents/{agent_id}", delete(control::delete_agent))
+        .route(
+            "/control/agents/{agent_id}/delete-status",
+            get(control::agent_deletion_status),
+        )
         .route(
             "/control/agents/{agent_id}/reset-callback",
             post(control::reset_callback),
@@ -1022,9 +1027,24 @@ pub(crate) fn agent_access_error(error: PublicAgentError) -> (StatusCode, Json<V
         PublicAgentError::NotFound { agent_id } => {
             not_found(format!("agent {} not found", agent_id))
         }
-        PublicAgentError::Archived { agent_id } => {
-            not_found(format!("agent {} is archived", agent_id))
-        }
+        PublicAgentError::Deleted { agent_id } => http_error(
+            StatusCode::GONE,
+            HttpErrorEnvelope::new(format!("agent {} was deleted", agent_id))
+                .code("agent_deleted")
+                .extension("agent_id", agent_id),
+        ),
+        PublicAgentError::Deleting { agent_id } => http_error(
+            StatusCode::CONFLICT,
+            HttpErrorEnvelope::new(format!("agent {} is being deleted", agent_id))
+                .code("agent_deleting")
+                .extension("agent_id", agent_id),
+        ),
+        PublicAgentError::DeleteForbidden { agent_id, reason } => http_error(
+            StatusCode::CONFLICT,
+            HttpErrorEnvelope::new(reason)
+                .code("agent_delete_forbidden")
+                .extension("agent_id", agent_id),
+        ),
         PublicAgentError::Stopped { agent_id } => stopped_agent_conflict(
             format!("agent {} is stopped; start first", agent_id),
             agent_id,

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -15,6 +15,28 @@ pub struct SearchRequest {
     pub types: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct DeleteAgentRequest {
+    #[serde(default)]
+    pub cascade_private_children: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentDeletionResponse {
+    pub ok: bool,
+    pub created: bool,
+    pub identity: crate::types::AgentIdentityView,
+    pub job: crate::types::AgentDeletionJob,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentDeletionStatusResponse {
+    pub identity: crate::types::AgentIdentityView,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job: Option<crate::types::AgentDeletionJob>,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct SearchResponse {
     pub query: String,

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -110,6 +110,10 @@ pub fn work_item_continuation_id() -> String {
     runtime_id("wic")
 }
 
+pub fn agent_deletion_id() -> String {
+    runtime_id("agentdel")
+}
+
 pub fn capability_id(prefix: &str) -> String {
     format!(
         "{prefix}_{}{}",
@@ -148,6 +152,7 @@ mod tests {
             (operator_notification_id(), "notify"),
             (operator_delivery_intent_id(), "odi"),
             (workspace_occupancy_id(), "occ"),
+            (agent_deletion_id(), "agentdel"),
             (audit_event_id(), "event"),
             (work_item_delegation_id(), "delegation"),
             (work_item_continuation_id(), "wic"),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -8,8 +8,9 @@ use serde_json::{json, Value};
 use crate::{
     diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
-        BatchGetBriefsRequest, BatchGetMessagesRequest, BatchGetTranscriptEntriesRequest,
-        CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest, MemoryGetRequest,
+        AgentDeletionResponse, AgentDeletionStatusResponse, BatchGetBriefsRequest,
+        BatchGetMessagesRequest, BatchGetTranscriptEntriesRequest, CancelTimerRequest,
+        CompleteWorkItemRequest, CreateTimerRequest, DeleteAgentRequest, MemoryGetRequest,
         ModelConfigMigrationRequest, PickWorkItemRequest, PickWorkItemResponse,
         RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
         SearchRequest, SearchResponse, UpdateWorkItemRequest,
@@ -128,6 +129,8 @@ const ROUTES: &[RouteSpec] = &[
     route_with_response("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), "TimerRecord", AuthKind::Control),
     route_with_response("post", "/control/agents/{agent_id}/timers/{timer_id}/cancel", "cancelTimer", "control", "Cancel timer", "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.", Some("CancelTimerRequest"), "TimerRecord", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/create", "createAgent", "control", "Create named agent", "Create a public named agent, optionally from a template.", Some("CreateAgentRequest"), AuthKind::Control),
+    route_with_response("delete", "/control/agents/{agent_id}", "deleteAgent", "control", "Delete agent", "Fence a public self-owned agent and create or return its durable deletion job.", Some("DeleteAgentRequest"), "AgentDeletionResponse", AuthKind::Control),
+    route_with_response("get", "/control/agents/{agent_id}/delete-status", "agentDeleteStatus", "control", "Agent deletion status", "Return the identity tombstone and current or completed deletion job.", None, "AgentDeletionStatusResponse", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/reset-callback", "resetCallback", "control", "Reset external trigger callback", "Revoke the current external trigger and provision a fresh one with a new token.", None, AuthKind::Control),
     route("post", "/control/agents/{agent_id}/workspace/attach", "attachWorkspace", "control", "Attach workspace", "Attach a workspace path to an agent.", Some("AttachWorkspaceRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/workspace/exit", "exitWorkspace", "control", "Exit workspace", "Return an agent to its default AgentHome workspace.", Some("ExitWorkspaceRequest"), AuthKind::Control),
@@ -656,6 +659,18 @@ fn component_schemas() -> Value {
     schemas.insert(
         "ModelConfigMigrationReport".into(),
         component_schema::<ModelConfigMigrationReport>(),
+    );
+    schemas.insert(
+        "DeleteAgentRequest".into(),
+        component_schema::<DeleteAgentRequest>(),
+    );
+    schemas.insert(
+        "AgentDeletionResponse".into(),
+        component_schema::<AgentDeletionResponse>(),
+    );
+    schemas.insert(
+        "AgentDeletionStatusResponse".into(),
+        component_schema::<AgentDeletionStatusResponse>(),
     );
     schemas.insert(
         "PickWorkItemRequest".into(),

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -10,9 +10,9 @@ use sha2::{Digest, Sha256};
 use crate::runtime_db::index_outbox::RuntimeIndexChange;
 use crate::runtime_db::EVIDENCE_PREVIEW_LIMIT;
 use crate::types::{
-    AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, DeliverySummaryRecord,
-    ExecutionRootEntry, MessageEnvelope, ToolExecutionRecord, TranscriptEntry, WorkspaceEntry,
-    WorkspaceOccupancyRecord,
+    AgentDeletionJob, AgentIdentityRecord, AgentState, AuditEvent, BriefRecord,
+    DeliverySummaryRecord, ExecutionRootEntry, MessageEnvelope, ToolExecutionRecord,
+    TranscriptEntry, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
 pub(crate) const AUDIT_EVENT_SEQUENCE_DOMAIN: &str = "audit_event";
@@ -413,7 +413,31 @@ pub(crate) fn upsert_agent_identity_tx(
             record.delegated_from_task_id,
             timestamp(record.created_at),
             timestamp(record.updated_at),
-            record.archived_at.map(timestamp),
+            record.deleted_at.map(timestamp),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn insert_agent_deletion_job_tx(
+    tx: &Transaction<'_>,
+    job: &AgentDeletionJob,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(job)?;
+    tx.execute(
+        "INSERT INTO agent_deletion_jobs (
+            deletion_id, agent_id, status, phase, created_at, updated_at,
+            completed_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            job.deletion_id,
+            job.agent_id,
+            enum_string(&job.status)?,
+            enum_string(&job.phase)?,
+            timestamp(job.created_at),
+            timestamp(job.updated_at),
+            job.completed_at.map(timestamp),
             payload_json,
         ],
     )?;

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -1764,6 +1764,26 @@ CREATE INDEX IF NOT EXISTS idx_scheduler_activation_inputs_activation
   ON scheduler_activation_inputs(agent_id, activation_id, round);
 "#,
     },
+    Migration {
+        version: 35,
+        name: "agent_deletion_jobs",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS agent_deletion_jobs (
+  deletion_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL,
+  phase TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  payload_json TEXT NOT NULL,
+  FOREIGN KEY (agent_id) REFERENCES agent_identities(agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_deletion_jobs_status_updated
+  ON agent_deletion_jobs(status, updated_at);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -35,13 +35,13 @@ pub use crate::runtime_db::retention::{
 };
 pub use crate::runtime_db::storage_domain::{ExpectedStorageDomain, StorageDomainSnapshot};
 pub use crate::runtime_db::types::{
-    AgentIdentityRepository, AgentStateRepository, AuditEventSink, ContextEpisodeRepository,
-    EvidenceRepository, ExecutionRootEntryRepository, ExternalTriggerRepository, MessageRepository,
-    OperatorDeliveryRepository, OperatorNotificationRepository, OperatorTransportBindingRepository,
-    QueueEntryRepository, TaskRepository, TimerRepository, TranscriptRepository,
-    TurnRecordRepository, WaitConditionRepository, WorkItemContinuationRepository,
-    WorkItemDelegationRepository, WorkItemRepository, WorkspaceEntryRepository,
-    WorkspaceOccupancyRepository,
+    AgentDeletionRepository, AgentIdentityRepository, AgentStateRepository, AuditEventSink,
+    ContextEpisodeRepository, EvidenceRepository, ExecutionRootEntryRepository,
+    ExternalTriggerRepository, MessageRepository, OperatorDeliveryRepository,
+    OperatorNotificationRepository, OperatorTransportBindingRepository, QueueEntryRepository,
+    TaskRepository, TimerRepository, TranscriptRepository, TurnRecordRepository,
+    WaitConditionRepository, WorkItemContinuationRepository, WorkItemDelegationRepository,
+    WorkItemRepository, WorkspaceEntryRepository, WorkspaceOccupancyRepository,
 };
 #[cfg(test)]
 mod tests;
@@ -385,6 +385,10 @@ impl RuntimeDb {
 
     pub fn agent_identities(&self) -> AgentIdentityRepository<'_> {
         AgentIdentityRepository { db: self }
+    }
+
+    pub fn agent_deletions(&self) -> AgentDeletionRepository<'_> {
+        AgentDeletionRepository { db: self }
     }
 
     pub fn work_item_delegations(&self) -> WorkItemDelegationRepository<'_> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -420,6 +420,95 @@ impl AgentIdentityRepository<'_> {
     }
 }
 
+impl AgentDeletionRepository<'_> {
+    pub fn latest_for_agent(&self, agent_id: &str) -> Result<Option<AgentDeletionJob>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM agent_deletion_jobs WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| {
+                serde_json::from_str(&payload).context("decoding agent deletion job payload")
+            })
+            .transpose()
+    }
+
+    pub fn begin(
+        &self,
+        agent_id: &str,
+        expected_identity_revision: u64,
+        requested_by: &str,
+        cascade_private_children: bool,
+    ) -> Result<(AgentIdentityRecord, AgentDeletionJob, bool)> {
+        self.db.transaction(|tx| {
+            let payload = tx
+                .query_row(
+                    "SELECT payload_json FROM agent_identities WHERE agent_id = ?1",
+                    [agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| anyhow!("agent {agent_id} not found"))?;
+            let mut identity = decode_agent_identity_payload(&payload)?;
+
+            if identity.status != AgentRegistryStatus::Active {
+                let job = tx
+                    .query_row(
+                        "SELECT payload_json FROM agent_deletion_jobs WHERE agent_id = ?1",
+                        [agent_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?
+                    .map(|payload| {
+                        serde_json::from_str(&payload)
+                            .context("decoding existing agent deletion job payload")
+                    })
+                    .transpose()?
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "agent {agent_id} has terminal identity status without a deletion job"
+                        )
+                    })?;
+                return Ok((identity, job, false));
+            }
+            if identity.revision != expected_identity_revision {
+                return Err(anyhow!(
+                    "agent {agent_id} identity revision mismatch: expected {expected_identity_revision}, current {}",
+                    identity.revision
+                ));
+            }
+
+            let now = std::cmp::max(
+                Utc::now(),
+                identity.updated_at + chrono::Duration::nanoseconds(1),
+            );
+            let job = AgentDeletionJob {
+                deletion_id: crate::ids::agent_deletion_id(),
+                agent_id: agent_id.to_string(),
+                status: AgentDeletionStatus::Pending,
+                phase: AgentDeletionPhase::Fence,
+                requested_by: requested_by.to_string(),
+                expected_identity_revision,
+                cascade_private_children,
+                attempts: 0,
+                last_error: None,
+                created_at: now,
+                updated_at: now,
+                completed_at: None,
+            };
+            identity.status = AgentRegistryStatus::Deleting;
+            identity.revision = identity.revision.saturating_add(1);
+            identity.updated_at = now;
+            upsert_agent_identity_tx(tx, &identity)?;
+            insert_agent_deletion_job_tx(tx, &job)?;
+            Ok((identity, job, true))
+        })
+    }
+}
+
 impl WorkItemDelegationRepository<'_> {
     pub fn import_legacy(&self, records: Vec<WorkItemDelegationRecord>) -> Result<()> {
         if self

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -5483,8 +5483,8 @@ CREATE TABLE working_memory_deltas (
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let older = agent_identity("agent-a", 1);
         let mut newer = agent_identity("agent-a", 5);
-        newer.status = AgentRegistryStatus::Archived;
-        newer.archived_at = Some(newer.updated_at);
+        newer.status = AgentRegistryStatus::Deleted;
+        newer.deleted_at = Some(newer.updated_at);
 
         db.agent_identities()
             .import_legacy(vec![older.clone(), newer.clone()])?;
@@ -5494,11 +5494,55 @@ CREATE TABLE working_memory_deltas (
             .agent_identities()
             .latest("agent-a")?
             .expect("agent identity");
-        assert_eq!(identity.status, AgentRegistryStatus::Archived);
-        assert!(identity.archived_at.is_some());
+        assert_eq!(identity.status, AgentRegistryStatus::Deleted);
+        assert!(identity.deleted_at.is_some());
         let identities = db.agent_identities().latest_all()?;
         assert_eq!(identities.len(), 1);
         assert_eq!(identities[0].agent_id, "agent-a");
+        Ok(())
+    }
+
+    #[test]
+    fn agent_deletion_begin_is_idempotent_and_survives_reopen() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let identity = agent_identity("agent-delete", 1);
+        db.agent_identities().upsert(&identity)?;
+
+        let (deleting, first_job, created) =
+            db.agent_deletions()
+                .begin("agent-delete", identity.revision, "operator:test", true)?;
+        assert!(created);
+        assert_eq!(deleting.status, AgentRegistryStatus::Deleting);
+        assert_eq!(deleting.revision, identity.revision + 1);
+        assert!(first_job.cascade_private_children);
+
+        let (same_identity, same_job, created) = db.agent_deletions().begin(
+            "agent-delete",
+            deleting.revision,
+            "operator:retry",
+            false,
+        )?;
+        assert!(!created);
+        assert_eq!(same_identity, deleting);
+        assert_eq!(same_job, first_job);
+
+        drop(db);
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(
+            reopened
+                .agent_deletions()
+                .latest_for_agent("agent-delete")?,
+            Some(first_job)
+        );
+        assert_eq!(
+            reopened
+                .agent_identities()
+                .latest("agent-delete")?
+                .expect("deleting identity")
+                .status,
+            AgentRegistryStatus::Deleting
+        );
         Ok(())
     }
 

--- a/src/runtime_db/types.rs
+++ b/src/runtime_db/types.rs
@@ -66,6 +66,10 @@ pub struct AgentIdentityRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }
 
+pub struct AgentDeletionRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}
+
 pub struct WorkItemDelegationRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3816,7 +3816,7 @@ mod tests {
         agent.status = AgentStatus::Stopped;
         assert_eq!(
             storage.agent_posture_projection(&agent).unwrap().posture,
-            AgentSchedulingPosture::Archived
+            AgentSchedulingPosture::Stopped
         );
     }
 

--- a/src/storage/read_models.rs
+++ b/src/storage/read_models.rs
@@ -208,7 +208,7 @@ impl RuntimeReadModels {
     ) -> Result<Option<AgentPostureProjection>> {
         if matches!(agent.status, AgentStatus::Stopped) {
             return Ok(Some(AgentPostureProjection {
-                posture: AgentSchedulingPosture::Archived,
+                posture: AgentSchedulingPosture::Stopped,
                 reason: "agent lifecycle is stopped".into(),
                 work_item_id: None,
                 task_id: None,

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -898,7 +898,7 @@ fn stable_active_activity_timestamp() -> DateTime<chrono::Utc> {
 fn agent_has_active_activity(agent: &AgentSummary) -> bool {
     match agent.scheduling_posture.posture {
         crate::types::AgentSchedulingPosture::Unknown => {}
-        crate::types::AgentSchedulingPosture::Archived
+        crate::types::AgentSchedulingPosture::Stopped
         | crate::types::AgentSchedulingPosture::Idle => {
             return false;
         }
@@ -967,7 +967,7 @@ fn is_progress_event(event: &crate::tui::projection::ProjectionEventRecord) -> b
 fn active_activity_speaker(agent: &AgentSummary) -> String {
     match agent.scheduling_posture.posture {
         crate::types::AgentSchedulingPosture::Unknown => {}
-        crate::types::AgentSchedulingPosture::Archived => return "Holon (stopped)".into(),
+        crate::types::AgentSchedulingPosture::Stopped => return "Holon (stopped)".into(),
         crate::types::AgentSchedulingPosture::ActiveTurn => return "Holon (working)".into(),
         crate::types::AgentSchedulingPosture::HasQueuedInput => return "Holon (queued)".into(),
         crate::types::AgentSchedulingPosture::HasRunnableWork => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -410,7 +410,9 @@ pub enum AgentDurability {
 #[serde(rename_all = "snake_case")]
 pub enum AgentRegistryStatus {
     Active,
-    Archived,
+    Deleting,
+    #[serde(alias = "archived")]
+    Deleted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -425,6 +427,8 @@ pub struct AgentIdentityRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub durability: Option<AgentDurability>,
     pub status: AgentRegistryStatus,
+    #[serde(default)]
+    pub revision: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -433,8 +437,12 @@ pub struct AgentIdentityRecord {
     pub delegated_from_task_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub archived_at: Option<DateTime<Utc>>,
+    #[serde(
+        default,
+        alias = "archived_at",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 impl AgentIdentityRecord {
@@ -456,12 +464,13 @@ impl AgentIdentityRecord {
             profile_preset: Some(profile_preset),
             durability: None,
             status: AgentRegistryStatus::Active,
+            revision: 0,
             parent_agent_id,
             lineage_parent_agent_id: None,
             delegated_from_task_id,
             created_at: now,
             updated_at: now,
-            archived_at: None,
+            deleted_at: None,
         }
     }
 
@@ -500,6 +509,46 @@ impl AgentIdentityRecord {
             }
         })
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentDeletionStatus {
+    Pending,
+    Running,
+    RetryableFailed,
+    Completed,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentDeletionPhase {
+    Fence,
+    Quiesce,
+    Ingress,
+    Scheduler,
+    Workspace,
+    Index,
+    Home,
+    Finalize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentDeletionJob {
+    pub deletion_id: String,
+    pub agent_id: String,
+    pub status: AgentDeletionStatus,
+    pub phase: AgentDeletionPhase,
+    pub requested_by: String,
+    pub expected_identity_revision: u64,
+    pub cascade_private_children: bool,
+    pub attempts: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -3745,7 +3794,8 @@ pub struct CommandTaskSpec {
 #[serde(rename_all = "snake_case")]
 pub enum AgentSchedulingPosture {
     Unknown,
-    Archived,
+    #[serde(alias = "archived")]
+    Stopped,
     ActiveTurn,
     HasQueuedInput,
     HasRunnableWork,

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -34,6 +34,8 @@ http_async_tests!(
     skill_library_reconcile_and_check_lock_file,
     control_agent_model_override_set_and_clear_updates_status,
     control_agent_model_override_validates_codex_reasoning_effort,
+    control_agent_delete_fences_runtime_and_is_idempotent,
+    control_agent_delete_rejects_default_and_reports_unknown,
     control_prompt_requires_bearer_token_when_required,
     control_prompt_rejects_oversized_body,
     remote_tcp_surfaces_require_bearer_token_when_required,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -86,7 +86,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 97, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 99, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -1,6 +1,28 @@
 [
   {
     "method": "delete",
+    "path": "/api/control/agents/{agent_id}",
+    "handler": "delete_agent",
+    "operation_id": "deleteAgent",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "DeleteAgentRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "delete",
     "path": "/api/control/runtime/credentials/{profile}",
     "handler": "delete_credential",
     "operation_id": "deleteRuntimeCredential",
@@ -540,6 +562,28 @@
     "operation_id": "defaultBriefs",
     "tag": "compat",
     "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/agents/{agent_id}/delete-status",
+    "handler": "agent_deletion_status",
+    "operation_id": "agentDeleteStatus",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
     "request_schema": null,
     "request_strict": null,
     "response_content_types": [

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -52,6 +52,97 @@ pub async fn control_prompt_is_open_on_loopback_auto() -> Result<()> {
     Ok(())
 }
 
+pub async fn control_agent_delete_fences_runtime_and_is_idempotent() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    host.create_named_agent("delete-me", None).await?;
+    let loaded = host.get_or_create_agent("delete-me").await?;
+    let (base, server) = spawn_server_for_host(host.clone()).await?;
+    let client = Client::new();
+
+    let first = client
+        .delete(format!("{base}/api/control/agents/delete-me"))
+        .json(&serde_json::json!({ "cascade_private_children": true }))
+        .send()
+        .await?;
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+    let first_payload: serde_json::Value = first.json().await?;
+    assert_eq!(first_payload["created"], true);
+    assert_eq!(first_payload["identity"]["status"], "deleting");
+    assert_eq!(first_payload["job"]["cascade_private_children"], true);
+    let deletion_id = first_payload["job"]["deletion_id"]
+        .as_str()
+        .expect("deletion id")
+        .to_string();
+
+    let second: serde_json::Value = client
+        .delete(format!("{base}/api/control/agents/delete-me"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(second["created"], false);
+    assert_eq!(second["job"]["deletion_id"], deletion_id);
+
+    let prompt = client
+        .post(format!("{base}/api/control/agents/delete-me/prompt"))
+        .json(&serde_json::json!({ "text": "must be fenced" }))
+        .send()
+        .await?;
+    assert_eq!(prompt.status(), reqwest::StatusCode::CONFLICT);
+    assert_eq!(
+        prompt.json::<serde_json::Value>().await?["code"],
+        "agent_deleting"
+    );
+
+    let status: serde_json::Value = client
+        .get(format!("{base}/api/control/agents/delete-me/delete-status"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(status["identity"]["status"], "deleting");
+    assert_eq!(status["job"]["deletion_id"], deletion_id);
+    assert!(loaded
+        .storage()
+        .read_recent_messages(10)?
+        .iter()
+        .all(|message| !matches!(
+            &message.body,
+            MessageBody::Text { text } if text == "must be fenced"
+        )));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn control_agent_delete_rejects_default_and_reports_unknown() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = Client::new();
+
+    let default = client
+        .delete(format!("{base}/api/control/agents/default"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(default.status(), reqwest::StatusCode::CONFLICT);
+    assert_eq!(
+        default.json::<serde_json::Value>().await?["code"],
+        "agent_delete_forbidden"
+    );
+
+    let unknown = client
+        .delete(format!("{base}/api/control/agents/missing-agent"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(unknown.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+    Ok(())
+}
+
 #[cfg(unix)]
 pub async fn control_prompt_is_open_over_unix_socket_auto() -> Result<()> {
     let config = test_config();


### PR DESCRIPTION
## Summary

Phase 0–1 of GitHub issue #2418 — separate reversible agent stop/start
control from the irreversible **delete** contract, and lay a durable,
restart-safe foundation for later cleanup phases.

## What this PR ships

**Identity state machine**
- `AgentIdentityState` now advances `Active → Deleting → Deleted`.
- Legacy `archived` identity payloads decode as `Deleted`, and the
  historical `archived_at` SQLite column keeps storing the Rust-level
  `deleted_at` field, so the v9 migration and existing databases stay
  binary-compatible.
- Public lists surface only `Active` identities; agent IDs are not
  reused.

**Durable deletion job**
- New `agent_deletion_jobs` repository records one job per deletion
  request before any resource cleanup begins.
- Job creation is idempotent: repeated deletes on the same identity
  return the same job, and the job survives process restart.

**Operator-only control fence**
- `RuntimeHost::begin_delete` verifies revision, rejects the configured
  default agent and identities that are not public/self-owned, flips
  `Active → Deleting`, and inserts the job in a single transaction.
- Authenticated control-plane HTTP surface:
  - `DELETE /api/control/agents/{agent_id}` — create or return the
    deletion job;
  - `GET /api/control/agents/{agent_id}/delete-status` — read identity
    and job status.
- Status semantics: `404` unknown, `409` on `Deleting` / forbidden
  target, `410` on `Deleted`.
- OpenAPI, route inventory snapshot, and `docs/website/spec/agent-state.md`
  are updated in the same PR.

**Docs**
- New RFC: `docs/rfcs/agent-deletion-lifecycle.md`.

## What is explicitly **not** in this PR

Phase 0–1 only establishes the identity/state/job foundation and the
HTTP control surface. Deferred to later phases and tracked separately:

- runtime unload on delete admission and identity-fence coverage of
  ingress, wake, prompt, enqueue, and scheduler paths;
- workspace/index/AgentHome cleanup and unified cleanup engine;
- CLI, TUI, and Web GUI deletion entry points.

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo test --tests -- --test-threads=1` — 2523 passed / 0 failed
  (some suites report separate 0/0 buckets; no regressions).
- New tests cover: migration compatibility, deletion-job idempotency and
  reopen-safety, default-agent protection, authority rejection, and the
  new HTTP delete/status surface.

Refs #2418
