### PR TITLE
fix(scheduler): align shadow delivery disposition and admit InternalFollowup through wait gate

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -2733,6 +2733,28 @@ mod tests {
     }
 
     #[test]
+    fn delivery_processed_turn_in_progress_invariant() {
+        // Documents the invariant reviewed in PR #2425: a Processed entry
+        // with turn_in_progress == true is structurally unreachable in
+        // production (settlement and turn termination are coupled by the
+        // run-loop). The function intentionally does not consult
+        // turn_in_progress; it delegates to last_turn_terminal instead.
+        let mut proj = test_projection();
+        proj.turn_in_progress = true;
+        proj.last_turn_terminal = Some(TurnTerminalKind::Completed);
+        let record = test_queue_record(QueueEntryStatus::Processed);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "completed");
+    }
+
+    #[test]
+    fn delivery_interjected_completed() {
+        let mut proj = test_projection();
+        proj.last_turn_terminal = Some(TurnTerminalKind::Completed);
+        let record = test_queue_record(QueueEntryStatus::Interjected);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "completed");
+    }
+
+    #[test]
     fn delivery_none_terminal_processed() {
         let proj = test_projection();
         let record = test_queue_record(QueueEntryStatus::Processed);

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1945,6 +1945,12 @@ fn restricted_delivery_disposition(
     {
         return "failed";
     }
+    // Delegate to the legacy classifier so the shadow candidate uses the same
+    // terminal-kind + queue-status logic. The `turn_in_progress` field is
+    // intentionally not consulted: a Processed entry with turn_in_progress is
+    // structurally unreachable in production (settlement and turn termination
+    // are coupled by the run-loop), so the last_turn_terminal is never stale
+    // when this function is reached for a settled entry.
     let category = turn_terminal_delivery_category(projection.last_turn_terminal, &record.status);
     match (category, &record.status) {
         ("none", QueueEntryStatus::Processed) => "completed",

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1940,19 +1940,15 @@ fn restricted_delivery_disposition(
     projection: &SchedulerProjection,
     record: &QueueEntryRecord,
 ) -> &'static str {
-    match record.status {
-        QueueEntryStatus::Aborted | QueueEntryStatus::Dropped => "failed",
-        QueueEntryStatus::Interrupted | QueueEntryStatus::Interjected => "interrupted",
-        QueueEntryStatus::Processed => {
-            if matches!(projection.status, AgentStatus::Stopped) {
-                "failed"
-            } else if projection.turn_in_progress {
-                "pending"
-            } else {
-                "completed"
-            }
-        }
-        QueueEntryStatus::Queued | QueueEntryStatus::Dequeued => "none",
+    if matches!(projection.status, AgentStatus::Stopped)
+        && matches!(record.status, QueueEntryStatus::Processed)
+    {
+        return "failed";
+    }
+    let category = turn_terminal_delivery_category(projection.last_turn_terminal, &record.status);
+    match (category, &record.status) {
+        ("none", QueueEntryStatus::Processed) => "completed",
+        _ => category,
     }
 }
 
@@ -2123,13 +2119,14 @@ fn restricted_message_model_reentry(
         ) | (
             Some(crate::types::WaitingReason::AwaitingTimer),
             crate::types::ContinuationTriggerKind::TimerFire
-        )
+        ) | (_, crate::types::ContinuationTriggerKind::InternalFollowup)
     );
     if expected {
         return match trigger_kind {
             crate::types::ContinuationTriggerKind::TaskResult => task_terminal && same_work_item,
             crate::types::ContinuationTriggerKind::ExternalEvent
             | crate::types::ContinuationTriggerKind::SystemTick => contentful,
+            crate::types::ContinuationTriggerKind::InternalFollowup => contentful,
             _ => true,
         };
     }
@@ -2661,5 +2658,155 @@ mod tests {
             AdmissionContext::RuntimeOwned,
         );
         assert!(!is_operator_interjection_message(&msg));
+    }
+
+    // --- restricted_delivery_disposition ---
+
+    fn test_projection() -> SchedulerProjection {
+        SchedulerProjection {
+            now: Utc::now(),
+            status: AgentStatus::AwakeIdle,
+            queue_len: 0,
+            active_run_id: None,
+            active_tasks: Vec::new(),
+            has_blocking_active_tasks: false,
+            current_work_item: None,
+            current_work_item_scheduling_state: None,
+            queued_runnable_work_items: Vec::new(),
+            queued_work_items: 0,
+            pending_wake_hint: false,
+            active_waiting_intents: 0,
+            active_work_item_waiting_intents: 0,
+            active_agent_waiting_intents: 0,
+            active_timers: 0,
+            waiting_work_item: None,
+            waiting_work_item_scheduling_state: None,
+            last_turn_terminal: None,
+            turn_in_progress: false,
+            runtime_error: false,
+            semantic_waits: Vec::new(),
+            activation_waits: Vec::new(),
+            canonical_work_statuses: None,
+            semantic_work_items: Vec::new(),
+        }
+    }
+
+    fn test_queue_record(status: QueueEntryStatus) -> QueueEntryRecord {
+        QueueEntryRecord {
+            message_id: "msg-test".into(),
+            agent_id: "agent-test".into(),
+            priority: Priority::Normal,
+            status,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn delivery_completed_processed() {
+        let mut proj = test_projection();
+        proj.last_turn_terminal = Some(TurnTerminalKind::Completed);
+        let record = test_queue_record(QueueEntryStatus::Processed);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "completed");
+    }
+
+    #[test]
+    fn delivery_deferred_to_fallback_processed() {
+        let mut proj = test_projection();
+        proj.last_turn_terminal = Some(TurnTerminalKind::DeferredToFallback);
+        let record = test_queue_record(QueueEntryStatus::Processed);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "pending");
+    }
+
+    #[test]
+    fn delivery_provider_failed_processed() {
+        let mut proj = test_projection();
+        proj.last_turn_terminal = Some(TurnTerminalKind::ProviderFailedNeedsRecovery);
+        let record = test_queue_record(QueueEntryStatus::Processed);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "failed");
+    }
+
+    #[test]
+    fn delivery_none_terminal_processed() {
+        let proj = test_projection();
+        let record = test_queue_record(QueueEntryStatus::Processed);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "completed");
+    }
+
+    #[test]
+    fn delivery_stopped_processed() {
+        let mut proj = test_projection();
+        proj.status = AgentStatus::Stopped;
+        proj.last_turn_terminal = Some(TurnTerminalKind::Completed);
+        let record = test_queue_record(QueueEntryStatus::Processed);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "failed");
+    }
+
+    #[test]
+    fn delivery_aborted_status() {
+        let mut proj = test_projection();
+        proj.last_turn_terminal = Some(TurnTerminalKind::Aborted);
+        let record = test_queue_record(QueueEntryStatus::Aborted);
+        assert_eq!(restricted_delivery_disposition(&proj, &record), "failed");
+    }
+
+    // --- restricted_message_model_reentry ---
+
+    fn internal_followup_msg(text: &str) -> MessageEnvelope {
+        MessageEnvelope::new(
+            "agent-1",
+            MessageKind::InternalFollowup,
+            MessageOrigin::System {
+                subsystem: "runtime".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text { text: text.into() },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        )
+    }
+
+    #[test]
+    fn internal_followup_with_external_wait_contentful_admits_model_turn() {
+        let mut proj = test_projection();
+        proj.active_agent_waiting_intents = 1;
+        let msg = internal_followup_msg("recovery continuation");
+        assert!(restricted_message_model_reentry(&proj, &msg));
+    }
+
+    #[test]
+    fn internal_followup_with_external_wait_empty_body_reduces_message_only() {
+        let mut proj = test_projection();
+        proj.active_agent_waiting_intents = 1;
+        let msg = internal_followup_msg("  ");
+        assert!(!restricted_message_model_reentry(&proj, &msg));
+    }
+
+    #[test]
+    fn internal_followup_without_wait_admits_model_turn() {
+        let proj = test_projection();
+        let msg = internal_followup_msg("continuation");
+        assert!(restricted_message_model_reentry(&proj, &msg));
+    }
+
+    #[test]
+    fn external_event_with_external_wait_empty_body_reduces_message_only() {
+        let mut proj = test_projection();
+        proj.active_agent_waiting_intents = 1;
+        let msg = MessageEnvelope::new(
+            "agent-1",
+            MessageKind::ChannelEvent,
+            MessageOrigin::Channel {
+                channel_id: "ch".into(),
+                sender_id: None,
+            },
+            AuthorityClass::ExternalEvidence,
+            Priority::Normal,
+            MessageBody::Text { text: "  ".into() },
+        );
+        assert!(!restricted_message_model_reentry(&proj, &msg));
     }
 }

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -2141,19 +2141,17 @@ fn delivery_shadow_comparison_detects_divergence_when_turn_aborted_but_settled_p
     });
     storage.write_agent(&agent).unwrap();
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
-    // Queue settled as Processed but the turn was Aborted
+    // Queue settled as Processed and the turn was Aborted — shadow now delegates
+    // to turn_terminal_delivery_category so both sides agree on "failed".
     let record = make_settlement_record("msg-1", QueueEntryStatus::Processed);
     let comparison = scheduler::shadow_comparison_for_delivery(&projection, &record)
         .expect("should produce comparison even with divergence");
