### PR TITLE
fix: decouple read APIs from runtime activation, add shutdown admission fence, recover orphaned dequeued claims

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -49,6 +49,7 @@ implementation and tests.
 - [Runtime Ledger Sequences and Object Revisions](./runtime-ledger-sequences-and-revisions.md)
 - [Runtime Ledger Files and Relations](./runtime-ledger-files-and-relations.md)
 - [Runtime Transition Commit Contract](./runtime-transition-commit-contract.md)
+- [Runtime Host Activation Admission And Read Projections](./runtime-host-activation-admission-and-read-projections.md)
 - [Runtime SQLite Retention And Space Reclamation](./runtime-db-retention.md)
 - [WorkItem Current Focus Canonical Fact](./work-item-current-focus.md)
 

--- a/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
+++ b/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
@@ -1,0 +1,119 @@
+# Runtime Host Activation Admission And Read Projections
+
+## Status
+
+Accepted for implementation by GitHub issue #2475.
+
+## Problem
+
+`RuntimeHost` historically exposed runtime handles to both read-only queries and
+execution-bearing requests. A read such as transcript retrieval could therefore
+create an agent runtime, start its scheduler loop, and claim durable input.
+
+That hidden side effect also raced with shutdown: shutdown drained the currently
+registered runtimes while a concurrent read could spawn and register a new one
+after the drain. The new runtime was not included in shutdown settlement and
+could leave a message permanently `dequeued` across restart.
+
+## Contract
+
+The host separates three operations.
+
+### Durable read
+
+A durable read validates agent identity and opens agent storage without loading,
+waking, or otherwise creating a runtime. Read-only HTTP and RPC handlers use this
+surface by default.
+
+### Loaded-runtime observation
+
+A loaded-runtime lookup returns an existing live `RuntimeHandle` or `None`. A
+miss is not an activation request. Read projections may use an existing runtime
+to enrich durable state with transient information.
+
+### Execution activation
+
+Runtime creation is an explicit admission operation with a reason such as
+scheduler dispatch, operator control, external ingress, wake, startup recovery,
+agent lifecycle, or child supervision. The reason is included in structured
+runtime activation logs.
+
+## Host registry state
+
+One lock protects both the activation phase and the loaded-runtime map:
+
+```text
+HostRuntimeRegistry {
+    phase: Open | Closing | Closed,
+    agents: Map<AgentId, AgentEntry>,
+}
+```
+
+Activation holds the registry write lock while it:
+
+1. verifies that the phase is `Open`;
+2. returns an existing live runtime or removes a finished entry;
+3. creates the runtime and its task;
+4. registers the entry.
+
+Shutdown holds the same write lock while it changes `Open` to `Closing` and
+drains every registered entry. It then requests shutdown and awaits or aborts
+the drained tasks before setting `Closed`.
+
+The lock is the linearization boundary:
+
+- activation registered first is included in shutdown;
+- shutdown closed admission first causes activation to fail without spawning.
+
+Repeated shutdown is idempotent. Execution-bearing HTTP requests rejected after
+admission closes return retryable `runtime_shutting_down` with HTTP 503.
+
+## Read behavior during shutdown
+
+Durable reads do not require activation and may continue while their storage
+dependencies remain available. Execution ingress is rejected once the registry
+enters `Closing`; this issue does not introduce a new durable mailbox acceptance
+contract for requests received during shutdown.
+
+Blocking task output is a live-runtime operation. If the target runtime is not
+loaded, callers may read already persisted output without blocking, but a
+blocking request returns a typed conflict instead of activating the agent.
+
+## Startup recovery of orphaned claims
+
+Startup recovery runs before listeners accept requests. It may change a queue
+entry from `dequeued` to `interrupted` only when one transaction proves:
+
+1. the queue entry is still `dequeued`;
+2. no canonical activation owns the message;
+3. no terminal turn exists for the message;
+4. startup has not admitted live runtimes;
+5. the target agent identity remains active.
+
+The transition is compare-and-set and records an audit event. Any canonical
+activation or terminal turn excludes the entry from orphan recovery. No age,
+posture, or heuristic threshold is sufficient evidence.
+
+Recovered non-stopped agents are explicitly activated with the startup recovery
+reason before HTTP listeners open. Stopped agents retain the recoverable durable
+claim but are not started.
+
+## Verification
+
+Tests cover:
+
+- durable reads of unloaded agents without map mutation;
+- activation and shutdown linearization in both orders;
+- execution ingress after admission closes;
+- orphan `dequeued` recovery and idempotence;
+- canonical or terminal ownership exclusions;
+- read-only HTTP routes without activation;
+- unloaded blocking task-output behavior.
+
+## Non-goals
+
+- Waking or preloading agents for read convenience.
+- Requeueing every `dequeued` entry.
+- Changing canonical activation settlement semantics.
+- Accepting shutdown-window ingress under a new delivery protocol.
+- Introducing a general service or plugin framework.

--- a/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
+++ b/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
@@ -79,6 +79,13 @@ Blocking task output is a live-runtime operation. If the target runtime is not
 loaded, callers may read already persisted output without blocking, but a
 blocking request returns a typed conflict instead of activating the agent.
 
+Event-stream filtering derives `awaiting_operator_input` from durable
+work-item scheduling state. It therefore reports open work items waiting for
+operator input, but does not project a transient agent-level
+`WaitFor(operator_input)` that has no associated work item. Preserving that
+broader live-runtime closure signal would require activation or a separate
+durable projection and is outside this read-only contract.
+
 ## Startup recovery of orphaned claims
 
 Startup recovery runs before listeners accept requests. It may change a queue

--- a/src/host.rs
+++ b/src/host.rs
@@ -33,24 +33,32 @@ use crate::{
     ids,
     prompt::{build_effective_prompt_with_apply_patch_surface, EffectivePrompt},
     provider::{build_provider_from_config, AgentProvider},
-    runtime::{InitialWorkspaceBinding, LightweightAgentStateProjection, RuntimeHandle},
+    runtime::{
+        InitialWorkspaceBinding, LightweightAgentStateProjection, RuntimeHandle,
+        SchedulerRepairInspection,
+    },
     runtime_db::RuntimeDb,
     skills::{
         effective_skill_root_registrations, skills_runtime_view_from_catalog, SkillVisibility,
         SkillsRegistry,
     },
     storage::{AppStorage, EventBus, PublishedAuditEvent},
-    system::{ExecutionScopeKind, HostLocalBoundary, WorkspaceAccessMode},
+    system::{
+        ExecutionProfile, ExecutionScopeKind, ExecutionSnapshot, HostLocalBoundary,
+        WorkspaceAccessMode,
+    },
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
         AdmissionContext, AgentDeletionJob, AgentIdentityRecord, AgentIdentityView, AgentKind,
         AgentLifecycleHint, AgentListEntry, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentVisibility,
-        AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord, MessageBody,
+        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentTokenUsageSummary,
+        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
+        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
-        OperatorNotificationRecord, Priority, RuntimeFailureSummary, SpawnAgentModelResolution,
-        SpawnAgentModelResolutionStatus, TaskKind, TaskRecord, TaskStatus, TimerRecord,
-        TranscriptEntry, TranscriptEntryKind, WorkspaceEntry, WorkspaceOccupancyRecord,
+        OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
+        SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
+        TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
+        WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -107,6 +115,7 @@ pub enum PublicAgentError {
     DeleteForbidden { agent_id: String, reason: String },
     Private { agent_id: String },
     Stopped { agent_id: String },
+    ShuttingDown,
     Runtime(anyhow::Error),
 }
 
@@ -126,6 +135,7 @@ impl std::fmt::Display for PublicAgentError {
             Self::Stopped { agent_id } => {
                 write!(f, "agent {} is stopped; start first", agent_id)
             }
+            Self::ShuttingDown => write!(f, "runtime is shutting down"),
             Self::Runtime(error) => write!(f, "{error}"),
         }
     }
@@ -146,13 +156,62 @@ pub(crate) struct HostInner {
     runtime_db_maintenance_lock: Mutex<Option<crate::runtime_db::RuntimeDbLock>>,
     skills_registry: Arc<RwLock<SkillsRegistry>>,
     static_provider: Option<Arc<dyn AgentProvider>>,
-    agents: RwLock<HashMap<String, AgentEntry>>,
+    runtimes: RwLock<HostRuntimeRegistry>,
 }
 
 struct AgentEntry {
     runtime: RuntimeHandle,
     task: JoinHandle<()>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostRuntimePhase {
+    Open,
+    Closing,
+    Closed,
+}
+
+struct HostRuntimeRegistry {
+    phase: HostRuntimePhase,
+    agents: HashMap<String, AgentEntry>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum RuntimeActivationReason {
+    SchedulerDispatch,
+    OperatorControl,
+    ExternalIngress,
+    Wake,
+    StartupRecovery,
+    AgentLifecycle,
+    ChildSupervision,
+}
+
+impl RuntimeActivationReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SchedulerDispatch => "scheduler_dispatch",
+            Self::OperatorControl => "operator_control",
+            Self::ExternalIngress => "external_ingress",
+            Self::Wake => "wake",
+            Self::StartupRecovery => "startup_recovery",
+            Self::AgentLifecycle => "agent_lifecycle",
+            Self::ChildSupervision => "child_supervision",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RuntimeAdmissionClosed;
+
+impl std::fmt::Display for RuntimeAdmissionClosed {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("runtime is shutting down")
+    }
+}
+
+impl std::error::Error for RuntimeAdmissionClosed {}
 
 fn stopped_unloaded_agent(agent_id: &str) -> AgentState {
     let mut agent = AgentState::new(agent_id.to_string());
@@ -269,7 +328,10 @@ impl RuntimeHost {
                 runtime_db_maintenance_lock: Mutex::new(None),
                 skills_registry: Arc::new(RwLock::new(SkillsRegistry::new())),
                 static_provider,
-                agents: RwLock::new(HashMap::new()),
+                runtimes: RwLock::new(HostRuntimeRegistry {
+                    phase: HostRuntimePhase::Open,
+                    agents: HashMap::new(),
+                }),
             }),
         };
         host.ensure_default_agent_identity()?;
