### PR TITLE
fix(web-gui): fetch newest events first during agent switch catch-up

### DIFF
--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -881,6 +881,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/control/agents/{agent_id}/scheduler-repair": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Inspect scheduler repair state
+         * @description Return active waits and queued wake-only messages eligible for an explicit scheduler repair transition.
+         */
+        get: operations["inspectSchedulerRepair"];
+        put?: never;
+        /**
+         * Apply scheduler repair
+         * @description Dry-run or apply one OCC-guarded scheduler repair operation and emit an audit event for committed changes.
+         */
+        post: operations["applySchedulerRepair"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/control/agents/{agent_id}/skills/disable": {
         parameters: {
             query?: never;
@@ -3106,6 +3130,7 @@ export interface components {
                 previous_work_item_id?: string | null;
                 reason?: string | null;
                 switch_kind: string;
+                terminal_transition: boolean;
                 warnings?: {
                     code: string;
                     message: string;
@@ -3325,6 +3350,96 @@ export interface components {
                     kind: string;
                 }[];
             };
+        };
+        /** SchedulerRepairInspection */
+        SchedulerRepairInspection: {
+            active_waits: {
+                agent_id: string;
+                /** Format: date-time */
+                cancelled_at?: string | null;
+                continuation?: unknown;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: date-time */
+                expires_at?: string | null;
+                id: string;
+                /** @enum {string} */
+                kind: "task" | "external" | "operator" | "timer" | "system";
+                /** Format: date-time */
+                resolved_at?: string | null;
+                source?: string | null;
+                /** @enum {string} */
+                status: "active" | "resolved" | "cancelled" | "expired";
+                subject_ref?: string | null;
+                turn_id?: string | null;
+                /** Format: date-time */
+                updated_at: string;
+                waiting_for: string;
+                wake_sources?: ({
+                    /** @constant */
+                    kind: "task_result";
+                    task_id: string;
+                } | {
+                    external_trigger_id?: string | null;
+                    /** @constant */
+                    kind: "external_ingress";
+                } | {
+                    /** @constant */
+                    kind: "timer";
+                    /** Format: date-time */
+                    wake_at: string;
+                } | {
+                    /** @constant */
+                    kind: "operator_input";
+                } | {
+                    /** @constant */
+                    kind: "system_tick";
+                })[];
+                work_item_id?: string | null;
+            }[];
+            agent_id: string;
+            wake_only_queue_entries: {
+                agent_id: string;
+                /** Format: date-time */
+                created_at: string;
+                message_id: string;
+                /** @enum {string} */
+                priority: "interject" | "next" | "normal" | "background";
+                status: ("queued" | "dequeued" | "processed" | "interjected" | "aborted" | "dropped") | "interrupted";
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+        };
+        /** SchedulerRepairRequest */
+        SchedulerRepairRequest: {
+            /** @default false */
+            dry_run: boolean;
+            operation: {
+                /** @enum {string} */
+                expected_status: "active" | "resolved" | "cancelled" | "expired";
+                /** Format: date-time */
+                expected_updated_at: string;
+                /** @constant */
+                kind: "cancel_wait";
+                wait_id: string;
+            } | {
+                expected_status: ("queued" | "dequeued" | "processed" | "interjected" | "aborted" | "dropped") | "interrupted";
+                /** Format: date-time */
+                expected_updated_at: string;
+                /** @constant */
+                kind: "drop_wake_only_queue_entry";
+                message_id: string;
+            };
+            reason: string;
+        };
+        /** SchedulerRepairResult */
+        SchedulerRepairResult: {
+            after: unknown;
+            agent_id: string;
+            before: unknown;
+            changed: boolean;
+            dry_run: boolean;
+            operation: string;
         };
         /** SearchRequest */
         SearchRequest: {
@@ -5978,6 +6093,92 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    inspectSchedulerRepair: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SchedulerRepairInspection"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    applySchedulerRepair: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SchedulerRepairRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SchedulerRepairResult"];
                 };
             };
             /** @description Client error JSON response. */

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -1031,6 +1031,22 @@ describe("agent event catch-up", () => {
       if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
       if (url.pathname.endsWith("/agents/agent-a/events")) {
         const afterSeq = Number(url.searchParams.get("after_seq"));
+        const order = url.searchParams.get("order");
+        // Phase 1: tail-first descending fetch returns newest 100 events (51-150)
+        if (order === "desc") {
+          return Promise.resolve(jsonResponse({
+            events: Array.from({ length: 100 }, (_, index) => event(150 - index)),
+            event_log_epoch: "epoch-1",
+            cursor_seq: 1428,
+            newest_seq: 150,
+            oldest_seq: 51,
+            has_older: true,
+            has_newer: false,
+            order: "desc",
+            limit: 100,
+          }));
+        }
+        // Phase 2: ascending backfill from cached cursor
         if (afterSeq === 1) {
           return Promise.resolve(jsonResponse({
             events: Array.from({ length: 100 }, (_, index) => event(index + 2)),
@@ -1093,7 +1109,9 @@ describe("agent event catch-up", () => {
     const eventRequests = fetchMock.mock.calls
       .map(([input]) => new URL(String(input), "http://localhost"))
       .filter((url) => url.pathname.endsWith("/agents/agent-a/events"));
-    expect(eventRequests.map((url) => url.searchParams.get("after_seq"))).toEqual(["1", "101"]);
+    // Phase 1: descending tail fetch, Phase 2: ascending backfill from cached cursor
+    expect(eventRequests.map((url) => url.searchParams.get("order"))).toEqual(["desc", "asc"]);
+    expect(eventRequests.map((url) => url.searchParams.get("after_seq"))).toEqual([null, "1"]);
     expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
       eventSeqs: Array.from({ length: 150 }, (_, index) => index + 1),
       newestSeq: 150,
@@ -1129,6 +1147,26 @@ describe("agent event catch-up", () => {
       if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
       if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
       if (url.pathname.endsWith("/agents/agent-a/events")) {
+        const order = url.searchParams.get("order");
+        // Phase 1: descending tail returns events 10-20, creating a gap
+        if (order === "desc") {
+          return Promise.resolve(jsonResponse({
+            events: Array.from({ length: 11 }, (_, index) => ({
+              ...event,
+              id: `event-${20 - index}`,
+              event_seq: 20 - index,
+            })),
+            event_log_epoch: "epoch-1",
+            cursor_seq: 1428,
+            newest_seq: 20,
+            oldest_seq: 10,
+            has_older: true,
+            has_newer: false,
+            order: "desc",
+            limit: 100,
+          }));
+        }
+        // Phase 2: ascending backfill returns empty page with has_newer: true
         return Promise.resolve(jsonResponse({
           events: [],
           event_log_epoch: "epoch-1",
@@ -1174,8 +1212,9 @@ describe("agent event catch-up", () => {
     await useRuntimeStore.getState().ensureAgentSession("agent-a", "info");
 
     expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
-      eventSeqs: [1],
-      newestSeq: 1,
+      // Tail events 10-20 merged before backfill error
+      eventSeqs: [1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+      newestSeq: 20,
       syncStatus: "error",
       error: "Agent event catch-up page did not advance its consumed cursor.",
     });
@@ -1209,8 +1248,23 @@ describe("agent event catch-up", () => {
       if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
       if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
       if (url.pathname.endsWith("/agents/agent-a/events")) {
+        const order = url.searchParams.get("order");
+        // Phase 1: descending tail returns the newest event (5)
+        if (order === "desc") {
+          return Promise.resolve(jsonResponse({
+            events: [event(5)],
+            event_log_epoch: "epoch-1",
+            cursor_seq: 5,
+            newest_seq: 5,
+            oldest_seq: 5,
+            has_older: true,
+            has_newer: false,
+            order: "desc",
+            limit: 100,
+          }));
+        }
+        // Phase 2: ascending backfill should query from gaps[0].afterSeq (1), not newestSeq (5).
         const afterSeq = Number(url.searchParams.get("after_seq"));
-        // The catch-up should query from gaps[0].afterSeq (1), not newestSeq (5).
         expect(afterSeq).toBe(1);
         return Promise.resolve(jsonResponse({
           events: [event(2), event(3), event(4), event(5)],

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4469,39 +4469,91 @@ async function catchUpAgentEvents(
     // instead so the catch-up fills the missing events.
     const catchUpGaps = catchUpSession?.gaps ?? [];
     const initialAfterSeq = catchUpGaps.length > 0 ? catchUpGaps[0].afterSeq : catchUpSession?.newestSeq;
-    let afterSeq = initialAfterSeq;
     let eventCount = 0;
     let pageCount = 0;
     let refreshWorkItems = false;
     let refreshAgentState = false;
-    while (true) {
-      const page = await runtimeClient.getAgentEvents(agentId, {
-        afterSeq,
-        limit: 100,
-        order: "asc",
-      });
-      if (!isCurrentClientGeneration(generation)) {
-        span.end("cancelled");
-        return;
+
+    // Phase 1 — Fetch the newest tail first (descending) so the user
+    // immediately sees the current state instead of watching old events
+    // replay page-by-page in ascending order.
+    const tailPage = await runtimeClient.getAgentEvents(agentId, {
+      limit: 100,
+      order: "desc",
+    });
+    if (!isCurrentClientGeneration(generation)) {
+      span.end("cancelled");
+      return;
+    }
+    const tailEvents = tailPage.events ?? [];
+    const tailConsumedSeq = Math.max(...tailEvents.map((event) => event.event_seq ?? 0)) || undefined;
+    const tailOldestSeq = tailPage.oldest_seq ?? undefined;
+    const tailHasOlder = tailPage.has_older ?? false;
+
+    set((state) =>
+      mergeEventPageIntoSession(state, agentId, tailEvents, tailOldestSeq, tailHasOlder, "debug", {
+        newestSeq: tailConsumedSeq,
+        append: true,
+        eventLogEpoch: tailPage.event_log_epoch,
+      }),
+    );
+
+    eventCount += tailEvents.length;
+    pageCount += 1;
+    refreshWorkItems ||= tailEvents.some(isWorkItemCacheInvalidationEvent);
+    refreshAgentState ||= tailEvents.some(isAgentStateCacheInvalidationEvent);
+
+    // Hydrate the tail immediately so the user sees latest content while
+    // the gap backfill runs in the background.
+    if (get().selectedAgentId === agentId) {
+      scheduleMessageHydration(get, set, agentId, "debug");
+      scheduleTranscriptHydration(get, set, agentId, "debug");
+      scheduleBriefHydration(get, set, agentId, "debug");
+    }
+
+    // Phase 2 — Backfill the gap between cached state and tail in ascending
+    // order.  This fills any missing events without blocking the tail
+    // display.  The stop condition checks whether the ascending cursor has
+    // reached the tail's oldest seq (meaning the ranges now overlap).
+    const hasGap =
+      tailHasOlder &&
+      tailOldestSeq != null &&
+      (initialAfterSeq == null || tailOldestSeq > initialAfterSeq + 1);
+
+    if (hasGap) {
+      let afterSeq = initialAfterSeq;
+      while (true) {
+        const page = await runtimeClient.getAgentEvents(agentId, {
+          afterSeq,
+          limit: 100,
+          order: "asc",
+        });
+        if (!isCurrentClientGeneration(generation)) {
+          span.end("cancelled");
+          return;
+        }
+        const pageEvents = page.events ?? [];
+        const consumedSeq = Math.max(...pageEvents.map((event) => event.event_seq ?? 0)) || undefined;
+        set((state) =>
+          mergeEventPageIntoSession(state, agentId, pageEvents, page.oldest_seq ?? undefined, page.has_older, "debug", {
+            newestSeq: consumedSeq,
+            append: true,
+            eventLogEpoch: page.event_log_epoch,
+          }),
+        );
+        eventCount += pageEvents.length;
+        pageCount += 1;
+        refreshWorkItems ||= pageEvents.some(isWorkItemCacheInvalidationEvent);
+        refreshAgentState ||= pageEvents.some(isAgentStateCacheInvalidationEvent);
+        // Stop when no more newer pages or when the ascending range has
+        // caught up to the tail (events overlap is safe via seq dedup).
+        if (!page.has_newer) break;
+        if (consumedSeq != null && tailOldestSeq != null && consumedSeq >= tailOldestSeq) break;
+        if (consumedSeq == null || (afterSeq != null && consumedSeq <= afterSeq)) {
+          throw new Error("Agent event catch-up page did not advance its consumed cursor.");
+        }
+        afterSeq = consumedSeq;
       }
-      const pageEvents = page.events ?? [];
-      const consumedSeq = Math.max(...pageEvents.map((event) => event.event_seq ?? 0)) || undefined;
-      set((state) =>
-        mergeEventPageIntoSession(state, agentId, pageEvents, page.oldest_seq ?? undefined, page.has_older, "debug", {
-          newestSeq: consumedSeq,
-          append: true,
-          eventLogEpoch: page.event_log_epoch,
-        }),
-      );
-      eventCount += pageEvents.length;
-      pageCount += 1;
-      refreshWorkItems ||= pageEvents.some(isWorkItemCacheInvalidationEvent);
-      refreshAgentState ||= pageEvents.some(isAgentStateCacheInvalidationEvent);
-      if (!page.has_newer) break;
-      if (consumedSeq == null || (afterSeq != null && consumedSeq <= afterSeq)) {
-        throw new Error("Agent event catch-up page did not advance its consumed cursor.");
-      }
-      afterSeq = consumedSeq;
     }
     if (refreshWorkItems) {
       void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
@@ -5115,7 +5167,12 @@ function mergeEventPageIntoSession(
       [agentId]: {
         ...projected,
         newestSeq: Math.max(options.newestSeq ?? 0, projected.newestSeq ?? 0) || undefined,
-        oldestSeq: pageOldestSeq ?? projected.oldestSeq,
+        // Take the true oldest across all events (cached + new page) so
+        // descending-order pages don't clobber the cached oldest seq.
+        oldestSeq:
+          pageOldestSeq != null && projected.oldestSeq != null
+            ? Math.min(pageOldestSeq, projected.oldestSeq)
+            : (pageOldestSeq ?? projected.oldestSeq),
         hasOlder: pageHasOlder,
         loadingOlder: false,
         historyError: undefined,


### PR DESCRIPTION
## Summary

Fix the agent switch "message list flash" issue: when switching agents, the UI briefly showed stale cached messages before the latest content appeared. This happened because `catchUpAgentEvents` fetched missing events in ascending order from the old cursor, replaying every intermediate page before the newest events arrived.

## Root Cause

- `ensureAgentSession` immediately renders the cached session snapshot (cache-first) with `syncStatus: "refreshing"`.
- `catchUpAgentEvents` then fetched events in ascending order (`order: "asc"`) starting from the cached cursor, so the newest events only appeared after all intermediate pages were fetched.
- For sessions with large gaps (e.g., 1383 events / 14 pages, 2.94s), the user saw the old list first, then a sudden jump to the latest.

## Fix

Restructure `catchUpAgentEvents` into two phases:

1. **Phase 1 — Tail-first (descending):** Fetch the newest 100 events and merge them immediately. Schedule message/transcript/brief hydration right away so the user sees current content without waiting.
2. **Phase 2 — Gap backfill (ascending):** If there's a gap between cached state and the tail, fill it in ascending order. The stop condition checks whether the ascending cursor has reached the tail's oldest seq (overlap is safe via seq dedup in `reduceEvents`).

Also fix `mergeEventPageIntoSession` to use `Math.min` for `oldestSeq` so descending-order pages don't clobber the cached oldest sequence number.

## Changed Files

- `web-gui/app/src/runtime/runtime-store.ts` — `catchUpAgentEvents` rewrite + `mergeEventPageIntoSession` `oldestSeq` fix
- `web-gui/app/src/runtime/runtime-store.test.ts` — updated 3 catch-up tests for the two-phase flow

## Verification

- `tsc --noEmit` — no type errors
- `vitest run` — 296 tests pass (29 test files)
