### PR TITLE
fix(web-gui): recover missed events by fetching from gap cursor instead of newestSeq

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -1170,6 +1170,92 @@ describe("agent event catch-up", () => {
       error: "Agent event catch-up page did not advance its consumed cursor.",
     });
   });
+
+  it("recovers missed events by fetching from the gap cursor instead of newestSeq", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const event = (seq: number) => ({
+      id: `event-${seq}`,
+      event_seq: seq,
+      event_log_epoch: "epoch-1",
+      contract_version: 1,
+      ts: "2026-07-24T00:00:00Z",
+      agent_id: "agent-a",
+      type: "legacy_event",
+      payload_schema: "holon.runtime_event.legacy",
+      payload_schema_version: 1,
+      provenance: {},
+      payload: {},
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        const afterSeq = Number(url.searchParams.get("after_seq"));
+        // The catch-up should query from gaps[0].afterSeq (1), not newestSeq (5).
+        expect(afterSeq).toBe(1);
+        return Promise.resolve(jsonResponse({
+          events: [event(2), event(3), event(4), event(5)],
+          event_log_epoch: "epoch-1",
+          cursor_seq: 5,
+          newest_seq: 5,
+          oldest_seq: 2,
+          has_older: false,
+          has_newer: false,
+          order: "asc",
+          limit: 100,
+        }));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+    const now = Date.now();
+    // Session has events 1 and 5, with a gap (2-4 missing).
+    // newestSeq is 5 (inflated by a streaming event), but gaps[0].afterSeq is 1.
+    useRuntimeStore.setState({
+      globalStreamStatus: "idle",
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          cacheStatus: "hit",
+          contentStatus: "available",
+          syncStatus: "stale",
+          detailValidatedAt: now,
+          eventsValidatedAt: now,
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          eventsBySeq: { 1: event(1), 5: event(5) },
+          eventSeqs: [1, 5],
+          newestSeq: 5,
+          oldestSeq: 1,
+          gaps: [{ afterSeq: 1, beforeSeq: 5 }],
+          eventLogEpoch: "epoch-1",
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().ensureAgentSession("agent-a", "info");
+
+    const session = useRuntimeStore.getState().sessionsByAgentId["agent-a"];
+    // Gap should be filled: events 1-5 all present, no gaps.
+    expect(session.eventSeqs).toEqual([1, 2, 3, 4, 5]);
+    expect(session.gaps).toEqual([]);
+    expect(session.newestSeq).toBe(5);
+    expect(session.syncStatus).toBe("idle");
+  });
 });
 
 describe("brief hydration retry limits", () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4450,7 +4450,13 @@ async function catchUpAgentEvents(
   const span = startRuntimeSpan(trace, "events.catch_up");
   const request = (async () => {
     const generation = clientGeneration;
-    const initialAfterSeq = get().sessionsByAgentId[agentId]?.newestSeq;
+    const catchUpSession = get().sessionsByAgentId[agentId];
+    // When the session has event gaps (e.g. from missed stream events or a
+    // failed backfill), newestSeq is ahead of the contiguous range.  Fetching
+    // from newestSeq would skip the gap entirely.  Use the last contiguous seq
+    // instead so the catch-up fills the missing events.
+    const catchUpGaps = catchUpSession?.gaps ?? [];
+    const initialAfterSeq = catchUpGaps.length > 0 ? catchUpGaps[0].afterSeq : catchUpSession?.newestSeq;
     let afterSeq = initialAfterSeq;
     let eventCount = 0;
     let pageCount = 0;
@@ -4499,6 +4505,8 @@ async function catchUpAgentEvents(
     scheduleCacheWrite(get, agentId);
     span.end("ok", {
       afterSeq: initialAfterSeq,
+      gapRecovery: catchUpGaps.length > 0,
+      gapCount: catchUpGaps.length,
       eventCount,
       pageCount,
     });


### PR DESCRIPTION
## Problem

When an agent event session has gaps (e.g. from missed SSE stream events or failed backfill), `catchUpAgentEvents` used `session.newestSeq` as the `after_seq` cursor. Since `newestSeq` is advanced by incoming stream events even when earlier events are missing, this cursor was set **beyond the gap** — the server returned 0 events, and re-opening the agent showed **stale messages** until the user did a manual force refresh.

## Root Cause

The evidence chain (from runtime trace):

1. `events.catch_up` used `session.newestSeq` as `afterSeq` for the incremental fetch.
2. Stream events with a gap arrived: `dispatchGlobalStreamEvent` applied them, setting `newestSeq` to the high seq, and triggered `backfillAgentEvents`.
3. `events.backfill` returned `outcome: error` — the error was silently ignored (`// Silently ignore backfill errors`), and retries only happened on the next stream event.
4. When the agent was idle (no new stream events), the gap persisted permanently. `newestSeq` stayed at the inflated value.
5. On re-open, `catchUpAgentEvents` queried `after_seq=newestSeq` (past the gap) → 0 events → UI showed old content.
6. Only `agent.detail` with `force: true` recovered (full fetch bypassing the cursor).

## Fix

In `catchUpAgentEvents` (`web-gui/app/src/runtime/runtime-store.ts`):

- When `session.gaps` is non-empty, use `gaps[0].afterSeq` (the last contiguous seq before the first gap) as the initial `afterSeq` cursor instead of `newestSeq`.
- This makes the catch-up fetch start from before the gap, filling the missing events.
- Added `gapRecovery` and `gapCount` to the trace span output for diagnostics.

## Test

New test case: session has events 1 and 5 (gap at 2–4), `newestSeq=5`, `gaps=[{afterSeq:1, beforeSeq:5}]`. Verifies that the catch-up queries `after_seq=1` (not 5) and fills all events 1–5, clearing the gaps.

All 42 existing tests in the file pass, plus the new one.