### PR TITLE
fix: atomically hand off lifecycle wait reservations

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -835,7 +835,18 @@ AdmitActivationCommand
 ClaimActivationCommand
 SettleActivationCommand
 TriggerWaitCommand
+AdoptActivationWorkStateCommand
 ```
+
+When a lifecycle nudge runs while dispatch is reserved by an active lifecycle
+wait and the turn creates a WorkItem wait, `AdoptActivationWorkStateCommand`
+may carry the exact source wait identity and expected dispatch revision. The
+same transaction must verify that the reservation belongs to the source
+lifecycle owner, settle the activation, resolve the source wait exactly once,
+and install the target WorkItem demand, wait, focus, and dispatch reservation.
+A stale revision or foreign reservation fails closed. After the adoption is
+recorded, settlement replay reuses the stored command result and must not
+reconstruct a different payload from the post-handoff dispatch state.
 
 The settlement transaction writes every durable fact changed by the
 disposition, including as applicable:

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -750,6 +750,12 @@ pub struct AdoptLegacyWorkStateCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleWaitHandoffProof {
+    pub wait: WaitIdentity,
+    pub expected_dispatch_revision: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AdoptActivationWorkStateCommand {
     pub source_activation_id: String,
     pub source_message_id: String,
@@ -758,6 +764,8 @@ pub struct AdoptActivationWorkStateCommand {
     pub work_item_id: String,
     pub source_work_item_revision: u64,
     pub wait: LegacyWaitAdoption,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_lifecycle_wait: Option<LifecycleWaitHandoffProof>,
     #[serde(default)]
     pub focus: bool,
     #[serde(default)]
@@ -1685,11 +1693,14 @@ fn replay_or_conflict(
                         ),
                     ));
                 }
+                if existing.scheduling_generation < command.wait.generation {
+                    return None;
+                }
                 return Some(rejected_command(
                     snapshot,
                     command_conflict(
-                        ProtocolConflictKind::IdentityConflict,
-                        "activation_work_state_adoption_conflict",
+                        ProtocolConflictKind::StaleGeneration,
+                        "activation_work_state_adoption_stale_generation",
                     ),
                 ));
             }
@@ -2221,8 +2232,12 @@ fn adopt_activation_work_state(
         || command.source_work_item_revision == 0
         || command.wait.wait_id.is_empty()
         || command.wait.owner_work_item_id != command.work_item_id
-        || command.wait.generation != command.source_work_item_revision
+        || command.wait.generation == 0
         || command.wait.source_updated_at.is_empty()
+        || command
+            .source_lifecycle_wait
+            .as_ref()
+            .is_some_and(|proof| proof.wait.id.is_empty() || proof.wait.generation == 0)
     {
         return rejected_command(
             snapshot,
@@ -2241,8 +2256,18 @@ fn adopt_activation_work_state(
             ),
         );
     };
+    let source_is_lifecycle_nudge = snapshot
+        .activation_admissions
+        .get(&command.source_activation_id)
+        .is_some_and(|admission| {
+            matches!(
+                admission.activation.cause,
+                ActivationCause::LifecycleExternalNudge { .. }
+            )
+        });
     if command.source_activation_id != format!("activation:message:{}", command.source_message_id)
         || activation.owner.lifecycle_agent_id().is_none()
+        || !source_is_lifecycle_nudge
         || activation.admitted_generation != command.source_admitted_generation
         || activation.state != ActivationState::Settled
     {
@@ -2277,12 +2302,23 @@ fn adopt_activation_work_state(
         _ => None,
     });
     if let Some(existing_work) = existing_work {
-        if existing_work.metadata_revision >= command.source_work_item_revision {
+        if existing_work.metadata_revision > command.source_work_item_revision {
             return rejected_command(
                 snapshot,
                 command_conflict(
                     ProtocolConflictKind::StaleRevision,
                     "activation_work_state_adoption_stale_revision",
+                ),
+            );
+        }
+        if existing_work.metadata_revision == command.source_work_item_revision
+            && existing_work.scheduling_generation >= command.wait.generation
+        {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::StaleGeneration,
+                    "activation_work_state_adoption_stale_generation",
                 ),
             );
         }
@@ -2365,18 +2401,45 @@ fn adopt_activation_work_state(
             );
         }
     }
+    let existing_work_dispatch_matches = existing_wait_id.is_some_and(|wait_id| {
+        snapshot.dispatch
+            == (AgentDispatchState::Awaiting {
+                wait: WaitIdentity {
+                    id: wait_id.to_string(),
+                    generation: existing_work
+                        .expect("existing wait requires existing work")
+                        .scheduling_generation,
+                },
+            })
+    });
+    let source_lifecycle_dispatch_matches =
+        command.source_lifecycle_wait.as_ref().is_some_and(|proof| {
+            snapshot.dispatch_revision == proof.expected_dispatch_revision
+                && snapshot.dispatch
+                    == (AgentDispatchState::Awaiting {
+                        wait: proof.wait.clone(),
+                    })
+                && snapshot
+                    .waits
+                    .get(&proof.wait.id)
+                    .and_then(|wait| wait.generations.get(&proof.wait.generation))
+                    .is_some_and(|generation| {
+                        generation.owner == activation.owner
+                            && matches!(generation.state, WaitState::Active | WaitState::Triggered)
+                    })
+        });
+    if command.source_lifecycle_wait.is_some() && !source_lifecycle_dispatch_matches {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::BindingConflict,
+                "activation_work_state_source_lifecycle_wait_mismatch",
+            ),
+        );
+    }
     if snapshot.dispatch != AgentDispatchState::Open
-        && !existing_wait_id.is_some_and(|wait_id| {
-            snapshot.dispatch
-                == (AgentDispatchState::Awaiting {
-                    wait: WaitIdentity {
-                        id: wait_id.to_string(),
-                        generation: existing_work
-                            .expect("existing wait requires existing work")
-                            .scheduling_generation,
-                    },
-                })
-        })
+        && !existing_work_dispatch_matches
+        && !source_lifecycle_dispatch_matches
     {
         return rejected_command(
             snapshot,
@@ -2386,10 +2449,49 @@ fn adopt_activation_work_state(
             ),
         );
     }
+    if snapshot.dispatch == AgentDispatchState::Open && command.source_lifecycle_wait.is_some() {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::BindingConflict,
+                "activation_work_state_source_lifecycle_wait_mismatch",
+            ),
+        );
+    }
 
     let mut next = snapshot.clone();
     let mut transitions = Vec::new();
+    if let Some(proof) = &command.source_lifecycle_wait {
+        let wait = next
+            .waits
+            .get_mut(&proof.wait.id)
+            .expect("validated source lifecycle wait exists");
+        let generation = wait
+            .generations
+            .get_mut(&proof.wait.generation)
+            .expect("validated source lifecycle wait generation exists");
+        generation.state = WaitState::Resolved;
+        generation.trigger = None;
+        generation.consuming_activation_id = None;
+        transitions.push(format!(
+            "wait:{}:generation:{}:resolved_by_work_item_handoff",
+            proof.wait.id, proof.wait.generation
+        ));
+    }
     if let Some(existing_wait_id) = existing_wait_id {
+        if command
+            .source_lifecycle_wait
+            .as_ref()
+            .is_some_and(|proof| proof.wait.id == existing_wait_id)
+        {
+            return rejected_command(
+                snapshot,
+                command_conflict(
+                    ProtocolConflictKind::IdentityConflict,
+                    "activation_work_state_wait_conflict",
+                ),
+            );
+        }
         if let Some(wait) = next.waits.get_mut(existing_wait_id) {
             let generation = wait
                 .generations

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -512,8 +512,9 @@ fn canonical_queue_settlement_commands_from_facts(
     };
     use crate::domain::scheduler_protocol::{
         ActivationDisposition, ActivationSettlement, AdoptActivationWorkStateCommand,
-        AgentDispatchDisposition, LegacyWaitAdoption, MissingSettlementRecord, ProtocolCommand,
-        SettleActivationCommand, WaitIdentity,
+        AgentDispatchDisposition, AgentDispatchState, LegacyWaitAdoption,
+        LifecycleWaitHandoffProof, MissingSettlementRecord, ProtocolCommand, SchedulerOwner,
+        SettleActivationCommand, WaitIdentity, WaitState,
     };
 
     let Some(snapshot) = runtime_db
@@ -630,11 +631,51 @@ fn canonical_queue_settlement_commands_from_facts(
             {
                 return Ok(vec![missing_settlement()]);
             }
+            if runtime_db
+                .transitions()
+                .activation_work_state_adoption_was_applied(
+                    &record.agent_id,
+                    &activation_id,
+                    work_item_id,
+                )?
+            {
+                return Ok(commands);
+            }
             let focus = storage
                 .read_agent()?
                 .and_then(|agent| agent.current_work_item_id)
                 .as_deref()
                 == Some(work_item_id);
+            let target_generation = snapshot
+                .work
+                .get(work_item_id)
+                .map(|demand| {
+                    demand
+                        .scheduling_generation
+                        .checked_add(1)
+                        .ok_or_else(|| anyhow!("WorkItem scheduling generation overflow"))
+                })
+                .transpose()?
+                .unwrap_or(work_item.revision)
+                .max(work_item.revision);
+            let source_lifecycle_wait = match &snapshot.dispatch {
+                AgentDispatchState::Awaiting { wait } => snapshot
+                    .waits
+                    .get(&wait.id)
+                    .and_then(|record| record.generations.get(&wait.generation))
+                    .filter(|generation| {
+                        generation.owner
+                            == (SchedulerOwner::AgentLifecycle {
+                                agent_id: record.agent_id.clone(),
+                            })
+                            && matches!(generation.state, WaitState::Active | WaitState::Triggered)
+                    })
+                    .map(|_| LifecycleWaitHandoffProof {
+                        wait: wait.clone(),
+                        expected_dispatch_revision: snapshot.dispatch_revision,
+                    }),
+                AgentDispatchState::Open => None,
+            };
             commands.push(ProtocolCommand::AdoptActivationWorkState(
                 AdoptActivationWorkStateCommand {
                     source_activation_id: activation_id.clone(),
@@ -647,10 +688,11 @@ fn canonical_queue_settlement_commands_from_facts(
                     source_work_item_revision: work_item.revision,
                     wait: LegacyWaitAdoption {
                         wait_id: wait.id.clone(),
-                        generation: work_item.revision,
+                        generation: target_generation,
                         owner_work_item_id: work_item_id.to_string(),
                         source_updated_at: wait.updated_at.to_rfc3339(),
                     },
+                    source_lifecycle_wait,
                     focus,
                     reserve_dispatch: focus,
                 },

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -183,6 +183,45 @@ fn canonical_waiting_snapshot(
     }
 }
 
+fn canonical_lifecycle_waiting_snapshot(wait_id: &str, wait_generation: u64) -> Snapshot {
+    Snapshot {
+        slot: ActivationSlot::Idle,
+        dispatch: AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: wait_id.into(),
+                generation: wait_generation,
+            },
+        },
+        dispatch_revision: 1,
+        focus: None,
+        work: Default::default(),
+        waits: std::collections::BTreeMap::from([(
+            wait_id.into(),
+            WaitRecord {
+                current_generation: wait_generation,
+                generations: std::collections::BTreeMap::from([(
+                    wait_generation,
+                    WaitGenerationRecord {
+                        owner: SchedulerOwner::AgentLifecycle {
+                            agent_id: "default".into(),
+                        },
+                        state: WaitState::Active,
+                        trigger: None,
+                        consuming_activation_id: None,
+                    },
+                )]),
+            },
+        )]),
+        activations: Default::default(),
+        activation_admissions: Default::default(),
+        settlements: Default::default(),
+        missing_settlements: Default::default(),
+        admitted_generations: Default::default(),
+        continuation_admissions: Default::default(),
+        activation_inputs: Default::default(),
+    }
+}
+
 #[test]
 fn append_state_changed_events_emits_single_lightweight_agent_event() {
     let dir = tempdir().unwrap();
@@ -2324,6 +2363,231 @@ async fn lifecycle_settlement_adopts_wait_without_work_item_turn_binding() {
             .find(|entry| entry.message_id == message.id)
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Processed)
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_restart_safe() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let lifecycle_wait = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#lifecycle-source".into()),
+            "waiting for lifecycle external event".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let lifecycle_generation = 1;
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition(
+            "default",
+            &canonical_lifecycle_waiting_snapshot(
+                &lifecycle_wait.condition.id,
+                lifecycle_generation,
+            ),
+        )
+        .unwrap();
+
+    let mut message = trusted_operator_prompt(None, "create a WorkItem and wait for its task");
+    message.turn_id = Some("turn-lifecycle-wait-handoff".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let admitted = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(matches!(
+        &admitted.activation_admissions[&activation_id]
+            .activation
+            .cause,
+        ActivationCause::LifecycleExternalNudge { message_id }
+            if message_id == &message.id
+    ));
+
+    runtime
+        .begin_interactive_turn(Some(&message), None, None)
+        .await
+        .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "work created by lifecycle nudge".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let work_wait = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-lifecycle-handoff".into()),
+            "waiting for lifecycle handoff task".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let updated_work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, None);
+    let processed = QueueEntryRecord {
+        message_id: message.id.clone(),
+        agent_id: message.agent_id.clone(),
+        priority: message.priority,
+        status: QueueEntryStatus::Processed,
+        created_at: message.created_at,
+        updated_at: Utc::now(),
+    };
+    runtime
+        .commit_queue_terminal_settlement(processed.clone(), Vec::new(), true, Some(&terminal))
+        .await
+        .unwrap();
+
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let work_generation = updated_work_item.revision;
+    assert_eq!(settled.slot, ActivationSlot::Idle);
+    assert_eq!(
+        settled.waits[&lifecycle_wait.condition.id].generations[&lifecycle_generation].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        settled.work[&work_item.id].status,
+        WorkStatus::Waiting {
+            wait_id: work_wait.condition.id.clone(),
+        }
+    );
+    assert_eq!(
+        settled.waits[&work_wait.condition.id].generations[&work_generation].owner,
+        SchedulerOwner::WorkItem {
+            work_item_id: work_item.id.clone(),
+        }
+    );
+    assert_eq!(
+        settled.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: work_wait.condition.id.clone(),
+                generation: work_generation,
+            },
+        }
+    );
+    assert_eq!(settled.focus.as_deref(), Some(work_item.id.as_str()));
+    assert!(settled.missing_settlements.is_empty());
+
+    let replay_commands = runtime
+        .canonical_queue_settlement_commands(&processed, Some(&terminal.turn_record))
+        .await
+        .unwrap();
+    assert!(matches!(
+        replay_commands.as_slice(),
+        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
+    ));
+    assert!(!runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .commit_scheduler_recovery_plan("default", &replay_commands)
+        .unwrap());
+
+    drop(runtime);
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let mut rejoin = task_result_message("task-lifecycle-handoff").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    rejoin.work_item_id = Some(work_item.id.clone());
+    rejoin.metadata = Some(serde_json::json!({
+        "task_id": "task-lifecycle-handoff",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-lifecycle-handoff",
+        "work_item_id": work_item.id,
+    }));
+    rejoin.turn_id = Some("turn-lifecycle-handoff-rejoin".into());
+    let rejoin = reopened.enqueue(rejoin).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let rejoined = reopened
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(matches!(
+        rejoined.slot,
+        ActivationSlot::Running {
+            owner: SchedulerOwner::WorkItem { ref work_item_id },
+            admitted_generation,
+            ..
+        } if work_item_id == &work_item.id && admitted_generation == work_generation
+    ));
+    assert_eq!(
+        rejoined.waits[&work_wait.condition.id].generations[&work_generation].state,
+        WaitState::Consumed
+    );
+    assert_eq!(
+        rejoined.waits[&work_wait.condition.id].generations[&work_generation]
+            .consuming_activation_id
+            .as_deref(),
+        Some(scheduler_executor::canonical_activation_id(&rejoin.id).as_str())
     );
 }
 

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -26,6 +26,7 @@ use crate::domain::scheduler_protocol::{
 
 const CANONICAL_COMMAND_SCHEMA_VERSION: i64 = 1;
 const LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION: i64 = 2;
+const ACTIVATION_WAIT_HANDOFF_SCHEMA_VERSION: i64 = 2;
 
 #[derive(Serialize)]
 struct LegacyActivationAuthorityPayload<'a> {
@@ -308,6 +309,29 @@ impl RuntimeTransitionRepository<'_> {
         let snapshot = load_snapshot_tx(&transaction, agent_id)?;
         transaction.commit()?;
         Ok(Some(snapshot))
+    }
+
+    pub(crate) fn activation_work_state_adoption_was_applied(
+        &self,
+        agent_id: &str,
+        activation_id: &str,
+        work_item_id: &str,
+    ) -> Result<bool> {
+        let connection = self.db.connection()?;
+        let command_identity = format!("{activation_id}:{work_item_id}");
+        let decision = enum_token(&Decision::LegacyWorkStateAdopted)?;
+        Ok(connection.query_row(
+            "SELECT EXISTS(
+               SELECT 1
+               FROM scheduler_protocol_command_results
+               WHERE agent_id = ?1
+                 AND command_kind = 'adopt_activation_work_state'
+                 AND command_identity = ?2
+                 AND decision = ?3
+             )",
+            params![agent_id, command_identity, decision],
+            |row| row.get(0),
+        )?)
     }
 
     pub(crate) fn inspect_retired_scheduler_rollout_metadata(
@@ -1031,6 +1055,11 @@ fn canonical_command_hash(command_kind: &str, command: &ProtocolCommand) -> Resu
             if command.replace_completed_focus.is_some() =>
         {
             LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION
+        }
+        ProtocolCommand::AdoptActivationWorkState(command)
+            if command.source_lifecycle_wait.is_some() =>
+        {
+            ACTIVATION_WAIT_HANDOFF_SCHEMA_VERSION
         }
         _ => CANONICAL_COMMAND_SCHEMA_VERSION,
     };
@@ -2549,6 +2578,7 @@ fn load_activations(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::scheduler_protocol::LifecycleWaitHandoffProof;
 
     fn legacy_adoption_command(replacement: Option<ReplaceCompletedFocusProof>) -> ProtocolCommand {
         ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
@@ -2567,6 +2597,28 @@ mod tests {
             focus: true,
             reserve_dispatch: false,
             replace_completed_focus: replacement,
+        })
+    }
+
+    fn activation_adoption_command(
+        source_lifecycle_wait: Option<LifecycleWaitHandoffProof>,
+    ) -> ProtocolCommand {
+        ProtocolCommand::AdoptActivationWorkState(AdoptActivationWorkStateCommand {
+            source_activation_id: "activation:message:message-a".into(),
+            source_message_id: "message-a".into(),
+            source_turn_id: "turn-a".into(),
+            source_admitted_generation: 2,
+            work_item_id: "work-a".into(),
+            source_work_item_revision: 3,
+            wait: LegacyWaitAdoption {
+                wait_id: "wait-work-a".into(),
+                generation: 3,
+                owner_work_item_id: "work-a".into(),
+                source_updated_at: "2026-08-01T00:00:00Z".into(),
+            },
+            source_lifecycle_wait,
+            focus: true,
+            reserve_dispatch: true,
         })
     }
 
@@ -2615,6 +2667,25 @@ mod tests {
         let (v2_schema, v2_hash) = canonical_command_hash("adopt_legacy_work_state", &v2)?;
         assert_eq!(v1_schema, 1);
         assert_eq!(v2_schema, LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION);
+        assert_ne!(v1_hash, v2_hash);
+        Ok(())
+    }
+
+    #[test]
+    fn activation_wait_handoff_uses_command_specific_v2_hash() -> Result<()> {
+        let v1 = activation_adoption_command(None);
+        let v2 = activation_adoption_command(Some(LifecycleWaitHandoffProof {
+            wait: WaitIdentity {
+                id: "wait-lifecycle-a".into(),
+                generation: 1,
+            },
+            expected_dispatch_revision: 4,
+        }));
+
+        let (v1_schema, v1_hash) = canonical_command_hash("adopt_activation_work_state", &v1)?;
+        let (v2_schema, v2_hash) = canonical_command_hash("adopt_activation_work_state", &v2)?;
+        assert_eq!(v1_schema, 1);
+        assert_eq!(v2_schema, ACTIVATION_WAIT_HANDOFF_SCHEMA_VERSION);
         assert_ne!(v1_hash, v2_hash);
         Ok(())
     }

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -10,10 +10,10 @@ use model::{
     ActivationProvenance, ActivationRecord, ActivationSettlement, ActivationSlot, ActivationState,
     ActivationTrust, AdmissionCause, AdmitActivationCommand, AdoptActivationWorkStateCommand,
     AgentActivation, AgentDispatchDisposition, AgentDispatchState, Decision, Event,
-    LegacyWaitAdoption, MissingSettlementRecord, PreemptionPolicy, ProtocolCommand,
-    ProtocolConflictKind, RegisterWorkDemandCommand, SchedulerOwner, SettleActivationCommand,
-    Settlement, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WaitTrigger,
-    WorkDemand, WorkStatus, YieldContinuationRecord,
+    LegacyWaitAdoption, LifecycleWaitHandoffProof, MissingSettlementRecord, PreemptionPolicy,
+    ProtocolCommand, ProtocolConflictKind, RegisterWorkDemandCommand, SchedulerOwner,
+    SettleActivationCommand, Settlement, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord,
+    WaitState, WaitTrigger, WorkDemand, WorkStatus, YieldContinuationRecord,
 };
 use proptest::prelude::*;
 use serde::Deserialize;
@@ -1803,6 +1803,7 @@ fn lifecycle_settlement_can_atomically_adopt_work_item_wait() {
             owner_work_item_id: "work-1".into(),
             source_updated_at: "2026-07-30T00:00:01Z".into(),
         },
+        source_lifecycle_wait: None,
         focus: true,
         reserve_dispatch: true,
     });
@@ -2075,6 +2076,183 @@ fn lifecycle_settlement_can_atomically_adopt_work_item_wait() {
         reused_wait.outcome.snapshot.dispatch_revision + 1
     );
     assert_invariants(&released.outcome.snapshot).unwrap();
+}
+
+#[test]
+fn lifecycle_wait_handoff_atomically_replaces_exact_reservation() {
+    let source_wait = WaitIdentity {
+        id: "wait-lifecycle".into(),
+        generation: 1,
+    };
+    let lifecycle_owner = SchedulerOwner::AgentLifecycle {
+        agent_id: "agent-1".into(),
+    };
+    let mut snapshot = minimal_snapshot(1);
+    snapshot.focus = None;
+    snapshot.work.clear();
+    snapshot.dispatch = AgentDispatchState::Awaiting {
+        wait: source_wait.clone(),
+    };
+    snapshot.dispatch_revision = 4;
+    snapshot.waits.insert(
+        source_wait.id.clone(),
+        WaitRecord {
+            current_generation: source_wait.generation,
+            generations: BTreeMap::from([(
+                source_wait.generation,
+                WaitGenerationRecord {
+                    owner: lifecycle_owner.clone(),
+                    state: WaitState::Active,
+                    trigger: None,
+                    consuming_activation_id: None,
+                },
+            )]),
+        },
+    );
+
+    let activation_id = "activation:message:msg-handoff";
+    let admitted = reduce_command(
+        &snapshot,
+        &ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: "authority-lifecycle-handoff".into(),
+            activation: AgentActivation {
+                id: activation_id.into(),
+                agent_id: "agent-1".into(),
+                state: ActivationLifecycleState::Admitted,
+                cause: ActivationCause::LifecycleExternalNudge {
+                    message_id: "msg-handoff".into(),
+                },
+                binding: ActivationBinding::Lifecycle {
+                    agent_id: "agent-1".into(),
+                },
+                priority: ActivationPriority::Normal,
+                preemption: PreemptionPolicy::NonPreemptive,
+                source_revision: None,
+                idempotency_key: "lifecycle-msg-handoff".into(),
+                provenance: ActivationProvenance {
+                    origin: ActivationOrigin::Operator,
+                    trust: ActivationTrust::OperatorInstruction,
+                    source_id: "msg-handoff".into(),
+                    correlation_id: None,
+                    causation_id: None,
+                },
+            },
+            expected_scheduling_generation: 2,
+            expected_dispatch_revision: 4,
+        }),
+    );
+    assert_eq!(admitted.outcome.decision, Decision::Admitted);
+    let settled = reduce_command(
+        &admitted.outcome.snapshot,
+        &ProtocolCommand::SettleActivation(SettleActivationCommand {
+            settlement: ActivationSettlement {
+                id: "settlement:message:msg-handoff".into(),
+                activation_id: activation_id.into(),
+                turn_terminal: Some("turn-handoff".into()),
+                disposition: ActivationDisposition::WorkContinues,
+                agent_dispatch: AgentDispatchDisposition::Open,
+                operator_delivery: None,
+                evidence: vec!["message:msg-handoff".into()],
+                created_at: "2026-08-01T00:00:00Z".into(),
+            },
+        }),
+    );
+    assert_eq!(settled.outcome.decision, Decision::Settled);
+    assert_eq!(
+        settled.outcome.snapshot.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: source_wait.clone(),
+        }
+    );
+
+    let command = ProtocolCommand::AdoptActivationWorkState(AdoptActivationWorkStateCommand {
+        source_activation_id: activation_id.into(),
+        source_message_id: "msg-handoff".into(),
+        source_turn_id: "turn-handoff".into(),
+        source_admitted_generation: 2,
+        work_item_id: "work-handoff".into(),
+        source_work_item_revision: 3,
+        wait: LegacyWaitAdoption {
+            wait_id: "wait-work".into(),
+            generation: 3,
+            owner_work_item_id: "work-handoff".into(),
+            source_updated_at: "2026-08-01T00:00:01Z".into(),
+        },
+        source_lifecycle_wait: Some(LifecycleWaitHandoffProof {
+            wait: source_wait.clone(),
+            expected_dispatch_revision: 4,
+        }),
+        focus: true,
+        reserve_dispatch: true,
+    });
+
+    let adopted = reduce_command(&settled.outcome.snapshot, &command);
+    assert_eq!(adopted.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(
+        adopted.outcome.snapshot.waits[&source_wait.id].generations[&source_wait.generation].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        adopted.outcome.snapshot.waits["wait-work"].generations[&3].owner,
+        SchedulerOwner::WorkItem {
+            work_item_id: "work-handoff".into(),
+        }
+    );
+    assert_eq!(
+        adopted.outcome.snapshot.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: "wait-work".into(),
+                generation: 3,
+            },
+        }
+    );
+    assert_eq!(adopted.outcome.snapshot.dispatch_revision, 5);
+    assert_eq!(
+        adopted.outcome.snapshot.focus.as_deref(),
+        Some("work-handoff")
+    );
+    assert_invariants(&adopted.outcome.snapshot).unwrap();
+
+    let replay = reduce_command(&adopted.outcome.snapshot, &command);
+    assert_eq!(replay.outcome.decision, Decision::DuplicateIgnored);
+    assert_eq!(replay.outcome.snapshot, adopted.outcome.snapshot);
+
+    let mut stale_command = command.clone();
+    let ProtocolCommand::AdoptActivationWorkState(stale) = &mut stale_command else {
+        unreachable!("fixture is an activation adoption command");
+    };
+    stale
+        .source_lifecycle_wait
+        .as_mut()
+        .expect("handoff proof")
+        .expected_dispatch_revision = 3;
+    let stale = reduce_command(&settled.outcome.snapshot, &stale_command);
+    assert_eq!(stale.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        stale.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::BindingConflict
+    );
+    assert_eq!(stale.outcome.snapshot, settled.outcome.snapshot);
+
+    let mut foreign = settled.outcome.snapshot.clone();
+    foreign
+        .waits
+        .get_mut(&source_wait.id)
+        .unwrap()
+        .generations
+        .get_mut(&source_wait.generation)
+        .unwrap()
+        .owner = SchedulerOwner::AgentLifecycle {
+        agent_id: "agent-foreign".into(),
+    };
+    let rejected = reduce_command(&foreign, &command);
+    assert_eq!(rejected.outcome.decision, Decision::Rejected);
+    assert_eq!(
+        rejected.conflict.expect("typed conflict").kind,
+        ProtocolConflictKind::BindingConflict
+    );
+    assert_eq!(rejected.outcome.snapshot, foreign);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- prove the exact lifecycle wait identity and dispatch revision before handing an activation over to a WorkItem wait
- atomically resolve the lifecycle reservation and install the WorkItem demand, wait, focus, and dispatch state
- reject stale or foreign reservations, preserve legacy command hashes, and make post-handoff settlement replay reuse the recorded result
- document the handoff contract and cover reducer, replay, restart, and task-result rejoin paths

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test lifecycle_wait_handoff -- --nocapture`
- `cargo test activation_wait_handoff_uses_command_specific_v2_hash -- --nocapture`
- `cargo test --test scheduler_workitem_mvp --test scheduler_lifecycle_owner`
- `cargo test --all-targets scheduler -- --nocapture`
- `cargo test --all-targets`

Closes #2476
