### PR TITLE
docs: simplify scheduler cutover contract

### DIFF
--- a/docs/rfc-implementation-notes/runtime-scheduler-contract.md
+++ b/docs/rfc-implementation-notes/runtime-scheduler-contract.md
@@ -20,22 +20,20 @@ scheduler blockers.
 ## Protocol transition layer
 
 An additive `QueueTransitionCommand` protocol layer wraps every scheduler
-boundary in an atomic SQLite transaction. Each boundary records a shadow
-comparison between the legacy decision and the canonical protocol outcome,
-plus a semantic shadow decision when trusted ingress conditions apply. The
-boundaries currently integrated are: message admission, wait resume,
-settlement recovery, delivery disposition, operator interjection (four typed
-boundaries), and work-queue idle tick. A public `SchedulerDiagnosticAuditEvent`
-stream is emitted alongside legacy audit for observability. See
+boundary in an atomic SQLite transaction. The canonical protocol is the
+production execution path for message admission, wait resume, settlement
+recovery, delivery disposition, operator interjection, and work-queue idle
+ticks. A public `SchedulerDiagnosticAuditEvent` stream is emitted for
+observability. See
 [scheduler spec](../website/spec/scheduler.md) and
 [implementation decision 098](../implementation-decisions/098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md).
 
-Rollout authority is scenario-local. `Shadow` records matched or divergent
-evidence without changing legacy behavior. `Authoritative` requires matched
-canonical evidence in the same transaction as the queue mutation; missing or
-divergent evidence rejects the complete transaction. A fenced hard-blocker
-command records the blocker and atomically restores the configured rollback
-target. These authority and rollback facts survive restart.
+Historical rollout metadata still leaks into snapshot loading and transaction
+invariants, but no longer provides a useful production choice. It is being
+retired under
+[Scheduler Cutover Simplification](../rfcs/scheduler-cutover-simplification.md).
+Production shadow comparison and semantic proposal routing are not part of the
+target dependency graph; release evidence moves to CI and release artifacts.
 
 ## Landed contract anchors
 
@@ -70,11 +68,11 @@ Focused verification currently lives in:
 - `src/runtime/runtime_db/transitions.rs` (protocol transition atomics)
 - `src/runtime_db/tests.rs` (authoritative cutover, rollback, concurrent load,
   and restart)
-- `src/runtime/turn/execution.rs` (operator interjection per-boundary shadow)
+- `src/runtime/turn/execution.rs` (operator interjection safe-point handling)
 - `src/storage/mod.rs` (FIFO WorkItem queue projection)
 - `tests/fixtures/scheduler/`
 - `tests/scheduler_workitem_mvp.rs` (canonical protocol invariants)
-- `tests/scheduler_intent_mvp.rs` (semantic decision plane shadow scoring)
+- `tests/scheduler_intent_mvp.rs` (offline semantic experiment coverage)
 
 Useful local checks:
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -23,6 +23,7 @@ implementation and tests.
 - [Agent Status Display Projection](./agent-status-display-projection.md)
 - [Agent Profile Model](./agent-profile-model.md)
 - [Runtime Scheduler Contract](./runtime-scheduler-contract.md)
+- [Scheduler Cutover Simplification](./scheduler-cutover-simplification.md)
 - [Agent Activation, Settlement, and Dispatch](./agent-activation-settlement-and-dispatch.md)
 - [Result Closure](./result-closure.md)
 - [Continuation Trigger](./continuation-trigger.md)

--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -40,11 +40,24 @@ remains authoritative while activation records and decisions run in shadow.
 Authority moves only after deterministic equivalence, persistence, restart,
 fault-injection, and divergence gates pass.
 
+> **Migration policy superseded:** The canonical activation, settlement,
+> generation, replay, and atomicity contract in this RFC remains accepted.
+> The production shadow, manifest/preflight, per-scenario authority,
+> hard-blocker rollback, and semantic-proposal migration described below are
+> superseded by
+> [Scheduler Cutover Simplification](./scheduler-cutover-simplification.md).
+> Those sections are retained as historical design context, not as the current
+> delivery plan.
+
 ## Status And Relationship To Existing RFCs
 
 This RFC is the normative target for scheduler admission, activation binding,
 terminal settlement, WorkItem dispatch generations, agent lane admission, and
 wait trigger/consume generations.
