### PR TITLE
test: add scheduler E2E Tier-1 scenarios and CI layering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ on:
       - "scripts/docker-e2e.py"
       - "scripts/docker-live-acceptance.py"
       - "scripts/docker_e2e/**"
+      - ".github/workflows/e2e-scheduler-nightly.yml"
+      - "tests/e2e/scheduler/**"
   pull_request:
     branches: [main]
     paths:
@@ -43,6 +45,9 @@ on:
       - "scripts/docker-e2e.py"
       - "scripts/docker-live-acceptance.py"
       - "scripts/docker_e2e/**"
+      - ".github/workflows/e2e-scheduler-nightly.yml"
+      - "tests/e2e/scheduler/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -240,3 +245,54 @@ jobs:
         with:
           name: coverage-report
           path: lcov.info
+
+  e2e-scheduler:
+    name: E2E Scheduler (optional)
+    needs: changes
+    if: contains(github.event.pull_request.labels.*.name, 'e2e-scheduler')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    env:
+      HOLON_E2E_MODEL: ${{ vars.HOLON_E2E_SCHEDULER_MODEL || 'deepseek/deepseek-v4-flash' }}
+      HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          tags: holon:e2e
+          cache-from: type=gha,scope=holon-docker
+          cache-to: type=gha,mode=max,scope=holon-docker
+
+      - name: Prepare provider environment
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${DEEPSEEK_API_KEY}"
+          umask 077
+          printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
+          chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+
+      - name: Run scheduler Tier-1 E2E
+        run: |
+          set -euo pipefail
+          python3 scripts/docker-e2e.py \
+            --image holon:e2e \
+            --skip-build \
+            --suite extended \
+            --tag e2e-tier-1 \
+            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
+            --timeout 600
+
+      - name: Remove provider environment
+        if: always()
+        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}"

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -19,6 +19,7 @@ jobs:
   nightly:
     name: Scheduler E2E Nightly
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       HOLON_E2E_MODEL: ${{ inputs.model || 'deepseek/deepseek-v4-flash' }}
       HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
@@ -92,13 +93,20 @@ jobs:
         with:
           script: |
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            await github.rest.issues.create({
+            const issueParams = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Scheduler E2E Nightly Failure (${new Date().toISOString().slice(0,10)})`,
-              body: `The nightly scheduler E2E suite failed. See [the run](${runUrl}).`,
-              labels: ["e2e-failure", "scheduler"]
-            });
+              body: `The nightly scheduler E2E suite failed. See [the run](${runUrl}).`
+            };
+            try {
+              await github.rest.issues.create({...issueParams, labels: ["e2e-failure", "scheduler"]});
+            } catch (labelError) {
+              // Labels may not exist in the repo; retry without them so the
+              // failure notification is never silently lost.
+              core.warning(`Could not apply labels: ${labelError.message}`);
+              await github.rest.issues.create(issueParams);
+            }
 
       - name: Remove provider environment
         if: always()

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -1,0 +1,105 @@
+name: E2E Scheduler Nightly
+
+on:
+  schedule:
+    # Daily at 03:00 UTC
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Real model route for E2E.
+        required: false
+        default: deepseek/deepseek-v4-flash
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  nightly:
+    name: Scheduler E2E Nightly
+    runs-on: ubuntu-latest
+    env:
+      HOLON_E2E_MODEL: ${{ inputs.model || 'deepseek/deepseek-v4-flash' }}
+      HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          tags: holon:nightly
+          cache-from: type=gha,scope=holon-docker
+          cache-to: type=gha,mode=max,scope=holon-docker
+
+      - name: Prepare provider environment
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${DEEPSEEK_API_KEY}"
+          umask 077
+          printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
+          chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+
+      - name: Run scheduler Tier-1 E2E
+        run: |
+          set -euo pipefail
+          python3 scripts/docker-e2e.py \
+            --image holon:nightly \
+            --skip-build \
+            --suite extended \
+            --tag e2e-tier-1 \
+            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
+            --timeout 900
+
+      - name: Publish run summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          summaries = sorted(Path("target/docker-e2e").glob("*/summary.json"))
+          if not summaries:
+              raise SystemExit("No Docker E2E summary was produced")
+          summary = json.loads(summaries[-1].read_text())
+          lines = [
+              "# Scheduler E2E Nightly",
+              "",
+              f"- Status: **{summary['status']}**",
+              f"- Model: `{summary['model_route']}`",
+              f"- Duration: `{summary['duration_seconds']}s`",
+              "",
+              "| Case | Result | Duration |",
+              "| --- | --- | ---: |",
+          ]
+          for case in summary["case_results"]:
+              lines.append(
+                  f"| `{case['id']}` | {case['status']} | {case['duration_seconds']}s |"
+              )
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n")
+          PY
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Scheduler E2E Nightly Failure (${new Date().toISOString().slice(0,10)})`,
+              body: `The nightly scheduler E2E suite failed. See [the run](${runUrl}).`,
+              labels: ["e2e-failure", "scheduler"]
+            });
+
+      - name: Remove provider environment
+        if: always()
+        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}"

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2724,6 +2724,285 @@ def run_scheduler_provider_failure_retry_case(
     )
 
 
