### PR TITLE
test: move scheduler evidence to release acceptance

### DIFF
--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -55,6 +55,7 @@ jobs:
           python3 scripts/docker-e2e.py \
             --image holon:nightly \
             --skip-build \
+            --scheduler-matrix \
             --suite extended \
             --tag e2e-tier-1 \
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
@@ -66,6 +67,7 @@ jobs:
           python3 scripts/docker-e2e.py \
             --image holon:nightly \
             --skip-build \
+            --scheduler-matrix \
             --suite extended \
             --tag e2e-tier-2 \
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -120,6 +120,7 @@ jobs:
           args=(
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
+            --scheduler-matrix
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
           )
           while IFS= read -r case_id; do
@@ -151,12 +152,18 @@ jobs:
           if not summaries:
               raise SystemExit("No Docker E2E summary was produced")
           summary = json.loads(summaries[-1].read_text())
+          scheduler_report = json.loads(
+              (summaries[-1].parent / "scheduler-acceptance-report.json").read_text()
+          )
           lines = [
               "# Release Docker E2E",
               "",
               f"- Status: **{summary['status']}**",
               f"- Candidate: `{summary['image']['ref']}`",
               f"- Git SHA: `{summary['git_sha']}`",
+              f"- Scheduler matrix: **{scheduler_report['status']}**",
+              f"- Runtime schema revision: `{scheduler_report['runtime_schema_revision']}`",
+              f"- Fixture corpus: `{scheduler_report['fixture_corpus_revision']}`",
               f"- Model: `{summary['model_route']}`",
               f"- Duration: `{summary['duration_seconds']}s`",
               "",
@@ -186,6 +193,16 @@ jobs:
           summary = json.loads(summaries[-1].read_text())
           if summary["status"] != "pass":
               raise SystemExit(f"Release E2E did not pass: {summary['status']}")
+          scheduler_report_path = summaries[-1].parent / "scheduler-acceptance-report.json"
+          scheduler_report = json.loads(scheduler_report_path.read_text())
+          if scheduler_report["status"] != "pass":
+              raise SystemExit(
+                  f"Scheduler acceptance did not pass: {scheduler_report['status']}"
+              )
+          if scheduler_report["git_sha"] != os.environ["CANDIDATE_SHA"]:
+              raise SystemExit("Scheduler acceptance Git SHA does not match candidate")
+          if scheduler_report["image_digest"] != summary["image_digest"]:
+              raise SystemExit("Scheduler acceptance image digest does not match summary")
           attestation = {
               "schema_version": 1,
               "release_tag": os.environ["RELEASE_TAG"],
@@ -196,7 +213,10 @@ jobs:
               "status": summary["status"],
               "model_route": summary["model_route"],
               "image": summary["image"],
+              "image_digest": summary["image_digest"],
+              "scheduler_acceptance": scheduler_report,
               "summary_path": str(summaries[-1]),
+              "scheduler_acceptance_path": str(scheduler_report_path),
           }
           Path("target/release-e2e-attestation").mkdir(parents=True, exist_ok=True)
           Path("target/release-e2e-attestation/release-e2e-attestation.json").write_text(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
-
 name: Release
 
 on:
@@ -74,7 +73,15 @@ jobs:
              and (.workflow_run_id | tostring) == $run_id
              and .status == "pass"
              and (.image.ref | contains("@sha256:"))
-             and (.model_route | length > 0)' \
+             and (.model_route | length > 0)
+             and .scheduler_acceptance.schema_version == 1
+             and .scheduler_acceptance.status == "pass"
+             and .scheduler_acceptance.git_sha == $sha
+             and (.scheduler_acceptance.runtime_schema_revision | type == "number")
+             and (.scheduler_acceptance.fixture_corpus_revision | length > 0)
+             and (.scheduler_acceptance.image_digest | contains("@sha256:"))
+             and ([.scheduler_acceptance.engines[] | .engine] == ["legacy", "canonical"])
+             and ([.scheduler_acceptance.engines[] | .status] | all(. == "pass"))' \
             release-e2e-gate/release-e2e-attestation.json >/dev/null
 
           candidate_image="$(jq -r '.image.ref' release-e2e-gate/release-e2e-attestation.json)"

--- a/docs/scheduler-drill.md
+++ b/docs/scheduler-drill.md
@@ -117,6 +117,9 @@ declared parameters alone never satisfy coverage. Historical hard blockers and
 manifest/preflight revisions remain visible while the collector reads the
 compatibility schema, but they do not grant runtime authority.
 
-The historical rollout checks must be removed when those repositories are
-retired. Release Go/No-Go is determined by collected scenario results and build
-identity, not by importing or activating runtime rollout rows.
+Release Go/No-Go is determined by collected scenario results and build
+identity, not by importing or activating runtime rollout rows. The protected
+release workflow separately runs the checked-in lifecycle corpus in isolated
+`legacy` and `canonical` processes and emits
+`scheduler-acceptance-report.json`; the drill remains the larger stress and
+fault corpus rather than a source of runtime authority.

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -48,15 +48,16 @@ deepseek/deepseek-v4-flash
 
 The suite requires network access and provider quota, so ordinary pull-request
 CI only validates its manifest and Python runner. Each release candidate runs
-the core cases plus all scheduler-tagged rollout cases through the protected
-`Release E2E` workflow.
+the core cases plus all scheduler-tagged cases through the protected
+`Release E2E` workflow. Scheduler cases run twice with
+`HOLON_SCHEDULER=legacy` and `HOLON_SCHEDULER=canonical`. Each engine uses a
+separate `holon serve` process, Docker volume, runtime database, and evidence
+directory while sharing the same user-visible and persistence assertions.
 
-The scheduler rollout cases use hidden offline fixtures guarded by
-`HOLON_SCHEDULER_ACCEPTANCE_FIXTURES=true`. Their manifest is explicitly
-synthetic acceptance data: it exercises the production reducer, revision
-fences, atomic batch application, rejection of insufficient evidence, cutover,
-and rollback. It does not claim that one Docker run collected the production
-sample counts or the full fleet evidence corpus encoded by those gates.
+The release gate does not install scheduler manifest/preflight rows, stage
+shadow authority, or import synthetic cutover evidence. It validates the
+temporary process-level rollback switch directly and records canonical-only
+protocol assertions only when the canonical engine is selected.
 
 Run locally with a credential environment variable:
 
@@ -120,7 +121,10 @@ python3 scripts/docker-e2e.py \
 
 The summary records the Git SHA, image ID and repository digest, requested
 model route, manifest hash, timings, provider attempts, token usage, tool
-counts, cleanup status, and previous image when supplied.
+counts, cleanup status, and previous image when supplied. A matrix run also
+writes `scheduler-acceptance-report.json`, which binds the result to the Git
+SHA, immutable image digest, runtime schema revision, fixture corpus revision,
+manifest hash, both scheduler engines, and their per-case evidence identities.
 
 ### Checked-in cases
 
@@ -173,17 +177,20 @@ counts, cleanup status, and previous image when supplied.
 5. Assert the required tools succeeded and the durable completion result
    contains the generated completion marker.
 
-#### Scheduler rollout cases
+#### Scheduler release acceptance cases
 
-The protected release run also selects every case tagged `scheduler`:
+The protected release run selects every case tagged `scheduler` and expands
+each into isolated `legacy` and `canonical` processes. The corpus includes:
 
-1. `scheduler-rollout-authoritative-autonomous` validates shadow evidence,
-   per-scenario authoritative cutover, task-result and external-wait
-   continuations, exact completion delivery binding, restart persistence, and
-   rollback.
-2. `scheduler-terminal-before-settlement-restart` uses a checked-in offline
-   fault fixture to validate bootstrap reconciliation and second-restart
-   idempotence without issuing a model prompt.
+1. `scheduler-task-wait-resume` validates autonomous scheduling, promoted task
+   yield/rejoin, external wait-resume, exact completion delivery binding, and
+   restart persistence.
+2. Provider-failure retry, multi-WorkItem scheduling, external/operator waits,
+   interjection, compaction, worktree isolation, child supervision, and
+   checkpoint replay retain their real process and persistence assertions.
+3. The canonical process additionally requires settled activation, demand,
+   and wait-generation state. The legacy process requires those canonical
+   execution tables to remain unused.
 
 These cases validate the complete boundary:
 
@@ -203,14 +210,17 @@ jobs:
 1. Build and push `candidate-<git-sha>` with OCI version, revision, and source
    labels.
 2. Pull and test the resulting immutable digest in the `release-e2e`
-   environment using `DEEPSEEK_API_KEY`, selecting all core and
-   scheduler-tagged cases in one attested runner invocation.
+   environment using `DEEPSEEK_API_KEY`, selecting all core cases and expanding
+   scheduler-tagged cases with `--scheduler-matrix` in one attested runner
+   invocation.
 
 The E2E job has read-only repository/package permissions and cannot publish a
 GitHub release, promote `latest`, or update Homebrew. Evidence is retained as a
-workflow artifact. The tag-triggered release workflow verifies the matching
-attestation before publishing, then promotes the exact candidate digest that
-passed this suite instead of rebuilding the container image.
+workflow artifact. Its attestation embeds the machine-readable scheduler
+acceptance report. The tag-triggered release workflow verifies that both
+engines passed against the same Git SHA, schema revision, fixture corpus, and
+candidate digest before publishing, then promotes that exact digest instead of
+rebuilding the container image.
 
 ## Phases
 

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -31,6 +31,8 @@ DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
 OFFLINE_MODEL_CREDENTIAL_ENV = "DEEPSEEK_API_KEY"
 OFFLINE_MODEL_CREDENTIAL = "docker-e2e-offline-provider-unused"
 EVIDENCE_SCHEMA_VERSION = 1
+SCHEDULER_ACCEPTANCE_REPORT_SCHEMA_VERSION = 1
+SCHEDULER_ENGINES = ("legacy", "canonical")
 TERMINAL_STATUSES = {"awake_idle", "asleep", "awaiting_task"}
 RUNTIME_DB_COPY_TIMEOUT_SECONDS = 120
 DOCKER_CONTROL_TIMEOUT_SECONDS = 30
@@ -217,6 +219,14 @@ class CaseHarness:
         }
         self.evidence.mkdir(parents=True, exist_ok=True)
 
+    @property
+    def scheduler_engine(self) -> str | None:
+        return self.runtime_env.get("HOLON_SCHEDULER")
+
+    @property
+    def canonical_scheduler_enabled(self) -> bool:
+        return self.scheduler_engine == "canonical"
+
     def docker(self, *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         with self._docker_health["lock"]:
             if self._docker_health["open"]:
@@ -387,41 +397,6 @@ class CaseHarness:
         value = json.loads(result.stdout)
         write_json(self.evidence / f"{label}.json", value)
         return value
-
-    def apply_scheduler_rollout(
-        self, label: str, commands: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        path = self.evidence / f"{label}-input.json"
-        write_json(path, {"commands": commands})
-        return self.offline_debug(
-            label,
-            "scheduler-rollout-apply",
-            "--input",
-            f"/acceptance-evidence/{path.name}",
-        )
-
-    def reject_scheduler_rollout(
-        self, label: str, commands: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        path = self.evidence / f"{label}-input.json"
-        write_json(path, {"commands": commands})
-        return self.offline_debug(
-            label,
-            "scheduler-rollout-apply",
-            "--input",
-            f"/acceptance-evidence/{path.name}",
-            expect_success=False,
-        )
-
-    def seed_scheduler_recovery_fixture(
-        self, label: str, objective: str
-    ) -> dict[str, Any]:
-        return self.offline_debug(
-            label,
-            "scheduler-recovery-fixture",
-            "--objective",
-            objective,
-        )
 
     def seed_scheduler_restart_fixture(
         self,
@@ -1102,6 +1077,9 @@ class CaseHarness:
         connection.row_factory = sqlite3.Row
         try:
             snapshot = {
+                "schema_revision": connection.execute(
+                    "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+                ).fetchone()[0],
                 "work_items": sqlite_rows(
                     connection,
                     "SELECT work_item_id, agent_id, state, objective, revision, "
@@ -1143,34 +1121,6 @@ class CaseHarness:
                     "subject_ref, waiting_for, last_turn_id, payload_json "
                     "FROM wait_conditions ORDER BY created_at",
                 ),
-                "scheduler_protocol_config": sqlite_rows(
-                    connection,
-                    "SELECT protocol_mode, config_revision, latest_preflight_revision "
-                    "FROM scheduler_protocol_config",
-                ),
-                "scheduler_rollout_preflights": sqlite_rows(
-                    connection,
-                    "SELECT preflight_revision, manifest_revision, state, manifest_json "
-                    "FROM scheduler_rollout_preflights ORDER BY preflight_revision",
-                ),
-                "scheduler_rollout_manifests": sqlite_rows(
-                    connection,
-                    "SELECT manifest_revision, preflight_revision, payload_json "
-                    "FROM scheduler_rollout_manifests ORDER BY manifest_revision",
-                ),
-                "scheduler_scenario_authorities": sqlite_rows(
-                    connection,
-                    "SELECT scenario_class, mode, rollback_target, manifest_revision, "
-                    "preflight_revision FROM scheduler_scenario_authorities "
-                    "ORDER BY scenario_class",
-                ),
-                "scheduler_rollout_command_results": sqlite_rows(
-                    connection,
-                    "SELECT command_kind, command_identity, decision, conflict_kind, "
-                    "conflict_code, result_references_json, pre_state_fence_json, "
-                    "post_state_fence_json FROM scheduler_rollout_command_results "
-                    "ORDER BY created_at",
-                ),
                 "scheduler_work_demands": sqlite_rows(
                     connection,
                     "SELECT agent_id, work_item_id, scheduling_generation, status, "
@@ -1211,12 +1161,6 @@ class CaseHarness:
                     "pre_state_fence_json, post_state_fence_json "
                     "FROM scheduler_protocol_command_results ORDER BY created_at",
                 ),
-                "scheduler_shadow_comparisons": sqlite_rows(
-                    connection,
-                    "SELECT agent_id, scenario_class, boundary, comparison_identity, "
-                    "comparison_outcome, authority_mode, input_identity "
-                    "FROM scheduler_shadow_comparisons ORDER BY created_at",
-                ),
             }
         finally:
             connection.close()
@@ -1246,314 +1190,60 @@ def require_processed_queue_entries(
     )
 
 
-SCHEDULER_ROLLOUT_GATES = {
-    "reducer_only_candidates": (
-        10_000,
-        72 * 60 * 60,
-        ["deterministic_replay", "duplicate_command_idempotency"],
-    ),
-    "exact_task_rejoin": (
-        1_000,
-        7 * 24 * 60 * 60,
-        [
-            "duplicate_task_result",
-            "out_of_order_task_result",
-            "restart_before_rejoin_settlement",
-        ],
-    ),
-    "exact_wait_resume": (
-        1_000,
-        7 * 24 * 60 * 60,
-        ["duplicate_trigger", "stale_generation", "restart_after_consume", "rearm"],
-    ),
-    "work_item_autonomous_continuation": (
-        2_000,
-        14 * 24 * 60 * 60,
-        [
-            "concurrent_claim",
-            "reservation_conflict",
-            "yield_return",
-            "work_item_rollback",
-        ],
-    ),
-    "settlement": (
-        1_000,
-        7 * 24 * 60 * 60,
-        [
-            "duplicate_settlement",
-            "missing_settlement_recovery",
-            "restart_before_settlement_commit",
-        ],
-    ),
-    "delivery": (
-        1_000,
-        7 * 24 * 60 * 60,
-        ["duplicate_delivery", "delivery_retry", "restart_before_delivery_commit"],
-    ),
-}
-
-
-def scheduler_rollout_manifest(
-    scenario_modes: dict[str, str],
-    *,
-    revision: int = 1,
-    preflight_revision: int = 1,
-) -> dict[str, Any]:
-    # Explicit acceptance-only synthetic data: exercise the production reducer
-    # and revision fences without claiming fleet shadow evidence collection.
-    universal = {"restart", "fault_injection", "rollback_drill"}
-    classes = {}
-    for scenario_class, configured_mode in scenario_modes.items():
-        minimum_samples, minimum_duration, class_evidence = SCHEDULER_ROLLOUT_GATES[
-            scenario_class
-        ]
-        evidence = sorted(universal.union(class_evidence))
-        classes[scenario_class] = {
-            "configured_mode": configured_mode,
-            "minimum_shadow_samples": minimum_samples,
-            "minimum_shadow_duration_secs": minimum_duration,
-            "observed_shadow_samples": minimum_samples,
-            "observed_shadow_duration_secs": minimum_duration,
-            "maximum_p99_latency_regression_bps": 500,
-            "observed_p99_latency_regression_bps": 0,
-            "hard_blocker_count": 0,
-            "unresolved_divergence_count": 0,
-            "required_evidence": evidence,
-            "verified_evidence": evidence,
-            "rollback_policy": {
-                "trigger": "any_hard_blocker",
-                "action": {
-                    "kind": "stop_admissions_and_revert",
-                    "target": "shadow",
-                },
-            },
-        }
-    return {
-        "revision": revision,
-        "preflight_revision": preflight_revision,
-        "preflight_for_manifest_revision": revision,
-        "preflight_succeeded": True,
-        "protocol_build": "holon-docker-e2e-synthetic-acceptance",
-        "schema_build": "scheduler-protocol-schema-v1",
-        "schema_revision": 1,
-        "fixture_corpus_revision": "scheduler-pr-g-synthetic-acceptance-v1",
-        "classes": classes,
-        "safety_divergence_bps": 0,
-        "canonical_state_divergence_bps": 0,
-        "allowed_observational_divergence": {
-            "diagnostic_order": {
-                "maximum_rate_bps": 0,
-                "reviewed_by": "docker-e2e",
-            }
-        },
-        "approver": "docker-e2e-synthetic-acceptance",
-        "approved_at": "2026-07-23T00:00:00Z",
-    }
-
-
-def scheduler_incomplete_rollout_commands(
-    scenario_modes: dict[str, str],
-) -> list[dict[str, Any]]:
-    manifest = scheduler_rollout_manifest(scenario_modes)
-    for evidence in manifest["classes"].values():
-        evidence["observed_shadow_samples"] = 0
-        evidence["observed_shadow_duration_secs"] = 0
-        evidence["verified_evidence"] = []
-    return [
-        {
-            "command_identity": "docker-e2e-rejected-rollout-open",
-            "command": {
-                "kind": "open_preflight",
-                "expected_config_revision": 0,
-                "manifest_revision": 1,
-            },
-        },
-        {
-            "command_identity": "docker-e2e-rejected-rollout-complete",
-            "command": {
-                "kind": "complete_preflight",
-                "expected_config_revision": 0,
-                "expected_preflight_revision": 1,
-                "manifest": manifest,
-            },
-        },
-    ]
-
-
-def scheduler_rollout_commands(
-    scenario_modes: dict[str, str],
-    *,
-    approved_scenario_modes: dict[str, str] | None = None,
-    rollback_scenario: str | None = None,
-) -> list[dict[str, Any]]:
-    manifest = scheduler_rollout_manifest(
-        approved_scenario_modes or scenario_modes
-    )
-    commands = [
-        {
-            "command_identity": "docker-e2e-rollout-open",
-            "command": {
-                "kind": "open_preflight",
-                "expected_config_revision": 0,
-                "manifest_revision": 1,
-            },
-        },
-        {
-            "command_identity": "docker-e2e-rollout-complete",
-            "command": {
-                "kind": "complete_preflight",
-                "expected_config_revision": 0,
-                "expected_preflight_revision": 1,
-                "manifest": manifest,
-            },
-        },
-        {
-            "command_identity": "docker-e2e-rollout-install",
-            "command": {
-                "kind": "install_manifest",
-                "expected_config_revision": 0,
-                "manifest": manifest,
-            },
-        },
-        {
-            "command_identity": "docker-e2e-rollout-configure",
-            "command": {
-                "kind": "configure_protocol",
-                "expected_config_revision": 1,
-                "mode": "authoritative",
-            },
-        },
-    ]
-    revision = 2
-    for scenario_class, target_mode in scenario_modes.items():
-        if target_mode == "off":
-            continue
-        commands.append(
-            {
-                "command_identity": f"docker-e2e-{scenario_class}-shadow",
-                "command": {
-                    "kind": "change_scenario_authority",
-                    "scenario_class": scenario_class,
-                    "expected_config_revision": revision,
-                    "expected_manifest_revision": 1,
-                    "expected_preflight_revision": 1,
-                    "mode": "shadow",
-                },
-            }
-        )
-        revision += 1
-        if target_mode == "authoritative":
-            commands.append(
-                {
-                    "command_identity": f"docker-e2e-{scenario_class}-authoritative",
-                    "command": {
-                        "kind": "change_scenario_authority",
-                        "scenario_class": scenario_class,
-                        "expected_config_revision": revision,
-                        "expected_manifest_revision": 1,
-                        "expected_preflight_revision": 1,
-                        "mode": "authoritative",
-                    },
-                }
-            )
-            revision += 1
-    if rollback_scenario is not None:
-        commands.append(
-            {
-                "command_identity": f"docker-e2e-{rollback_scenario}-rollback",
-                "command": {
-                    "kind": "change_scenario_authority",
-                    "scenario_class": rollback_scenario,
-                    "expected_config_revision": revision,
-                    "expected_manifest_revision": 1,
-                    "expected_preflight_revision": 1,
-                    "mode": "shadow",
-                },
-            }
-        )
-    return commands
-
-
-def scheduler_scenario_mode_commands(
-    scenario_modes: dict[str, str],
-    *,
-    expected_config_revision: int,
-    identity_suffix: str,
-) -> list[dict[str, Any]]:
-    commands = []
-    revision = expected_config_revision
-    for scenario_class, mode in scenario_modes.items():
-        commands.append(
-            {
-                "command_identity": (
-                    f"docker-e2e-{scenario_class}-{mode}-{identity_suffix}"
-                ),
-                "command": {
-                    "kind": "change_scenario_authority",
-                    "scenario_class": scenario_class,
-                    "expected_config_revision": revision,
-                    "expected_manifest_revision": 1,
-                    "expected_preflight_revision": 1,
-                    "mode": mode,
-                },
-            }
-        )
-        revision += 1
-    return commands
-
-
-def require_rollout_state(
+def require_scheduler_engine_activation_chain(
+    harness: CaseHarness,
     snapshot: dict[str, Any],
-    expected_modes: dict[str, str],
+    *,
+    work_item_id: str,
+    expected_activation_count: int,
 ) -> None:
-    require(
-        snapshot["scheduler_protocol_config"]
-        and snapshot["scheduler_protocol_config"][0]["protocol_mode"]
-        == "authoritative",
-        f"scheduler protocol ceiling is not authoritative: "
-        f"{snapshot['scheduler_protocol_config']}",
-    )
-    preflights = snapshot["scheduler_rollout_preflights"]
-    require(
-        len(preflights) == 1
-        and preflights[0]["preflight_revision"] == 1
-        and preflights[0]["manifest_revision"] == 1
-        and preflights[0]["state"] == "consumed",
-        f"rollout preflight was not consumed exactly once: {preflights}",
-    )
-    require(
-        len(snapshot["scheduler_rollout_manifests"]) == 1
-        and snapshot["scheduler_rollout_manifests"][0]["manifest_revision"] == 1,
-        f"rollout manifest is missing or duplicated: "
-        f"{snapshot['scheduler_rollout_manifests']}",
-    )
-    authorities = {
-        row["scenario_class"]: row for row in snapshot["scheduler_scenario_authorities"]
-    }
-    for scenario_class, mode in expected_modes.items():
-        require(
-            authorities.get(scenario_class, {}).get("mode") == mode,
-            f"scenario {scenario_class} did not reach {mode}: {authorities}",
+    if harness.canonical_scheduler_enabled:
+        require_scheduler_activation_chain(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_id=work_item_id,
+            expected_activation_count=expected_activation_count,
         )
-        row = authorities[scenario_class]
-        if mode == "authoritative":
-            require(
-                row["manifest_revision"] == 1 and row["preflight_revision"] == 1,
-                f"authoritative scenario lacks rollout fence: {row}",
-            )
-        else:
-            require(
-                row["manifest_revision"] is None
-                and row["preflight_revision"] is None,
-                f"non-authoritative scenario retained authority fence: {row}",
-            )
+        return
+    activations = [
+        row
+        for row in snapshot["scheduler_activations"]
+        if row["work_item_id"] == work_item_id
+    ]
+    demands = [
+        row
+        for row in snapshot["scheduler_work_demands"]
+        if row["work_item_id"] == work_item_id
+    ]
     require(
-        all(
-            row["conflict_kind"] is None
-            for row in snapshot["scheduler_rollout_command_results"]
-        ),
-        f"rollout command chain contains conflicts: "
-        f"{snapshot['scheduler_rollout_command_results']}",
+        not activations and not demands,
+        f"legacy scheduler wrote canonical execution state: "
+        f"activations={activations}, demands={demands}",
+    )
+
+
+def require_scheduler_engine_wait_resolution(
+    harness: CaseHarness,
+    snapshot: dict[str, Any],
+    *,
+    work_item_id: str,
+    wait_ids: set[str],
+) -> None:
+    canonical_waits = [
+        row
+        for row in snapshot["scheduler_wait_generations"]
+        if row["wait_id"] in wait_ids or row["owner_work_item_id"] == work_item_id
+    ]
+    if harness.canonical_scheduler_enabled:
+        require(
+            len(canonical_waits) == len(wait_ids)
+            and all(row["lifecycle_state"] == "resolved" for row in canonical_waits),
+            f"canonical waits did not resolve exactly once: {canonical_waits}",
+        )
+        return
+    require(
+        not canonical_waits,
+        f"legacy scheduler wrote canonical wait generations: {canonical_waits}",
     )
 
 
@@ -1701,24 +1391,6 @@ def require_lifecycle_wait_adoption(
         },
         f"lifecycle adoption did not preserve wait ownership/generation: {adoption_rows}",
     )
-
-
-def require_scheduler_comparisons(
-    snapshot: dict[str, Any],
-    expected: dict[str, int],
-) -> None:
-    for scenario_class, minimum_count in expected.items():
-        rows = [
-            row
-            for row in snapshot["scheduler_shadow_comparisons"]
-            if row["scenario_class"] == scenario_class
-        ]
-        require(
-            len(rows) >= minimum_count
-            and all(row["comparison_outcome"] == "matched" for row in rows),
-            f"scheduler comparison evidence missing or divergent for "
-            f"{scenario_class}: {rows}",
-        )
 
 
 def find_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
@@ -2103,547 +1775,6 @@ def run_workitem_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     )
 
 
-def run_scheduler_protocol_case(harness: CaseHarness, case: dict[str, Any]) -> None:
-    harness.initialize_workspace()
-    harness.start()
-    marker = secrets.token_hex(4)
-    objective_marker = f"SCHEDULER-AUTONOMOUS-{marker}"
-    completion_marker = f"SCHEDULER-COMPLETE-{marker}"
-    objective = (
-        f"{objective_marker}. Complete this WorkItem only after the Runtime resumes it "
-        "through an autonomous work_queue SystemTick. On that autonomous turn, inspect "
-        "the exact current item with ListWorkItems using filter current and optionally "
-        "GetWorkItem, update both existing todos to completed, then emit a concise "
-        f"completion result containing {completion_marker} immediately followed by "
-        "CompleteWorkItem for that exact item. Do not wait for more operator input."
-    )
-
-    phase = case["phases"][0]
-    baseline, _ = harness.prompt(
-        "scheduler-autonomous",
-        phase["prompt"].format(
-            case_id=case["id"],
-            objective=json.dumps(objective, ensure_ascii=False),
-            objective_marker=objective_marker,
-            completion_marker=completion_marker,
-        ),
-    )
-    item = harness.wait_work_item(
-        objective_marker=objective_marker,
-        expected_state="completed",
-        label="scheduler-autonomous-completed",
-    )
-    required, forbidden = phase_tools(phase)
-    harness.assert_tools("scheduler-autonomous", baseline, required, forbidden)
-
-    items = harness.work_items("scheduler-autonomous-assert")
-    matches = [item for item in items if objective_marker in item["objective"]]
-    require(len(matches) == 1, f"expected one scheduler WorkItem: {matches}")
-    require(
-        matches[0]["id"] == item["id"],
-        f"scheduler WorkItem identity changed during completion: {matches}",
-    )
-    item = matches[0]
-    work_item_id = item["id"]
-    require(item["state"] == "completed", f"scheduler WorkItem not completed: {item}")
-    require(
-        len(item.get("todo_list", [])) == 2
-        and all(todo["state"] == "completed" for todo in item["todo_list"]),
-        f"scheduler WorkItem todos were not completed: {item}",
-    )
-    result_brief_id = item.get("result_brief_id")
-    require(
-        isinstance(result_brief_id, str) and result_brief_id,
-        f"scheduler WorkItem omitted result brief: {item}",
-    )
-    result_brief = harness.brief(result_brief_id, "scheduler-result")
-    require(
-        result_brief.get("work_item_id") == work_item_id
-        and completion_marker in (result_brief.get("text") or ""),
-        f"scheduler completion brief mismatch: {result_brief}",
-    )
-
-    harness.restart()
-    restarted_items = harness.work_items("scheduler-after-restart")
-    restarted = next(item for item in restarted_items if item["id"] == work_item_id)
-    require(
-        restarted["state"] == "completed"
-        and restarted.get("result_brief_id") == result_brief_id,
-        f"scheduler WorkItem identity did not survive restart: {restarted}",
-    )
-
-    snapshot = harness.runtime_db_snapshot("scheduler")
-    message_rows = [
-        row
-        for row in snapshot["messages"]
-        if row.get("work_item_id") == work_item_id
-        and "work_queue" in row.get("payload_json", "")
-        and (
-            "SystemTick" in row.get("payload_json", "")
-            or "system_tick" in row.get("payload_json", "")
-        )
-    ]
-    require(message_rows, "autonomous work_queue SystemTick evidence is missing")
-    message_ids = {row["message_id"] for row in message_rows}
-    # queue_entries is a message_id-keyed current-state view, so queued and
-    # dequeued are intentionally overwritten by the terminal processed row.
-    require_processed_queue_entries(snapshot["queue_entries"], message_ids)
-
-    demands = [
-        row
-        for row in snapshot["scheduler_work_demands"]
-        if row["work_item_id"] == work_item_id
-    ]
-    activations = [
-        row
-        for row in snapshot["scheduler_activations"]
-        if row["work_item_id"] == work_item_id
-    ]
-    activation_ids = {row["activation_id"] for row in activations}
-    settlements = [
-        row
-        for row in snapshot["scheduler_activation_settlements"]
-        if row["activation_id"] in activation_ids
-    ]
-    command_rows = [
-        row
-        for row in snapshot["scheduler_protocol_command_results"]
-        if row["command_identity"] == work_item_id
-        or any(
-            message_id in row["command_identity"] for message_id in message_ids
-        )
-    ]
-
-    require(
-        len(demands) == 1 and demands[0]["status"] == "terminal",
-        f"canonical demand did not settle terminal: {demands}",
-    )
-    require(
-        len(activations) == 1 and activations[0]["lifecycle_state"] == "settled",
-        f"canonical activation did not settle exactly once: {activations}",
-    )
-    require(
-        len(settlements) == 1,
-        f"canonical settlement is missing or duplicated: {settlements}",
-    )
-    slots = [
-        row
-        for row in snapshot["scheduler_agent_slots"]
-        if row["agent_id"] == harness.agent_id
-    ]
-    require(
-        len(slots) == 1
-        and slots[0]["slot_kind"] == "idle"
-        and slots[0]["activation_id"] is None,
-        f"canonical activation slot was not released: {slots}",
-    )
-    command_kinds = {row["command_kind"] for row in command_rows}
-    require(
-        {
-            "register_work_demand",
-            "issue_activation_authority",
-            "admit_activation",
-            "settle_activation",
-        }.issubset(command_kinds),
-        f"canonical command chain is incomplete: {command_rows}",
-    )
-    require(
-        all(row["conflict_kind"] is None for row in command_rows),
-        f"canonical command chain contains conflicts: {command_rows}",
-    )
-
-
-def run_scheduler_rollout_authoritative_case(
-    harness: CaseHarness, case: dict[str, Any]
-) -> None:
-    harness.initialize_workspace()
-    scenario_modes = {
-        "work_item_autonomous_continuation": "shadow",
-        "exact_task_rejoin": "shadow",
-        "exact_wait_resume": "shadow",
-        "settlement": "shadow",
-        "delivery": "shadow",
-    }
-    authoritative_modes = {
-        scenario_class: "authoritative" for scenario_class in scenario_modes
-    }
-    rejected = harness.reject_scheduler_rollout(
-        "scheduler-rollout-insufficient-evidence",
-        scheduler_incomplete_rollout_commands(authoritative_modes),
-    )
-    require(
-        "rejected" in rejected["stderr"].lower(),
-        f"insufficient rollout evidence did not report rejection: {rejected}",
-    )
-    rejected_snapshot = harness.runtime_db_snapshot(
-        "scheduler-rollout-insufficient-evidence"
-    )
-    require(
-        not rejected_snapshot["scheduler_rollout_preflights"]
-        and not rejected_snapshot["scheduler_rollout_manifests"]
-        and not rejected_snapshot["scheduler_rollout_command_results"],
-        "rejected rollout batch left partial canonical state",
-    )
-    harness.apply_scheduler_rollout(
-        "scheduler-rollout-shadow",
-        scheduler_rollout_commands(
-            scenario_modes,
-            approved_scenario_modes=authoritative_modes,
-        ),
-    )
-    harness.start()
-
-    shadow_marker = secrets.token_hex(4)
-    shadow_objective = f"SCHEDULER-SHADOW-WAIT-{shadow_marker}"
-    shadow_completion = f"SCHEDULER-SHADOW-COMPLETE-{shadow_marker}"
-    callback = harness.reset_callback("scheduler-shadow-callback")
-    shadow_phase = case["phases"][0]
-    baseline, _ = harness.prompt(
-        "scheduler-shadow-wait",
-        shadow_phase["prompt"].format(
-            case_id=case["id"],
-            objective=shadow_objective,
-            completion_marker=shadow_completion,
-        ),
-    )
-    waiting = harness.wait_work_item_scheduling_state(
-        objective_marker=shadow_objective,
-        expected_scheduling_state="waiting_external",
-        label="scheduler-shadow-waiting",
-    )
-    harness.fire_callback(
-        "scheduler-shadow-wake",
-        callback["trigger_url"],
-        {"case_id": case["id"], "marker": shadow_marker},
-    )
-    shadow_item = harness.wait_work_item(
-        objective_marker=shadow_objective,
-        expected_state="completed",
-        label="scheduler-shadow-completed",
-    )
-    required, forbidden = phase_tools(shadow_phase)
-    harness.assert_tools("scheduler-shadow-wait", baseline, required, forbidden)
-    require(
-        shadow_item["id"] == waiting["id"],
-        "shadow wait-resume changed WorkItem identity",
-    )
-    shadow_snapshot = harness.runtime_db_snapshot("scheduler-shadow")
-    shadow_comparisons = [
-        row
-        for row in shadow_snapshot["scheduler_shadow_comparisons"]
-        if row["scenario_class"] == "exact_wait_resume"
-    ]
-    require(
-        len(shadow_comparisons) == 1
-        and shadow_comparisons[0]["authority_mode"] == "shadow"
-        and shadow_comparisons[0]["comparison_outcome"] == "matched",
-        f"shadow wait-resume evidence is incomplete: {shadow_comparisons}",
-    )
-    require(
-        not shadow_snapshot["scheduler_activations"],
-        f"shadow mode unexpectedly acquired canonical execution ownership: "
-        f"{shadow_snapshot['scheduler_activations']}",
-    )
-
-    harness.stop()
-    first_authoritative_revision = 2 + len(scenario_modes)
-    harness.apply_scheduler_rollout(
-        "scheduler-rollout-authoritative",
-        scheduler_scenario_mode_commands(
-            authoritative_modes,
-            expected_config_revision=first_authoritative_revision,
-            identity_suffix="cutover",
-        ),
-    )
-    harness.start()
-
-    marker = secrets.token_hex(4)
-    objective_marker = f"SCHEDULER-AUTHORITATIVE-CONTINUATIONS-{marker}"
-    task_marker = f"SCHEDULER-TASK-RESULT-{marker}"
-    completion_marker = f"SCHEDULER-AUTHORITATIVE-COMPLETE-{marker}"
-    objective = (
-        f"{objective_marker}. This WorkItem must exercise two continuation boundaries. "
-        f"On the first autonomous work_queue turn, call ExecCommand with command "
-        f"`sleep 15; printf {task_marker}`, yield_time_ms=50, and a bounded output limit. "
-        "Use the returned promoted command task_id to call WaitFor with wake=task_result. "
-        "Do not poll the task and do not complete the WorkItem. On the task-result rejoin, "
-        "call GetWorkItem for the current WorkItem, then call WaitFor with wake=external, "
-        f"resource=docker-e2e:{marker}, and a concrete reason. Do not complete it yet. "
-        "On the later external wake, call GetWorkItem, update both existing todos to "
-        "completed, then emit a concise operator-facing completion report containing "
-        f"{completion_marker} immediately followed by CompleteWorkItem for the exact "
-        "current item. Do not create another WorkItem."
-    )
-    authoritative_phase = case["phases"][1]
-    baseline, _ = harness.prompt(
-        "scheduler-authoritative-seed",
-        authoritative_phase["prompt"].format(
-            case_id=case["id"],
-            objective=json.dumps(objective, ensure_ascii=False),
-            completion_marker=completion_marker,
-        ),
-    )
-    task_waiting = harness.wait_work_item_scheduling_state(
-        objective_marker=objective_marker,
-        expected_scheduling_state="waiting_task",
-        label="scheduler-authoritative-task-wait",
-    )
-    external_waiting = harness.wait_work_item_scheduling_state(
-        objective_marker=objective_marker,
-        expected_scheduling_state="waiting_external",
-        label="scheduler-authoritative-external-wait",
-    )
-    require(
-        external_waiting["id"] == task_waiting["id"],
-        "task-result rejoin changed WorkItem identity",
-    )
-    callback = harness.reset_callback("scheduler-authoritative-callback")
-    harness.fire_callback(
-        "scheduler-authoritative-wake",
-        callback["trigger_url"],
-        {"case_id": case["id"], "marker": marker},
-    )
-    item = harness.wait_work_item(
-        objective_marker=objective_marker,
-        expected_state="completed",
-        label="scheduler-authoritative-completed",
-    )
-    required, forbidden = phase_tools(authoritative_phase)
-    harness.assert_tools(
-        "scheduler-authoritative-seed", baseline, required, forbidden
-    )
-    work_item_id = item["id"]
-    result_brief_id = item.get("result_brief_id")
-    require(
-        isinstance(result_brief_id, str) and result_brief_id,
-        f"authoritative WorkItem omitted result brief: {item}",
-    )
-    result_brief = harness.brief(result_brief_id, "scheduler-authoritative-result")
-    require(
-        result_brief.get("work_item_id") == work_item_id
-        and completion_marker in (result_brief.get("text") or ""),
-        f"authoritative completion brief mismatch: {result_brief}",
-    )
-
-    snapshot = harness.runtime_db_snapshot("scheduler-authoritative")
-    require_rollout_state(snapshot, authoritative_modes)
-    activation_rows = [
-        row
-        for row in snapshot["scheduler_activations"]
-        if row["work_item_id"] == work_item_id
-    ]
-    message_ids = {
-        json.loads(row["payload_json"])["activation"]["provenance"]["source_id"]
-        for row in activation_rows
-    }
-    scheduler_messages = [
-        row for row in snapshot["messages"] if row["message_id"] in message_ids
-    ]
-    require(
-        len(activation_rows) == 3
-        and len(message_ids) == 3
-        and len(scheduler_messages) == 3,
-        f"expected autonomous, task-result, and wait-resume messages: {scheduler_messages}",
-    )
-    require_processed_queue_entries(snapshot["queue_entries"], message_ids)
-    turns = require_turns_terminal(snapshot, message_ids)
-    activations = require_scheduler_activation_chain(
-        snapshot,
-        agent_id=harness.agent_id,
-        work_item_id=work_item_id,
-        expected_activation_count=3,
-    )
-    demand = [
-        row
-        for row in snapshot["scheduler_work_demands"]
-        if row["work_item_id"] == work_item_id
-    ]
-    require(
-        len(demand) == 1
-        and demand[0]["status"] == "terminal"
-        and demand[0]["scheduling_generation"]
-        == max(row["admitted_generation"] for row in activations) + 1,
-        f"canonical WorkItem demand did not converge at the final generation: {demand}",
-    )
-    final_turn_id = result_brief.get("turn_id")
-    final_message_id = result_brief.get("related_message_id")
-    require(
-        any(
-            row["turn_id"] == final_turn_id
-            and row["trigger_message_id"] == final_message_id
-            for row in turns
-        ),
-        f"result brief was not bound to the terminal continuation turn: {result_brief}",
-    )
-    brief_rows = [
-        row for row in snapshot["briefs"] if row["evidence_id"] == result_brief_id
-    ]
-    require(
-        len(brief_rows) == 1
-        and brief_rows[0]["work_item_id"] == work_item_id
-        and brief_rows[0]["turn_id"] == final_turn_id
-        and brief_rows[0]["message_id"] == final_message_id,
-        f"database result brief binding is not exact: {brief_rows}",
-    )
-    waits = [
-        row
-        for row in snapshot["wait_conditions"]
-        if row["work_item_id"] == work_item_id
-    ]
-    require(
-        len(waits) == 2
-        and {row["kind"] for row in waits} == {"task", "external"}
-        and {
-            row["kind"]: row["status"]
-            for row in waits
-        }
-        == {"task": "resolved", "external": "cancelled"},
-        f"legacy task/external waits did not reach their terminal states: {waits}",
-    )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["owner_work_item_id"] == work_item_id
-    ]
-    require(
-        len(canonical_waits) == 2
-        and all(row["lifecycle_state"] == "resolved" for row in canonical_waits)
-        and all(row["consuming_activation_id"] is None for row in canonical_waits),
-        f"canonical task/external waits did not resolve exactly once: {canonical_waits}",
-    )
-    require_scheduler_comparisons(
-        snapshot,
-        {
-            "work_item_autonomous_continuation": 1,
-            "exact_task_rejoin": 1,
-            "exact_wait_resume": 1,
-            "settlement": 3,
-            "delivery": 3,
-        },
-    )
-
-    harness.stop()
-    rollback_revision = first_authoritative_revision + len(authoritative_modes)
-    harness.apply_scheduler_rollout(
-        "scheduler-rollout-rollback",
-        scheduler_scenario_mode_commands(
-            {"work_item_autonomous_continuation": "shadow"},
-            expected_config_revision=rollback_revision,
-            identity_suffix="rollback",
-        ),
-    )
-    harness.start()
-    restarted = harness.work_items("scheduler-authoritative-after-rollback")
-    restored = next(candidate for candidate in restarted if candidate["id"] == work_item_id)
-    require(
-        restored["state"] == "completed"
-        and restored.get("result_brief_id") == result_brief_id,
-        f"rollback/restart changed completed WorkItem identity: {restored}",
-    )
-    rollback_snapshot = harness.runtime_db_snapshot("scheduler-rollback")
-    expected_after_rollback = dict(authoritative_modes)
-    expected_after_rollback["work_item_autonomous_continuation"] = "shadow"
-    require_rollout_state(rollback_snapshot, expected_after_rollback)
-    require_scheduler_activation_chain(
-        rollback_snapshot,
-        agent_id=harness.agent_id,
-        work_item_id=work_item_id,
-        expected_activation_count=3,
-    )
-
-
-def run_scheduler_terminal_recovery_case(
-    harness: CaseHarness, case: dict[str, Any]
-) -> None:
-    scenario_modes = {
-        "work_item_autonomous_continuation": "authoritative",
-        "settlement": "authoritative",
-    }
-    harness.apply_scheduler_rollout(
-        "scheduler-recovery-rollout",
-        scheduler_rollout_commands(scenario_modes),
-    )
-    objective = f"SCHEDULER-TERMINAL-RECOVERY-{secrets.token_hex(4)}"
-    fixture = harness.seed_scheduler_recovery_fixture(
-        "scheduler-terminal-recovery-fixture",
-        objective,
-    )
-    harness.start(wait_idle=False)
-    deadline = time.monotonic() + harness.timeout_seconds
-    recovered = False
-    while time.monotonic() < deadline:
-        recovered = any(
-            event["type"] == "scheduler_bootstrap_claim_recovered"
-            and event["payload"].get("message_id") == fixture["message_id"]
-            for event in harness.events("scheduler-recovery-poll")
-        )
-        if recovered:
-            break
-        time.sleep(1)
-    require(recovered, "serve bootstrap did not reconcile the recovery fixture")
-    first = harness.runtime_db_snapshot("scheduler-recovery-first")
-    require_rollout_state(first, scenario_modes)
-    require_processed_queue_entries(first["queue_entries"], {fixture["message_id"]})
-    require_turns_terminal(first, {fixture["message_id"]})
-    activations = require_scheduler_activation_chain(
-        first,
-        agent_id=fixture["agent_id"],
-        work_item_id=fixture["work_item_id"],
-        expected_activation_count=1,
-    )
-    require(
-        activations[0]["activation_id"] == fixture["activation_id"]
-        and activations[0]["admitted_generation"] == fixture["admitted_generation"],
-        f"recovery changed activation identity or generation: {activations}",
-    )
-    work_items = [
-        row
-        for row in first["work_items"]
-        if row["work_item_id"] == fixture["work_item_id"]
-    ]
-    require(
-        len(work_items) == 1 and work_items[0]["state"] == "open",
-        f"recovery fixture WorkItem disposition changed unexpectedly: {work_items}",
-    )
-    demands = [
-        row
-        for row in first["scheduler_work_demands"]
-        if row["work_item_id"] == fixture["work_item_id"]
-    ]
-    require(
-        len(demands) == 1
-        and demands[0]["status"] == "runnable"
-        and demands[0]["scheduling_generation"]
-        == fixture["admitted_generation"] + 1,
-        f"terminal recovery did not advance the successor WorkItem generation: {demands}",
-    )
-    require(
-        not first["scheduler_missing_settlements"],
-        f"terminal recovery produced missing-settlement evidence: "
-        f"{first['scheduler_missing_settlements']}",
-    )
-
-    harness.restart(wait_idle=False)
-    second = harness.runtime_db_snapshot("scheduler-recovery-second")
-    require(
-        second["queue_entries"] == first["queue_entries"]
-        and second["scheduler_activations"] == first["scheduler_activations"]
-        and second["scheduler_activation_settlements"]
-        == first["scheduler_activation_settlements"]
-        and second["scheduler_missing_settlements"]
-        == first["scheduler_missing_settlements"]
-        and second["scheduler_work_demands"] == first["scheduler_work_demands"]
-        and second["scheduler_agent_slots"] == first["scheduler_agent_slots"]
-        and second["scheduler_wait_generations"]
-        == first["scheduler_wait_generations"]
-        and second["scheduler_protocol_command_results"]
-        == first["scheduler_protocol_command_results"]
-        and second["turn_records"] == first["turn_records"]
-        and second["audit_events"] == first["audit_events"],
-        "second restart changed reconciled scheduler state",
-    )
-
-
 def work_queue_message_evidence(
     snapshot: dict[str, Any],
     *,
@@ -2672,6 +1803,144 @@ def work_queue_message_evidence(
             }
         )
     return evidence
+
+
+def run_scheduler_task_wait_resume_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    harness.initialize_workspace()
+    harness.start()
+    marker = secrets.token_hex(4)
+    objective_marker = f"SCHEDULER-TASK-WAIT-{marker}"
+    task_marker = f"SCHEDULER-TASK-RESULT-{marker}"
+    completion_marker = f"SCHEDULER-TASK-WAIT-COMPLETE-{marker}"
+    objective = (
+        f"{objective_marker}. On the first autonomous work_queue turn, call "
+        f"ExecCommand with command `sleep 15; printf {task_marker}`, "
+        "yield_time_ms=50, and a bounded output limit. Use the returned promoted "
+        "task_id to call WaitFor with wake=task_result. Do not poll the task or "
+        "complete the WorkItem. On the task-result rejoin, call GetWorkItem for "
+        "the current WorkItem, then call WaitFor with wake=external, "
+        f"resource=docker-e2e:{marker}, and a concrete reason. On the external "
+        "wake, call GetWorkItem, update both existing todos to completed, then "
+        "emit a concise completion result containing "
+        f"{completion_marker} immediately followed by CompleteWorkItem for the "
+        "exact current item. Do not create another WorkItem."
+    )
+    phase = case["phases"][0]
+    baseline, _ = harness.prompt(
+        "scheduler-task-wait-seed",
+        phase["prompt"].format(
+            case_id=case["id"],
+            objective=json.dumps(objective, ensure_ascii=False),
+            completion_marker=completion_marker,
+        ),
+    )
+    task_waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=objective_marker,
+        expected_scheduling_state="waiting_task",
+        label="scheduler-task-wait-task",
+    )
+    external_waiting = harness.wait_work_item_scheduling_state(
+        objective_marker=objective_marker,
+        expected_scheduling_state="waiting_external",
+        label="scheduler-task-wait-external",
+    )
+    require(
+        external_waiting["id"] == task_waiting["id"],
+        "task-result rejoin changed WorkItem identity",
+    )
+    callback = harness.reset_callback("scheduler-task-wait-callback")
+    harness.fire_callback(
+        "scheduler-task-wait-wake",
+        callback["trigger_url"],
+        {"case_id": case["id"], "marker": marker},
+    )
+    item = harness.wait_work_item(
+        objective_marker=objective_marker,
+        expected_state="completed",
+        label="scheduler-task-wait-completed",
+    )
+    required, forbidden = phase_tools(phase)
+    harness.assert_tools("scheduler-task-wait-seed", baseline, required, forbidden)
+    work_item_id = item["id"]
+    result_brief_id = item.get("result_brief_id")
+    require(
+        isinstance(result_brief_id, str) and result_brief_id,
+        f"task/wait WorkItem omitted result brief: {item}",
+    )
+    result_brief = harness.brief(result_brief_id, "scheduler-task-wait-result")
+    require(
+        result_brief.get("work_item_id") == work_item_id
+        and completion_marker in (result_brief.get("text") or ""),
+        f"task/wait completion brief mismatch: {result_brief}",
+    )
+
+    snapshot = harness.runtime_db_snapshot("scheduler-task-wait")
+    turns = [
+        row
+        for row in snapshot["turn_records"]
+        if row.get("current_work_item_id") == work_item_id
+        and row.get("terminal_kind") == "completed"
+    ]
+    message_ids = {row["trigger_message_id"] for row in turns}
+    require(
+        len(turns) == 3 and None not in message_ids,
+        f"expected autonomous, task-result, and external-wake turns: {turns}",
+    )
+    require_processed_queue_entries(snapshot["queue_entries"], message_ids)
+    final_turn_id = result_brief.get("turn_id")
+    final_message_id = result_brief.get("related_message_id")
+    require(
+        any(
+            row["turn_id"] == final_turn_id
+            and row["trigger_message_id"] == final_message_id
+            for row in turns
+        ),
+        f"result brief was not bound to the terminal continuation turn: {result_brief}",
+    )
+    brief_rows = [
+        row for row in snapshot["briefs"] if row["evidence_id"] == result_brief_id
+    ]
+    require(
+        len(brief_rows) == 1
+        and brief_rows[0]["work_item_id"] == work_item_id
+        and brief_rows[0]["turn_id"] == final_turn_id
+        and brief_rows[0]["message_id"] == final_message_id,
+        f"database result brief binding is not exact: {brief_rows}",
+    )
+    require_scheduler_engine_activation_chain(
+        harness,
+        snapshot,
+        work_item_id=work_item_id,
+        expected_activation_count=3,
+    )
+    waits = [
+        row
+        for row in snapshot["wait_conditions"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(waits) == 2
+        and {row["kind"] for row in waits} == {"task", "external"}
+        and {row["kind"]: row["status"] for row in waits}
+        == {"task": "resolved", "external": "cancelled"},
+        f"task/external waits did not reach terminal states: {waits}",
+    )
+    require_scheduler_engine_wait_resolution(
+        harness,
+        snapshot,
+        work_item_id=work_item_id,
+        wait_ids={wait["wait_condition_id"] for wait in waits},
+    )
+    harness.restart()
+    restarted_items = harness.work_items("scheduler-task-wait-after-restart")
+    restarted = next(item for item in restarted_items if item["id"] == work_item_id)
+    require(
+        restarted["state"] == "completed"
+        and restarted.get("result_brief_id") == result_brief_id,
+        f"task/wait WorkItem did not survive restart: {restarted}",
+    )
 
 
 def run_scheduler_provider_failure_retry_case(
@@ -2893,22 +2162,23 @@ def run_scheduler_multi_workitem_case(
         )
     snapshot = harness.runtime_db_snapshot("scheduler-multi")
     for wid in (work_item_a_id, work_item_b_id):
-        require_scheduler_activation_chain(
+        require_scheduler_engine_activation_chain(
+            harness,
             snapshot,
-            agent_id=harness.agent_id,
             work_item_id=wid,
             expected_activation_count=1,
         )
-    demands = [
-        row
-        for row in snapshot["scheduler_work_demands"]
-        if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-    ]
-    require(
-        len(demands) == 2
-        and all(d["status"] == "terminal" for d in demands),
-        f"multi-WorkItem demands did not converge: {demands}",
-    )
+    if harness.canonical_scheduler_enabled:
+        demands = [
+            row
+            for row in snapshot["scheduler_work_demands"]
+            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
+        ]
+        require(
+            len(demands) == 2
+            and all(d["status"] == "terminal" for d in demands),
+            f"multi-WorkItem demands did not converge: {demands}",
+        )
     harness.restart()
     restarted_items = harness.work_items("scheduler-multi-after-restart")
     for wid, brief_id in (
@@ -2983,9 +2253,9 @@ def run_scheduler_external_wait_resume_case(
         f"external wait completion brief mismatch: {result_brief}",
     )
     snapshot = harness.runtime_db_snapshot("scheduler-external")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
         expected_activation_count=1,
     )
@@ -3000,21 +2270,18 @@ def run_scheduler_external_wait_resume_case(
         and waits[0]["status"] == "resolved",
         f"external wait condition did not resolve: {waits}",
     )
-    require_lifecycle_wait_adoption(
+    if harness.canonical_scheduler_enabled:
+        require_lifecycle_wait_adoption(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_id=work_item_id,
+            wait=waits[0],
+        )
+    require_scheduler_engine_wait_resolution(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
-        wait=waits[0],
-    )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["wait_id"] in {w["wait_condition_id"] for w in waits}
-    ]
-    require(
-        len(canonical_waits) == 1
-        and canonical_waits[0]["lifecycle_state"] == "resolved",
-        f"canonical external wait did not resolve: {canonical_waits}",
+        wait_ids={wait["wait_condition_id"] for wait in waits},
     )
 
 
@@ -3077,9 +2344,9 @@ def run_scheduler_operator_wait_resume_case(
         f"operator wait completion brief mismatch: {result_brief}",
     )
     snapshot = harness.runtime_db_snapshot("scheduler-operator")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
         expected_activation_count=1,
     )
@@ -3094,21 +2361,18 @@ def run_scheduler_operator_wait_resume_case(
         and waits[0]["status"] == "resolved",
         f"operator wait condition did not resolve: {waits}",
     )
-    require_lifecycle_wait_adoption(
+    if harness.canonical_scheduler_enabled:
+        require_lifecycle_wait_adoption(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_id=work_item_id,
+            wait=waits[0],
+        )
+    require_scheduler_engine_wait_resolution(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
-        wait=waits[0],
-    )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["wait_id"] in {w["wait_condition_id"] for w in waits}
-    ]
-    require(
-        len(canonical_waits) == 1
-        and canonical_waits[0]["lifecycle_state"] == "resolved",
-        f"canonical operator wait did not resolve: {canonical_waits}",
+        wait_ids={wait["wait_condition_id"] for wait in waits},
     )
 
 
@@ -3206,15 +2470,15 @@ def run_scheduler_concurrent_claim_fencing_case(
             f"WorkItem {letter} brief mismatch: {brief}",
         )
     snapshot = harness.runtime_db_snapshot("scheduler-concurrent")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_a_id,
         expected_activation_count=2,
     )
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_b_id,
         expected_activation_count=1,
     )
@@ -3229,26 +2493,23 @@ def run_scheduler_concurrent_claim_fencing_case(
         and waits[0]["status"] == "resolved",
         f"concurrent external wait did not resolve: {waits}",
     )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["owner_work_item_id"] == work_item_a_id
-    ]
-    require(
-        len(canonical_waits) == 1
-        and canonical_waits[0]["lifecycle_state"] == "resolved",
-        f"canonical external wait did not resolve: {canonical_waits}",
+    require_scheduler_engine_wait_resolution(
+        harness,
+        snapshot,
+        work_item_id=work_item_a_id,
+        wait_ids={wait["wait_condition_id"] for wait in waits},
     )
-    demands = [
-        row
-        for row in snapshot["scheduler_work_demands"]
-        if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-    ]
-    require(
-        len(demands) == 2
-        and all(d["status"] == "terminal" for d in demands),
-        f"concurrent demands did not converge: {demands}",
-    )
+    if harness.canonical_scheduler_enabled:
+        demands = [
+            row
+            for row in snapshot["scheduler_work_demands"]
+            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
+        ]
+        require(
+            len(demands) == 2
+            and all(d["status"] == "terminal" for d in demands),
+            f"concurrent demands did not converge: {demands}",
+        )
     harness.restart()
     restarted_items = harness.work_items("scheduler-concurrent-after-restart")
     for wid, brief_id in (
@@ -3355,15 +2616,15 @@ def run_scheduler_operator_interject_during_wait_case(
             f"WorkItem {letter} brief mismatch: {brief}",
         )
     snapshot = harness.runtime_db_snapshot("scheduler-interject")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_a_id,
         expected_activation_count=2,
     )
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_b_id,
         expected_activation_count=1,
     )
@@ -3378,26 +2639,23 @@ def run_scheduler_operator_interject_during_wait_case(
         and waits[0]["status"] == "resolved",
         f"interject operator wait did not resolve: {waits}",
     )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["owner_work_item_id"] == work_item_a_id
-    ]
-    require(
-        len(canonical_waits) == 1
-        and canonical_waits[0]["lifecycle_state"] == "resolved",
-        f"canonical operator wait did not resolve: {canonical_waits}",
+    require_scheduler_engine_wait_resolution(
+        harness,
+        snapshot,
+        work_item_id=work_item_a_id,
+        wait_ids={wait["wait_condition_id"] for wait in waits},
     )
-    demands = [
-        row
-        for row in snapshot["scheduler_work_demands"]
-        if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-    ]
-    require(
-        len(demands) == 2
-        and all(d["status"] == "terminal" for d in demands),
-        f"interject demands did not converge: {demands}",
-    )
+    if harness.canonical_scheduler_enabled:
+        demands = [
+            row
+            for row in snapshot["scheduler_work_demands"]
+            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
+        ]
+        require(
+            len(demands) == 2
+            and all(d["status"] == "terminal" for d in demands),
+            f"interject demands did not converge: {demands}",
+        )
     harness.restart()
     restarted_items = harness.work_items("scheduler-interject-after-restart")
     for wid, brief_id in (
@@ -3471,9 +2729,9 @@ def run_scheduler_compaction_continuity_case(
         f"compaction completion brief mismatch: {result_brief}",
     )
     snapshot = harness.runtime_db_snapshot("scheduler-compaction")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
         expected_activation_count=2,
     )
@@ -3498,15 +2756,11 @@ def run_scheduler_compaction_continuity_case(
         and waits[0]["status"] == "resolved",
         f"compaction operator wait did not resolve: {waits}",
     )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["owner_work_item_id"] == work_item_id
-    ]
-    require(
-        len(canonical_waits) == 1
-        and canonical_waits[0]["lifecycle_state"] == "resolved",
-        f"canonical compaction wait did not resolve: {canonical_waits}",
+    require_scheduler_engine_wait_resolution(
+        harness,
+        snapshot,
+        work_item_id=work_item_id,
+        wait_ids={wait["wait_condition_id"] for wait in waits},
     )
     harness.restart()
     restarted_items = harness.work_items("scheduler-compaction-after-restart")
@@ -3592,9 +2846,9 @@ def run_scheduler_worktree_isolation_case(
         f"managed worktree was not removed cleanly:\n{worktrees}",
     )
     snapshot = harness.runtime_db_snapshot("scheduler-worktree")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
         expected_activation_count=1,
     )
@@ -3673,9 +2927,9 @@ def run_scheduler_spawn_agent_supervision_case(
         f"SpawnAgent result missing task_id: {spawn_result}",
     )
     snapshot = harness.runtime_db_snapshot("scheduler-spawn")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_id,
         expected_activation_count=1,
     )
@@ -3790,15 +3044,15 @@ def run_scheduler_checkpoint_replay_case(
             f"WorkItem {letter} brief mismatch: {brief}",
         )
     snapshot = harness.runtime_db_snapshot("scheduler-replay")
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_a_id,
         expected_activation_count=2,
     )
