### PR TITLE
fix: reconcile recovery dispatch reservations

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -848,6 +848,13 @@ A stale revision or foreign reservation fails closed. After the adoption is
 recorded, settlement replay reuses the stored command result and must not
 reconstruct a different payload from the post-handoff dispatch state.
 
+Bootstrap reconciliation has the same atomicity requirement when
+`AdoptLegacyWorkStateCommand` refreshes the WorkItem that owns the exact current
+dispatch reservation. A newer waiting generation resolves the old generation
+and advances dispatch to the replacement wait in the same transaction. A newer
+runnable or paused state resolves the old wait and opens dispatch. Adoption of
+an unrelated WorkItem leaves the existing reservation unchanged.
+
 The settlement transaction writes every durable fact changed by the
 disposition, including as applicable:
 

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -2051,6 +2051,17 @@ fn adopt_legacy_work_state(
             ),
         );
     }
+    let source_dispatch_wait = snapshot
+        .work
+        .get(&command.work_item_id)
+        .and_then(|demand| match &demand.status {
+            WorkStatus::Waiting { wait_id } => Some(WaitIdentity {
+                id: wait_id.clone(),
+                generation: demand.scheduling_generation,
+            }),
+            _ => None,
+        })
+        .filter(|wait| snapshot.dispatch == (AgentDispatchState::Awaiting { wait: wait.clone() }));
     if command.focus
         && snapshot
             .focus
@@ -2121,7 +2132,10 @@ fn adopt_legacy_work_state(
             }
         }
     }