+def run_scheduler_multi_workitem_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    marker = secrets.token_hex(4)
+    objective_a_marker = f"SCHEDULER-MULTI-A-{marker}"
+    objective_b_marker = f"SCHEDULER-MULTI-B-{marker}"
+    completion_a = f"SCHEDULER-MULTI-COMPLETE-A-{marker}"
+    completion_b = f"SCHEDULER-MULTI-COMPLETE-B-{marker}"
+    objective_a = (
+        f"{objective_a_marker}. Complete this WorkItem only after the Runtime "
+        "resumes it through an autonomous work_queue SystemTick. On that "
+        "autonomous turn, inspect the exact current item with ListWorkItems "
+        "using filter current and optionally GetWorkItem, update both existing "
+        f"todos to completed, then emit a concise completion result containing "
+        f"{completion_a} immediately followed by CompleteWorkItem for that "
+        "exact item. Do not wait for more operator input."
+    )
+    objective_b = (
+        f"{objective_b_marker}. Complete this WorkItem only after the Runtime "
+        "resumes it through an autonomous work_queue SystemTick. On that "
+        "autonomous turn, inspect the exact current item with ListWorkItems "
+        "using filter current and optionally GetWorkItem, update both existing "
+        f"todos to completed, then emit a concise completion result containing "
+        f"{completion_b} immediately followed by CompleteWorkItem for that "
+        "exact item. Do not wait for more operator input."
+    )
+    phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "scheduler-multi-create",
+        phase["prompt"].format(
+            case_id=case["id"],
+            objective_a=json.dumps(objective_a, ensure_ascii=False),
+            objective_b=json.dumps(objective_b, ensure_ascii=False),
+            completion_a=completion_a,
+            completion_b=completion_b,
+        ),
+    )
+    item_a = harness.wait_work_item(
+        objective_marker=objective_a_marker,
+        expected_state="completed",
+        label="scheduler-multi-a-completed",
+    )
+    item_b = harness.wait_work_item(
+        objective_marker=objective_b_marker,
+        expected_state="completed",
+        label="scheduler-multi-b-completed",
+    )
+    required, forbidden = phase_tools(phase)
+    harness.assert_tools("scheduler-multi-create", baseline, required, forbidden)
+    work_item_a_id = item_a["id"]
+    work_item_b_id = item_b["id"]
+    require(item_a["state"] == "completed", f"WorkItem A not completed: {item_a}")
+    require(item_b["state"] == "completed", f"WorkItem B not completed: {item_b}")
+    require(work_item_a_id != work_item_b_id, "WorkItem A and B share the same id")
+    for item, label_letter, completion, brief_label in (
+        (item_a, "A", completion_a, "scheduler-multi-result-a"),
+        (item_b, "B", completion_b, "scheduler-multi-result-b"),
+    ):
+        brief_id = item.get("result_brief_id")
+        require(
+            isinstance(brief_id, str) and brief_id,
+            f"WorkItem {label_letter} omitted result brief: {item}",
+        )
+        brief = harness.brief(brief_id, brief_label)
+        require(
+            brief.get("work_item_id") == item["id"]
+            and completion in (brief.get("text") or ""),
+            f"WorkItem {label_letter} brief mismatch: {brief}",
+        )
+    snapshot = harness.runtime_db_snapshot("scheduler-multi")
+    for wid in (work_item_a_id, work_item_b_id):
+        require_scheduler_activation_chain(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_id=wid,
+            expected_activation_count=1,
+        )
+    demands = [
+        row
+        for row in snapshot["scheduler_work_demands"]
+        if row["work_item_id"] in (work_item_a_id, work_item_b_id)
+    ]
+    require(
+        len(demands) == 2
+        and all(d["status"] == "terminal" for d in demands),
+        f"multi-WorkItem demands did not converge: {demands}",
+    )
+    harness.restart()
+    restarted_items = harness.work_items("scheduler-multi-after-restart")
+    for wid, brief_id in (
+        (work_item_a_id, item_a.get("result_brief_id")),
+        (work_item_b_id, item_b.get("result_brief_id")),
+    ):
+        restarted = next(item for item in restarted_items if item["id"] == wid)
+        require(
+            restarted["state"] == "completed"
+            and restarted.get("result_brief_id") == brief_id,
+            f"multi-WorkItem did not survive restart: {restarted}",
+        )
+
+
+def run_scheduler_external_wait_resume_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    marker = secrets.token_hex(4)
+    objective_marker = f"SCHEDULER-EXTERNAL-WAIT-{marker}"
+    completion_marker = f"SCHEDULER-EXTERNAL-COMPLETE-{marker}"
+    objective = (
+        f"{objective_marker}. Complete this WorkItem only after an external "
+        "trigger wakes it. On the resume turn, call GetWorkItem, update both "
+        "existing todos to completed, then emit a concise completion result "
+        f"containing {completion_marker} immediately followed by "
+        "CompleteWorkItem for the exact current item. Do not wait for more "
+        "operator input."
+    )
+    callback = harness.reset_callback("scheduler-external-callback")
+    phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "scheduler-external-wait",
+        phase["prompt"].format(
+            case_id=case["id"],
+            objective=json.dumps(objective, ensure_ascii=False),
+            marker=marker,
+            completion_marker=completion_marker,
+        ),
+    )
+    waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=objective_marker,
+        expected_scheduling_state="waiting_external",
+        label="scheduler-external-waiting",
+    )
+    harness.wait_agent_asleep()
+    harness.fire_callback(
+        "scheduler-external-wake",
+        callback["trigger_url"],
+        {"case_id": case["id"], "marker": marker},
+    )
+    item = harness.wait_work_item(
+        objective_marker=objective_marker,
+        expected_state="completed",
+        label="scheduler-external-completed",
+    )
+    required, forbidden = phase_tools(phase)
+    harness.assert_tools("scheduler-external-wait", baseline, required, forbidden)
+    work_item_id = item["id"]
+    require(item["state"] == "completed", f"WorkItem not completed: {item}")
+    require(item["id"] == waiting["id"], "external wait-resume changed WorkItem identity")
+    result_brief_id = item.get("result_brief_id")
+    require(
+        isinstance(result_brief_id, str) and result_brief_id,
+        f"external wait WorkItem omitted result brief: {item}",
+    )
+    result_brief = harness.brief(result_brief_id, "scheduler-external-result")
+    require(
+        result_brief.get("work_item_id") == work_item_id
+        and completion_marker in (result_brief.get("text") or ""),
+        f"external wait completion brief mismatch: {result_brief}",
+    )
+    snapshot = harness.runtime_db_snapshot("scheduler-external")
+    require_scheduler_activation_chain(
+        snapshot,
+        agent_id=harness.agent_id,
+        work_item_id=work_item_id,
+        expected_activation_count=2,
+    )
+    waits = [
+        row
+        for row in snapshot["wait_conditions"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(waits) == 1
+        and waits[0]["kind"] == "external"
+        and waits[0]["status"] == "resolved",
+        f"external wait condition did not resolve: {waits}",
+    )
+    canonical_waits = [
+        row
+        for row in snapshot["scheduler_wait_generations"]
+        if row["owner_work_item_id"] == work_item_id
+    ]
+    require(
+        len(canonical_waits) == 1
+        and canonical_waits[0]["lifecycle_state"] == "resolved",
+        f"canonical external wait did not resolve: {canonical_waits}",
+    )
+
+
+def run_scheduler_operator_wait_resume_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    marker = secrets.token_hex(4)
+    objective_marker = f"SCHEDULER-OPERATOR-WAIT-{marker}"
+    completion_marker = f"SCHEDULER-OPERATOR-COMPLETE-{marker}"
+    objective = (
+        f"{objective_marker}. Complete this WorkItem only after the operator "
+        "sends a message. On the resume turn, call GetWorkItem, update both "
+        "existing todos to completed, then emit a concise completion result "
+        f"containing {completion_marker} immediately followed by "
+        "CompleteWorkItem for the exact current item. Do not wait for more "
+        "operator input."
+    )
+    phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "scheduler-operator-wait",
+        phase["prompt"].format(
+            case_id=case["id"],
+            objective=json.dumps(objective, ensure_ascii=False),
+            completion_marker=completion_marker,
+        ),
+    )
+    waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=objective_marker,
+        expected_scheduling_state="waiting_operator",
+        label="scheduler-operator-waiting",
+    )
+    harness.wait_agent_asleep()
+    harness.prompt(
+        "scheduler-operator-resume",
+        f"The operator is resuming WorkItem {marker}. Proceed with the "
+        "completion steps described in the objective.",
+    )
+    item = harness.wait_work_item(
+        objective_marker=objective_marker,
+        expected_state="completed",
+        label="scheduler-operator-completed",
+    )
+    required, forbidden = phase_tools(phase)
+    harness.assert_tools("scheduler-operator-wait", baseline, required, forbidden)
+    work_item_id = item["id"]
+    require(item["state"] == "completed", f"WorkItem not completed: {item}")
+    require(item["id"] == waiting["id"], "operator wait-resume changed WorkItem identity")
+    result_brief_id = item.get("result_brief_id")
+    require(
+        isinstance(result_brief_id, str) and result_brief_id,
+        f"operator wait WorkItem omitted result brief: {item}",
+    )
+    result_brief = harness.brief(result_brief_id, "scheduler-operator-result")
+    require(
+        result_brief.get("work_item_id") == work_item_id
+        and completion_marker in (result_brief.get("text") or ""),
+        f"operator wait completion brief mismatch: {result_brief}",
+    )
+    snapshot = harness.runtime_db_snapshot("scheduler-operator")
+    require_scheduler_activation_chain(
+        snapshot,
+        agent_id=harness.agent_id,
+        work_item_id=work_item_id,
+        expected_activation_count=2,
+    )
+    waits = [
+        row
+        for row in snapshot["wait_conditions"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(waits) == 1
+        and waits[0]["kind"] == "operator"
+        and waits[0]["status"] == "resolved",
+        f"operator wait condition did not resolve: {waits}",
+    )
+    canonical_waits = [
+        row
+        for row in snapshot["scheduler_wait_generations"]
+        if row["owner_work_item_id"] == work_item_id
+    ]
+    require(
+        len(canonical_waits) == 1
+        and canonical_waits[0]["lifecycle_state"] == "resolved",
+        f"canonical operator wait did not resolve: {canonical_waits}",
+    )
+
+
 CASE_RUNNERS = {
     "runtime-auth-model-delivery": run_runtime_case,
     "memory-agent-home-persistence": run_memory_case,
@@ -2740,6 +3019,9 @@ CASE_RUNNERS = {
     "scheduler-provider-failure-work-queue-retry": (
         run_scheduler_provider_failure_retry_case
     ),
+    "scheduler-multi-workitem-scheduling": run_scheduler_multi_workitem_case,
+    "scheduler-external-wait-resume": run_scheduler_external_wait_resume_case,
+    "scheduler-operator-wait-resume": run_scheduler_operator_wait_resume_case,
 }
 
 

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -231,6 +231,93 @@
           "prompt": "This case creates and focuses the WorkItem through the public control API. The first autonomous turn uses an intentionally unreachable provider endpoint. After a real serve restart with the normal endpoint restored, the WorkItem objective requires ListWorkItems and CompleteWorkItem."
         }
       ]