-    assert!(!comparison.matched);
-    assert_eq!(
-        comparison.divergence_code,
-        Some("delivery_outcome_mismatch"),
-    );
+    assert!(comparison.matched);
+    assert_eq!(comparison.divergence_code, None);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
     assert_eq!(observation["turn_terminal"], "aborted");
     let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
-    assert_eq!(candidate["delivery_disposition"], "completed");
+    assert_eq!(candidate["delivery_disposition"], "failed");
 }
 
 #[test]
@@ -2197,12 +2195,14 @@ fn delivery_shadow_comparison_matches_interrupted_settlement() {
     let record = make_settlement_record("msg-1", QueueEntryStatus::Interrupted);
     let comparison = scheduler::shadow_comparison_for_delivery(&projection, &record)
         .expect("interrupted delivery should produce comparison");
-    // No turn terminal → "none", restricted says "interrupted" → divergence
-    assert!(!comparison.matched);
+    // No turn terminal → both sides now delegate to turn_terminal_delivery_category
+    // which returns "none" for (None, Interrupted) → match.
+    assert!(comparison.matched);
+    assert_eq!(comparison.divergence_code, None);
     let observation = serde_json::to_value(&comparison.legacy_observation).unwrap();
     assert_eq!(observation["turn_terminal"], "none");
     let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
-    assert_eq!(candidate["delivery_disposition"], "interrupted");
+    assert_eq!(candidate["delivery_disposition"], "none");
 }
 
 #[test]
