### PR TITLE
fix: preserve scheduler adoption compatibility

### DIFF
--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -1650,36 +1650,48 @@ fn replay_or_conflict(
                                     consuming_activation_id: None,
                                 })
                     });
-                return Some(
-                    if existing.metadata_revision == command.source_work_item_revision
-                        && existing.scheduling_generation == command.wait.generation
-                        && existing.status
-                            == (WorkStatus::Waiting {
-                                wait_id: command.wait.wait_id.clone(),
-                            })
-                        && wait_matches
-                        && (!command.focus
-                            || snapshot.focus.as_deref() == Some(command.work_item_id.as_str()))
-                        && (!command.reserve_dispatch
-                            || snapshot.dispatch
-                                == (AgentDispatchState::Awaiting {
-                                    wait: WaitIdentity {
-                                        id: command.wait.wait_id.clone(),
-                                        generation: command.wait.generation,
-                                    },
-                                }))
-                    {
-                        duplicate_command(snapshot, "activation_work_state_already_adopted")
-                    } else {
-                        rejected_command(
-                            snapshot,
-                            command_conflict(
-                                ProtocolConflictKind::IdentityConflict,
-                                "activation_work_state_adoption_conflict",
-                            ),
-                        )
-                    },
-                );
+                if existing.metadata_revision == command.source_work_item_revision
+                    && existing.scheduling_generation == command.wait.generation
+                    && existing.status
+                        == (WorkStatus::Waiting {
+                            wait_id: command.wait.wait_id.clone(),
+                        })
+                    && wait_matches
+                    && (!command.focus
+                        || snapshot.focus.as_deref() == Some(command.work_item_id.as_str()))
+                    && (!command.reserve_dispatch
+                        || snapshot.dispatch
+                            == (AgentDispatchState::Awaiting {
+                                wait: WaitIdentity {
+                                    id: command.wait.wait_id.clone(),
+                                    generation: command.wait.generation,
+                                },
+                            }))
+                {
+                    return Some(duplicate_command(
+                        snapshot,
+                        "activation_work_state_already_adopted",
+                    ));
+                }
+                if existing.metadata_revision < command.source_work_item_revision {
+                    return None;
+                }
+                if existing.metadata_revision > command.source_work_item_revision {
+                    return Some(rejected_command(
+                        snapshot,
+                        command_conflict(
+                            ProtocolConflictKind::StaleRevision,
+                            "activation_work_state_adoption_stale_revision",
+                        ),
+                    ));
+                }
+                return Some(rejected_command(
+                    snapshot,
+                    command_conflict(
+                        ProtocolConflictKind::IdentityConflict,
+                        "activation_work_state_adoption_conflict",
+                    ),
+                ));
             }
         }
         ProtocolCommand::AdmitActivation(command) => {
@@ -2259,18 +2271,113 @@ fn adopt_activation_work_state(
             ),
         );
     }
-    if snapshot.work.contains_key(&command.work_item_id)
-        || snapshot.waits.contains_key(&command.wait.wait_id)
-    {
-        return rejected_command(
-            snapshot,
-            command_conflict(
-                ProtocolConflictKind::IdentityConflict,
-                "activation_work_state_identity_conflict",
-            ),
-        );
+    let existing_work = snapshot.work.get(&command.work_item_id);
+    let existing_wait_id = existing_work.and_then(|work| match &work.status {
+        WorkStatus::Waiting { wait_id } => Some(wait_id.as_str()),
+        _ => None,
+    });
+    if let Some(existing_work) = existing_work {
+        if existing_work.metadata_revision >= command.source_work_item_revision {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StaleRevision,
+                    "activation_work_state_adoption_stale_revision",
+                ),
+            );
+        }
+        if existing_wait_id.is_none() {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "activation_work_state_existing_work_not_waiting",
+                ),
+            );
+        }
+        if existing_work.scheduling_generation >= command.wait.generation {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StaleGeneration,
+                    "activation_work_state_adoption_stale_generation",
+                ),
+            );
+        }
+        let existing_wait_id = existing_wait_id.expect("checked existing waiting work");
+        let Some(existing_wait) = snapshot.waits.get(existing_wait_id) else {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "activation_work_state_existing_wait_conflict",
+                ),
+            );
+        };
+        let Some(current) = existing_wait
+            .generations
+            .get(&existing_wait.current_generation)
+        else {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "activation_work_state_existing_wait_conflict",
+                ),
+            );
+        };
+        if existing_wait.current_generation != existing_work.scheduling_generation
+            || current.owner
+                != (SchedulerOwner::WorkItem {
+                    work_item_id: command.work_item_id.clone(),
+                })
+            || !matches!(current.state, WaitState::Active | WaitState::Triggered)
+        {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StateConflict,
+                    "activation_work_state_existing_wait_conflict",
+                ),
+            );
+        }
     }