+    },
+    {
+      "id": "scheduler-multi-workitem-scheduling",
+      "tier": "extended",
+      "tags": ["scheduler", "workitem", "multi", "priority", "e2e-tier-1"],
+      "timeout_seconds": 600,
+      "description": "Verify real-LLM multi-WorkItem scheduling: two WorkItems created in one turn both complete autonomously without conflicts or duplicate settlements.",
+      "scheduler_protocol_commands_enabled": true,
+      "runtime_env": {
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true"
+      },
+      "phases": [
+        {
+          "id": "create-and-complete",
+          "required_tools": [
+            "CreateWorkItem",
+            "ListWorkItems"
+          ],
+          "forbidden_tools": [
+            "ApplyPatch",
+            "ExecCommand",
+            "WaitFor",
+            "PickWorkItem",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "prompt": "Scheduler Docker E2E case {case_id}. Create exactly two WorkItems. For the first, use objective {objective_a}, plan_status ready, and todos: seed-a completed, complete-a pending. For the second, use objective {objective_b}, plan_status ready, and todos: seed-b completed, complete-b pending. Do not PickWorkItem, UpdateWorkItem, CompleteWorkItem, or WaitFor in this operator-triggered turn. After both CreateWorkItem calls succeed, end this response with a concise acknowledgement. The objectives govern the later autonomous work_queue turns. Do not modify files. The expected completion markers are {completion_a} and {completion_b}."
+        }
+      ]
+    },
+    {
+      "id": "scheduler-external-wait-resume",
+      "tier": "extended",
+      "tags": ["scheduler", "workitem", "external", "wait", "resume", "e2e-tier-1"],
+      "timeout_seconds": 600,
+      "description": "Verify real-LLM WaitFor(external) + external trigger callback + autonomous resume and completion.",
+      "scheduler_protocol_commands_enabled": true,
+      "runtime_env": {
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true"
+      },
+      "phases": [
+        {
+          "id": "wait-and-complete",
+          "required_tools": [
+            "CreateWorkItem",
+            "PickWorkItem",
+            "WaitFor",
+            "GetWorkItem",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "forbidden_tools": [
+            "ApplyPatch",
+            "ExecCommand"
+          ],
+          "prompt": "Scheduler Docker E2E case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: external-wait pending, external-complete pending. Pick that WorkItem, then call WaitFor with wake=external, resource=docker-e2e:{marker}, and a concrete reason. Do not complete it in this turn. When the external wake later resumes this exact WorkItem, call GetWorkItem, update both todos to completed, then emit a concise completion result containing {completion_marker} immediately followed by CompleteWorkItem for the exact current item. Do not create another WorkItem and do not modify files."
+        }
+      ]
+    },
+    {
+      "id": "scheduler-operator-wait-resume",
+      "tier": "extended",
+      "tags": ["scheduler", "workitem", "operator", "wait", "resume", "e2e-tier-1"],
+      "timeout_seconds": 600,
+      "description": "Verify real-LLM WaitFor(operator_input) + operator message + autonomous resume and completion.",
+      "scheduler_protocol_commands_enabled": true,
+      "runtime_env": {
+        "HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS": "true"
+      },
+      "phases": [
+        {
+          "id": "wait-and-complete",
+          "required_tools": [
+            "CreateWorkItem",
+            "PickWorkItem",
+            "WaitFor",
+            "GetWorkItem",
+            "UpdateWorkItem",
+            "CompleteWorkItem"
+          ],
+          "forbidden_tools": [
+            "ApplyPatch",
+            "ExecCommand"
+          ],
+          "prompt": "Scheduler Docker E2E case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: operator-wait pending, operator-complete pending. Pick that WorkItem, then call WaitFor with wake=operator_input and a concrete reason. Do not complete it in this turn. When the operator message later resumes this exact WorkItem, call GetWorkItem, update both todos to completed, then emit a concise completion result containing {completion_marker} immediately followed by CompleteWorkItem for the exact current item. Do not create another WorkItem and do not modify files."
+        }
+      ]
     }
   ]
 }

