### PR TITLE
fix(web-gui): redirect to dashboard after agent deletion and for non-existent agents

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -46,7 +46,7 @@ import { canUseRemoteRuntimeConnections, readStoredRemoteConnectionProfiles, use
 import { useAgentDetail } from "../runtime/useAgentDetail";
 import { useRuntimeDashboard } from "../runtime/useRuntimeDashboard";
 import type { AgentSummary, DisplayLevel, RouteKey, RuntimeConnection, RuntimeConnectionConfig, RuntimeConnectionProfile } from "../runtime/types";
-import { pushBrowserRoute, routeFromLocation } from "./routes";
+import { pushBrowserRoute, replaceBrowserRoute, routeFromLocation } from "./routes";
 
 const globalRoutes: Array<{ key: RouteKey; labelKey: string; icon: LucideIcon }> = [
   { key: "dashboard", labelKey: "nav.dashboard", icon: LayoutDashboard },
@@ -341,6 +341,16 @@ export function App() {
       disableDeveloperDiagnosticsUi(selectedAgentId);
     }
   }, [developerDiagnosticsEnabled, disableDeveloperDiagnosticsUi, selectedAgentId]);
+
+  // Redirect to dashboard when the user opens a non-existent agent (e.g. typed
+  // a stale URL). Wait for both bootstrap and agent-detail loading to finish
+  // so we don't redirect during initial load.
+  useEffect(() => {
+    if (route === "agent" && !loading && !bootstrap.connection.error && !activeAgent && !agentDetailLoading) {
+      setRoute("dashboard");
+      replaceBrowserRoute("dashboard");
+    }
+  }, [route, loading, bootstrap.connection.error, activeAgent, agentDetailLoading, setRoute]);
 
   function navigateRoute(nextRoute: RouteKey) {
     setRoute(nextRoute);
@@ -759,7 +769,10 @@ export function App() {
         <RightSidePanel
           agent={selectedAgent}
           onControlAgent={async (action) => { await controlAgent(selectedAgent.id, action); }}
-          onDeleteAgent={async (cascade) => { await deleteAgent(selectedAgent.id, cascade); }}
+          onDeleteAgent={async (cascade) => {
+            await deleteAgent(selectedAgent.id, cascade);
+            pushBrowserRoute("dashboard");
+          }}
           connection={bootstrap.connection}
           skillCatalog={agentSkillCatalog}
           availableSkillCatalog={skillCatalog}

--- a/web-gui/app/src/app/routes.ts
+++ b/web-gui/app/src/app/routes.ts
@@ -68,6 +68,12 @@ export function pushBrowserRoute(route: RouteKey, agentId?: string, templateId?:
   window.history.pushState(null, "", nextPath);
 }
 
+export function replaceBrowserRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>): void {
+  const nextPath = pathForRoute(route, agentId, templateId, query);
+  if (`${window.location.pathname}${window.location.search}` === nextPath) return;
+  window.history.replaceState(null, "", nextPath);
+}
+
 function safeDecodeURIComponent(value: string): string {
   try {
     return decodeURIComponent(value);

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -3068,6 +3068,17 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       await request.client.deleteAgent(agentId, cascadePrivateChildren);
       if (!isCurrentClientRequest(request)) return;
       await get().refreshBootstrap({ background: true });
+      // If we deleted the currently selected agent, clean up and reset to dashboard
+      // so the UI doesn't stay on a stale agent page that errors on refresh.
+      if (get().selectedAgentId === agentId) {
+        stopAgentEventStream(agentId, set);
+        set({
+          selectedAgentId: "",
+          route: "dashboard",
+          rightPanelView: undefined,
+          rightPanelViewStack: [],
+        });
+      }
     } catch (error) {
       if (!isCurrentClientRequest(request)) return;
       throw error;


### PR DESCRIPTION
## Changes

### 1. Redirect after agent deletion

When the user deletes an agent from the agent overview panel, the UI used to stay on the deleted agent's page. Refreshing would then error because the agent no longer exists.

- `runtime-store.ts` `deleteAgent`: after successful deletion, if the deleted agent is the currently selected one, stop its event stream, clear `selectedAgentId`, reset `route` to `dashboard`, and clear right-panel state.
- `App.tsx` `onDeleteAgent`: after `deleteAgent` resolves, call `pushBrowserRoute("dashboard")` to update the browser URL.

### 2. Redirect for non-existent agent

When a user manually types or opens a URL for an agent that doesn't exist (e.g. a stale bookmark), the page would show errors instead of navigating away.

- `App.tsx`: new `useEffect` that redirects to dashboard when `route === "agent"` and both bootstrap and agent-detail loading have finished but `activeAgent` is `null`.
- `routes.ts`: new `replaceBrowserRoute` helper using `history.replaceState` so the invalid URL doesn't stay in browser history, preventing a redirect loop via the back button.

## Verification

- TypeScript compilation passes (`tsc --noEmit`).
