### PR TITLE
fix: terminalize stale canonical focus during legacy adoption (#2460)

### DIFF
--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -929,6 +929,21 @@ pub struct LegacyWaitAdoption {
     pub source_updated_at: String,
 }
 
+/// Proof that allows an `AdoptLegacyWorkState` command to atomically replace
+/// a stale canonical focus whose legacy WorkItem is provably completed.
+///
+/// This is NOT a general-purpose focus replacement. It only permits
+/// terminalizing one old focus demand and switching to the new adoption
+/// target in the same reducer transition, within the narrow legacy→canonical
+/// migration window described in issue #2460.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplaceCompletedFocusProof {
+    pub work_item_id: String,
+    pub source_work_item_revision: u64,
+    pub expected_metadata_revision: u64,
+    pub expected_scheduling_generation: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AdoptLegacyWorkStateCommand {
     pub work_item_id: String,
@@ -940,6 +955,8 @@ pub struct AdoptLegacyWorkStateCommand {
     pub focus: bool,
     #[serde(default)]
     pub reserve_dispatch: bool,
+    #[serde(default)]
+    pub replace_completed_focus: Option<ReplaceCompletedFocusProof>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2038,7 +2055,13 @@ fn replay_or_conflict(
                     None => true,
                 };
                 let focus_matches = !command.focus
-                    || snapshot.focus.as_deref() == Some(command.work_item_id.as_str());
+                    || snapshot.focus.as_deref() == Some(command.work_item_id.as_str())
+                    || command
+                        .replace_completed_focus
+                        .as_ref()
+                        .is_some_and(|proof| {
+                            snapshot.focus.as_deref() == Some(proof.work_item_id.as_str())
+                        });
                 let dispatch_matches = !command.reserve_dispatch
                     || command.wait.as_ref().is_some_and(|wait| {
                         snapshot.dispatch
@@ -2425,13 +2448,69 @@ fn adopt_legacy_work_state(
             .as_deref()
             .is_some_and(|focus| focus != command.work_item_id)
     {
-        return rejected_command(
-            snapshot,
-            command_conflict(
-                ProtocolConflictKind::StateConflict,
-                "legacy_focus_adoption_conflict",
-            ),
-        );
+        // Without a replacement proof, any focus mismatch is a hard conflict.
+        let Some(proof) = &command.replace_completed_focus else {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "legacy_focus_adoption_conflict",
+                ),
+            );
+        };
+        // Current focus must match the proof's work item.
+        if snapshot.focus.as_deref() != Some(proof.work_item_id.as_str()) {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "legacy_focus_replacement_focus_mismatch",
+                ),
+            );
+        }
+        // Old focus demand must exist and match the proof fence.
+        let old_demand = match snapshot.work.get(&proof.work_item_id) {
+            Some(demand)
+                if demand.metadata_revision == proof.expected_metadata_revision
+                    && demand.scheduling_generation == proof.expected_scheduling_generation =>
+            {
+                demand
+            }
+            _ => {
+                return rejected_command(
+                    snapshot,
+                    command_conflict(
+                        ProtocolConflictKind::StaleRevision,
+                        "legacy_focus_replacement_demand_fence_mismatch",
+                    ),
+                );
+            }
+        };
+        // Old focus must be in a safe state: Runnable or Paused only.
+        if !matches!(
+            old_demand.status,
+            WorkStatus::Runnable | WorkStatus::Paused { .. }
+        ) {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "legacy_focus_replacement_unsafe_status",
+                ),
+            );
+        }
+        // Activation slot must not be occupied by the old focus.
+        if let ActivationSlot::Running { owner, .. } = &snapshot.slot {
+            if owner.work_item_id() == Some(proof.work_item_id.as_str()) {
+                return rejected_command(
+                    snapshot,
+                    command_conflict(
+                        ProtocolConflictKind::StateConflict,
+                        "legacy_focus_replacement_slot_occupied",
+                    ),
+                );
+            }
+        }
     }
     if command.reserve_dispatch && snapshot.dispatch != AgentDispatchState::Open {
         return rejected_command(
@@ -2507,16 +2586,24 @@ fn adopt_legacy_work_state(
             next.dispatch_revision += 1;
         }
     }
+    // Terminalize the replaced old focus demand if a proof was provided and validated.
+    let mut transitions = vec![format!(
+        "work:{}:legacy_state_adopted:generation:{}",
+        command.work_item_id, command.demand.scheduling_generation
+    )];
+    if let Some(proof) = &command.replace_completed_focus {
+        if let Some(old_demand) = next.work.get_mut(&proof.work_item_id) {
+            old_demand.status = WorkStatus::Terminal;
+            transitions.push(format!("work:{}:legacy_focus_replaced", proof.work_item_id));
+        }
+    }
     if command.focus {
         next.focus = Some(command.work_item_id.clone());
     }
     ProtocolCommandOutcome {
         outcome: Outcome {
             decision: Decision::LegacyWorkStateAdopted,
-            transitions: vec![format!(
-                "work:{}:legacy_state_adopted:generation:{}",
-                command.work_item_id, command.demand.scheduling_generation
-            )],
+            transitions,
             diagnostics: Vec::new(),
             snapshot: next,
         },

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -20,11 +20,11 @@ use crate::domain::scheduler_protocol::{
     ActivationRecord, ActivationSlot, ActivationState, AdmitActivationCommand,
     AdoptLegacyWorkStateCommand, AgentDispatchState, ContinuationAdmissionRecord, Decision,
     LegacyWaitAdoption, MissingSettlementRecord, ProtocolCommand, ProtocolConflict,
-    ProtocolConflictKind, ProtocolMode, RollbackAction, RollbackTrigger, RolloutCommand,
-    RolloutManifest, RolloutPreflightRecord, RolloutPreflightState, RolloutState,
-    ScenarioAuthority, ScenarioHardBlockerRecord, ScenarioMode, SchedulerOwner,
-    SchedulerScenarioClass, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState,
-    WaitTrigger, WorkDemand, WorkStatus,
+    ProtocolConflictKind, ProtocolMode, ReplaceCompletedFocusProof, RollbackAction,
+    RollbackTrigger, RolloutCommand, RolloutManifest, RolloutPreflightRecord,
+    RolloutPreflightState, RolloutState, ScenarioAuthority, ScenarioHardBlockerRecord,
+    ScenarioMode, SchedulerOwner, SchedulerScenarioClass, Snapshot, WaitGenerationRecord,
+    WaitIdentity, WaitRecord, WaitState, WaitTrigger, WorkDemand, WorkStatus,
 };
 use crate::domain::scheduler_semantic::{
     resolve_semantic_proposal, validate_semantic_decision_input, validate_semantic_provider_config,
@@ -1493,7 +1493,7 @@ fn legacy_scheduler_adoption_candidate_tx(
                 crate::types::AgentStatus::AwaitingTask | crate::types::AgentStatus::Asleep
             )
         });
-    let command = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+    let mut command = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
         work_item_id: work_item.id.clone(),
         source_work_item_revision: work_item.revision,
         demand: WorkDemand {
@@ -1508,7 +1508,26 @@ fn legacy_scheduler_adoption_candidate_tx(
         wait,
         focus: is_current,
         reserve_dispatch,
+        replace_completed_focus: None,
     });
+    // Check for a stale canonical focus that can be provably replaced.
+    if is_current && scheduler_protocol_partition_exists_tx(tx, &work_item.agent_id)? {
+        let snapshot = load_snapshot_tx(tx, &work_item.agent_id)?;
+        if let Some(stale_focus_id) = snapshot.focus.as_deref() {
+            if stale_focus_id != work_item.id {
+                if let Some(proof) = build_replace_completed_focus_proof_tx(
+                    tx,
+                    &work_item.agent_id,
+                    stale_focus_id,
+                    &snapshot,
+                )? {
+                    if let ProtocolCommand::AdoptLegacyWorkState(ref mut cmd) = command {
+                        cmd.replace_completed_focus = Some(proof);
+                    }
+                }
+            }
+        }
+    }
     Ok(LegacySchedulerAdoptionCandidate {
         agent_id: work_item.agent_id.clone(),
         work_item_id: work_item.id.clone(),
@@ -1516,6 +1535,54 @@ fn legacy_scheduler_adoption_candidate_tx(
         reason: "eligible".into(),
         command: Some(command),
     })
+}
+
+/// Builds a proof that the stale canonical focus can be safely replaced because
+/// its legacy WorkItem is provably completed and its canonical demand is in a
+/// safe state. Returns `None` if any condition is not met (fail-closed).
+fn build_replace_completed_focus_proof_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    stale_focus_id: &str,
+    snapshot: &Snapshot,
+) -> Result<Option<ReplaceCompletedFocusProof>> {
+    // The old focus must be a completed legacy WorkItem of the same agent.
+    let stale_payload = tx
+        .query_row(
+            "SELECT payload_json FROM work_items
+             WHERE work_item_id = ?1 AND agent_id = ?2 AND state = 'completed'",
+            [stale_focus_id, agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let stale_work_item = match stale_payload {
+        Some(payload) => crate::runtime_db::repositories::decode_work_item_payload(&payload)?,
+        None => return Ok(None),
+    };
+    // The old focus demand must exist in the canonical snapshot.
+    let old_demand = match snapshot.work.get(stale_focus_id) {
+        Some(demand) => demand,
+        None => return Ok(None),
+    };
+    // Safe states only: Runnable or Paused.
+    if !matches!(
+        old_demand.status,
+        WorkStatus::Runnable | WorkStatus::Paused { .. }
+    ) {
+        return Ok(None);
+    }
+    // Activation slot must not be occupied by the old focus.
+    if let ActivationSlot::Running { owner, .. } = &snapshot.slot {
+        if owner.work_item_id() == Some(stale_focus_id) {
+            return Ok(None);
+        }
+    }
+    Ok(Some(ReplaceCompletedFocusProof {
+        work_item_id: stale_focus_id.to_string(),
+        source_work_item_revision: stale_work_item.revision,
+        expected_metadata_revision: old_demand.metadata_revision,
+        expected_scheduling_generation: old_demand.scheduling_generation,
+    }))
 }
 
 fn ineligible_legacy_adoption(
@@ -1727,6 +1794,9 @@ fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
                     "wait:{}:generation:{}",
                     wait.wait_id, wait.generation
                 ));
+            }
+            if let Some(proof) = &command.replace_completed_focus {
+                references.push(format!("work:{}:legacy_focus_replaced", proof.work_item_id));
             }
             references
         }

