### PR TITLE
fix(skills): discover workspace skill roots

### DIFF
--- a/docs/rfcs/skill-discovery-and-activation.md
+++ b/docs/rfcs/skill-discovery-and-activation.md
@@ -21,13 +21,20 @@ Phase-1 skill behavior should be:
 
 ## Discovery Roots
 
-Phase-1 compatibility roots should remain:
+Agent and workspace discovery search these roots in declaration order:
 
+- `skills`
 - `.agents/skills`
 - `.codex/skills`
 - `.claude/skills`
 
-Discovery should search agent scope and workspace scope separately.
+User-global discovery remains limited to the three hidden compatibility roots
+and does not search a bare `~/skills` directory.
+
+Discovery searches agent scope and workspace scope separately. Within one
+scope, all physically distinct roots are merged. If multiple configured paths
+resolve to the same physical directory, discovery keeps the first path in the
+order above and scans that directory only once.
 
 ## Root Selection
 
@@ -40,6 +47,18 @@ Agent-scoped discovery is rooted under `agent_home`.
 Workspace-scoped discovery is rooted under `workspace_anchor`.
 
 Skill discovery should not drift with shell cwd.
+
+## Catalog Precedence
+
+When multiple scopes provide a skill with the same declared name, the catalog
+keeps the highest-precedence entry:
+
+1. workspace
+2. agent
+3. user-global
+
+This precedence only selects the effective skill catalog entry. Skill content
+does not gain authority over system, developer, or operator instructions.
 
 ## Visibility Rules
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -431,7 +431,7 @@ pub fn build_context_with_default_external_ingress(
             section(
                 "skills_catalog",
                 format!(
-                    "Discovered skills catalog (same-name precedence: agent > workspace > user; lower-precedence duplicates are omitted):\n{rendered}"
+                    "Discovered skills catalog (same-name precedence: workspace > agent > user; lower-precedence duplicates are omitted):\n{rendered}"
                 ),
             ),
             None,
@@ -5092,7 +5092,7 @@ mod tests {
             .expect("skills_catalog section should be present");
         assert!(catalog
             .content
-            .contains("same-name precedence: agent > workspace > user"));
+            .contains("same-name precedence: workspace > agent > user"));
         assert!(catalog.content.contains("agent demo skill summary"));
         assert!(catalog.content.contains("/tmp/agent/skills/demo/SKILL.md"));
         assert!(catalog.content.contains("other skill summary"));

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -8000,7 +8000,7 @@ async fn runtime_does_not_force_completion_after_post_verification_stagnation() 
 async fn runtime_skills_view_filters_active_skills_to_effective_registry_snapshot() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let skill_dir = workspace.path().join(".agents/skills/demo");
+    let skill_dir = workspace.path().join("skills/demo");
     let skill_path = skill_dir.join("SKILL.md");
     std::fs::create_dir_all(&skill_dir).unwrap();
     std::fs::write(
@@ -8019,7 +8019,7 @@ async fn runtime_skills_view_filters_active_skills_to_effective_registry_snapsho
         context_config(),
     )
     .unwrap();
-    let ws_skill_root = workspace.path().join(".agents/skills");
+    let ws_skill_root = workspace.path().join("skills");
     let ws_demo_skill_id = format!(
         "{}:demo",
         crate::skills::skill_root_id_for_scope(SkillScope::Workspace, &ws_skill_root)

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -48,7 +48,7 @@ pub fn load_skills_runtime_view(
     let mut discoverable_skills = Vec::new();
 
     if matches!(visibility, SkillVisibility::DefaultAgent) {
-        if let Some(root) = select_skill_root(user_home, &COMPAT_SKILL_ROOT_SUFFIXES) {
+        for root in user_global_skill_roots(user_home) {
             discoverable_skills.extend(load_catalog_for_scope(SkillScope::UserGlobal, &root)?);
             discovered_roots.push(SkillRootView {
                 scope: SkillScope::UserGlobal,
@@ -57,7 +57,7 @@ pub fn load_skills_runtime_view(
         }
     }
 
-    for root in existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
+    for root in agent_skill_roots(agent_home) {
         discoverable_skills.extend(load_catalog_for_scope(SkillScope::Agent, &root)?);
         discovered_roots.push(SkillRootView {
             scope: SkillScope::Agent,
@@ -65,7 +65,7 @@ pub fn load_skills_runtime_view(
         });
     }
 
-    if let Some(root) = select_skill_root(workspace_anchor, &COMPAT_SKILL_ROOT_SUFFIXES) {
+    for root in workspace_skill_roots(workspace_anchor) {
         discoverable_skills.extend(load_catalog_for_scope(SkillScope::Workspace, &root)?);
         discovered_roots.push(SkillRootView {
             scope: SkillScope::Workspace,
@@ -122,11 +122,29 @@ pub(crate) fn existing_skill_roots(base: Option<&Path>, suffixes: &[&str]) -> Ve
     let Some(base) = base else {
         return Vec::new();
     };
+    let mut seen = BTreeSet::new();
     suffixes
         .iter()
         .map(|suffix| base.join(suffix))
         .filter(|candidate| candidate.is_dir())
+        .filter(|candidate| {
+            let identity = fs::canonicalize(candidate)
+                .unwrap_or_else(|_| candidate.components().collect::<PathBuf>());
+            seen.insert(identity)
+        })
         .collect()
+}
+
+pub(crate) fn user_global_skill_roots(user_home: Option<&Path>) -> Vec<PathBuf> {
+    existing_skill_roots(user_home, &COMPAT_SKILL_ROOT_SUFFIXES)
+}
+
+pub(crate) fn agent_skill_roots(agent_home: &Path) -> Vec<PathBuf> {
+    existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES)
+}
+
+pub(crate) fn workspace_skill_roots(workspace_anchor: Option<&Path>) -> Vec<PathBuf> {
+    existing_skill_roots(workspace_anchor, &SKILL_ROOT_SUFFIXES)
 }
 
 pub fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<SkillCatalogEntry>> {
@@ -214,26 +232,22 @@ pub fn effective_skill_root_registrations(
     let mut roots = Vec::new();
     if matches!(visibility, SkillVisibility::DefaultAgent) {
         roots.extend(
-            existing_skill_roots(user_home, &COMPAT_SKILL_ROOT_SUFFIXES)
+            user_global_skill_roots(user_home)
                 .into_iter()
                 .map(|root_path| {
                     skill_root_registration(SkillRootSourceKind::UserGlobal, None, root_path)
                 }),
         );
     }
+    roots.extend(agent_skill_roots(agent_home).into_iter().map(|root_path| {
+        skill_root_registration(
+            SkillRootSourceKind::AgentHome,
+            Some(agent_id.to_string()),
+            root_path,
+        )
+    }));
     roots.extend(
-        existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES)
-            .into_iter()
-            .map(|root_path| {
-                skill_root_registration(
-                    SkillRootSourceKind::AgentHome,
-                    Some(agent_id.to_string()),
-                    root_path,
-                )
-            }),
-    );
-    roots.extend(
-        existing_skill_roots(workspace_anchor, &COMPAT_SKILL_ROOT_SUFFIXES)
+        workspace_skill_roots(workspace_anchor)
             .into_iter()
             .map(|root_path| {
                 skill_root_registration(SkillRootSourceKind::Workspace, None, root_path)
@@ -279,8 +293,8 @@ fn collect_discovered_roots_from_registrations(
         })
         .collect::<Vec<_>>();
     roots.sort_by(|left, right| {
-        skill_precedence(left.scope)
-            .cmp(&skill_precedence(right.scope))
+        skill_scope_precedence(right.scope)
+            .cmp(&skill_scope_precedence(left.scope))
             .then_with(|| left.path.cmp(&right.path))
     });
     roots.dedup_by(|left, right| left.scope == right.scope && left.path == right.path);
@@ -368,21 +382,21 @@ fn retain_active_skills_for_catalog(
         .collect()
 }
 
-fn skill_wins_catalog_selection(
+pub(crate) fn skill_wins_catalog_selection(
     candidate: &SkillCatalogEntry,
     existing: &SkillCatalogEntry,
 ) -> bool {
-    let candidate_precedence = skill_precedence(candidate.scope);
-    let existing_precedence = skill_precedence(existing.scope);
+    let candidate_precedence = skill_scope_precedence(candidate.scope);
+    let existing_precedence = skill_scope_precedence(existing.scope);
     candidate_precedence > existing_precedence
         || (candidate_precedence == existing_precedence
             && (&candidate.skill_id, &candidate.path) < (&existing.skill_id, &existing.path))
 }
 
-fn skill_precedence(scope: SkillScope) -> u8 {
+pub(crate) fn skill_scope_precedence(scope: SkillScope) -> u8 {
     match scope {
-        SkillScope::Agent => 3,
-        SkillScope::Workspace => 2,
+        SkillScope::Workspace => 3,
+        SkillScope::Agent => 2,
         SkillScope::UserGlobal => 1,
     }
 }
@@ -2790,6 +2804,79 @@ mod tests {
     }
 
     #[test]
+    fn workspace_skill_discovery_merges_bare_and_compatible_roots() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let agent_home = dir.path().join("agent");
+        let bare_root = workspace.join("skills");
+        let compat_root = workspace.join(".codex/skills");
+        for (root, name) in [(&bare_root, "alpha"), (&compat_root, "beta")] {
+            fs::create_dir_all(root.join(name)).unwrap();
+            fs::write(
+                root.join(name).join(SKILL_ENTRYPOINT),
+                format!("---\nname: {name}\ndescription: {name}\n---\nbody"),
+            )
+            .unwrap();
+        }
+
+        let view = load_skills_runtime_view(
+            SkillVisibility::NonDefaultAgent,
+            None,
+            &agent_home,
+            Some(&workspace),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(view.discovered_roots.len(), 2);
+        assert_eq!(
+            view.discovered_roots
+                .iter()
+                .map(|root| root.path.as_path())
+                .collect::<Vec<_>>(),
+            vec![bare_root.as_path(), compat_root.as_path()]
+        );
+        let mut names = view
+            .discoverable_skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(names, vec!["alpha", "beta"]);
+        assert!(view
+            .discoverable_skills
+            .iter()
+            .all(|skill| skill.scope == SkillScope::Workspace));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_skill_roots_deduplicate_symlink_aliases() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+        let bare_root = workspace.join("skills");
+        fs::create_dir_all(&bare_root).unwrap();
+        fs::create_dir_all(workspace.join(".codex")).unwrap();
+        create_symlink(Path::new("../skills"), &workspace.join(".codex/skills")).unwrap();
+
+        assert_eq!(
+            workspace_skill_roots(Some(workspace)),
+            vec![bare_root.clone()]
+        );
+
+        let registrations = effective_skill_root_registrations(
+            SkillVisibility::NonDefaultAgent,
+            None,
+            "default",
+            &workspace.join("agent"),
+            Some(workspace),
+        );
+        assert_eq!(registrations.len(), 1);
+        assert_eq!(registrations[0].root_path, bare_root);
+        assert_eq!(registrations[0].source_kind, SkillRootSourceKind::Workspace);
+    }
+
+    #[test]
     fn default_agent_sees_user_scope_but_non_default_does_not() {
         let dir = tempdir().unwrap();
         let user_home = dir.path().join("user");
@@ -2900,9 +2987,9 @@ mod tests {
         assert_eq!(view.discoverable_skills.len(), 1);
         assert!(view.discoverable_skills[0]
             .skill_id
-            .starts_with("agent_home:"));
+            .starts_with("workspace:"));
         assert!(view.discoverable_skills[0].skill_id.ends_with(":ghx"));
-        assert_eq!(view.discoverable_skills[0].description, "agent skill");
+        assert_eq!(view.discoverable_skills[0].description, "workspace skill");
         assert_eq!(view.active_skills.len(), 1);
         assert_eq!(
             view.active_skills[0].skill_id,

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -20,7 +20,7 @@ use crate::types::{
 /// Read-only skills registry.
 ///
 /// The registry maintains skill entries from registered roots and provides
-/// a catalog view with precedence resolution (agent > workspace > user).
+/// a catalog view with precedence resolution (workspace > agent > user).
 #[derive(Debug, Clone, Default)]
 pub struct SkillsRegistry {
     roots: Vec<SkillRootRegistration>,
@@ -216,7 +216,7 @@ impl SkillsRegistry {
             .fold(BTreeMap::new(), |mut acc, entry| {
                 let existing = acc.get(&entry.name);
                 if existing.map_or(true, |existing| {
-                    self.skill_wins_catalog_selection(entry, existing)
+                    crate::skills::skill_wins_catalog_selection(entry, existing)
                 }) {
                     acc.insert(entry.name.clone(), entry);
                 }
@@ -228,26 +228,6 @@ impl SkillsRegistry {
     /// Get all registered roots.
     pub fn roots(&self) -> &[SkillRootRegistration] {
         &self.roots
-    }
-
-    fn skill_wins_catalog_selection(
-        &self,
-        candidate: &SkillCatalogEntry,
-        existing: &SkillCatalogEntry,
-    ) -> bool {
-        let candidate_precedence = self.skill_precedence(candidate.scope);
-        let existing_precedence = self.skill_precedence(existing.scope);
-        candidate_precedence > existing_precedence
-            || (candidate_precedence == existing_precedence
-                && (&candidate.skill_id, &candidate.path) < (&existing.skill_id, &existing.path))
-    }
-
-    fn skill_precedence(&self, scope: SkillScope) -> u8 {
-        match scope {
-            SkillScope::Agent => 3,
-            SkillScope::Workspace => 2,
-            SkillScope::UserGlobal => 1,
-        }
     }
 }
 
@@ -324,10 +304,20 @@ mod tests {
             scope: SkillScope::Agent,
         });
 
+        registry.entries.push(SkillCatalogEntry {
+            skill_id: "workspace_skill".to_string(),
+            root_id: "workspace:test-root".to_string(),
+            skill_dir: "test".to_string(),
+            name: "test".to_string(),
+            description: "workspace".to_string(),
+            path: PathBuf::from("/workspace/test"),
+            scope: SkillScope::Workspace,
+        });
+
         let catalog = registry.catalog();
         assert_eq!(catalog.len(), 1);
-        assert_eq!(catalog[0].scope, SkillScope::Agent);
-        assert_eq!(catalog[0].description, "agent");
+        assert_eq!(catalog[0].scope, SkillScope::Workspace);
+        assert_eq!(catalog[0].description, "workspace");
     }
 
     #[test]

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -803,10 +803,7 @@ pub async fn agent_skills_endpoint_uses_effective_registry_snapshot() -> Result<
         "---\nname: shared-demo\ndescription: agent\n---\nbody",
     )?;
 
-    let workspace_skill_dir = host
-        .config()
-        .workspace_dir
-        .join(".agents/skills/workspace-demo");
+    let workspace_skill_dir = host.config().workspace_dir.join("skills/workspace-demo");
     std::fs::create_dir_all(&workspace_skill_dir)?;
     std::fs::write(
         workspace_skill_dir.join("SKILL.md"),


### PR DESCRIPTION
## Summary

- discover every physically distinct workspace skill root across `skills`, `.agents/skills`, `.codex/skills`, and `.claude/skills`
- deduplicate symlink aliases by canonical path while preserving declared root order
- centralize same-name selection as Workspace > Agent > UserGlobal across legacy and registry-backed catalogs
- keep user-global discovery limited to compatibility roots and update the runtime prompt/RFC contract

Closes #2434.

## Verification

- `cargo test skills`
- `cargo test runtime_skills_view_filters_active_skills_to_effective_registry_snapshot`
- `cargo test agent_skills_endpoint_uses_effective_registry_snapshot`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
