### PR TITLE
refactor: add process-wide scheduler engine selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ docker run --rm \
 
 Replace the model and credential environment variable when using another
 provider. Holon validates that the configured model provider is available
-before the service starts. The canonical scheduler is the only production
-execution path; no scheduler-mode environment variable is required.
+before the service starts. The canonical scheduler remains the default and
+long-term production path. During the bounded compatibility window,
+`HOLON_SCHEDULER=legacy|canonical` selects one process-wide engine at startup.
 
 The base image includes Git and common shell/network utilities. Mount a
 writable workspace at `/workspace`, or derive a project-specific image when

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -36,6 +36,7 @@ and description.
 | `model.default` | model_route_ref | Default executable route, e.g. `"anthropic@default/claude-sonnet-4-6"` |
 | `model.fallbacks` | model_route_ref_list | Ordered executable fallback routes |
 | `runtime.disable_provider_fallback` | boolean | Disable provider/model fallback; require deterministic single-provider execution |
+| `runtime.scheduler` | `legacy` or `canonical` | Startup-only process-wide scheduler engine; defaults to `canonical` |
 
 ```bash
 # Set the default model
@@ -103,11 +104,17 @@ Do not combine `api.cors.allow_credentials=true` with
 
 ### Scheduler
 
-The canonical scheduler is always authoritative in production. There is no
-`HOLON_SCHEDULER` or production-command feature switch. Existing rollout rows
-remain readable for database migration, recovery evidence, and historical
-diagnostics, but they do not select a legacy or shadow execution path at
-startup.
+The process selects exactly one scheduler engine at startup:
+
+```text
+HOLON_SCHEDULER > runtime.scheduler > canonical
+```
+
+Accepted values are `legacy` and `canonical`. The selected engine is immutable
+until process restart, global to every agent in the process, and never enables
+shadow execution or per-scenario authority. `runtime.scheduler` is startup-only:
+stop the daemon before changing it with `holon config set`, or use the
+`HOLON_SCHEDULER` environment override for the next process start.
 
 Migration 40 marks the rollout tables as retired compatibility data without
 dropping them. `holon debug scheduler-recovery` reports their retained row
@@ -115,10 +122,11 @@ counts and stale authoritative rows. They are diagnostic only: startup,
 ordinary scheduler transactions, and typed repair do not read them to decide
 authority.
 
-The accepted scheduler transition permits a temporary process-wide
-`legacy|canonical` selector during the compatibility release. It is not
-implemented in the current configuration schema. When introduced, it will
-default to `canonical` and will be removed with the legacy engine.
+`legacy` is a temporary compatibility fallback. It does not write canonical
+activation or settlement facts, and startup fails closed if non-terminal
+canonical activations remain. Stop admission and settle or interrupt in-flight
+canonical work before changing engines. The selector will be removed with the
+legacy engine after the compatibility release.
 
 ## Credential Management
 

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4374,6 +4374,13 @@
                 "minimum": 0,
                 "type": "integer"
               },
+              "scheduler": {
+                "enum": [
+                  "legacy",
+                  "canonical"
+                ],
+                "type": "string"
+              },
               "unknown_model_fallback_configured": {
                 "type": "boolean"
               },
@@ -4469,6 +4476,7 @@
               "default_tool_output_tokens",
               "max_tool_output_tokens",
               "disable_provider_fallback",
+              "scheduler",
               "runtime_db_retention",
               "providers",
               "web_search",
@@ -4807,6 +4815,13 @@
                 "minimum": 0,
                 "type": "integer"
               },
+              "scheduler": {
+                "enum": [
+                  "legacy",
+                  "canonical"
+                ],
+                "type": "string"
+              },
               "unknown_model_fallback_configured": {
                 "type": "boolean"
               },
@@ -4902,6 +4917,7 @@
               "default_tool_output_tokens",
               "max_tool_output_tokens",
               "disable_provider_fallback",
+              "scheduler",
               "runtime_db_retention",
               "providers",
               "web_search",

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -148,9 +148,9 @@ WorkItems flow through scheduling states that the scheduler consumes:
 
 ## Protocol transition layer
 
-The scheduler decision flow above is implemented by the canonical protocol.
-Every scheduler boundary is committed through an atomic
-`QueueTransitionCommand` transaction that can simultaneously:
+The scheduler decision flow above is shared by both startup-selectable engines.
+The canonical engine wraps each boundary in an atomic `QueueTransitionCommand`
+transaction that can simultaneously:
 
 1. commit the queue operation (admit, claim, or enqueue);
 2. update the agent state projection;
@@ -162,19 +162,18 @@ All effects commit in the same SQLite transaction. If the transaction fails or
 the CAS does not match, no partial queue, activation, settlement, or delivery
 state is left behind.
 
-The canonical protocol is the only production scheduler path. Historical
-rollout tables and enum values remain readable for migration and recovery
-diagnostics, but startup configuration cannot select legacy or shadow
-execution. Missing activation, terminal-turn, or settlement evidence fails
-closed and the transaction leaves no partial queue, projection, audit,
-activation, or settlement writes.
+The process selects `legacy` or `canonical` once at startup through
+`HOLON_SCHEDULER` or `runtime.scheduler`; canonical is the default. The legacy
+engine uses the shared queue, WorkItem, wait, task, Turn, transcript, brief,
+delivery, and audit contracts but does not write canonical activation or
+settlement facts. It fails closed when startup finds non-terminal canonical
+activations or unreconciled dequeued claims.
 
 The accepted transition contract retires runtime manifest/preflight gates,
 per-scenario authority, automatic hard-blocker rollback, and production shadow
-comparison. A temporary process-wide `legacy|canonical` startup selector may be
-added during implementation, defaults to canonical, and will be deleted with
-legacy after one compatibility release. It is not available in the current
-configuration surface.
+comparison. The process-wide selector is temporary, cannot change while the
+process is running, never enables mixed or per-scenario authority, and will be
+deleted with legacy after one compatibility release.
 
 ### Integration points
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -230,6 +230,8 @@ pub struct RuntimeConfigFile {
     pub max_tool_output_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disable_provider_fallback: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<SchedulerEngineMode>,
     #[serde(default, skip_serializing_if = "RuntimeRetentionConfigFile::is_empty")]
     pub retention: RuntimeRetentionConfigFile,
 }
@@ -440,6 +442,7 @@ impl RuntimeConfigFile {
             && self.default_tool_output_tokens.is_none()
             && self.max_tool_output_tokens.is_none()
             && self.disable_provider_fallback.is_none()
+            && self.scheduler.is_none()
             && self.retention.is_empty()
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use axum::http::{HeaderName, HeaderValue, Method};
+use schemars::JsonSchema;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};
 
@@ -73,6 +74,7 @@ pub struct AppConfig {
     pub default_tool_output_tokens: u32,
     pub max_tool_output_tokens: u32,
     pub disable_provider_fallback: bool,
+    pub scheduler_engine: SchedulerEngineMode,
     pub tui_alternate_screen: AltScreenMode,
     pub validated_model_overrides: HashMap<ModelRef, ModelRuntimeOverride>,
     pub validated_unknown_model_fallback: Option<ModelRuntimeOverride>,
@@ -87,6 +89,14 @@ pub enum AltScreenMode {
     Auto,
     Always,
     Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SchedulerEngineMode {
+    Legacy,
+    #[default]
+    Canonical,
 }
 
 impl AppConfig {
@@ -128,6 +138,7 @@ impl AppConfig {
         reloaded.max_relevant_episodes = self.max_relevant_episodes;
         reloaded.control_token = self.control_token.clone();
         reloaded.control_auth_mode = self.control_auth_mode;
+        reloaded.scheduler_engine = self.scheduler_engine;
         reloaded.config_file_path = self.config_file_path.clone();
         Ok(reloaded)
     }
@@ -253,6 +264,7 @@ impl AppConfig {
             .max(default_tool_output_tokens);
 
         let disable_provider_fallback = resolve_disable_provider_fallback(&stored_config)?;
+        let scheduler_engine = resolve_scheduler_engine(&stored_config)?;
         resolve_runtime_db_retention_policy(&stored_config)?;
         let validated_model_overrides = resolve_model_catalog(&stored_config)?;
         let validated_unknown_model_fallback =
@@ -336,6 +348,7 @@ impl AppConfig {
             default_tool_output_tokens,
             max_tool_output_tokens,
             disable_provider_fallback,
+            scheduler_engine,
             tui_alternate_screen,
             validated_model_overrides,
             validated_unknown_model_fallback,
@@ -449,6 +462,27 @@ impl AltScreenMode {
     }
 }
 
+impl SchedulerEngineMode {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "legacy" => Ok(Self::Legacy),
+            "canonical" => Ok(Self::Canonical),
+            _ => Err(anyhow!("scheduler engine expects legacy or canonical")),
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Legacy => "legacy",
+            Self::Canonical => "canonical",
+        }
+    }
+
+    pub const fn is_canonical(self) -> bool {
+        matches!(self, Self::Canonical)
+    }
+}
+
 pub fn load_settings_env() -> Result<HashMap<String, String>> {
     let path = settings_path();
     if !path.exists() {
@@ -482,6 +516,21 @@ fn resolve_disable_provider_fallback(stored_config: &HolonConfigFile) -> Result<
         env::var("HOLON_DISABLE_PROVIDER_FALLBACK").ok().as_deref(),
         stored_config,
     )
+}
+
+fn resolve_scheduler_engine(stored_config: &HolonConfigFile) -> Result<SchedulerEngineMode> {
+    resolve_scheduler_engine_from_values(env::var("HOLON_SCHEDULER").ok().as_deref(), stored_config)
+}
+
+fn resolve_scheduler_engine_from_values(
+    env_override: Option<&str>,
+    stored_config: &HolonConfigFile,
+) -> Result<SchedulerEngineMode> {
+    env_override
+        .map(SchedulerEngineMode::parse)
+        .transpose()?
+        .or(stored_config.runtime.scheduler)
+        .map_or(Ok(SchedulerEngineMode::Canonical), Ok)
 }
 
 fn resolve_runtime_db_retention_policy(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -348,6 +348,13 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             allowed_values: vec!["true", "false"],
         },
         ConfigSchemaEntry {
+            key: "runtime.scheduler",
+            kind: "enum",
+            description: "Startup-only process-wide scheduler engine. Canonical is the default; legacy is a temporary compatibility fallback.",
+            default: json!("canonical"),
+            allowed_values: vec!["legacy", "canonical"],
+        },
+        ConfigSchemaEntry {
             key: "runtime.retention.enabled",
             kind: "boolean",
             description: "Enable bounded runtime SQLite retention. Disabled unless explicitly configured.",
@@ -752,6 +759,11 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .disable_provider_fallback
             .map(Value::Bool)
             .unwrap_or(Value::Null)),
+        "runtime.scheduler" => Ok(config
+            .runtime
+            .scheduler
+            .map(|mode| json!(mode.as_str()))
+            .unwrap_or(Value::Null)),
         "runtime.retention.enabled" => Ok(config
             .runtime
             .retention
@@ -1095,6 +1107,9 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
             );
         }
+        "runtime.scheduler" => {
+            config.runtime.scheduler = Some(SchedulerEngineMode::parse(raw_value)?);
+        }
         "runtime.retention.enabled" => {
             config.runtime.retention.enabled = Some(
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
@@ -1395,6 +1410,7 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "runtime.default_tool_output_tokens" => config.runtime.default_tool_output_tokens = None,
         "runtime.max_tool_output_tokens" => config.runtime.max_tool_output_tokens = None,
         "runtime.disable_provider_fallback" => config.runtime.disable_provider_fallback = None,
+        "runtime.scheduler" => config.runtime.scheduler = None,
         "runtime.retention.enabled" => config.runtime.retention.enabled = None,
         "runtime.retention.audit_events_days" => {
             config.runtime.retention.audit_events_days = None;
@@ -1642,8 +1658,7 @@ pub(crate) fn parse_url_value(key: &str, raw_value: &str) -> Result<()> {
 }
 
 pub(crate) fn is_startup_only_config_key(key: &str) -> bool {
-    let _ = key;
-    false
+    key == "runtime.scheduler"
 }
 
 pub(crate) fn startup_only_config_key_error(key: &str) -> anyhow::Error {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -27,7 +27,7 @@ use crate::config::{
     ProviderAuthConfig, ProviderBuiltinWebSearchConfig, ProviderConfigFile,
     ProviderEndpointConfigFile, ProviderEndpointId, ProviderId, ProviderPlanConfigFile,
     ProviderRegistry, ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog,
-    XSearchRuntimeConfig, DEFAULT_LOCAL_AGENT_ID, DEFAULT_X_SEARCH_MODEL,
+    SchedulerEngineMode, XSearchRuntimeConfig, DEFAULT_LOCAL_AGENT_ID, DEFAULT_X_SEARCH_MODEL,
     OPENAI_CODEX_CREDENTIAL_PROFILE,
 };
 
@@ -167,6 +167,7 @@ fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConf
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
         max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
         disable_provider_fallback: false,
+        scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: crate::config::AltScreenMode::Auto,
         validated_model_overrides: HashMap::new(),
         validated_unknown_model_fallback: None,
@@ -592,6 +593,64 @@ fn set_get_and_unset_round_trip_runtime_disable_provider_fallback() {
         get_config_key(&config, "runtime.disable_provider_fallback").unwrap(),
         Value::Null
     );
+}
+
+#[test]
+fn set_get_and_unset_round_trip_runtime_scheduler() {
+    let mut config = HolonConfigFile::default();
+    set_config_key(&mut config, "runtime.scheduler", "legacy").unwrap();
+    assert_eq!(
+        get_config_key(&config, "runtime.scheduler").unwrap(),
+        json!("legacy")
+    );
+
+    unset_config_key(&mut config, "runtime.scheduler").unwrap();
+    assert_eq!(
+        get_config_key(&config, "runtime.scheduler").unwrap(),
+        Value::Null
+    );
+}
+
+#[test]
+fn scheduler_engine_precedence_is_env_then_config_then_canonical() {
+    let mut config = HolonConfigFile::default();
+    assert_eq!(
+        super::resolve_scheduler_engine_from_values(None, &config).unwrap(),
+        SchedulerEngineMode::Canonical
+    );
+
+    config.runtime.scheduler = Some(SchedulerEngineMode::Legacy);
+    assert_eq!(
+        super::resolve_scheduler_engine_from_values(None, &config).unwrap(),
+        SchedulerEngineMode::Legacy
+    );
+    assert_eq!(
+        super::resolve_scheduler_engine_from_values(Some("canonical"), &config).unwrap(),
+        SchedulerEngineMode::Canonical
+    );
+    assert!(
+        super::resolve_scheduler_engine_from_values(Some("shadow"), &config)
+            .unwrap_err()
+            .to_string()
+            .contains("expects legacy or canonical")
+    );
+}
+
+#[test]
+fn app_config_rejects_invalid_scheduler_env() {
+    let home = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+    )
+    .unwrap();
+    let _env = EnvVarGuard::set("HOLON_SCHEDULER", "shadow");
+
+    let error = AppConfig::load_with_home_for_config_inspection(Some(home.path().to_path_buf()))
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("scheduler engine expects legacy or canonical"));
 }
 
 #[test]
@@ -2198,6 +2257,7 @@ fn schema_contains_expected_keys() {
     assert!(keys.contains(&"runtime.default_tool_output_tokens"));
     assert!(keys.contains(&"runtime.max_tool_output_tokens"));
     assert!(keys.contains(&"runtime.disable_provider_fallback"));
+    assert!(keys.contains(&"runtime.scheduler"));
     assert!(keys.contains(&"tui.alternate_screen"));
     assert!(keys.contains(&"web.fetch.enabled"));
     assert!(keys.contains(&"web.fetch.allowed_hosts"));

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -91,6 +91,7 @@ pub struct RuntimeConfigSurface {
     pub default_tool_output_tokens: u32,
     pub max_tool_output_tokens: u32,
     pub disable_provider_fallback: bool,
+    pub scheduler: crate::config::SchedulerEngineMode,
     pub runtime_db_retention: crate::runtime_db::RuntimeDbRetentionPolicy,
     pub providers: Vec<RuntimeProviderSummary>,
     pub web_search: RuntimeWebSearchSummary,
@@ -167,6 +168,7 @@ impl RuntimeConfigSurface {
             default_tool_output_tokens: config.default_tool_output_tokens,
             max_tool_output_tokens: config.max_tool_output_tokens,
             disable_provider_fallback: config.disable_provider_fallback,
+            scheduler: config.scheduler_engine,
             runtime_db_retention: config
                 .runtime_db_retention_policy()
                 .expect("runtime database retention policy was validated during config load"),

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -91,6 +91,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
         max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
         disable_provider_fallback: false,
+        scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: crate::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/src/host.rs
+++ b/src/host.rs
@@ -2229,6 +2229,7 @@ impl RuntimeHost {
                 self.bridge(),
                 RuntimeModelCatalog::from_config(&config),
                 self.inner.event_bus.clone(),
+                config.scheduler_engine,
             )?
         } else {
             RuntimeHandle::new_reconfigurable_with_host_bridge(
@@ -2794,6 +2795,7 @@ mod tests {
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
             max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
             disable_provider_fallback: false,
+            scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: std::collections::HashMap::new(),
             validated_unknown_model_fallback: None,

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -1070,6 +1070,7 @@ mod tests {
     fn runtime_mutable_config_keys_include_visual_model_defaults() {
         assert!(is_runtime_mutable_config_key("vision.default"));
         assert!(is_runtime_mutable_config_key("image_generation.default"));
+        assert!(!is_runtime_mutable_config_key("runtime.scheduler"));
     }
 
     fn encoded(bytes: &[u8]) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1100,6 +1100,7 @@ mod tests {
             default_tool_output_tokens: 8_000,
             max_tool_output_tokens: 64_000,
             disable_provider_fallback: false,
+            scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
             tui_alternate_screen: AltScreenMode::Auto,
             validated_model_overrides: Default::default(),
             validated_unknown_model_fallback: None,

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1038,6 +1038,7 @@ mod tests {
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
             max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
             disable_provider_fallback: false,
+            scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: HashMap::new(),
             validated_unknown_model_fallback: None,

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -170,6 +170,7 @@ mod tests {
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
             max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
             disable_provider_fallback: false,
+            scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: Default::default(),
             validated_unknown_model_fallback: None,

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -576,6 +576,7 @@ mod tests {
             default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
             max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
             disable_provider_fallback: false,
+            scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: HashMap::new(),
             validated_unknown_model_fallback: None,

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -317,6 +317,7 @@ pub fn test_config(
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
         max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
         disable_provider_fallback: false,
+        scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: crate::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -264,6 +264,7 @@ struct RuntimeInner {
     notify: Notify,
     storage: AppStorage,
     runtime_db: RuntimeDb,
+    scheduler_engine: crate::config::SchedulerEngineMode,
     clock: Arc<dyn clock::Clock>,
     provider: RwLock<Arc<dyn AgentProvider>>,
     context_config: RwLock<ContextConfig>,
@@ -2955,7 +2956,9 @@ impl RuntimeHandle {
         transcript_entries: Vec<TranscriptEntry>,
         brief_evidence: Vec<BriefRecord>,
     ) -> Result<bool> {
-        if record.status == QueueEntryStatus::Processed {
+        if self.inner.scheduler_engine.is_canonical()
+            && record.status == QueueEntryStatus::Processed
+        {
             if let Some(message) = self.inner.storage.read_message_by_id(&record.message_id)? {
                 if let Some(snapshot) = self
                     .inner
@@ -2987,12 +2990,15 @@ impl RuntimeHandle {
                 }
             }
         }
-        let scheduler_protocol_commands = self
-            .canonical_queue_settlement_commands(
+        let scheduler_protocol_commands = if self.inner.scheduler_engine.is_canonical() {
+            self.canonical_queue_settlement_commands(
                 &record,
                 terminal_transition.map(|transition| &transition.turn_record),
             )
-            .await?;
+            .await?
+        } else {
+            Vec::new()
+        };
         let original_audit_len = audit_events.len();
         let mut command = crate::runtime_db::transitions::QueueTransitionCommand {
             agent_id: record.agent_id.clone(),
@@ -3097,21 +3103,28 @@ impl RuntimeHandle {
     }
 
     pub async fn run(self) -> Result<()> {
-        self.bootstrap_recovery().await?;
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        let recovery =
-            scheduler_recovery_report(&self.inner.storage, &self.inner.runtime_db, &agent_id)?;
-        apply_scheduler_recovery_plan(
-            &self.inner.storage,
-            &self.inner.runtime_db,
-            &agent_id,
-            &recovery,
-        )?;
+        if !self.inner.scheduler_engine.is_canonical() {
+            self.validate_legacy_engine_startup(&agent_id)?;
+        }
+        self.bootstrap_recovery().await?;
+        if self.inner.scheduler_engine.is_canonical() {
+            let recovery =
+                scheduler_recovery_report(&self.inner.storage, &self.inner.runtime_db, &agent_id)?;
+            apply_scheduler_recovery_plan(
+                &self.inner.storage,
+                &self.inner.runtime_db,
+                &agent_id,
+                &recovery,
+            )?;
+        }
         scheduler_executor::SchedulerDecisionExecutor::new(&self)
             .bootstrap_recovered()
             .await?;
-        self.recover_scheduler_bootstrap_claims().await?;
-        self.record_scheduler_bootstrap_diagnostics().await?;
+        if self.inner.scheduler_engine.is_canonical() {
+            self.recover_scheduler_bootstrap_claims().await?;
+            self.record_scheduler_bootstrap_diagnostics().await?;
+        }
 
         loop {
             let poll = scheduler_executor::SchedulerDecisionExecutor::new(&self)
@@ -3468,13 +3481,16 @@ impl RuntimeHandle {
 
     async fn release_claimed_messages_for_runtime_restart(&self) -> Result<usize> {
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        let canonical_activations = self
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
-            .map(|snapshot| snapshot.activations)
-            .unwrap_or_default();
+        let canonical_activations = if self.inner.scheduler_engine.is_canonical() {
+            self.inner
+                .runtime_db
+                .transitions()
+                .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
+                .map(|snapshot| snapshot.activations)
+                .unwrap_or_default()
+        } else {
+            Default::default()
+        };
         let claimed = self
             .inner
             .runtime_db
@@ -3523,6 +3539,48 @@ impl RuntimeHandle {
             self.apply_transition_commit(commit).await;
         }
         Ok(released)
+    }
+
+    fn validate_legacy_engine_startup(&self, agent_id: &str) -> Result<()> {
+        if let Some(snapshot) = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+        {
+            let running = snapshot
+                .activations
+                .iter()
+                .filter(|(_, activation)| {
+                    activation.state == crate::domain::scheduler_protocol::ActivationState::Running
+                })
+                .map(|(activation_id, _)| activation_id.as_str())
+                .collect::<Vec<_>>();
+            if !running.is_empty() {
+                return Err(anyhow!(
+                    "legacy scheduler startup refused for agent {agent_id}: non-terminal \
+                     canonical activations remain ({})",
+                    running.join(", ")
+                ));
+            }
+        }
+        let dequeued = self
+            .inner
+            .runtime_db
+            .queue_entries()
+            .recent(Some(agent_id), usize::MAX)?
+            .into_iter()
+            .filter(|entry| entry.status == QueueEntryStatus::Dequeued)
+            .map(|entry| entry.message_id)
+            .collect::<Vec<_>>();
+        if dequeued.is_empty() {
+            return Ok(());
+        }
+        Err(anyhow!(
+            "legacy scheduler startup refused for agent {agent_id}: dequeued queue claims \
+             require diagnosis or repair ({})",
+            dequeued.join(", ")
+        ))
     }
 
     async fn recover_scheduler_bootstrap_claims(&self) -> Result<usize> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3105,6 +3105,7 @@ impl RuntimeHandle {
     pub async fn run(self) -> Result<()> {
         let agent_id = self.inner.agent.lock().await.state.id.clone();
         if !self.inner.scheduler_engine.is_canonical() {
+            // Fail fast on residual canonical state before general recovery mutates runtime state.
             self.validate_legacy_engine_startup(&agent_id)?;
         }
         self.bootstrap_recovery().await?;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -135,6 +135,42 @@ impl RuntimeHandle {
             None,
             None,
             None,
+            crate::config::SchedulerEngineMode::Canonical,
+            Arc::new(SystemClock),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_scheduler_engine(
+        agent_id: impl Into<String>,
+        data_dir: PathBuf,
+        initial_workspace: impl Into<InitialWorkspaceBinding>,
+        callback_base_url: String,
+        provider: Arc<dyn AgentProvider>,
+        default_agent_id: String,
+        context_config: ContextConfig,
+        scheduler_engine: crate::config::SchedulerEngineMode,
+    ) -> Result<Self> {
+        let base_context_config = context_config.clone();
+        Self::new_internal(
+            agent_id,
+            data_dir,
+            initial_workspace,
+            callback_base_url,
+            provider,
+            default_agent_id,
+            base_context_config,
+            context_config,
+            RuntimeModelCatalog::default(),
+            Vec::new(),
+            crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
+            crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS,
+            crate::web::WebConfig::default(),
+            None,
+            None,
+            None,
+            None,
+            scheduler_engine,
             Arc::new(SystemClock),
         )
     }
@@ -163,6 +199,7 @@ impl RuntimeHandle {
             Some(runtime_db),
             None,
             None,
+            crate::config::SchedulerEngineMode::Canonical,
             Arc::new(SystemClock),
         )
     }
@@ -197,6 +234,7 @@ impl RuntimeHandle {
             None,
             None,
             None,
+            crate::config::SchedulerEngineMode::Canonical,
             clock,
         )
     }
@@ -213,6 +251,7 @@ impl RuntimeHandle {
         host_bridge: RuntimeHostBridge,
         model_catalog: RuntimeModelCatalog,
         event_bus: EventBus,
+        scheduler_engine: crate::config::SchedulerEngineMode,
     ) -> Result<Self> {
         let base_context_config = context_config.clone();
         Self::new_internal(
@@ -233,6 +272,7 @@ impl RuntimeHandle {
             Some(runtime_db),
             Some(host_bridge),
             Some(event_bus),
+            scheduler_engine,
             Arc::new(SystemClock),
         )
     }
@@ -260,6 +300,7 @@ impl RuntimeHandle {
             build_provider_from_model_chain(&provider_config, &model_catalog.provider_chain(None))?;
         let resolved_context_config =
             model_catalog.resolved_context_config(&base_context_config, None);
+        let scheduler_engine = config.scheduler_engine;
         Self::new_internal(
             agent_id,
             data_dir,
@@ -278,6 +319,7 @@ impl RuntimeHandle {
             Some(runtime_db),
             Some(host_bridge),
             Some(event_bus),
+            scheduler_engine,
             Arc::new(SystemClock),
         )
     }
@@ -300,6 +342,7 @@ impl RuntimeHandle {
         runtime_db: Option<RuntimeDb>,
         host_bridge: Option<RuntimeHostBridge>,
         event_bus: Option<EventBus>,
+        scheduler_engine: crate::config::SchedulerEngineMode,
         clock: Arc<dyn Clock>,
     ) -> Result<Self> {
         let x_search_config = provider_reconfig
@@ -368,6 +411,7 @@ impl RuntimeHandle {
                 notify: Notify::new(),
                 storage,
                 runtime_db,
+                scheduler_engine,
                 clock,
                 provider: RwLock::new(provider),
                 config_snapshot: ArcSwap::from(config_snapshot),

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -81,6 +81,11 @@ impl RuntimeHandle {
             scheduler_state.pending,
             self.now(),
         )?;
+        let scheduler_projection = if self.inner.scheduler_engine.is_canonical() {
+            scheduler_projection
+        } else {
+            scheduler_projection.without_canonical_authority()
+        };
         let scheduler_decision = scheduler::decide_next_action(
             &scheduler_projection,
             scheduler::SchedulerBoundary::MessageProcessing,

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -191,6 +191,12 @@ impl SchedulerAgentSnapshot {
 }
 
 impl SchedulerProjection {
+    pub(crate) fn without_canonical_authority(mut self) -> Self {
+        self.canonical_work_statuses = None;
+        self.canonical_wait_generations.clear();
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn set_canonical_wait_generation_for_test(
         &mut self,

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -192,6 +192,7 @@ impl SchedulerAgentSnapshot {
 
 impl SchedulerProjection {
     pub(crate) fn without_canonical_authority(mut self) -> Self {
+        // activation_waits remains shared input for legacy wait-to-WorkItem correlation.
         self.canonical_work_statuses = None;
         self.canonical_wait_generations.clear();
         self

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -115,6 +115,12 @@ impl RuntimeHandle {
         continuation_resolution: Option<&ContinuationResolution>,
         task: Option<&TaskRecord>,
     ) -> Result<ExecutionAdmissionProvenance> {
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(ExecutionAdmissionProvenance::LegacyCompat {
+                scenario_class: None,
+                effective_mode: crate::domain::scheduler_protocol::ScenarioMode::Off,
+            });
+        }
         let scenario_class = if matches!(
             message.kind,
             crate::types::MessageKind::TaskStatus | crate::types::MessageKind::TaskResult
@@ -381,6 +387,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             candidate.queue_len,
             self.runtime.now(),
         )?;
+        let projection = if self.runtime.inner.scheduler_engine.is_canonical() {
+            projection
+        } else {
+            projection.without_canonical_authority()
+        };
         let legacy_decision = scheduler::decide_next_action(
             &projection,
             scheduler::SchedulerBoundary::RunLoop,
@@ -398,7 +409,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .storage
             .read_message_by_id(&candidate.message.id)?
             .ok_or_else(|| anyhow!("claimed message is missing persisted ingress evidence"))?;
-        let canonical_claim =
+        let canonical_claim = if self.runtime.inner.scheduler_engine.is_canonical() {
             match self.canonical_activation_plan(&projection, &persisted_message, &dispatch_plan) {
                 Ok(CanonicalClaimOutcome::NotApplicable) => None,
                 Ok(CanonicalClaimOutcome::Plan(plan)) => Some(plan),
@@ -444,7 +455,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     }
                     return Err(error);
                 }
-            };
+            }
+        } else {
+            None
+        };
         if let Some(plan) = canonical_claim.as_ref() {
             dispatch_plan.execution_admission_provenance =
                 ExecutionAdmissionProvenance::Canonical {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1754,6 +1754,152 @@ async fn bootstrap_recovery_fault_rolls_back_queue_canonical_and_audit() {
 }
 
 #[tokio::test]
+async fn legacy_engine_claim_and_settlement_do_not_write_canonical_protocol() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("legacy production loop".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "run legacy work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.turn_id = Some("turn-legacy-production-loop".into());
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&work_item.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn legacy_engine_startup_rejects_running_canonical_activation() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(CountingProvider {
+        calls: Mutex::new(0),
+        reply: "unused",
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("canonical in flight".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "leave canonical activation running".into(),
+        },
+    );
+    message.work_item_id = Some(work_item.id);
+    message.turn_id = Some("turn-canonical-in-flight".into());
+    runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    drop(runtime);
+
+    let legacy = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let error = legacy.run().await.unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("non-terminal canonical activations remain"));
+}
+
+#[tokio::test]
 async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -7412,6 +7558,113 @@ async fn task_result_records_wait_reconciliation_and_resolves_task_wait_conditio
     assert!(latest_conditions.iter().any(|condition| {
         condition.id == "wait-task-1" && condition.status == WaitConditionStatus::Resolved
     }));
+}
+
+#[tokio::test]
+async fn legacy_task_result_resolves_unique_wait_without_canonical_partition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "legacy task follow-up",
+        }),
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let now = Utc::now();
+    let mut work_item = WorkItemRecord::new("default", "legacy task wait", WorkItemState::Open);
+    work_item.id = "wi-legacy-task".into();
+    work_item.blocked_by = Some("task result".into());
+    runtime.storage().append_work_item(&work_item).unwrap();
+    runtime
+        .storage()
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-legacy-task".into(),
+            agent_id: "default".into(),
+            work_item_id: Some(work_item.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Task,
+            source: None,
+            subject_ref: Some("task-legacy".into()),
+            waiting_for: "task result".into(),
+            wake_sources: vec![WakeSource::TaskResult {
+                task_id: "task-legacy".into(),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        })
+        .unwrap();
+
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-legacy".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "task completed".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-legacy",
+        "task_kind": "child_agent_task",
+        "task_status": "completed",
+        "work_item_id": work_item.id,
+    }));
+    message.task_id = Some("task-legacy".into());
+    message.work_item_id = Some(work_item.id.clone());
+
+    runtime
+        .process_message(
+            message,
+            closure_decision(
+                ClosureOutcome::Waiting,
+                Some(WaitingReason::AwaitingTaskResult),
+            ),
+        )
+        .await
+        .unwrap();
+
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+    assert!(runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .iter()
+        .any(|condition| {
+            condition.id == "wait-legacy-task" && condition.status == WaitConditionStatus::Resolved
+        }));
+    assert!(runtime
+        .inner
+        .runtime_db
+        .work_items()
+        .latest(&work_item.id)
+        .unwrap()
+        .is_some_and(|work| work.blocked_by.is_none()));
 }
 
 #[tokio::test]

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -768,6 +768,9 @@ impl RuntimeHandle {
         &self,
         external_trigger_id: Option<&str>,
     ) -> Result<Option<(String, u64)>> {
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(None);
+        }
         let Some(external_trigger_id) = external_trigger_id else {
             return Ok(None);
         };
@@ -938,6 +941,23 @@ impl RuntimeHandle {
                 .is_some();
         if !operator_input && !callback_event && !external_wake_hint {
             return Ok(active_conditions);
+        }
+
+        if !self.inner.scheduler_engine.is_canonical() {
+            let matching = active_conditions
+                .into_iter()
+                .filter(|condition| {
+                    reconciliation_signal_for_condition(message, condition).is_some()
+                })
+                .collect::<Vec<_>>();
+            if matching.len() > 1 {
+                return Err(anyhow!(
+                    "legacy wait resume is ambiguous for message {}: {} matching waits",
+                    message.id,
+                    matching.len()
+                ));
+            }
+            return Ok(matching);
         }
 
         let exact_condition = self

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -3178,6 +3178,7 @@ mod tests {
             default_tool_output_tokens: 4096,
             max_tool_output_tokens: 16384,
             disable_provider_fallback: false,
+            scheduler: crate::config::SchedulerEngineMode::Canonical,
             runtime_db_retention: crate::runtime_db::RuntimeDbRetentionPolicy::default(),
             providers: Vec::new(),
             web_search: crate::daemon::RuntimeWebSearchSummary {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -79,6 +79,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
         max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
         disable_provider_fallback: false,
+        scheduler_engine: crate::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -494,6 +494,31 @@ fn config_set_surfaces_daemon_rejection_reason() {
 }
 
 #[test]
+fn config_set_rejects_runtime_scheduler_while_daemon_is_running() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let (_serve, addr) = spawn_local_serve(&home);
+
+    let (stdout, stderr) = run_failure_with_env(
+        &home,
+        &["config", "set", "runtime.scheduler", "legacy"],
+        &[("HOLON_HTTP_ADDR", &addr)],
+    );
+
+    assert!(
+        stdout.is_empty(),
+        "failed config set should not emit JSON stdout"
+    );
+    assert!(
+        stderr.contains("daemon rejected runtime config update for runtime.scheduler"),
+        "stderr should name the startup-only key: {stderr}"
+    );
+    assert!(
+        stderr.contains("unsupported or startup-only config key"),
+        "stderr should explain that scheduler selection requires restart: {stderr}"
+    );
+}
+
+#[test]
 fn onboard_json_contract_is_secret_safe_and_actionable() {
     let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
     let _set = run_json(

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -50,6 +50,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: 8_000,
         max_tool_output_tokens: 64_000,
         disable_provider_fallback: false,
+        scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -214,6 +214,7 @@ impl TestConfigBuilder {
             default_tool_output_tokens: 8_000,
             max_tool_output_tokens: 64_000,
             disable_provider_fallback: false,
+            scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
             tui_alternate_screen: holon::config::AltScreenMode::Auto,
             validated_model_overrides: std::collections::HashMap::new(),
             validated_unknown_model_fallback: None,

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -52,6 +52,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: 8_000,
         max_tool_output_tokens: 64_000,
         disable_provider_fallback: false,
+        scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -51,6 +51,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: 8_000,
         max_tool_output_tokens: 64_000,
         disable_provider_fallback: false,
+        scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -51,6 +51,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: 8_000,
         max_tool_output_tokens: 64_000,
         disable_provider_fallback: false,
+        scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -51,6 +51,7 @@ fn test_config() -> AppConfig {
         default_tool_output_tokens: 8_000,
         max_tool_output_tokens: 64_000,
         disable_provider_fallback: false,
+        scheduler_engine: holon::config::SchedulerEngineMode::Canonical,
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,


### PR DESCRIPTION
## 概要

实现 accepted scheduler cutover contract 的 Phase 2：加入临时、进程级、启动时不可变的 `legacy|canonical` scheduler engine selector，同时不恢复 rollout、shadow、manifest/preflight 或 per-scenario authority。

- 新增 `SchedulerEngineMode::{Legacy, Canonical}`
- 支持 `HOLON_SCHEDULER > runtime.scheduler > canonical` precedence
- `runtime.scheduler` 标记为 startup-only，daemon 热更新拒绝修改
- engine mode 在 host/runtime 构造时解析并注入，运行期不传播到深层 transition command
- legacy 模式复用现存 queue / `AgentState` / WorkItem / wait / task / Turn 公共路径
- legacy 模式不写 canonical activation 或 settlement facts，也不运行 canonical adoption/recovery
- legacy wait resume 使用唯一公共 wait record；歧义时 fail closed
- legacy 启动遇到 running canonical activation 或残留 `Dequeued` claim 时 fail closed
- 更新配置文档、scheduler spec、README 与 OpenAPI snapshot

## Runtime contract

Canonical 仍是默认和长期 engine。一个进程只选择一个 engine：

```text
HOLON_SCHEDULER > runtime.scheduler > canonical
```

本 PR 不重新引入：

- runtime shadow comparison
- rollout manifest / preflight
- per-scenario authority
- automatic hard-blocker rollback
- semantic proposal production path

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test scheduler --quiet`（核心 91 项 + 集成 8 项通过）
- `cargo test --lib runtime::tests::runtime_state --quiet`（109 项通过）
- `cargo test config::tests --lib --quiet`（100 项通过）
- `cargo test --test cli_json_contract --quiet`（9 项通过）
- `cargo test openapi_snapshot_matches_generated_schema --test openapi_snapshot`
- legacy claim/settlement、startup fail-closed、task wait resume 定向测试
- docs link check 与 contract reference check

文档站 `build:index` 通过；完整本地 search build 因当前 Linux 环境缺少 `indexbind` native addon 停止，该问题与本次 Markdown 内容无关。

## 备注

本地开发环境遗留 `HOLON_SCHEDULER=shadow`；新契约会正确拒绝该旧值。验证命令显式使用 `HOLON_SCHEDULER=canonical`，invalid-mode 配置测试单独覆盖 `shadow` 拒绝行为。
