### PR TITLE
fix(skills): resolve workspace details through active execution roots

### DIFF
--- a/docs/rfcs/skill-discovery-and-activation.md
+++ b/docs/rfcs/skill-discovery-and-activation.md
@@ -44,9 +44,27 @@ Agent-scoped discovery is rooted under `agent_home`.
 
 ### Workspace Scope
 
-Workspace-scoped discovery is rooted under `workspace_anchor`.
+Workspace-scoped discovery is rooted under the agent's active
+`execution_root`. A canonical projection therefore reads the canonical
+workspace, while a Git worktree projection reads that worktree.
 
-Skill discovery should not drift with shell cwd.
+Worktree discovery does not merge or fall back to `workspace_anchor`: a skill
+removed from the worktree must not reappear from the canonical checkout, and an
+untracked canonical skill must not leak into the worktree. Skill discovery
+should not drift with shell cwd.
+
+Skills created or changed during a turn become available on the next runtime
+skill-view or prompt-context build; Holon does not mutate an already-built
+system prompt.
+
+Agent-scoped detail lookup uses the target agent as execution-root/version
+context:
+
+`GET /agents/{agent_id}/skills/{skill_id}`
+
+Skill content is not an agent isolation boundary. A caller with remote-access
+permission may read another public agent's effective skill detail, while each
+agent's own catalog and prompt still load only its active execution root.
 
 ## Catalog Precedence
 

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -172,6 +172,7 @@ response directly.
 | `GET` | `/agents/:agent_id/transcript` | Path `agent_id`; query `limit?`. | `TranscriptEntry[]` | Experimental | Transcript data can include provider/tool internals. |
 | `GET` | `/agents/:agent_id/worktree-summary` | Path `agent_id`. | `{ agent_id, summary }` | Experimental | Summary shape follows managed worktree internals. |
 | `GET` | `/agents/:agent_id/skills` | Path `agent_id`; auth header when bearer mode is active. | `{ ok, agent_id, skills }` | Experimental | Skills list shape follows local skill catalog records. |
+| `GET` | `/agents/:agent_id/skills/:skill_id` | Path `agent_id`, `skill_id`; auth header when bearer mode is active. | `{ ok, skill, content }` | Experimental | Resolves detail from the target agent's effective catalog and active execution root. |
 
 Default-agent aliases:
 
@@ -332,6 +333,7 @@ Skill management separates library operations from agent enablement:
 | `POST` | `/api/skills/catalog/refresh` | `{ }` | `{ ok, catalog }` | Experimental | Refreshes runtime catalog by rescanning local skill roots. Does not reconcile with lock file or fetch remote updates. |
 | `POST` | `/api/skills/catalog/check` | `{ name? }` | `{ ... }` | Experimental | Checks library consistency. |
 | `GET` | `/agents/:agent_id/skills` | none | `{ skills: [...] }` | Experimental | Lists skills enabled for an agent. |
+| `GET` | `/agents/:agent_id/skills/:skill_id` | none | `{ skill, content }` | Experimental | Returns an effective skill using the target agent's active execution root as version context. |
 | `POST` | `/control/agents/:agent_id/skills/enable` | `{ name, copy? }` | `{ ok, agent_id, skill_name }` | Experimental | Enables a library skill for an agent. |
 | `POST` | `/control/agents/:agent_id/skills/disable` | `{ name }` | `{ ok, agent_id, skill_name }` | Experimental | Disables a skill for an agent. |
 | `POST` | `/control/agents/:agent_id/skills/install` | `{ kind }` | `{ ok, agent_id, skill_name }` | Deprecated | Compatibility alias for add/enable. |

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -8866,6 +8866,73 @@
         ]
       }
     },