-    require_scheduler_activation_chain(
+    require_scheduler_engine_activation_chain(
+        harness,
         snapshot,
-        agent_id=harness.agent_id,
         work_item_id=work_item_b_id,
         expected_activation_count=1,
     )
@@ -3813,26 +3067,23 @@ def run_scheduler_checkpoint_replay_case(
         and waits[0]["status"] == "resolved",
         f"replay external wait did not resolve: {waits}",
     )
-    canonical_waits = [
-        row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["owner_work_item_id"] == work_item_a_id
-    ]
-    require(
-        len(canonical_waits) == 1
-        and canonical_waits[0]["lifecycle_state"] == "resolved",
-        f"canonical replay wait did not resolve: {canonical_waits}",
+    require_scheduler_engine_wait_resolution(
+        harness,
+        snapshot,
+        work_item_id=work_item_a_id,
+        wait_ids={wait["wait_condition_id"] for wait in waits},
     )
-    demands = [
-        row
-        for row in snapshot["scheduler_work_demands"]
-        if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-    ]
-    require(
-        len(demands) == 2
-        and all(d["status"] == "terminal" for d in demands),
-        f"replay demands did not converge: {demands}",
-    )
+    if harness.canonical_scheduler_enabled:
+        demands = [
+            row
+            for row in snapshot["scheduler_work_demands"]
+            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
+        ]
+        require(
+            len(demands) == 2
+            and all(d["status"] == "terminal" for d in demands),
+            f"replay demands did not converge: {demands}",
+        )
 
 
 
@@ -3841,13 +3092,7 @@ CASE_RUNNERS = {
     "memory-agent-home-persistence": run_memory_case,
     "workspace-restart-lifecycle": run_workspace_case,
     "workitem-wait-restart-complete": run_workitem_case,
-    "scheduler-autonomous-authoritative": run_scheduler_protocol_case,
-    "scheduler-rollout-authoritative-autonomous": (
-        run_scheduler_rollout_authoritative_case
-    ),
-    "scheduler-terminal-before-settlement-restart": (
-        run_scheduler_terminal_recovery_case
-    ),
+    "scheduler-task-wait-resume": run_scheduler_task_wait_resume_case,
     "scheduler-provider-failure-work-queue-retry": (
         run_scheduler_provider_failure_retry_case
     ),
@@ -3865,6 +3110,11 @@ CASE_RUNNERS = {
 
 def validate_manifest(manifest: dict[str, Any]) -> None:
     require(manifest.get("version") == 2, "manifest version must be 2")
+    fixture_corpus_revision = manifest.get("scheduler_fixture_corpus_revision")
+    require(
+        isinstance(fixture_corpus_revision, str) and fixture_corpus_revision,
+        "scheduler_fixture_corpus_revision must be non-empty",
+    )
     cases = manifest.get("cases")
     require(isinstance(cases, list) and cases, "manifest cases must be non-empty")
     seen: set[str] = set()
@@ -3894,6 +3144,10 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             )
         runtime_env = case.get("runtime_env", {})
         require(isinstance(runtime_env, dict), f"{case_id} runtime_env must be an object")
+        require(
+            "HOLON_SCHEDULER" not in runtime_env,
+            f"{case_id} must leave HOLON_SCHEDULER to the process matrix",
+        )
         require(
             all(
                 isinstance(name, str)
@@ -3952,6 +3206,20 @@ def select_cases(
         ]
     require(selected, "case selection is empty")
     return selected
+
+
+def expand_case_matrix(
+    cases: list[dict[str, Any]], *, scheduler_matrix: bool
+) -> list[tuple[dict[str, Any], str | None]]:
+    return [
+        (case, engine)
+        for case in cases
+        for engine in (
+            SCHEDULER_ENGINES
+            if scheduler_matrix and "scheduler" in case.get("tags", [])
+            else (None,)
+        )
+    ]
 
 
 def parse_env_file(path: Path) -> dict[str, str]:
@@ -4060,6 +3328,122 @@ def collect_case_metrics(evidence: Path) -> dict[str, Any]:
     }
 
 
+def collect_case_schema_revision(evidence: Path) -> int | None:
+    revisions = set()
+    for path in evidence.glob("*-runtime-db.json"):
+        try:
+            value = json.loads(path.read_text()).get("schema_revision")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(value, int):
+            revisions.add(value)
+    require(
+        len(revisions) <= 1,
+        f"runtime schema revision changed during case {evidence.name}: {revisions}",
+    )
+    return next(iter(revisions), None)
+
+
+def scheduler_acceptance_report(
+    *,
+    run_record: dict[str, Any],
+    case_results: list[dict[str, Any]],
+    fixture_corpus_revision: str,
+) -> dict[str, Any]:
+    scheduler_results = [
+        result
+        for result in case_results
+        if result.get("scheduler_engine") in SCHEDULER_ENGINES
+    ]
+    expected_cases = {result["base_id"] for result in scheduler_results}
+    engines = []
+    all_revisions = set()
+    diagnostics = []
+    for engine in SCHEDULER_ENGINES:
+        results = [
+            result for result in scheduler_results if result["scheduler_engine"] == engine
+        ]
+        actual_cases = {result["base_id"] for result in results}
+        matrix_complete = (
+            actual_cases == expected_cases and len(results) == len(expected_cases)
+        )
+        revisions = {
+            result["schema_revision"]
+            for result in results
+            if result.get("schema_revision") is not None
+        }
+        schema_complete = len(revisions) == 1 and all(
+            result.get("schema_revision") in revisions for result in results
+        )
+        if not matrix_complete:
+            diagnostics.append(
+                {
+                    "code": "engine_case_matrix_incomplete",
+                    "engine": engine,
+                    "missing_cases": sorted(expected_cases - actual_cases),
+                    "extra_cases": sorted(actual_cases - expected_cases),
+                }
+            )
+        if not schema_complete:
+            diagnostics.append(
+                {
+                    "code": "engine_schema_revision_invalid",
+                    "engine": engine,
+                    "schema_revisions": sorted(revisions),
+                }
+            )
+        all_revisions.update(revisions)
+        engines.append(
+            {
+                "engine": engine,
+                "status": (
+                    "pass"
+                    if results
+                    and matrix_complete
+                    and schema_complete
+                    and all(result["status"] == "pass" for result in results)
+                    else "fail"
+                ),
+                "schema_revision": next(iter(revisions), None),
+                "cases": [
+                    {
+                        "id": result["base_id"],
+                        "status": result["status"],
+                        "evidence_id": result["id"],
+                    }
+                    for result in results
+                ],
+            }
+        )
+    if len(all_revisions) != 1:
+        diagnostics.append(
+            {
+                "code": "scheduler_schema_revision_mismatch",
+                "schema_revisions": sorted(all_revisions),
+            }
+        )
+    return {
+        "schema_version": SCHEDULER_ACCEPTANCE_REPORT_SCHEMA_VERSION,
+        "status": (
+            "pass"
+            if scheduler_results
+            and not diagnostics
+            and all(engine["status"] == "pass" for engine in engines)
+            else "fail"
+        ),
+        "git_sha": run_record["git_sha"],
+        "runtime_schema_revision": (
+            next(iter(all_revisions)) if len(all_revisions) == 1 else None
+        ),
+        "image": run_record["image"],
+        "image_digest": run_record["image_digest"],
+        "fixture_corpus_revision": fixture_corpus_revision,
+        "manifest_sha256": run_record["manifest_sha256"],
+        "engines": engines,
+        "diagnostics": diagnostics,
+    }
+
+
 def write_junit(path: Path, cases: list[dict[str, Any]], duration: float) -> None:
     suite = ElementTree.Element(
         "testsuite",
@@ -4101,6 +3485,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--evidence-dir", type=Path)
     parser.add_argument("--keep-on-failure", action="store_true")
+    parser.add_argument("--scheduler-matrix", action="store_true")
     parser.add_argument("--list", action="store_true")
     parser.add_argument("--validate-manifest", action="store_true")
     return parser.parse_args(argv)
@@ -4126,6 +3511,11 @@ def main(argv: list[str] | None = None) -> int:
         suite=args.suite,
         tags=args.tag,
     )
+    if args.scheduler_matrix:
+        require(
+            any("scheduler" in case.get("tags", []) for case in selected),
+            "--scheduler-matrix requires at least one scheduler-tagged case",
+        )
     requires_model = any(case.get("requires_model", True) for case in selected)
     model = args.model or first_env(
         "HOLON_E2E_MODEL", "HOLON_LIVE_MODEL", default=DEFAULT_MODEL
@@ -4181,11 +3571,16 @@ def main(argv: list[str] | None = None) -> int:
     started_monotonic = time.monotonic()
     git_sha = run(["git", "rev-parse", "HEAD"]).stdout.strip()
     identity = image_identity(image)
+    image_digest = (
+        args.image_digest
+        or next(iter(identity.get("repo_digests") or []), None)
+    )
     run_record = {
         "schema_version": EVIDENCE_SCHEMA_VERSION,
         "started_at": started_at,
         "git_sha": git_sha,
         "image": identity,
+        "image_digest": image_digest,
         "previous_image": args.previous_image,
         "model_route": model,
         "suite": args.suite,
@@ -4193,6 +3588,7 @@ def main(argv: list[str] | None = None) -> int:
         "credential_env_names": credential_envs,
         "env_file_used": env_file is not None,
         "manifest_sha256": hashlib.sha256(args.manifest.read_bytes()).hexdigest(),
+        "scheduler_matrix": args.scheduler_matrix,
     }
     write_json(evidence_root / "run.json", run_record)
 
@@ -4204,18 +3600,31 @@ def main(argv: list[str] | None = None) -> int:
     )
     case_results: list[dict[str, Any]] = []
     control_tokens: list[str] = []
-    for case in selected:
+    expanded_cases = expand_case_matrix(
+        selected,
+        scheduler_matrix=args.scheduler_matrix,
+    )
+    for case, scheduler_engine in expanded_cases:
         case_id = case["id"]
+        evidence_id = (
+            f"{case_id}-{scheduler_engine}" if scheduler_engine is not None else case_id
+        )
         case_started = time.monotonic()
-        print(f"Running {case_id} with {model}")
+        engine_suffix = (
+            f" using scheduler={scheduler_engine}" if scheduler_engine else ""
+        )
+        print(f"Running {case_id} with {model}{engine_suffix}")
+        runtime_env = dict(case.get("runtime_env", {}))
+        if scheduler_engine is not None:
+            runtime_env["HOLON_SCHEDULER"] = scheduler_engine
         harness = CaseHarness(
-            case_id=case_id,
+            case_id=evidence_id,
             image=image,
             model=model,
             requires_model=case.get("requires_model", True),
             credential_envs=credential_envs,
             env_file=env_file,
-            runtime_env=dict(case.get("runtime_env", {})),
+            runtime_env=runtime_env,
             evidence_root=evidence_root,
             timeout_seconds=(
                 int(timeout_override)
@@ -4256,7 +3665,9 @@ def main(argv: list[str] | None = None) -> int:
                     else f"cleanup failed: {cleanup_error}"
                 )
         result = {
-            "id": case_id,
+            "id": evidence_id,
+            "base_id": case_id,
+            "scheduler_engine": scheduler_engine,
             "tier": case["tier"],
             "tags": case.get("tags", []),
             "status": status,
@@ -4264,6 +3675,7 @@ def main(argv: list[str] | None = None) -> int:
             "duration_seconds": round(time.monotonic() - case_started, 3),
             "cleanup": cleanup_result["status"],
             "cleanup_errors": cleanup_result["errors"],
+            "schema_revision": collect_case_schema_revision(harness.evidence),
             **collect_case_metrics(harness.evidence),
         }
         write_json(harness.evidence / "case.json", result)
@@ -4301,6 +3713,13 @@ def main(argv: list[str] | None = None) -> int:
         "secret_scan": scan["status"],
     }
     write_json(evidence_root / "summary.json", summary)
+    if args.scheduler_matrix:
+        report = scheduler_acceptance_report(
+            run_record=run_record,
+            case_results=case_results,
+            fixture_corpus_revision=manifest["scheduler_fixture_corpus_revision"],
+        )
+        write_json(evidence_root / "scheduler-acceptance-report.json", report)
     write_junit(evidence_root / "junit.xml", case_results, duration)
 
     print(f"Evidence: {evidence_root}")

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -1237,7 +1237,8 @@ def require_scheduler_engine_wait_resolution(
     if harness.canonical_scheduler_enabled:
         require(
             len(canonical_waits) == len(wait_ids)
-            and all(row["lifecycle_state"] == "resolved" for row in canonical_waits),
+            and all(row["lifecycle_state"] == "resolved" for row in canonical_waits)
+            and all(row["consuming_activation_id"] is None for row in canonical_waits),
             f"canonical waits did not resolve exactly once: {canonical_waits}",
         )
         return
@@ -1245,23 +1246,6 @@ def require_scheduler_engine_wait_resolution(
         not canonical_waits,
         f"legacy scheduler wrote canonical wait generations: {canonical_waits}",
     )
-
-
-def require_turns_terminal(
-    snapshot: dict[str, Any], message_ids: set[str]
-) -> list[dict[str, Any]]:
-    turns = [
-        row
-        for row in snapshot["turn_records"]
-        if row.get("trigger_message_id") in message_ids
-    ]
-    require(
-        len(turns) == len(message_ids)
-        and all(row.get("terminal_kind") == "completed" for row in turns),
-        f"scheduler turns did not reach completed terminal state: {turns}",
-    )
-    return turns
-
 
 def require_scheduler_activation_chain(
     snapshot: dict[str, Any],

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "scheduler_fixture_corpus_revision": "scheduler-release-acceptance-v1",
   "cases": [
     {
       "id": "runtime-auth-model-delivery",
@@ -118,33 +119,14 @@
       ]
     },
     {
-      "id": "scheduler-rollout-authoritative-autonomous",
+      "id": "scheduler-task-wait-resume",
       "tier": "extended",
-      "tags": ["scheduler", "workitem", "rollout", "shadow", "authoritative", "task-result", "wait", "restart", "rollback", "delivery"],
+      "tags": ["scheduler", "workitem", "task-result", "yield", "wait", "restart", "replay", "delivery"],
       "timeout_seconds": 900,
-      "description": "Verify shadow evidence, per-scenario authoritative cutover, autonomous/task-result/external-wait continuation settlements, exact completion delivery binding, restart persistence, and rollback.",
-      "runtime_env": {
-        "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES": "true"
-      },
+      "description": "Verify one WorkItem crosses autonomous scheduling, promoted task-result rejoin, external wait-resume, exact completion delivery, and process restart.",
       "phases": [
         {
-          "id": "shadow-wait-resume",
-          "required_tools": [
-            "CreateWorkItem",
-            "PickWorkItem",
-            "WaitFor",
-            "GetWorkItem",
-            "UpdateWorkItem",
-            "CompleteWorkItem"
-          ],
-          "forbidden_tools": [
-            "ApplyPatch",
-            "ExecCommand"
-          ],
-          "prompt": "Scheduler rollout Docker E2E case {case_id}, shadow phase. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: shadow-wait pending, shadow-complete pending. Pick that WorkItem, then call WaitFor with wake=external, resource=docker-e2e-shadow, and a concrete reason. Do not complete it in this turn. When the external wake later resumes this exact WorkItem, call GetWorkItem, update both todos to completed, then emit a concise completion result containing {completion_marker} immediately followed by CompleteWorkItem for the exact current item. Do not create another WorkItem and do not modify files."
-        },
-        {
-          "id": "authoritative-continuations",
+          "id": "task-result-wait-complete",
           "required_tools": [
             "CreateWorkItem",
             "ExecCommand",
@@ -158,26 +140,7 @@
             "TaskStatus",
             "TaskOutput"
           ],
-          "prompt": "Scheduler rollout Docker E2E case {case_id}, authoritative phase. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: task-continuation pending, external-continuation pending. Do not PickWorkItem, ExecCommand, WaitFor, UpdateWorkItem, or CompleteWorkItem in this operator-triggered turn. After CreateWorkItem succeeds, end this response with a concise acknowledgement. The objective governs all later autonomous continuation turns. Do not create another WorkItem and do not modify files. The expected final completion marker is {completion_marker}."
-        }
-      ]
-    },
-    {
-      "id": "scheduler-terminal-before-settlement-restart",
-      "tier": "extended",
-      "tags": ["scheduler", "rollout", "authoritative", "fault", "restart", "recovery", "settlement"],
-      "timeout_seconds": 600,
-      "requires_model": false,
-      "description": "Construct a controlled terminal-before-settlement crash cut through the hidden acceptance fixture and verify real serve bootstrap reconciliation plus second-restart idempotence.",
-      "runtime_env": {
-        "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES": "true"
-      },
-      "phases": [
-        {
-          "id": "offline-fixture-and-restart-recovery",
-          "required_tools": [],
-          "forbidden_tools": [],
-          "prompt": "This phase is driven by the checked-in offline acceptance fixture and real holon serve restart path; no model prompt is issued."
+          "prompt": "Scheduler release acceptance case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: task-continuation pending, external-continuation pending. Do not PickWorkItem, ExecCommand, WaitFor, UpdateWorkItem, or CompleteWorkItem in this operator-triggered turn. After CreateWorkItem succeeds, end this response with a concise acknowledgement. The objective governs all later autonomous continuation turns. Do not create another WorkItem and do not modify files. The expected final completion marker is {completion_marker}."
         }
       ]
     },

--- a/tests/e2e/scheduler/README.md
+++ b/tests/e2e/scheduler/README.md
@@ -17,10 +17,9 @@ implicitly.
 
 | Scenario ID | Case ID | Description | Key Assertions |
 |---|---|---|---|
-| SCHED-E2E-001 | `scheduler-autonomous-legacy` | Single agent autonomous loop | brief exists; settlement completed; no duplicate settlement; restart persistence |
+| SCHED-E2E-001 | `scheduler-task-wait-resume` | Autonomous task-result and external-wait continuity | brief binding; task yield/rejoin; wait resolved; restart persistence |
 | SCHED-E2E-002 | `scheduler-multi-workitem-scheduling` | Multi-WorkItem concurrent scheduling | both complete; no conflicts; 2 activations; 2 settlements; restart persistence |
 | SCHED-E2E-003 | `scheduler-provider-failure-work-queue-retry` | Provider failure recovery | recovery turn scheduled; final brief; no death loop; idempotency key preserved |
-| SCHED-E2E-004 | `scheduler-terminal-before-settlement-restart` | SIGKILL crash recovery | settlement idempotent; brief not lost; exactly-once |
 | SCHED-E2E-005 | `scheduler-external-wait-resume` | WaitFor external trigger + resume | wait state correct; external callback wakes; WorkItem resumes; wait resolved |
 | SCHED-E2E-006 | `scheduler-operator-wait-resume` | WaitFor operator_input + resume | wait state correct; operator message wakes; WorkItem resumes; wait resolved |
 
@@ -48,9 +47,11 @@ implicitly.
 
 Each case asserts three layers:
 
-1. **State layer**: SQLite `state.db` queries via `runtime_db_snapshot()`
+1. **State layer**: SQLite `runtime.sqlite` queries via `runtime_db_snapshot()`
    verifying WorkItem state, scheduling_state, settlement records, wait
-   conditions, and activation chains.
+   conditions, and activation chains. Release and nightly matrix runs execute
+   every selected scheduler case once in an isolated `legacy` process and once
+   in an isolated `canonical` process.
 2. **Artifact layer**: Brief existence, content, and work_item binding via
    `brief()` and work-items API.
 3. **Behavior layer**: Event sequence and tool execution checks via

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -751,6 +751,37 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 {"scheduler-tick"},
             )
 
+    def test_canonical_wait_resolution_rejects_consuming_activation(self) -> None:
+        harness = type(
+            "CanonicalHarness",
+            (),
+            {"canonical_scheduler_enabled": True},
+        )()
+        canonical_wait = {
+            "wait_id": "wait-1",
+            "owner_work_item_id": "work-1",
+            "lifecycle_state": "resolved",
+            "consuming_activation_id": None,
+        }
+        snapshot = {"scheduler_wait_generations": [canonical_wait]}
+        runner.require_scheduler_engine_wait_resolution(
+            harness,
+            snapshot,
+            work_item_id="work-1",
+            wait_ids={"wait-1"},
+        )
+
+        canonical_wait["consuming_activation_id"] = "activation-unexpected"
+        with self.assertRaisesRegex(
+            AssertionError, "canonical waits did not resolve exactly once"
+        ):
+            runner.require_scheduler_engine_wait_resolution(
+                harness,
+                snapshot,
+                work_item_id="work-1",
+                wait_ids={"wait-1"},
+            )
+
     def test_wait_work_item_fails_fast_on_duplicate_objective_marker(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             harness = runner.CaseHarness(

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -553,15 +553,14 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 docker_run,
             )
 
-    def test_scheduler_extended_cases_declare_rollout_modes(self) -> None:
+    def test_scheduler_extended_cases_use_real_lifecycle_fixtures(self) -> None:
         selected = runner.select_cases(
             self.manifest, requested=None, suite="extended", tags=["scheduler"]
         )
         self.assertEqual(
             [case["id"] for case in selected],
             [
-                "scheduler-rollout-authoritative-autonomous",
-                "scheduler-terminal-before-settlement-restart",
+                "scheduler-task-wait-resume",
                 "scheduler-provider-failure-work-queue-retry",
                 "scheduler-multi-workitem-scheduling",
                 "scheduler-external-wait-resume",
@@ -574,27 +573,43 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "scheduler-checkpoint-replay",
             ],
         )
-        rollout_cases = selected[:2]
-        self.assertEqual(
-            [
-                case["runtime_env"]["HOLON_SCHEDULER_ACCEPTANCE_FIXTURES"]
-                for case in rollout_cases
-            ],
-            ["true", "true"],
-        )
-        authoritative = rollout_cases[0]
-        recovery = rollout_cases[1]
-        self.assertEqual(len(authoritative["phases"]), 2)
+        task_wait = selected[0]
+        self.assertEqual(len(task_wait["phases"]), 1)
         self.assertIn(
-            "WaitFor", authoritative["phases"][0]["required_tools"]
+            "ExecCommand", task_wait["phases"][0]["required_tools"]
         )
-        self.assertIn(
-            "ExecCommand", authoritative["phases"][1]["required_tools"]
-        )
+        self.assertIn("WaitFor", task_wait["phases"][0]["required_tools"])
         self.assertNotIn(
-            "PickWorkItem", authoritative["phases"][1]["required_tools"]
+            "PickWorkItem", task_wait["phases"][0]["required_tools"]
         )
-        self.assertFalse(recovery["requires_model"])
+        for case in selected:
+            self.assertNotIn(
+                "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES",
+                case.get("runtime_env", {}),
+            )
+            self.assertNotIn("HOLON_SCHEDULER", case.get("runtime_env", {}))
+
+    def test_scheduler_matrix_expands_only_scheduler_cases(self) -> None:
+        selected = runner.select_cases(
+            self.manifest, requested=None, suite="core", tags=[]
+        ) + runner.select_cases(
+            self.manifest,
+            requested=["scheduler-task-wait-resume"],
+            suite="extended",
+            tags=[],
+        )
+        expanded = runner.expand_case_matrix(selected, scheduler_matrix=True)
+        self.assertEqual(
+            [(case["id"], engine) for case, engine in expanded],
+            [
+                ("runtime-auth-model-delivery", None),
+                ("memory-agent-home-persistence", None),
+                ("workspace-restart-lifecycle", None),
+                ("workitem-wait-restart-complete", None),
+                ("scheduler-task-wait-resume", "legacy"),
+                ("scheduler-task-wait-resume", "canonical"),
+            ],
+        )
 
     def test_e2e_tier_1_cases_have_correct_config(self) -> None:
         selected = runner.select_cases(
@@ -645,124 +660,80 @@ class DockerE2ERunnerTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "requires_model must be boolean"):
             runner.validate_manifest(invalid)
 
-    def test_scheduler_rollout_commands_are_revision_fenced(self) -> None:
-        commands = runner.scheduler_rollout_commands(
-            {
-                "work_item_autonomous_continuation": "authoritative",
-                "settlement": "shadow",
-            }
-        )
-        self.assertEqual(
-            [entry["command"]["kind"] for entry in commands],
-            [
-                "open_preflight",
-                "complete_preflight",
-                "install_manifest",
-                "configure_protocol",
-                "change_scenario_authority",
-                "change_scenario_authority",
-                "change_scenario_authority",
-            ],
-        )
-        self.assertEqual(
-            [
-                entry["command"]["expected_config_revision"]
-                for entry in commands[4:]
-            ],
-            [2, 3, 4],
-        )
-        manifest = commands[1]["command"]["manifest"]
-        self.assertEqual(
-            manifest["classes"]["work_item_autonomous_continuation"][
-                "configured_mode"
-            ],
-            "authoritative",
-        )
-        self.assertIn(
-            "work_item_rollback",
-            manifest["classes"]["work_item_autonomous_continuation"][
-                "verified_evidence"
-            ],
-        )
-
-    def test_scheduler_rollout_commands_can_stage_shadow_under_authoritative_approval(
-        self,
-    ) -> None:
-        commands = runner.scheduler_rollout_commands(
-            {"exact_wait_resume": "shadow"},
-            approved_scenario_modes={"exact_wait_resume": "authoritative"},
-        )
-        manifest = commands[1]["command"]["manifest"]
-        self.assertEqual(
-            manifest["classes"]["exact_wait_resume"]["configured_mode"],
-            "authoritative",
-        )
-        self.assertEqual(
-            [
-                entry["command"]["mode"]
-                for entry in commands
-                if entry["command"]["kind"] == "change_scenario_authority"
-            ],
-            ["shadow"],
-        )
-
-    def test_incomplete_scheduler_rollout_fixture_fails_after_open_command(self) -> None:
-        commands = runner.scheduler_incomplete_rollout_commands(
-            {"exact_wait_resume": "authoritative"}
-        )
-        self.assertEqual(
-            [entry["command"]["kind"] for entry in commands],
-            ["open_preflight", "complete_preflight"],
-        )
-        evidence = commands[1]["command"]["manifest"]["classes"][
-            "exact_wait_resume"
-        ]
-        self.assertEqual(evidence["observed_shadow_samples"], 0)
-        self.assertEqual(evidence["verified_evidence"], [])
-
-    def test_scheduler_rollout_oracle_requires_consumed_preflight(self) -> None:
-        snapshot = {
-            "scheduler_protocol_config": [
-                {
-                    "protocol_mode": "authoritative",
-                    "config_revision": 5,
-                    "latest_preflight_revision": 1,
-                }
-            ],
-            "scheduler_rollout_preflights": [
-                {
-                    "preflight_revision": 1,
-                    "manifest_revision": 1,
-                    "state": "consumed",
-                    "manifest_json": "{}",
-                }
-            ],
-            "scheduler_rollout_manifests": [
-                {
-                    "manifest_revision": 1,
-                    "preflight_revision": 1,
-                    "payload_json": "{}",
-                }
-            ],
-            "scheduler_scenario_authorities": [
-                {
-                    "scenario_class": "settlement",
-                    "mode": "authoritative",
-                    "rollback_target": "shadow",
-                    "manifest_revision": 1,
-                    "preflight_revision": 1,
-                }
-            ],
-            "scheduler_rollout_command_results": [
-                {"conflict_kind": None}
-            ],
+    def test_scheduler_acceptance_report_binds_build_and_fixture_identity(self) -> None:
+        run_record = {
+            "git_sha": "abc123",
+            "image": {
+                "ref": "ghcr.io/holon-run/holon@sha256:deadbeef",
+                "id": "sha256:image",
+                "repo_digests": ["ghcr.io/holon-run/holon@sha256:deadbeef"],
+            },
+            "image_digest": "ghcr.io/holon-run/holon@sha256:deadbeef",
+            "manifest_sha256": "manifest-hash",
         }
-        runner.require_rollout_state(snapshot, {"settlement": "authoritative"})
-        snapshot["scheduler_rollout_preflights"][0]["state"] = "completed"
-        with self.assertRaisesRegex(AssertionError, "not consumed"):
-            runner.require_rollout_state(
-                snapshot, {"settlement": "authoritative"}
-            )
+        case_results = [
+            {
+                "id": f"scheduler-task-wait-resume-{engine}",
+                "base_id": "scheduler-task-wait-resume",
+                "scheduler_engine": engine,
+                "status": "pass",
+                "schema_revision": 40,
+            }
+            for engine in runner.SCHEDULER_ENGINES
+        ]
+        report = runner.scheduler_acceptance_report(
+            run_record=run_record,
+            case_results=case_results,
+            fixture_corpus_revision="scheduler-release-acceptance-v1",
+        )
+        self.assertEqual(
+            report["schema_version"],
+            runner.SCHEDULER_ACCEPTANCE_REPORT_SCHEMA_VERSION,
+        )
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["git_sha"], "abc123")
+        self.assertEqual(report["runtime_schema_revision"], 40)
+        self.assertEqual(
+            report["image_digest"],
+            "ghcr.io/holon-run/holon@sha256:deadbeef",
+        )
+        self.assertEqual(
+            report["fixture_corpus_revision"],
+            "scheduler-release-acceptance-v1",
+        )
+        self.assertEqual(
+            [engine["engine"] for engine in report["engines"]],
+            ["legacy", "canonical"],
+        )
+
+    def test_scheduler_acceptance_report_rejects_schema_drift(self) -> None:
+        run_record = {
+            "git_sha": "abc123",
+            "image": {"ref": "holon:test", "id": None, "repo_digests": []},
+            "image_digest": None,
+            "manifest_sha256": "manifest-hash",
+        }
+        case_results = [
+            {
+                "id": f"scheduler-task-wait-resume-{engine}",
+                "base_id": "scheduler-task-wait-resume",
+                "scheduler_engine": engine,
+                "status": "pass",
+                "schema_revision": revision,
+            }
+            for engine, revision in (("legacy", 39), ("canonical", 40))
+        ]
+        report = runner.scheduler_acceptance_report(
+            run_record=run_record,
+            case_results=case_results,
+            fixture_corpus_revision="scheduler-release-acceptance-v1",
+        )
+        self.assertEqual(report["status"], "fail")
+        self.assertIsNone(report["runtime_schema_revision"])
+        self.assertIn(
+            "scheduler_schema_revision_mismatch",
+            {diagnostic["code"] for diagnostic in report["diagnostics"]},
+        )
 
     def test_scheduler_queue_oracle_uses_current_processed_state(self) -> None:
         runner.require_processed_queue_entries(


### PR DESCRIPTION
## 概要

将 scheduler rollout evidence 从 synthetic runtime authority fixture 迁移为 CI/release acceptance：

- 删除 Docker E2E 中的 synthetic manifest/preflight/shadow/cutover/rollback fixture 与对应 oracle
- 新增 `--scheduler-matrix`，对同一组真实 scheduler lifecycle case 分别以 `HOLON_SCHEDULER=legacy` 和 `canonical` 启动独立进程、volume 与数据库
- 保留 task-result yield/rejoin、external/operator wait、restart、provider fault/retry、interjection、compaction、worktree、child supervision 与 replay 等真实不变量
- 生成 `scheduler-acceptance-report.json`，绑定 git SHA、runtime schema revision、immutable image digest、fixture corpus revision、manifest hash 与双 engine case evidence
- release attestation 嵌入该报告；tag release gate 要求 legacy/canonical 都通过且身份一致

## Runtime 边界

本 PR 不恢复 production shadow 双写或 per-scenario rollout authority，也不删除 Phase 4 才处理的生产兼容类型/schema。scheduler drill 的真实 restart/fault 注入接口保持不变。

## 验证

- `make docker-e2e-validate`
- `actionlint .github/workflows/release-e2e.yml .github/workflows/e2e-scheduler-nightly.yml .github/workflows/release.yml`
- `yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}' .github/workflows/release-e2e.yml .github/workflows/e2e-scheduler-nightly.yml .github/workflows/release.yml`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

完整 Docker 双 engine 矩阵依赖 protected candidate image 与模型凭证，由 `Release E2E` workflow 执行并产出 attested report。