+
+Its protocol semantics remain normative. Its rollout and semantic-provider
+phases are superseded by
+[Scheduler Cutover Simplification](./scheduler-cutover-simplification.md).
 
 It extends:
 

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -54,6 +54,12 @@ activation in the same transaction as the legacy `Interjected` state,
 transcript, and audit evidence. Queue, Turn, and `AgentState` records remain
 compatibility bindings while scenario rollout policy is handled separately.
 
+The rollout policy for this protocol is now defined by
+[Scheduler Cutover Simplification](./scheduler-cutover-simplification.md).
+Runtime shadow comparison, manifest/preflight gates, and per-scenario authority
+are being retired. Canonical remains the default and long-term engine; any
+legacy selector is a temporary process-wide compatibility mechanism.
+
 ## Problem
 
 Holon is headless, event-driven, and long-lived. Scheduler bugs therefore have

--- a/docs/rfcs/scheduler-cutover-simplification.md
+++ b/docs/rfcs/scheduler-cutover-simplification.md
@@ -1,0 +1,365 @@
+---
+title: RFC: Scheduler Cutover Simplification
+date: 2026-07-31
+status: accepted
+handle: rfc-scheduler-cutover-simplification
+---
+
+# RFC: Scheduler Cutover Simplification
+
+## Summary
+
+Holon will keep the canonical scheduler protocol and remove the runtime rollout
+control plane that was used to introduce it.
+
+The canonical reducer, typed facts, atomic SQLite transitions, append-only
+ledger, replay, generation fences, and fail-closed ambiguity handling remain
+the scheduler foundation. Runtime shadow comparison, rollout manifests,
+preflight revisions, per-scenario authority, automatic hard-blocker rollback,
+and semantic proposal routing are not part of the long-term production
+contract.
+
+During one bounded compatibility window, a process-wide startup selector may
+choose either the legacy or canonical scheduler. It has two values, defaults to
+`canonical`, never mixes engines within one process, and must be deleted with
+the legacy engine after the compatibility window.
+
+Scheduler qualification evidence belongs in CI and release acceptance. Runtime
+databases store scheduling facts, not approval evidence for the binary that is
+currently running.
+
+## Decision
+
+The migration model is:
+
+```text
+CI and release environments qualify one build
+                    |
+                    v
+        operator makes one release decision
+                    |
+                    v
+ process starts with legacy or canonical selected
+                    |
+                    v
+       exactly one scheduler owns all admissions
+                    |
+                    v
+ legacy and the temporary selector are deleted
+```
+
+Holon will not maintain a production path that:
+
+- runs legacy and canonical admission for the same input;
+- compares internal outcomes at every scheduler boundary;
+- grants authority independently by scenario class;
+- requires a runtime manifest or preflight revision before ordinary work can
+  run;
+- automatically changes scheduler authority in response to a divergence; or
+- lets a semantic model or provider participate in production admission.
+
+## Relationship To Existing Scheduler RFCs
+
+This RFC supersedes the migration and rollout policy in
+[Agent Activation, Settlement, and Dispatch](./agent-activation-settlement-and-dispatch.md).
+That RFC remains normative for canonical activation, settlement, wait,
+generation, replay, and atomicity semantics.
+
+This RFC also supersedes implementation notes or website text that describes:
+
+- `legacy -> shadow -> authoritative` as the production rollout path;
+- `RolloutManifest` or runtime preflight as an authority prerequisite;
+- per-scenario promotion or rollback;
+- production semantic proposal routing; or
+- long-lived legacy/canonical shadow comparison.
+
+[Runtime Scheduler Contract](./runtime-scheduler-contract.md) remains the
+broader scheduler vocabulary and projection contract.
+
+## Current, Transition, And Target States
+
+### Current state
+
+As of July 31, 2026, the production path is intended to be canonical-only.
+Startup configuration does not expose a scheduler selector. Historical rollout
+tables and protocol types still participate in snapshot loading, invariants,
+and transaction parameters even though they no longer provide a useful
+production choice.
+
+This residual control plane can reject startup when historical
+scenario-authority rows are marked authoritative but have missing or stale
+manifest/preflight revisions. Such rejection is a migration defect: rollout
+approval metadata must not prevent the canonical scheduler from loading valid
+business facts.
+
+Production code no longer writes normal scheduler shadow-comparison rows.
+The semantic proposal module is not part of production admission, although its
+types and tests remain in the repository.
+
+### Transition state
+
+The transition removes runtime rollout metadata from scheduler authority before
+performing destructive schema cleanup.
+
+A temporary process-wide selector may then be introduced:
+
+```text
+runtime.scheduler = legacy | canonical
+HOLON_SCHEDULER=legacy|canonical
+```
+
+The precedence is:
+
+```text
+environment override > persisted configuration > canonical default
+```
+
+The selector is:
+
+- parsed once during process startup;
+- immutable until process restart;
+- global to the runtime, not per agent or scenario;
+- restricted to `legacy` and `canonical`;
+- rejected when its value is invalid; and
+- prohibited from changing the meaning of already admitted work inside the
+  running process.
+
+The selector may be implemented only if the remaining legacy path can be
+restored without reintroducing the deleted shadow and rollout systems. If that
+requires rebuilding a second large scheduler, Holon will remain canonical-only
+and use binary/database rollback instead.
+
+### Target state
+
+The target runtime has:
+
+- one canonical scheduler engine;
+- no scheduler engine selector;
+- no legacy admission path;
+- no runtime rollout authority repository;
+- no production shadow comparison;
+- no production semantic proposal dependency;
+- no manifest, preflight, scenario authority, or hard-blocker gate in ordinary
+  scheduler transactions; and
+- no schema whose rows can change scheduler authority at runtime.
+
+Historical tables may remain unread for one compatibility release before a
+later destructive migration removes them.
+
+## Preserved Canonical Contract
+
+Simplifying cutover must not weaken the scheduler protocol. The following
+remain required:
+
+- one activation owns one granted execution quantum;
+- every activation reaches one durable terminal settlement or an explicit
+  recovery state;
+- queue, WorkItem, wait, activation, settlement, transcript, audit, and
+  delivery effects that form one scheduler boundary commit atomically;
+- WorkItem, wait, claim, and continuation generations reject stale work;
+- duplicate and out-of-order inputs are idempotent or fail closed;
+- durable facts, rather than `AgentState.status`, prose, or display state, own
+  scheduling;
+- restart and replay reproduce the same externally visible outcome; and
+- ambiguous ownership never falls through to an implicit legacy decision.
+
+The simplification removes transition machinery, not safety invariants.
+
+## Engine Isolation
+
+If the temporary selector is implemented, the engine choice occurs at the
+highest scheduler admission/execution boundary. Deep transition commands must
+not carry mode flags.
+
+The two engines may share:
+
+- message envelopes;
+- WorkItem, task, and wait persistence;
+- terminal queue contracts;
+- transcripts, briefs, delivery, and audit records; and
+- end-to-end scenarios and externally visible assertions.
+
+They must not, for the same production input:
+
+- both decide admission;
+- both reserve or consume scheduler ownership;
+- both write activation or settlement facts;
+- generate a shadow candidate;
+- compare internal dispositions; or
+- fall through from canonical to legacy after canonical has claimed the input.
+
+Comparison belongs in tests that run separate processes and databases. Tests
+compare user-visible behavior and durable invariants, not byte-for-byte
+internal records.
+
+## Adoption Boundary
+
+Switching engines is an offline startup operation:
+
+1. stop the runtime;
+2. create a database backup;
+3. select the target engine;
+4. perform one bounded, transactional, idempotent adoption;
+5. start serving only after adoption and invariant checks succeed.
+
+Adoption may reconstruct only business state needed by the selected engine,
+including:
+
+- open WorkItem scheduling generations;
+- current focus and execution ownership;
+- active wait generations;
+- dequeued but non-terminal queue claims; and
+- recoverable task rejoins.
+
+Adoption must not install a rollout manifest, collect approval evidence, or
+grant authority by scenario class.
+
+## Scheduler Diagnose And Repair
+
+Holon must provide an operator-facing scheduler diagnose/repair surface before
+removing the last emergency fallback.
+
+The repair contract is:
+
+- diagnosis is read-only by default;
+- every mutating operation supports dry-run;
+- a mutating operation requires a verified backup or creates one before the
+  transaction;
+- repair actions are finite, typed, versioned, and idempotent;
+- arbitrary SQL is not exposed as a repair action;
+- normal startup and repair share the same business invariant checks;
+- every mutation records an audit event with the selected action and affected
+  identities;
+- an unsafe or ambiguous repair fails closed and explains why it refused; and
+- stale rollout metadata is diagnosed as retired compatibility data, not
+  repaired into a new authoritative revision.
+
+Initial diagnosis must cover:
+
+- open WorkItem demand and generation;
+- current focus and execution ownership;
+- active wait identity and generation;
+- queue claims without terminal disposition;
+- recoverable task rejoin;
+- activation without settlement;
+- settlement without required delivery disposition; and
+- projection drift that can be rebuilt from canonical facts.
+
+The repair tool must call the same domain transitions used by the runtime. It
+must not edit scheduler tables directly.
+
+If canonical facts cannot be safely projected back to legacy, the supported
+recovery is the pre-cutover database backup and previous binary. Holon does not
+promise lossless hot rollback.
+
+## Release Evidence
+
+Scheduler qualification is bound to:
+
+```text
+git SHA + schema revision + image digest + fixture corpus revision
+```
+
+The release gate includes:
+
+- formatter and warning-free compilation;
+- reducer and property tests;
+- migration and representative upgrade tests;
+- restart, replay, duplicate, and out-of-order tests;
+- SQLite transaction fault injection;
+- Tier-1 and Tier-2 scheduler Docker E2E;
+- Tier-3 concurrent, crash, provider-degradation, and external-trigger stress;
+- database backup and rollback drills; and
+- a machine-readable acceptance report.
+
+The report is a CI or release artifact. It is not imported into runtime tables,
+and agents do not validate it while starting or scheduling work.
+
+Production observation after cutover uses ordinary error rate, latency,
+duplicate-activation, stuck-wait, missing-settlement, and data-integrity
+signals. It does not require a legacy implementation to generate divergence
+records.
+
+## Semantic Proposal Plane
+
+The semantic proposal plane is outside the production scheduler scope.
+
+The production dependency and module export will be removed. Useful fixtures
+or design material may remain as an offline benchmark or experiment, but they:
+
+- cannot propose or grant production admission;
+- cannot add scheduler authority classes;
+- cannot block deterministic structural binding; and
+- cannot require runtime scheduler persistence.
+
+Reintroducing semantic routing requires a separate RFC after the canonical
+lifecycle is stable.
+
+## Compatibility And Schema
+
+Published migrations are immutable. The transition therefore:
+
+1. adds a later migration or code path that retires rollout authority reads;
+2. stops loading rollout state into production scheduler snapshots;
+3. stops passing rollout expectations through ordinary transactions;
+4. tolerates historical authoritative rows with missing or stale evidence;
+5. leaves historical tables intact for at least one compatibility release; and
+6. drops them only in a later, independently reversible schema change.
+
+The database stores scheduler facts and audit history. Configuration selects a
+temporary engine. Neither historical rollout rows nor repair records select
+authority.
+
+## Rollback
+
+There is no automatic per-scenario rollback.
+
+During the compatibility window, supported rollback is:
+
+1. stop new admission;
+2. settle or explicitly interrupt in-flight activation;
+3. stop the runtime;
+4. run diagnosis and any safe typed repair;
+5. restart with the other engine if reverse projection is supported.
+
+When reverse projection is not supported, restore the pre-cutover backup and
+run the previous binary.
+
+Every supported path must be exercised in release acceptance. A rollback path
+that has not been tested is not a supported recovery promise.
+
+## Delivery Plan And Exit Criteria
+
+Implementation is split into independently reversible changes:
+
+1. publish this contract and mark superseded rollout text;
+2. retire rollout metadata from production startup and transactions, while
+   adding the safe diagnose/repair skeleton;
+3. inventory the surviving legacy implementation and add the temporary global
+   selector only if it remains small and isolated;
+4. move qualification evidence into CI/release acceptance;
+5. delete dead rollout, shadow, and semantic production surfaces;
+6. reduce activation types only after rollout authority is gone; and
+7. delete legacy and the selector after one compatibility release.
+
+The final legacy removal requires:
+
+- canonical release gates passing continuously;
+- representative upgrade, restart, fault-injection, and rollback drills;
+- Tier-1 and Tier-2 without blockers;
+- Tier-3 release acceptance;
+- no unexplained data loss, duplicate activation, stuck wait, or missing
+  settlement; and
+- explicit operator approval for the removal release.
+
+## Non-goals
+
+- Do not replace the canonical scheduler with the legacy implementation.
+- Do not weaken activation, settlement, wait, replay, or transaction
+  invariants.
+- Do not support live engine switching.
+- Do not support per-agent or per-scenario engine selection.
+- Do not preserve shadow comparison as a permanent observability system.
+- Do not make the repair tool a general database editor.
+- Do not combine destructive schema cleanup with the startup compatibility
+  fix.

