### PR TITLE
fix: preserve UTF-8 across streaming chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +848,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "encoding_rs",
  "flate2",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ arc-swap = "1.7"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 crossterm = "0.28"
+encoding_rs = "0.8"
 hyper = { version = "1.5", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["server-auto", "tokio", "service", "http1", "http2"] }
 libc = "0.2"

--- a/docs/implementation-decisions/100-streaming-utf8-boundaries.md
+++ b/docs/implementation-decisions/100-streaming-utf8-boundaries.md
@@ -1,0 +1,15 @@
+# Streaming UTF-8 boundaries
+
+Transport and process read chunks are byte boundaries, not text boundaries.
+
+Holon decodes command output, OpenAI streaming bodies, and provider HTTP trace
+text with one incremental UTF-8 decoder per independent byte stream. The
+decoder retains incomplete code points between chunks and applies lossy
+replacement only to malformed input or an incomplete sequence at end of
+stream. OpenAI keeps its existing SSE framing, while Anthropic keeps its
+existing strict UTF-8 event parsing.
+
+ApplyPatch receives an already decoded Rust `String`, so it cannot recover the
+original bytes or prove why U+FFFD is present. It therefore permits the patch
+but emits a model-visible diagnostic, and failed patches add a recovery hint to
+reread the exact target region before retrying.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod tool;
 pub mod tui;
 mod tui_markdown;
 pub mod types;
+mod utf8;
 pub mod web;
 pub mod work_item_plan;
 pub mod work_item_refs;

--- a/src/provider/http_trace.rs
+++ b/src/provider/http_trace.rs
@@ -11,6 +11,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::utf8::IncrementalUtf8LossyDecoder;
+
 static PROVIDER_HTTP_TRACE_SEQ: AtomicU64 = AtomicU64::new(1);
 
 const PROVIDER_HTTP_TRACE_ENV: &str = "HOLON_PROVIDER_HTTP_TRACE";