--- a/tests/e2e/scheduler/README.md
+++ b/tests/e2e/scheduler/README.md
@@ -60,8 +60,8 @@ Each case asserts three layers:
 
 | Layer | Trigger | Tiers | Timeout | Blocking |
 |---|---|---|---|---|
-| PR optional | `e2e-scheduler` label | Tier-1 subset | 15 min | no (`continue-on-error`) |
-| Nightly | schedule | Tier-1 all | 45 min | creates issue on failure |
+| PR optional | `e2e-scheduler` label | Tier-1 subset | 20 min | no (`continue-on-error`) |
+| Nightly | schedule | Tier-1 all | 45 min (job) / 15 min (suite `--timeout 900`) | creates issue on failure |
 | Release | release pipeline | Tier-1 + Tier-2 + Tier-3 | 90 min | yes |
 
 ### Approved Decisions

--- a/tests/e2e/scheduler/README.md
+++ b/tests/e2e/scheduler/README.md
@@ -1,0 +1,78 @@
+# Scheduler E2E Test Suite
+
+This directory documents the scheduler-specific E2E scenario matrix,
+execution architecture, and CI layering plan. The actual case definitions
+and runner functions live in the shared Docker E2E infrastructure:
+
+- Case definitions: `tests/e2e/docker/manifest.json`
+- Runner functions: `scripts/docker_e2e/runner.py`
+- Drill harness: `scripts/docker_e2e/scheduler_drill.py`
+- Entry point: `scripts/docker-e2e.py`
+
+## Scenario Matrix
+
+Cases tagged `e2e-tier-1` in `manifest.json` map to the Tier-1 core
+scheduling scenarios. Existing cases cover additional Tier-1 scenarios
+implicitly.
+
+| Scenario ID | Case ID | Description | Key Assertions |
+|---|---|---|---|
+| SCHED-E2E-001 | `scheduler-autonomous-legacy` | Single agent autonomous loop | brief exists; settlement completed; no duplicate settlement; restart persistence |
+| SCHED-E2E-002 | `scheduler-multi-workitem-scheduling` | Multi-WorkItem concurrent scheduling | both complete; no conflicts; 2 activations; 2 settlements; restart persistence |
+| SCHED-E2E-003 | `scheduler-provider-failure-work-queue-retry` | Provider failure recovery | recovery turn scheduled; final brief; no death loop; idempotency key preserved |
+| SCHED-E2E-004 | `scheduler-terminal-before-settlement-restart` | SIGKILL crash recovery | settlement idempotent; brief not lost; exactly-once |
+| SCHED-E2E-005 | `scheduler-external-wait-resume` | WaitFor external trigger + resume | wait state correct; external callback wakes; WorkItem resumes; wait resolved |
+| SCHED-E2E-006 | `scheduler-operator-wait-resume` | WaitFor operator_input + resume | wait state correct; operator message wakes; WorkItem resumes; wait resolved |
+
+### Tier-2 (Nightly)
+
+| Scenario ID | Description | Status |
+|---|---|---|
+| SCHED-E2E-010 | Dual agent WorkItem claim competition | planned |
+| SCHED-E2E-011 | Operator interject during turn | planned |
+| SCHED-E2E-012 | Compaction continuity | planned |
+| SCHED-E2E-013 | Worktree isolation execution binding | planned |
+| SCHED-E2E-014 | SpawnAgent private_child supervision | planned |
+| SCHED-E2E-015 | Restart checkpoint full replay (drill) | planned |
+
+### Tier-3 (Release)
+
+| Scenario ID | Description | Status |
+|---|---|---|---|
+| SCHED-E2E-020 | 10 concurrent WorkItem stress | planned |
+| SCHED-E2E-021 | Random SIGKILL chaos (drill stress) | planned |
+| SCHED-E2E-022 | Provider full-chain degradation | planned |
+| SCHED-E2E-023 | External trigger duplicate/out-of-order | planned |
+
+## Assertion Layers
+
+Each case asserts three layers:
+
+1. **State layer**: SQLite `state.db` queries via `runtime_db_snapshot()`
+   verifying WorkItem state, scheduling_state, settlement records, wait
+   conditions, and activation chains.
+2. **Artifact layer**: Brief existence, content, and work_item binding via
+   `brief()` and work-items API.
+3. **Behavior layer**: Event sequence and tool execution checks via
+   `events()` and `assert_tools()`.
+
+## CI Layering
+
+| Layer | Trigger | Tiers | Timeout | Blocking |
+|---|---|---|---|---|
+| PR optional | `e2e-scheduler` label | Tier-1 subset | 15 min | no (`continue-on-error`) |
+| Nightly | schedule | Tier-1 all | 45 min | creates issue on failure |
+| Release | release pipeline | Tier-1 + Tier-2 + Tier-3 | 90 min | yes |
+
+### Approved Decisions
+
+- **CI Provider**: single low-cost model via env var; multi-provider matrix
+  only in release pipeline (max 2 providers).
+- **PR blocking**: `continue-on-error: true`; nightly is the regression gate.
+- **Phase order**: Phase 1 (infrastructure) → 2 (Tier-1) → 3 (Tier-2) → 4
+  (Tier-3); within Phase 2, crash recovery and provider failure are highest
+  priority.
+- **Case migration**: existing 4 scheduler cases remain in the shared
+  `manifest.json`; new cases are added alongside them.
+- **Drill harness**: `scheduler_drill.py` is reused for Tier-2 checkpoint
+  replay; no separate Python module extracted yet.

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -564,6 +564,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "scheduler-rollout-authoritative-autonomous",
                 "scheduler-terminal-before-settlement-restart",
                 "scheduler-provider-failure-work-queue-retry",