--- a/tests/scheduler_intent_mvp.rs
+++ b/tests/scheduler_intent_mvp.rs
@@ -8,8 +8,8 @@ use std::{
 
 use holon::domain::scheduler_protocol::{
     ActivationOrigin, ActivationSlot, ActivationTrust, AdoptLegacyWorkStateCommand,
-    AgentDispatchState, Decision, LegacyWaitAdoption, ProtocolCommand, SchedulerOwner, Snapshot,
-    WaitGenerationRecord, WaitRecord, WaitState, WorkDemand, WorkStatus,
+    AgentDispatchState, Decision, LegacyWaitAdoption, ProtocolCommand, ReplaceCompletedFocusProof,
+    SchedulerOwner, Snapshot, WaitGenerationRecord, WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
 use holon::domain::scheduler_semantic::{
     resolve_semantic_proposal, validate_semantic_decision_input, validate_semantic_decision_inputs,
@@ -66,6 +66,7 @@ fn legacy_work_state_adoption_is_typed_and_idempotent() {
         }),
         focus: true,
         reserve_dispatch: true,
+        replace_completed_focus: None,
     });
 
     let adopted = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
@@ -112,6 +113,7 @@ fn legacy_work_state_adoption_rejects_same_revision_conflicts() {
         wait: None,
         focus: false,
         reserve_dispatch: false,
+        replace_completed_focus: None,
     });
 
     let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &conflicting);