-    if snapshot.dispatch != AgentDispatchState::Open {
+    if let Some(existing_wait) = snapshot.waits.get(&command.wait.wait_id) {
+        let current = existing_wait
+            .generations
+            .get(&existing_wait.current_generation)
+            .expect("current wait generation exists");
+        let target_is_current_wait = existing_wait_id == Some(command.wait.wait_id.as_str());
+        if !target_is_current_wait
+            && (current.owner
+                != (SchedulerOwner::WorkItem {
+                    work_item_id: command.work_item_id.clone(),
+                })
+                || existing_wait.current_generation >= command.wait.generation
+                || current.state != WaitState::Resolved)
+        {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::IdentityConflict,
+                    "activation_work_state_wait_conflict",
+                ),
+            );
+        }
+    }
+    if snapshot.dispatch != AgentDispatchState::Open
+        && !existing_wait_id.is_some_and(|wait_id| {
+            snapshot.dispatch
+                == (AgentDispatchState::Awaiting {
+                    wait: WaitIdentity {
+                        id: wait_id.to_string(),
+                        generation: existing_work
+                            .expect("existing wait requires existing work")
+                            .scheduling_generation,
+                    },
+                })
+        })
+    {
         return rejected_command(
             snapshot,
             command_conflict(
@@ -2281,6 +2388,24 @@ fn adopt_activation_work_state(
     }
 
     let mut next = snapshot.clone();
+    let mut transitions = Vec::new();
+    if let Some(existing_wait_id) = existing_wait_id {
+        if let Some(wait) = next.waits.get_mut(existing_wait_id) {
+            let generation = wait
+                .generations
+                .get_mut(&wait.current_generation)
+                .expect("current wait generation exists");
+            if matches!(generation.state, WaitState::Active | WaitState::Triggered) {
+                generation.state = WaitState::Resolved;
+                generation.trigger = None;
+                generation.consuming_activation_id = None;
+                transitions.push(format!(
+                    "wait:{existing_wait_id}:generation:{}:resolved_by_activation_rearm",
+                    wait.current_generation
+                ));
+            }
+        }
+    }
     next.work.insert(
         command.work_item_id.clone(),
         WorkDemand {
@@ -2295,48 +2420,70 @@ fn adopt_activation_work_state(
             cost_class: "default".into(),
         },
     );
-    next.waits.insert(
-        command.wait.wait_id.clone(),
-        WaitRecord {
-            current_generation: command.wait.generation,
-            generations: BTreeMap::from([(
-                command.wait.generation,
-                WaitGenerationRecord {
-                    owner: SchedulerOwner::WorkItem {
-                        work_item_id: command.work_item_id.clone(),
-                    },
-                    state: WaitState::Active,
-                    trigger: None,
-                    consuming_activation_id: None,
+    if let Some(wait) = next.waits.get_mut(&command.wait.wait_id) {
+        wait.current_generation = command.wait.generation;
+        wait.generations.insert(
+            command.wait.generation,
+            WaitGenerationRecord {
+                owner: SchedulerOwner::WorkItem {
+                    work_item_id: command.work_item_id.clone(),
                 },
-            )]),
-        },
-    );
+                state: WaitState::Active,
+                trigger: None,
+                consuming_activation_id: None,
+            },
+        );
+    } else {
+        next.waits.insert(
+            command.wait.wait_id.clone(),
+            WaitRecord {
+                current_generation: command.wait.generation,
+                generations: BTreeMap::from([(
+                    command.wait.generation,
+                    WaitGenerationRecord {
+                        owner: SchedulerOwner::WorkItem {
+                            work_item_id: command.work_item_id.clone(),
+                        },
+                        state: WaitState::Active,
+                        trigger: None,
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        );
+    }
     if command.reserve_dispatch {
-        next.dispatch = AgentDispatchState::Awaiting {
+        let dispatch = AgentDispatchState::Awaiting {
             wait: WaitIdentity {
                 id: command.wait.wait_id.clone(),
                 generation: command.wait.generation,
             },
         };
+        if next.dispatch != dispatch {
+            next.dispatch = dispatch;
+            next.dispatch_revision += 1;
+        }
+    } else if next.dispatch != AgentDispatchState::Open {
+        next.dispatch = AgentDispatchState::Open;
         next.dispatch_revision += 1;
     }
     if command.focus {
         next.focus = Some(command.work_item_id.clone());
     }
+    transitions.extend([
+        format!(
+            "work:{}:activation_state_adopted:generation:{}",
+            command.work_item_id, command.wait.generation
+        ),
+        format!(
+            "wait:{}:generation:{}:armed",
+            command.wait.wait_id, command.wait.generation
+        ),
+    ]);
     ProtocolCommandOutcome {
         outcome: Outcome {
             decision: Decision::LegacyWorkStateAdopted,
-            transitions: vec![
-                format!(
-                    "work:{}:activation_state_adopted:generation:{}",
-                    command.work_item_id, command.wait.generation
-                ),
-                format!(
-                    "wait:{}:generation:{}:armed",
-                    command.wait.wait_id, command.wait.generation
-                ),
-            ],
+            transitions,
             diagnostics: Vec::new(),
             snapshot: next,
         },

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -25,6 +25,7 @@ use crate::domain::scheduler_protocol::{
 };
 
 const CANONICAL_COMMAND_SCHEMA_VERSION: i64 = 1;
+const LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION: i64 = 2;
 
 #[derive(Serialize)]
 struct LegacyActivationAuthorityPayload<'a> {
@@ -73,6 +74,7 @@ impl PreparedProtocolCommands {
 struct PreparedProtocolCommandResult {
     command_kind: &'static str,
     command_identity: String,
+    schema_version: i64,
     payload_hash: String,
     result: SchedulerProtocolCommandResult,
 }
@@ -183,7 +185,7 @@ pub(super) fn validate_protocol_commands_tx(
 
     for command in commands {
         let (command_kind, command_identity) = command_identity(command)?;
-        let payload_hash = canonical_command_hash(command_kind, command)?;
+        let (schema_version, payload_hash) = canonical_command_hash(command_kind, command)?;
         if let Some(stored) =
             stored_command_result_tx(tx, agent_id, command_kind, &command_identity)?
         {
@@ -233,6 +235,7 @@ pub(super) fn validate_protocol_commands_tx(
         results.push(PreparedProtocolCommandResult {
             command_kind,
             command_identity,
+            schema_version,
             payload_hash,
             result,
         });
@@ -262,6 +265,7 @@ pub(super) fn persist_protocol_commands_tx(
             agent_id,
             result.command_kind,
             &result.command_identity,
+            result.schema_version,
             &result.payload_hash,
             &result.result,
         )?;
@@ -443,7 +447,7 @@ impl RuntimeTransitionRepository<'_> {
     ) -> Result<SchedulerProtocolTransitionCommit> {
         validate_command_agent(agent_id, command)?;
         let (command_kind, command_identity) = command_identity(command)?;
-        let payload_hash = canonical_command_hash(command_kind, command)?;
+        let (schema_version, payload_hash) = canonical_command_hash(command_kind, command)?;
 
         let outcome = self.db.transaction(|tx| {
             if let Some(stored) =
@@ -456,6 +460,7 @@ impl RuntimeTransitionRepository<'_> {
                         agent_id,
                         command_kind,
                         &command_identity,
+                        schema_version,
                         &stored.payload_hash,
                         &payload_hash,
                     )?;
@@ -504,6 +509,7 @@ impl RuntimeTransitionRepository<'_> {
                 agent_id,
                 command_kind,
                 &command_identity,
+                schema_version,
                 &payload_hash,
                 &result,
             )?;
@@ -1019,13 +1025,36 @@ fn command_identity(command: &ProtocolCommand) -> Result<(&'static str, String)>
     })
 }
 
-fn canonical_command_hash(command_kind: &str, command: &ProtocolCommand) -> Result<String> {
+fn canonical_command_hash(command_kind: &str, command: &ProtocolCommand) -> Result<(i64, String)> {
+    let schema_version = match command {
+        ProtocolCommand::AdoptLegacyWorkState(command)
+            if command.replace_completed_focus.is_some() =>
+        {
+            LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION
+        }
+        _ => CANONICAL_COMMAND_SCHEMA_VERSION,
+    };
+    let mut command_value = serde_json::to_value(command)?;
+    if matches!(
+        command,
+        ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+            replace_completed_focus: None,
+            ..
+        })
+    ) {
+        if let Some(payload) = command_value.as_object_mut() {
+            payload.remove("replace_completed_focus");
+        }
+    }
     let canonical = serde_json::to_vec(&serde_json::json!({
-        "schema_version": CANONICAL_COMMAND_SCHEMA_VERSION,
+        "schema_version": schema_version,
         "command_kind": command_kind,
-        "command": command,
+        "command": command_value,
     }))?;
-    Ok(format!("sha256:{:x}", Sha256::digest(canonical)))
+    Ok((
+        schema_version,
+        format!("sha256:{:x}", Sha256::digest(canonical)),
+    ))
 }
 
 fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
@@ -1205,6 +1234,7 @@ fn insert_command_identity_conflict_attempt_tx(
     partition_key: &str,
     command_kind: &str,
     command_identity: &str,
+    schema_version: i64,
     existing_payload_hash: &str,
     incoming_payload_hash: &str,
 ) -> Result<SchedulerProtocolCommandIdentityConflict> {
@@ -1230,7 +1260,7 @@ fn insert_command_identity_conflict_attempt_tx(
             partition_key,
             command_kind,
             command_identity,
-            CANONICAL_COMMAND_SCHEMA_VERSION,
+            schema_version,
             existing_payload_hash,
             incoming_payload_hash,
             enum_token(&conflict.kind)?,
@@ -1255,6 +1285,7 @@ fn insert_command_result_tx(
     agent_id: &str,
     command_kind: &str,
     command_identity: &str,
+    schema_version: i64,
     payload_hash: &str,
     result: &SchedulerProtocolCommandResult,
 ) -> Result<()> {
@@ -1287,7 +1318,7 @@ fn insert_command_result_tx(
             agent_id,
             command_kind,
             command_identity,
-            CANONICAL_COMMAND_SCHEMA_VERSION,
+            schema_version,
             payload_hash,
             enum_token(&result.decision)?,
             conflict_kind,
@@ -2513,4 +2544,78 @@ fn load_activations(
         );
     }
     Ok(activations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_adoption_command(replacement: Option<ReplaceCompletedFocusProof>) -> ProtocolCommand {
+        ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+            work_item_id: "work-a".into(),
+            source_work_item_revision: 3,
+            demand: WorkDemand {
+                metadata_revision: 3,
+                scheduling_generation: 3,
+                status: WorkStatus::Runnable,
+                capabilities: BTreeSet::new(),
+                locks: BTreeSet::new(),
+                locality: "runtime".into(),
+                cost_class: "default".into(),
+            },
+            wait: None,
+            focus: true,
+            reserve_dispatch: false,
+            replace_completed_focus: replacement,
+        })
+    }
+
+    #[test]
+    fn legacy_adoption_default_field_preserves_v1_command_hash() -> Result<()> {
+        let command = legacy_adoption_command(None);
+        let (schema_version, payload_hash) =
+            canonical_command_hash("adopt_legacy_work_state", &command)?;
+        assert_eq!(schema_version, 1);
+
+        let ProtocolCommand::AdoptLegacyWorkState(command) = command else {
+            unreachable!("fixture is a legacy adoption command");
+        };
+        let old_wire_payload = serde_json::json!({
+            "kind": "adopt_legacy_work_state",
+            "work_item_id": command.work_item_id,
+            "source_work_item_revision": command.source_work_item_revision,
+            "demand": command.demand,
+            "wait": command.wait,
+            "focus": command.focus,
+            "reserve_dispatch": command.reserve_dispatch,
+        });
+        let canonical = serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "command_kind": "adopt_legacy_work_state",
+            "command": old_wire_payload,
+        }))?;
+        assert_eq!(
+            payload_hash,
+            format!("sha256:{:x}", Sha256::digest(canonical))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_adoption_replacement_uses_command_specific_v2_hash() -> Result<()> {
+        let v1 = legacy_adoption_command(None);
+        let v2 = legacy_adoption_command(Some(ReplaceCompletedFocusProof {
+            work_item_id: "work-old".into(),
+            source_work_item_revision: 5,
+            expected_metadata_revision: 4,
+            expected_scheduling_generation: 4,
+        }));
+
+        let (v1_schema, v1_hash) = canonical_command_hash("adopt_legacy_work_state", &v1)?;
+        let (v2_schema, v2_hash) = canonical_command_hash("adopt_legacy_work_state", &v2)?;
+        assert_eq!(v1_schema, 1);
+        assert_eq!(v2_schema, LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION);
+        assert_ne!(v1_hash, v2_hash);
+        Ok(())
+    }
 }

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -1823,6 +1823,258 @@ fn lifecycle_settlement_can_atomically_adopt_work_item_wait() {
 
     let replay = reduce_command(&adopted.outcome.snapshot, &command);
     assert_eq!(replay.outcome.decision, Decision::DuplicateIgnored);
+
+    let mut rearm_command = command.clone();
+    let ProtocolCommand::AdoptActivationWorkState(rearm) = &mut rearm_command else {
+        unreachable!("fixture is an activation adoption command");
+    };
+    rearm.source_work_item_revision = 3;
+    rearm.wait.wait_id = "wait-2".into();
+    rearm.wait.generation = 3;
+    rearm.wait.source_updated_at = "2026-07-30T00:00:02Z".into();
+
+    let mut stale_command = rearm_command.clone();
+    let ProtocolCommand::AdoptActivationWorkState(stale) = &mut stale_command else {
+        unreachable!("fixture is an activation adoption command");
+    };
+    stale.source_work_item_revision = 1;
+    stale.wait.generation = 1;
+    let stale = reduce_command(&adopted.outcome.snapshot, &stale_command);
+    assert_eq!(stale.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        stale.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::StaleRevision
+    );
+
+    let mut terminal_snapshot = adopted.outcome.snapshot.clone();
+    terminal_snapshot.focus = None;
+    terminal_snapshot.dispatch = AgentDispatchState::Open;
+    terminal_snapshot.work.get_mut("work-1").unwrap().status = WorkStatus::Terminal;
+    terminal_snapshot
+        .work
+        .get_mut("work-1")
+        .unwrap()
+        .scheduling_generation = 3;
+    terminal_snapshot
+        .waits
+        .get_mut("wait-1")
+        .unwrap()
+        .generations
+        .get_mut(&2)
+        .unwrap()
+        .state = WaitState::Resolved;
+    assert_invariants(&terminal_snapshot).unwrap();
+    let mut terminal_command = rearm_command.clone();
+    let ProtocolCommand::AdoptActivationWorkState(terminal) = &mut terminal_command else {
+        unreachable!("fixture is an activation adoption command");
+    };
+    terminal.source_work_item_revision = 4;
+    terminal.wait.generation = 4;
+    let terminal = reduce_command(&terminal_snapshot, &terminal_command);
+    assert_eq!(terminal.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        terminal.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::StateConflict
+    );
+
+    let mut stale_generation_snapshot = adopted.outcome.snapshot.clone();
+    let work = stale_generation_snapshot.work.get_mut("work-1").unwrap();
+    work.scheduling_generation = 5;
+    let wait = stale_generation_snapshot.waits.get_mut("wait-1").unwrap();
+    wait.generations.get_mut(&2).unwrap().state = WaitState::Resolved;
+    wait.current_generation = 5;
+    wait.generations.insert(
+        5,
+        WaitGenerationRecord {
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: "work-1".into(),
+            },
+            state: WaitState::Active,
+            trigger: None,
+            consuming_activation_id: None,
+        },
+    );
+    stale_generation_snapshot.dispatch = AgentDispatchState::Awaiting {
+        wait: WaitIdentity {
+            id: "wait-1".into(),
+            generation: 5,
+        },
+    };
+    assert_invariants(&stale_generation_snapshot).unwrap();
+    let stale_generation = reduce_command(&stale_generation_snapshot, &rearm_command);
+    assert_eq!(stale_generation.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        stale_generation.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::StaleGeneration
+    );
+
+    let mut unrelated_dispatch_snapshot = adopted.outcome.snapshot.clone();
+    unrelated_dispatch_snapshot.waits.insert(
+        "wait-lifecycle".into(),
+        WaitRecord {
+            current_generation: 1,
+            generations: BTreeMap::from([(
+                1,
+                WaitGenerationRecord {
+                    owner: SchedulerOwner::AgentLifecycle {
+                        agent_id: "agent-1".into(),
+                    },
+                    state: WaitState::Active,
+                    trigger: None,
+                    consuming_activation_id: None,
+                },
+            )]),
+        },
+    );
+    unrelated_dispatch_snapshot.dispatch = AgentDispatchState::Awaiting {
+        wait: WaitIdentity {
+            id: "wait-lifecycle".into(),
+            generation: 1,
+        },
+    };
+    assert_invariants(&unrelated_dispatch_snapshot).unwrap();
+    let unrelated_dispatch = reduce_command(&unrelated_dispatch_snapshot, &rearm_command);
+    assert_eq!(unrelated_dispatch.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        unrelated_dispatch.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::StateConflict
+    );
+
+    let mut ownership_conflict_snapshot = adopted.outcome.snapshot.clone();
+    ownership_conflict_snapshot.work.insert(
+        "work-2".into(),
+        WorkDemand {
+            metadata_revision: 5,
+            scheduling_generation: 5,
+            status: WorkStatus::Runnable,
+            capabilities: BTreeSet::new(),
+            locks: BTreeSet::new(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+    );
+    ownership_conflict_snapshot.waits.insert(
+        "wait-2".into(),
+        WaitRecord {
+            current_generation: 1,
+            generations: BTreeMap::from([(
+                1,
+                WaitGenerationRecord {
+                    owner: SchedulerOwner::WorkItem {
+                        work_item_id: "work-2".into(),
+                    },
+                    state: WaitState::Resolved,
+                    trigger: None,
+                    consuming_activation_id: None,
+                },
+            )]),
+        },
+    );
+    assert_invariants(&ownership_conflict_snapshot).unwrap();
+    let ownership_conflict = reduce_command(&ownership_conflict_snapshot, &rearm_command);
+    assert_eq!(ownership_conflict.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        ownership_conflict.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::IdentityConflict
+    );
+
+    let mut reusable_wait_snapshot = adopted.outcome.snapshot.clone();
+    reusable_wait_snapshot.waits.insert(
+        "wait-2".into(),
+        WaitRecord {
+            current_generation: 1,
+            generations: BTreeMap::from([(
+                1,
+                WaitGenerationRecord {
+                    owner: SchedulerOwner::WorkItem {
+                        work_item_id: "work-1".into(),
+                    },
+                    state: WaitState::Resolved,
+                    trigger: None,
+                    consuming_activation_id: None,
+                },
+            )]),
+        },
+    );
+    assert_invariants(&reusable_wait_snapshot).unwrap();
+    let reusable_wait = reduce_command(&reusable_wait_snapshot, &rearm_command);
+    assert_eq!(
+        reusable_wait.outcome.decision,
+        Decision::LegacyWorkStateAdopted
+    );
+    assert_eq!(
+        reusable_wait.outcome.snapshot.waits["wait-2"].current_generation,
+        3
+    );
+    assert_eq!(
+        reusable_wait.outcome.snapshot.waits["wait-2"].generations[&1].state,
+        WaitState::Resolved
+    );
+    assert_invariants(&reusable_wait.outcome.snapshot).unwrap();
+
+    let rearmed = reduce_command(&adopted.outcome.snapshot, &rearm_command);
+    assert_eq!(rearmed.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(
+        rearmed.outcome.snapshot.work["work-1"].status,
+        WorkStatus::Waiting {
+            wait_id: "wait-2".into(),
+        }
+    );
+    assert_eq!(
+        rearmed.outcome.snapshot.waits["wait-1"].generations[&2].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        rearmed.outcome.snapshot.waits["wait-2"].generations[&3].state,
+        WaitState::Active
+    );
+    assert_eq!(
+        rearmed.outcome.snapshot.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: "wait-2".into(),
+                generation: 3,
+            },
+        }
+    );
+    assert_invariants(&rearmed.outcome.snapshot).unwrap();
+
+    let mut reused_wait_command = rearm_command.clone();
+    let ProtocolCommand::AdoptActivationWorkState(reused_wait) = &mut reused_wait_command else {
+        unreachable!("fixture is an activation adoption command");
+    };
+    reused_wait.source_work_item_revision = 4;
+    reused_wait.wait.generation = 4;
+    reused_wait.wait.source_updated_at = "2026-07-30T00:00:03Z".into();
+    let reused_wait = reduce_command(&rearmed.outcome.snapshot, &reused_wait_command);
+    assert_eq!(
+        reused_wait.outcome.decision,
+        Decision::LegacyWorkStateAdopted
+    );
+    let wait = &reused_wait.outcome.snapshot.waits["wait-2"];
+    assert_eq!(wait.current_generation, 4);
+    assert_eq!(wait.generations[&3].state, WaitState::Resolved);
+    assert_eq!(wait.generations[&4].state, WaitState::Active);
+    assert_invariants(&reused_wait.outcome.snapshot).unwrap();
+
+    let mut release_dispatch_command = rearm_command;
+    let ProtocolCommand::AdoptActivationWorkState(release_dispatch) = &mut release_dispatch_command
+    else {
+        unreachable!("fixture is an activation adoption command");
+    };
+    release_dispatch.source_work_item_revision = 5;
+    release_dispatch.wait.wait_id = "wait-3".into();
+    release_dispatch.wait.generation = 5;
+    release_dispatch.wait.source_updated_at = "2026-07-30T00:00:04Z".into();
+    release_dispatch.reserve_dispatch = false;
+    let released = reduce_command(&reused_wait.outcome.snapshot, &release_dispatch_command);
+    assert_eq!(released.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(released.outcome.snapshot.dispatch, AgentDispatchState::Open);
+    assert_eq!(
+        released.outcome.snapshot.dispatch_revision,
+        reused_wait.outcome.snapshot.dispatch_revision + 1
+    );
+    assert_invariants(&released.outcome.snapshot).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve the historical v1 command identity for `AdoptLegacyWorkStateCommand` when `replace_completed_focus` is absent
- use a command-specific v2 schema when `replace_completed_focus` is present without changing unrelated command hashes
- allow activation adoption to atomically refresh an already-adopted canonical WorkItem from a strictly newer legacy revision and safely re-arm its wait
- reject stale revisions, terminal demand updates, unrelated dispatches, ownership conflicts, and unsafe wait generations
- add regression coverage for command identity compatibility and adopted WorkItem wait/revision transitions

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test legacy_adoption_`
- `cargo test --test scheduler_workitem_mvp` (38 passed)
- `cargo test --test runtime_tasks -- --test-threads=1` (45 passed)
- `cargo test --all-targets` completed the 2,539 core unit tests and other targets, but four timing-sensitive `runtime_tasks` cases timed out under concurrent full-suite load; the two reported cases were then passed by exact rerun, and the complete `runtime_tasks` target passed serially
