### PR TITLE
feat: implement reentrant agent deletion cleanup coordinator (#2420)

### DIFF
--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -79,13 +79,16 @@ impl RuntimeHost {
         // Optimistic concurrency guard: re-read the job from the database and
         // check if it's still actionable. If another coordinator already picked
         // it up (status changed to Running or Completed), skip it.
+        // However, if the caller explicitly passed a Running job (crash-restart
+        // resume), allow execution to proceed.
+        let caller_intends_resume = job.status == AgentDeletionStatus::Running;
         if let Some(fresh) = self
             .runtime_db()
             .agent_deletions()
             .latest_for_agent(&job.agent_id)?
         {
-            if fresh.status == AgentDeletionStatus::Running
-                || fresh.status == AgentDeletionStatus::Completed
+            if fresh.status == AgentDeletionStatus::Completed
+                || (fresh.status == AgentDeletionStatus::Running && !caller_intends_resume)
             {
                 debug!(agent_id = %job.agent_id, "deletion job already claimed by another coordinator");
                 return Ok(());

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -62,9 +62,11 @@ impl RuntimeHost {
     pub(crate) async fn execute_pending_deletions(&self) -> Result<()> {
         let jobs = self.runtime_db().agent_deletions().actionable_jobs()?;
         for job in jobs {
+            let agent_id = job.agent_id.clone();
             if let Err(err) = self.execute_deletion_job(job).await {
                 warn!(
-                    agent_id = %err,
+                    agent_id = %agent_id,
+                    error = %err,
                     "deletion job execution failed"
                 );
             }
@@ -74,6 +76,22 @@ impl RuntimeHost {
 
     /// Drive a single deletion job through its remaining phases.
     pub(crate) async fn execute_deletion_job(&self, mut job: AgentDeletionJob) -> Result<()> {
+        // Optimistic concurrency guard: re-read the job from the database and
+        // check if it's still actionable. If another coordinator already picked
+        // it up (status changed to Running or Completed), skip it.
+        if let Some(fresh) = self
+            .runtime_db()
+            .agent_deletions()
+            .latest_for_agent(&job.agent_id)?
+        {
+            if fresh.status == AgentDeletionStatus::Running
+                || fresh.status == AgentDeletionStatus::Completed
+            {
+                debug!(agent_id = %job.agent_id, "deletion job already claimed by another coordinator");
+                return Ok(());
+            }
+            job = fresh;
+        }
         let agent_id = job.agent_id.clone();
         info!(
             agent_id = %agent_id,

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -1,0 +1,553 @@
+//! Reentrant agent deletion cleanup coordinator.
+//!
+//! Drives an [`AgentDeletionJob`] through its ordered phases from `Fence` to
+//! `Finalize`. Each phase is idempotent: re-running a phase that has already
+//! been completed is a safe no-op. On transient failure the job is marked
+//! `RetryableFailed` with an actionable `last_error`; a subsequent retry
+//! resumes from the failed phase.
+//!
+//! The coordinator is triggered:
+//! - inline after `begin_public_agent_deletion`;
+//! - on daemon startup for crash recovery;
+//! - periodically for retry of failed jobs.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use tracing::{debug, info, warn};
+
+use crate::host::RuntimeHost;
+use crate::types::*;
+
+/// Interval between periodic deletion coordinator sweeps.
+const DELETION_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+impl RuntimeHost {
+    /// Spawn the background deletion coordinator task.
+    ///
+    /// The coordinator periodically sweeps for actionable deletion jobs and
+    /// drives them to completion. It is cancelled during graceful shutdown.
+    pub fn spawn_daemon_deletion_coordinator(&self) {
+        if tokio::runtime::Handle::try_current().is_err() {
+            debug!("deletion coordinator not spawned: no Tokio runtime");
+            return;
+        }
+        let host = self.clone();
+        tokio::spawn(async move {
+            host.run_daemon_deletion_coordinator().await;
+        });
+    }
+
+    async fn run_daemon_deletion_coordinator(self) {
+        let mut interval = tokio::time::interval(DELETION_SWEEP_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = self.inner.daemon_deletion_token.cancelled() => {
+                    debug!("deletion coordinator cancelled");
+                    break;
+                }
+                _ = interval.tick() => {
+                    if let Err(err) = self.execute_pending_deletions().await {
+                        warn!(error = %err, "deletion coordinator sweep failed");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Execute all actionable deletion jobs (Pending, Running, RetryableFailed).
+    pub(crate) async fn execute_pending_deletions(&self) -> Result<()> {
+        let jobs = self.runtime_db().agent_deletions().actionable_jobs()?;
+        for job in jobs {
+            if let Err(err) = self.execute_deletion_job(job).await {
+                warn!(
+                    agent_id = %err,
+                    "deletion job execution failed"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Drive a single deletion job through its remaining phases.
+    pub(crate) async fn execute_deletion_job(&self, mut job: AgentDeletionJob) -> Result<()> {
+        let agent_id = job.agent_id.clone();
+        info!(
+            agent_id = %agent_id,
+            deletion_id = %job.deletion_id,
+            phase = ?job.phase,
+            status = ?job.status,
+            "executing deletion job"
+        );
+
+        // Mark as Running if currently Pending or RetryableFailed.
+        if job.status != AgentDeletionStatus::Running {
+            job.status = AgentDeletionStatus::Running;
+            job.attempts = job.attempts.saturating_add(1);
+            job.last_error = None;
+            job.updated_at = Utc::now();
+            self.runtime_db().agent_deletions().update(&job)?;
+        }
+
+        // Execute each phase from the current one onward.
+        let phases = AgentDeletionPhase::ALL;
+        let start_idx = phases.iter().position(|p| *p == job.phase).unwrap_or(0);
+
+        for phase in &phases[start_idx..] {
+            // Skip if we've already advanced past this phase.
+            if job.phase > *phase {
+                continue;
+            }
+
+            let result = self.execute_deletion_phase(&agent_id, *phase, &job).await;
+            match result {
+                Ok(()) => {
+                    // Advance to next phase.
+                    if let Some(next) = phase.next() {
+                        job.phase = next;
+                        job.updated_at = Utc::now();
+                        self.runtime_db().agent_deletions().update(&job)?;
+                    }
+                }
+                Err(err) => {
+                    let error_msg = format!("{err:#}");
+                    warn!(
+                        agent_id = %agent_id,
+                        phase = ?phase,
+                        error = %error_msg,
+                        "deletion phase failed"
+                    );
+                    job.status = AgentDeletionStatus::RetryableFailed;
+                    job.last_error = Some(error_msg);
+                    job.updated_at = Utc::now();
+                    self.runtime_db().agent_deletions().update(&job)?;
+                    return Err(anyhow!(
+                        "deletion job for {agent_id} failed at phase {phase:?}: {err}"
+                    ));
+                }
+            }
+        }
+
+        // All phases completed.
+        job.status = AgentDeletionStatus::Completed;
+        job.completed_at = Some(Utc::now());
+        job.updated_at = Utc::now();
+        self.runtime_db().agent_deletions().update(&job)?;
+
+        info!(
+            agent_id = %agent_id,
+            deletion_id = %job.deletion_id,
+            "deletion job completed"
+        );
+        Ok(())
+    }
+
+    async fn execute_deletion_phase(
+        &self,
+        agent_id: &str,
+        phase: AgentDeletionPhase,
+        job: &AgentDeletionJob,
+    ) -> Result<()> {
+        match phase {
+            AgentDeletionPhase::Fence => self.deletion_phase_fence(agent_id).await,
+            AgentDeletionPhase::Quiesce => self.deletion_phase_quiesce(agent_id, job).await,
+            AgentDeletionPhase::Ingress => self.deletion_phase_ingress(agent_id).await,
+            AgentDeletionPhase::Scheduler => self.deletion_phase_scheduler(agent_id).await,
+            AgentDeletionPhase::Workspace => self.deletion_phase_workspace(agent_id).await,
+            AgentDeletionPhase::Index => self.deletion_phase_index(agent_id).await,
+            AgentDeletionPhase::Home => self.deletion_phase_home(agent_id).await,
+            AgentDeletionPhase::Finalize => self.deletion_phase_finalize(agent_id).await,
+        }
+    }
+
+    /// Fence: verify the identity is in Deleting state and the runtime is
+    /// unloaded. Phase 0-1 already sets the identity and unloads; this is a
+    /// safety check for crash recovery.
+    async fn deletion_phase_fence(&self, agent_id: &str) -> Result<()> {
+        let identity = self
+            .agent_identity_record(agent_id)?
+            .ok_or_else(|| anyhow!("agent {agent_id} identity not found"))?;
+        if identity.status != AgentRegistryStatus::Deleting {
+            return Err(anyhow!(
+                "agent {agent_id} identity is {:?}, expected Deleting",
+                identity.status
+            ));
+        }
+        // Ensure runtime is unloaded.
+        self.unload_runtime(agent_id).await;
+        Ok(())
+    }
+
+    /// Quiesce: terminalize active tasks, cancel wait conditions and timers.
+    /// If cascade_private_children is set, drive private children through
+    /// deletion first.
+    async fn deletion_phase_quiesce(&self, agent_id: &str, job: &AgentDeletionJob) -> Result<()> {
+        // Cascade private children first.
+        if job.cascade_private_children {
+            self.cascade_private_children_deletion(agent_id, job)
+                .await?;
+        }
+
+        let storage = match self.agent_storage(agent_id) {
+            Ok(s) => s,
+            Err(_) => {
+                // Agent data dir already gone; nothing to quiesce.
+                debug!(
+                    agent_id,
+                    "agent storage unavailable during quiesce; skipping"
+                );
+                return Ok(());
+            }
+        };
+
+        let now = Utc::now();
+
+        // Terminalize active tasks.
+        let active_tasks = self
+            .runtime_db()
+            .tasks()
+            .active_for_agent(agent_id, usize::MAX)?;
+        let tasks_count = active_tasks.len();
+        for mut task in active_tasks {
+            task.status = TaskStatus::Cancelled;
+            task.updated_at = now;
+            self.runtime_db().tasks().upsert(&task)?;
+        }
+        if tasks_count > 0 {
+            debug!(agent_id, count = tasks_count, "terminalized active tasks");
+        }
+
+        // Cancel active wait conditions.
+        let active_waits = self
+            .runtime_db()
+            .wait_conditions()
+            .active_for_agent(agent_id)?;
+        let waits_count = active_waits.len();
+        for mut wait in active_waits {
+            wait.status = WaitConditionStatus::Cancelled;
+            wait.updated_at = now;
+            wait.cancelled_at = Some(now);
+            self.runtime_db().wait_conditions().upsert(&wait)?;
+        }
+        if waits_count > 0 {
+            debug!(
+                agent_id,
+                count = waits_count,
+                "cancelled active wait conditions"
+            );
+        }
+
+        // Cancel active timers.
+        let timers = self
+            .runtime_db()
+            .timers()
+            .recent_for_agent(agent_id, usize::MAX)?;
+        for mut timer in timers {
+            if timer.status == TimerStatus::Active {
+                timer.status = TimerStatus::Cancelled;
+
+                self.runtime_db().timers().upsert(&timer)?;
+            }
+        }
+
+        // Emit audit event via storage if available.
+        let _ = storage.append_event(&AuditEvent::legacy(
+            "deletion_quiesce",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "tasks_cancelled": tasks_count,
+                "waits_cancelled": waits_count,
+            }),
+        ));
+
+        Ok(())
+    }
+
+    /// Ingress: revoke all active external triggers for the agent.
+    async fn deletion_phase_ingress(&self, agent_id: &str) -> Result<()> {
+        let triggers = self
+            .runtime_db()
+            .external_triggers()
+            .latest_for_agent(agent_id)?;
+        let now = Utc::now();
+        let mut revoked_count = 0;
+        for mut trigger in triggers {
+            if trigger.status == ExternalTriggerStatus::Active {
+                trigger.status = ExternalTriggerStatus::Revoked;
+                trigger.revoked_at = Some(now);
+                self.runtime_db().external_triggers().upsert(&trigger)?;
+                revoked_count += 1;
+            }
+        }
+        if revoked_count > 0 {
+            debug!(agent_id, count = revoked_count, "revoked external triggers");
+        }
+        Ok(())
+    }
+
+    /// Scheduler: ensure no scheduler state references this agent.
+    ///
+    /// Since the identity fence prevents new dispatches and the runtime is
+    /// unloaded, this phase verifies there are no lingering activations.
+    /// The per-agent scheduler state lives in the agent data directory and
+    /// will be removed in the Home phase.
+    async fn deletion_phase_scheduler(&self, agent_id: &str) -> Result<()> {
+        // The scheduler protocol snapshot is per-agent and stored in the
+        // agent's own data directory. Since the runtime is unloaded and the
+        // identity fence prevents new activations, no shared scheduler state
+        // needs cleanup here. This phase exists as an explicit checkpoint for
+        // future shared scheduler extensions.
+        debug!(agent_id, "scheduler phase: no shared state to terminalize");
+        Ok(())
+    }
+
+    /// Workspace: release all workspace occupancies held by this agent and
+    /// remove owned clean managed worktrees.
+    async fn deletion_phase_workspace(&self, agent_id: &str) -> Result<()> {
+        // Release all active occupancies held by this agent.
+        let all_occupancies = self.runtime_db().workspace_occupancies().latest_all()?;
+        let now = Utc::now();
+        let mut released_count = 0;
+        for mut occupancy in all_occupancies {
+            if occupancy.holder_agent_id == agent_id && occupancy.released_at.is_none() {
+                occupancy.released_at = Some(now);
+                self.runtime_db()
+                    .workspace_occupancies()
+                    .upsert(&occupancy)?;
+                released_count += 1;
+            }
+        }
+        if released_count > 0 {
+            debug!(
+                agent_id,
+                count = released_count,
+                "released workspace occupancies"
+            );
+        }
+
+        // Remove owned managed worktrees that are clean.
+        let all_roots = self.runtime_db().execution_root_entries().latest_all()?;
+        for root in all_roots {
+            if root.removed_at.is_some() {
+                continue;
+            }
+            let Some(worktree) = root.worktree.as_ref() else {
+                continue;
+            };
+            // Only remove worktrees registered by this agent.
+            let dominated_by_agent = worktree.registered_by_agent_id.as_deref() == Some(agent_id)
+                || worktree
+                    .authorized_agent_ids
+                    .iter()
+                    .all(|id| id == agent_id);
+            if !dominated_by_agent {
+                continue;
+            }
+            let worktree_path = &root.filesystem_path;
+            if !worktree_path.exists() {
+                // Already gone; just mark removed.
+                self.runtime_db()
+                    .execution_root_entries()
+                    .mark_removed(&root.execution_root_id)?;
+                continue;
+            }
+            // Check if the worktree is clean (no uncommitted changes).
+            if self.worktree_is_dirty(worktree_path) {
+                return Err(anyhow!(
+                    "worktree {} at {} has uncommitted changes; resolve before deletion can proceed",
+                    root.execution_root_id,
+                    worktree_path.display()
+                ));
+            }
+            // Safe to remove.
+            self.remove_worktree_directory(worktree_path)?;
+            self.runtime_db()
+                .execution_root_entries()
+                .mark_removed(&root.execution_root_id)?;
+            debug!(
+                agent_id,
+                execution_root_id = %root.execution_root_id,
+                "removed managed worktree"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Index: remove the agent's documents from the shared memory index.
+    async fn deletion_phase_index(&self, agent_id: &str) -> Result<()> {
+        // The memory index is a shared SQLite database. Remove all rows
+        // belonging to this agent.
+        let storage = match self.agent_storage(agent_id) {
+            Ok(s) => s,
+            Err(_) => {
+                debug!(
+                    agent_id,
+                    "agent storage unavailable during index cleanup; skipping"
+                );
+                return Ok(());
+            }
+        };
+        let index_path = crate::memory::index::memory_index_path(&storage);
+        if !index_path.exists() {
+            return Ok(());
+        }
+        let connection = rusqlite::Connection::open(&index_path)
+            .with_context(|| format!("opening memory index at {}", index_path.display()))?;
+        let tx = connection.unchecked_transaction()?;
+        // Delete FTS entries first (references memory_documents).
+        let _ = tx.execute(
+            "DELETE FROM memory_documents_fts
+             WHERE document_key IN (
+                SELECT document_key FROM memory_documents WHERE agent_id = ?1
+             )",
+            [agent_id],
+        );
+        tx.execute(
+            "DELETE FROM memory_documents WHERE agent_id = ?1",
+            [agent_id],
+        )?;
+        tx.execute(
+            "DELETE FROM memory_index_source_state WHERE agent_id = ?1",
+            [agent_id],
+        )?;
+        let _ = tx.execute(
+            "DELETE FROM memory_index_pending_sources WHERE agent_id = ?1",
+            [agent_id],
+        );
+        let _ = tx.execute(
+            "DELETE FROM memory_index_checkpoints WHERE agent_id = ?1",
+            [agent_id],
+        );
+        let _ = tx.execute(
+            "DELETE FROM memory_index_meta WHERE agent_id = ?1",
+            [agent_id],
+        );
+        let _ = tx.execute(
+            "DELETE FROM memory_index_cursors WHERE agent_id = ?1",
+            [agent_id],
+        );
+        tx.commit()?;
+        debug!(agent_id, "removed agent from memory index");
+        Ok(())
+    }
+
+    /// Home: rename agent home to trash then delete.
+    async fn deletion_phase_home(&self, agent_id: &str) -> Result<()> {
+        let data_dir = self.agent_data_dir(agent_id);
+        if !data_dir.exists() {
+            return Ok(());
+        }
+        // Rename to a trash name first to avoid partial-state visibility.
+        let trash_dir = data_dir.with_extension("deleting_trash");
+        if trash_dir.exists() {
+            // Previous attempt left trash; remove it.
+            std::fs::remove_dir_all(&trash_dir).with_context(|| {
+                format!("removing leftover trash directory {}", trash_dir.display())
+            })?;
+        }
+        std::fs::rename(&data_dir, &trash_dir).with_context(|| {
+            format!(
+                "renaming agent home {} to trash {}",
+                data_dir.display(),
+                trash_dir.display()
+            )
+        })?;
+        std::fs::remove_dir_all(&trash_dir)
+            .with_context(|| format!("removing agent home trash {}", trash_dir.display()))?;
+        info!(agent_id, "removed agent home directory");
+        Ok(())
+    }
+
+    /// Finalize: set identity to Deleted and emit audit event.
+    async fn deletion_phase_finalize(&self, agent_id: &str) -> Result<()> {
+        let mut identity = self
+            .agent_identity_record(agent_id)?
+            .ok_or_else(|| anyhow!("agent {agent_id} identity not found during finalize"))?;
+        if identity.status != AgentRegistryStatus::Deleted {
+            identity.status = AgentRegistryStatus::Deleted;
+            identity.deleted_at = Some(Utc::now());
+            identity.updated_at = Utc::now();
+            identity.revision = identity.revision.saturating_add(1);
+            self.append_agent_identity(&identity)?;
+        }
+        info!(agent_id, "agent identity finalized as Deleted");
+        Ok(())
+    }
+
+    /// Cascade deletion to private children of the given agent.
+    async fn cascade_private_children_deletion(
+        &self,
+        parent_agent_id: &str,
+        parent_job: &AgentDeletionJob,
+    ) -> Result<()> {
+        let identities = self.agent_identity_records()?;
+        let children: Vec<_> = identities
+            .into_iter()
+            .filter(|id| {
+                id.visibility == AgentVisibility::Private
+                    && id.ownership() == AgentOwnership::ParentSupervised
+                    && id.parent_agent_id.as_deref() == Some(parent_agent_id)
+                    && id.status == AgentRegistryStatus::Active
+            })
+            .collect();
+
+        for child in children {
+            let child_id = &child.agent_id;
+            // Create a deletion job for the child if one doesn't exist.
+            let existing = self
+                .runtime_db()
+                .agent_deletions()
+                .latest_for_agent(child_id)?;
+            let child_job = match existing {
+                Some(job) if job.status == AgentDeletionStatus::Completed => continue,
+                Some(job) => job,
+                None => {
+                    let (updated_identity, job, _) = self.runtime_db().agent_deletions().begin(
+                        child_id,
+                        child.revision,
+                        &parent_job.requested_by,
+                        false, // Don't recurse further
+                    )?;
+                    self.append_agent_identity(&updated_identity)?;
+                    job
+                }
+            };
+            Box::pin(self.execute_deletion_job(child_job))
+                .await
+                .with_context(|| format!("cascading deletion to private child {child_id}"))?;
+        }
+        Ok(())
+    }
+
+    /// Check if a git worktree has uncommitted changes.
+    fn worktree_is_dirty(&self, path: &Path) -> bool {
+        let output = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(path)
+            .output();
+        match output {
+            Ok(output) => !output.stdout.is_empty(),
+            Err(_) => true, // If we can't check, treat as dirty for safety.
+        }
+    }
+
+    /// Remove a worktree directory (git worktree remove or fallback to rm).
+    fn remove_worktree_directory(&self, path: &Path) -> Result<()> {
+        // Try git worktree remove first for clean git state.
+        let output = std::process::Command::new("git")
+            .args(["worktree", "remove", "--force"])
+            .arg(path)
+            .output();
+        match output {
+            Ok(output) if output.status.success() => return Ok(()),
+            _ => {}
+        }
+        // Fallback: remove directory directly.
+        std::fs::remove_dir_all(path)
+            .with_context(|| format!("removing worktree directory {}", path.display()))
+    }
+}

--- a/src/host.rs
+++ b/src/host.rs
@@ -88,7 +88,7 @@ pub(crate) struct AgentStateReadProjection {
 
 #[derive(Clone)]
 pub struct RuntimeHost {
-    inner: Arc<HostInner>,
+    pub(crate) inner: Arc<HostInner>,
 }
 
 pub(crate) const TEMP_AGENT_PREFIX: &str = "tmp_";
@@ -134,7 +134,7 @@ impl std::fmt::Display for PublicAgentError {
 
 impl std::error::Error for PublicAgentError {}
 
-struct HostInner {
+pub(crate) struct HostInner {
     registry: RuntimeRegistry,
     runtime_db: RuntimeDb,
     event_bus: EventBus,
@@ -143,6 +143,7 @@ struct HostInner {
     daemon_indexer_handle: Mutex<Option<JoinHandle<()>>>,
     daemon_retention_token: CancellationToken,
     daemon_retention_handle: Mutex<Option<JoinHandle<()>>>,
+    pub(crate) daemon_deletion_token: CancellationToken,
     runtime_db_maintenance_lock: Mutex<Option<crate::runtime_db::RuntimeDbLock>>,
     skills_registry: Arc<RwLock<SkillsRegistry>>,
     static_provider: Option<Arc<dyn AgentProvider>>,
@@ -266,6 +267,7 @@ impl RuntimeHost {
                 daemon_indexer_handle: Mutex::new(None),
                 daemon_retention_token: CancellationToken::new(),
                 daemon_retention_handle: Mutex::new(None),
+                daemon_deletion_token: CancellationToken::new(),
                 runtime_db_maintenance_lock: Mutex::new(None),
                 skills_registry: Arc::new(RwLock::new(SkillsRegistry::new())),
                 static_provider,
@@ -396,6 +398,11 @@ impl RuntimeHost {
             .lock()
             .unwrap()
             .take();
+    }
+
+    /// Signal the deletion coordinator to stop.
+    pub async fn shutdown_daemon_deletion_coordinator(&self) {
+        self.inner.daemon_deletion_token.cancel();
     }
 
     async fn run_daemon_runtime_db_retention(self) {
@@ -580,6 +587,7 @@ impl RuntimeHost {
     pub async fn shutdown(&self) -> Result<()> {
         self.shutdown_daemon_runtime_db_retention().await;
         self.shutdown_daemon_memory_indexer().await;
+        self.shutdown_daemon_deletion_coordinator().await;
         let entries = {
             let mut agents = self.inner.agents.write().await;
             agents.drain().map(|(_, entry)| entry).collect::<Vec<_>>()
@@ -708,6 +716,13 @@ impl RuntimeHost {
         self.append_agent_identity(&updated_identity)
             .map_err(PublicAgentError::Runtime)?;
         self.unload_runtime(agent_id).await;
+        // Trigger the deletion coordinator inline for immediate progress.
+        if created {
+            let host = self.clone();
+            tokio::spawn(async move {
+                let _ = host.execute_pending_deletions().await;
+            });
+        }
         Ok((updated_identity, job, created))
     }
 
@@ -1152,7 +1167,7 @@ impl RuntimeHost {
         self.inner.registry.agent_identity_record(agent_id)
     }
 
-    fn agent_identity_records(&self) -> Result<Vec<AgentIdentityRecord>> {
+    pub(crate) fn agent_identity_records(&self) -> Result<Vec<AgentIdentityRecord>> {
         self.inner.registry.agent_identity_records()
     }
 
@@ -2603,10 +2618,10 @@ mod tests {
         storage::AppStorage,
         system::WorkspaceProjectionKind,
         types::{
-            AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus,
-            AgentVisibility, AuthorityClass, ControlAction, MessageBody, MessageEnvelope,
-            MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
-            TaskRecoverySpec, TaskStatus, TurnTerminalKind,
+            AgentDeletionPhase, AgentDeletionStatus, AgentKind, AgentOwnership, AgentProfilePreset,
+            AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, ControlAction,
+            MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord,
+            QueueEntryStatus, TaskRecord, TaskRecoverySpec, TaskStatus, TurnTerminalKind,
         },
     };
 
@@ -3841,6 +3856,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let error = host
             .create_named_agent(agent_id, None)
@@ -3889,6 +3905,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = host.agent_storage("child_test").unwrap();
         let mut child_state = AgentState::new("child_test");
@@ -3979,6 +3996,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = host.agent_storage("child_test").unwrap();
         let mut child_state = AgentState::new("child_test");
@@ -4062,6 +4080,7 @@ mod tests {
         )
         .with_lineage_parent_agent_id(Some(parent_agent_id.clone()));
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = host.agent_storage("child_recover").unwrap();
         let mut child_state = AgentState::new("child_recover");
@@ -4182,6 +4201,7 @@ mod tests {
         )
         .with_lineage_parent_agent_id(Some(parent_agent_id.clone()));
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = host.agent_storage("child_recover_active_task").unwrap();
         let mut child_state = AgentState::new("child_recover_active_task");
@@ -4308,6 +4328,7 @@ mod tests {
         )
         .with_lineage_parent_agent_id(Some(parent_agent_id.clone()));
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = host.agent_storage("child_recover_active_wait").unwrap();
         let mut child_state = AgentState::new("child_recover_active_wait");
@@ -4387,6 +4408,7 @@ mod tests {
             Some("missing-task".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage =
             AppStorage::new_for_agent_for_test(host.agent_data_dir("child_orphan"), "child_orphan")
@@ -4423,6 +4445,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
         host.archive_private_agent("child_archived").await.unwrap();
 
         drop(host);
@@ -4451,6 +4474,10 @@ mod tests {
             None,
         );
         host.append_agent_identity(&parent).unwrap();
+        host.runtime_db()
+            .agent_identities()
+            .upsert(&parent)
+            .unwrap();
 
         let child = AgentIdentityRecord::new(
             "child_parent_missing",
@@ -4462,6 +4489,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = AppStorage::new_for_agent_for_test(
             host.agent_data_dir("child_parent_missing"),
@@ -4525,6 +4553,7 @@ mod tests {
             Some("task-stop".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage =
             AppStorage::new_for_agent_for_test(host.agent_data_dir("child_stop"), "child_stop")
@@ -5080,6 +5109,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let err = host
             .get_public_agent("child_private_1")
@@ -5108,6 +5138,7 @@ mod tests {
             Some("task-1".into()),
         );
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let child_storage = host.agent_storage("child_local_1").unwrap();
         let mut child_state = AgentState::new("child_local_1");
@@ -5139,6 +5170,7 @@ mod tests {
         );
         child.status = AgentRegistryStatus::Deleted;
         host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
 
         let err = host
             .get_agent_for_local_status("child_archived_1")
@@ -5182,5 +5214,174 @@ mod tests {
         let summary = runtime.agent_summary().await.unwrap();
         assert_eq!(summary.identity.agent_id, default_id);
         assert_eq!(summary.identity.visibility, AgentVisibility::Public);
+    }
+
+    #[tokio::test]
+    async fn deletion_coordinator_drives_job_to_completed() {
+        let (_home, host) = test_host();
+
+        // Create a public self-owned agent to delete.
+        let agent = AgentIdentityRecord::new(
+            "delete-me",
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        host.append_agent_identity(&agent).unwrap();
+        host.runtime_db().agent_identities().upsert(&agent).unwrap();
+
+        // Begin deletion.
+        let (identity, job, created) = host
+            .begin_public_agent_deletion("delete-me", false, "operator")
+            .await
+            .unwrap();
+        assert!(created);
+        assert_eq!(identity.status, AgentRegistryStatus::Deleting);
+        assert_eq!(job.status, AgentDeletionStatus::Pending);
+
+        // Execute the deletion job.
+        match host.execute_deletion_job(job).await {
+            Ok(_) => {}
+            Err(e) => panic!("deletion failed: {e:#}"),
+        }
+
+        // Verify identity is Deleted.
+        let final_identity = host
+            .agent_identity_record("delete-me")
+            .unwrap()
+            .expect("identity should still exist");
+        assert_eq!(final_identity.status, AgentRegistryStatus::Deleted);
+        assert!(final_identity.deleted_at.is_some());
+
+        // Verify job is Completed.
+        let final_job = host
+            .runtime_db()
+            .agent_deletions()
+            .latest_for_agent("delete-me")
+            .unwrap()
+            .expect("job should exist");
+        assert_eq!(final_job.status, AgentDeletionStatus::Completed);
+        assert!(final_job.completed_at.is_some());
+
+        // Agent home should be removed.
+        assert!(!host.agent_data_dir("delete-me").exists());
+    }
+
+    #[tokio::test]
+    async fn deletion_coordinator_resumes_from_persisted_phase() {
+        let (_home, host) = test_host();
+
+        // Create a public self-owned agent.
+        let agent = AgentIdentityRecord::new(
+            "resume-me",
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        host.append_agent_identity(&agent).unwrap();
+        host.runtime_db().agent_identities().upsert(&agent).unwrap();
+
+        // Begin deletion.
+        let (_, job, _) = host
+            .begin_public_agent_deletion("resume-me", false, "operator")
+            .await
+            .unwrap();
+
+        // Simulate a crash after Quiesce by manually advancing the job phase.
+        let mut advanced_job = job.clone();
+        advanced_job.status = AgentDeletionStatus::Running;
+        advanced_job.phase = AgentDeletionPhase::Ingress;
+        advanced_job.updated_at = Utc::now();
+        host.runtime_db()
+            .agent_deletions()
+            .update(&advanced_job)
+            .unwrap();
+
+        // Execute should resume from Ingress.
+        host.execute_deletion_job(advanced_job).await.unwrap();
+
+        // Verify completion.
+        let final_job = host
+            .runtime_db()
+            .agent_deletions()
+            .latest_for_agent("resume-me")
+            .unwrap()
+            .expect("job should exist");
+        assert_eq!(final_job.status, AgentDeletionStatus::Completed);
+        assert_eq!(
+            host.agent_identity_record("resume-me")
+                .unwrap()
+                .unwrap()
+                .status,
+            AgentRegistryStatus::Deleted
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_cascade_private_children() {
+        let (_home, host) = test_host();
+        let parent_id = "cascade-parent";
+
+        // Create parent agent.
+        let parent = AgentIdentityRecord::new(
+            parent_id,
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        host.append_agent_identity(&parent).unwrap();
+        host.runtime_db()
+            .agent_identities()
+            .upsert(&parent)
+            .unwrap();
+
+        // Create a private child.
+        let child = AgentIdentityRecord::new(
+            "cascade-child",
+            AgentKind::Child,
+            AgentVisibility::Private,
+            AgentOwnership::ParentSupervised,
+            AgentProfilePreset::PrivateChild,
+            Some(parent_id.to_string()),
+            Some("task-1".to_string()),
+        );
+        host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
+
+        // Begin deletion with cascade.
+        let (_, job, _) = host
+            .begin_public_agent_deletion(parent_id, true, "operator")
+            .await
+            .unwrap();
+
+        match host.execute_deletion_job(job).await {
+            Ok(_) => {}
+            Err(e) => panic!("deletion failed: {e:#}"),
+        }
+
+        // Both parent and child should be Deleted.
+        assert_eq!(
+            host.agent_identity_record(parent_id)
+                .unwrap()
+                .unwrap()
+                .status,
+            AgentRegistryStatus::Deleted
+        );
+        assert_eq!(
+            host.agent_identity_record("cascade-child")
+                .unwrap()
+                .unwrap()
+                .status,
+            AgentRegistryStatus::Deleted
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod context;
 pub mod contract_inventory;
 pub mod daemon;
+pub mod deletion;
 pub mod diagnostics;
 pub mod domain;
 pub mod fd_limit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -842,6 +842,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
     host.spawn_daemon_runtime_db_retention();
+    host.spawn_daemon_deletion_coordinator();
     spawn_stale_agent_template_remote_source_sync(&config, &host);
     emit_first_run_intro(&config, &runtime).await;
     let runtime_service = RuntimeServiceHandle::new(&config)?;

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -507,6 +507,48 @@ impl AgentDeletionRepository<'_> {
             Ok((identity, job, true))
         })
     }
+
+    /// Persist an updated deletion job (phase advance, status change, etc.).
+    pub fn update(&self, job: &AgentDeletionJob) -> Result<()> {
+        self.db.transaction(|tx| {
+            let payload_json = serde_json::to_string(job)?;
+            let updated = tx.execute(
+                "UPDATE agent_deletion_jobs
+                 SET status = ?1, phase = ?2, updated_at = ?3,
+                     completed_at = ?4, payload_json = ?5
+                 WHERE deletion_id = ?6",
+                params![
+                    enum_string(&job.status)?,
+                    enum_string(&job.phase)?,
+                    timestamp(job.updated_at),
+                    job.completed_at.map(timestamp),
+                    payload_json,
+                    job.deletion_id,
+                ],
+            )?;
+            if updated == 0 {
+                return Err(anyhow!(
+                    "deletion job {} not found for update",
+                    job.deletion_id
+                ));
+            }
+            Ok(())
+        })
+    }
+
+    /// Find all deletion jobs that are actionable (Pending, Running, or
+    /// RetryableFailed) and not yet Completed.
+    pub fn actionable_jobs(&self) -> Result<Vec<AgentDeletionJob>> {
+        let connection = self.db.connection()?;
+        let mut stmt = connection.prepare(
+            "SELECT payload_json FROM agent_deletion_jobs
+             WHERE status IN ('pending', 'running', 'retryable_failed')
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| serde_json::from_str(&row?).context("decoding agent deletion job payload"))
+            .collect()
+    }
 }
 
 impl WorkItemDelegationRepository<'_> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -520,7 +520,9 @@ pub enum AgentDeletionStatus {
     Completed,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentDeletionPhase {
     Fence,
@@ -531,6 +533,26 @@ pub enum AgentDeletionPhase {
     Index,
     Home,
     Finalize,
+}
+
+impl AgentDeletionPhase {
+    /// All phases in execution order.
+    pub const ALL: [Self; 8] = [
+        Self::Fence,
+        Self::Quiesce,
+        Self::Ingress,
+        Self::Scheduler,
+        Self::Workspace,
+        Self::Index,
+        Self::Home,
+        Self::Finalize,
+    ];
+
+    /// The next phase in execution order, or `None` after `Finalize`.
+    pub fn next(self) -> Option<Self> {
+        let idx = Self::ALL.iter().position(|p| *p == self)?;
+        Self::ALL.get(idx + 1).copied()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -90,10 +90,18 @@ pub async fn control_agent_delete_fences_runtime_and_is_idempotent() -> Result<(
         .json(&serde_json::json!({ "text": "must be fenced" }))
         .send()
         .await?;
-    assert_eq!(prompt.status(), reqwest::StatusCode::CONFLICT);
-    assert_eq!(
-        prompt.json::<serde_json::Value>().await?["code"],
-        "agent_deleting"
+    // The inline deletion coordinator may advance the agent to Deleted before
+    // this assertion runs. Both 409 (deleting) and 410 (deleted) indicate the
+    // agent is correctly fenced from prompts.
+    let prompt_status = prompt.status();
+    let prompt_body = prompt.json::<serde_json::Value>().await?;
+    assert!(
+        prompt_status == reqwest::StatusCode::CONFLICT
+            || prompt_status == reqwest::StatusCode::GONE,
+        "expected 409 or 410, got {prompt_status}"
+    );
+    assert!(
+        ["agent_deleting", "agent_deleted"].contains(&prompt_body["code"].as_str().unwrap_or(""))
     );
 
     let status: serde_json::Value = client
@@ -102,7 +110,12 @@ pub async fn control_agent_delete_fences_runtime_and_is_idempotent() -> Result<(
         .await?
         .json()
         .await?;
-    assert_eq!(status["identity"]["status"], "deleting");
+    // The inline coordinator may have already completed the deletion.
+    assert!(
+        ["deleting", "deleted"].contains(&status["identity"]["status"].as_str().unwrap_or("")),
+        "expected deleting or deleted, got {:?}",
+        status["identity"]["status"]
+    );
     assert_eq!(status["job"]["deletion_id"], deletion_id);
     assert!(loaded
         .storage()


### PR DESCRIPTION
## Summary

Implements Phase 2 of the agent deletion lifecycle (#2418): a reentrant cleanup coordinator that drives `AgentDeletionJob` through ordered phases from Fence to Finalize.

## Changes

### New module: `src/deletion.rs`
- **Phase-by-phase execution**: Fence → Quiesce → Ingress → Scheduler → Workspace → Index → Home → Finalize
- **Reentrancy**: each phase is idempotent; crash-restart resumes from the last persisted phase
- **Private child cascade**: recursive `Box::pin` delegation drives children through the same engine
- **Background coordinator**: periodic sweep (30s) for actionable jobs; inline trigger after `begin_public_agent_deletion`

### Phase details
| Phase | Action |
|-------|--------|
| Fence | Verify identity is Deleting, unload runtime |
| Quiesce | Terminalize active tasks, cancel wait conditions/timers, cascade children |
| Ingress | Revoke all active external triggers |
| Scheduler | Checkpoint (per-agent state removed with Home) |
| Workspace | Release occupancies, remove clean owned worktrees, block on dirty |
| Index | Remove agent rows from shared memory index |
| Home | Rename-then-delete agent home directory |
| Finalize | Set identity to Deleted, mark job Completed |

### Supporting changes
- `AgentDeletionPhase`: added `PartialOrd`, `Ord`, `ALL` constant, `next()` method
- `AgentDeletionRepository`: added `update()` and `actionable_jobs()`
- `RuntimeHost`: added `spawn_daemon_deletion_coordinator()`, `shutdown_daemon_deletion_coordinator()`
- Daemon startup spawns the coordinator; graceful shutdown cancels it

### Tests
- `deletion_coordinator_drives_job_to_completed` – full lifecycle
- `deletion_coordinator_resumes_from_persisted_phase` – crash-restart resume
- `deletion_cascade_private_children` – parent+child cascade

## Verification
- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✓
- All 57 host tests + 141 runtime_db tests pass
- 5 deletion-specific tests pass

Closes #2420