### PR TITLE
feat: CLI agent delete command with --wait polling and status progress

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -632,6 +632,26 @@ pub enum AgentCommands {
     Stop {
         agent_id: Option<String>,
     },
+    /// Permanently delete an agent and its associated data
+    #[command(name = "delete")]
+    Delete {
+        agent_id: String,
+        /// Skip interactive confirmation (required in non-interactive mode)
+        #[arg(short = 'y', long)]
+        yes: bool,
+        /// Also delete private supervised child agents
+        #[arg(long)]
+        cascade_private_children: bool,
+        /// Wait for the deletion job to complete
+        #[arg(long)]
+        wait: bool,
+        /// Timeout in seconds for --wait (default: 300)
+        #[arg(long)]
+        timeout: Option<u64>,
+        /// Output structured JSON
+        #[arg(long)]
+        json: bool,
+    },
     Abort {
         agent_id: Option<String>,
     },

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,12 +11,14 @@ use crate::{
     daemon::{RuntimeShutdownResponse, RuntimeStatusResponse},
     diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
-        AttachWorkspaceRequest, BatchGetBriefsRequest, BatchGetBriefsResponse,
-        BatchGetMessagesRequest, BatchGetMessagesResponse, BatchGetTranscriptEntriesRequest,
+        AgentDeletionResponse, AgentDeletionStatusResponse, AttachWorkspaceRequest,
+        BatchGetBriefsRequest, BatchGetBriefsResponse, BatchGetMessagesRequest,
+        BatchGetMessagesResponse, BatchGetTranscriptEntriesRequest,
         BatchGetTranscriptEntriesResponse, ClearAgentModelRequest, ControlPromptRequest,
-        CreateAgentRequest, DebugPromptRequest, DetachWorkspaceRequest, ExitWorkspaceRequest,
-        ModelConfigMigrationRequest, RuntimeConfigReadResponse, RuntimeConfigUpdateRequest,
-        RuntimeConfigUpdateResponse, SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
+        CreateAgentRequest, DebugPromptRequest, DeleteAgentRequest, DetachWorkspaceRequest,
+        ExitWorkspaceRequest, ModelConfigMigrationRequest, RuntimeConfigReadResponse,
+        RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse, SetAgentModelRequest,
+        TaskInputRequest, TaskStopRequest,
     },
     http_dto::AgentStateSnapshotDto,
     model_catalog::BuiltInModelMetadata,
@@ -634,6 +636,28 @@ impl LocalClient {
         .await
     }
 
+    pub async fn delete_agent(
+        &self,
+        agent_id: &str,
+        cascade_private_children: bool,
+    ) -> Result<AgentDeletionResponse> {
+        self.delete_control_json(
+            &format!("/control/agents/{agent_id}"),
+            &DeleteAgentRequest {
+                cascade_private_children,
+            },
+        )
+        .await
+    }
+
+    pub async fn get_agent_deletion_status(
+        &self,
+        agent_id: &str,
+    ) -> Result<AgentDeletionStatusResponse> {
+        self.get_control_json(&format!("/control/agents/{agent_id}/delete-status"))
+            .await
+    }
+
     pub async fn create_agent(&self, agent_id: &str) -> Result<Value> {
         self.create_agent_with_template(agent_id, None).await
     }
@@ -936,6 +960,19 @@ impl LocalClient {
             .with_context(|| format!("failed to decode response body for POST {}", path))
     }
 
+    pub async fn delete_control_json<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        payload: &B,
+    ) -> Result<T> {
+        let path = api_path(path);
+        let body = self
+            .send(RequestSpec::delete_json(&path, payload)?, true)
+            .await?;
+        serde_json::from_slice(&body)
+            .with_context(|| format!("failed to decode response body for DELETE {}", path))
+    }
+
     async fn patch_control_json<B: Serialize, T: DeserializeOwned>(
         &self,
         path: &str,
@@ -1020,6 +1057,7 @@ impl LocalClient {
         let mut builder = match request.method {
             HttpMethod::Get => self.http.get(self.http_url_for(&request.path)),
             HttpMethod::Post => self.http.post(self.http_url_for(&request.path)),
+            HttpMethod::Delete => self.http.delete(self.http_url_for(&request.path)),
             HttpMethod::Patch => self.http.patch(self.http_url_for(&request.path)),
         };
         if let Some(remote) = &self.remote {
@@ -1071,6 +1109,7 @@ impl LocalClient {
         let method = match request.method {
             HttpMethod::Get => "GET",
             HttpMethod::Post => "POST",
+            HttpMethod::Delete => "DELETE",
             HttpMethod::Patch => "PATCH",
         };
         let mut raw = format!(
@@ -1242,6 +1281,14 @@ impl RequestSpec {
         })
     }
 
+    fn delete_json<B: Serialize>(path: &str, payload: &B) -> Result<Self> {
+        Ok(Self {
+            method: HttpMethod::Delete,
+            path: path.to_string(),
+            body: Some(serde_json::to_vec(payload)?),
+        })
+    }
+
     fn patch_json<B: Serialize>(path: &str, payload: &B) -> Result<Self> {
         Ok(Self {
             method: HttpMethod::Patch,
@@ -1255,6 +1302,7 @@ impl RequestSpec {
 enum HttpMethod {
     Get,
     Post,
+    Delete,
     Patch,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,10 +32,7 @@ use holon::{
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
-    http::{
-        self, AgentDeletionStatusResponse, AppState, ControlRequest, CreateCommandTaskRequest,
-        CreateTimerRequest,
-    },
+    http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
     memory::{rebuild_memory_index, request_memory_index_rebuild},
     model_discovery::{discovery_cache_path, refresh_provider_models},
     onboarding::{
@@ -3162,12 +3159,12 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
             match client.agent_status(&agent).await {
                 Ok(summary) => print_json(&serde_json::to_value(summary)?),
                 Err(err) => {
-                    // If the agent is being deleted, show deletion progress instead.
+                    // If the agent is being deleted, show deletion status as JSON instead.
                     if let Some(http_err) = err.downcast_ref::<LocalHttpError>() {
                         if http_err.has_code("agent_deleting") || http_err.has_code("agent_deleted")
                         {
                             let deletion = client.get_agent_deletion_status(&agent).await?;
-                            return print_deletion_status(&deletion);
+                            return print_json(&serde_json::to_value(&deletion)?);
                         }
                     }
                     Err(err)
@@ -3365,7 +3362,7 @@ async fn wait_for_deletion(client: &LocalClient, agent_id: &str, timeout_secs: u
                     );
                     return Ok(());
                 }
-                _ => {} // Pending or Running: continue polling
+                AgentDeletionStatus::Pending | AgentDeletionStatus::Running => {}
             }
         }
         match status.identity.status {
@@ -3394,43 +3391,6 @@ fn format_deletion_phase(phase: &AgentDeletionPhase) -> &'static str {
         Home => "Home",
         Finalize => "Finalize",
     }
-}
-
-fn format_deletion_job_status(status: &AgentDeletionStatus) -> &'static str {
-    use AgentDeletionStatus::*;
-    match status {
-        Pending => "pending",
-        Running => "in progress",
-        RetryableFailed => "failed (retryable)",
-        Completed => "completed",
-    }
-}
-
-fn print_deletion_status(deletion: &AgentDeletionStatusResponse) -> Result<()> {
-    let agent_id = &deletion.identity.agent_id;
-    let status_str = match deletion.identity.status {
-        AgentRegistryStatus::Active => "active",
-        AgentRegistryStatus::Deleting => "deleting",
-        AgentRegistryStatus::Deleted => "deleted",
-    };
-    println!("Agent: {agent_id}");
-    println!("Status: {status_str}");
-    if let Some(ref job) = deletion.job {
-        println!();
-        println!("Deletion Progress:");
-        println!(
-            "  Phase: {} ({})",
-            format_deletion_phase(&job.phase),
-            format_deletion_job_status(&job.status)
-        );
-        println!("  Attempts: {}", job.attempts);
-        if let Some(ref err) = job.last_error {
-            println!("  Last error: {err}");
-        } else {
-            println!("  Last error: (none)");
-        }
-    }
-    Ok(())
 }
 
 async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ use holon::{
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
-    http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
+    http::{
+        self, AgentDeletionStatusResponse, AppState, ControlRequest, CreateCommandTaskRequest,
+        CreateTimerRequest,
+    },
     memory::{rebuild_memory_index, request_memory_index_rebuild},
     model_discovery::{discovery_cache_path, refresh_provider_models},
     onboarding::{
@@ -47,7 +50,10 @@ use holon::{
     solve::{run_solve, SolveRequest},
     storage::AppStorage,
     tui::run_tui,
-    types::{AuditEvent, AuthorityClass, ControlAction, TimerStatus},
+    types::{
+        AgentDeletionPhase, AgentDeletionStatus, AgentRegistryStatus, AuditEvent, AuthorityClass,
+        ControlAction, TimerStatus,
+    },
 };
 use tokio::net::TcpListener;
 use tracing::warn;
@@ -3153,7 +3159,39 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
         Some(AgentCommands::Status { agent_id }) => {
             let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
             let client = LocalClient::new(config.clone())?;
-            print_json(&serde_json::to_value(client.agent_status(&agent).await?)?)
+            match client.agent_status(&agent).await {
+                Ok(summary) => print_json(&serde_json::to_value(summary)?),
+                Err(err) => {
+                    // If the agent is being deleted, show deletion progress instead.
+                    if let Some(http_err) = err.downcast_ref::<LocalHttpError>() {
+                        if http_err.has_code("agent_deleting") || http_err.has_code("agent_deleted")
+                        {
+                            let deletion = client.get_agent_deletion_status(&agent).await?;
+                            return print_deletion_status(&deletion);
+                        }
+                    }
+                    Err(err)
+                }
+            }
+        }
+        Some(AgentCommands::Delete {
+            agent_id,
+            yes,
+            cascade_private_children,
+            wait,
+            timeout,
+            json,
+        }) => {
+            handle_agent_delete(
+                config,
+                &agent_id,
+                yes,
+                cascade_private_children,
+                wait,
+                timeout,
+                json,
+            )
+            .await
         }
         Some(AgentCommands::Create { agent_id, template }) => {
             post_control_json(
@@ -3223,6 +3261,176 @@ async fn control_agent_lifecycle(
     let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
     let client = LocalClient::new(config.clone())?;
     print_json(&client.control_agent(&agent, action).await?)
+}
+
+async fn handle_agent_delete(
+    config: &AppConfig,
+    agent_id: &str,
+    yes: bool,
+    cascade_private_children: bool,
+    wait: bool,
+    timeout: Option<u64>,
+    json: bool,
+) -> Result<()> {
+    let client = LocalClient::new(config.clone())?;
+
+    // Confirmation
+    if !yes {
+        if std::io::stdin().is_terminal() {
+            eprintln!();
+            eprintln!("⚠  Permanently delete agent \"{agent_id}\"?");
+            eprintln!("   This operation is irreversible.");
+            eprintln!("   Agent home and all associated data will be removed.");
+            eprint!("\n   Proceed? [y/N]: ");
+            std::io::stderr().flush()?;
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+            if !input.trim().eq_ignore_ascii_case("y") {
+                eprintln!("Cancelled.");
+                return Ok(());
+            }
+        } else {
+            anyhow::bail!(
+                "interactive confirmation unavailable in non-interactive mode.\n\
+                 Re-run with --yes (-y) to skip confirmation:\n  \
+                 holon agent delete {agent_id} --yes"
+            );
+        }
+    }
+
+    // Initiate deletion
+    let response = match client
+        .delete_agent(agent_id, cascade_private_children)
+        .await
+    {
+        Ok(resp) => resp,
+        Err(err) => {
+            if let Some(http_err) = err.downcast_ref::<LocalHttpError>() {
+                if http_err.has_code("agent_deleting") {
+                    eprintln!(
+                        "Agent \"{agent_id}\" is already being deleted.\n\
+                         Check progress: holon agent status {agent_id}"
+                    );
+                    return Ok(());
+                }
+                if http_err.has_code("agent_deleted") {
+                    eprintln!("Agent \"{agent_id}\" was already deleted.");
+                    return Ok(());
+                }
+            }
+            return Err(err);
+        }
+    };
+
+    if json {
+        return print_json(&serde_json::to_value(&response)?);
+    }
+
+    eprintln!(
+        "Deleting agent \"{agent_id}\" (phase: {})",
+        format_deletion_phase(&response.job.phase)
+    );
+
+    if wait {
+        let timeout_secs = timeout.unwrap_or(300);
+        wait_for_deletion(&client, agent_id, timeout_secs).await?;
+    }
+    Ok(())
+}
+
+async fn wait_for_deletion(client: &LocalClient, agent_id: &str, timeout_secs: u64) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for deletion to complete ({timeout_secs}s)\n\
+                 Agent \"{agent_id}\" is still in Deleting state.\n\
+                 Check progress: holon agent status {agent_id}"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let status = client.get_agent_deletion_status(agent_id).await?;
+        if let Some(ref job) = status.job {
+            match job.status {
+                AgentDeletionStatus::Completed => {
+                    eprintln!("Deleted agent \"{agent_id}\"");
+                    return Ok(());
+                }
+                AgentDeletionStatus::RetryableFailed => {
+                    eprintln!(
+                        "Deletion failed (retryable): {}\n\
+                         The deletion job will be retried.\n\
+                         Check progress: holon agent status {agent_id}",
+                        job.last_error.as_deref().unwrap_or("unknown error")
+                    );
+                    return Ok(());
+                }
+                _ => {} // Pending or Running: continue polling
+            }
+        }
+        match status.identity.status {
+            AgentRegistryStatus::Deleted => {
+                eprintln!("Deleted agent \"{agent_id}\"");
+                return Ok(());
+            }
+            AgentRegistryStatus::Active => {
+                eprintln!("Agent \"{agent_id}\" is active (deletion may have been cancelled).");
+                return Ok(());
+            }
+            AgentRegistryStatus::Deleting => {} // keep polling
+        }
+    }
+}
+
+fn format_deletion_phase(phase: &AgentDeletionPhase) -> &'static str {
+    use AgentDeletionPhase::*;
+    match phase {
+        Fence => "Fence",
+        Quiesce => "Quiesce",
+        Ingress => "Ingress",
+        Scheduler => "Scheduler",
+        Workspace => "Workspace",
+        Index => "Index",
+        Home => "Home",
+        Finalize => "Finalize",
+    }
+}
+
+fn format_deletion_job_status(status: &AgentDeletionStatus) -> &'static str {
+    use AgentDeletionStatus::*;
+    match status {
+        Pending => "pending",
+        Running => "in progress",
+        RetryableFailed => "failed (retryable)",
+        Completed => "completed",
+    }
+}
+
+fn print_deletion_status(deletion: &AgentDeletionStatusResponse) -> Result<()> {
+    let agent_id = &deletion.identity.agent_id;
+    let status_str = match deletion.identity.status {
+        AgentRegistryStatus::Active => "active",
+        AgentRegistryStatus::Deleting => "deleting",
+        AgentRegistryStatus::Deleted => "deleted",
+    };
+    println!("Agent: {agent_id}");
+    println!("Status: {status_str}");
+    if let Some(ref job) = deletion.job {
+        println!();
+        println!("Deletion Progress:");
+        println!(
+            "  Phase: {} ({})",
+            format_deletion_phase(&job.phase),
+            format_deletion_job_status(&job.status)
+        );
+        println!("  Attempts: {}", job.attempts);
+        if let Some(ref err) = job.last_error {
+            println!("  Last error: {err}");
+        } else {
+            println!("  Last error: (none)");
+        }
+    }
+    Ok(())
 }
 
 async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> Result<()> {

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -40,6 +40,67 @@
     "aliases": []
   },
   {
+    "path": "agent.delete",
+    "positionals": [
+      {
+        "name": "agent_id",
+        "value_name": "AGENT_ID",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "cascade-private-children",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "timeout",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "wait",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "yes",
+        "short": "-y",
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "agent.list",
     "positionals": [],
     "flags": [],


### PR DESCRIPTION
## Summary

Implements Phase 3 PR 1: CLI delete command + agent status deletion progress display.

## Changes

### `holon agent delete <AGENT_ID>` command
- Interactive `y/N` confirmation in TTY; requires `--yes`/`-y` in non-interactive mode
- `--cascade-private-children` flag for supervised descendant cleanup
- `--wait` polls deletion job status with 2s interval; `--timeout` (default 300s) controls max wait
- `--json` for structured output
- Gracefully handles already-deleting (`agent_deleting`) and already-deleted (`agent_deleted`) states

### `holon agent status <ID>` enhancement
- When agent is in `Deleting` or `Deleted` state, automatically fetches and displays deletion job progress (phase, status, attempts, last error)

### `LocalClient` methods
- `delete_agent(agent_id, cascade_private_children)` → calls `DELETE /api/control/agents/{id}`
- `get_agent_deletion_status(agent_id)` → calls `GET /api/control/agents/{id}/delete-status`
- `delete_control_json` helper + `HttpMethod::Delete` variant for HTTP DELETE with JSON body

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- CLI unit tests (`agent_lifecycle_commands_parse_with_optional_agent_id`, etc.) ✅
- HTTP control delete tests (`control_agent_delete_fences_runtime_and_is_idempotent`, `control_agent_delete_rejects_default_and_reports_unknown`) ✅

## Related

- Phase 0–1 PRs: #2419, #2421
- Design: Phase 3 plan (`work_605cea243d44e24`)