### PR TITLE
fix: scheduler shadow comparison identity conflict + 统一 OCC 重试

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2246,7 +2246,10 @@ impl RuntimeHandle {
         Ok(commit)
     }
 
-    pub(crate) async fn refresh_enqueue_agent_state_baseline(&self, agent_id: &str) -> Result<bool> {
+    pub(crate) async fn refresh_enqueue_agent_state_baseline(
+        &self,
+        agent_id: &str,
+    ) -> Result<bool> {
         let mut guard = self.inner.agent.lock().await;
         let Some(latest_persisted_state) = self.inner.runtime_db.agent_states().latest(agent_id)?
         else {
@@ -2347,7 +2350,9 @@ impl RuntimeHandle {
             // Rebuild guard-dependent fields from the current baseline.
             let (agent_state, shadow_comparison, delivery_shadow_comparison) = {
                 let guard = self.inner.agent.lock().await;
-                let mut state = committed_agent_state.clone().unwrap_or_else(|| guard.state.clone());
+                let mut state = committed_agent_state
+                    .clone()
+                    .unwrap_or_else(|| guard.state.clone());
                 let agent_state = if let Some(transition) = terminal_transition {
                     state.current_turn_id = Some(transition.terminal.turn_id.clone());
                     state.last_turn_terminal = Some(transition.terminal.clone());
@@ -2365,18 +2370,14 @@ impl RuntimeHandle {
                     queue_len,
                     self.now(),
                 )?;
-                let shadow_comparison = scheduler::shadow_comparison_for_settlement(
-                    &projection,
-                    &record,
-                )
-                .map(scheduler_executor::scheduler_shadow_comparison_command)
-                .transpose()?;
-                let delivery_shadow_comparison = scheduler::shadow_comparison_for_delivery(
-                    &projection,
-                    &record,
-                )
-                .map(scheduler_executor::scheduler_shadow_comparison_command)
-                .transpose()?;
+                let shadow_comparison =
+                    scheduler::shadow_comparison_for_settlement(&projection, &record)
+                        .map(scheduler_executor::scheduler_shadow_comparison_command)
+                        .transpose()?;
+                let delivery_shadow_comparison =
+                    scheduler::shadow_comparison_for_delivery(&projection, &record)
+                        .map(scheduler_executor::scheduler_shadow_comparison_command)
+                        .transpose()?;
                 (agent_state, shadow_comparison, delivery_shadow_comparison)
             };
             command.agent_state = agent_state;
@@ -3438,7 +3439,10 @@ fn normalized_turn_id(turn_id: Option<&str>) -> Option<String> {
         .map(ToString::to_string)
 }
 
-pub(crate) fn retryable_enqueue_agent_state_conflict(error: &anyhow::Error, agent_id: &str) -> bool {
+pub(crate) fn retryable_enqueue_agent_state_conflict(
+    error: &anyhow::Error,
+    agent_id: &str,
+) -> bool {
     error.chain().any(|source| {
         source
             .downcast_ref::<RuntimeStateTransitionConflict>()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1041,6 +1041,12 @@ struct RuntimeAgent {
 impl RuntimeAgent {
     fn persist_state(&mut self, storage: &AppStorage) -> Result<()> {
         let started = std::time::Instant::now();
+        // persist_state bypasses OCC (uses upsert, not expected-snapshot
+        // validation). This is intentional for control-plane operations
+        // (Start/Stop/shutdown) that need to force-write agent state.
+        // After a successful write, last_persisted_state is set to
+        // self.state so subsequent commit_queue OCC checks use the
+        // correct baseline. On failure, self.state is reverted.
         if let Err(error) = storage.write_agent(&self.state) {
             self.state = self.last_persisted_state.clone();
             crate::diagnostics::record_storage_persist_state(started.elapsed());
@@ -2893,6 +2899,7 @@ impl RuntimeHandle {
         let mut recovered = 0;
 
         for mut entry in claimed {
+            let _guard = self.inner.agent.lock().await;
             let expected_entry = entry.clone();
             let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
             let Some(activation) = snapshot.activations.get(&activation_id) else {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -129,7 +129,7 @@ use continuation::{resolve_continuation, ContinuationTrigger};
 use subagent::sanitize_subagent_result;
 use turn::LoopControlOptions;
 
-const ENQUEUE_AGENT_STATE_MAX_ATTEMPTS: usize = 3;
+pub(crate) const ENQUEUE_AGENT_STATE_MAX_ATTEMPTS: usize = 3;
 
 #[derive(Debug, Clone)]
 pub(super) struct WorkItemCompletionReportPromotion {
@@ -2240,7 +2240,7 @@ impl RuntimeHandle {
         Ok(commit)
     }
 
-    async fn refresh_enqueue_agent_state_baseline(&self, agent_id: &str) -> Result<bool> {
+    pub(crate) async fn refresh_enqueue_agent_state_baseline(&self, agent_id: &str) -> Result<bool> {
         let mut guard = self.inner.agent.lock().await;
         let Some(latest_persisted_state) = self.inner.runtime_db.agent_states().latest(agent_id)?
         else {
@@ -2296,7 +2296,7 @@ impl RuntimeHandle {
     async fn commit_queue_terminal_settlement_with_evidence(
         &self,
         record: QueueEntryRecord,
-        mut audit_events: Vec<AuditEvent>,
+        audit_events: Vec<AuditEvent>,
         notify_scheduler: bool,
         terminal_transition: Option<&turn::TurnTerminalTransition>,
         committed_agent_state: Option<AgentState>,
@@ -2312,77 +2312,100 @@ impl RuntimeHandle {
                 &[scheduler::SETTLEMENT_SCENARIO, scheduler::DELIVERY_SCENARIO],
                 self.scheduler_protocol_production_commands_enabled(),
             )?;
-        let (projection_state, queue_len, agent_state) = {
-            let guard = self.inner.agent.lock().await;
-            let mut state = committed_agent_state.unwrap_or_else(|| guard.state.clone());
-            let agent_state = if let Some(transition) = terminal_transition {
-                state.current_turn_id = Some(transition.terminal.turn_id.clone());
-                state.last_turn_terminal = Some(transition.terminal.clone());
-                Some(crate::runtime_db::transitions::AgentStateMutation {
-                    expected: Some(Box::new(guard.last_persisted_state.clone())),
-                    record: Box::new(state.clone()),
-                })
-            } else {
-                None
+        let original_audit_len = audit_events.len();
+        let mut command = crate::runtime_db::transitions::QueueTransitionCommand {
+            agent_id: record.agent_id.clone(),
+            operation: crate::runtime_db::transitions::QueueOperation::Settle,
+            mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record.clone()),
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: scheduler_protocol_commands.clone(),
+            scheduler_authority_scenarios: vec![
+                scheduler::SETTLEMENT_SCENARIO,
+                scheduler::DELIVERY_SCENARIO,
+            ],
+            scheduler_rollout_expectations: scheduler_rollout_expectations.clone(),
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: transcript_entries.clone(),
+            turn_record: terminal_transition.map(|transition| transition.turn_record.clone()),
+            audit_events: audit_events.clone(),
+            scheduler_shadow_comparison: None,
+            scheduler_delivery_shadow_comparison: None,
+            scheduler_semantic_shadow: None,
+            notify_scheduler,
+            fault: None,
+            brief_evidence: brief_evidence.clone(),
+        };
+        for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+            // Rebuild guard-dependent fields from the current baseline.
+            let (agent_state, shadow_comparison, delivery_shadow_comparison) = {
+                let guard = self.inner.agent.lock().await;
+                let mut state = committed_agent_state.clone().unwrap_or_else(|| guard.state.clone());
+                let agent_state = if let Some(transition) = terminal_transition {
+                    state.current_turn_id = Some(transition.terminal.turn_id.clone());
+                    state.last_turn_terminal = Some(transition.terminal.clone());
+                    Some(crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(guard.last_persisted_state.clone())),
+                        record: Box::new(state.clone()),
+                    })
+                } else {
+                    None
+                };
+                let queue_len = guard.queue.len();
+                let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
+                    &self.inner.storage,
+                    &state,
+                    queue_len,
+                    self.now(),
+                )?;
+                let shadow_comparison = scheduler::shadow_comparison_for_settlement(
+                    &projection,
+                    &record,
+                )
+                .map(scheduler_executor::scheduler_shadow_comparison_command)
+                .transpose()?;
+                let delivery_shadow_comparison = scheduler::shadow_comparison_for_delivery(
+                    &projection,
+                    &record,
+                )
+                .map(scheduler_executor::scheduler_shadow_comparison_command)
+                .transpose()?;
+                (agent_state, shadow_comparison, delivery_shadow_comparison)
             };
-            (state, guard.queue.len(), agent_state)
-        };
-        let shadow_comparison = {
-            let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
-                &self.inner.storage,
-                &projection_state,
-                queue_len,
-                self.now(),
-            )?;
-            scheduler::shadow_comparison_for_settlement(&projection, &record)
-                .map(scheduler_executor::scheduler_shadow_comparison_command)
-                .transpose()?
-        };
-        let delivery_shadow_comparison = {
-            let projection = scheduler::SchedulerProjection::from_state_with_queue_len_at(
-                &self.inner.storage,
-                &projection_state,
-                queue_len,
-                self.now(),
-            )?;
-            scheduler::shadow_comparison_for_delivery(&projection, &record)
-                .map(scheduler_executor::scheduler_shadow_comparison_command)
-                .transpose()?
-        };
-        if let Some(transition) = terminal_transition {
-            audit_events.push(AuditEvent::legacy(
-                "turn_terminal",
-                serde_json::to_value(&transition.terminal)?,
-            ));
-            audit_events.push(Self::turn_record_audit_event(&transition.turn_record));
+            command.agent_state = agent_state;
+            command.scheduler_shadow_comparison = shadow_comparison;
+            command.scheduler_delivery_shadow_comparison = delivery_shadow_comparison;
+            command.audit_events = audit_events.clone();
+            command.audit_events.truncate(original_audit_len);
+            if let Some(transition) = terminal_transition {
+                command.audit_events.push(AuditEvent::legacy(
+                    "turn_terminal",
+                    serde_json::to_value(&transition.terminal)?,
+                ));
+                command
+                    .audit_events
+                    .push(Self::turn_record_audit_event(&transition.turn_record));
+            }
+            command.fault = self.take_transition_fault();
+            match self.inner.runtime_db.transitions().commit_queue(&command) {
+                Ok(commit) => {
+                    return Ok(self.apply_transition_commit(commit).await.applied);
+                }
+                Err(error) => {
+                    let can_retry = attempt + 1 < ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                        && retryable_enqueue_agent_state_conflict(&error, &record.agent_id);
+                    if !can_retry
+                        || !self
+                            .refresh_enqueue_agent_state_baseline(&record.agent_id)
+                            .await?
+                    {
+                        return Err(error);
+                    }
+                }
+            }
         }
-        let commit = self.inner.runtime_db.transitions().commit_queue(
-            &crate::runtime_db::transitions::QueueTransitionCommand {
-                agent_id: record.agent_id.clone(),
-                operation: crate::runtime_db::transitions::QueueOperation::Settle,
-                mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record),
-                scheduler_claim_work_item: None,
-                scheduler_protocol_bootstrap: None,
-                scheduler_protocol_commands,
-                scheduler_authority_scenarios: vec![
-                    scheduler::SETTLEMENT_SCENARIO,
-                    scheduler::DELIVERY_SCENARIO,
-                ],
-                scheduler_rollout_expectations,
-                agent_state,
-                message_evidence: Vec::new(),
-                transcript_entries,
-                turn_record: terminal_transition.map(|transition| transition.turn_record.clone()),
-                audit_events,
-                scheduler_shadow_comparison: shadow_comparison,
-                scheduler_delivery_shadow_comparison: delivery_shadow_comparison,
-                scheduler_semantic_shadow: None,
-                notify_scheduler,
-                fault: self.take_transition_fault(),
-                brief_evidence,
-            },
-        )?;
-        Ok(self.apply_transition_commit(commit).await.applied)
+        unreachable!("settlement OCC retry loop always returns or errors")
     }
 
     async fn canonical_queue_settlement_commands(
@@ -3408,7 +3431,7 @@ fn normalized_turn_id(turn_id: Option<&str>) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn retryable_enqueue_agent_state_conflict(error: &anyhow::Error, agent_id: &str) -> bool {
+pub(crate) fn retryable_enqueue_agent_state_conflict(error: &anyhow::Error, agent_id: &str) -> bool {
     error.chain().any(|source| {
         source
             .downcast_ref::<RuntimeStateTransitionConflict>()

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -820,8 +820,9 @@ impl RuntimeHandle {
                     &crate::runtime_db::transitions::QueueTransitionCommand {
                         agent_id: message.agent_id.clone(),
                         operation: crate::runtime_db::transitions::QueueOperation::Admit,
-                        mutation:
-                            crate::runtime_db::transitions::QueueMutation::Upsert(queue_record),
+                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
+                            queue_record,
+                        ),
                         scheduler_claim_work_item: None,
                         scheduler_protocol_bootstrap: None,
                         scheduler_protocol_commands: Vec::new(),
@@ -848,20 +849,13 @@ impl RuntimeHandle {
                 let mut commit = match commit_result {
                     Ok(commit) => commit,
                     Err(error) => {
-                        let can_retry = attempt + 1
-                            < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
-                            && super::retryable_enqueue_agent_state_conflict(
-                                &error,
-                                &agent_id,
-                            );
+                        let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                            && super::retryable_enqueue_agent_state_conflict(&error, &agent_id);
                         if !can_retry {
                             return Err(error);
                         }
                         drop(guard);
-                        if !self
-                            .refresh_enqueue_agent_state_baseline(&agent_id)
-                            .await?
-                        {
+                        if !self.refresh_enqueue_agent_state_baseline(&agent_id).await? {
                             return Err(error);
                         }
                         attempt += 1;

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -763,86 +763,122 @@ impl RuntimeHandle {
                 &MessageLifecycleAuditEvent::from_message(&message),
             )?,
         ]);
+        let base_audit_events = audit_events.clone();
         let mut commit = {
-            let mut guard = self.inner.agent.lock().await;
-            let expected_persisted_state = guard.last_persisted_state.clone();
-            let mut committed_state = guard.state.clone();
-            let previous_status = committed_state.status.clone();
-            let previous_sleeping_until = committed_state.sleeping_until;
-            committed_state.pending = guard.queue.len().saturating_add(1);
-            committed_state.last_wake_reason = Some(format!("{:?}", message.kind));
-            committed_state.total_message_count =
-                self.inner.storage.count_messages()?.saturating_add(1);
-            if scheduler::apply_message_wake_projection(&mut committed_state) {
-                audit_events.push(AuditEvent::legacy(
-                    "scheduler_posture_decision",
-                    serde_json::json!({
-                        "boundary": "message_admission",
-                        "reason": "message_admission_wake",
-                        "previous_status": previous_status,
-                        "next_status": committed_state.status,
-                        "evidence": [
-                            format!("message_id={}", message.id),
-                            format!("message_kind={:?}", message.kind),
-                            format!("previous_sleeping_until={previous_sleeping_until:?}"),
-                        ],
-                    }),
-                ));
-            }
-            let queue_record = QueueEntryRecord {
-                message_id: message.id.clone(),
-                agent_id: message.agent_id.clone(),
-                priority: message.priority.clone(),
-                status: QueueEntryStatus::Queued,
-                created_at: message.created_at,
-                updated_at: Utc::now(),
-            };
-            let scheduler_rollout_expectations = self
-                .inner
-                .runtime_db
-                .transitions()
-                .scheduler_rollout_expectations(
-                    &[scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO],
-                    self.scheduler_protocol_production_commands_enabled(),
-                )?;
-            let mut commit = self.inner.runtime_db.transitions().commit_queue(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
+            let agent_id = message.agent_id.clone();
+            let mut attempt = 0;
+            loop {
+                if attempt >= super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+                    return Err(anyhow!(
+                        "work queue tick admission OCC retry exhausted for agent {}",
+                        agent_id
+                    ));
+                }
+                let mut guard = self.inner.agent.lock().await;
+                let expected_persisted_state = guard.last_persisted_state.clone();
+                let mut committed_state = guard.state.clone();
+                let previous_status = committed_state.status.clone();
+                let previous_sleeping_until = committed_state.sleeping_until;
+                committed_state.pending = guard.queue.len().saturating_add(1);
+                committed_state.last_wake_reason = Some(format!("{:?}", message.kind));
+                committed_state.total_message_count =
+                    self.inner.storage.count_messages()?.saturating_add(1);
+                let mut audit_events = base_audit_events.clone();
+                if scheduler::apply_message_wake_projection(&mut committed_state) {
+                    audit_events.push(AuditEvent::legacy(
+                        "scheduler_posture_decision",
+                        serde_json::json!({
+                            "boundary": "message_admission",
+                            "reason": "message_admission_wake",
+                            "previous_status": previous_status,
+                            "next_status": committed_state.status,
+                            "evidence": [
+                                format!("message_id={}", message.id),
+                                format!("message_kind={:?}", message.kind),
+                                format!("previous_sleeping_until={previous_sleeping_until:?}"),
+                            ],
+                        }),
+                    ));
+                }
+                let queue_record = QueueEntryRecord {
+                    message_id: message.id.clone(),
                     agent_id: message.agent_id.clone(),
-                    operation: crate::runtime_db::transitions::QueueOperation::Admit,
-                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(queue_record),
-                    scheduler_claim_work_item: None,
-                    scheduler_protocol_bootstrap: None,
-                    scheduler_protocol_commands: Vec::new(),
-                    scheduler_authority_scenarios: vec![
-                        scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
-                    ],
-                    scheduler_rollout_expectations,
-                    agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(expected_persisted_state)),
-                        record: Box::new(committed_state.clone()),
-                    }),
-                    message_evidence: vec![message.clone()],
-                    transcript_entries: Vec::new(),
-                    turn_record: None,
-                    audit_events,
-                    scheduler_shadow_comparison,
-                    scheduler_delivery_shadow_comparison: None,
-                    scheduler_semantic_shadow: None,
-                    notify_scheduler: true,
-                    fault: self.take_transition_fault(),
-                    brief_evidence: Vec::new(),
-                },
-            )?;
-            if !commit.applied {
-                return Err(anyhow!(
-                    "work queue tick admission made no durable progress"
-                ));
+                    priority: message.priority.clone(),
+                    status: QueueEntryStatus::Queued,
+                    created_at: message.created_at,
+                    updated_at: Utc::now(),
+                };
+                let scheduler_rollout_expectations = self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .scheduler_rollout_expectations(
+                        &[scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO],
+                        self.scheduler_protocol_production_commands_enabled(),
+                    )?;
+                let commit_result = self.inner.runtime_db.transitions().commit_queue(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: message.agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Admit,
+                        mutation:
+                            crate::runtime_db::transitions::QueueMutation::Upsert(queue_record),
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        scheduler_authority_scenarios: vec![
+                            scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
+                        ],
+                        scheduler_rollout_expectations,
+                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                            expected: Some(Box::new(expected_persisted_state)),
+                            record: Box::new(committed_state.clone()),
+                        }),
+                        message_evidence: vec![message.clone()],
+                        transcript_entries: Vec::new(),
+                        turn_record: None,
+                        audit_events,
+                        scheduler_shadow_comparison: scheduler_shadow_comparison.clone(),
+                        scheduler_delivery_shadow_comparison: None,
+                        scheduler_semantic_shadow: None,
+                        notify_scheduler: true,
+                        fault: self.take_transition_fault(),
+                        brief_evidence: Vec::new(),
+                    },
+                );
+                let mut commit = match commit_result {
+                    Ok(commit) => commit,
+                    Err(error) => {
+                        let can_retry = attempt + 1
+                            < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                            && super::retryable_enqueue_agent_state_conflict(
+                                &error,
+                                &agent_id,
+                            );
+                        if !can_retry {
+                            return Err(error);
+                        }
+                        drop(guard);
+                        if !self
+                            .refresh_enqueue_agent_state_baseline(&agent_id)
+                            .await?
+                        {
+                            return Err(error);
+                        }
+                        attempt += 1;
+                        continue;
+                    }
+                };
+                if !commit.applied {
+                    return Err(anyhow!(
+                        "work queue tick admission made no durable progress"
+                    ));
+                }
+                guard.queue.push(message.clone());
+                guard.state = committed_state.clone();
+                guard.last_persisted_state = committed_state;
+                commit.effects.agent_state = None;
+                break commit;
             }
-            guard.queue.push(message);
-            guard.state = committed_state.clone();
-            guard.last_persisted_state = committed_state;
-            commit.effects.agent_state = None;
-            commit
         };
         commit.effects.notify_scheduler = true;
         self.apply_transition_commit(commit).await;

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -449,21 +449,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         )?;
 
         let (message, running_state, transition_commit) = {
-            let mut guard = self.runtime.inner.agent.lock().await;
-            if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
-                return self.shutdown(guard);
-            }
-            if matches!(guard.state.status, AgentStatus::Stopped) {
-                return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
-            }
-            if !guard
-                .queue
-                .peek()
-                .is_some_and(|message| message.id == candidate.message.id)
-            {
-                return Ok(RunLoopPoll::Idle);
-            }
-
             let queue_record = QueueEntryRecord {
                 message_id: candidate.message.id.clone(),
                 agent_id: candidate.message.agent_id.clone(),
@@ -474,82 +459,124 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             };
             let run_id = crate::ids::run_id();
             let abort_token = CancellationToken::new();
-            let mut running_state = guard.state.clone();
-            running_state.pending = guard.queue.len().saturating_sub(1);
-            scheduler::apply_running_projection(&mut running_state, run_id.clone());
-            running_state.last_wake_reason = Some(format!("{:?}", candidate.message.kind));
-            let mut commit = self.runtime.inner.runtime_db.transitions().commit_queue(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
-                    agent_id: candidate.message.agent_id.clone(),
-                    operation: crate::runtime_db::transitions::QueueOperation::Claim,
-                    mutation: crate::runtime_db::transitions::QueueMutation::Consume(
-                        queue_record.clone(),
-                    ),
-                    scheduler_claim_work_item: canonical_claim
-                        .as_ref()
-                        .and_then(|plan| plan.scheduler_claim_work_item.clone()),
-                    scheduler_protocol_bootstrap: canonical_claim
-                        .as_ref()
-                        .and_then(|plan| plan.bootstrap.clone()),
-                    scheduler_protocol_commands: canonical_claim
-                        .as_ref()
-                        .map(|plan| plan.commands.clone())
-                        .unwrap_or_default(),
-                    scheduler_authority_scenarios,
-                    scheduler_rollout_expectations,
-                    agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(guard.state.clone())),
-                        record: Box::new(running_state.clone()),
+            let claim_audit_events = vec![
+                scheduler_decision_events[0].clone(),
+                scheduler_decision_events[1].clone(),
+                AuditEvent::legacy(
+                    "queue_entry_claimed",
+                    serde_json::json!({
+                        "message_id": queue_record.message_id,
+                        "agent_id": queue_record.agent_id,
+                        "status": QueueEntryStatus::Dequeued,
+                        "run_id": run_id,
                     }),
-                    message_evidence: Vec::new(),
-                    transcript_entries: Vec::new(),
-                    turn_record: None,
-                    audit_events: vec![
-                        scheduler_decision_events[0].clone(),
-                        scheduler_decision_events[1].clone(),
-                        AuditEvent::legacy(
-                            "queue_entry_claimed",
-                            serde_json::json!({
-                                "message_id": queue_record.message_id,
-                                "agent_id": queue_record.agent_id,
-                                "status": QueueEntryStatus::Dequeued,
-                                "run_id": run_id,
-                            }),
+                ),
+            ];
+            let agent_id = candidate.message.agent_id.clone();
+            let mut attempt = 0;
+            loop {
+                if attempt >= super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+                    return Err(anyhow!("claim OCC retry exhausted for agent {}", agent_id));
+                }
+                let mut guard = self.runtime.inner.agent.lock().await;
+                if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
+                    return self.shutdown(guard);
+                }
+                if matches!(guard.state.status, AgentStatus::Stopped) {
+                    return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
+                }
+                if !guard
+                    .queue
+                    .peek()
+                    .is_some_and(|message| message.id == candidate.message.id)
+                {
+                    return Ok(RunLoopPoll::Idle);
+                }
+                let mut running_state = guard.state.clone();
+                running_state.pending = guard.queue.len().saturating_sub(1);
+                scheduler::apply_running_projection(&mut running_state, run_id.clone());
+                running_state.last_wake_reason = Some(format!("{:?}", candidate.message.kind));
+                let commit_result = self.runtime.inner.runtime_db.transitions().commit_queue(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Claim,
+                        mutation: crate::runtime_db::transitions::QueueMutation::Consume(
+                            queue_record.clone(),
                         ),
-                    ],
-                    scheduler_shadow_comparison: shadow_comparison,
-                    scheduler_delivery_shadow_comparison: None,
-                    scheduler_semantic_shadow: semantic_shadow,
-                    notify_scheduler: false,
-                    fault: self.runtime.take_transition_fault(),
-                    brief_evidence: Vec::new(),
-                },
-            )?;
-            if commit.scheduler_authority_blocked {
+                        scheduler_claim_work_item: canonical_claim
+                            .as_ref()
+                            .and_then(|plan| plan.scheduler_claim_work_item.clone()),
+                        scheduler_protocol_bootstrap: canonical_claim
+                            .as_ref()
+                            .and_then(|plan| plan.bootstrap.clone()),
+                        scheduler_protocol_commands: canonical_claim
+                            .as_ref()
+                            .map(|plan| plan.commands.clone())
+                            .unwrap_or_default(),
+                        scheduler_authority_scenarios: scheduler_authority_scenarios.clone(),
+                        scheduler_rollout_expectations: scheduler_rollout_expectations.clone(),
+                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                            expected: Some(Box::new(guard.state.clone())),
+                            record: Box::new(running_state.clone()),
+                        }),
+                        message_evidence: Vec::new(),
+                        transcript_entries: Vec::new(),
+                        turn_record: None,
+                        audit_events: claim_audit_events.clone(),
+                        scheduler_shadow_comparison: shadow_comparison.clone(),
+                        scheduler_delivery_shadow_comparison: None,
+                        scheduler_semantic_shadow: semantic_shadow.clone(),
+                        notify_scheduler: false,
+                        fault: self.runtime.take_transition_fault(),
+                        brief_evidence: Vec::new(),
+                    },
+                );
+                let mut commit = match commit_result {
+                    Ok(commit) => commit,
+                    Err(error) => {
+                        let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                            && super::retryable_enqueue_agent_state_conflict(&error, &agent_id);
+                        if !can_retry {
+                            return Err(error);
+                        }
+                        drop(guard);
+                        if !self
+                            .runtime
+                            .refresh_enqueue_agent_state_baseline(&agent_id)
+                            .await?
+                        {
+                            return Err(error);
+                        }
+                        attempt += 1;
+                        continue;
+                    }
+                };
+                if commit.scheduler_authority_blocked {
+                    commit.effects.agent_state = None;
+                    drop(guard);
+                    self.runtime.apply_transition_commit(commit).await;
+                    return Ok(RunLoopPoll::Idle);
+                }
+                if !commit.applied {
+                    let _ = guard.queue.pop_if_next(&candidate.message.id);
+                    guard.state.pending = guard.queue.len();
+                    guard.persist_state(&self.runtime.inner.storage)?;
+                    return Ok(RunLoopPoll::Idle);
+                }
+                let message = guard
+                    .queue
+                    .pop_if_next(&candidate.message.id)
+                    .expect("queue head was just checked");
+                guard.state = running_state.clone();
+                guard.last_persisted_state = running_state.clone();
+                guard.current_run_abort = Some(CurrentRunAbortHandle {
+                    run_id: run_id.clone(),
+                    token: abort_token,
+                    reason: Arc::new(StdMutex::new("operator_aborted".into())),
+                });
                 commit.effects.agent_state = None;
-                drop(guard);
-                self.runtime.apply_transition_commit(commit).await;
-                return Ok(RunLoopPoll::Idle);
+                break (message, running_state, commit);
             }
-            if !commit.applied {
-                let _ = guard.queue.pop_if_next(&candidate.message.id);
-                guard.state.pending = guard.queue.len();
-                guard.persist_state(&self.runtime.inner.storage)?;
-                return Ok(RunLoopPoll::Idle);
-            }
-            let message = guard
-                .queue
-                .pop_if_next(&candidate.message.id)
-                .expect("queue head was just checked");
-            guard.state = running_state.clone();
-            guard.last_persisted_state = running_state.clone();
-            guard.current_run_abort = Some(CurrentRunAbortHandle {
-                run_id: run_id.clone(),
-                token: abort_token,
-                reason: Arc::new(StdMutex::new("operator_aborted".into())),
-            });
-            commit.effects.agent_state = None;
-            (message, running_state, commit)
         };
         self.runtime
             .apply_transition_commit(transition_commit)

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -8870,3 +8870,231 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
         Some(runtime.agent_state().await.unwrap())
     );
 }
+
+#[tokio::test]
+async fn release_interrupts_message_and_cleans_up_shadow_comparison_records() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let connection = runtime.inner.runtime_db.connection().unwrap();
+    connection
+        .execute(
+            "UPDATE scheduler_protocol_config
+             SET protocol_mode = 'shadow',
+                 config_revision = 1,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE config_id = 1",
+            [],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO scheduler_scenario_authorities (
+               scenario_class, mode, rollback_target,
+               manifest_revision, preflight_revision, updated_at
+             ) VALUES (
+               'reducer_only_candidates', 'shadow', 'off',
+               NULL, NULL, CURRENT_TIMESTAMP
+             )",
+            [],
+        )
+        .unwrap();
+
+    let message = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::WebhookEvent,
+            MessageOrigin::Webhook {
+                source: "shadow-cleanup-test".into(),
+                event_type: Some("ping".into()),
+            },
+            AuthorityClass::ExternalEvidence,
+            Priority::Normal,
+            MessageBody::Text {
+                text: String::new(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Claim the message — this writes a shadow comparison record.
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+
+    // Verify the shadow comparison record exists.
+    let shadow_count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM scheduler_shadow_comparisons WHERE agent_id = 'default'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        shadow_count > 0,
+        "shadow comparison records should exist after claim"
+    );
+
+    // Release the message (interrupt it).
+    let interrupted = QueueEntryRecord {
+        message_id: message.id.clone(),
+        agent_id: "default".to_string(),
+        priority: Priority::Normal,
+        status: QueueEntryStatus::Interrupted,
+        created_at: message.created_at,
+        updated_at: Utc::now(),
+    };
+    runtime
+        .commit_queue_settlement(interrupted, Vec::new(), false)
+        .await
+        .unwrap();
+
+    // Verify the shadow comparison records for this message are cleaned up.
+    let remaining_count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM scheduler_shadow_comparisons
+             WHERE agent_id = 'default'
+               AND comparison_identity LIKE '%' || ?1",
+            [&message.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        remaining_count, 0,
+        "shadow comparison records should be cleaned up after release"
+    );
+}
+
+#[tokio::test]
+async fn shadow_comparison_identity_conflict_allows_overwrite() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let conn = runtime.inner.runtime_db.connection().unwrap();
+    conn.execute(
+        "UPDATE scheduler_protocol_config
+         SET protocol_mode = 'shadow',
+             config_revision = 1,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE config_id = 1",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO scheduler_scenario_authorities (
+           scenario_class, mode, rollback_target,
+           manifest_revision, preflight_revision, updated_at
+         ) VALUES (
+           'reducer_only_candidates', 'shadow', 'off',
+           NULL, NULL, CURRENT_TIMESTAMP
+         )",
+        [],
+    )
+    .unwrap();
+
+    // Insert a stale shadow comparison record directly.
+    conn.execute(
+        "INSERT INTO scheduler_shadow_comparisons (
+           agent_id, scenario_class, comparison_identity,
+           canonical_schema_version, payload_hash, boundary, input_identity,
+           authority_mode, legacy_observation_json, shadow_candidate_json,
+           comparison_outcome, divergence_code, created_at
+         ) VALUES ('default', 'reducer_only_candidates', 'message_admission:msg_stale',
+           1, 'sha256:old_hash', 'run_loop', 'old_input',
+           'shadow', '{}', '{}', 'matched', NULL, '2025-01-01T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    // Build a new shadow comparison with the same identity but different payload.
+    let new_command = crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerShadowComparisonCommand {
+        scenario_class: "reducer_only_candidates".into(),
+        comparison_identity: "message_admission:msg_stale".into(),
+        boundary: "run_loop".into(),
+        input_identity: "new_input".into(),
+        legacy_observation: serde_json::json!({}),
+        shadow_candidate: serde_json::json!({}),
+        matched: true,
+        divergence_code: None,
+    };
+
+    // Validate via commit_queue — should NOT fail with identity conflict.
+    let record = QueueEntryRecord {
+        message_id: "msg_stale".into(),
+        agent_id: "default".into(),
+        priority: Priority::Normal,
+        status: QueueEntryStatus::Queued,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let result = runtime.inner.runtime_db.transitions().commit_queue(
+        &crate::runtime_db::transitions::QueueTransitionCommand {
+            agent_id: "default".into(),
+            operation: crate::runtime_db::transitions::QueueOperation::Admit,
+            mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record),
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: None,
+            scheduler_protocol_commands: Vec::new(),
+            scheduler_authority_scenarios: Vec::new(),
+            scheduler_rollout_expectations: Vec::new(),
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: Vec::new(),
+            scheduler_shadow_comparison: Some(new_command),
+            scheduler_delivery_shadow_comparison: None,
+            scheduler_semantic_shadow: None,
+            notify_scheduler: false,
+            fault: None,
+            brief_evidence: Vec::new(),
+        },
+    );
+
+    assert!(
+        result.is_ok(),
+        "identity conflict should allow overwrite, not fail: {:?}",
+        result.err()
+    );
+
+    // Verify the new record replaced the old one.
+    let new_hash: String = conn
+        .query_row(
+            "SELECT payload_hash FROM scheduler_shadow_comparisons
+             WHERE agent_id = 'default'
+               AND comparison_identity = 'message_admission:msg_stale'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_ne!(
+        new_hash, "sha256:old_hash",
+        "stale record should be replaced"
+    );
+}

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -483,17 +483,13 @@ impl RuntimeHandle {
                             let can_retry = attempt + 1
                                 < crate::runtime::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
                                 && crate::runtime::retryable_enqueue_agent_state_conflict(
-                                    &error,
-                                    agent_id,
+                                    &error, agent_id,
                                 );
                             if !can_retry {
                                 return Err(error);
                             }
                             drop(guard);
-                            if !self
-                                .refresh_enqueue_agent_state_baseline(agent_id)
-                                .await?
-                            {
+                            if !self.refresh_enqueue_agent_state_baseline(agent_id).await? {
                                 return Err(error);
                             }
                             attempt += 1;

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -349,144 +349,176 @@ impl RuntimeHandle {
     ) -> Result<Vec<String>> {
         let boundary_str = boundary.as_str();
         let mut follow_up_texts = Vec::new();
-        loop {
+        'outer: loop {
             let committed = {
-                let mut guard = self.inner.agent.lock().await;
-                let Some(message) = guard
-                    .queue
-                    .peek_next_matching(scheduler::is_operator_interjection_message)
-                    .cloned()
-                else {
-                    break;
-                };
-                let expected_state = guard.state.clone();
-                let production_commands_enabled =
-                    self.scheduler_protocol_production_commands_enabled();
-                let protocol_commands = self.operator_interjection_protocol_commands(
-                    agent_id,
-                    &expected_state,
-                    &message,
-                    round,
-                    boundary_str,
-                    production_commands_enabled,
-                )?;
-                let mut committed_state = expected_state.clone();
-                committed_state.pending = guard.queue.len().saturating_sub(1);
-                let text = render_operator_interjection_text(&message);
-                let shadow_comparison =
-                    scheduler::SchedulerProjection::from_state_with_queue_len_at(
-                        &self.inner.storage,
-                        &guard.state,
-                        guard.queue.len(),
-                        self.now(),
-                    )
-                    .ok()
-                    .and_then(|projection| {
-                        scheduler::shadow_comparison_for_operator_interjection(
-                            &projection,
-                            &message,
-                            boundary,
-                        )
-                    })
-                    .map(scheduler_executor::scheduler_shadow_comparison_command)
-                    .transpose()?;
-                let transcript = TranscriptEntry::new(
-                    message.agent_id.clone(),
-                    TranscriptEntryKind::IncomingMessage,
-                    None,
-                    Some(message.id.clone()),
-                    serde_json::json!({
-                        "authority_class": message.authority_class,
-                        "delivery_surface": message.delivery_surface,
-                        "admission_context": message.admission_context,
-                        "trigger_kind": message.trigger_kind,
-                        "work_item_id": message.work_item_id.clone(),
-                        "task_id": message.task_id.clone(),
-                        "source_refs": message.source_refs.clone(),
-                        "correlation_id": message.correlation_id.clone(),
-                        "causation_id": message.causation_id.clone(),
-                    }),
-                );
-                let queue_record = QueueEntryRecord {
-                    message_id: message.id.clone(),
-                    agent_id: message.agent_id.clone(),
-                    priority: message.priority.clone(),
-                    status: QueueEntryStatus::Interjected,
-                    created_at: message.created_at,
-                    updated_at: chrono::Utc::now(),
-                };
-                let audit_event = AuditEvent::legacy(
-                    "operator_interjection_admitted",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "round": round,
-                        "boundary": boundary_str,
-                        "message_id": message.id,
-                        "origin": message.origin,
-                        "authority_class": message.authority_class,
-                        "priority": message.priority,
-                        "delivery_surface": message.delivery_surface,
-                        "admission_context": message.admission_context,
-                        "text_preview": truncate_preview(
-                            &message_text(&message.body),
-                            ROUND_TEXT_PREVIEW_LIMIT
-                        ),
-                    }),
-                );
-                let scheduler_rollout_expectations = self
-                    .inner
-                    .runtime_db
-                    .transitions()
-                    .scheduler_rollout_expectations(
-                        &[scheduler::INTERJECTION_SCENARIO],
+                let mut attempt = 0;
+                loop {
+                    if attempt >= crate::runtime::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+                        return Err(anyhow::anyhow!(
+                            "interjection OCC retry exhausted for agent {}",
+                            agent_id
+                        ));
+                    }
+                    let mut guard = self.inner.agent.lock().await;
+                    let Some(message) = guard
+                        .queue
+                        .peek_next_matching(scheduler::is_operator_interjection_message)
+                        .cloned()
+                    else {
+                        break 'outer;
+                    };
+                    let expected_state = guard.state.clone();
+                    let production_commands_enabled =
+                        self.scheduler_protocol_production_commands_enabled();
+                    let protocol_commands = self.operator_interjection_protocol_commands(
+                        agent_id,
+                        &expected_state,
+                        &message,
+                        round,
+                        boundary_str,
                         production_commands_enabled,
                     )?;
-                let mut commit = self.inner.runtime_db.transitions().commit_queue(
-                    &crate::runtime_db::transitions::QueueTransitionCommand {
-                        agent_id: message.agent_id.clone(),
-                        operation: crate::runtime_db::transitions::QueueOperation::Interject,
-                        mutation: crate::runtime_db::transitions::QueueMutation::Consume(
-                            queue_record,
-                        ),
-                        scheduler_claim_work_item: None,
-                        scheduler_protocol_bootstrap: None,
-                        scheduler_protocol_commands: protocol_commands,
-                        scheduler_authority_scenarios: vec![scheduler::INTERJECTION_SCENARIO],
-                        scheduler_rollout_expectations,
-                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                            expected: Some(Box::new(expected_state)),
-                            record: Box::new(committed_state.clone()),
+                    let mut committed_state = expected_state.clone();
+                    committed_state.pending = guard.queue.len().saturating_sub(1);
+                    let text = render_operator_interjection_text(&message);
+                    let shadow_comparison =
+                        scheduler::SchedulerProjection::from_state_with_queue_len_at(
+                            &self.inner.storage,
+                            &guard.state,
+                            guard.queue.len(),
+                            self.now(),
+                        )
+                        .ok()
+                        .and_then(|projection| {
+                            scheduler::shadow_comparison_for_operator_interjection(
+                                &projection,
+                                &message,
+                                boundary,
+                            )
+                        })
+                        .map(scheduler_executor::scheduler_shadow_comparison_command)
+                        .transpose()?;
+                    let transcript = TranscriptEntry::new(
+                        message.agent_id.clone(),
+                        TranscriptEntryKind::IncomingMessage,
+                        None,
+                        Some(message.id.clone()),
+                        serde_json::json!({
+                            "authority_class": message.authority_class,
+                            "delivery_surface": message.delivery_surface,
+                            "admission_context": message.admission_context,
+                            "trigger_kind": message.trigger_kind,
+                            "work_item_id": message.work_item_id.clone(),
+                            "task_id": message.task_id.clone(),
+                            "source_refs": message.source_refs.clone(),
+                            "correlation_id": message.correlation_id.clone(),
+                            "causation_id": message.causation_id.clone(),
                         }),
-                        message_evidence: Vec::new(),
-                        transcript_entries: vec![transcript],
-                        turn_record: None,
-                        audit_events: vec![audit_event],
-                        scheduler_shadow_comparison: shadow_comparison,
-                        scheduler_delivery_shadow_comparison: None,
-                        scheduler_semantic_shadow: None,
-                        notify_scheduler: false,
-                        fault: self.take_transition_fault(),
-                        brief_evidence: Vec::new(),
-                    },
-                )?;
-                if commit.scheduler_authority_blocked {
-                    drop(guard);
-                    self.apply_transition_commit(commit).await;
-                    break;
+                    );
+                    let queue_record = QueueEntryRecord {
+                        message_id: message.id.clone(),
+                        agent_id: message.agent_id.clone(),
+                        priority: message.priority.clone(),
+                        status: QueueEntryStatus::Interjected,
+                        created_at: message.created_at,
+                        updated_at: chrono::Utc::now(),
+                    };
+                    let audit_event = AuditEvent::legacy(
+                        "operator_interjection_admitted",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "round": round,
+                            "boundary": boundary_str,
+                            "message_id": message.id,
+                            "origin": message.origin,
+                            "authority_class": message.authority_class,
+                            "priority": message.priority,
+                            "delivery_surface": message.delivery_surface,
+                            "admission_context": message.admission_context,
+                            "text_preview": truncate_preview(
+                                &message_text(&message.body),
+                                ROUND_TEXT_PREVIEW_LIMIT
+                            ),
+                        }),
+                    );
+                    let scheduler_rollout_expectations = self
+                        .inner
+                        .runtime_db
+                        .transitions()
+                        .scheduler_rollout_expectations(
+                            &[scheduler::INTERJECTION_SCENARIO],
+                            production_commands_enabled,
+                        )?;
+                    let commit_result = self.inner.runtime_db.transitions().commit_queue(
+                        &crate::runtime_db::transitions::QueueTransitionCommand {
+                            agent_id: message.agent_id.clone(),
+                            operation: crate::runtime_db::transitions::QueueOperation::Interject,
+                            mutation: crate::runtime_db::transitions::QueueMutation::Consume(
+                                queue_record,
+                            ),
+                            scheduler_claim_work_item: None,
+                            scheduler_protocol_bootstrap: None,
+                            scheduler_protocol_commands: protocol_commands,
+                            scheduler_authority_scenarios: vec![scheduler::INTERJECTION_SCENARIO],
+                            scheduler_rollout_expectations,
+                            agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                                expected: Some(Box::new(expected_state)),
+                                record: Box::new(committed_state.clone()),
+                            }),
+                            message_evidence: Vec::new(),
+                            transcript_entries: vec![transcript],
+                            turn_record: None,
+                            audit_events: vec![audit_event],
+                            scheduler_shadow_comparison: shadow_comparison,
+                            scheduler_delivery_shadow_comparison: None,
+                            scheduler_semantic_shadow: None,
+                            notify_scheduler: false,
+                            fault: self.take_transition_fault(),
+                            brief_evidence: Vec::new(),
+                        },
+                    );
+                    let mut commit = match commit_result {
+                        Ok(commit) => commit,
+                        Err(error) => {
+                            let can_retry = attempt + 1
+                                < crate::runtime::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                                && crate::runtime::retryable_enqueue_agent_state_conflict(
+                                    &error,
+                                    agent_id,
+                                );
+                            if !can_retry {
+                                return Err(error);
+                            }
+                            drop(guard);
+                            if !self
+                                .refresh_enqueue_agent_state_baseline(agent_id)
+                                .await?
+                            {
+                                return Err(error);
+                            }
+                            attempt += 1;
+                            continue;
+                        }
+                    };
+                    if commit.scheduler_authority_blocked {
+                        drop(guard);
+                        self.apply_transition_commit(commit).await;
+                        break 'outer;
+                    }
+                    if !commit.applied {
+                        return Err(anyhow::anyhow!(
+                            "interjection settlement made no durable progress"
+                        ));
+                    }
+                    guard
+                        .queue
+                        .pop_next_matching(|candidate| candidate.id == message.id)
+                        .expect("peeked interjection remains queued while agent lock is held");
+                    guard.state = committed_state.clone();
+                    guard.last_persisted_state = committed_state;
+                    commit.effects.agent_state = None;
+                    break (text, commit);
                 }
-                if !commit.applied {
-                    return Err(anyhow::anyhow!(
-                        "interjection settlement made no durable progress"
-                    ));
-                }
-                guard
-                    .queue
-                    .pop_next_matching(|candidate| candidate.id == message.id)
-                    .expect("peeked interjection remains queued while agent lock is held");
-                guard.state = committed_state.clone();
-                guard.last_persisted_state = committed_state;
-                commit.effects.agent_state = None;
-                (text, commit)
             };
             self.apply_transition_commit(committed.1).await;
             follow_up_texts.push(committed.0);

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -499,6 +499,21 @@ impl RuntimeTransitionRepository<'_> {
             if !matches!(&command.mutation, QueueMutation::Upsert(_)) && !mutation_applied {
                 return Ok(TransitionCommit::default());
             }
+            // When a message is released (transitioned to Interrupted), clean up
+            // any shadow comparison records written during the prior Claim/Settlement
+            // phase. Without this, stale records cause identity conflicts after
+            // restart when the scheduler re-processes the interrupted message.
+            if command.operation == QueueOperation::Release {
+                let message_id = match &command.mutation {
+                    QueueMutation::Upsert(record) => &record.message_id,
+                    _ => unreachable!("queue operation validation rejects this combination"),
+                };
+                scheduler_protocol_repository::delete_shadow_comparisons_for_message_tx(
+                    tx,
+                    &command.agent_id,
+                    message_id,
+                )?;
+            }
             let shadow_comparison = scheduler_protocol_repository::validate_shadow_comparison_tx(
                 tx,
                 &command.agent_id,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -499,11 +499,21 @@ impl RuntimeTransitionRepository<'_> {
             if !matches!(&command.mutation, QueueMutation::Upsert(_)) && !mutation_applied {
                 return Ok(TransitionCommit::default());
             }
-            // When a message is released (transitioned to Interrupted), clean up
-            // any shadow comparison records written during the prior Claim/Settlement
-            // phase. Without this, stale records cause identity conflicts after
-            // restart when the scheduler re-processes the interrupted message.
-            if command.operation == QueueOperation::Release {
+            // When a message transitions to Interrupted (via Release or Settle),
+            // clean up any shadow comparison records written during the prior
+            // Claim/Settlement phase. Without this, stale records cause identity
+            // conflicts after restart when the scheduler re-processes the
+            // interrupted message with a new payload_hash.
+            let is_interrupted = matches!(
+                (&command.operation, &command.mutation),
+                (QueueOperation::Release, QueueMutation::Upsert(r))
+                    if r.status == QueueEntryStatus::Interrupted
+            ) || matches!(
+                (&command.operation, &command.mutation),
+                (QueueOperation::Settle, QueueMutation::Upsert(r))
+                    if r.status == QueueEntryStatus::Interrupted
+            );
+            if is_interrupted {
                 let message_id = match &command.mutation {
                     QueueMutation::Upsert(record) => &record.message_id,
                     _ => unreachable!("queue operation validation rejects this combination"),

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -537,6 +537,21 @@ pub(super) fn validate_shadow_comparison_tx(
     }))
 }
 
+pub(super) fn delete_shadow_comparisons_for_message_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    message_id: &str,
+) -> Result<()> {
+    let suffix = format!(":{message_id}");
+    tx.execute(
+        "DELETE FROM scheduler_shadow_comparisons
+         WHERE agent_id = ?1
+           AND comparison_identity LIKE '%' || ?2",
+        params![agent_id, suffix],
+    )?;
+    Ok(())
+}
+
 pub(super) fn validate_semantic_shadow_decision_tx(
     tx: &Transaction<'_>,
     agent_id: &str,

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -518,14 +518,28 @@ pub(super) fn validate_shadow_comparison_tx(
             |row| row.get::<_, String>(0),
         )
         .optional()?;
+    let mut already_recorded = existing_payload_hash.is_some();
     if let Some(existing_payload_hash) = existing_payload_hash.as_ref() {
         if existing_payload_hash != &payload_hash {
-            bail!(
-                "scheduler shadow comparison identity conflict for agent {}, scenario {}, comparison {}",
-                agent_id,
-                command.scenario_class,
-                command.comparison_identity
-            );
+            // Identity conflict: the existing record was written during a prior
+            // claim that failed (settlement error → interrupted). Fix 1 should
+            // have cleaned it up on Release/Settle→Interrupted, but if a stale
+            // record survives, allow the new record to overwrite it instead of
+            // permanently blocking the agent in a failure loop.
+            // Mark not already_recorded so persist_shadow_comparison_tx
+            // inserts the new record.
+            tx.execute(
+                "DELETE FROM scheduler_shadow_comparisons
+                 WHERE agent_id = ?1
+                   AND scenario_class = ?2
+                   AND comparison_identity = ?3",
+                params![
+                    agent_id,
+                    command.scenario_class,
+                    command.comparison_identity
+                ],
+            )?;
+            already_recorded = false;
         }
     }
 
@@ -533,7 +547,7 @@ pub(super) fn validate_shadow_comparison_tx(
         command: command.clone(),
         payload_hash,
         authority_mode,
-        already_recorded: existing_payload_hash.is_some(),
+        already_recorded,
     }))
 }
 


### PR DESCRIPTION
## Summary

Fixes a critical defect where an agent gets permanently stuck in a failure loop after CLAIM succeeds but SETTLEMENT fails (e.g., due to OCC conflict). The shadow comparison record written during CLAIM survives the interrupted message, and on restart the new payload_hash conflicts with the stale record — with `retryable=false`, the agent can never self-heal.

## Root Cause

1. **`commit_queue` in scheduler executor lacks OCC retry** — when concurrent operations modify agent_state between snapshot read and commit, the OCC check fails and the message is interrupted.
2. **Shadow comparison records are not cleaned up on Release/Settle→Interrupted** — stale records persist after settlement failure.
3. **Identity conflict is non-retryable** — the agent is permanently blocked when a new payload_hash conflicts with a stale record.
4. **Bootstrap recovery runs outside agent lock** — `recover_scheduler_bootstrap_claims()` releases the lock before calling `commit_queue`, creating a memory/DB divergence window.
5. **`persist_state()` bypasses OCC** — intentional for control-plane operations, but consistency of `last_persisted_state` needed documentation.

## Changes (Fix 1–5)

### Fix 1: Clean up stale shadow comparison records on Release/Settle→Interrupted
- **`src/runtime_db/transitions.rs`**: When a message transitions to `Interrupted` (via Release or Settle), delete its shadow comparison records in the same transaction.
- Added `delete_shadow_comparisons_for_message_tx()` in `scheduler_protocol_repository.rs`.

### Fix 2: Allow identity conflict to overwrite stale records (safety net)
- **`src/runtime_db/transitions/scheduler_protocol_repository.rs`**: When `validate_shadow_comparison_tx` detects a payload_hash mismatch for the same comparison_identity, delete the stale record and allow the new one to be inserted instead of bailing with a non-retryable error. This is the safety net for Fix 1 — if any stale record survives cleanup, the agent can still self-heal.

### Fix 3: Unified OCC retry across all `commit_queue` call sites
- **`src/runtime/scheduler_executor.rs`** (Claim): Wrapped `commit_queue` in a retry loop matching the `enqueue()` pattern — up to `ENQUEUE_AGENT_STATE_MAX_ATTEMPTS=3` retries with `refresh_enqueue_agent_state_baseline()` between attempts.
- **`src/runtime.rs`** (Settle): `commit_queue_terminal_settlement_with_evidence()` now has the same OCC retry loop.
- **`src/runtime/turn/execution.rs`** (Interject): `drain_operator_interjections()` now has OCC retry.
- **`src/runtime/memory_refresh.rs`** (Admit): Memory refresh admit path now has OCC retry.

### Fix 4: Hold agent lock during bootstrap recovery
- **`src/runtime.rs`**: `recover_scheduler_bootstrap_claims()` now acquires `agent.lock()` at the start of each recovery iteration and holds it during `commit_queue` + `apply_transition_commit`. Safe because `apply_transition_commit` does not re-acquire the lock when `effects.agent_state` is `None` (the case for bootstrap recovery commands).

### Fix 5: Document persist_state OCC semantics
- **`src/runtime.rs`**: Added documentation explaining that `persist_state` intentionally bypasses OCC (uses upsert) for control-plane operations. The existing implementation already correctly maintains `last_persisted_state` consistency (Option B from the plan): on success, sets it to `self.state`; on failure, reverts `self.state` to `last_persisted_state`.

## Tests

- `release_interrupts_message_and_cleans_up_shadow_comparison_records` — verifies Fix 1: Release → Interrupted cleans up shadow comparison records.
- `shadow_comparison_identity_conflict_allows_overwrite` — verifies Fix 2: stale record is overwritten when identity conflict occurs.
- All 2546 existing tests pass (1 ignored, 0 failed).

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib` — 2545 passed, 0 failed, 1 ignored ✅

## Relationship to prior fixes

- **PR #2417 (issue #2415)**: Fixed canonical activation wait resolution in non-authoritative scenarios — different problem (wait resolution logic).
- **PR #2425**: Fixed shadow divergence `delivery_outcome_mismatch` and `message_admission_outcome_mismatch` — different problem (shadow comparison expected-value calculation).
- **This PR**: Fixes shadow comparison record **lifecycle management** — stale records after settlement failure, and unifies OCC retry coverage.