+                "scheduler-multi-workitem-scheduling",
+                "scheduler-external-wait-resume",
+                "scheduler-operator-wait-resume",
             ],
         )
         rollout_cases = selected[:3]
@@ -600,6 +603,35 @@ class DockerE2ERunnerTests(unittest.TestCase):
             "PickWorkItem", authoritative["phases"][1]["required_tools"]
         )
         self.assertFalse(recovery["requires_model"])
+
+    def test_e2e_tier_1_cases_have_correct_config(self) -> None:
+        selected = runner.select_cases(
+            self.manifest, requested=None, suite="extended", tags=["e2e-tier-1"]
+        )
+        self.assertEqual(
+            [case["id"] for case in selected],
+            [
+                "scheduler-multi-workitem-scheduling",
+                "scheduler-external-wait-resume",
+                "scheduler-operator-wait-resume",
+            ],
+        )
+        for case in selected:
+            self.assertTrue(
+                case.get("scheduler_protocol_commands_enabled"),
+                f"{case['id']} must enable scheduler protocol commands",
+            )
+            self.assertEqual(
+                case["runtime_env"]["HOLON_SCHEDULER_PROTOCOL_PRODUCTION_COMMANDS"],
+                "true",
+                f"{case['id']} must set production commands to true",
+            )
+            self.assertNotIn(
+                "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES",
+                case["runtime_env"],
+                f"{case['id']} should not use acceptance fixtures",
+            )
+            self.assertEqual(len(case["phases"]), 1)
 
     def test_manifest_rejects_non_boolean_requires_model(self) -> None:
         invalid = json.loads(json.dumps(self.manifest))


