### PR TITLE
fix(runtime): terminalize open WorkItems during agent deletion

### DIFF
--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -309,19 +309,56 @@ impl RuntimeHost {
         Ok(())
     }
 
-    /// Scheduler: ensure no scheduler state references this agent.
-    ///
-    /// Since the identity fence prevents new dispatches and the runtime is
-    /// unloaded, this phase verifies there are no lingering activations.
-    /// The per-agent scheduler state lives in the agent data directory and
-    /// will be removed in the Home phase.
+    /// Scheduler: terminalize durable work that could participate in future
+    /// scheduler promotion or dispatch.
     async fn deletion_phase_scheduler(&self, agent_id: &str) -> Result<()> {
-        // The scheduler protocol snapshot is per-agent and stored in the
-        // agent's own data directory. Since the runtime is unloaded and the
-        // identity fence prevents new activations, no shared scheduler state
-        // needs cleanup here. This phase exists as an explicit checkpoint for
-        // future shared scheduler extensions.
-        debug!(agent_id, "scheduler phase: no shared state to terminalize");
+        let storage = self.agent_storage(agent_id)?;
+        let open_work_items = self
+            .runtime_db()
+            .work_items()
+            .latest_for_agent(agent_id, usize::MAX)?
+            .into_iter()
+            .filter(|work_item| work_item.state == WorkItemState::Open)
+            .collect::<Vec<_>>();
+        let now = Utc::now();
+        for existing in &open_work_items {
+            let mut completed = existing.clone();
+            completed.revision = existing.revision.saturating_add(1);
+            completed.state = WorkItemState::Completed;
+            completed.blocked_by = None;
+            completed.recheck_at = None;
+            completed.recheck_consumed_at = None;
+            completed.result_summary = Some("Agent deleted before work completed".into());
+            completed.updated_at = now;
+            self.runtime_db().transitions().commit_work_item(
+                &crate::runtime_db::transitions::WorkItemTransitionCommand {
+                    agent_id: agent_id.to_string(),
+                    mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
+                        record: completed.clone(),
+                        expected_revision: existing.revision,
+                    },
+                    agent_state: None,
+                    brief_evidence: Vec::new(),
+                    audit_events: vec![AuditEvent::legacy(
+                        "work_item_completed_for_agent_deletion",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "work_item_id": completed.id,
+                            "revision": completed.revision,
+                            "reason": "agent_deleted",
+                        }),
+                    )],
+                    index_changes: storage.index_changes_for_work_item(&completed)?,
+                    notify_scheduler: true,
+                    fault: None,
+                },
+            )?;
+        }
+        debug!(
+            agent_id,
+            work_items_completed = open_work_items.len(),
+            "scheduler phase terminalized open work items"
+        );
         Ok(())
     }
 

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -284,7 +284,7 @@ pub struct WaitRecord {
     pub generations: BTreeMap<u64, WaitGenerationRecord>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct WaitGenerationRecord {
     pub owner: SchedulerOwner,
     pub state: WaitState,
@@ -292,6 +292,36 @@ pub struct WaitGenerationRecord {
     pub trigger: Option<WaitTrigger>,
     #[serde(default)]
     pub consuming_activation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct WaitGenerationRecordWire {
+    #[serde(default)]
+    owner: Option<SchedulerOwner>,
+    #[serde(default)]
+    owner_work_item_id: Option<String>,
+    state: WaitState,
+    #[serde(default)]
+    trigger: Option<WaitTrigger>,
+    #[serde(default)]
+    consuming_activation_id: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for WaitGenerationRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = WaitGenerationRecordWire::deserialize(deserializer)?;
+        let owner = scheduler_owner_from_wire_fields(wire.owner, wire.owner_work_item_id)
+            .map_err(D::Error::custom)?;
+        Ok(Self {
+            owner,
+            state: wire.state,
+            trigger: wire.trigger,
+            consuming_activation_id: wire.consuming_activation_id,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -659,7 +689,7 @@ pub struct WaitResumeClaim {
     pub trigger_generation: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ActivationBinding {
     Unbound,
@@ -676,6 +706,70 @@ pub enum ActivationBinding {
     Lifecycle {
         agent_id: String,
     },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ActivationBindingWire {
+    Unbound,
+    WorkItem {
+        work_item_id: String,
+    },
+    WaitOwner {
+        wait_id: String,
+        #[serde(default)]
+        owner: Option<SchedulerOwner>,
+        #[serde(default)]
+        owner_work_item_id: Option<String>,
+    },
+    Interaction {
+        interaction_id: String,
+    },
+    Lifecycle {
+        agent_id: String,
+    },
+}
+
+impl<'de> Deserialize<'de> for ActivationBinding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match ActivationBindingWire::deserialize(deserializer)? {
+            ActivationBindingWire::Unbound => Ok(Self::Unbound),
+            ActivationBindingWire::WorkItem { work_item_id } => Ok(Self::WorkItem { work_item_id }),
+            ActivationBindingWire::WaitOwner {
+                wait_id,
+                owner,
+                owner_work_item_id,
+            } => Ok(Self::WaitOwner {
+                wait_id,
+                owner: scheduler_owner_from_wire_fields(owner, owner_work_item_id)
+                    .map_err(D::Error::custom)?,
+            }),
+            ActivationBindingWire::Interaction { interaction_id } => {
+                Ok(Self::Interaction { interaction_id })
+            }
+            ActivationBindingWire::Lifecycle { agent_id } => Ok(Self::Lifecycle { agent_id }),
+        }
+    }
+}
+
+fn scheduler_owner_from_wire_fields(
+    owner: Option<SchedulerOwner>,
+    owner_work_item_id: Option<String>,
+) -> Result<SchedulerOwner, String> {
+    match (owner, owner_work_item_id) {
+        (Some(owner), None) => Ok(owner),
+        (None, Some(work_item_id)) => Ok(SchedulerOwner::WorkItem { work_item_id }),
+        (Some(SchedulerOwner::WorkItem { work_item_id }), Some(legacy_work_item_id))
+            if work_item_id == legacy_work_item_id =>
+        {
+            Ok(SchedulerOwner::WorkItem { work_item_id })
+        }
+        (Some(_), Some(_)) => Err("scheduler owner fields conflict".into()),
+        (None, None) => Err("scheduler owner is missing".into()),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -5764,4 +5858,68 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod wire_compatibility_tests {
+    use super::{ActivationBinding, SchedulerOwner, WaitGenerationRecord, WaitState};
+
+    #[test]
+    fn legacy_wait_owner_fields_deserialize_as_work_item_owner() {
+        let binding: ActivationBinding = serde_json::from_value(serde_json::json!({
+            "kind": "wait_owner",
+            "wait_id": "wait-a",
+            "owner_work_item_id": "work-a"
+        }))
+        .unwrap();
+        assert_eq!(
+            binding,
+            ActivationBinding::WaitOwner {
+                wait_id: "wait-a".into(),
+                owner: SchedulerOwner::WorkItem {
+                    work_item_id: "work-a".into(),
+                },
+            }
+        );
+
+        let generation: WaitGenerationRecord = serde_json::from_value(serde_json::json!({
+            "owner_work_item_id": "work-a",
+            "state": "active"
+        }))
+        .unwrap();
+        assert_eq!(
+            generation,
+            WaitGenerationRecord {
+                owner: SchedulerOwner::WorkItem {
+                    work_item_id: "work-a".into(),
+                },
+                state: WaitState::Active,
+                trigger: None,
+                consuming_activation_id: None,
+            }
+        );
+    }
+
+    #[test]
+    fn wait_owner_wire_fields_reject_missing_or_conflicting_owner() {
+        let missing = serde_json::from_value::<ActivationBinding>(serde_json::json!({
+            "kind": "wait_owner",
+            "wait_id": "wait-a"
+        }))
+        .unwrap_err();
+        assert!(missing.to_string().contains("scheduler owner is missing"));
+
+        let conflicting = serde_json::from_value::<WaitGenerationRecord>(serde_json::json!({
+            "owner": {
+                "kind": "agent_lifecycle",
+                "agent_id": "agent-a"
+            },
+            "owner_work_item_id": "work-a",
+            "state": "active"
+        }))
+        .unwrap_err();
+        assert!(conflicting
+            .to_string()
+            .contains("scheduler owner fields conflict"));
+    }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -2622,6 +2622,7 @@ mod tests {
             AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, ControlAction,
             MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord,
             QueueEntryStatus, TaskRecord, TaskRecoverySpec, TaskStatus, TurnTerminalKind,
+            WorkItemRecord, WorkItemState,
         },
     };
 
@@ -5268,6 +5269,54 @@ mod tests {
 
         // Agent home should be removed.
         assert!(!host.agent_data_dir("delete-me").exists());
+    }
+
+    #[tokio::test]
+    async fn deletion_coordinator_terminalizes_open_work_items() {
+        let (_home, host) = test_host();
+        let agent = AgentIdentityRecord::new(
+            "delete-work",
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        host.append_agent_identity(&agent).unwrap();
+        host.runtime_db().agent_identities().upsert(&agent).unwrap();
+        let mut work_item =
+            WorkItemRecord::new("delete-work", "unfinished work", WorkItemState::Open);
+        work_item.blocked_by = Some("operator input".into());
+        host.runtime_db()
+            .work_items()
+            .insert_new(&work_item)
+            .unwrap();
+
+        let (_, job, _) = host
+            .begin_public_agent_deletion("delete-work", false, "operator")
+            .await
+            .unwrap();
+        host.execute_deletion_job(job).await.unwrap();
+
+        let completed = host
+            .runtime_db()
+            .work_items()
+            .latest(&work_item.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(completed.state, WorkItemState::Completed);
+        assert_eq!(completed.blocked_by, None);
+        assert_eq!(
+            completed.result_summary.as_deref(),
+            Some("Agent deleted before work completed")
+        );
+        assert!(host
+            .runtime_db()
+            .transitions()
+            .legacy_scheduler_adoption_candidates("delete-work")
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -468,6 +468,84 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_authoritative_promotion_ignores_deleted_agent_work_items() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("runtime.sqlite"),
+            dir.path().join("runtime.lock"),
+        )?;
+        let mut identity = agent_identity("deleted-agent", 1);
+        identity.status = AgentRegistryStatus::Deleted;
+        identity.deleted_at = Some(identity.updated_at);
+        db.agent_identities().upsert(&identity)?;
+        let mut work = WorkItemRecord::new("deleted-agent", "legacy blocked", WorkItemState::Open);
+        work.blocked_by = Some("operator resolution".into());
+        db.work_items().insert_new(&work)?;
+        let manifest = scheduler_rollout_manifest(1, 1);
+        let commands = vec![
+            (
+                "deleted-open".into(),
+                RolloutCommand::OpenPreflight {
+                    expected_config_revision: 0,
+                    manifest_revision: 1,
+                },
+            ),
+            (
+                "deleted-complete".into(),
+                RolloutCommand::CompletePreflight {
+                    expected_config_revision: 0,
+                    expected_preflight_revision: 1,
+                    manifest: manifest.clone(),
+                },
+            ),
+            (
+                "deleted-install".into(),
+                RolloutCommand::InstallManifest {
+                    expected_config_revision: 0,
+                    manifest,
+                },
+            ),
+            (
+                "deleted-protocol".into(),
+                RolloutCommand::ConfigureProtocol {
+                    expected_config_revision: 1,
+                    mode: ProtocolMode::Authoritative,
+                },
+            ),
+            (
+                "deleted-shadow".into(),
+                RolloutCommand::ChangeScenarioAuthority {
+                    scenario_class: "exact_wait_resume".into(),
+                    expected_config_revision: 2,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                    mode: ScenarioMode::Shadow,
+                },
+            ),
+            (
+                "deleted-authority".into(),
+                RolloutCommand::ChangeScenarioAuthorityFromExplicitMode {
+                    scenario_class: "exact_wait_resume".into(),
+                    expected_config_revision: 3,
+                    expected_manifest_revision: 1,
+                    expected_preflight_revision: 1,
+                },
+            ),
+        ];
+
+        db.apply_scheduler_rollout_commands(&commands)?;
+        assert!(db
+            .transitions()
+            .legacy_scheduler_adoption_candidates("deleted-agent")?
+            .is_empty());
+        assert_eq!(
+            db.work_items().latest(&work.id)?.unwrap().state,
+            WorkItemState::Open
+        );
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_recovery_plan_rolls_back_adoption_when_later_command_rejects() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let db = RuntimeDb::open_and_migrate(

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -1316,7 +1316,14 @@ fn legacy_scheduler_adoption_candidates_tx(
     let mut statement = tx.prepare(
         "SELECT payload_json
          FROM work_items
-         WHERE state = 'open' AND (?1 IS NULL OR agent_id = ?1)
+         WHERE state = 'open'
+           AND (?1 IS NULL OR agent_id = ?1)
+           AND NOT EXISTS (
+               SELECT 1
+               FROM agent_identities
+               WHERE agent_identities.agent_id = work_items.agent_id
+                 AND agent_identities.status = 'deleted'
+           )
          ORDER BY agent_id, work_item_id",
     )?;
     let work_items = statement


### PR DESCRIPTION
## Summary

- terminalize every remaining open WorkItem through the durable WorkItem transition contract during agent deletion
- exclude tombstoned agents' historical open WorkItems from authoritative promotion blockers while preserving blocker semantics for live agents
- preserve compatibility when reading scheduler snapshots that use the legacy `owner_work_item_id` wire field
- add deletion, promotion, idempotency, atomicity, and wire-compatibility regressions

## Runtime contract

Agent deletion now leaves no open WorkItem demand that can participate in later scheduler promotion or dispatch. Historical records and audit evidence remain available; cleanup is performed through normal runtime transitions rather than direct database mutation.

## Verification

- `cargo fmt --all -- --check`
- four focused scheduler/deletion compatibility regressions
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`

Fixes #2452