@@ -295,8 +357,12 @@ impl RuntimeHost {
             .map_err(|e| anyhow!("failed to reload config: {}", e))?;
         self.inner.registry.replace_config(new_config.clone());
         let agent_handles: Vec<RuntimeHandle> = {
-            let agents = self.inner.agents.read().await;
-            agents.values().map(|entry| entry.runtime.clone()).collect()
+            let registry = self.inner.runtimes.read().await;
+            registry
+                .agents
+                .values()
+                .map(|entry| entry.runtime.clone())
+                .collect()
         };
         for runtime in &agent_handles {
             if let Err(e) = runtime.reload_config(&new_config).await {
@@ -583,16 +649,23 @@ impl RuntimeHost {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
+        let entries = {
+            let mut registry = self.inner.runtimes.write().await;
+            match registry.phase {
+                HostRuntimePhase::Open => {
+                    registry.phase = HostRuntimePhase::Closing;
+                    registry
+                        .agents
+                        .drain()
+                        .map(|(_, entry)| entry)
+                        .collect::<Vec<_>>()
+                }
+                HostRuntimePhase::Closing | HostRuntimePhase::Closed => return Ok(()),
+            }
+        };
         self.shutdown_daemon_runtime_db_retention().await;
         self.shutdown_daemon_memory_indexer().await;
         self.shutdown_daemon_deletion_coordinator().await;
-        let entries = {
-            let mut agents = self.inner.agents.write().await;
-            agents.drain().map(|(_, entry)| entry).collect::<Vec<_>>()
-        };
-        if entries.is_empty() {
-            return Ok(());
-        }
         let mut tasks = Vec::with_capacity(entries.len());
         for entry in entries {
             let _ = entry.runtime.request_service_shutdown().await;
@@ -613,11 +686,12 @@ impl RuntimeHost {
                 let _ = task.await;
             }
         }
+        self.inner.runtimes.write().await.phase = HostRuntimePhase::Closed;
         Ok(())
     }
 
     pub(crate) async fn unload_runtime(&self, agent_id: &str) {
-        let entry = self.inner.agents.write().await.remove(agent_id);
+        let entry = self.inner.runtimes.write().await.agents.remove(agent_id);
         if let Some(entry) = entry {
             entry.task.abort();
             let _ = entry.task.await;
@@ -625,8 +699,29 @@ impl RuntimeHost {
     }
 
     pub async fn default_runtime(&self) -> Result<RuntimeHandle> {
-        self.get_or_create_agent(&self.config().default_agent_id)
-            .await
+        self.activate_agent(
+            &self.config().default_agent_id,
+            RuntimeActivationReason::AgentLifecycle,
+        )
+        .await
+    }
+
+    pub async fn recover_orphaned_queue_claims_at_startup(&self) -> Result<Vec<String>> {
+        let recovered_agent_ids = self
+            .runtime_db()
+            .recover_orphaned_dequeued_claims_at_startup()?;
+        for agent_id in &recovered_agent_ids {
+            let state = self
+                .agent_storage_read_only(agent_id)?
+                .read_agent()?
+                .unwrap_or_else(|| AgentState::new(agent_id));
+            if state.status == AgentStatus::Stopped {
+                continue;
+            }
+            self.activate_agent(agent_id, RuntimeActivationReason::StartupRecovery)
+                .await?;
+        }
+        Ok(recovered_agent_ids)
     }
 
     fn active_agent_identity(
@@ -663,14 +758,345 @@ impl RuntimeHost {
         Ok(identity)
     }
 
+    fn public_activation_error(error: anyhow::Error) -> PublicAgentError {
+        if error.downcast_ref::<RuntimeAdmissionClosed>().is_some() {
+            PublicAgentError::ShuttingDown
+        } else {
+            PublicAgentError::Runtime(error)
+        }
+    }
+
+    pub(crate) fn public_agent_read_storage(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<AppStorage, PublicAgentError> {
+        self.public_agent_identity(agent_id)?;
+        self.agent_storage_read_only(agent_id)
+            .map_err(PublicAgentError::Runtime)
+    }
+
+    pub(crate) async fn try_get_loaded_runtime(&self, agent_id: &str) -> Option<RuntimeHandle> {
+        let registry = self.inner.runtimes.read().await;
+        registry
+            .agents
+            .get(agent_id)
+            .filter(|entry| !entry.task.is_finished())
+            .map(|entry| entry.runtime.clone())
+    }
+
+    pub(crate) async fn try_get_public_loaded_runtime(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<Option<RuntimeHandle>, PublicAgentError> {
+        self.public_agent_identity(agent_id)?;
+        Ok(self.try_get_loaded_runtime(agent_id).await)
+    }
+
+    pub(crate) async fn public_agent_skills_view(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<crate::types::SkillsRuntimeView, PublicAgentError> {
+        let identity = self.public_agent_identity(agent_id)?;
+        let identity_view =
+            AgentIdentityView::from_record(&identity, &self.config().default_agent_id);
+        let storage = self
+            .agent_storage_read_only(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let state = storage
+            .read_agent()
+            .map_err(PublicAgentError::Runtime)?
+            .unwrap_or_else(|| AgentState::new(agent_id));
+        let agent_home = self.agent_data_dir(agent_id);
+        let workspace_skill_root = state
+            .active_workspace_entry
+            .as_ref()
+            .map(|entry| entry.execution_root.as_path());
+        let skill_roots = effective_skill_root_registrations(
+            skill_visibility(&identity_view),
+            Some(self.config().home_dir.as_path()),
+            agent_id,
+            &agent_home,
+            workspace_skill_root,
+        );
+        let mut registry = self.inner.skills_registry.write().await;
+        registry
+            .sync_effective_roots(skill_roots.clone())
+            .map_err(PublicAgentError::Runtime)?;
+        let mut skills = skills_runtime_view_from_catalog(
+            registry.catalog_for_roots(&skill_roots, None),
+            &skill_roots,
+            &state.active_skills,
+        );
+        skills.agent_templates_catalog =
+            discover_agent_templates_catalog(Some(self.config().home_dir.as_path()), &agent_home);
+        Ok(skills)
+    }
+
+    pub(crate) async fn search_memory_read_only(
+        &self,
+        query: &str,
+        limit: usize,
+        include_all_workspaces: bool,
+        agent_ids: &[String],
+    ) -> Result<crate::memory::MemorySearchQueryResult> {
+        let default_agent_id = self.config().default_agent_id.clone();
+        let storage = self.agent_storage_read_only(&default_agent_id)?;
+        let active_workspace_id = storage
+            .read_agent()?
+            .and_then(|agent| agent.active_workspace_entry)
+            .map(|entry| entry.workspace_id);
+        let mut agent_storages = Vec::new();
+        for agent_id in agent_ids {
+            self.public_agent_identity(agent_id)
+                .map_err(anyhow::Error::new)?;
+            agent_storages.push(self.agent_storage_read_only(agent_id)?);
+        }
+        let query = query.to_string();
+        let agent_ids = agent_ids.to_vec();
+        tokio::task::spawn_blocking(move || {
+            let _ = crate::memory::ensure_memory_indexes_fresh(
+                &storage,
+                active_workspace_id.as_deref(),
+                &agent_storages,
+            );
+            crate::memory::search_memory_query_for_agent_storages(
+                &storage,
+                &query,
+                limit,
+                active_workspace_id.as_deref(),
+                include_all_workspaces,
+                &agent_ids,
+                &agent_storages,
+            )
+        })
+        .await?
+    }
+
+    pub(crate) async fn get_memory_read_only(
+        &self,
+        source_ref: &str,
+        max_chars: Option<usize>,
+    ) -> Result<Option<crate::memory::MemoryGetResult>> {
+        let storage = self.agent_storage_read_only(&self.config().default_agent_id)?;
+        let active_workspace_id = storage
+            .read_agent()?
+            .and_then(|agent| agent.active_workspace_entry)
+            .map(|entry| entry.workspace_id);
+        let source_ref = source_ref.to_string();
+        tokio::task::spawn_blocking(move || {
+            crate::memory::get_memory(
+                &storage,
+                &source_ref,
+                max_chars,
+                active_workspace_id.as_deref(),
+            )
+        })
+        .await?
+    }
+
+    pub(crate) fn public_agent_scheduler_repair_inspection(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<SchedulerRepairInspection, PublicAgentError> {
+        self.public_agent_identity(agent_id)?;
+        let storage = self
+            .agent_storage_read_only(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let active_waits = storage
+            .raw_active_wait_conditions_for_agent(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let mut wake_only_queue_entries = Vec::new();
+        for entry in storage
+            .latest_queue_entries()
+            .map_err(PublicAgentError::Runtime)?
+        {
+            if entry.agent_id != agent_id
+                || !matches!(
+                    entry.status,
+                    QueueEntryStatus::Queued | QueueEntryStatus::Interrupted
+                )
+            {
+                continue;
+            }
+            if storage
+                .read_message_by_id(&entry.message_id)
+                .map_err(PublicAgentError::Runtime)?
+                .as_ref()
+                .is_some_and(crate::runtime::is_wake_only_message)
+            {
+                wake_only_queue_entries.push(entry);
+            }
+        }
+        Ok(SchedulerRepairInspection {
+            agent_id: agent_id.to_string(),
+            active_waits,
+            wake_only_queue_entries,
+        })
+    }
+
+    pub(crate) fn public_agent_worktree_summary(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<String, PublicAgentError> {
+        self.public_agent_identity(agent_id)?;
+        let storage = self
+            .agent_storage_read_only(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let tasks = storage
+            .latest_all_task_records(usize::MAX)
+            .map_err(PublicAgentError::Runtime)?;
+        let messages = storage
+            .read_recent_messages(200)
+            .map_err(PublicAgentError::Runtime)?;
+        Ok(crate::runtime::format_worktree_task_summary(
+            &tasks, &messages,
+        ))
+    }
+
+    pub(crate) async fn local_agent_summary(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<AgentSummary, PublicAgentError> {
+        self.active_agent_identity(agent_id)?;
+        if let Some(runtime) = self.try_get_loaded_runtime(agent_id).await {
+            return runtime
+                .agent_summary()
+                .await
+                .map_err(PublicAgentError::Runtime);
+        }
+        // Storage-backed fallback: build AgentSummary without activating runtime.
+        let identity = self.active_agent_identity(agent_id)?;
+        let storage = self
+            .agent_storage_read_only(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let agent_state = storage
+            .read_agent()
+            .map_err(PublicAgentError::Runtime)?
+            .unwrap_or_else(|| stopped_unloaded_agent(agent_id));
+        let work_queue = storage
+            .work_queue_read_model()
+            .map_err(PublicAgentError::Runtime)?;
+        let scheduling_posture = storage
+            .agent_posture_projection_with_work_queue(&agent_state, &work_queue)
+            .map_err(PublicAgentError::Runtime)?;
+        let closure = RuntimeHandle::closure_decision_from_storage(&storage, &agent_state)
+            .map_err(PublicAgentError::Runtime)?;
+        let active_children = self
+            .child_agent_summaries(agent_id)
+            .await
+            .map_err(PublicAgentError::Runtime)?;
+        let identity_view =
+            AgentIdentityView::from_record(&identity, &self.config().default_agent_id);
+        let model = crate::runtime::agent_model_state_for_catalog(
+            &RuntimeModelCatalog::from_config(&self.config()),
+            &self.runtime_context_config(),
+            &agent_state,
+        );
+        let token_usage = AgentTokenUsageSummary {
+            total: TokenUsage::new(
+                agent_state.total_input_tokens,
+                agent_state.total_output_tokens,
+            ),
+            total_model_rounds: agent_state.total_model_rounds,
+            last_turn: agent_state.last_turn_token_usage.clone(),
+        };
+        let execution = if let Some(entry) = agent_state.active_workspace_entry.as_ref() {
+            ExecutionSnapshot {
+                profile: ExecutionProfile::default(),
+                policy: ExecutionProfile::default().policy_snapshot(),
+                attached_workspaces: Vec::new(),
+                workspace_id: Some(entry.workspace_id.clone()),
+                workspace_anchor: entry.workspace_anchor.clone(),
+                execution_root: entry.execution_root.clone(),
+                cwd: entry.cwd.clone(),
+                execution_root_id: Some(entry.execution_root_id.clone()),
+                projection_kind: Some(entry.projection_kind),
+                access_mode: Some(entry.access_mode),
+                worktree_root: None,
+                execution_roots: Vec::new(),
+            }
+        } else {
+            ExecutionSnapshot {
+                profile: ExecutionProfile::default(),
+                policy: ExecutionProfile::default().policy_snapshot(),
+                attached_workspaces: Vec::new(),
+                workspace_id: None,
+                workspace_anchor: PathBuf::new(),
+                execution_root: PathBuf::new(),
+                cwd: PathBuf::new(),
+                execution_root_id: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree_root: None,
+                execution_roots: Vec::new(),
+            }
+        };
+        let active_wait_conditions = storage
+            .active_wait_conditions_for_agent(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .into_iter()
+            .map(WaitConditionSummary::from)
+            .collect();
+        let active_external_triggers = storage
+            .latest_external_triggers()
+            .map_err(PublicAgentError::Runtime)?
+            .into_iter()
+            .filter(|record| record.status == ExternalTriggerStatus::Active)
+            .map(|record| ExternalTriggerSummary {
+                external_trigger_id: record.external_trigger_id,
+                target_agent_id: record.target_agent_id,
+                scope: record.scope,
+                delivery_mode: record.delivery_mode,
+                status: record.status,
+                delivery_count: record.delivery_count,
+                created_at: record.created_at,
+                revoked_at: record.revoked_at,
+                last_delivered_at: record.last_delivered_at,
+            })
+            .collect();
+        let skills = self.public_agent_skills_view(agent_id).await?;
+        let loaded_agents_md = LoadedAgentsMdView::default();
+        let summary = AgentSummary {
+            identity: identity_view,
+            lifecycle: AgentLifecycleHint::from_status(agent_id, agent_state.status.clone()),
+            agent: agent_state,
+            scheduling_posture,
+            active_task_count: storage
+                .active_task_count_for_agent(agent_id)
+                .map_err(PublicAgentError::Runtime)?,
+            model,
+            token_usage,
+            closure,
+            execution,
+            active_workspace_occupancy: None,
+            loaded_agents_md,
+            skills,
+            active_children,
+            active_wait_conditions,
+            active_external_triggers,
+            recent_operator_notifications: storage
+                .read_recent_operator_notifications(10)
+                .map_err(PublicAgentError::Runtime)?,
+            recent_brief_count: storage
+                .read_recent_briefs(50)
+                .map_err(PublicAgentError::Runtime)?
+                .len(),
+            recent_event_count: storage
+                .read_recent_events(100)
+                .map_err(PublicAgentError::Runtime)?
+                .len(),
+        };
+        Ok(summary)
+    }
+
     pub async fn get_public_agent(
         &self,
         agent_id: &str,
     ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
         self.public_agent_identity(agent_id)?;
-        self.get_or_create_agent(agent_id)
+        self.activate_agent(agent_id, RuntimeActivationReason::OperatorControl)
             .await
-            .map_err(PublicAgentError::Runtime)
+            .map_err(Self::public_activation_error)
     }
 
     pub async fn begin_public_agent_deletion(
@@ -760,8 +1186,9 @@ impl RuntimeHost {
     ) -> std::result::Result<AgentStateReadProjection, PublicAgentError> {
         let identity = self.public_agent_identity(agent_id)?;
         let runtime = {
-            let agents = self.inner.agents.read().await;
-            agents
+            let registry = self.inner.runtimes.read().await;
+            registry
+                .agents
                 .get(agent_id)
                 .filter(|entry| !entry.task.is_finished())
                 .map(|entry| entry.runtime.clone())
@@ -917,9 +1344,9 @@ impl RuntimeHost {
                 agent_id: agent_id.to_string(),
             });
         }
-        self.get_or_create_agent(agent_id)
+        self.activate_agent(agent_id, RuntimeActivationReason::ExternalIngress)
             .await
-            .map_err(PublicAgentError::Runtime)
+            .map_err(Self::public_activation_error)
     }
 
     pub async fn control_public_agent(
@@ -1068,13 +1495,23 @@ impl RuntimeHost {
         )
         .with_lineage_parent_agent_id(lineage_parent_agent_id.map(ToString::to_string));
         self.append_agent_identity(&record)?;
-        let _ = self.get_or_create_agent(agent_id).await?;
+        let _ = self
+            .activate_agent(agent_id, RuntimeActivationReason::AgentLifecycle)
+            .await?;
         Ok((record, true))
     }
 
     pub fn get_or_create_agent<'a>(
         &'a self,
         agent_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<RuntimeHandle>> + Send + 'a>> {
+        self.activate_agent(agent_id, RuntimeActivationReason::AgentLifecycle)
+    }
+
+    pub(crate) fn activate_agent<'a>(
+        &'a self,
+        agent_id: &'a str,
+        reason: RuntimeActivationReason,
     ) -> Pin<Box<dyn Future<Output = Result<RuntimeHandle>> + Send + 'a>> {
         Box::pin(async move {
             self.validate_agent_id(agent_id)?;
@@ -1086,53 +1523,34 @@ impl RuntimeHost {
             if agent_id == self.config().default_agent_id {
                 self.ensure_default_agent_home_initialized().await?;
             }
-            {
-                let agents = self.inner.agents.read().await;
-                if let Some(entry) = agents.get(agent_id) {
-                    if !entry.task.is_finished() {
-                        return Ok(entry.runtime.clone());
-                    }
-                }
-            }
-
-            let stale_entry = {
-                let mut agents = self.inner.agents.write().await;
-                if agents
-                    .get(agent_id)
-                    .is_some_and(|entry| entry.task.is_finished())
-                {
-                    agents.remove(agent_id)
-                } else {
-                    None
-                }
-            };
-            if let Some(entry) = stale_entry {
-                let _ = entry.task.await;
-            }
-
-            let (runtime, runtime_task) = self.spawn_runtime(agent_id)?;
-
             let mut stale_entry = None;
-            let mut agents = self.inner.agents.write().await;
+            let mut registry = self.inner.runtimes.write().await;
+            if registry.phase != HostRuntimePhase::Open {
+                return Err(anyhow::Error::new(RuntimeAdmissionClosed));
+            }
             if let Err(error) = self.active_agent_identity(agent_id) {
-                runtime_task.abort();
                 return Err(anyhow::Error::new(error));
             }
-            if let Some(entry) = agents.get(agent_id) {
+            if let Some(entry) = registry.agents.get(agent_id) {
                 if !entry.task.is_finished() {
-                    runtime_task.abort();
                     return Ok(entry.runtime.clone());
                 }
-                stale_entry = agents.remove(agent_id);
+                stale_entry = registry.agents.remove(agent_id);
             }
-            agents.insert(
+            let (runtime, runtime_task) = self.spawn_runtime(agent_id)?;
+            tracing::debug!(
+                agent_id,
+                activation_reason = reason.as_str(),
+                "activating agent runtime"
+            );
+            registry.agents.insert(
                 agent_id.to_string(),
                 AgentEntry {
                     runtime: runtime.clone(),
                     task: runtime_task,
                 },
             );
-            drop(agents);
+            drop(registry);
             if let Some(entry) = stale_entry {
                 let _ = entry.task.await;
             }
@@ -1263,8 +1681,9 @@ impl RuntimeHost {
                 && record.visibility == AgentVisibility::Public
         }) {
             let runtime = {
-                let agents = self.inner.agents.read().await;
-                agents
+                let registry = self.inner.runtimes.read().await;
+                registry
+                    .agents
                     .get(&identity.agent_id)
                     .filter(|entry| !entry.task.is_finished())
                     .map(|entry| entry.runtime.clone())
@@ -1338,7 +1757,7 @@ impl RuntimeHost {
             record.status == AgentRegistryStatus::Active
                 && record.visibility == AgentVisibility::Public
         }) {
-            if let Some(runtime) = self.loaded_runtime(&identity.agent_id).await {
+            if let Some(runtime) = self.try_get_loaded_runtime(&identity.agent_id).await {
                 let state = runtime.agent_state().await?;
                 let active_task_count = runtime.active_tasks(usize::MAX).await?.len();
                 snapshots.push(PublicAgentActivitySnapshot {
@@ -1601,15 +2020,10 @@ impl RuntimeHost {
         storage: &AppStorage,
         state: &AgentState,
     ) -> Result<crate::types::ChildAgentObservabilitySnapshot> {
-        if let Some(runtime) = self.loaded_runtime(agent_id).await {
+        if let Some(runtime) = self.try_get_loaded_runtime(agent_id).await {
             return runtime.child_agent_observability().await;
         }
         RuntimeHandle::child_agent_observability_from_storage(storage, state)
-    }
-
-    async fn loaded_runtime(&self, agent_id: &str) -> Option<RuntimeHandle> {
-        let agents = self.inner.agents.read().await;
-        agents.get(agent_id).map(|entry| entry.runtime.clone())
     }
 
     pub async fn resolve_external_trigger(
@@ -1703,7 +2117,7 @@ impl RuntimeHost {
             }
         }
 
-        let entry = self.inner.agents.write().await.remove(agent_id);
+        let entry = self.inner.runtimes.write().await.agents.remove(agent_id);
         if let Some(entry) = entry {
             let _ = entry
                 .runtime
@@ -2689,7 +3103,7 @@ mod tests {
             .unwrap();
 
         assert!(prompt.render_dump().contains("inspect prompt"));
-        assert!(host.inner.agents.read().await.is_empty());
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
         assert_eq!(storage.read_agent().unwrap(), None);
         let entries = storage.latest_queue_entries().unwrap();
         assert_eq!(entries.len(), 1);
@@ -2967,7 +3381,7 @@ mod tests {
         state.status = AgentStatus::Asleep;
         host.runtime_db().agent_states().upsert(&state).unwrap();
 
-        assert!(host.inner.agents.read().await.is_empty());
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
         assert!(!host
             .agent_data_dir(&agent_id)
             .join(".holon/state/agent.json")
@@ -2980,7 +3394,7 @@ mod tests {
 
         assert_eq!(projection.source, AgentStateProjectionSource::Storage);
         assert_eq!(projection.agent.agent.status, AgentStatus::Asleep);
-        assert!(host.inner.agents.read().await.is_empty());
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
         assert!(!host
             .agent_data_dir(&agent_id)
             .join(".holon/state/agent.json")
@@ -3903,9 +4317,9 @@ mod tests {
             crate::types::ChildAgentPhase::Running
         );
         {
-            let agents = host.inner.agents.read().await;
+            let registry = host.inner.runtimes.read().await;
             assert!(
-                !agents.contains_key("child_test"),
+                !registry.agents.contains_key("child_test"),
                 "child summary inspection should not start the child runtime"
             );
         }
@@ -4552,17 +4966,17 @@ mod tests {
         let _beta = host.get_public_agent("beta").await.unwrap();
 
         {
-            let agents = host.inner.agents.read().await;
-            assert!(agents.contains_key("alpha"));
-            assert!(agents.contains_key("beta"));
+            let registry = host.inner.runtimes.read().await;
+            assert!(registry.agents.contains_key("alpha"));
+            assert!(registry.agents.contains_key("beta"));
         }
 
         host.unload_runtime("alpha").await;
 
         {
-            let agents = host.inner.agents.read().await;
-            assert!(!agents.contains_key("alpha"));
-            assert!(agents.contains_key("beta"));
+            let registry = host.inner.runtimes.read().await;
+            assert!(!registry.agents.contains_key("alpha"));
+            assert!(registry.agents.contains_key("beta"));
         }
 
         let beta_runtime = host.get_public_agent("beta").await.unwrap();
@@ -4676,8 +5090,9 @@ mod tests {
         };
 
         let old_task = {
-            let mut agents = host.inner.agents.write().await;
-            let entry = agents
+            let mut registry = host.inner.runtimes.write().await;
+            let entry = registry
+                .agents
                 .get_mut(&agent_id)
                 .expect("default runtime should be loaded");
             std::mem::replace(&mut entry.task, replacement_task)
@@ -4832,8 +5247,9 @@ mod tests {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         loop {
             let finished = {
-                let agents = host.inner.agents.read().await;
-                agents
+                let registry = host.inner.runtimes.read().await;
+                registry
+                    .agents
                     .get(&agent_id)
                     .map(|entry| entry.task.is_finished())
                     .unwrap_or(false)
@@ -4867,13 +5283,16 @@ mod tests {
             .unwrap();
         wait_for_brief_count(&started, 1).await;
 
-        let agents = host.inner.agents.read().await;
-        let entry = agents.get(&agent_id).expect("expected live runtime entry");
+        let registry = host.inner.runtimes.read().await;
+        let entry = registry
+            .agents
+            .get(&agent_id)
+            .expect("expected live runtime entry");
         assert!(
             !entry.task.is_finished(),
             "start should restore a live runtime loop"
         );
-        drop(agents);
+        drop(registry);
 
         let briefs = started.storage().read_recent_briefs(10).unwrap();
         assert!(briefs.iter().any(|brief| brief.text.contains("done")));
@@ -4909,9 +5328,10 @@ mod tests {
             let events = runtime.storage().read_recent_events(32).unwrap();
             let task_finished = host
                 .inner
-                .agents
+                .runtimes
                 .read()
                 .await
+                .agents
                 .get(&agent_id)
                 .is_some_and(|entry| entry.task.is_finished());
             if task_finished
@@ -4990,8 +5410,9 @@ mod tests {
             .unwrap()
             .iter()
             .all(|brief| brief.related_message_id.as_deref() != Some(message.id.as_str())));
-        let agents = host.inner.agents.read().await;
-        let entry = agents
+        let registry = host.inner.runtimes.read().await;
+        let entry = registry
+            .agents
             .get(&agent_id)
             .expect("rebuilt runtime should be registered");
         assert!(
@@ -5357,5 +5778,167 @@ mod tests {
                 .status,
             AgentRegistryStatus::Deleted
         );
+    }
+
+    #[tokio::test]
+    async fn read_only_host_methods_do_not_activate_runtime() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+
+        let _storage = host
+            .public_agent_read_storage(&agent_id)
+            .expect("read storage");
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
+
+        let loaded = host.try_get_loaded_runtime(&agent_id).await;
+        assert!(loaded.is_none());
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
+
+        let summary = host
+            .local_agent_summary(&agent_id)
+            .await
+            .expect("local agent summary");
+        assert_eq!(summary.agent.id, agent_id);
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
+
+        let _worktree_summary = host
+            .public_agent_worktree_summary(&agent_id)
+            .expect("worktree summary");
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
+
+        let _inspection = host
+            .public_agent_scheduler_repair_inspection(&agent_id)
+            .expect("scheduler repair inspection");
+        assert!(host.inner.runtimes.read().await.agents.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_new_runtime_activation() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+
+        host.shutdown().await.expect("shutdown");
+
+        match host.get_public_agent(&agent_id).await {
+            Err(PublicAgentError::ShuttingDown) => {}
+            Err(err) => panic!("expected ShuttingDown, got {err:?}"),
+            Ok(_) => panic!("activation should be rejected after shutdown"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_dequeued_claims_recovers_only_orphaned() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        let runtime_db = host.runtime_db().clone();
+        let storage = AppStorage::new_for_agent(
+            host.agent_data_dir(&agent_id),
+            agent_id.clone(),
+            runtime_db.clone(),
+        )
+        .unwrap();
+
+        let make_message = |id: &str| {
+            let mut msg = MessageEnvelope::new(
+                &agent_id,
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: format!("test {id}"),
+                },
+            );
+            msg.id = id.to_string();
+            msg
+        };
+        let make_queue_entry = |msg: &MessageEnvelope, status: QueueEntryStatus| QueueEntryRecord {
+            message_id: msg.id.clone(),
+            agent_id: agent_id.clone(),
+            priority: msg.priority.clone(),
+            status,
+            created_at: msg.created_at,
+            updated_at: Utc::now(),
+        };
+
+        // Orphaned: no activation, no terminal turn
+        let msg_a = make_message("msg-orphaned");
+        storage.append_message(&msg_a).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_a, QueueEntryStatus::Dequeued))
+            .unwrap();
+
+        // Has scheduler activation: should NOT be recovered
+        let msg_b = make_message("msg-activated");
+        storage.append_message(&msg_b).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_b, QueueEntryStatus::Dequeued))
+            .unwrap();
+        runtime_db
+            .transaction(|tx| {
+                tx.execute(
+                    "INSERT INTO scheduler_activations
+                       (agent_id, activation_id, authority_id, owner_kind, owner_id,
+                        work_item_id, admitted_generation, admission_kind,
+                        recovery_for_activation_id, wait_id, wait_generation,
+                        lifecycle_state, idempotency_key, payload_json, created_at, updated_at)
+                     VALUES (?, ?, '', 'work_item', 'test-work', 'test-work', 0, 'scheduling', NULL, NULL, NULL, 'running', '', '{}', ?, ?)",
+                    rusqlite::params![
+                        &agent_id,
+                        format!("activation:message:{}", msg_b.id),
+                        Utc::now().timestamp_millis(),
+                        Utc::now().timestamp_millis(),
+                    ],
+                )?;
+                Ok(())
+            })
+            .expect("insert activation");
+
+        // Has terminal turn: should NOT be recovered
+        let msg_c = make_message("msg-terminal");
+        storage.append_message(&msg_c).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_c, QueueEntryStatus::Dequeued))
+            .unwrap();
+        let mut turn = crate::types::TurnRecord::new(&agent_id, "turn-terminal", 0);
+        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&msg_c));
+        turn.terminal = Some(crate::types::TurnTerminalSummary {
+            kind: crate::types::TurnTerminalKind::Completed,
+            reason: None,
+            completed_at: Utc::now(),
+            duration_ms: 100,
+        });
+        runtime_db
+            .turn_records()
+            .upsert(&turn)
+            .expect("upsert turn");
+
+        let recovered = host
+            .recover_orphaned_queue_claims_at_startup()
+            .await
+            .expect("recovery");
+        assert_eq!(recovered, vec![agent_id.clone()]);
+
+        let entries = storage.latest_queue_entries().unwrap();
+        for entry in &entries {
+            match entry.message_id.as_str() {
+                "msg-orphaned" => assert_eq!(
+                    entry.status,
+                    QueueEntryStatus::Interrupted,
+                    "orphaned should be recovered"
+                ),
+                "msg-activated" | "msg-terminal" => assert_eq!(
+                    entry.status,
+                    QueueEntryStatus::Dequeued,
+                    "non-orphaned should not be recovered"
+                ),
+                _ => {}
+            }
+        }
+
+        let events = storage.read_recent_events(32).unwrap();
+        assert!(events
+            .iter()
+            .any(|e| e.kind == "orphaned_queue_claim_recovered"));
     }
 }

--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::{
+    config::RuntimeModelCatalog,
+    model_discovery::{discovery_cache_path, load_discovery_cache_at},
+    provider::resolved_model_availability,
+};
 
 pub async fn root(
     State(state): State<Arc<AppState>>,
@@ -23,13 +28,16 @@ pub async fn models_handler(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     let started_at = std::time::Instant::now();
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state.host.default_runtime().await.map_err(error_response)?;
-    let available_models = runtime.available_models().await.map_err(error_response)?;
-    let model_availability = runtime.model_availability().await.map_err(error_response)?;
-    let model_discovery_cache = runtime
-        .model_discovery_status()
-        .await
-        .map_err(error_response)?;
+    let mut config = (*state.host.config()).clone();
+    let cache_path = discovery_cache_path(&config.home_dir);
+    config.model_discovery_cache =
+        tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path))
+            .await
+            .map_err(|error| error_response(error.into()))?
+            .map_err(error_response)?;
+    let available_models = RuntimeModelCatalog::from_config(&config).available_models();
+    let model_availability = resolved_model_availability(&config);
+    let model_discovery_cache = Vec::<crate::model_discovery::ModelDiscoveryCacheStatus>::new();
     traced_json(
         "/models",
         started_at,
@@ -56,26 +64,12 @@ pub async fn search(
         .limit
         .unwrap_or(SEARCH_DEFAULT_LIMIT)
         .clamp(1, SEARCH_MAX_LIMIT);
-    let runtime = state.host.default_runtime().await.map_err(error_response)?;
     let agent_ids = normalize_search_agent_ids(request.agent_ids)?;
-    let search_result = if agent_ids.is_empty() {
-        runtime
-            .search_memory(&query, limit, request.include_all_workspaces)
-            .await
-            .map_err(error_response)?
-    } else {
-        for agent_id in &agent_ids {
-            state
-                .host
-                .get_public_agent(agent_id)
-                .await
-                .map_err(agent_access_error)?;
-        }
-        runtime
-            .search_memory_for_agents(&query, limit, request.include_all_workspaces, &agent_ids)
-            .await
-            .map_err(error_response)?
-    };
+    let search_result = state
+        .host
+        .search_memory_read_only(&query, limit, request.include_all_workspaces, &agent_ids)
+        .await
+        .map_err(error_response)?;
     let results = filter_search_results(search_result.results, &request.types);
     traced_json(
         "/search",
@@ -100,9 +94,9 @@ pub async fn memory_get(
     if source_ref.is_empty() {
         return Err(bad_request("source_ref must not be empty"));
     }
-    let runtime = state.host.default_runtime().await.map_err(error_response)?;
-    let memory = runtime
-        .get_memory(source_ref, request.max_chars)
+    let memory = state
+        .host
+        .get_memory_read_only(source_ref, request.max_chars)
         .await
         .map_err(error_response)?
         .ok_or_else(|| not_found(format!("memory source {source_ref} not found")))?;

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -62,17 +62,11 @@ pub async fn scheduler_repair_inspect(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let inspection = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_scheduler_repair_inspection(&agent_id)
         .map_err(agent_access_error)?;
-    Ok(Json(
-        runtime
-            .inspect_scheduler_repair()
-            .await
-            .map_err(error_response)?,
-    ))
+    Ok(Json(inspection))
 }
 
 pub async fn scheduler_repair_apply(

--- a/src/http/events.rs
+++ b/src/http/events.rs
@@ -11,33 +11,21 @@ pub async fn events(
         .unwrap_or(DEFAULT_EVENT_STREAM_WINDOW)
         .clamp(1, MAX_EVENT_STREAM_WINDOW);
     let order = query.order.unwrap_or(EventPageOrder::Desc);
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     if state.require_control_token {
         authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     }
-    let cursor_seq = runtime
-        .storage()
-        .latest_event_seq()
-        .map_err(error_response)?;
-    let event_log_epoch = runtime
-        .storage()
-        .event_log_epoch()
-        .map_err(error_response)?;
+    let cursor_seq = storage.latest_event_seq().map_err(error_response)?;
+    let event_log_epoch = storage.event_log_epoch().map_err(error_response)?;
     let max_level = query.max_level;
     let filter_context = match max_level {
-        Some(_) => Some(
-            event_filter_context(&runtime)
-                .await
-                .map_err(error_response)?,
-        ),
+        Some(_) => Some(event_filter_context(&storage).map_err(error_response)?),
         None => None,
     };
-    let page = runtime
-        .storage()
+    let page = storage
         .read_event_page_matching(
             query.before_seq,
             query.after_seq,
@@ -80,16 +68,14 @@ pub async fn message(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     if state.require_control_token {
         authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     }
-    let Some(message) = runtime
-        .storage()
+    let Some(message) = storage
         .read_message_by_id(&message_id)
         .map_err(error_response)?
     else {
@@ -107,10 +93,9 @@ pub async fn messages_batch_get(
     headers: HeaderMap,
     Json(request): Json<BatchGetMessagesRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     if state.require_control_token {
         authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
@@ -118,8 +103,7 @@ pub async fn messages_batch_get(
     let mut messages = Vec::new();
     let mut missing_message_ids = Vec::new();
     for message_id in request.message_ids {
-        match runtime
-            .storage()
+        match storage
             .read_message_by_id(&message_id)
             .map_err(error_response)?
         {
@@ -144,25 +128,16 @@ pub async fn events_stream(
         .unwrap_or(DEFAULT_EVENT_STREAM_WINDOW)
         .clamp(1, MAX_EVENT_STREAM_WINDOW);
     let after_seq = query.after_seq;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     if state.require_control_token {
         authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     }
-    let mut live_rx = runtime
-        .storage()
-        .subscribe_events()
-        .map_err(error_response)?
-        .ok_or_else(|| error_response(anyhow!("event bus unavailable")))?;
-    let event_log_epoch = runtime
-        .storage()
-        .event_log_epoch()
-        .map_err(error_response)?;
-    let events = runtime
-        .storage()
+    let mut live_rx = state.host.subscribe_events();
+    let event_log_epoch = storage.event_log_epoch().map_err(error_response)?;
+    let events = storage
         .read_recent_events(event_window_limit.saturating_add(1))
         .map_err(error_response)?;
     let buffered = initial_buffered_events(&events, after_seq)?;
@@ -329,20 +304,18 @@ async fn send_stream_event(
         .await
 }
 
-async fn event_filter_context(
-    runtime: &crate::runtime::RuntimeHandle,
+fn event_filter_context(
+    storage: &crate::storage::AppStorage,
 ) -> Result<OperatorPresentationContext> {
-    let agent = runtime.agent_summary().await?;
-    let completed_work_item_ids = runtime
-        .latest_work_items()
-        .await?
+    let work_queue = storage.work_queue_read_model()?;
+    let completed_work_item_ids = storage
+        .latest_work_items()?
         .into_iter()
         .filter(|item| item.state == WorkItemState::Completed)
         .map(|item| item.id)
         .collect();
     Ok(OperatorPresentationContext {
-        awaiting_operator_input: agent.closure.waiting_reason
-            == Some(WaitingReason::AwaitingOperatorInput),
+        awaiting_operator_input: !work_queue.waiting_for_operator.is_empty(),
         completed_work_item_ids,
     })
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -88,7 +88,7 @@ pub(crate) use crate::{
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskStatus,
         TaskStatusSnapshot, TaskStopResult, TodoItem, TranscriptEntry, TurnTerminalRecord,
-        WaitingReason, WorkItemPlanStatus, WorkItemRecord, WorkItemState,
+        WorkItemPlanStatus, WorkItemRecord, WorkItemState,
     },
 };
 mod agents;
@@ -1056,6 +1056,12 @@ pub(crate) fn agent_access_error(error: PublicAgentError) -> (StatusCode, Json<V
         PublicAgentError::Stopped { agent_id } => stopped_agent_conflict(
             format!("agent {} is stopped; start first", agent_id),
             agent_id,
+        ),
+        PublicAgentError::ShuttingDown => http_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            HttpErrorEnvelope::new("runtime is shutting down")
+                .code("runtime_shutting_down")
+                .retryable(true),
         ),
         PublicAgentError::Runtime(error) => error_response(error),
     }

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -9,19 +9,11 @@ pub async fn list_skills(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let skills = state
         .host
-        .get_public_agent(&agent_id)
+        .public_agent_skills_view(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    let identity = runtime
-        .agent_identity_view()
-        .await
-        .map_err(error_response)?;
-    let skills = runtime
-        .skills_runtime_view(&identity)
-        .await
-        .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,
         "agent_id": agent_id,
@@ -396,19 +388,11 @@ async fn agent_scoped_skill_detail(
     skill_id: &str,
     state: &AppState,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let runtime = state
+    let skills = state
         .host
-        .get_public_agent(agent_id)
+        .public_agent_skills_view(agent_id)
         .await
         .map_err(agent_access_error)?;
-    let identity = runtime
-        .agent_identity_view()
-        .await
-        .map_err(error_response)?;
-    let skills = runtime
-        .skills_runtime_view(&identity)
-        .await
-        .map_err(error_response)?;
     let Some(skill) = skills
         .discoverable_skills
         .into_iter()

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -185,12 +185,11 @@ pub async fn status(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     let started_at = std::time::Instant::now();
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let agent = state
         .host
-        .get_agent_for_local_status(&agent_id)
+        .local_agent_summary(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    let agent = runtime.agent_summary().await.map_err(error_response)?;
     traced_json("/agents/{agent_id}/status", started_at, agent)
 }
 
@@ -1019,14 +1018,12 @@ pub async fn briefs(
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let briefs = runtime
-        .recent_briefs(query.limit.unwrap_or(20))
-        .await
+    let briefs = storage
+        .read_recent_briefs(query.limit.unwrap_or(20))
         .map_err(error_response)?;
     Ok(Json(briefs))
 }
@@ -1037,14 +1034,12 @@ pub async fn brief(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let Some(brief) = runtime
-        .brief_by_id(&brief_id)
-        .await
+    let Some(brief) = storage
+        .read_brief_by_id(&brief_id)
         .map_err(error_response)?
         .filter(|brief| brief.agent_id == agent_id)
     else {
@@ -1060,10 +1055,9 @@ pub async fn briefs_batch_get(
     Json(request): Json<BatchGetBriefsRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let brief_ids = request
         .brief_ids
@@ -1075,9 +1069,8 @@ pub async fn briefs_batch_get(
             }
             brief_ids
         });
-    let briefs_by_id = runtime
-        .briefs_by_ids(&brief_ids)
-        .await
+    let briefs_by_id = storage
+        .read_briefs_by_ids(&brief_ids)
         .map_err(error_response)?
         .into_iter()
         .filter(|brief| brief.agent_id == agent_id)
@@ -1130,14 +1123,12 @@ pub async fn transcript(
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let transcript = runtime
-        .recent_transcript(query.limit.unwrap_or(50))
-        .await
+    let transcript = storage
+        .read_recent_transcript(query.limit.unwrap_or(50))
         .map_err(error_response)?;
     Ok(Json(transcript))
 }
@@ -1148,14 +1139,12 @@ pub async fn transcript_entry(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let Some(entry) = runtime
-        .transcript_entry_by_id(&entry_id)
-        .await
+    let Some(entry) = storage
+        .read_transcript_entry_by_id(&entry_id)
         .map_err(error_response)?
         .filter(|entry| entry.agent_id == agent_id)
     else {
@@ -1171,17 +1160,15 @@ pub async fn transcript_batch_get(
     Json(request): Json<BatchGetTranscriptEntriesRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let mut entries = Vec::new();
     let mut missing_entry_ids = Vec::new();
     for entry_id in request.entry_ids {
-        match runtime
-            .transcript_entry_by_id(&entry_id)
-            .await
+        match storage
+            .read_transcript_entry_by_id(&entry_id)
             .map_err(error_response)?
         {
             Some(entry) if entry.agent_id == agent_id => entries.push(entry),
@@ -1200,15 +1187,10 @@ pub async fn worktree_summary(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let summary = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_worktree_summary(&agent_id)
         .map_err(agent_access_error)?;
-    let summary = runtime
-        .summarize_worktree_tasks()
-        .await
-        .map_err(error_response)?;
     Ok(Json(json!({
         "agent_id": agent_id,
         "summary": summary,

--- a/src/http/tasks.rs
+++ b/src/http/tasks.rs
@@ -15,15 +15,13 @@ pub async fn tasks(
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     Ok(Json(
-        runtime
-            .active_tasks(query.limit.unwrap_or(50))
-            .await
+        storage
+            .latest_active_task_records(query.limit.unwrap_or(50))
             .map_err(error_response)?,
     ))
 }
@@ -34,24 +32,30 @@ pub async fn task_status(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    if !runtime
-        .task_record(&task_id)
-        .await
+    let Some(task) = storage
+        .latest_task_record(&task_id)
         .map_err(error_response)?
-        .is_some_and(|task| task.agent_id == agent_id)
-    {
+        .filter(|task| task.agent_id == agent_id)
+    else {
         return Err(task_not_found_response(&task_id));
-    }
-    let snapshot = runtime
-        .managed_tasks()
-        .task_status_snapshot(&task_id)
+    };
+    let snapshot = match state
+        .host
+        .try_get_public_loaded_runtime(&agent_id)
         .await
-        .map_err(task_lifecycle_error)?;
+        .map_err(agent_access_error)?
+    {
+        Some(runtime) => runtime
+            .managed_tasks()
+            .task_status_snapshot(&task_id)
+            .await
+            .map_err(task_lifecycle_error)?,
+        None => TaskStatusSnapshot::from_task_record(&task),
+    };
     Ok(Json(snapshot))
 }
 
@@ -62,19 +66,33 @@ pub async fn task_output(
     Query(query): Query<TaskOutputQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    if !runtime
-        .task_record(&task_id)
-        .await
+    if !storage
+        .latest_task_record(&task_id)
         .map_err(error_response)?
         .is_some_and(|task| task.agent_id == agent_id)
     {
         return Err(task_not_found_response(&task_id));
     }
+    let runtime = state
+        .host
+        .try_get_public_loaded_runtime(&agent_id)
+        .await
+        .map_err(agent_access_error)?
+        .ok_or_else(|| {
+            error_response(
+                RuntimeError::new(
+                    crate::runtime_error::RuntimeErrorDomain::Conflict,
+                    "task_not_live",
+                    format!("task {task_id} is not managed by a loaded runtime"),
+                )
+                .with_safe_context("task_id", &task_id)
+                .into(),
+            )
+        })?;
     let output = runtime
         .managed_tasks()
         .task_output(
@@ -93,13 +111,11 @@ pub async fn tool_execution(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let Some(record) = runtime
-        .storage()
+    let Some(record) = storage
         .read_tool_execution_by_id(&tool_execution_id)
         .map_err(error_response)?
         .filter(|record| record.agent_id == agent_id)
@@ -117,13 +133,11 @@ pub async fn tool_execution_artifact(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let Some(record) = runtime
-        .storage()
+    let Some(record) = storage
         .read_tool_execution_by_id(&tool_execution_id)
         .map_err(error_response)?
         .filter(|record| record.agent_id == agent_id)
@@ -150,8 +164,8 @@ pub async fn tool_execution_artifact(
         .and_then(Value::as_str)
         .ok_or_else(|| not_found(format!("artifact {artifact_index} not found")))?;
 
-    let data_dir = std::fs::canonicalize(runtime.storage().data_dir())
-        .map_err(|error| error_response(error.into()))?;
+    let data_dir =
+        std::fs::canonicalize(storage.data_dir()).map_err(|error| error_response(error.into()))?;
     let requested_path = PathBuf::from(artifact_path);
     let requested_path = if requested_path.is_absolute() {
         requested_path
@@ -521,13 +535,11 @@ pub async fn work_items(
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let work_items = runtime
-        .storage()
+    let work_items = storage
         .work_queue_read_model()
         .map_err(error_response)?
         .items
@@ -543,13 +555,11 @@ pub async fn work_item(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let Some(work_item) = runtime
-        .storage()
+    let Some(work_item) = storage
         .work_queue_read_model()
         .map_err(error_response)?
         .items
@@ -575,15 +585,13 @@ pub async fn timers(
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     Ok(Json(
-        runtime
-            .recent_timers(query.limit.unwrap_or(50))
-            .await
+        storage
+            .read_recent_timers(query.limit.unwrap_or(50))
             .map_err(error_response)?,
     ))
 }
@@ -594,14 +602,12 @@ pub async fn timer(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    let runtime = state
+    let storage = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    let Some(timer) = runtime
-        .latest_timer(&timer_id)
-        .await
+    let Some(timer) = storage
+        .latest_timer_record(&timer_id)
         .map_err(error_response)?
         .filter(|timer| timer.agent_id == agent_id)
     else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -840,6 +840,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     }
 
     let host = RuntimeHost::new(config.clone())?;
+    host.recover_orphaned_queue_claims_at_startup().await?;
     let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
     host.spawn_daemon_runtime_db_retention();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -31,6 +31,7 @@ mod worktree;
 
 pub use first_run_intro::maybe_enqueue_first_run_intro;
 pub(crate) use lifecycle::LightweightAgentStateProjection;
+pub(crate) use repair::is_wake_only_message;
 pub use repair::{
     SchedulerRepairInspection, SchedulerRepairOperation, SchedulerRepairRequest,
     SchedulerRepairResult,
@@ -44,6 +45,7 @@ pub use tasks::{
     WorkItemFocusTransitionWarning,
 };
 pub(crate) use waiting::{WaitForScope, WaitForWakeKind};
+pub(crate) use worktree::format_worktree_task_summary;
 
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -15,7 +15,6 @@ use crate::{
     config::{AppConfig, ModelRef, ModelRouteCapability, ModelRouteRef, RuntimeModelCatalog},
     context::ContextConfig,
     host::RuntimeHostBridge,
-    model_catalog::BuiltInModelMetadata,
     model_discovery::{
         discovery_cache_needs_refresh, discovery_cache_path, discovery_cache_status_for_provider,
         load_discovery_cache_at, refresh_provider_models, ModelDiscoveryCacheFile,
@@ -806,14 +805,6 @@ impl RuntimeHandle {
                 )
             })
             .collect())
-    }
-
-    pub(crate) async fn available_models(&self) -> Result<Vec<BuiltInModelMetadata>> {
-        if let Some(config) = self.model_config_with_fresh_discovery_cache().await {
-            return Ok(RuntimeModelCatalog::from_config(&config).available_models());
-        }
-        let snap = self.inner.config_snapshot.load();
-        Ok(snap.model_catalog.available_models())
     }
 
     pub(crate) async fn model_availability(&self) -> Result<Vec<ResolvedModelAvailability>> {

--- a/src/runtime/repair.rs
+++ b/src/runtime/repair.rs
@@ -253,7 +253,7 @@ impl RuntimeHandle {
     }
 }
 
-fn is_wake_only_message(message: &MessageEnvelope) -> bool {
+pub(crate) fn is_wake_only_message(message: &MessageEnvelope) -> bool {
     matches!(
         (&message.kind, &message.origin),
         (MessageKind::SystemTick, MessageOrigin::System { subsystem })

--- a/src/runtime/worktree.rs
+++ b/src/runtime/worktree.rs
@@ -980,7 +980,6 @@ impl RuntimeHandle {
         Ok(changed_files)
     }
 }
-
 pub(super) fn format_worktree_task_result(result: &WorktreeSubagentResult) -> String {
     let mut lines = Vec::new();
     let cleaned = result.text.trim();
@@ -998,6 +997,145 @@ pub(super) fn format_worktree_task_result(result: &WorktreeSubagentResult) -> St
         ));
     }
     lines.join("\n")
+}
+
+pub(crate) fn format_worktree_task_summary(
+    tasks: &[TaskRecord],
+    messages: &[MessageEnvelope],
+) -> String {
+    let worktree_tasks: Vec<_> = tasks
+        .iter()
+        .filter(|task| task.is_worktree_child_agent_task())
+        .collect();
+
+    if worktree_tasks.is_empty() {
+        return "No worktree tasks found.".to_string();
+    }
+
+    let mut summary_lines = Vec::new();
+    summary_lines.push("=".repeat(60));
+    summary_lines.push("Worktree Task Summary".to_string());
+    summary_lines.push(format!("Total tasks: {}", worktree_tasks.len()));
+    summary_lines.push("=".repeat(60));
+    summary_lines.push(String::new());
+
+    let mut completed = Vec::new();
+    let mut failed = Vec::new();
+    let mut running = Vec::new();
+    let mut queued = Vec::new();
+    for task in &worktree_tasks {
+        match task.status {
+            TaskStatus::Completed => completed.push(task),
+            TaskStatus::Failed | TaskStatus::Interrupted => failed.push(task),
+            TaskStatus::Running | TaskStatus::Cancelling => running.push(task),
+            TaskStatus::Queued => queued.push(task),
+            TaskStatus::Cancelled => {}
+        }
+    }
+
+    let format_task = |task: &&TaskRecord| -> String {
+        let task_id = &task.id;
+        let task_summary = task.summary.as_deref().unwrap_or("(no summary)");
+        let worktree_info = task
+            .detail
+            .as_ref()
+            .and_then(|detail| detail.get("worktree").cloned())
+            .or_else(|| {
+                messages
+                    .iter()
+                    .find(|msg| {
+                        matches!(msg.kind, MessageKind::TaskResult)
+                            && msg
+                                .metadata
+                                .as_ref()
+                                .and_then(|m| m.get("task_id"))
+                                .and_then(|id| id.as_str())
+                                == Some(task_id)
+                    })
+                    .and_then(|msg| msg.metadata.as_ref())
+                    .and_then(|m| m.get("worktree").cloned())
+            });
+        let mut lines = Vec::new();
+        lines.push(format!("Task ID: {}", task_id));
+        lines.push(format!("Summary: {}", task_summary));
+        if let Some(worktree) = worktree_info {
+            if let Some(path) = worktree.get("worktree_path").and_then(|v| v.as_str()) {
+                lines.push(format!("Worktree path: {}", path));
+            }
+            if let Some(branch) = worktree.get("worktree_branch").and_then(|v| v.as_str()) {
+                lines.push(format!("Branch: {}", branch));
+            }
+            if let Some(changed) = worktree.get("changed_files").and_then(|v| v.as_array()) {
+                let changed_files: Vec<_> = changed.iter().filter_map(|v| v.as_str()).collect();
+                if changed_files.is_empty() {
+                    lines.push("Changed files: none".to_string());
+                } else {
+                    lines.push(format!("Changed files: {}", changed_files.join(", ")));
+                }
+            }
+            if let Some(retained) = worktree
+                .get("retained_for_review")
+                .and_then(|v| v.as_bool())
+            {
+                if retained {
+                    lines.push("Status: Worktree retained for review".to_string());
+                }
+            }
+            if let Some(cleaned) = worktree.get("auto_cleaned_up").and_then(|v| v.as_bool()) {
+                if cleaned {
+                    lines.push("Status: Worktree auto-cleaned".to_string());
+                }
+            }
+            if let Some(status) = worktree.get("cleanup_status").and_then(|v| v.as_str()) {
+                lines.push(format!("Cleanup status: {}", status));
+            }
+            if let Some(reason) = worktree.get("cleanup_reason").and_then(|v| v.as_str()) {
+                lines.push(format!("Cleanup reason: {}", reason));
+            }
+        }
+        lines.join("\n  ")
+    };
+
+    if !completed.is_empty() {
+        summary_lines.push(format!("Completed Tasks ({})", completed.len()));
+        summary_lines.push("-".repeat(40));
+        for task in completed {
+            summary_lines.push(format!("  {}", format_task(task)));
+            summary_lines.push(String::new());
+        }
+    }
+    if !failed.is_empty() {
+        summary_lines.push(format!("Failed Tasks ({})", failed.len()));
+        summary_lines.push("-".repeat(40));
+        for task in failed {
+            summary_lines.push(format!("  {}", format_task(task)));
+            summary_lines.push(String::new());
+        }
+    }
+    if !running.is_empty() {
+        summary_lines.push(format!("Running Tasks ({})", running.len()));
+        summary_lines.push("-".repeat(40));
+        for task in running {
+            summary_lines.push(format!("  {}", format_task(task)));
+            summary_lines.push(String::new());
+        }
+    }
+    if !queued.is_empty() {
+        summary_lines.push(format!("Queued Tasks ({})", queued.len()));
+        summary_lines.push("-".repeat(40));
+        for task in queued {
+            summary_lines.push(format!("  {}", format_task(task)));
+            summary_lines.push(String::new());
+        }
+    }
+    summary_lines.push("=".repeat(60));
+    summary_lines.push("Review Guidance:".to_string());
+    summary_lines.push("- Inspect worktrees with changes to evaluate approaches".to_string());
+    summary_lines
+        .push("- Use 'git worktree remove <path>' to discard unwanted attempts".to_string());
+    summary_lines.push("- Use 'git diff <worktree-path>' to see detailed changes".to_string());
+    summary_lines.push("=".repeat(60));
+    summary_lines.join("\n")
 }
 
 fn parse_task_owned_worktree_artifact(

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -6,6 +6,7 @@
 pub(crate) mod scheduler_protocol_repository;
 
 use anyhow::{anyhow, bail, Result};
+use chrono::Utc;
 use rusqlite::{OptionalExtension, Transaction};
 use std::collections::BTreeMap;
 
@@ -214,6 +215,71 @@ pub(crate) struct RuntimeTransitionRepository<'a> {
 impl RuntimeDb {
     pub(crate) fn transitions(&self) -> RuntimeTransitionRepository<'_> {
         RuntimeTransitionRepository { db: self }
+    }
+
+    pub(crate) fn recover_orphaned_dequeued_claims_at_startup(&self) -> Result<Vec<String>> {
+        self.transaction(|tx| {
+            let mut statement = tx.prepare(
+                "SELECT q.payload_json
+                 FROM queue_entries q
+                 JOIN agent_identities i
+                   ON i.agent_id = q.agent_id
+                  AND i.status = 'active'
+                 WHERE q.status = 'dequeued'
+                   AND NOT EXISTS (
+                     SELECT 1
+                     FROM scheduler_activations a
+                     WHERE a.agent_id = q.agent_id
+                       AND a.activation_id = 'activation:message:' || q.message_id
+                   )
+                   AND NOT EXISTS (
+                     SELECT 1
+                     FROM turn_records t
+                     WHERE t.agent_id = q.agent_id
+                       AND t.trigger_message_id = q.message_id
+                       AND t.terminal_kind IS NOT NULL
+                   )
+                 ORDER BY q.agent_id, q.updated_at, q.message_id",
+            )?;
+            let candidates = statement
+                .query_map([], |row| row.get::<_, String>(0))?
+                .map(|row| Ok(serde_json::from_str::<QueueEntryRecord>(&row?)?))
+                .collect::<Result<Vec<_>>>()?;
+            drop(statement);
+
+            let recovered_at = Utc::now();
+            let mut recovered_agents = Vec::new();
+            for expected in candidates {
+                let mut recovered = expected.clone();
+                recovered.status = QueueEntryStatus::Interrupted;
+                recovered.updated_at = recovered_at;
+                if !compare_and_set_queue_entry_tx(tx, &expected, &recovered)? {
+                    continue;
+                }
+                let event = AuditEvent {
+                    id: format!("audit:orphaned-queue-claim:{}", expected.message_id),
+                    event_seq: 0,
+                    event_log_epoch: String::new(),
+                    created_at: recovered_at,
+                    kind: "orphaned_queue_claim_recovered".into(),
+                    contract_version: crate::runtime_event::LEGACY_RUNTIME_EVENT_CONTRACT_VERSION,
+                    payload_schema: crate::runtime_event::LEGACY_PAYLOAD_SCHEMA.to_string(),
+                    payload_schema_version: 1,
+                    data: serde_json::json!({
+                        "message_id": expected.message_id,
+                        "agent_id": expected.agent_id,
+                        "reason": "no_canonical_activation_or_terminal_turn",
+                        "previous_status": "dequeued",
+                        "next_status": "interrupted",
+                    }),
+                };
+                append_audit_event_tx(tx, Some(&recovered.agent_id), &event)?;
+                recovered_agents.push(recovered.agent_id);
+            }
+            recovered_agents.sort();
+            recovered_agents.dedup();
+            Ok(recovered_agents)
+        })
     }
 }
 

--- a/src/storage/events.rs
+++ b/src/storage/events.rs
@@ -121,6 +121,7 @@ impl RuntimeEventLog {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(crate) fn subscribe(&self) -> Result<Option<broadcast::Receiver<PublishedAuditEvent>>> {
         Ok(self
             .event_bus

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -246,16 +246,17 @@ impl AppStorage {
         self.store.event_log().enable_event_bus(event_bus)
     }
 
-    /// Attach a shared memory-index notify so the daemon-level indexer is
-    /// woken immediately after new evidence is enqueued for indexing.
-    pub(crate) fn enable_memory_index_notify(&self, notify: Arc<Notify>) -> Result<()> {
-        self.store.index_outbox().enable_notify(notify)
-    }
-
+    #[cfg(test)]
     pub(crate) fn subscribe_events(
         &self,
     ) -> Result<Option<tokio::sync::broadcast::Receiver<PublishedAuditEvent>>> {
         self.store.event_log().subscribe()
+    }
+
+    /// Attach a shared memory-index notify so the daemon-level indexer is
+    /// woken immediately after new evidence is enqueued for indexing.
+    pub(crate) fn enable_memory_index_notify(&self, notify: Arc<Notify>) -> Result<()> {
+        self.store.index_outbox().enable_notify(notify)
     }
 
     pub(crate) fn publish_transition_events(
@@ -827,6 +828,16 @@ impl AppStorage {
             ));
         }
         return Ok(take_recent(runtime_db.tasks().latest_all()?, history_limit));
+    }
+
+    /// Returns all recent task records (including terminal) for the current
+    /// agent scope, deduplicated by task ID. Unlike `latest_active_task_records`,
+    /// this includes completed, failed, and cancelled tasks.
+    pub fn latest_all_task_records(&self, limit: usize) -> Result<Vec<TaskRecord>> {
+        let runtime_db = self.runtime_db.clone();
+        let mut tasks = runtime_db.tasks().latest_all()?;
+        tasks.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        Ok(take_recent(tasks, limit))
     }
 
     pub fn latest_active_task_records(&self, limit: usize) -> Result<Vec<TaskRecord>> {


### PR DESCRIPTION
## Summary

Fixes #2475.

Three interrelated fixes that close runtime activation, shutdown, and startup-recovery race conditions:

### 1. Read-only HTTP/RPC routes no longer create or wake agent runtime

Added a unified host read API surface that validates identity and opens storage without loading, waking, or creating a runtime:

- `public_agent_read_storage()` — identity-checked read-only storage access
- `try_get_loaded_runtime()` / `try_get_public_loaded_runtime()` — non-activating loaded-runtime lookup
- `public_agent_skills_view()` — skills projection from registry/config/agent-home
- `public_agent_scheduler_repair_inspection()` — scheduler repair inspection from storage
- `public_agent_worktree_summary()` — worktree task summary from storage
- `local_agent_summary()` — AgentSummary with loaded-runtime-first, storage-fallback
- `search_memory_read_only()` / `get_memory_read_only()` — memory reads without default_runtime()

Migrated ~20 read-only HTTP routes to these paths: events, message, messages batch, event stream, briefs, brief, briefs batch, transcript, transcript entry, transcript batch, tool execution, tool execution artifact, work items, work item, timer, timers, tasks, task status, task output, skills list, skills detail, models, search, memory get, scheduler repair inspect, worktree summary, and status.

`task_status` and `task_output` use `try_get_loaded_runtime` and degrade to a storage snapshot when unloaded instead of activating. `task_output(block=true)` returns a clear `task_not_live` error when no runtime is loaded rather than silently activating.

### 2. Shutdown atomically closes runtime activation admission

Introduced `HostRuntimeRegistry` with a phase (`Open` / `Closing` / `Closed`) under one lock. `shutdown()` sets `Closing` before draining registered runtimes, preventing a concurrent read or ingress from spawning a new runtime excluded from shutdown settlement.

`activate_agent()` checks the phase and returns `RuntimeAdmissionClosed`, mapped to `PublicAgentError::ShuttingDown` (HTTP 503, retryable).

`RuntimeActivationReason` enum makes activation intent explicit in logs (`scheduler_dispatch`, `operator_control`, `external_ingress`, `wake`, `startup_recovery`, `agent_lifecycle`, `child_supervision`).

### 3. Startup recovers only provably orphaned dequeued claims

`recover_orphaned_dequeued_claims_at_startup()` uses a single transaction to find `dequeued` queue entries that have no canonical scheduler activation and no terminal turn, then CAS them to `interrupted` with an audit event. This prevents stealing claims that canonical execution still owns while recovering claims genuinely orphaned by a crash.

Wired into `main.rs serve()` before `default_runtime()`.

### Tests

- `read_only_host_methods_do_not_activate_runtime` — verifies all new read-only host methods leave the runtime registry empty
- `shutdown_rejects_new_runtime_activation` — verifies `get_public_agent` returns `ShuttingDown` after shutdown
- `recover_orphaned_dequeued_claims_recovers_only_orphaned` — verifies only truly orphaned claims are recovered; claims with activations or terminal turns are left alone

### RFC

`docs/rfcs/runtime-host-activation-admission-and-read-projections.md`

### Note

`runtime_loop_failure_preserves_canonical_claim_and_reconciles_on_next_host_access` is a pre-existing failure on the base branch (confirmed via stash + clean checkout), not introduced by this PR.