### PR DESCRIPTION
## Summary

Implements the approved scheduler E2E test supplement plan. Adds 3 new Tier-1 Docker E2E cases covering scheduler scenarios that unit/integration tests cannot cover, plus CI layering for nightly and optional PR checks.

### New E2E Cases

| Scenario ID | Case ID | Description |
|---|---|---|
| SCHED-E2E-002 | `scheduler-multi-workitem-scheduling` | Multi-WorkItem concurrent scheduling: both complete without conflicts, duplicate settlements, or activation chain errors |
| SCHED-E2E-005 | `scheduler-external-wait-resume` | WaitFor(external) + external trigger callback + autonomous resume and completion |
| SCHED-E2E-006 | `scheduler-operator-wait-resume` | WaitFor(operator_input) + operator message + autonomous resume and completion |

Existing cases already cover SCHED-E2E-001 (autonomous loop), 003 (provider failure), and 004 (crash recovery).

Each case includes runner functions with three-layer assertions:
- **State layer**: SQLite DB snapshot verifying WorkItem state, scheduling state, settlement records, wait conditions, and activation chains
- **Artifact layer**: Brief existence, content, and work_item binding
- **Behavior layer**: Event sequence and tool execution checks

### CI Layering

| Layer | Trigger | Timeout | Blocking |
|---|---|---|---|
| PR optional | `e2e-scheduler` label | 20 min | no (`continue-on-error`) |
| Nightly | daily 03:00 UTC | 15 min | creates issue on failure |
| Release | release pipeline | 90 min | yes (existing) |

### Approved Decisions

- **CI Provider**: single low-cost model via env var; multi-provider matrix only in release pipeline
- **PR blocking**: non-blocking (`continue-on-error: true`); nightly is the regression gate
- **Case migration**: existing 4 scheduler cases remain in shared `manifest.json`; new cases added alongside
- **Drill harness**: `scheduler_drill.py` reused for Tier-2 checkpoint replay; no separate module extracted

### Files Changed

- `tests/e2e/docker/manifest.json`: 3 new case definitions with `e2e-tier-1` tag
- `scripts/docker_e2e/runner.py`: 3 new runner functions + CASE_RUNNERS registration
- `tests/e2e/scheduler/README.md`: scenario matrix, assertion layers, CI plan documentation
- `.github/workflows/e2e-scheduler-nightly.yml`: nightly pipeline with issue creation
- `.github/workflows/ci.yml`: optional PR job + path triggers
- `tests/test_docker_e2e_runner.py`: updated test expectations + new `test_e2e_tier_1_cases_have_correct_config`

### Test Results

- `make docker-e2e-validate`: 48 tests pass (31 runner + 17 drill)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`: clean