### PR TITLE
fix(scheduler): close authoritative cutover gaps

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -1379,6 +1379,58 @@ and later re-authorization. Every class mode (`off`, `shadow`, or
 `authoritative`) must reject a rollback action whose target is
 `authoritative`.
 
+#### Legacy Cutover Adoption
+
+Promotion from `shadow` to any authoritative scenario is also a migration
+boundary. Before the first authority-granting command in a rollout batch, the
+same database transaction must inspect every open legacy WorkItem and adopt
+its uniquely reconstructable scheduling state into the canonical partition:
+
+- the WorkItem revision becomes both the metadata fence and the initial
+  scheduling generation;
+- one active WorkItem-owned wait becomes a canonical active wait at that
+  generation;
+- current focus is copied independently from execution ownership; and
+- an agent-wide wait reserves dispatch only when the legacy agent posture
+  actually held the lane.
+
+Adoption is a typed, idempotent protocol command. Existing equal state is a
+replay; existing different state at the same fence is a conflict. A running
+legacy turn, dequeued queue claim, ambiguous wait, cross-agent ownership,
+generic blocker, or yielded state without settlement history rejects the
+whole rollout batch. Adoption and authority therefore either commit together
+or leave both the canonical partition and rollout state unchanged.
+
+`holon debug scheduler-recovery` reports the same adoption candidates and
+stable ineligibility reasons. `--apply` executes the same reducer-backed
+commands and never edits scheduler tables directly.
+
+#### Restart Task Rejoin
+
+Daemon restart marks each non-reattached in-flight task `interrupted` exactly
+once and enqueues one standard runtime-owned `TaskResult` per task. The
+message preserves the original task id and effective WorkItem binding and
+uses the ordinary `TaskRejoin` delivery surface. Tasks from different
+WorkItems never share an aggregate model turn. The former unbound
+`task_restart` content message is not an execution or scheduling mechanism;
+restart aggregation may remain only as audit evidence.
+
+#### Pre-claim Authority Failure
+
+Canonical activation planning has explicit `not applicable`, `plan`, and
+`hard blocker` outcomes. Once a candidate scenario is authoritative, missing
+demand, missing or mismatched wait generation, unresolved canonical
+scenario, or incompatible WorkItem state cannot silently fall back to a
+legacy model turn and cannot return an ordinary pre-claim error that leaves a
+hot retry loop.
+
+The runtime reports a fenced scenario hard blocker before queue claim. That
+transaction records the stable blocker code and rolls the scenario back to
+its manifest target. The queue entry remains unclaimed; the next poll
+observes the downgraded authority and may consume the original message
+through the compatibility path. No activation, wait trigger, queue claim, or
+partial agent-state mutation is committed with the blocker.
+
 ### Phase 5: Semantic Proposal Providers
 
 - structural resolution remains first;

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -789,6 +789,27 @@ pub struct RegisterWorkDemandCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegacyWaitAdoption {
+    pub wait_id: String,
+    pub generation: u64,
+    pub owner_work_item_id: String,
+    pub source_updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdoptLegacyWorkStateCommand {
+    pub work_item_id: String,
+    pub source_work_item_revision: u64,
+    pub demand: WorkDemand,
+    #[serde(default)]
+    pub wait: Option<LegacyWaitAdoption>,
+    #[serde(default)]
+    pub focus: bool,
+    #[serde(default)]
+    pub reserve_dispatch: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LegacyCompletionReport {
     pub turn_terminal: String,
     pub operator_delivery: String,
@@ -854,6 +875,7 @@ pub struct AttachActivationInputCommand {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ProtocolCommand {
     RegisterWorkDemand(RegisterWorkDemandCommand),
+    AdoptLegacyWorkState(AdoptLegacyWorkStateCommand),
     IssueActivationAuthority(IssueActivationAuthorityCommand),
     AdmitActivation(AdmitActivationCommand),
     SettleActivation(SettleActivationCommand),
@@ -1192,6 +1214,7 @@ pub struct Outcome {
 #[serde(rename_all = "snake_case")]
 pub enum Decision {
     WorkDemandRegistered,
+    LegacyWorkStateAdopted,
     AuthorityIssued,
     Admitted,
     Settled,
@@ -1679,6 +1702,9 @@ pub fn reduce_command(snapshot: &Snapshot, command: &ProtocolCommand) -> Protoco
     if let ProtocolCommand::RegisterWorkDemand(command) = command {
         return register_work_demand(snapshot, command);
     }
+    if let ProtocolCommand::AdoptLegacyWorkState(command) = command {
+        return adopt_legacy_work_state(snapshot, command);
+    }
     if let ProtocolCommand::IssueActivationAuthority(command) = command {
         return issue_activation_authority(snapshot, command);
     }
@@ -1776,6 +1802,55 @@ fn replay_or_conflict(
                         ),
                     )
                 });
+            }
+        }
+        ProtocolCommand::AdoptLegacyWorkState(command) => {
+            if let Some(existing) = snapshot.work.get(&command.work_item_id) {
+                if existing.metadata_revision != command.source_work_item_revision {
+                    return None;
+                }
+                let wait_matches = match &command.wait {
+                    Some(wait) => snapshot.waits.get(&wait.wait_id).is_some_and(|existing| {
+                        existing.current_generation == wait.generation
+                            && existing.generations.get(&wait.generation)
+                                == Some(&WaitGenerationRecord {
+                                    owner_work_item_id: wait.owner_work_item_id.clone(),
+                                    state: WaitState::Active,
+                                    trigger: None,
+                                    consuming_activation_id: None,
+                                })
+                    }),
+                    None => true,
+                };
+                let focus_matches = !command.focus
+                    || snapshot.focus.as_deref() == Some(command.work_item_id.as_str());
+                let dispatch_matches = !command.reserve_dispatch
+                    || command.wait.as_ref().is_some_and(|wait| {
+                        snapshot.dispatch
+                            == (AgentDispatchState::Awaiting {
+                                wait: WaitIdentity {
+                                    id: wait.wait_id.clone(),
+                                    generation: wait.generation,
+                                },
+                            })
+                    });
+                return Some(
+                    if existing == &command.demand
+                        && wait_matches
+                        && focus_matches
+                        && dispatch_matches
+                    {
+                        duplicate_command(snapshot, "legacy_work_state_already_adopted")
+                    } else {
+                        rejected_command(
+                            snapshot,
+                            command_conflict(
+                                ProtocolConflictKind::IdentityConflict,
+                                "legacy_work_state_adoption_conflict",
+                            ),
+                        )
+                    },
+                );
             }
         }
         ProtocolCommand::IssueActivationAuthority(command) => {
@@ -1932,8 +2007,8 @@ fn lower_command(
     command: &ProtocolCommand,
 ) -> Result<Event, ProtocolConflict> {
     match command {
-        ProtocolCommand::RegisterWorkDemand(_) => {
-            unreachable!("work demand registration is reduced directly")
+        ProtocolCommand::RegisterWorkDemand(_) | ProtocolCommand::AdoptLegacyWorkState(_) => {
+            unreachable!("work demand mutations are reduced directly")
         }
         ProtocolCommand::IssueActivationAuthority(_) => {
             unreachable!("authority issuance is reduced directly")
@@ -2065,6 +2140,155 @@ fn register_work_demand(
             decision: Decision::WorkDemandRegistered,
             transitions: vec![format!(
                 "work:{}:registered:generation:{}",
+                command.work_item_id, command.demand.scheduling_generation
+            )],
+            diagnostics: Vec::new(),
+            snapshot: next,
+        },
+        conflict: None,
+    }
+}
+
+fn adopt_legacy_work_state(
+    snapshot: &Snapshot,
+    command: &AdoptLegacyWorkStateCommand,
+) -> ProtocolCommandOutcome {
+    if command.work_item_id.is_empty()
+        || command.source_work_item_revision == 0
+        || command.demand.metadata_revision != command.source_work_item_revision
+        || command.demand.scheduling_generation == 0
+        || command.demand.locality.is_empty()
+        || command.demand.cost_class.is_empty()
+    {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::InvalidCommand,
+                "legacy_work_state_adoption_fields_required",
+            ),
+        );
+    }
+    match (&command.demand.status, &command.wait) {
+        (WorkStatus::Runnable, None) => {}
+        (WorkStatus::Waiting { wait_id }, Some(wait))
+            if wait_id == &wait.wait_id
+                && wait.owner_work_item_id == command.work_item_id
+                && wait.generation == command.demand.scheduling_generation
+                && !wait.source_updated_at.is_empty() => {}
+        (WorkStatus::Yielded { .. } | WorkStatus::Paused { .. }, None) => {}
+        _ => {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::UnsupportedCommand,
+                    "legacy_work_state_adoption_shape_unsupported",
+                ),
+            );
+        }
+    }
+    if command.reserve_dispatch && command.wait.is_none() {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::InvalidCommand,
+                "legacy_dispatch_adoption_requires_wait",
+            ),
+        );
+    }
+    if command.focus
+        && snapshot
+            .focus
+            .as_deref()
+            .is_some_and(|focus| focus != command.work_item_id)
+    {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::StateConflict,
+                "legacy_focus_adoption_conflict",
+            ),
+        );
+    }
+    if command.reserve_dispatch && snapshot.dispatch != AgentDispatchState::Open {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::StateConflict,
+                "legacy_dispatch_adoption_conflict",
+            ),
+        );
+    }
+    if snapshot
+        .work
+        .get(&command.work_item_id)
+        .is_some_and(|existing| {
+            existing.metadata_revision > command.source_work_item_revision
+                || matches!(
+                    existing.status,
+                    WorkStatus::NeedsSettlement { .. } | WorkStatus::Terminal
+                )
+        })
+    {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::StaleRevision,
+                "legacy_work_state_adoption_stale",
+            ),
+        );
+    }
+
+    let mut next = snapshot.clone();
+    if let Some(existing) = next.work.get(&command.work_item_id) {
+        if let WorkStatus::Waiting { wait_id } = &existing.status {
+            if command.wait.as_ref().map(|wait| wait.wait_id.as_str()) != Some(wait_id.as_str()) {
+                if let Some(wait) = next.waits.get_mut(wait_id) {
+                    if let Some(generation) = wait.generations.get_mut(&wait.current_generation) {
+                        if matches!(generation.state, WaitState::Active | WaitState::Triggered) {
+                            generation.state = WaitState::Resolved;
+                            generation.trigger = None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    next.work
+        .insert(command.work_item_id.clone(), command.demand.clone());
+    if let Some(wait) = &command.wait {
+        next.waits.insert(
+            wait.wait_id.clone(),
+            WaitRecord {
+                current_generation: wait.generation,
+                generations: BTreeMap::from([(
+                    wait.generation,
+                    WaitGenerationRecord {
+                        owner_work_item_id: wait.owner_work_item_id.clone(),
+                        state: WaitState::Active,
+                        trigger: None,
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        );
+        if command.reserve_dispatch {
+            next.dispatch = AgentDispatchState::Awaiting {
+                wait: WaitIdentity {
+                    id: wait.wait_id.clone(),
+                    generation: wait.generation,
+                },
+            };
+            next.dispatch_revision += 1;
+        }
+    }
+    if command.focus {
+        next.focus = Some(command.work_item_id.clone());
+    }
+    ProtocolCommandOutcome {
+        outcome: Outcome {
+            decision: Decision::LegacyWorkStateAdopted,
+            transitions: vec![format!(
+                "work:{}:legacy_state_adopted:generation:{}",
                 command.work_item_id, command.demand.scheduling_generation
             )],
             diagnostics: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2415,6 +2415,12 @@ fn print_scheduler_recovery_report(
             candidate.target_queue_status
         );
     }
+    for candidate in report.legacy_adoptions {
+        println!(
+            "- work_item:{}: adoption eligible={} reason={}",
+            candidate.work_item_id, candidate.eligible, candidate.reason
+        );
+    }
     Ok(())
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -590,6 +590,15 @@ pub struct SchedulerRecoveryReport {
     pub agent_id: String,
     pub partition_initialized: bool,
     pub candidates: Vec<SchedulerRecoveryCandidate>,
+    pub legacy_adoptions: Vec<SchedulerLegacyAdoptionCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerLegacyAdoptionCandidate {
+    pub work_item_id: String,
+    pub eligible: bool,
+    pub reason: String,
+    pub proposed_command: Option<crate::domain::scheduler_protocol::ProtocolCommand>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -720,6 +729,17 @@ pub fn scheduler_recovery_report(
             agent_id: agent_id.to_string(),
             partition_initialized: false,
             candidates: Vec::new(),
+            legacy_adoptions: runtime_db
+                .transitions()
+                .legacy_scheduler_adoption_candidates(agent_id)?
+                .into_iter()
+                .map(|candidate| SchedulerLegacyAdoptionCandidate {
+                    work_item_id: candidate.work_item_id,
+                    eligible: candidate.eligible,
+                    reason: candidate.reason,
+                    proposed_command: candidate.command,
+                })
+                .collect(),
         });
     };
     let all_queue_entries = runtime_db
@@ -1009,6 +1029,17 @@ pub fn scheduler_recovery_report(
         agent_id: agent_id.to_string(),
         partition_initialized: true,
         candidates,
+        legacy_adoptions: runtime_db
+            .transitions()
+            .legacy_scheduler_adoption_candidates(agent_id)?
+            .into_iter()
+            .map(|candidate| SchedulerLegacyAdoptionCandidate {
+                work_item_id: candidate.work_item_id,
+                eligible: candidate.eligible,
+                reason: candidate.reason,
+                proposed_command: candidate.command,
+            })
+            .collect(),
     })
 }
 
@@ -1018,22 +1049,22 @@ pub fn apply_scheduler_recovery_plan(
     agent_id: &str,
     report: &SchedulerRecoveryReport,
 ) -> Result<usize> {
-    let Some(candidate) = report.candidates.iter().find(|candidate| {
+    let mut commands = report
+        .legacy_adoptions
+        .iter()
+        .filter(|candidate| candidate.eligible)
+        .filter_map(|candidate| candidate.proposed_command.clone())
+        .collect::<Vec<_>>();
+    if let Some(candidate) = report.candidates.iter().find(|candidate| {
         candidate.kind == SchedulerRecoveryCandidateKind::NeedsSettlement && candidate.eligible
-    }) else {
-        return Ok(0);
-    };
-    if candidate.proposed_commands.is_empty() {
-        return Ok(0);
+    }) {
+        commands.extend(candidate.proposed_commands.clone());
     }
-    let mut changed = false;
-    for command in &candidate.proposed_commands {
-        let commit = runtime_db
+    Ok(usize::from(
+        runtime_db
             .transitions()
-            .commit_scheduler_recovery_command(agent_id, command, None)?;
-        changed |= commit.applied;
-    }
-    Ok(usize::from(changed))
+            .commit_scheduler_recovery_plan(agent_id, &commands)?,
+    ))
 }
 
 fn runtime_error_queue_settlement(
@@ -2111,6 +2142,57 @@ impl RuntimeHandle {
         operator_binding_id: Option<&str>,
         operator_reply_route_id: Option<&str>,
     ) -> Result<()> {
+        if let Some(message) = message {
+            let work_item_id = message.work_item_id.clone().or_else(|| {
+                self.inner.agent.try_lock().ok().and_then(|guard| {
+                    guard
+                        .state
+                        .current_turn_work_item_id
+                        .clone()
+                        .or_else(|| guard.state.current_work_item_id.clone())
+                })
+            });
+            let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+            let scenario = match message.delivery_surface {
+                Some(MessageDeliverySurface::TaskRejoin) => {
+                    Some(scheduler::EXACT_TASK_REJOIN_SCENARIO)
+                }
+                Some(MessageDeliverySurface::RuntimeSystem) => {
+                    Some(scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO)
+                }
+                _ => None,
+            };
+            let authoritative_without_activation = work_item_id.is_some()
+                && message.authority_class == AuthorityClass::RuntimeInstruction
+                && self.scheduler_protocol_production_commands_enabled()
+                && scenario
+                    .map(|scenario| {
+                        self.inner
+                            .runtime_db
+                            .transitions()
+                            .scheduler_scenario_mode(scenario)
+                    })
+                    .transpose()?
+                    == Some(crate::domain::scheduler_protocol::ScenarioMode::Authoritative)
+                && self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?
+                    .is_none_or(|snapshot| !snapshot.activations.contains_key(&activation_id));
+            if authoritative_without_activation {
+                self.inner.storage.append_event(&AuditEvent::legacy(
+                    "authoritative_work_item_turn_without_activation",
+                    serde_json::json!({
+                        "agent_id": message.agent_id,
+                        "message_id": message.id,
+                        "work_item_id": work_item_id,
+                        "scenario_class": scenario.map(|scenario| scenario.as_str()),
+                        "delivery_surface": message.delivery_surface,
+                    }),
+                ))?;
+            }
+        }
         let state = {
             let mut guard = self.inner.agent.lock().await;
             guard.state.turn_index += 1;
@@ -3558,6 +3640,7 @@ impl RuntimeHandle {
     }
 
     async fn bootstrap_recovery(&self) -> Result<()> {
+        let mut interrupted_for_delivery = self.missing_interrupted_task_results().await?;
         if let Some(tasks) = self.inner.recovered_tasks.lock().await.take() {
             let (reattached, interrupted_tasks) =
                 self.recover_supervised_child_tasks(tasks).await?;
@@ -3571,10 +3654,13 @@ impl RuntimeHandle {
                     }),
                 ))?;
             }
-            if !interrupted.is_empty() {
-                self.emit_system_tick_from_interrupted_tasks(&interrupted)
-                    .await?;
-            }
+            interrupted_for_delivery.extend(interrupted);
+        }
+        interrupted_for_delivery.sort_by(|left, right| left.id.cmp(&right.id));
+        interrupted_for_delivery.dedup_by(|left, right| left.id == right.id);
+        if !interrupted_for_delivery.is_empty() {
+            self.emit_task_results_from_interrupted_tasks(&interrupted_for_delivery)
+                .await?;
         }
         if let Some(timers) = self.inner.recovered_timers.lock().await.take() {
             self.recover_active_timers(timers).await?;

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -944,65 +944,65 @@ impl RuntimeHandle {
         Ok(())
     }
 
-    pub(super) async fn emit_system_tick_from_interrupted_tasks(
+    pub(super) async fn emit_task_results_from_interrupted_tasks(
         &self,
         tasks: &[TaskRecord],
     ) -> Result<()> {
-        let items = tasks
-            .iter()
-            .map(|task| {
-                serde_json::json!({
+        let agent_id = self.agent_id().await?;
+        let mut message_ids = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            let status_before_restart = task
+                .detail
+                .as_ref()
+                .and_then(|detail| detail.get("status_before_restart"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("running");
+            let message = MessageEnvelope {
+                id: super::tasks::restart_task_result_message_id(&task.id),
+                turn_id: Some(crate::ids::turn_id()),
+                work_item_id: task.effective_work_item_id().map(ToString::to_string),
+                metadata: Some(serde_json::json!({
                     "task_id": task.id,
-                    "kind": task.kind,
-                    "status_before_restart": task
-                        .detail
-                        .as_ref()
-                        .and_then(|detail| detail.get("status_before_restart"))
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("running"),
-                    "summary": task.summary,
-                    "wait_policy": task.wait_policy()
-                })
-            })
-            .collect::<Vec<_>>();
-        let mut message = MessageEnvelope::new(
-            self.agent_id().await?,
-            MessageKind::SystemTick,
-            MessageOrigin::System {
-                subsystem: "task_restart".into(),
-            },
-            AuthorityClass::RuntimeInstruction,
-            Priority::Next,
-            MessageBody::Text {
-                text: format!(
-                    "runtime restarted and interrupted {} task{}",
-                    tasks.len(),
-                    if tasks.len() == 1 { "" } else { "s" }
-                ),
-            },
-        )
-        .with_admission(
-            MessageDeliverySurface::RuntimeSystem,
-            AdmissionContext::RuntimeOwned,
-        );
-        message.metadata = Some(serde_json::json!({
-            "interrupted_tasks": {
-                "count": tasks.len(),
-                "items": items
-            }
-        }));
+                    "task_kind": task.kind,
+                    "task_status": "interrupted",
+                    "task_summary": task.summary,
+                    "task_detail": task.detail,
+                    "task_recovery": task.recovery,
+                    "work_item_id": task.effective_work_item_id(),
+                    "status_before_restart": status_before_restart,
+                    "interrupted_reason": "runtime_restarted"
+                })),
+                ..MessageEnvelope::new(
+                    agent_id.clone(),
+                    MessageKind::TaskResult,
+                    MessageOrigin::Task {
+                        task_id: task.id.clone(),
+                    },
+                    AuthorityClass::RuntimeInstruction,
+                    Priority::Next,
+                    MessageBody::Text {
+                        text: format!(
+                            "task {} was interrupted because the runtime restarted",
+                            task.id
+                        ),
+                    },
+                )
+                .with_admission(
+                    MessageDeliverySurface::TaskRejoin,
+                    AdmissionContext::RuntimeOwned,
+                )
+            };
+            message_ids.push(message.id.clone());
+            let _ = self.enqueue(message).await?;
+        }
         self.inner.storage.append_event(&AuditEvent::legacy(
-            "system_tick_emitted",
+            "task_restart_results_emitted",
             serde_json::json!({
-                "subsystem": "task_restart",
-                "interrupted_tasks": message
-                    .metadata
-                    .as_ref()
-                    .and_then(|value| value.get("interrupted_tasks"))
-                    .cloned()
+                "agent_id": agent_id,
+                "task_ids": tasks.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
+                "message_ids": message_ids,
             }),
         ))?;
-        let _ = self.enqueue(message).await?;
         Ok(())
     }
 }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -83,6 +83,20 @@ struct CanonicalClaimPlan {
     >,
 }
 
+enum CanonicalClaimOutcome {
+    NotApplicable,
+    Plan(CanonicalClaimPlan),
+    HardBlocker(CanonicalClaimHardBlocker),
+}
+
+struct CanonicalClaimHardBlocker {
+    scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
+    blocker_code: &'static str,
+    expected_config_revision: u64,
+    expected_manifest_revision: u64,
+    expected_preflight_revision: u64,
+}
+
 pub(super) struct SchedulerDecisionExecutor<'a> {
     runtime: &'a RuntimeHandle,
 }
@@ -428,7 +442,12 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &dispatch_plan,
             production_commands_enabled,
         ) {
-            Ok(plan) => plan,
+            Ok(CanonicalClaimOutcome::NotApplicable) => None,
+            Ok(CanonicalClaimOutcome::Plan(plan)) => Some(plan),
+            Ok(CanonicalClaimOutcome::HardBlocker(blocker)) => {
+                self.report_canonical_claim_hard_blocker(&persisted_message, blocker)?;
+                return Ok(RunLoopPoll::Idle);
+            }
             Err(error) => {
                 if let Some(ambiguous) = error.downcast_ref::<scheduler::AmbiguousCanonicalWaits>()
                 {
@@ -613,9 +632,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         message: &MessageEnvelope,
         dispatch_plan: &MessageDispatchPlan,
         production_commands_enabled: bool,
-    ) -> Result<Option<CanonicalClaimPlan>> {
+    ) -> Result<CanonicalClaimOutcome> {
         if !production_commands_enabled {
-            return Ok(None);
+            return Ok(CanonicalClaimOutcome::NotApplicable);
         }
         let task = dispatch_plan.task.as_ref().ok().and_then(Option::as_ref);
         let Some(candidate) = scheduler::canonical_activation_candidate(
@@ -624,8 +643,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             task,
         )?
         else {
-            return Ok(None);
+            return Ok(CanonicalClaimOutcome::NotApplicable);
         };
+        let scenario_class = candidate.scenario_class();
         let mut rollout_expectations = self
             .runtime
             .inner
@@ -638,12 +658,16 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         if rollout_expectations.iter().any(|expectation| {
             expectation.mode != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
         }) {
-            return Ok(None);
+            return Ok(CanonicalClaimOutcome::NotApplicable);
         }
         let Some(mut scenario) =
             scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?
         else {
-            return Ok(None);
+            return Ok(canonical_claim_hard_blocker(
+                &rollout_expectations,
+                scenario_class,
+                "canonical_activation_scenario_unresolved",
+            )?);
         };
 
         use crate::domain::scheduler_protocol::WorkStatus;
@@ -696,28 +720,52 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .inner
             .storage
             .latest_work_item(work_item_id)?
-            .ok_or_else(|| anyhow!("canonical activation references unknown WorkItem"))?;
+            .ok_or_else(|| anyhow!("canonical activation references unknown WorkItem"));
+        let work_item = match work_item {
+            Ok(work_item) => work_item,
+            Err(_) => {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_work_item_missing",
+                )?);
+            }
+        };
         let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
         let work_projection = work_queue
             .items
             .iter()
             .find(|candidate| candidate.id == work_item.id)
-            .ok_or_else(|| anyhow!("canonical activation has no WorkItem scheduling projection"))?;
+            .ok_or_else(|| anyhow!("canonical activation has no WorkItem scheduling projection"));
+        let work_projection = match work_projection {
+            Ok(work_projection) => work_projection,
+            Err(_) => {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_work_item_projection_missing",
+                )?);
+            }
+        };
         if work_item.agent_id != message.agent_id
             || work_item.state != crate::types::WorkItemState::Open
         {
-            return Err(anyhow!(
-                "canonical activation requires an open same-agent WorkItem"
-            ));
+            return Ok(canonical_claim_hard_blocker(
+                &rollout_expectations,
+                scenario_class,
+                "canonical_work_item_not_open_same_agent",
+            )?);
         }
         if matches!(
             scenario,
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
         ) && work_projection.scheduling_state != crate::types::WorkItemSchedulingState::Runnable
         {
-            return Err(anyhow!(
-                "canonical autonomous activation requires a runnable WorkItem"
-            ));
+            return Ok(canonical_claim_hard_blocker(
+                &rollout_expectations,
+                scenario_class,
+                "canonical_autonomous_work_item_not_runnable",
+            )?);
         }
         let activation_id = canonical_activation_id(&message.id);
 
@@ -751,7 +799,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             canonical_admission_matches_scenario(admission, message, &scenario)
                         })
                 {
-                    return Ok(Some(CanonicalClaimPlan {
+                    return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
                         scheduler_claim_work_item: matches!(
                             scenario,
                             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
@@ -764,9 +812,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         rollout_expectations,
                     }));
                 }
-                return Err(anyhow!(
-                    "canonical work queue replay references a non-running activation"
-                ));
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_activation_replay_conflict",
+                )?);
             }
         }
         let new_demand = || WorkDemand {
@@ -793,9 +843,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             if let Some(snapshot) = existing.as_ref() {
                 if let Some(demand) = snapshot.work.get(work_item_id) {
                     if wait_id.is_none() && demand.status != WorkStatus::Runnable {
-                        return Err(anyhow!(
-                            "canonical WorkItem demand is not runnable for activation"
-                        ));
+                        return Ok(canonical_claim_hard_blocker(
+                            &rollout_expectations,
+                            scenario_class,
+                            "canonical_work_demand_not_runnable",
+                        )?);
                     }
                     (
                         None,
@@ -805,9 +857,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     )
                 } else {
                     if wait_id.is_some() {
-                        return Err(anyhow!(
-                            "canonical wait resume requires an existing WorkItem demand"
-                        ));
+                        return Ok(canonical_claim_hard_blocker(
+                            &rollout_expectations,
+                            scenario_class,
+                            "canonical_wait_resume_work_demand_missing",
+                        )?);
                     }
                     let demand = new_demand();
                     (
@@ -824,9 +878,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 }
             } else {
                 if wait_id.is_some() {
-                    return Err(anyhow!(
-                        "canonical wait resume requires an initialized protocol partition"
-                    ));
+                    return Ok(canonical_claim_hard_blocker(
+                        &rollout_expectations,
+                        scenario_class,
+                        "canonical_wait_resume_partition_uninitialized",
+                    )?);
                 }
                 let demand = new_demand();
                 (
@@ -858,35 +914,51 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 )
             };
 
-        let resume = wait_id
-            .map(|wait_id| -> Result<WaitResumeClaim> {
-                let snapshot = existing.as_ref().ok_or_else(|| {
-                    anyhow!("canonical wait resume requires an initialized snapshot")
-                })?;
-                let wait = snapshot
-                    .waits
-                    .get(wait_id)
-                    .ok_or_else(|| anyhow!("canonical activation references unknown wait"))?;
-                let generation = wait
-                    .generations
-                    .get(&wait.current_generation)
-                    .ok_or_else(|| anyhow!("canonical wait has no current generation"))?;
-                if generation.owner_work_item_id != work_item_id {
-                    return Err(anyhow!(
-                        "canonical wait owner does not match WorkItem binding"
-                    ));
-                }
-                let trigger_generation = message.message_seq.ok_or_else(|| {
-                    anyhow!("canonical activation requires persisted message sequence")
-                })?;
-                Ok(WaitResumeClaim {
-                    wait_id: wait_id.to_string(),
-                    wait_generation: wait.current_generation,
-                    trigger_id: canonical_wait_trigger_id(message),
-                    trigger_generation,
-                })
+        let resume = if let Some(wait_id) = wait_id {
+            let Some(snapshot) = existing.as_ref() else {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_wait_resume_partition_uninitialized",
+                )?);
+            };
+            let Some(wait) = snapshot.waits.get(wait_id) else {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_wait_missing",
+                )?);
+            };
+            let Some(generation) = wait.generations.get(&wait.current_generation) else {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_wait_generation_missing",
+                )?);
+            };
+            if generation.owner_work_item_id != work_item_id {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_wait_owner_mismatch",
+                )?);
+            }
+            let Some(trigger_generation) = message.message_seq else {
+                return Ok(canonical_claim_hard_blocker(
+                    &rollout_expectations,
+                    scenario_class,
+                    "canonical_trigger_sequence_missing",
+                )?);
+            };
+            Some(WaitResumeClaim {
+                wait_id: wait_id.to_string(),
+                wait_generation: wait.current_generation,
+                trigger_id: canonical_wait_trigger_id(message),
+                trigger_generation,
             })
-            .transpose()?;
+        } else {
+            None
+        };
         let (cause, binding, provenance_origin, provenance_trust, idempotency_key) = match &scenario
         {
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. } => (
@@ -1006,7 +1078,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         if rollout_expectations.iter().any(|expectation| {
             expectation.mode != crate::domain::scheduler_protocol::ScenarioMode::Authoritative
         }) {
-            return Ok(None);
+            return Ok(canonical_claim_hard_blocker(
+                &rollout_expectations,
+                scenario_class,
+                "canonical_work_demand_authority_unavailable",
+            )?);
         }
         commands.extend(register);
         if let Some(resume) = resume {
@@ -1020,7 +1096,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         commands.push(ProtocolCommand::IssueActivationAuthority(authority));
         commands.push(ProtocolCommand::AdmitActivation(admission));
 
-        Ok(Some(CanonicalClaimPlan {
+        Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
             scheduler_claim_work_item: matches!(
                 scenario,
                 scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
@@ -1030,6 +1106,46 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             commands,
             rollout_expectations,
         }))
+    }
+
+    fn report_canonical_claim_hard_blocker(
+        &self,
+        message: &MessageEnvelope,
+        blocker: CanonicalClaimHardBlocker,
+    ) -> Result<()> {
+        use crate::domain::scheduler_protocol::RolloutCommand;
+        let scenario_class = blocker.scenario_class.as_str();
+        let command = RolloutCommand::ReportScenarioHardBlocker {
+            scenario_class: scenario_class.to_string(),
+            blocker_code: blocker.blocker_code.to_string(),
+            expected_config_revision: blocker.expected_config_revision,
+            expected_manifest_revision: blocker.expected_manifest_revision,
+            expected_preflight_revision: blocker.expected_preflight_revision,
+        };
+        let identity = format!(
+            "runtime-hard-blocker:{}:{}:{}",
+            scenario_class, blocker.expected_config_revision, message.id
+        );
+        self.runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .commit_scheduler_rollout_command(&identity, &command, None)?;
+        self.runtime
+            .inner
+            .storage
+            .append_event(&AuditEvent::legacy(
+                "scheduler_authority_hard_blocker",
+                serde_json::json!({
+                    "message_id": message.id,
+                    "agent_id": message.agent_id,
+                    "scenario_class": scenario_class,
+                    "blocker_code": blocker.blocker_code,
+                    "queue_disposition": "retained_queued",
+                }),
+            ))?;
+        self.runtime.inner.notify.notify_one();
+        Ok(())
     }
 
     fn append_posture_decision(
@@ -1055,6 +1171,41 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
 pub(super) fn canonical_activation_id(message_id: &str) -> String {
     format!("activation:message:{message_id}")
+}
+
+fn canonical_claim_hard_blocker(
+    expectations: &[crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRolloutExpectation],
+    scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
+    blocker_code: &'static str,
+) -> Result<CanonicalClaimOutcome> {
+    let expectation = expectations
+        .iter()
+        .find(|expectation| expectation.scenario_class == scenario_class)
+        .ok_or_else(|| {
+            anyhow!(
+                "canonical hard blocker is missing rollout expectation for {}",
+                scenario_class.as_str()
+            )
+        })?;
+    Ok(CanonicalClaimOutcome::HardBlocker(
+        CanonicalClaimHardBlocker {
+            scenario_class,
+            blocker_code,
+            expected_config_revision: expectation.config_revision,
+            expected_manifest_revision: expectation.manifest_revision.ok_or_else(|| {
+                anyhow!(
+                    "authoritative scenario {} has no manifest revision",
+                    scenario_class.as_str()
+                )
+            })?,
+            expected_preflight_revision: expectation.preflight_revision.ok_or_else(|| {
+                anyhow!(
+                    "authoritative scenario {} has no preflight revision",
+                    scenario_class.as_str()
+                )
+            })?,
+        },
+    ))
 }
 
 fn canonical_wait_trigger_id(message: &MessageEnvelope) -> String {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -175,6 +175,10 @@ fn task_with_result_message(
     terminal_task
 }
 
+pub(super) fn restart_task_result_message_id(task_id: &str) -> String {
+    format!("message:task-restart:{task_id}")
+}
+
 impl RuntimeHandle {
     pub(super) async fn task_work_item_binding(&self) -> Option<String> {
         let guard = self.inner.agent.lock().await;
@@ -1465,7 +1469,7 @@ impl RuntimeHandle {
                 status: TaskStatus::Interrupted,
                 created_at: task.created_at,
                 updated_at: Utc::now(),
-                parent_message_id: None,
+                parent_message_id: Some(restart_task_result_message_id(&task.id)),
                 work_item_id: task.work_item_id.clone(),
                 summary: task.summary.clone(),
                 detail: Some(detail),
@@ -1476,6 +1480,32 @@ impl RuntimeHandle {
             interrupted.push(interrupted_task);
         }
         Ok(interrupted)
+    }
+
+    pub(super) async fn missing_interrupted_task_results(&self) -> Result<Vec<TaskRecord>> {
+        let agent_id = self.agent_id().await?;
+        let mut missing = Vec::new();
+        for task in self
+            .inner
+            .runtime_db
+            .tasks()
+            .latest_for_agent(&agent_id, usize::MAX)?
+        {
+            if task.status != TaskStatus::Interrupted {
+                continue;
+            }
+            let Some(message_id) = task
+                .parent_message_id
+                .as_deref()
+                .filter(|message_id| message_id.starts_with("message:task-restart:"))
+            else {
+                continue;
+            };
+            if self.inner.storage.read_message_by_id(message_id)?.is_none() {
+                missing.push(task);
+            }
+        }
+        Ok(missing)
     }
 
     pub(super) async fn interrupt_active_tasks_for_lifecycle_stop(

--- a/src/runtime/tests/contracts/task.rs
+++ b/src/runtime/tests/contracts/task.rs
@@ -122,7 +122,7 @@ async fn task_restart_interrupts_inflight_task_once() {
             created_at: now - chrono::Duration::seconds(1),
             updated_at: now - chrono::Duration::seconds(1),
             parent_message_id: None,
-            work_item_id: None,
+            work_item_id: Some("work-restart-a".into()),
             summary: Some("recoverable command".into()),
             detail: None,
             recovery: Some(TaskRecoverySpec::CommandTask {
@@ -141,6 +141,23 @@ async fn task_restart_interrupts_inflight_task_once() {
                 authority_class: AuthorityClass::OperatorInstruction,
                 promoted_from_exec_command: false,
             }),
+        })
+        .unwrap();
+    harness
+        .runtime()
+        .storage()
+        .append_task(&TaskRecord {
+            id: "task-restart-contract-b".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: Some("work-restart-b".into()),
+            summary: Some("second recoverable command".into()),
+            detail: None,
+            recovery: None,
         })
         .unwrap();
 
@@ -183,37 +200,53 @@ async fn task_restart_interrupts_inflight_task_once() {
     assert_eq!(output.retrieval_status, TaskOutputRetrievalStatus::NotReady);
     assert_eq!(output.task.status, TaskStatus::Interrupted);
     let messages = harness.snapshot().messages;
-    assert!(messages.iter().any(|message| {
-        message.kind == MessageKind::SystemTick
-            && matches!(
-                message.origin,
-                MessageOrigin::System { ref subsystem } if subsystem == "task_restart"
-            )
-    }));
-    assert!(messages.iter().any(|message| {
-        message
+    let result = messages
+        .iter()
+        .find(|message| {
+            message.kind == MessageKind::TaskResult
+                && matches!(
+                    message.origin,
+                    MessageOrigin::Task { ref task_id } if task_id == "task-restart-contract"
+                )
+        })
+        .expect("restart should enqueue a structured task result");
+    assert_eq!(result.task_id.as_deref(), Some("task-restart-contract"));
+    assert_eq!(
+        result
             .metadata
             .as_ref()
-            .and_then(|value| value.get("interrupted_tasks"))
-            .and_then(|value| value.get("count"))
-            .and_then(serde_json::Value::as_u64)
-            == Some(1)
-    }));
-    assert!(messages.iter().any(|message| {
-        message
+            .and_then(|value| value.get("task_status"))
+            .and_then(serde_json::Value::as_str),
+        Some("interrupted")
+    );
+    assert_eq!(
+        result
             .metadata
             .as_ref()
-            .and_then(|value| value.get("interrupted_tasks"))
-            .and_then(|value| value.get("items"))
-            .and_then(serde_json::Value::as_array)
-            .is_some_and(|items| {
-                items.iter().any(|item| {
-                    item.get("status_before_restart")
-                        .and_then(serde_json::Value::as_str)
-                        == Some("running")
-                })
-            })
-    }));
+            .and_then(|value| value.get("status_before_restart"))
+            .and_then(serde_json::Value::as_str),
+        Some("running")
+    );
+    assert_eq!(result.work_item_id.as_deref(), Some("work-restart-a"));
+    let second_result = messages
+        .iter()
+        .find(|message| {
+            message.kind == MessageKind::TaskResult
+                && matches!(
+                    message.origin,
+                    MessageOrigin::Task { ref task_id } if task_id == "task-restart-contract-b"
+                )
+        })
+        .expect("each interrupted task should receive its own result");
+    assert_eq!(
+        second_result.task_id.as_deref(),
+        Some("task-restart-contract-b")
+    );
+    assert_eq!(
+        second_result.work_item_id.as_deref(),
+        Some("work-restart-b")
+    );
+    assert_ne!(second_result.turn_id, result.turn_id);
     assert_eq!(
         harness
             .snapshot()
@@ -221,7 +254,7 @@ async fn task_restart_interrupts_inflight_task_once() {
             .iter()
             .filter(|event| event.kind == "task_interrupted_on_restart")
             .count(),
-        1
+        2
     );
     let interrupted_events = harness
         .snapshot()
@@ -252,5 +285,66 @@ async fn task_restart_interrupts_inflight_task_once() {
             .filter(|event| event.kind == "task_interrupted_on_restart")
             .count(),
         interrupted_events
+    );
+}
+
+#[tokio::test]
+async fn task_restart_recovers_interrupted_task_with_missing_result_message() {
+    let mut harness = LifecycleHarness::new();
+    let now = harness.now();
+    harness
+        .runtime()
+        .storage()
+        .append_task(&TaskRecord {
+            id: "task-restart-missing-result".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Interrupted,
+            created_at: now - chrono::Duration::seconds(1),
+            updated_at: now,
+            parent_message_id: Some(super::super::super::tasks::restart_task_result_message_id(
+                "task-restart-missing-result",
+            )),
+            work_item_id: Some("work-restart-missing-result".into()),
+            summary: Some("interrupted before result enqueue".into()),
+            detail: Some(serde_json::json!({
+                "status_before_restart": "running",
+                "interrupted_reason": "runtime_restarted",
+            })),
+            recovery: None,
+        })
+        .unwrap();
+
+    harness.restart();
+    let runtime = harness.runtime().clone();
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    wait_for_audit_events(
+        &runtime,
+        100,
+        |events| {
+            events
+                .iter()
+                .any(|event| event.kind == "task_restart_results_emitted")
+        },
+        "missing interrupted task result recovery",
+    )
+    .await;
+    runtime_task.abort();
+
+    let message = harness
+        .snapshot()
+        .messages
+        .into_iter()
+        .find(|message| {
+            message.id
+                == super::super::super::tasks::restart_task_result_message_id(
+                    "task-restart-missing-result",
+                )
+        })
+        .expect("restart should recover the missing interrupted task result");
+    assert_eq!(message.kind, MessageKind::TaskResult);
+    assert_eq!(
+        message.work_item_id.as_deref(),
+        Some("work-restart-missing-result")
     );
 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2877,6 +2877,121 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
 }
 
 #[tokio::test]
+async fn authoritative_task_rejoin_missing_demand_rolls_back_and_retains_queue_entry() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime.set_scheduler_protocol_production_commands_enabled(true);
+    enable_production_protocol_authority_for(&runtime, &[SchedulerScenarioClass::ExactTaskRejoin]);
+    let work_item = runtime
+        .create_work_item("legacy-only task rejoin".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-missing-demand".into()),
+            "waiting for task-missing-demand".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    runtime
+        .persist_task_transition(
+            &TaskRecord {
+                id: "task-missing-demand".into(),
+                agent_id: "default".into(),
+                kind: TaskKind::CommandTask,
+                status: TaskStatus::Completed,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                parent_message_id: None,
+                work_item_id: Some(work_item.id.clone()),
+                summary: Some("task-missing-demand".into()),
+                detail: None,
+                recovery: None,
+            },
+            "task_completed",
+        )
+        .await
+        .unwrap();
+    let mut message = task_result_message("task-missing-demand").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-missing-demand",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-missing-demand",
+        "work_item_id": work_item.id,
+    }));
+    let message = runtime.enqueue(message).await.unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .scheduler_scenario_mode(SchedulerScenarioClass::ExactTaskRejoin)
+            .unwrap(),
+        ScenarioMode::Shadow
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(64)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_hard_blocker"
+                && event.data["message_id"] == message.id
+        }));
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+}
+
+#[tokio::test]
 async fn terminal_task_result_without_work_item_uses_ordinary_dispatch() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -5556,6 +5671,7 @@ async fn lifecycle_sleep_work_queue_override_allows_matched_authoritative_eviden
     )
     .unwrap();
     let work_item_id = seed_bound_work_item(&runtime, WorkItemState::Open, None, None).await;
+    enable_production_protocol_authority(&runtime);
     {
         let mut guard = runtime.inner.agent.lock().await;
         guard.state.status = AgentStatus::AwakeRunning;
@@ -5563,7 +5679,6 @@ async fn lifecycle_sleep_work_queue_override_allows_matched_authoritative_eviden
         guard.state.current_work_item_id = Some(work_item_id.clone());
         guard.persist_state(&runtime.inner.storage).unwrap();
     }
-    enable_production_protocol_authority(&runtime);
     let connection = runtime.inner.runtime_db.connection().unwrap();
 
     runtime.transition_to_sleep(None).await.unwrap();

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -83,11 +83,11 @@ mod tests {
             ActivationTrust, AdmitActivationCommand, AgentActivation, AgentDispatchDisposition,
             AgentDispatchState, AttachActivationInputCommand, Continuation, Decision,
             IssueActivationAuthorityCommand, ObservationalDivergenceAllowance, PreemptionPolicy,
-            ProtocolCommand, ProtocolMode, RollbackAction, RollbackPolicy, RollbackTrigger,
-            RolloutClassEvidence, RolloutCommand, RolloutManifest, RolloutPreflightState,
-            ScenarioMode, SchedulerScenarioClass, SettleActivationCommand, Snapshot,
-            TriggerWaitCommand, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitResumeClaim,
-            WaitState, WaitTrigger, WorkDemand, WorkStatus,
+            ProtocolCommand, ProtocolMode, RegisterWorkDemandCommand, RollbackAction,
+            RollbackPolicy, RollbackTrigger, RolloutClassEvidence, RolloutCommand, RolloutManifest,
+            RolloutPreflightState, ScenarioMode, SchedulerScenarioClass, SettleActivationCommand,
+            Snapshot, TriggerWaitCommand, WaitGenerationRecord, WaitIdentity, WaitRecord,
+            WaitResumeClaim, WaitState, WaitTrigger, WorkDemand, WorkStatus,
         },
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
@@ -384,6 +384,217 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(stored_results, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_authoritative_promotion_atomically_adopts_legacy_work_state() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("runtime.sqlite"),
+            dir.path().join("runtime.lock"),
+        )?;
+        let mut work = WorkItemRecord::new("agent-a", "legacy runnable", WorkItemState::Open);
+        work.id = "work-legacy-adoption".into();
+        db.work_items().insert_new(&work)?;
+        let mut state = AgentState::new("agent-a");
+        state.current_work_item_id = Some(work.id.clone());
+        db.agent_states().upsert(&state)?;
+        let manifest = scheduler_rollout_manifest(1, 1);
+        let commands = vec![
+            (
+                "adoption-open".into(),
+                RolloutCommand::OpenPreflight {
+                    expected_config_revision: 0,
+                    manifest_revision: 1,
+                },
+            ),
+            (
+                "adoption-complete".into(),
+                RolloutCommand::CompletePreflight {
+                    expected_config_revision: 0,
+                    expected_preflight_revision: 1,
+                    manifest: manifest.clone(),
+                },
+            ),
+            (
+                "adoption-install".into(),
+                RolloutCommand::InstallManifest {
+                    expected_config_revision: 0,
+                    manifest,
+                },
+            ),
+            (
+                "adoption-protocol".into(),
+                RolloutCommand::ConfigureProtocol {
+                    expected_config_revision: 1,
+                    mode: ProtocolMode::Authoritative,
+                },
+            ),
+            (
+                "adoption-shadow".into(),
+                RolloutCommand::ChangeScenarioAuthority {
+                    scenario_class: "exact_wait_resume".into(),
+                    expected_config_revision: 2,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                    mode: ScenarioMode::Shadow,
+                },
+            ),
+            (
+                "adoption-authority".into(),
+                RolloutCommand::ChangeScenarioAuthorityFromExplicitMode {
+                    scenario_class: "exact_wait_resume".into(),
+                    expected_config_revision: 3,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                },
+            ),
+        ];
+
+        db.apply_scheduler_rollout_commands(&commands)?;
+        let snapshot = db
+            .transitions()
+            .load_scheduler_protocol_snapshot("agent-a")?;
+        assert_eq!(snapshot.focus.as_deref(), Some(work.id.as_str()));
+        assert_eq!(snapshot.work[&work.id].metadata_revision, 1);
+        assert_eq!(snapshot.work[&work.id].status, WorkStatus::Runnable);
+        assert_eq!(
+            snapshot.rollout.scenarios["exact_wait_resume"].mode,
+            ScenarioMode::Authoritative
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_recovery_plan_rolls_back_adoption_when_later_command_rejects() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("runtime.sqlite"),
+            dir.path().join("runtime.lock"),
+        )?;
+        let mut work = WorkItemRecord::new("agent-a", "legacy recovery", WorkItemState::Open);
+        work.id = "work-legacy-recovery".into();
+        db.work_items().insert_new(&work)?;
+        let adoption = db
+            .transitions()
+            .legacy_scheduler_adoption_candidates("agent-a")?
+            .into_iter()
+            .find(|candidate| candidate.work_item_id == work.id)
+            .and_then(|candidate| candidate.command)
+            .expect("eligible legacy adoption command");
+        let rejected = ProtocolCommand::RegisterWorkDemand(RegisterWorkDemandCommand {
+            work_item_id: "work-invalid-recovery".into(),
+            demand: WorkDemand {
+                metadata_revision: 0,
+                scheduling_generation: 1,
+                status: WorkStatus::Runnable,
+                capabilities: Default::default(),
+                locks: Default::default(),
+                locality: "runtime".into(),
+                cost_class: "default".into(),
+            },
+        });
+
+        let error = db
+            .transitions()
+            .commit_scheduler_recovery_plan("agent-a", &[adoption, rejected])
+            .expect_err("rejected recovery command should roll back the whole plan");
+        assert!(error
+            .to_string()
+            .contains("work_demand_registration_fields_required"));
+        assert!(db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized("agent-a")?
+            .is_none());
+        let stored_results: i64 = db.connection()?.query_row(
+            "SELECT COUNT(*) FROM scheduler_protocol_command_results
+             WHERE agent_id = 'agent-a'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(stored_results, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_authoritative_promotion_rejects_running_legacy_turn_without_partial_adoption(
+    ) -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("runtime.sqlite"),
+            dir.path().join("runtime.lock"),
+        )?;
+        let mut work = WorkItemRecord::new("agent-a", "legacy running", WorkItemState::Open);
+        work.id = "work-legacy-running".into();
+        db.work_items().insert_new(&work)?;
+        let mut state = AgentState::new("agent-a");
+        state.status = AgentStatus::AwakeRunning;
+        state.current_run_id = Some("run-legacy".into());
+        state.current_work_item_id = Some(work.id.clone());
+        db.agent_states().upsert(&state)?;
+        let manifest = scheduler_rollout_manifest(1, 1);
+        let commands = vec![
+            (
+                "running-open".into(),
+                RolloutCommand::OpenPreflight {
+                    expected_config_revision: 0,
+                    manifest_revision: 1,
+                },
+            ),
+            (
+                "running-complete".into(),
+                RolloutCommand::CompletePreflight {
+                    expected_config_revision: 0,
+                    expected_preflight_revision: 1,
+                    manifest: manifest.clone(),
+                },
+            ),
+            (
+                "running-install".into(),
+                RolloutCommand::InstallManifest {
+                    expected_config_revision: 0,
+                    manifest,
+                },
+            ),
+            (
+                "running-protocol".into(),
+                RolloutCommand::ConfigureProtocol {
+                    expected_config_revision: 1,
+                    mode: ProtocolMode::Authoritative,
+                },
+            ),
+            (
+                "running-shadow".into(),
+                RolloutCommand::ChangeScenarioAuthority {
+                    scenario_class: "exact_wait_resume".into(),
+                    expected_config_revision: 2,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                    mode: ScenarioMode::Shadow,
+                },
+            ),
+            (
+                "running-authority".into(),
+                RolloutCommand::ChangeScenarioAuthorityFromExplicitMode {
+                    scenario_class: "exact_wait_resume".into(),
+                    expected_config_revision: 3,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                },
+            ),
+        ];
+
+        let error = db.apply_scheduler_rollout_commands(&commands).unwrap_err();
+        assert!(error.to_string().contains("legacy_agent_turn_running"));
+        assert!(db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized("agent-a")?
+            .is_none());
+        assert_eq!(
+            db.transitions().load_scheduler_rollout_state()?,
+            Default::default()
+        );
         Ok(())
     }
 

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -1,3 +1,7 @@
+use crate::types::{
+    WaitConditionRecord, WorkItemContinuationFrame, WorkItemPlanStatus, WorkItemRecord,
+    WorkItemSchedulingState,
+};
 use std::{
     collections::{BTreeMap, BTreeSet},
     error::Error as StdError,
@@ -13,10 +17,11 @@ use sha2::{Digest, Sha256};
 
 use crate::domain::scheduler_protocol::{
     self, ActivationAdmissionAuthority, ActivationCause, ActivationInputAttachment,
-    ActivationRecord, ActivationSlot, ActivationState, AdmitActivationCommand, AgentDispatchState,
-    ContinuationAdmissionRecord, Decision, MissingSettlementRecord, ProtocolCommand,
-    ProtocolConflict, ProtocolConflictKind, ProtocolMode, RollbackAction, RollbackTrigger,
-    RolloutCommand, RolloutManifest, RolloutPreflightRecord, RolloutPreflightState, RolloutState,
+    ActivationRecord, ActivationSlot, ActivationState, AdmitActivationCommand,
+    AdoptLegacyWorkStateCommand, AgentDispatchState, ContinuationAdmissionRecord, Decision,
+    LegacyWaitAdoption, MissingSettlementRecord, ProtocolCommand, ProtocolConflict,
+    ProtocolConflictKind, ProtocolMode, RollbackAction, RollbackTrigger, RolloutCommand,
+    RolloutManifest, RolloutPreflightRecord, RolloutPreflightState, RolloutState,
     ScenarioAuthority, ScenarioHardBlockerRecord, ScenarioMode, SchedulerScenarioClass, Snapshot,
     WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
@@ -61,6 +66,15 @@ pub(crate) struct SchedulerRolloutExpectation {
     pub config_revision: u64,
     pub manifest_revision: Option<u64>,
     pub preflight_revision: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LegacySchedulerAdoptionCandidate {
+    pub agent_id: String,
+    pub work_item_id: String,
+    pub eligible: bool,
+    pub reason: String,
+    pub command: Option<ProtocolCommand>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -311,6 +325,7 @@ fn required_protocol_command_scenarios(
             ProtocolCommand::RegisterWorkDemand(_) => {
                 required_scenarios.insert(SchedulerScenarioClass::WorkItemAutonomousContinuation);
             }
+            ProtocolCommand::AdoptLegacyWorkState(_) => {}
             ProtocolCommand::IssueActivationAuthority(command) => {
                 required_scenarios.insert(activation_authority_scenario(&command.activation));
                 required_scenarios.insert(SchedulerScenarioClass::Settlement);
@@ -387,6 +402,9 @@ pub(super) fn validate_protocol_commands_tx(
     let mut results = Vec::new();
 
     for command in commands {
+        if let ProtocolCommand::AdoptLegacyWorkState(command) = command {
+            validate_legacy_adoption_source_tx(tx, agent_id, command)?;
+        }
         let (command_kind, command_identity) = command_identity(command)?;
         let payload_hash = canonical_command_hash(command_kind, command)?;
         if let Some(stored) =
@@ -928,6 +946,54 @@ impl RuntimeTransitionRepository<'_> {
         load_rollout(&connection)
     }
 
+    pub(crate) fn legacy_scheduler_adoption_candidates(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<LegacySchedulerAdoptionCandidate>> {
+        self.db
+            .transaction(|tx| legacy_scheduler_adoption_candidates_tx(tx, Some(agent_id)))
+    }
+
+    pub(crate) fn commit_scheduler_recovery_plan(
+        &self,
+        agent_id: &str,
+        commands: &[ProtocolCommand],
+    ) -> Result<bool> {
+        if commands.is_empty() {
+            return Ok(false);
+        }
+        self.db.transaction(|tx| {
+            for command in commands {
+                match command {
+                    ProtocolCommand::AdoptLegacyWorkState(_)
+                    | ProtocolCommand::RegisterWorkDemand(_)
+                    | ProtocolCommand::SettleActivation(_)
+                    | ProtocolCommand::RecordMissingSettlement(_) => {}
+                    ProtocolCommand::IssueActivationAuthority(command)
+                        if matches!(
+                            command.activation.cause,
+                            ActivationCause::SettlementRecovery { .. }
+                        ) => {}
+                    ProtocolCommand::AdmitActivation(command)
+                        if matches!(
+                            command.activation.cause,
+                            ActivationCause::SettlementRecovery { .. }
+                        ) => {}
+                    _ => bail!("scheduler recovery plan contains a non-recovery protocol command"),
+                }
+            }
+            let bootstrap = (!scheduler_protocol_partition_exists_tx(tx, agent_id)?)
+                .then(|| rollout_snapshot(load_rollout(tx).expect("rollout state is readable")));
+            let prepared =
+                validate_protocol_commands_tx(tx, agent_id, bootstrap.as_ref(), commands)?;
+            let changed = prepared
+                .as_ref()
+                .is_some_and(PreparedProtocolCommands::has_writes);
+            persist_protocol_commands_tx(tx, agent_id, prepared)?;
+            Ok(changed)
+        })
+    }
+
     fn load_scheduler_protocol_snapshot_with_hook(
         &self,
         agent_id: &str,
@@ -957,31 +1023,6 @@ impl RuntimeTransitionRepository<'_> {
         fault: Option<TransitionFaultPoint>,
     ) -> Result<SchedulerProtocolTransitionCommit> {
         self.commit_scheduler_protocol_command_inner(agent_id, command, fault, true)
-    }
-
-    pub(crate) fn commit_scheduler_recovery_command(
-        &self,
-        agent_id: &str,
-        command: &ProtocolCommand,
-        fault: Option<TransitionFaultPoint>,
-    ) -> Result<SchedulerProtocolTransitionCommit> {
-        match command {
-            ProtocolCommand::RegisterWorkDemand(_) => {}
-            ProtocolCommand::IssueActivationAuthority(command)
-                if matches!(
-                    command.activation.cause,
-                    ActivationCause::SettlementRecovery { .. }
-                ) => {}
-            ProtocolCommand::AdmitActivation(command)
-                if matches!(
-                    command.activation.cause,
-                    ActivationCause::SettlementRecovery { .. }
-                ) => {}
-            ProtocolCommand::SettleActivation(_) => {}
-            ProtocolCommand::RecordMissingSettlement(_) => {}
-            _ => bail!("scheduler recovery commit only accepts settlement recovery commands"),
-        }
-        self.commit_scheduler_protocol_command_inner(agent_id, command, fault, false)
     }
 
     #[cfg(test)]
@@ -1044,6 +1085,9 @@ impl RuntimeTransitionRepository<'_> {
             }
 
             let snapshot = load_snapshot_tx(tx, agent_id)?;
+            if let ProtocolCommand::AdoptLegacyWorkState(command) = command {
+                validate_legacy_adoption_source_tx(tx, agent_id, command)?;
+            }
             let outcome = scheduler_protocol::reduce_command(&snapshot, command);
             scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
                 anyhow!("scheduler protocol reducer produced invalid state: {error}")
@@ -1097,6 +1141,9 @@ impl RuntimeTransitionRepository<'_> {
         fault: Option<TransitionFaultPoint>,
     ) -> Result<SchedulerRolloutTransitionCommit> {
         let outcome = self.db.transaction(|tx| {
+            if rollout_command_grants_authority(command) {
+                adopt_legacy_scheduler_state_tx(tx)?;
+            }
             apply_scheduler_rollout_command_tx(tx, command_identity, command, fault)
         })?;
         match outcome {
@@ -1114,6 +1161,12 @@ impl RuntimeTransitionRepository<'_> {
             bail!("scheduler rollout command list must not be empty");
         }
         self.db.transaction(|tx| {
+            if commands
+                .iter()
+                .any(|(_, command)| rollout_command_grants_authority(command))
+            {
+                adopt_legacy_scheduler_state_tx(tx)?;
+            }
             let mut commits = Vec::with_capacity(commands.len());
             for (command_identity, command) in commands {
                 let commit =
@@ -1213,6 +1266,290 @@ fn apply_scheduler_rollout_command_tx(
             result,
         },
     ))
+}
+
+fn rollout_command_grants_authority(command: &RolloutCommand) -> bool {
+    matches!(
+        command,
+        RolloutCommand::ChangeScenarioAuthority {
+            mode: ScenarioMode::Authoritative,
+            ..
+        } | RolloutCommand::ChangeScenarioAuthorityFromExplicitMode { .. }
+    )
+}
+
+fn adopt_legacy_scheduler_state_tx(tx: &Transaction<'_>) -> Result<()> {
+    let candidates = legacy_scheduler_adoption_candidates_tx(tx, None)?;
+    if let Some(candidate) = candidates.iter().find(|candidate| !candidate.eligible) {
+        bail!(
+            "scheduler authoritative promotion blocked by legacy state {}:{}: {}",
+            candidate.agent_id,
+            candidate.work_item_id,
+            candidate.reason
+        );
+    }
+    let mut by_agent = BTreeMap::<String, Vec<ProtocolCommand>>::new();
+    for candidate in candidates {
+        if let Some(command) = candidate.command {
+            by_agent
+                .entry(candidate.agent_id)
+                .or_default()
+                .push(command);
+        }
+    }
+    for (agent_id, commands) in by_agent {
+        let bootstrap = (!scheduler_protocol_partition_exists_tx(tx, &agent_id)?)
+            .then(|| rollout_snapshot(load_rollout(tx).expect("rollout state was just readable")));
+        let prepared = validate_protocol_commands_tx(tx, &agent_id, bootstrap.as_ref(), &commands)?;
+        persist_protocol_commands_tx(tx, &agent_id, prepared)?;
+    }
+    Ok(())
+}
+
+fn legacy_scheduler_adoption_candidates_tx(
+    tx: &Transaction<'_>,
+    agent_filter: Option<&str>,
+) -> Result<Vec<LegacySchedulerAdoptionCandidate>> {
+    let mut statement = tx.prepare(
+        "SELECT payload_json
+         FROM work_items
+         WHERE state = 'open' AND (?1 IS NULL OR agent_id = ?1)
+         ORDER BY agent_id, work_item_id",
+    )?;
+    let work_items = statement
+        .query_map([agent_filter], |row| row.get::<_, String>(0))?
+        .map(|row| crate::runtime_db::repositories::decode_work_item_payload(&row?))
+        .collect::<Result<Vec<_>>>()?;
+    let mut candidates = Vec::with_capacity(work_items.len());
+    for work_item in work_items {
+        candidates.push(legacy_scheduler_adoption_candidate_tx(tx, &work_item)?);
+    }
+    Ok(candidates)
+}
+
+fn legacy_scheduler_adoption_candidate_tx(
+    tx: &Transaction<'_>,
+    work_item: &WorkItemRecord,
+) -> Result<LegacySchedulerAdoptionCandidate> {
+    let agent_state = tx
+        .query_row(
+            "SELECT payload_json FROM agent_states WHERE agent_id = ?1",
+            [&work_item.agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| crate::runtime_db::repositories::decode_agent_state_payload(&payload))
+        .transpose()?;
+    if agent_state.as_ref().is_some_and(|state| {
+        state.current_run_id.is_some()
+            || matches!(state.status, crate::types::AgentStatus::AwakeRunning)
+    }) {
+        return Ok(ineligible_legacy_adoption(
+            work_item,
+            "legacy_agent_turn_running",
+        ));
+    }
+    let dequeued = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM queue_entries
+             WHERE agent_id = ?1 AND status = 'dequeued'
+         )",
+        [&work_item.agent_id],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if dequeued {
+        return Ok(ineligible_legacy_adoption(
+            work_item,
+            "legacy_queue_claim_in_progress",
+        ));
+    }
+
+    let mut wait_statement = tx.prepare(
+        "SELECT payload_json
+         FROM wait_conditions
+         WHERE agent_id = ?1 AND work_item_id = ?2 AND status = 'active'
+         ORDER BY created_at, wait_condition_id",
+    )?;
+    let active_waits = wait_statement
+        .query_map(
+            [work_item.agent_id.as_str(), work_item.id.as_str()],
+            |row| row.get::<_, String>(0),
+        )?
+        .map(|row| serde_json::from_str::<WaitConditionRecord>(&row?).map_err(Into::into))
+        .collect::<Result<Vec<_>>>()?;
+    if active_waits.len() > 1 {
+        return Ok(ineligible_legacy_adoption(
+            work_item,
+            "multiple_active_legacy_waits",
+        ));
+    }
+
+    let mut continuation_statement = tx.prepare(
+        "SELECT payload_json
+         FROM work_item_continuations
+         WHERE agent_id = ?1 AND suspended_work_item_id = ?2 AND state = 'active'",
+    )?;
+    let continuations = continuation_statement
+        .query_map(
+            [work_item.agent_id.as_str(), work_item.id.as_str()],
+            |row| row.get::<_, String>(0),
+        )?
+        .map(|row| crate::runtime_db::repositories::decode_work_item_continuation_payload(&row?))
+        .collect::<Result<Vec<WorkItemContinuationFrame>>>()?;
+    if !continuations.is_empty() {
+        return Ok(ineligible_legacy_adoption(
+            work_item,
+            "legacy_yielded_work_item_requires_settlement_history",
+        ));
+    }
+
+    let is_current = agent_state
+        .as_ref()
+        .and_then(|state| state.current_work_item_id.as_deref())
+        == Some(work_item.id.as_str());
+    let trigger_delivery_by_id = BTreeMap::new();
+    let scheduling = crate::work_item_scheduling::derive_work_item_scheduling(
+        crate::work_item_scheduling::WorkItemSchedulingFacts {
+            work_item,
+            is_current,
+            is_yielded: false,
+            active_wait_conditions: &active_waits,
+            trigger_delivery_by_id: &trigger_delivery_by_id,
+        },
+    );
+    let generation = work_item.revision.max(1);
+    let (status, wait) = match scheduling.scheduling_state {
+        WorkItemSchedulingState::Runnable => (WorkStatus::Runnable, None),
+        WorkItemSchedulingState::WaitingTask
+        | WorkItemSchedulingState::WaitingExternal
+        | WorkItemSchedulingState::WaitingTimer
+        | WorkItemSchedulingState::WaitingSystem
+        | WorkItemSchedulingState::WaitingOperator
+            if active_waits.len() == 1 =>
+        {
+            let wait = &active_waits[0];
+            (
+                WorkStatus::Waiting {
+                    wait_id: wait.id.clone(),
+                },
+                Some(LegacyWaitAdoption {
+                    wait_id: wait.id.clone(),
+                    generation,
+                    owner_work_item_id: work_item.id.clone(),
+                    source_updated_at: wait.updated_at.to_rfc3339(),
+                }),
+            )
+        }
+        WorkItemSchedulingState::WaitingOperator
+            if work_item.plan_status == WorkItemPlanStatus::NeedsInput =>
+        {
+            (
+                WorkStatus::Paused {
+                    hold_id: format!("legacy-plan-needs-input:{}", work_item.id),
+                },
+                None,
+            )
+        }
+        WorkItemSchedulingState::Blocked => {
+            return Ok(ineligible_legacy_adoption(
+                work_item,
+                "legacy_blocked_work_item_requires_operator_resolution",
+            ));
+        }
+        WorkItemSchedulingState::YieldedToWorkItem => {
+            return Ok(ineligible_legacy_adoption(
+                work_item,
+                "legacy_yielded_work_item_requires_settlement_history",
+            ));
+        }
+        WorkItemSchedulingState::Completed => {
+            return Ok(ineligible_legacy_adoption(
+                work_item,
+                "legacy_open_work_item_projects_completed",
+            ));
+        }
+        _ => {
+            return Ok(ineligible_legacy_adoption(
+                work_item,
+                "legacy_waiting_work_item_has_no_unique_active_wait",
+            ));
+        }
+    };
+    let reserve_dispatch = wait.is_some()
+        && is_current
+        && agent_state.as_ref().is_some_and(|state| {
+            matches!(
+                state.status,
+                crate::types::AgentStatus::AwaitingTask | crate::types::AgentStatus::Asleep
+            )
+        });
+    let command = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: work_item.id.clone(),
+        source_work_item_revision: work_item.revision,
+        demand: WorkDemand {
+            metadata_revision: work_item.revision,
+            scheduling_generation: generation,
+            status,
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait,
+        focus: is_current,
+        reserve_dispatch,
+    });
+    Ok(LegacySchedulerAdoptionCandidate {
+        agent_id: work_item.agent_id.clone(),
+        work_item_id: work_item.id.clone(),
+        eligible: true,
+        reason: "eligible".into(),
+        command: Some(command),
+    })
+}
+
+fn ineligible_legacy_adoption(
+    work_item: &WorkItemRecord,
+    reason: &str,
+) -> LegacySchedulerAdoptionCandidate {
+    LegacySchedulerAdoptionCandidate {
+        agent_id: work_item.agent_id.clone(),
+        work_item_id: work_item.id.clone(),
+        eligible: false,
+        reason: reason.into(),
+        command: None,
+    }
+}
+
+fn validate_legacy_adoption_source_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &AdoptLegacyWorkStateCommand,
+) -> Result<()> {
+    let work_item = tx
+        .query_row(
+            "SELECT payload_json FROM work_items
+             WHERE work_item_id = ?1 AND agent_id = ?2 AND state = 'open'",
+            [command.work_item_id.as_str(), agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| crate::runtime_db::repositories::decode_work_item_payload(&payload))
+        .transpose()?
+        .ok_or_else(|| anyhow!("legacy adoption source WorkItem is missing or closed"))?;
+    let candidate = legacy_scheduler_adoption_candidate_tx(tx, &work_item)?;
+    if !candidate.eligible
+        || candidate.command.as_ref()
+            != Some(&ProtocolCommand::AdoptLegacyWorkState(command.clone()))
+    {
+        bail!(
+            "legacy adoption source changed for {}:{} ({})",
+            agent_id,
+            command.work_item_id,
+            candidate.reason
+        );
+    }
+    Ok(())
 }
 
 fn decision_fact_references(decision: &Decision, references: Vec<String>) -> Vec<String> {
@@ -1330,6 +1667,13 @@ fn command_identity(command: &ProtocolCommand) -> Result<(&'static str, String)>
         ProtocolCommand::RegisterWorkDemand(command) => {
             ("register_work_demand", command.work_item_id.clone())
         }
+        ProtocolCommand::AdoptLegacyWorkState(command) => (
+            "adopt_legacy_work_state",
+            format!(
+                "{}:{}",
+                command.work_item_id, command.source_work_item_revision
+            ),
+        ),
         ProtocolCommand::IssueActivationAuthority(command) => {
             ("issue_activation_authority", command.authority_id.clone())
         }
@@ -1366,6 +1710,16 @@ fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
         ProtocolCommand::RegisterWorkDemand(command) => {
             vec![format!("work:{}", command.work_item_id)]
         }
+        ProtocolCommand::AdoptLegacyWorkState(command) => {
+            let mut references = vec![format!("work:{}", command.work_item_id)];
+            if let Some(wait) = &command.wait {
+                references.push(format!(
+                    "wait:{}:generation:{}",
+                    wait.wait_id, wait.generation
+                ));
+            }
+            references
+        }
         ProtocolCommand::IssueActivationAuthority(command) => {
             vec![format!("activation_authority:{}", command.authority_id)]
         }
@@ -1394,7 +1748,7 @@ fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
 
 fn validate_command_agent(agent_id: &str, command: &ProtocolCommand) -> Result<()> {
     let command_agent_id = match command {
-        ProtocolCommand::RegisterWorkDemand(_) => None,
+        ProtocolCommand::RegisterWorkDemand(_) | ProtocolCommand::AdoptLegacyWorkState(_) => None,
         ProtocolCommand::IssueActivationAuthority(command) => Some(&command.activation.agent_id),
         ProtocolCommand::AdmitActivation(command) => Some(&command.activation.agent_id),
         ProtocolCommand::SettleActivation(_)

--- a/tests/scheduler_intent_mvp.rs
+++ b/tests/scheduler_intent_mvp.rs
@@ -7,8 +7,9 @@ use std::{
 };
 
 use holon::domain::scheduler_protocol::{
-    ActivationOrigin, ActivationSlot, ActivationTrust, AgentDispatchState, ProtocolCommand,
-    Snapshot, WaitGenerationRecord, WaitRecord, WaitState, WorkDemand, WorkStatus,
+    ActivationOrigin, ActivationSlot, ActivationTrust, AdoptLegacyWorkStateCommand,
+    AgentDispatchState, Decision, LegacyWaitAdoption, ProtocolCommand, Snapshot,
+    WaitGenerationRecord, WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
 use holon::domain::scheduler_semantic::{
     resolve_semantic_proposal, validate_semantic_decision_input, validate_semantic_decision_inputs,
@@ -22,6 +23,103 @@ use model::{
 
 fn fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scheduler_intent_mvp")
+}
+
+#[test]
+fn legacy_work_state_adoption_is_typed_and_idempotent() {
+    let snapshot = Snapshot {
+        slot: ActivationSlot::Idle,
+        dispatch: AgentDispatchState::Open,
+        dispatch_revision: 0,
+        focus: None,
+        work: BTreeMap::new(),
+        waits: BTreeMap::new(),
+        activations: BTreeMap::new(),
+        activation_authorities: BTreeMap::new(),
+        activation_admissions: BTreeMap::new(),
+        settlements: BTreeMap::new(),
+        missing_settlements: BTreeMap::new(),
+        rollout: Default::default(),
+        admitted_generations: Default::default(),
+        continuation_admissions: BTreeMap::new(),
+        activation_inputs: BTreeMap::new(),
+    };
+    let command = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "work-restart".into(),
+        source_work_item_revision: 4,
+        demand: WorkDemand {
+            metadata_revision: 4,
+            scheduling_generation: 4,
+            status: WorkStatus::Waiting {
+                wait_id: "wait-task".into(),
+            },
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: Some(LegacyWaitAdoption {
+            wait_id: "wait-task".into(),
+            generation: 4,
+            owner_work_item_id: "work-restart".into(),
+            source_updated_at: "2026-07-26T00:00:00Z".into(),
+        }),
+        focus: true,
+        reserve_dispatch: true,
+    });
+
+    let adopted = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(adopted.outcome.decision, Decision::LegacyWorkStateAdopted);
+    holon::domain::scheduler_protocol::assert_invariants(&adopted.outcome.snapshot).unwrap();
+    let replay =
+        holon::domain::scheduler_protocol::reduce_command(&adopted.outcome.snapshot, &command);
+    assert_eq!(replay.outcome.decision, Decision::DuplicateIgnored);
+}
+
+#[test]
+fn legacy_work_state_adoption_rejects_same_revision_conflicts() {
+    let mut snapshot = semantic_authority_snapshot();
+    snapshot.dispatch = AgentDispatchState::Open;
+    snapshot.focus = None;
+    snapshot.work.clear();
+    snapshot.waits.clear();
+    snapshot.work.insert(
+        "work-restart".into(),
+        WorkDemand {
+            metadata_revision: 4,
+            scheduling_generation: 4,
+            status: WorkStatus::Runnable,
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+    );
+    let conflicting = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "work-restart".into(),
+        source_work_item_revision: 4,
+        demand: WorkDemand {
+            metadata_revision: 4,
+            scheduling_generation: 4,
+            status: WorkStatus::Paused {
+                hold_id: "legacy-plan-needs-input:work-restart".into(),
+            },
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: None,
+        focus: false,
+        reserve_dispatch: false,
+    });
+
+    let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &conflicting);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.unwrap().code,
+        "legacy_work_state_adoption_conflict"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 摘要

- 在 `shadow -> authoritative` promotion/recovery 中，通过受 revision fence 保护的 protocol command 原子收编 legacy WorkItem scheduling state、active wait、focus 与 dispatch reservation。
- 将 restart 中断任务从聚合的 unbound `task_restart` turn 改为逐任务标准 `TaskResult`，保留 task 与 effective WorkItem identity。
- 将 authoritative pre-claim 规划改为显式 `NotApplicable` / `Plan` / `HardBlocker`；结构冲突会在 claim 前记录 blocker、回退该 scenario，并保留 queued message 供降级后的路径消费。
- 扩展 scheduler recovery/debug surface、authority-boundary 诊断、RFC 与覆盖 adoption、rollback、restart rejoin、恢复幂等性的测试。

## 关键不变量

- authoritative WorkItem reentry 不再允许无 canonical activation 的 legacy model turn。
- adoption 与 authority promotion 同事务提交，失败时不会暴露半迁移状态。
- restart delivery 保持一条 task 对应一条结构化 rejoin message。
- pre-claim conflict 不 claim/drop queue message，也不留下 partial canonical state。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- scheduler protocol、runtime DB、task restart、authority rollback 定向回归
- `cargo test --test runtime_tasks -- --nocapture --test-threads=1`（45/45 通过）
- `cargo test --all-targets -- --test-threads=1`（通过）

Closes #2445