--- a/docs/scheduler-drill.md
+++ b/docs/scheduler-drill.md
@@ -5,6 +5,12 @@ collecting authoritative scheduler evidence from one fresh candidate node.
 It never imports a report into the runtime and never writes scheduler protocol
 tables directly.
 
+The report is release acceptance evidence, not runtime scheduler authority.
+Under
+[Scheduler Cutover Simplification](rfcs/scheduler-cutover-simplification.md),
+runtime manifest/preflight/scenario rows are retired from the engine-selection
+contract.
+
 ## Credentials
 
 Create an env file outside the repository and restrict it to the current user:
@@ -107,6 +113,10 @@ The collector reports No-Go when any requested production scenario lacks a
 completed stress operation, a current-revision hard blocker exists, JSON
 evidence is malformed, or canonical activation/settlement/delivery tail state
 is inconsistent. It also requires planned injections to have completed;
-declared parameters alone never satisfy coverage. Historical hard blockers
-remain visible but do not count as current unless their
-config/manifest/preflight fences match current authority.
+declared parameters alone never satisfy coverage. Historical hard blockers and
+manifest/preflight revisions remain visible while the collector reads the
+compatibility schema, but they do not grant runtime authority.
+
+The historical rollout checks must be removed when those repositories are
+retired. Release Go/No-Go is determined by collected scenario results and build
+identity, not by importing or activating runtime rollout rows.

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -109,6 +109,11 @@ remain readable for database migration, recovery evidence, and historical
 diagnostics, but they do not select a legacy or shadow execution path at
 startup.
 