-    if command.reserve_dispatch && snapshot.dispatch != AgentDispatchState::Open {
+    if command.reserve_dispatch
+        && snapshot.dispatch != AgentDispatchState::Open
+        && source_dispatch_wait.is_none()
+    {
         return rejected_command(
             snapshot,
             command_conflict(
@@ -2153,9 +2167,16 @@ fn adopt_legacy_work_state(
     let mut next = snapshot.clone();
     if let Some(existing) = next.work.get(&command.work_item_id) {
         if let WorkStatus::Waiting { wait_id } = &existing.status {
-            if command.wait.as_ref().map(|wait| wait.wait_id.as_str()) != Some(wait_id.as_str()) {
+            let existing_wait = WaitIdentity {
+                id: wait_id.clone(),
+                generation: existing.scheduling_generation,
+            };
+            let target_preserves_generation = command.wait.as_ref().is_some_and(|wait| {
+                wait.wait_id == existing_wait.id && wait.generation == existing_wait.generation
+            });
+            if !target_preserves_generation {
                 if let Some(wait) = next.waits.get_mut(wait_id) {
-                    if let Some(generation) = wait.generations.get_mut(&wait.current_generation) {
+                    if let Some(generation) = wait.generations.get_mut(&existing_wait.generation) {
                         if matches!(generation.state, WaitState::Active | WaitState::Triggered) {
                             generation.state = WaitState::Resolved;
                             generation.trigger = None;
@@ -2168,32 +2189,48 @@ fn adopt_legacy_work_state(
     next.work
         .insert(command.work_item_id.clone(), command.demand.clone());
     if let Some(wait) = &command.wait {
-        next.waits.insert(
-            wait.wait_id.clone(),
-            WaitRecord {
-                current_generation: wait.generation,
-                generations: BTreeMap::from([(
-                    wait.generation,
-                    WaitGenerationRecord {
-                        owner: SchedulerOwner::WorkItem {
-                            work_item_id: wait.owner_work_item_id.clone(),
-                        },
-                        state: WaitState::Active,
-                        trigger: None,
-                        consuming_activation_id: None,
-                    },
-                )]),
+        let target_generation = WaitGenerationRecord {
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: wait.owner_work_item_id.clone(),
             },
-        );
-        if command.reserve_dispatch {
-            next.dispatch = AgentDispatchState::Awaiting {
-                wait: WaitIdentity {
-                    id: wait.wait_id.clone(),
-                    generation: wait.generation,
+            state: WaitState::Active,
+            trigger: None,
+            consuming_activation_id: None,
+        };
+        if source_dispatch_wait
+            .as_ref()
+            .is_some_and(|source| source.id == wait.wait_id)
+        {
+            let record = next
+                .waits
+                .get_mut(&wait.wait_id)
+                .expect("source dispatch wait exists");
+            record.current_generation = wait.generation;
+            record
+                .generations
+                .insert(wait.generation, target_generation);
+        } else {
+            next.waits.insert(
+                wait.wait_id.clone(),
+                WaitRecord {
+                    current_generation: wait.generation,
+                    generations: BTreeMap::from([(wait.generation, target_generation)]),
                 },
-            };
-            next.dispatch_revision += 1;
+            );
         }
+        if command.reserve_dispatch || source_dispatch_wait.is_some() {
+            set_dispatch_state(
+                &mut next,
+                AgentDispatchState::Awaiting {
+                    wait: WaitIdentity {
+                        id: wait.wait_id.clone(),
+                        generation: wait.generation,
+                    },
+                },
+            );
+        }
+    } else if source_dispatch_wait.is_some() {
+        set_dispatch_state(&mut next, AgentDispatchState::Open);
     }
     // Terminalize the replaced old focus demand if a proof was provided and validated.
     let mut transitions = vec![format!(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -675,6 +675,184 @@ async fn runtime_failure_preserves_canonical_claim_for_bootstrap_reconciliation(
 }
 
 #[tokio::test]
+async fn legacy_recovery_plan_reconciles_an_existing_dispatch_reservation() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "legacy recovery dispatch v1".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            Some("legacy recovery dispatch v2".into()),
+            None,
+            None,
+            None,
+            Some(None),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#recovery-dispatch".into()),
+            "waiting before legacy recovery".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_source = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let old_generation = waiting_source
+        .revision
+        .checked_sub(1)
+        .filter(|generation| *generation > 0)
+        .expect("fixture must have an older canonical generation");
+    let mut canonical =
+        canonical_waiting_snapshot(&waiting_source, &registration.condition.id, old_generation);
+    let demand = canonical.work.get_mut(&work_item.id).unwrap();
+    demand.metadata_revision = old_generation;
+    demand.scheduling_generation = old_generation;
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &canonical)
+        .unwrap();
+
+    let waiting_report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    let waiting_candidate = waiting_report
+        .legacy_adoptions
+        .iter()
+        .find(|candidate| candidate.work_item_id == work_item.id)
+        .expect("waiting legacy adoption candidate");
+    assert!(waiting_candidate.eligible);
+    apply_scheduler_recovery_plan(
+        &runtime.inner.storage,
+        &runtime.inner.runtime_db,
+        "default",
+        &waiting_report,
+    )
+    .unwrap();
+    let rearmed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(
+        rearmed.waits[&registration.condition.id].generations[&old_generation].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        rearmed.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: registration.condition.id.clone(),
+                generation: waiting_source.revision,
+            },
+        }
+    );
+
+    let mut resolved = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == registration.condition.id)
+        .expect("legacy wait condition");
+    let resolved_at = Utc::now();
+    resolved.status = WaitConditionStatus::Resolved;
+    resolved.updated_at = resolved_at;
+    resolved.resolved_at = Some(resolved_at);
+    runtime
+        .inner
+        .runtime_db
+        .wait_conditions()
+        .upsert(&resolved)
+        .unwrap();
+    runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            Some("legacy recovery dispatch runnable".into()),
+            None,
+            None,
+            None,
+            Some(None),
+        )
+        .await
+        .unwrap();
+    let runnable_source = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let runnable_report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    let runnable_candidate = runnable_report
+        .legacy_adoptions
+        .iter()
+        .find(|candidate| candidate.work_item_id == work_item.id)
+        .expect("runnable legacy adoption candidate");
+    assert!(
+        runnable_candidate.eligible,
+        "runnable candidate rejected: {}",
+        runnable_candidate.reason
+    );
+    apply_scheduler_recovery_plan(
+        &runtime.inner.storage,
+        &runtime.inner.runtime_db,
+        "default",
+        &runnable_report,
+    )
+    .unwrap();
+    let released = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert_eq!(released.dispatch, AgentDispatchState::Open);
+    assert_eq!(
+        released.waits[&registration.condition.id].generations[&waiting_source.revision].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        released.work[&work_item.id].scheduling_generation,
+        runnable_source.revision
+    );
+    assert_eq!(released.work[&work_item.id].status, WorkStatus::Runnable);
+}
+
+#[tokio::test]
 async fn bootstrap_diagnostics_report_cross_model_scheduler_invariant_failures() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -9,11 +9,12 @@ use model::{
     ActivationDisposition, ActivationLifecycleState, ActivationOrigin, ActivationPriority,
     ActivationProvenance, ActivationRecord, ActivationSettlement, ActivationSlot, ActivationState,
     ActivationTrust, AdmissionCause, AdmitActivationCommand, AdoptActivationWorkStateCommand,
-    AgentActivation, AgentDispatchDisposition, AgentDispatchState, Decision, Event,
-    LegacyWaitAdoption, LifecycleWaitHandoffProof, MissingSettlementRecord, PreemptionPolicy,
-    ProtocolCommand, ProtocolConflictKind, RegisterWorkDemandCommand, SchedulerOwner,
-    SettleActivationCommand, Settlement, Snapshot, WaitGenerationRecord, WaitIdentity, WaitRecord,
-    WaitState, WaitTrigger, WorkDemand, WorkStatus, YieldContinuationRecord,
+    AdoptLegacyWorkStateCommand, AgentActivation, AgentDispatchDisposition, AgentDispatchState,
+    Decision, Event, LegacyWaitAdoption, LifecycleWaitHandoffProof, MissingSettlementRecord,
+    PreemptionPolicy, ProtocolCommand, ProtocolConflictKind, RegisterWorkDemandCommand,
+    SchedulerOwner, SettleActivationCommand, Settlement, Snapshot, WaitGenerationRecord,
+    WaitIdentity, WaitRecord, WaitState, WaitTrigger, WorkDemand, WorkStatus,
+    YieldContinuationRecord,
 };
 use proptest::prelude::*;
 use serde::Deserialize;
@@ -2954,6 +2955,103 @@ fn reducer_rejections_have_explicit_stable_conflict_kinds() {
         rejected.outcome.diagnostics,
         ["settlement_recovery_pending"]
     );
+}
+
+#[test]
+fn legacy_recovery_adoption_reconciles_the_work_items_dispatch_reservation() {
+    let mut snapshot = minimal_snapshot(4);
+    snapshot.work.get_mut("w1").unwrap().status = WorkStatus::Waiting {
+        wait_id: "wait-1".into(),
+    };
+    snapshot.waits.insert(
+        "wait-1".into(),
+        wait_record("w1", 4, WaitState::Active, None, None),
+    );
+    snapshot.dispatch = AgentDispatchState::Awaiting {
+        wait: WaitIdentity {
+            id: "wait-1".into(),
+            generation: 4,
+        },
+    };
+    snapshot.dispatch_revision = 7;
+    assert_invariants(&snapshot).expect("waiting recovery prestate is canonical");
+
+    let rearm = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "w1".into(),
+        source_work_item_revision: 5,
+        demand: WorkDemand {
+            metadata_revision: 5,
+            scheduling_generation: 5,
+            status: WorkStatus::Waiting {
+                wait_id: "wait-1".into(),
+            },
+            capabilities: BTreeSet::new(),
+            locks: BTreeSet::new(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: Some(LegacyWaitAdoption {
+            wait_id: "wait-1".into(),
+            generation: 5,
+            owner_work_item_id: "w1".into(),
+            source_updated_at: "2026-08-01T00:00:00Z".into(),
+        }),
+        focus: true,
+        reserve_dispatch: false,
+        replace_completed_focus: None,
+    });
+    let rearmed = reduce_command(&snapshot, &rearm);
+    assert_eq!(rearmed.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(
+        rearmed.outcome.snapshot.waits["wait-1"].generations[&4].state,
+        WaitState::Resolved
+    );
+    assert_eq!(
+        rearmed.outcome.snapshot.waits["wait-1"].generations[&5].state,
+        WaitState::Active
+    );
+    assert_eq!(
+        rearmed.outcome.snapshot.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: "wait-1".into(),
+                generation: 5,
+            },
+        }
+    );
+    assert_eq!(rearmed.outcome.snapshot.dispatch_revision, 8);
+    assert_invariants(&rearmed.outcome.snapshot).expect("rearmed recovery state is canonical");
+
+    let replay = reduce_command(&rearmed.outcome.snapshot, &rearm);
+    assert_eq!(replay.outcome.decision, Decision::DuplicateIgnored);
+    assert_eq!(replay.outcome.snapshot, rearmed.outcome.snapshot);
+
+    let release = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "w1".into(),
+        source_work_item_revision: 6,
+        demand: WorkDemand {
+            metadata_revision: 6,
+            scheduling_generation: 6,
+            status: WorkStatus::Runnable,
+            capabilities: BTreeSet::new(),
+            locks: BTreeSet::new(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: None,
+        focus: true,
+        reserve_dispatch: false,
+        replace_completed_focus: None,
+    });
+    let released = reduce_command(&rearmed.outcome.snapshot, &release);
+    assert_eq!(released.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(
+        released.outcome.snapshot.waits["wait-1"].generations[&5].state,
+        WaitState::Resolved
+    );
+    assert_eq!(released.outcome.snapshot.dispatch, AgentDispatchState::Open);
+    assert_eq!(released.outcome.snapshot.dispatch_revision, 9);
+    assert_invariants(&released.outcome.snapshot).expect("released recovery state is canonical");
 }
 
 fn typed_admission(


### PR DESCRIPTION
## Summary

- reconcile bootstrap `AdoptLegacyWorkState` updates with the exact dispatch reservation already owned by that WorkItem
- resolve the previous wait generation and atomically advance dispatch when recovery rearms the wait
- resolve the previous wait and open dispatch when newer legacy state makes the WorkItem runnable or paused
- preserve unrelated dispatch reservations and retain same-wait generation history

## Root cause

The first #2476 fix covered lifecycle activation handoff, but startup recovery has a separate adoption path. When legacy state was newer than canonical state, `AdoptLegacyWorkState` updated the WorkItem demand and wait without updating the dispatch reservation. A `waiting@4 -> waiting@5` refresh left dispatch at generation 4, while a `waiting@5 -> runnable@6` refresh left dispatch pointing at a resolved wait. The reducer then rejected its own output with `canonical settlement dispatch disagrees with authoritative lane state`, rolling back the whole recovery plan on every restart.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test scheduler_workitem_mvp --test scheduler_lifecycle_owner`
- `cargo test legacy_recovery_plan_reconciles_an_existing_dispatch_reservation -- --nocapture`
- `cargo test --all-targets recovery -- --nocapture`

Closes #2476