@@ -119,6 +121,236 @@ fn legacy_work_state_adoption_rejects_same_revision_conflicts() {
     assert_eq!(
         rejected.conflict.unwrap().code,
         "legacy_work_state_adoption_conflict"
+    );
+}
+
+/// Builds a snapshot whose canonical focus points to a stale work item
+/// (simulating the legacy→canonical migration gap from issue #2460).
+fn stale_focus_snapshot(
+    stale_focus_id: &str,
+    stale_status: WorkStatus,
+    stale_metadata_revision: u64,
+    stale_scheduling_generation: u64,
+    slot: ActivationSlot,
+) -> Snapshot {
+    let mut snapshot = semantic_authority_snapshot();
+    snapshot.dispatch = AgentDispatchState::Open;
+    snapshot.focus = Some(stale_focus_id.into());
+    snapshot.work.clear();
+    snapshot.waits.clear();
+    snapshot.work.insert(
+        stale_focus_id.into(),
+        WorkDemand {
+            metadata_revision: stale_metadata_revision,
+            scheduling_generation: stale_scheduling_generation,
+            status: stale_status,
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+    );
+    snapshot.slot = slot;
+    snapshot
+}
+
+fn replace_focus_proof(
+    stale_focus_id: &str,
+    expected_metadata_revision: u64,
+    expected_scheduling_generation: u64,
+) -> ReplaceCompletedFocusProof {
+    ReplaceCompletedFocusProof {
+        work_item_id: stale_focus_id.into(),
+        source_work_item_revision: 3,
+        expected_metadata_revision,
+        expected_scheduling_generation,
+    }
+}
+
+/// Builds an AdoptLegacyWorkState command targeting `work-new` with focus
+/// and an optional replacement proof for the stale focus.
+fn adopt_new_with_proof(proof: Option<ReplaceCompletedFocusProof>) -> ProtocolCommand {
+    ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "work-new".into(),
+        source_work_item_revision: 5,
+        demand: WorkDemand {
+            metadata_revision: 5,
+            scheduling_generation: 5,
+            status: WorkStatus::Paused {
+                hold_id: "legacy-plan-needs-input:work-new".into(),
+            },
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: None,
+        focus: true,
+        reserve_dispatch: false,
+        replace_completed_focus: proof,
+    })
+}
+
+#[test]
+fn replace_completed_focus_succeeds_for_stale_runnable_focus() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Runnable,
+        10,
+        10,
+        ActivationSlot::Idle,
+    );
+    let command = adopt_new_with_proof(Some(replace_focus_proof("work-old", 10, 10)));
+
+    let adopted = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(adopted.outcome.decision, Decision::LegacyWorkStateAdopted);
+    holon::domain::scheduler_protocol::assert_invariants(&adopted.outcome.snapshot).unwrap();
+    assert_eq!(adopted.outcome.snapshot.focus, Some("work-new".into()));
+    assert_eq!(
+        adopted
+            .outcome
+            .snapshot
+            .work
+            .get("work-old")
+            .unwrap()
+            .status,
+        WorkStatus::Terminal
+    );
+    assert!(adopted.outcome.snapshot.work.contains_key("work-new"));
+
+    // Replay should be idempotent.
+    let replay =
+        holon::domain::scheduler_protocol::reduce_command(&adopted.outcome.snapshot, &command);
+    assert_eq!(replay.outcome.decision, Decision::DuplicateIgnored);
+}
+
+#[test]
+fn replace_completed_focus_succeeds_for_paused_focus() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Paused {
+            hold_id: "hold:work-old".into(),
+        },
+        10,
+        10,
+        ActivationSlot::Idle,
+    );
+    let command = adopt_new_with_proof(Some(replace_focus_proof("work-old", 10, 10)));
+
+    let adopted = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(adopted.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(adopted.outcome.snapshot.focus, Some("work-new".into()));
+    assert_eq!(
+        adopted
+            .outcome
+            .snapshot
+            .work
+            .get("work-old")
+            .unwrap()
+            .status,
+        WorkStatus::Terminal
+    );
+}
+
+#[test]
+fn replace_completed_focus_rejected_without_proof() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Runnable,
+        10,
+        10,
+        ActivationSlot::Idle,
+    );
+    let command = adopt_new_with_proof(None);
+
+    let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.unwrap().code,
+        "legacy_focus_adoption_conflict"
+    );
+}
+
+#[test]
+fn replace_completed_focus_rejected_on_focus_mismatch() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Runnable,
+        10,
+        10,
+        ActivationSlot::Idle,
+    );
+    let command = adopt_new_with_proof(Some(replace_focus_proof("work-other", 10, 10)));
+
+    let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.unwrap().code,
+        "legacy_focus_replacement_focus_mismatch"
+    );
+}
+
+#[test]
+fn replace_completed_focus_rejected_on_demand_fence_mismatch() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Runnable,
+        10,
+        10,
+        ActivationSlot::Idle,
+    );
+    let command = adopt_new_with_proof(Some(replace_focus_proof("work-old", 99, 10)));
+
+    let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.unwrap().code,
+        "legacy_focus_replacement_demand_fence_mismatch"
+    );
+}
+
+#[test]
+fn replace_completed_focus_rejected_on_unsafe_status() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Terminal,
+        10,
+        10,
+        ActivationSlot::Idle,
+    );
+    let command = adopt_new_with_proof(Some(replace_focus_proof("work-old", 10, 10)));
+
+    let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.unwrap().code,
+        "legacy_focus_replacement_unsafe_status"
+    );
+}
+
+#[test]
+fn replace_completed_focus_rejected_when_slot_occupied() {
+    let snapshot = stale_focus_snapshot(
+        "work-old",
+        WorkStatus::Runnable,
+        10,
+        10,
+        ActivationSlot::Running {
+            activation_id: "act-1".into(),
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: "work-old".into(),
+            },
+            admitted_generation: 10,
+            recovery_for: None,
+        },
+    );
+    let command = adopt_new_with_proof(Some(replace_focus_proof("work-old", 10, 10)));
+
+    let rejected = holon::domain::scheduler_protocol::reduce_command(&snapshot, &command);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.unwrap().code,
+        "legacy_focus_replacement_slot_occupied"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #2460.