@@ -59,6 +61,7 @@ struct ProviderHttpTraceRequestState {
     sequence: u64,
     file_path: Option<PathBuf>,
     events: VecDeque<Value>,
+    stream_text_decoder: IncrementalUtf8LossyDecoder,
 }
 
 impl ProviderHttpTrace {
@@ -116,6 +119,7 @@ impl ProviderHttpTrace {
                 sequence,
                 file_path: None,
                 events: VecDeque::new(),
+                stream_text_decoder: IncrementalUtf8LossyDecoder::new(),
             })),
         };
         request.write_event(json!({
@@ -157,24 +161,39 @@ impl ProviderHttpTraceRequest {
     }
 
     pub(crate) fn write_stream_chunk(&self, chunk: &[u8]) {
-        self.write_event(json!({
-            "type": "stream_chunk",
-            "created_at_ms": current_time_millis(),
-            "bytes": chunk.len(),
-            "text": String::from_utf8_lossy(chunk),
-        }));
+        let Ok(mut guard) = self.inner.lock() else {
+            return;
+        };
+        let text = guard.stream_text_decoder.push(chunk);
+        write_event(
+            &mut guard,
+            json!({
+                "type": "stream_chunk",
+                "created_at_ms": current_time_millis(),
+                "bytes": chunk.len(),
+                "text": text,
+            }),
+        );
     }
 
     pub(crate) fn write_stream_terminal(&self, body: &Value) {
-        self.write_event(json!({
-            "type": "stream_terminal_response",
-            "created_at_ms": current_time_millis(),
-            "body": body,
-        }));
+        let Ok(mut guard) = self.inner.lock() else {
+            return;
+        };
+        flush_stream_text(&mut guard);
+        write_event(
+            &mut guard,
+            json!({
+                "type": "stream_terminal_response",
+                "created_at_ms": current_time_millis(),
+                "body": body,
+            }),
+        );
     }
 
     pub(crate) fn diagnostics(&self, status: Option<u16>) -> Option<ProviderHttpTraceDiagnostics> {
         let mut guard = self.inner.lock().ok()?;
+        flush_stream_text(&mut guard);
         let path = ensure_trace_file(&mut guard)?;
         Some(ProviderHttpTraceDiagnostics {
             mode: guard.mode.as_str().to_string(),
@@ -187,18 +206,37 @@ impl ProviderHttpTraceRequest {
         let Ok(mut guard) = self.inner.lock() else {
             return;
         };
-        match guard.mode {
-            ProviderHttpTraceMode::All => {
-                let Some(path) = ensure_trace_file(&mut guard) else {
-                    return;
-                };
-                append_trace_event(&path, &event);
-            }
-            ProviderHttpTraceMode::FailureOnly => {
-                guard.events.push_back(event);
-                if guard.events.len() > PROVIDER_HTTP_FAILURE_TRACE_MAX_EVENTS {
-                    guard.events.pop_front();
-                }
+        write_event(&mut guard, event);
+    }
+}
+
+fn flush_stream_text(state: &mut ProviderHttpTraceRequestState) {
+    let text = state.stream_text_decoder.finish();
+    if text.is_empty() {
+        return;
+    }
+    write_event(
+        state,
+        json!({
+            "type": "stream_text_flush",
+            "created_at_ms": current_time_millis(),
+            "text": text,
+        }),
+    );
+}
+
+fn write_event(state: &mut ProviderHttpTraceRequestState, event: Value) {
+    match state.mode {
+        ProviderHttpTraceMode::All => {
+            let Some(path) = ensure_trace_file(state) else {
+                return;
+            };
+            append_trace_event(&path, &event);
+        }
+        ProviderHttpTraceMode::FailureOnly => {
+            state.events.push_back(event);
+            if state.events.len() > PROVIDER_HTTP_FAILURE_TRACE_MAX_EVENTS {
+                state.events.pop_front();
             }
         }
     }
@@ -521,6 +559,83 @@ mod tests {
         assert!(trace_text.contains("\"name\":\"ExecCommand\""));
         assert!(trace_text.contains("[REDACTED]"));
         assert!(!trace_text.contains("Bearer secret"));
+    }
+
+    #[test]
+    fn provider_http_trace_preserves_utf8_across_stream_chunks() {
+        let home = tempfile::tempdir().unwrap();
+        let trace = ProviderHttpTrace {
+            home_dir: home.path().to_path_buf(),
+            mode: super::ProviderHttpTraceMode::All,
+        };
+        let request = trace
+            .begin_request(
+                Some("agent/one"),
+                "openai",
+                Some("openai/gpt-test"),
+                "https://api.example.com/v1/responses",
+                "responses",
+                &[],
+                &json!({}),
+            )
+            .unwrap();
+
+        for byte in "😀".as_bytes() {
+            request.write_stream_chunk(std::slice::from_ref(byte));
+        }
+        request.write_stream_terminal(&json!({ "status": "completed" }));
+
+        let trace_dir = home.path().join(".holon/http-trace/agent_one");
+        let path = fs::read_dir(trace_dir)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let events = fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let text = events
+            .iter()
+            .filter_map(|event| {
+                matches!(
+                    event["type"].as_str(),
+                    Some("stream_chunk" | "stream_text_flush")
+                )
+                .then(|| event["text"].as_str().unwrap_or_default())
+            })
+            .collect::<String>();
+
+        assert_eq!(text, "😀");
+        assert!(!text.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn provider_http_failure_trace_flushes_incomplete_utf8_lossily() {
+        let home = tempfile::tempdir().unwrap();
+        let trace = ProviderHttpTrace {
+            home_dir: home.path().to_path_buf(),
+            mode: super::ProviderHttpTraceMode::FailureOnly,
+        };
+        let request = trace
+            .begin_request(
+                Some("agent/one"),
+                "openai",
+                Some("openai/gpt-test"),
+                "https://api.example.com/v1/responses",
+                "responses",
+                &[],
+                &json!({}),
+            )
+            .unwrap();
+        request.write_stream_chunk(&[0xF0, 0x9F]);
+
+        let diagnostics = request.diagnostics(Some(500)).unwrap();
+        let trace_text = fs::read_to_string(diagnostics.path).unwrap();
+        assert!(trace_text.contains("\"type\":\"stream_text_flush\""));
+        assert!(trace_text.contains('�'));
     }
 
     #[test]

--- a/src/provider/tests/openai_chat_completions.rs
+++ b/src/provider/tests/openai_chat_completions.rs
@@ -6,7 +6,10 @@ use crate::config::{ModelRef, ModelRouteRef, ProviderId, ProviderTransportKind};
 use crate::model_catalog::{ModelRuntimeOverride, ModelVerbosity};
 use crate::provider::provider_transport_diagnostics;
 use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
-use crate::provider::transports::{build_chat_completion_messages, OpenAiChatCompletionsProvider};
+use crate::provider::transports::{
+    build_chat_completion_messages, send_chat_completion_stream_request,
+    OpenAiChatCompletionsProvider,
+};
 use crate::tool::ToolSpec;
 use axum::{routing::post, Json, Router};
 use serde_json::json;
@@ -587,6 +590,36 @@ fn chat_completion_streaming_processes_content_delta_events() {
     let message = &result["choices"][0]["message"];
     assert_eq!(message["content"], "Hello world!");
     assert!(message.get("tool_calls").is_none());
+}
+
+#[tokio::test]
+async fn chat_completion_streaming_preserves_utf8_across_every_http_chunk_boundary() {
+    let body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"中文😀\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_unicode\",\"function\":{\"name\":\"ApplyPatch\",\"arguments\":\"{\\\"path\\\":\\\"目录/文件😀.rs\\\"}\"}}]}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let chunks = body.as_bytes().chunks(1).collect::<Vec<_>>();
+    let raw_response = chunked_http_response(&chunks);
+    let base_url = spawn_raw_http_server_bytes_sequence(vec![raw_response]).await;
+    let parsed = send_chat_completion_stream_request(
+        &reqwest::Client::new(),
+        format!("{base_url}/v1/chat/completions"),
+        json!({ "model": "gpt-test", "stream": true }),
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        &parsed.response.blocks[0],
+        ModelBlock::Text { text } if text == "中文😀"
+    ));
+    assert!(matches!(
+        &parsed.response.blocks[1],
+        ModelBlock::ToolUse { name, input, .. }
+            if name == "ApplyPatch" && *input == json!({"path": "目录/文件😀.rs"})
+    ));
 }
 
 #[test]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -159,6 +159,34 @@ fn openai_reasoning_and_tool_call_sse_response(response_id: &str) -> String {
     )
 }
 
+fn openai_unicode_text_and_tool_call_sse_response(response_id: &str) -> String {
+    let response = json!({
+        "id": response_id,
+        "status": "completed",
+        "usage": { "input_tokens": 4, "output_tokens": 4 },
+        "output": [{
+            "type": "message",
+            "id": "msg_unicode",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "中文😀" }]
+        }, {
+            "type": "function_call",
+            "id": "fc_unicode",
+            "call_id": "call_unicode",
+            "name": "ApplyPatch",
+            "arguments": "{\"path\":\"目录/文件😀.rs\"}"
+        }]
+    });
+    format!(
+        "event: response.completed\ndata: {}\n\n",
+        json!({
+            "type": "response.completed",
+            "response": response,
+        })
+    )
+}
+
 fn provider_large_window_request_with_prompt_frame() -> ProviderTurnRequest {
     let mut request = provider_turn_request_with_prompt_frame();
     request.conversation = (0..8)
@@ -1532,6 +1560,37 @@ async fn openai_codex_streaming_incomplete_max_output_tokens_returns_recoverable
     assert!(matches!(
         &response.blocks[0],
         ModelBlock::Text { text } if text == "partial report"
+    ));
+}
+
+#[tokio::test]
+async fn openai_codex_streaming_preserves_utf8_across_every_http_chunk_boundary() {
+    let body = openai_unicode_text_and_tool_call_sse_response("resp_unicode");
+    let chunks = body.as_bytes().chunks(1).collect::<Vec<_>>();
+    let raw_response = chunked_http_response(&chunks);
+    let base_url = spawn_raw_http_server_bytes_sequence(vec![raw_response]).await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+
+    let response = provider
+        .complete_turn(provider_turn_request())
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        &response.blocks[0],
+        ModelBlock::Text { text } if text == "中文😀"
+    ));
+    assert!(matches!(
+        &response.blocks[1],
+        ModelBlock::ToolUse { name, input, .. }
+            if name == "ApplyPatch" && *input == json!({"path": "目录/文件😀.rs"})
     ));
 }
 

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -96,6 +96,17 @@ pub async fn spawn_raw_http_server_scripted(responses: Vec<Vec<(u64, Vec<u8>)>>)
     format!("http://{}", addr)
 }
 
+pub fn chunked_http_response(chunks: &[&[u8]]) -> Vec<u8> {
+    let mut response = b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n".to_vec();
+    for chunk in chunks {
+        response.extend_from_slice(format!("{:X}\r\n", chunk.len()).as_bytes());
+        response.extend_from_slice(chunk);
+        response.extend_from_slice(b"\r\n");
+    }
+    response.extend_from_slice(b"0\r\n\r\n");
+    response
+}
+
 async fn drain_http_request(stream: &mut TcpStream) {
     let mut buffer = [0u8; 1024];
     let mut request = Vec::new();

--- a/src/provider/transports/mod.rs
+++ b/src/provider/transports/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use openai::{
     accumulate_chat_completion_stream_events, build_chat_completion_messages,
     build_chat_completion_request, build_openai_input, build_openai_responses_request,
     classify_openai_chat_completion_error, parse_chat_completion_response, parse_openai_response,
+    send_chat_completion_stream_request,
 };
 pub use openai::{OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiProvider};
 

--- a/src/provider/transports/openai/chat/mod.rs
+++ b/src/provider/transports/openai/chat/mod.rs
@@ -7,6 +7,6 @@ pub(crate) use parse::{accumulate_chat_completion_stream_events, parse_chat_comp
 pub(super) use plan::plan_chat_completion_request;
 #[cfg(test)]
 pub(crate) use plan::{build_chat_completion_messages, build_chat_completion_request};
-#[cfg(test)]
-pub(crate) use send::classify_openai_chat_completion_error;
 pub(super) use send::send_chat_completion_request;
+#[cfg(test)]
+pub(crate) use send::{classify_openai_chat_completion_error, send_chat_completion_stream_request};

--- a/src/provider/transports/openai/chat/send.rs
+++ b/src/provider/transports/openai/chat/send.rs
@@ -277,6 +277,7 @@ async fn read_chat_completion_stream(response: Response) -> Result<Value> {
     let mut response = response;
     let mut pending = String::new();
     let mut data_lines = Vec::new();
+    let mut text_decoder = crate::utf8::IncrementalUtf8LossyDecoder::new();
 
     while let Some(chunk) = response.chunk().await.map_err(|error| {
         crate::provider::retry::classify_reqwest_transport_error_with_trace(
@@ -289,7 +290,7 @@ async fn read_chat_completion_stream(response: Response) -> Result<Value> {
             None,
         )
     })? {
-        pending.push_str(&String::from_utf8_lossy(&chunk));
+        pending.push_str(&text_decoder.push(&chunk));
         while let Some(newline_idx) = pending.find('\n') {
             let mut line = pending[..newline_idx].to_string();
             pending.drain(..newline_idx + 1);
@@ -335,6 +336,7 @@ async fn read_chat_completion_stream(response: Response) -> Result<Value> {
         }
     }
 
+    pending.push_str(&text_decoder.finish());
     // Process remaining data
     if !pending.is_empty() {
         let line = pending.trim();

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -77,7 +77,7 @@ use images::{
 pub(crate) use chat::{
     accumulate_chat_completion_stream_events, build_chat_completion_messages,
     build_chat_completion_request, classify_openai_chat_completion_error,
-    parse_chat_completion_response,
+    parse_chat_completion_response, send_chat_completion_stream_request,
 };
 use chat::{plan_chat_completion_request, send_chat_completion_request};
 #[cfg(test)]

--- a/src/provider/transports/openai/responses/parse.rs
+++ b/src/provider/transports/openai/responses/parse.rs
@@ -20,6 +20,7 @@ async fn read_openai_streaming_response_with_timeout(
     let mut pending = String::new();
     let mut data_lines = Vec::new();
     let mut streamed_output_items = Vec::new();
+    let mut text_decoder = crate::utf8::IncrementalUtf8LossyDecoder::new();
 
     while let Some(chunk) = tokio::time::timeout(idle_timeout, response.chunk())
         .await
@@ -50,7 +51,7 @@ async fn read_openai_streaming_response_with_timeout(
         })?
     {
         trace_stream_chunk(trace, &chunk);
-        pending.push_str(&String::from_utf8_lossy(&chunk));
+        pending.push_str(&text_decoder.push(&chunk));
         while let Some(newline_idx) = pending.find('\n') {
             let mut line = pending[..newline_idx].to_string();
             pending.drain(..=newline_idx);
@@ -84,6 +85,7 @@ async fn read_openai_streaming_response_with_timeout(
         }
     }
 
+    pending.push_str(&text_decoder.finish());
     if !pending.is_empty() {
         let line = pending.trim_end_matches('\r');
         if let Some(data) = line.strip_prefix("data:") {

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -27,6 +27,7 @@ use crate::{
         ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
         TaskHandle, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, ToolArtifactRef,
     },
+    utf8::IncrementalUtf8LossyDecoder,
 };
 
 use super::{task_state_reducer, RuntimeHandle};
@@ -1125,17 +1126,22 @@ where
     R: AsyncRead + Unpin + Send + 'static,
 {
     let mut buffer = [0u8; 4096];
+    let mut decoder = IncrementalUtf8LossyDecoder::new();
     loop {
         match reader.read(&mut buffer).await {
             Ok(0) => break,
             Ok(read) => {
-                let text = String::from_utf8_lossy(&buffer[..read]).to_string();
-                if tx.send(OutputChunk { stream, text }).await.is_err() {
+                let text = decoder.push(&buffer[..read]);
+                if !text.is_empty() && tx.send(OutputChunk { stream, text }).await.is_err() {
                     break;
                 }
             }
             Err(_) => break,
         }
+    }
+    let text = decoder.finish();
+    if !text.is_empty() {
+        let _ = tx.send(OutputChunk { stream, text }).await;
     }
 }
 
@@ -1320,7 +1326,7 @@ fn trim_to_tail(buffer: &mut String, max_chars: usize) {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, path::Path, sync::Arc};
+    use std::{collections::BTreeMap, io::Cursor, path::Path, sync::Arc};
 
     use anyhow::Result;
     use async_trait::async_trait;
@@ -1541,6 +1547,33 @@ mod tests {
 
     fn resolved_env(resolved: &ResolvedCommandTask) -> BTreeMap<String, String> {
         resolved.env.iter().cloned().collect()
+    }
+
+    async fn read_output_text(bytes: Vec<u8>, stream: OutputStream) -> String {
+        let (tx, mut rx) = mpsc::channel(OUTPUT_CHANNEL_CAPACITY);
+        read_output(Cursor::new(bytes), stream, tx).await;
+        let mut output = String::new();
+        while let Some(chunk) = rx.recv().await {
+            assert!(matches!(
+                (chunk.stream, stream),
+                (OutputStream::Stdout, OutputStream::Stdout)
+                    | (OutputStream::Stderr, OutputStream::Stderr)
+            ));
+            output.push_str(&chunk.text);
+        }
+        output
+    }
+
+    #[tokio::test]
+    async fn command_output_preserves_utf8_across_the_4096_byte_read_boundary() {
+        for stream in [OutputStream::Stdout, OutputStream::Stderr] {
+            let mut bytes = vec![b'a'; 4095];
+            bytes.extend_from_slice("中".as_bytes());
+            let output = read_output_text(bytes, stream).await;
+
+            assert_eq!(output, format!("{}中", "a".repeat(4095)));
+            assert!(!output.contains('\u{FFFD}'));
+        }
     }
 
     #[tokio::test]

--- a/src/tool/tools/apply_patch_tool.rs
+++ b/src/tool/tools/apply_patch_tool.rs
@@ -78,12 +78,25 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let surface = runtime.current_apply_patch_surface().await;
     let patch_input = extract_patch_input(input, surface)?;
+    let contains_replacement_character = patch_input.contains('\u{FFFD}');
     let execution = runtime
         .effective_execution(ExecutionScopeKind::AgentTurn)
         .await?;
-    let outcome =
+    let mut outcome =
         apply_patch::apply_patch(execution.workspace.execution_root(), &patch_input, surface)
-            .await?;
+            .await
+            .map_err(|error| {
+                if contains_replacement_character {
+                    anyhow::Error::new(add_replacement_character_recovery_hint(
+                        ToolError::from_anyhow(&error),
+                    ))
+                } else {
+                    error
+                }
+            })?;
+    if contains_replacement_character {
+        outcome.diagnostics.push(replacement_character_diagnostic());
+    }
     let mut summary_text = if outcome.changed_files.is_empty() {
         "patched no files".to_string()
     } else {
@@ -111,6 +124,23 @@ pub(crate) async fn execute(
             summary_text: Some(summary_text),
         },
     )
+}
+
+fn replacement_character_diagnostic() -> ApplyPatchDiagnostic {
+    ApplyPatchDiagnostic {
+        path: String::new(),
+        kind: "replacement_character_in_input".into(),
+        message: "patch input contains U+FFFD (�), which may be original content or upstream decoding damage; reread the exact target region before constructing another patch".into(),
+    }
+}
+
+fn add_replacement_character_recovery_hint(mut error: ToolError) -> ToolError {
+    let warning = "The patch input contains U+FFFD (�), which may come from upstream streaming decode damage. Reread the exact target region and rebuild the patch from the fresh content; do not retry the old U+FFFD-containing context unchanged.";
+    error.recovery_hint = Some(match error.recovery_hint.take() {
+        Some(existing) => format!("{existing} {warning}"),
+        None => warning.to_string(),
+    });
+    error
 }
 
 pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
@@ -396,6 +426,42 @@ mod tests {
         assert!(rendered.contains("Diagnostics:"));
         assert!(rendered.contains("hunk_count_mismatch"));
         assert!(rendered.contains("Inspect the affected target region"));
+    }
+
+    #[test]
+    fn apply_patch_replacement_character_warning_is_model_visible() {
+        let diagnostic = replacement_character_diagnostic();
+        assert_eq!(diagnostic.kind, "replacement_character_in_input");
+        assert!(render_diagnostic_for_model(&diagnostic).contains("U+FFFD"));
+
+        let error = add_replacement_character_recovery_hint(ToolError::new(
+            "context_not_found",
+            "patch context was not found",
+        ));
+        assert_eq!(error.kind, "context_not_found");
+        assert!(error
+            .recovery_hint
+            .as_deref()
+            .is_some_and(|hint| hint.contains("do not retry")));
+    }
+
+    #[test]
+    fn apply_patch_both_surfaces_preserve_replacement_character_for_warning() {
+        let codex = extract_patch_input(
+            &json!("*** Begin Patch\n*** Add File: x\n+�\n*** End Patch\n"),
+            ApplyPatchSurface::CodexDslFreeform,
+        )
+        .unwrap();
+        let unified = extract_patch_input(
+            &json!({
+                "patch": "--- /dev/null\n+++ b/x\n@@ -0,0 +1 @@\n+�\n"
+            }),
+            ApplyPatchSurface::UnifiedDiffJson,
+        )
+        .unwrap();
+
+        assert!(codex.contains('\u{FFFD}'));
+        assert!(unified.contains('\u{FFFD}'));
     }
 
     #[test]

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -1,0 +1,127 @@
+use encoding_rs::{CoderResult, Decoder, UTF_8};
+
+pub(crate) struct IncrementalUtf8LossyDecoder {
+    decoder: Decoder,
+    finished: bool,
+}
+
+impl IncrementalUtf8LossyDecoder {
+    pub(crate) fn new() -> Self {
+        Self {
+            decoder: UTF_8.new_decoder_without_bom_handling(),
+            finished: false,
+        }
+    }
+
+    pub(crate) fn push(&mut self, bytes: &[u8]) -> String {
+        debug_assert!(!self.finished, "cannot decode bytes after stream finish");
+        if self.finished || bytes.is_empty() {
+            return String::new();
+        }
+        self.decode(bytes, false)
+    }
+
+    pub(crate) fn finish(&mut self) -> String {
+        if self.finished {
+            return String::new();
+        }
+        self.finished = true;
+        self.decode(&[], true)
+    }
+
+    fn decode(&mut self, mut bytes: &[u8], last: bool) -> String {
+        let initial_capacity = self
+            .decoder
+            .max_utf8_buffer_length(bytes.len())
+            .unwrap_or_else(|| bytes.len().saturating_mul(3).saturating_add(3))
+            .max(3);
+        let mut output = String::with_capacity(initial_capacity);
+
+        loop {
+            let (result, read, _) = self.decoder.decode_to_string(bytes, &mut output, last);
+            bytes = &bytes[read..];
+            match result {
+                CoderResult::InputEmpty => {
+                    debug_assert!(bytes.is_empty());
+                    return output;
+                }
+                CoderResult::OutputFull => {
+                    output.reserve(bytes.len().saturating_mul(3).saturating_add(3));
+                }
+            }
+        }
+    }
+}
+
+impl Default for IncrementalUtf8LossyDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for IncrementalUtf8LossyDecoder {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IncrementalUtf8LossyDecoder")
+            .field("finished", &self.finished)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn decode_chunks(bytes: &[u8], split_points: &[usize]) -> String {
+        let mut decoder = IncrementalUtf8LossyDecoder::new();
+        let mut output = String::new();
+        let mut start = 0;
+        for &end in split_points {
+            output.push_str(&decoder.push(&bytes[start..end]));
+            start = end;
+        }
+        output.push_str(&decoder.push(&bytes[start..]));
+        output.push_str(&decoder.finish());
+        output
+    }
+
+    #[test]
+    fn decoder_preserves_multibyte_characters_across_every_boundary() {
+        let text = "ASCII 中文 😀 終";
+        let bytes = text.as_bytes();
+        for split in 0..=bytes.len() {
+            assert_eq!(decode_chunks(bytes, &[split]), text, "split at {split}");
+        }
+    }
+
+    #[test]
+    fn decoder_flushes_incomplete_utf8_with_replacement() {
+        assert_eq!(decode_chunks(&[b'a', 0xF0, 0x9F], &[2]), "a�");
+    }
+
+    #[test]
+    fn decoder_does_not_strip_utf8_bom() {
+        assert_eq!(decode_chunks(b"\xEF\xBB\xBFtext", &[1, 2]), "\u{FEFF}text");
+    }
+
+    proptest! {
+        #[test]
+        fn decoder_matches_whole_stream_lossy_decode(
+            bytes in proptest::collection::vec(any::<u8>(), 0..256),
+            cuts in proptest::collection::vec(0usize..256, 0..32),
+        ) {
+            let mut split_points = cuts
+                .into_iter()
+                .map(|cut| cut.min(bytes.len()))
+                .collect::<Vec<_>>();
+            split_points.sort_unstable();
+            split_points.dedup();
+            prop_assert_eq!(
+                decode_chunks(&bytes, &split_points),
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared incremental lossy UTF-8 decoder backed by `encoding_rs`
- decode command stdout/stderr, OpenAI Responses/Chat streams, and HTTP trace text across byte-chunk boundaries without changing existing SSE framing
- surface model-visible ApplyPatch diagnostics when U+FFFD is present, including a reread hint on failures
- document the decoding and historical-data boundary

## Behavior

- valid multi-byte UTF-8 split across arbitrary process or HTTP chunks is preserved
- malformed UTF-8 and incomplete EOF sequences retain the existing lossy replacement behavior
- Anthropic's existing strict event parsing is unchanged
- existing stored text containing U+FFFD is not rewritten automatically because the original bytes and intended characters cannot be recovered reliably

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib -- --test-threads=1`
- targeted decoder, command output, HTTP trace, OpenAI streaming, and ApplyPatch regression tests

Closes #2442