+    "/api/agents/{agent_id}/skills/{skill_id}": {
+      "get": {
+        "description": "Return metadata and SKILL.md content for a skill in the target agent's effective catalog. The agent selects the active execution-root version.",
+        "operationId": "agentSkillDetail",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Root-qualified skill id.",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent skill detail",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
     "/api/agents/{agent_id}/state": {
       "get": {
         "description": "Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.",

--- a/src/host.rs
+++ b/src/host.rs
@@ -1465,16 +1465,16 @@ impl RuntimeHost {
         let loaded_agent_memory = load_agent_memory(agent_home.as_path())?;
         let skill_visibility = skill_visibility(&identity_view);
         let user_home = self.config().home_dir.clone();
-        let workspace_anchor = state
+        let workspace_skill_root = state
             .active_workspace_entry
             .as_ref()
-            .map(|entry| entry.workspace_anchor.as_path());
+            .map(|entry| entry.execution_root.as_path());
         let skill_roots = effective_skill_root_registrations(
             skill_visibility,
             Some(user_home.as_path()),
             &state.id,
             agent_home.as_path(),
-            workspace_anchor,
+            workspace_skill_root,
         );
         let mut skill_registry = self.inner.skills_registry.write().await;
         skill_registry.sync_effective_roots(skill_roots.clone())?;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -558,6 +558,10 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/enqueue", post(state::enqueue_default))
         .route("/agents/{agent_id}/skills", get(skills::list_skills))
+        .route(
+            "/agents/{agent_id}/skills/{skill_id}",
+            get(skills::agent_skill_detail),
+        )
         .route("/skills/catalog", get(skills::skills_catalog))
         .route("/skills/catalog/{skill_id}", get(skills::skill_detail))
         .route("/skills/catalog/add", post(skills::add_skill_to_catalog))

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -371,6 +371,15 @@ pub async fn skill_detail(
     })))
 }
 
+pub async fn agent_skill_detail(
+    Path((agent_id, skill_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    agent_scoped_skill_detail(&agent_id, &skill_id, &state).await
+}
+
 /// If `skill_id` starts with `agent_home:{owner}:`, return the owner agent_id.
 fn parse_agent_owner_from_skill_id(skill_id: &str) -> Option<String> {
     let rest = skill_id.strip_prefix("agent_home:")?;
@@ -392,26 +401,16 @@ async fn agent_scoped_skill_detail(
         .get_public_agent(agent_id)
         .await
         .map_err(agent_access_error)?;
-    let agent_home = runtime.agent_home();
-
-    let roots =
-        crate::skills::existing_skill_roots(Some(&agent_home), &crate::skills::SKILL_ROOT_SUFFIXES)
-            .into_iter()
-            .map(|root| {
-                crate::skills::skill_root_registration(
-                    crate::types::SkillRootSourceKind::AgentHome,
-                    Some(agent_id.to_string()),
-                    root,
-                )
-            })
-            .collect::<Vec<_>>();
-
-    let mut registry = state.skills_registry.write().await;
-    registry
-        .sync_effective_roots(roots.clone())
+    let identity = runtime
+        .agent_identity_view()
+        .await
         .map_err(error_response)?;
-    let Some(skill) = registry
-        .catalog_for_roots(&roots, Some(crate::types::SkillScope::Agent))
+    let skills = runtime
+        .skills_runtime_view(&identity)
+        .await
+        .map_err(error_response)?;
+    let Some(skill) = skills
+        .discoverable_skills
         .into_iter()
         .find(|entry| entry.skill_id == skill_id)
     else {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -98,6 +98,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List agent skills", "Return skills enabled/effective for an agent.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/skills/{skill_id}", "agentSkillDetail", "skills", "Agent skill detail", "Return metadata and SKILL.md content for a skill in the target agent's effective catalog. The agent selects the active execution-root version.", None, AuthKind::RemoteAccess),
     route("get", "/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the global user Skill Library catalog. Query parameter: scope.", None, AuthKind::RemoteAccess),
     route("get", "/skills/catalog/{skill_id}", "skillDetail", "skills", "Skill detail", "Return catalog metadata and SKILL.md content for a Global Skill Library skill.", None, AuthKind::RemoteAccess),
     route("get", "/workspaces/{workspace_id}/files", "workspaceFilesRoot", "workspaces", "Browse workspace root", "List directory entries at the workspace root. Query parameters: execution_root_id.", None, AuthKind::RemoteAccess),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1790,7 +1790,7 @@ impl RuntimeHandle {
             state
                 .active_workspace_entry
                 .as_ref()
-                .map(|entry| entry.workspace_anchor.as_path()),
+                .map(|entry| entry.execution_root.as_path()),
         );
         let mut view = if let Some(bridge) = self.inner.host_bridge.as_ref() {
             let registry = bridge.skills_registry()?;
@@ -1829,7 +1829,7 @@ impl RuntimeHandle {
             state
                 .active_workspace_entry
                 .as_ref()
-                .map(|entry| entry.workspace_anchor.as_path()),
+                .map(|entry| entry.execution_root.as_path()),
         );
         let registry = bridge.skills_registry()?;
         registry.write().await.sync_effective_roots(skill_roots)?;

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -25,6 +25,7 @@ http_async_tests!(
     list_skills_includes_all_agent_skill_roots,
     agent_skills_endpoint_uses_effective_registry_snapshot,
     agent_skills_endpoint_does_not_leak_stale_roots_between_agents,
+    agent_skill_detail_follows_active_execution_root_without_canonical_fallback,
     skills_catalog_returns_global_user_library_only,
     skill_detail_returns_catalog_skill_markdown,
     install_skill_existing_destination_returns_conflict,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -86,7 +86,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 99, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 100, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -214,6 +214,33 @@
   },
   {
     "method": "get",
+    "path": "/api/agents/{agent_id}/skills/{skill_id}",
+    "handler": "agent_skill_detail",
+    "operation_id": "agentSkillDetail",
+    "tag": "skills",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "skill_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/agents/{agent_id}/state",
     "handler": "agent_state",
     "operation_id": "agentState",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -899,6 +899,122 @@ pub async fn agent_skills_endpoint_does_not_leak_stale_roots_between_agents() ->
     Ok(())
 }
 
+pub async fn agent_skill_detail_follows_active_execution_root_without_canonical_fallback(
+) -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let workspace_root = host.config().workspace_dir.clone();
+    let canonical_shared = workspace_root.join("skills/shared-detail");
+    let canonical_only = workspace_root.join("skills/canonical-only");
+    for (skill_dir, name, body) in [
+        (&canonical_shared, "shared-detail", "canonical body"),
+        (&canonical_only, "canonical-only", "canonical only body"),
+    ] {
+        std::fs::create_dir_all(skill_dir)?;
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: canonical\n---\n{body}"),
+        )?;
+    }
+
+    let client = Client::new();
+    let canonical_catalog: serde_json::Value = client
+        .get(format!("{base}/api/agents/default/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let canonical_skill_id = canonical_catalog["skills"]
+        .as_array()
+        .and_then(|skills| {
+            skills
+                .iter()
+                .find(|skill| skill["name"] == "shared-detail")
+                .and_then(|skill| skill["skill_id"].as_str())
+        })
+        .ok_or_else(|| anyhow::anyhow!("canonical workspace skill should be listed"))?;
+    let canonical_detail: serde_json::Value = client
+        .get(format!(
+            "{base}/api/agents/default/skills/{canonical_skill_id}"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(canonical_detail["content"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("canonical body"));
+
+    let worktree_root = tempdir()?.keep();
+    let worktree_shared = worktree_root.join("skills/shared-detail");
+    let worktree_only = worktree_root.join("skills/worktree-only");
+    for (skill_dir, name, body) in [
+        (&worktree_shared, "shared-detail", "worktree body"),
+        (&worktree_only, "worktree-only", "worktree only body"),
+    ] {
+        std::fs::create_dir_all(skill_dir)?;
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: worktree\n---\n{body}"),
+        )?;
+    }
+    runtime
+        .enter_worktree(
+            workspace_root,
+            "main".into(),
+            worktree_root,
+            "skill-detail-test".into(),
+        )
+        .await?;
+
+    let worktree_catalog: serde_json::Value = client
+        .get(format!("{base}/api/agents/default/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let worktree_skills = worktree_catalog["skills"]
+        .as_array()
+        .expect("worktree skills should be an array");
+    assert!(worktree_skills
+        .iter()
+        .any(|skill| skill["name"] == "worktree-only"));
+    assert!(!worktree_skills
+        .iter()
+        .any(|skill| skill["name"] == "canonical-only"));
+    let worktree_skill_id = worktree_skills
+        .iter()
+        .find(|skill| skill["name"] == "shared-detail")
+        .and_then(|skill| skill["skill_id"].as_str())
+        .ok_or_else(|| anyhow::anyhow!("worktree workspace skill should be listed"))?;
+    assert_ne!(worktree_skill_id, canonical_skill_id);
+
+    let worktree_detail: serde_json::Value = client
+        .get(format!(
+            "{base}/api/agents/default/skills/{worktree_skill_id}"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(worktree_detail["content"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("worktree body"));
+
+    let stale_canonical = client
+        .get(format!(
+            "{base}/api/agents/default/skills/{canonical_skill_id}"
+        ))
+        .send()
+        .await?;
+    assert_eq!(stale_canonical.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn skills_catalog_returns_global_user_library_only() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let skill_name = format!("http-global-catalog-{}", std::process::id());

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -946,7 +946,8 @@ pub async fn agent_skill_detail_follows_active_execution_root_without_canonical_
         .unwrap_or_default()
         .contains("canonical body"));
 
-    let worktree_root = tempdir()?.keep();
+    let worktree_dir = tempdir()?;
+    let worktree_root = worktree_dir.path().to_path_buf();
     let worktree_shared = worktree_root.join("skills/shared-detail");
     let worktree_only = worktree_root.join("skills/worktree-only");
     for (skill_dir, name, body) in [

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -42,7 +42,7 @@ import {
   subscribeRuntimeTrace,
 } from "../runtime/runtime-trace";
 import { selectSelectedAgent } from "../runtime/runtime-selectors";
-import { canUseRemoteRuntimeConnections, readStoredRemoteConnectionProfiles, useRuntimeStore } from "../runtime/runtime-store";
+import { canUseRemoteRuntimeConnections, readStoredRemoteConnectionProfiles, skillDetailCacheKey, useRuntimeStore } from "../runtime/runtime-store";
 import { useAgentDetail } from "../runtime/useAgentDetail";
 import { useRuntimeDashboard } from "../runtime/useRuntimeDashboard";
 import type { AgentSummary, DisplayLevel, RouteKey, RuntimeConnection, RuntimeConnectionConfig, RuntimeConnectionProfile } from "../runtime/types";
@@ -71,6 +71,7 @@ export function App() {
   const route = useRuntimeStore((state) => state.route);
   const selectedAgentId = useRuntimeStore((state) => state.selectedAgentId);
   const selectedSkillId = useRuntimeStore((state) => state.selectedSkillId);
+  const selectedSkillAgentId = useRuntimeStore((state) => state.selectedSkillAgentId);
   const selectedTemplateId = useRuntimeStore((state) => state.selectedTemplateId);
   const displayLevel = useRuntimeStore((state) =>
     state.displayLevelsByAgentId[selectedAgentId] ?? "info",
@@ -124,14 +125,17 @@ export function App() {
   const skillCatalog = useRuntimeStore((state) => state.skillCatalog);
   const skillCatalogLoading = useRuntimeStore((state) => state.skillCatalogLoading);
   const skillCatalogError = useRuntimeStore((state) => state.skillCatalogError);
+  const selectedSkillCacheKey = selectedSkillId
+    ? skillDetailCacheKey(selectedSkillId, selectedSkillAgentId || undefined)
+    : "";
   const skillDetail = useRuntimeStore((state) =>
-    selectedSkillId ? state.skillDetailById[selectedSkillId] : undefined,
+    selectedSkillCacheKey ? state.skillDetailById[selectedSkillCacheKey] : undefined,
   );
   const skillDetailLoading = useRuntimeStore((state) =>
-    selectedSkillId ? state.skillDetailLoadingById[selectedSkillId] ?? false : false,
+    selectedSkillCacheKey ? state.skillDetailLoadingById[selectedSkillCacheKey] ?? false : false,
   );
   const skillDetailError = useRuntimeStore((state) =>
-    selectedSkillId ? state.skillDetailErrorById[selectedSkillId] : undefined,
+    selectedSkillCacheKey ? state.skillDetailErrorById[selectedSkillCacheKey] : undefined,
   );
   const templateCatalog = useRuntimeStore((state) => state.templateCatalog);
   const templateCatalogLoading = useRuntimeStore((state) => state.templateCatalogLoading);
@@ -282,7 +286,7 @@ export function App() {
         return;
       }
       if (nextRoute.route === "skillDetail" && nextRoute.skillId) {
-        openSkill(nextRoute.skillId);
+        openSkill(nextRoute.skillId, nextRoute.agentId);
         return;
       }
       if (nextRoute.route === "templateDetail" && nextRoute.templateId) {
@@ -314,8 +318,8 @@ export function App() {
 
   useEffect(() => {
     if (route !== "skillDetail" || !selectedSkillId || skillDetailLoading || skillDetail) return;
-    void refreshSkillDetail(selectedSkillId);
-  }, [refreshSkillDetail, route, selectedSkillId, skillDetail, skillDetailLoading]);
+    void refreshSkillDetail(selectedSkillId, selectedSkillAgentId || undefined);
+  }, [refreshSkillDetail, route, selectedSkillAgentId, selectedSkillId, skillDetail, skillDetailLoading]);
 
   useEffect(() => {
     if ((route !== "templates" && route !== "templateDetail") || templateCatalogLoading || templateCatalog.source !== "fixture") return;
@@ -357,9 +361,9 @@ export function App() {
     pushBrowserRoute(nextRoute, selectedAgentId);
   }
 
-  function navigateSkill(skillId: string) {
-    openSkill(skillId);
-    pushBrowserRoute("skillDetail", skillId);
+  function navigateSkill(skillId: string, agentId?: string) {
+    openSkill(skillId, agentId);
+    pushBrowserRoute("skillDetail", skillId, undefined, undefined, agentId);
   }
 
   function navigateTemplate(catalogId: string) {
@@ -707,7 +711,7 @@ export function App() {
             loading={skillDetailLoading}
             error={skillDetailError}
             onBack={() => navigateRoute("skills")}
-            onRefresh={() => refreshSkillDetail(selectedSkillId)}
+            onRefresh={() => refreshSkillDetail(selectedSkillId, selectedSkillAgentId || undefined)}
           />
         ) : null}
         {route === "templates" ? (
@@ -805,7 +809,7 @@ export function App() {
           onDisableAgentSkill={(name) => {
             void disableAgentSkill(selectedAgent.id, name);
           }}
-          onOpenSkill={navigateSkill}
+          onOpenSkill={(skillId) => navigateSkill(skillId, selectedAgent.id)}
           onShowAgentOverview={showAgentOverview}
           onRefreshTimelineEvents={() => {
             void refreshTimelineEvents(selectedAgent.id);

--- a/web-gui/app/src/app/routes.test.ts
+++ b/web-gui/app/src/app/routes.test.ts
@@ -31,4 +31,15 @@ describe("routeFromLocation", () => {
       skillId: "user_global:ghx",
     });
   });
+
+  it("parses agent-scoped skill detail links", () => {
+    expect(routeFromLocation({
+      pathname: "/agents/holon-dev2/skills/workspace%3Aroot%3Atrace-report-analysis",
+      search: "",
+    })).toEqual({
+      route: "skillDetail",
+      agentId: "holon-dev2",
+      skillId: "workspace:root:trace-report-analysis",
+    });
+  });
 });

--- a/web-gui/app/src/app/routes.ts
+++ b/web-gui/app/src/app/routes.ts
@@ -21,6 +21,14 @@ export function routeFromLocation(location: Pick<Location, "pathname" | "search"
   if (path === "/") return { route: "dashboard" };
   if (path === "/search") return { route: "search" };
   if (path === "/skills") return { route: "skills" };
+  const agentSkillMatch = path.match(/^\/agents\/([^/]+)\/skills\/([^/]+)$/);
+  if (agentSkillMatch) {
+    return {
+      route: "skillDetail",
+      agentId: safeDecodeURIComponent(agentSkillMatch[1]),
+      skillId: safeDecodeURIComponent(agentSkillMatch[2]),
+    };
+  }
   const skillMatch = path.match(/^\/skills\/([^/]+)$/);
   if (skillMatch) {
     return {
@@ -50,11 +58,15 @@ export function routeFromLocation(location: Pick<Location, "pathname" | "search"
   return { route: "dashboard" };
 }
 
-export function pathForRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>): string {
+export function pathForRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>, skillAgentId?: string): string {
   const queryString = query ? new URLSearchParams(Object.entries(query).flatMap(([key, value]) => (value == null ? [] : [[key, String(value)]]))).toString() : "";
   if (route === "search") return "/search";
   if (route === "skills") return "/skills";
-  if (route === "skillDetail" && agentId) return `/skills/${encodeURIComponent(agentId)}`;
+  if (route === "skillDetail" && agentId) {
+    return skillAgentId
+      ? `/agents/${encodeURIComponent(skillAgentId)}/skills/${encodeURIComponent(agentId)}`
+      : `/skills/${encodeURIComponent(agentId)}`;
+  }
   if (route === "templates") return "/templates";
   if (route === "templateDetail" && templateId) return `/templates/${encodeURIComponent(templateId)}`;
   if (route === "settings") return "/settings";
@@ -62,14 +74,14 @@ export function pathForRoute(route: RouteKey, agentId?: string, templateId?: str
   return "/";
 }
 
-export function pushBrowserRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>): void {
-  const nextPath = pathForRoute(route, agentId, templateId, query);
+export function pushBrowserRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>, skillAgentId?: string): void {
+  const nextPath = pathForRoute(route, agentId, templateId, query, skillAgentId);
   if (`${window.location.pathname}${window.location.search}` === nextPath) return;
   window.history.pushState(null, "", nextPath);
 }
 
-export function replaceBrowserRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>): void {
-  const nextPath = pathForRoute(route, agentId, templateId, query);
+export function replaceBrowserRoute(route: RouteKey, agentId?: string, templateId?: string, query?: Record<string, string | number | undefined>, skillAgentId?: string): void {
+  const nextPath = pathForRoute(route, agentId, templateId, query, skillAgentId);
   if (`${window.location.pathname}${window.location.search}` === nextPath) return;
   window.history.replaceState(null, "", nextPath);
 }

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -209,6 +209,35 @@ describe("projectModelOptions", () => {
 });
 
 describe("createRuntimeClient", () => {
+  it("uses the agent-scoped endpoint when loading an agent skill detail", async () => {
+    const seen: string[] = [];
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: (async (input: RequestInfo | URL) => {
+        seen.push(String(input));
+        return Response.json({
+          skill: {
+            skill_id: "workspace:root:trace-report-analysis",
+            name: "trace-report-analysis",
+            description: "Analyze traces",
+            scope: "workspace",
+          },
+          content: "# Trace report analysis",
+        });
+      }) as typeof fetch,
+    });
+
+    await expect(
+      client.getSkillDetail("workspace:root:trace-report-analysis", "holon-dev2"),
+    ).resolves.toEqual(expect.objectContaining({
+      content: "# Trace report analysis",
+    }));
+    expect(seen).toEqual([
+      "http://example.test:7878/api/agents/holon-dev2/skills/workspace%3Aroot%3Atrace-report-analysis",
+    ]);
+  });
+
   it("loads agent state without fetching the full roster", async () => {
     const seen: string[] = [];
     const client = createRuntimeClient({

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -823,14 +823,17 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       const response = await getJson<SkillCatalogResponseDto>(fetchImpl, baseUrl, "/skills/catalog", { headers: requestHeaders });
       return projectSkillCatalog(response, agentId);
     },
-    async getSkillDetail(skillId: string): Promise<SkillDetailState> {
+    async getSkillDetail(skillId: string, agentId?: string): Promise<SkillDetailState> {
       if (!baseUrl) {
         return { source: "fixture", error: "Holon API base URL is not configured." };
       }
+      const path = agentId
+        ? `/agents/${encodeURIComponent(agentId)}/skills/${encodeURIComponent(skillId)}`
+        : `/skills/catalog/${encodeURIComponent(skillId)}`;
       const response = await getJson<SkillDetailResponseDto>(
         fetchImpl,
         baseUrl,
-        `/skills/catalog/${encodeURIComponent(skillId)}`,
+        path,
         { headers: requestHeaders },
       );
       return {

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -221,6 +221,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agents/{agent_id}/skills/{skill_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent skill detail
+         * @description Return metadata and SKILL.md content for a skill in the target agent's effective catalog. The agent selects the active execution-root version.
+         */
+        get: operations["agentSkillDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/agents/{agent_id}/state": {
         parameters: {
             query?: never;
@@ -4534,6 +4554,49 @@ export interface operations {
             path: {
                 /** @description Agent id. */
                 agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentSkillDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+                /** @description Root-qualified skill id. */
+                skill_id: string;
             };
             cookie?: never;
         };

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -20,6 +20,7 @@ import {
   readStoredRuntimeConnectionConfig,
   runWithConcurrencyLimit,
   sessionForEventLogEpoch,
+  skillDetailCacheKey,
   streamEventFromBackfill,
   useRuntimeStore,
   writeStoredRuntimeConnectionConfig,
@@ -74,6 +75,15 @@ function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionS
     ...overrides,
   };
 }
+
+describe("skillDetailCacheKey", () => {
+  it("keeps global and agent-scoped versions separate", () => {
+    expect(skillDetailCacheKey("workspace:root:demo")).toBe("workspace:root:demo");
+    expect(skillDetailCacheKey("workspace:root:demo", "agent-a")).toBe(
+      "agent-a\u0000workspace:root:demo",
+    );
+  });
+});
 
 function agentSummary(overrides: Partial<AgentSummary> = {}): AgentSummary {
   return {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -258,6 +258,7 @@ export interface RuntimeStoreState {
   route: RouteKey;
   selectedAgentId: string;
   selectedSkillId: string;
+  selectedSkillAgentId: string;
   selectedTemplateId: string;
   displayLevel: DisplayLevel;
   displayLevelsByAgentId: Record<string, DisplayLevel>;
@@ -313,7 +314,7 @@ export interface RuntimeStoreState {
 
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string, targetEventSeq?: number) => void;
-  openSkill: (skillId: string) => void;
+  openSkill: (skillId: string, agentId?: string) => void;
   openTemplate: (catalogId: string) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
   disableDeveloperDiagnosticsUi: (agentId?: string) => void;
@@ -350,7 +351,7 @@ export interface RuntimeStoreState {
   refreshRuntimeConfig: () => Promise<void>;
   updateRuntimeConfig: (updates: Array<{ key: string; value?: unknown; unset?: boolean }>) => Promise<RuntimeConfigState | undefined>;
   refreshSkillCatalog: () => Promise<void>;
-  refreshSkillDetail: (skillId: string | undefined) => Promise<void>;
+  refreshSkillDetail: (skillId: string | undefined, agentId?: string) => Promise<void>;
   refreshTemplateCatalog: () => Promise<void>;
   refreshTemplateDetail: (catalogId: string | undefined) => Promise<void>;
   installTemplate: (githubUrl: string) => Promise<boolean>;
@@ -548,6 +549,10 @@ function isCurrentClientGeneration(generation: number): boolean {
 }
 
 type RuntimeClient = ReturnType<typeof createRuntimeClient>;
+
+export function skillDetailCacheKey(skillId: string, agentId?: string): string {
+  return agentId ? `${agentId}\u0000${skillId}` : skillId;
+}
 
 interface ClientRequest {
   client: RuntimeClient;
@@ -1115,6 +1120,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   route: "dashboard",
   selectedAgentId: "",
   selectedSkillId: "",
+  selectedSkillAgentId: "",
   selectedTemplateId: "",
   displayLevel: "info",
   displayLevelsByAgentId: readStoredDisplayLevels(),
@@ -1164,7 +1170,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   resumeRevision: 0,
 
   setRoute: (route) => set({ route }),
-  openSkill: (skillId) => set({ route: "skillDetail", selectedSkillId: skillId }),
+  openSkill: (skillId, agentId) =>
+    set({
+      route: "skillDetail",
+      selectedSkillId: skillId,
+      selectedSkillAgentId: agentId ?? "",
+    }),
   openTemplate: (catalogId) => set({ route: "templateDetail", selectedTemplateId: catalogId }),
   openAgent: (agentId, targetEventSeq) =>
     set((state) => {
@@ -1569,6 +1580,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(normalizedConfig)),
       selectedAgentId: "",
       selectedSkillId: "",
+      selectedSkillAgentId: "",
       selectedTemplateId: "",
       route: "dashboard",
       resumeRevision: get().resumeRevision + 1,
@@ -1811,21 +1823,21 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }
   },
 
-  refreshSkillDetail: async (skillId) => {
+  refreshSkillDetail: async (skillId, agentId) => {
     if (!skillId) return;
+    const cacheKey = skillDetailCacheKey(skillId, agentId);
     const request = captureClientRequest();
     set((state) => ({
-      skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: true },
-      skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: undefined },
+      skillDetailLoadingById: { ...state.skillDetailLoadingById, [cacheKey]: true },
+      skillDetailErrorById: { ...state.skillDetailErrorById, [cacheKey]: undefined },
     }));
     try {
-      // The backend resolves scope from the skill_id prefix automatically.
-      const detail = await request.client.getSkillDetail(skillId);
+      const detail = await request.client.getSkillDetail(skillId, agentId);
       if (!isCurrentClientRequest(request)) return;
       set((state) => ({
-        skillDetailById: { ...state.skillDetailById, [skillId]: detail },
-        skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: false },
-        skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: detail.error },
+        skillDetailById: { ...state.skillDetailById, [cacheKey]: detail },
+        skillDetailLoadingById: { ...state.skillDetailLoadingById, [cacheKey]: false },
+        skillDetailErrorById: { ...state.skillDetailErrorById, [cacheKey]: detail.error },
       }));
     } catch (error) {
       if (!isCurrentClientRequest(request)) return;
@@ -1833,10 +1845,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set((state) => ({
         skillDetailById: {
           ...state.skillDetailById,
-          [skillId]: { source: "http", error: message },
+          [cacheKey]: { source: "http", error: message },
         },
-        skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: false },
-        skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: message },
+        skillDetailLoadingById: { ...state.skillDetailLoadingById, [cacheKey]: false },
+        skillDetailErrorById: { ...state.skillDetailErrorById, [cacheKey]: message },
       }));
     }
   },


### PR DESCRIPTION
## Summary

- resolve workspace skill details through the target agent's active execution root
- add `GET /agents/{agent_id}/skills/{skill_id}` while preserving the global catalog endpoint
- keep Web GUI navigation and deep links agent-aware for workspace and agent-home skills
- document worktree discovery, no-canonical-fallback, cross-agent read, and precedence semantics

## Verification

- `cargo test agent_skill_detail_follows_active_execution_root_without_canonical_fallback`
- `cargo test --test http_control`
- `cargo test --test openapi_snapshot`
- `cargo test --test http_route_snapshot`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- relevant Web GUI route, client, and runtime-store tests

Closes #2437