When a legacy→canonical migration leaves a stale canonical focus whose legacy WorkItem is provably completed, adoption of the new legacy focus was rejected with `legacy_focus_adoption_conflict`, causing agent restart loops.

## Root Cause

This is a **legacy/shadow → canonical transition gap**, not a core scheduler state machine defect:

- Pure canonical completion drives `ActivationSettlement::WorkCompleted` → demand set to `Terminal` → focus released.
- The production failure requires two simultaneous facts: legacy `current_work_item_id` already switched to a new open WorkItem, while the shadow/canonical partition still retains the old focus.
- The conflict only triggers on the `AdoptLegacyWorkState(focus=true)` legacy→canonical import bridge.
- Legacy `CompleteWorkItem` updates WorkItem, legacy focus, wait, and continuation, but does not sync the already-initialized shadow partition, leaving a stale canonical focus during the transition window.

## Fix

Add an optional `ReplaceCompletedFocusProof` to `AdoptLegacyWorkStateCommand`. When all of the following are true:

1. The old focus's legacy WorkItem is provably **completed** (checked via DB query)
2. The old focus demand is in a **safe state** (Runnable or Paused only)
3. The activation slot is **not occupied** by the old focus
4. The proof fence (metadata_revision + scheduling_generation) matches the snapshot

…adoption atomically terminalizes the old demand and switches focus to the new work item in the same reducer transition.

All other conflicts remain **fail-closed**:
- No proof → `legacy_focus_adoption_conflict` (original behavior preserved)
- Focus mismatch → `legacy_focus_replacement_focus_mismatch`
- Demand fence mismatch → `legacy_focus_replacement_demand_fence_mismatch`
- Unsafe status (Terminal/Settling/etc.) → `legacy_focus_replacement_unsafe_status`
- Slot occupied → `legacy_focus_replacement_slot_occupied`

## Changes

- `src/domain/scheduler_protocol.rs`: Add `ReplaceCompletedFocusProof` struct, extend `AdoptLegacyWorkStateCommand`, update reducer and replay logic.
- `src/runtime_db/transitions/scheduler_protocol_repository.rs`: Add `build_replace_completed_focus_proof_tx` to construct proofs during adoption candidate enumeration, update fact references.
- `tests/scheduler_intent_mvp.rs`: 6 new tests covering success (Runnable, Paused) and all rejection paths.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib` ✅ (2601 passed, 0 failed)
- `cargo test --test scheduler_intent_mvp` ✅