### PR TITLE
fix: suppress stale cached content during agent switch catch-up

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -2515,7 +2515,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
               ...state.sessionsByAgentId,
               [agentId]: {
                 ...state.sessionsByAgentId[agentId],
-                loading: false,
+                loading: true,
                 syncStatus: "refreshing",
               },
             },
@@ -2532,6 +2532,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
                   syncStatus: get().globalStreamStatus === "streaming" ? "streaming" : "idle",
                   contentStatus: "available",
                   eventsValidatedAt: Date.now(),
+                  detailValidatedAt: Date.now(),
                 },
               },
             }));


### PR DESCRIPTION
## Problem

PR #2459 implemented tail-first catch-up to fix the agent switch flash, but the trace shows the problem persists. The tail-first fetch is working correctly (100 events, 1 page, descending), but the old cached content is still rendered during the ~800ms catch-up window because `ensureAgentSession` sets `loading: false` before `catchUpAgentEvents` starts.

The trace also shows a redundant second catch-up cycle ~8s later with the same cursor (`afterSeq: 48597`), because `detailValidatedAt` is never set after catch-up — so the next `ensureAgentSession` call sees `detailFresh = false` and runs catch-up again.

## Fix

1. **Set `loading: true` before catch-up** in the `hasCachedContent` branch of `ensureAgentSession`. This makes the component show a loading state instead of rendering stale cached content during the tail fetch. After catch-up completes (or errors), `loading` is set back to `false`.

2. **Set `detailValidatedAt: Date.now()` after catch-up** so the next `ensureAgentSession` call within the 60s TTL sees `fresh = true` and skips catch-up when the stream is active.

## Verification

- `tsc --noEmit` passes
- All 43 runtime-store tests pass
- All 35 session-projection and client tests pass