+The accepted scheduler transition permits a temporary process-wide
+`legacy|canonical` selector during the compatibility release. It is not
+implemented in the current configuration schema. When introduced, it will
+default to `canonical` and will be removed with the legacy engine.
+
 ## Credential Management
 
 Credentials are stored securely in `~/.holon/credentials.json`. Use `config credentials` subcommands — **never edit this file directly**.

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -9,10 +9,10 @@ order: 30
 This page defines the current contract for Holon's scheduler: what inputs it
 consumes, how it derives posture and runnability, and what decisions it emits.
 It also documents the additive protocol transition layer that wraps scheduler
-decisions in atomic transactions with shadow comparison, semantic decision
-plane integration, and a public diagnostic event stream.
+decisions in atomic transactions with replay protection, explicit activation
+ownership, terminal settlement, and a public diagnostic event stream.
 
-> **Last verified:** 2026-07-21 against `src/runtime/scheduler.rs`,
+> **Last verified:** 2026-07-31 against `src/runtime/scheduler.rs`,
 > `src/runtime/scheduler_executor.rs`, `src/runtime/waiting.rs`,
 > `src/runtime/closure.rs`, `src/runtime/turn/execution.rs`,
 > `src/runtime_event.rs`, `src/types.rs`.
@@ -20,6 +20,7 @@ plane integration, and a public diagnostic event stream.
 ## Source RFCs
 
 - [Runtime Scheduler Contract](https://github.com/holon-run/holon/blob/main/docs/rfcs/runtime-scheduler-contract.md)
+- [Scheduler Cutover Simplification](https://github.com/holon-run/holon/blob/main/docs/rfcs/scheduler-cutover-simplification.md)
 - [Scheduler Wait State And Recoverable Agent Continuation](https://github.com/holon-run/holon/blob/main/docs/rfcs/scheduler-wait-state.md)
 - [Waiting Plane And Reactivation](https://github.com/holon-run/holon/blob/main/docs/rfcs/waiting-plane-and-reactivation.md)
 - [Continuation Trigger](https://github.com/holon-run/holon/blob/main/docs/rfcs/continuation-trigger.md)
@@ -166,9 +167,14 @@ rollout tables and enum values remain readable for migration and recovery
 diagnostics, but startup configuration cannot select legacy or shadow
 execution. Missing activation, terminal-turn, or settlement evidence fails
 closed and the transaction leaves no partial queue, projection, audit,
-activation, or settlement writes. A reported hard blocker atomically records the
-blocker and returns the affected class to its configured `Shadow` or `Off`
-rollback target.
+activation, or settlement writes.
+
+The accepted transition contract retires runtime manifest/preflight gates,
+per-scenario authority, automatic hard-blocker rollback, and production shadow
+comparison. A temporary process-wide `legacy|canonical` startup selector may be
+added during implementation, defaults to canonical, and will be deleted with
+legacy after one compatibility release. It is not available in the current
+configuration surface.
 
 ### Integration points
 
@@ -184,15 +190,10 @@ boundary records the canonical facts required by the next boundary:
 | Operator interjection | `Admit` | running activation and safe-point identity |
 | Work-queue idle tick (`memory_refresh::emit_system_tick_from_work_queue`) | `Admit` | runnable demand and dispatch revision |
 
-The semantic decision plane provides trusted-ingress construction, provider
-validation, and response policy. It returns `Ok(None)` when trusted ingress
-conditions are not met, preventing observation errors from blocking the run
-loop. No provider owns runtime authority; the deterministic resolver and
-validator retain all state-transition control. Wait resume shadow comparison
-is evaluated within the message admission path via `.or_else`, so the same
-`QueueTransitionCommand` transaction records whichever comparison applies.
-Settlement recovery and delivery disposition shadow comparisons are recorded
-in the same `commit_queue_settlement` transaction.
+The semantic decision plane is not part of production admission. Its remaining
+module and fixtures are offline experimental surface and will be removed from
+the production dependency graph. Deterministic structural binding and the
+canonical protocol retain all state-transition control.
 
 ### Public diagnostic event stream
 
@@ -207,8 +208,8 @@ decision that passes through `append_scheduler_decision`. This event carries:
 | `message_id` | Optional message that triggered the decision |
 | `evidence` | Evidence strings used by the decision |
 | `scenario_class` | Optional scenario classification (e.g. `operator_interjection`) |
-| `shadow_matched` | Whether legacy and canonical outcomes agreed, when shadow was present |
-| `divergence_code` | Optional divergence code if outcomes disagreed |
+| `shadow_matched` | Historical compatibility field; production does not require shadow comparison |
+| `divergence_code` | Historical compatibility field for previously recorded comparisons |
 
 The event is emitted via `RuntimeEventKind::SchedulerDiagnostic` alongside
 the legacy `scheduler_decision` audit event. Both are persisted in the same
@@ -235,7 +236,7 @@ authority for scheduling decisions.
   RFC posture labels. The RFC posture is the stable turn-end vocabulary;
   decision variants are concrete runtime actions and duplicate-suppression
   outcomes.
-- The current authoritative acceptance gate validates atomic matched-evidence
-  pass-through, divergence rejection, rollback, restart, bounded concurrent
-  load, and FIFO WorkItem projection. It is not a calibrated production SLO or
-  a substitute for deployment-specific soak and capacity testing.
+- Scheduler release acceptance validates atomicity, restart, bounded
+  concurrent load, fault handling, and FIFO WorkItem projection outside the
+  runtime authority path. It is not a calibrated production SLO or a
+  substitute for deployment-specific soak and capacity testing.


### PR DESCRIPTION
## Summary

- define a three-stage scheduler cutover contract with canonical as the default and long-term target
- replace production rollout evidence and per-scenario authority with a temporary process-wide `legacy|canonical` startup selector
- define bounded diagnose/repair behavior, remove the semantic plane from the production dependency graph, and require legacy removal after one release cycle
- mark superseded scheduler RFC sections and website references with current/transition/target guidance

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- RFC link/reference validation
- website index generation (`npm --prefix .tools run build:index`); excluded an unrelated existing generator issue that removes non-Markdown OpenAPI navigation entries