@@ -2242,13 +2242,16 @@ fn delivery_shadow_comparison_detects_divergence_when_turn_in_progress() {
     agent.current_run_id = Some("run-1".into());
     storage.write_agent(&agent).unwrap();
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
-    // Queue settled as Processed but turn is still in progress
+    // Queue settled as Processed but turn is still in progress. This state is
+    // structurally unreachable in production but tested here to document the
+    // residual divergence: legacy returns "none" (no terminal), shadow returns
+    // "completed" via the (none, Processed) → "completed" mapping.
     let record = make_settlement_record("msg-1", QueueEntryStatus::Processed);
     let comparison = scheduler::shadow_comparison_for_delivery(&projection, &record)
         .expect("should produce comparison even with divergence");
     assert!(!comparison.matched);
     let candidate = serde_json::to_value(&comparison.shadow_candidate).unwrap();
-    assert_eq!(candidate["delivery_disposition"], "pending");
+    assert_eq!(candidate["delivery_disposition"], "completed");
 }
 
 // --- operator interjection shadow comparison (per-boundary) ---


### PR DESCRIPTION
## Summary

Fix two shadow divergence classes in the new scheduler that block authoritative switch:

### Fix A — `delivery_outcome_mismatch` (43 cases)
`restricted_delivery_disposition` did not read `projection.last_turn_terminal`, so when a turn terminated with `DeferredToFallback` or `ProviderFailedNeedsRecovery` and the queue entry was `Processed`, the shadow candidate returned `"completed"` while the legacy classifier `turn_terminal_delivery_category` returned `"pending"` or `"failed"`.

**Fix**: delegate `restricted_delivery_disposition` to `turn_terminal_delivery_category(last_turn_terminal, &record.status)` with:
- `Stopped + Processed` short-circuit → `"failed"` (preserved)
- `(None, Processed)` wrapper → `"completed"` (preserves old shadow behavior for edge case)

### Fix B — `message_admission_outcome_mismatch` (16 cases)
`restricted_message_model_reentry` only allowed `ExternalEvent | SystemTick` as expected triggers for `AwaitingExternalChange` wait; `InternalFollowup` (runtime recovery, provider failover) was rejected and reduced to `message_only`, swallowing continuations.

**Fix**: add `(_, InternalFollowup)` to the expected-pair match; admit when `contentful` (non-empty body), preserving the wait gate for empty/no-op ticks.

### Not addressed
`wait_resume_outcome_mismatch` (1 case) is a legacy deficiency that will auto-resolve on authoritative switch.

## Test plan
- [x] 6 new unit tests for `restricted_delivery_disposition` covering `Completed/DeferredToFallback/ProviderFailedNeedsRecovery/None + Processed`, `Stopped + Processed`, `Aborted + Aborted`
- [x] 4 new unit tests for `restricted_message_model_reentry` covering `InternalFollowup + AwaitingExternalChange` (contentful/empty), `InternalFollowup` without wait, `ExternalEvent + AwaitingExternalChange` empty body
- [x] `cargo test -p holon --lib runtime::scheduler::tests` — 21/21 passed
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean