### PR TITLE
fix: simplify canonical scheduler lane recovery

### DIFF
--- a/docs/rfc-implementation-notes/canonical-scheduler-activation-settlement-review.md
+++ b/docs/rfc-implementation-notes/canonical-scheduler-activation-settlement-review.md
@@ -307,6 +307,23 @@ owner 检查。
 
 Runtime loop 不应把普通 protocol rejection 无差别转成 agent restart。
 
+## 已采用的近期收缩
+
+在不更换 scheduler、不修改持久化 schema 的前提下，近期实现先收缩最容易反复出错的
+lane 边界：
+
+- settlement 中的 dispatch disposition 保留为 attempt 结束时的不可变证据，不再通过
+  扫描历史 settlement 推导当前 lane；
+- 当前 lane 只校验实时 dispatch、当前 wait generation、WorkDemand 和 activation slot；
+- legacy adoption、activation adoption、WorkItem settlement 和 lifecycle settlement 通过
+  同一个内部 lane transition 同步 resolve/rearm wait、WorkDemand 与 dispatch revision；
+- legacy compatibility adoption 按 WorkItem 隔离，单个 stale/rejected candidate 留在
+  canonical partition 之外并产生诊断，不再阻止 agent 处理已经合法的 canonical work；
+- canonical prestate 损坏、存储错误和 missing-settlement recovery 仍然 fail closed。
+
+这是面向稳定性的有界修正，不代表 activation/settlement 的长期职责收缩已经完成。后续
+是否继续简化，应以生产 trace replay、restart drill 和 invariant 规模是否明显下降为依据。
+
 ## 验证和测试缺口
 
 本次复核的 focused tests 结果为：

--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -222,7 +222,7 @@ activated.
 
 ### Agent Dispatch State
 
-The agent's explicit terminal choice about whether its free lane accepts
+The current canonical fact describing whether the agent's free lane accepts
 ordinary autonomous work:
 
 ```text
@@ -599,6 +599,13 @@ AgentDispatchDisposition =
     Open
   | Awaiting(wait_id)
 ```
+
+`AgentDispatchDisposition` records the lane outcome committed by that attempt.
+It is immutable execution evidence, not continuing authority over the live
+lane: a later fenced transition may rearm the wait, hand the lane to another
+owner, or open it. Current admission validates `scheduler_agent_dispatch`
+against the current wait generation, WorkItem demand, and activation slot; it
+does not reconstruct current dispatch from historical settlements.
 
 `WorkYielded(target, mode)` has two distinct forms:
 
@@ -1110,6 +1117,15 @@ read-only and reports the same ordered recovery plan, typed evidence,
 conflicts, holds, and stable command identities that the apply path would use.
 No debug path may repair protocol state through direct SQL.
 
+Compatibility adoption is isolated per legacy WorkItem. Each candidate is
+revalidated and committed in deterministic order. A stale source, typed
+protocol rejection, or invalid candidate poststate rolls back and diagnoses
+only that candidate; other valid candidates and the agent runtime continue.
+The rejected WorkItem remains outside the canonical partition and is retried
+from fresh source facts on a later recovery pass. An invalid canonical
+prestate, storage failure, or canonical missing-settlement recovery failure
+remains fail closed.
+
 An optional serialized snapshot may be stored only as a versioned,
 checksummed recovery cache. Canonical rows remain the source of truth, and the
 cache must be discarded and rebuilt when its schema version, checksum, or
@@ -1190,7 +1206,8 @@ expose it initially.
 ### Agent Lane
 
 22. `Awaiting(wait_id)` references a live owned wait.
-23. Only settlement or explicit runtime control writes agent dispatch state.
+23. Wait, WorkDemand, and dispatch changes use one fenced lane transition; a
+    historical settlement does not constrain a later valid lane state.
 24. `Running` and `Unavailable` are runtime projections.
 25. Display posture is never admission authority.
 

--- a/scripts/docker_e2e/scheduler_drill.py
+++ b/scripts/docker_e2e/scheduler_drill.py
@@ -91,7 +91,7 @@ RESTART_CHECKPOINT_CUT_KINDS = {
     "settlement_delivery": "durable_recovery",
     "post_commit_notification": "post_commit_recovery",
     "targeted_yield_return": "durable_recovery",
-    "legacy_adoption_atomicity": "atomic_rollback",
+    "legacy_adoption_atomicity": "candidate_isolation",
 }
 RUN_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{5,63}$")
 FAULT_SCENARIOS = {

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -2164,79 +2164,83 @@ fn adopt_legacy_work_state(
         );
     }
 
-    let mut next = snapshot.clone();
-    if let Some(existing) = next.work.get(&command.work_item_id) {
-        if let WorkStatus::Waiting { wait_id } = &existing.status {
-            let existing_wait = WaitIdentity {
-                id: wait_id.clone(),
-                generation: existing.scheduling_generation,
-            };
-            let target_preserves_generation = command.wait.as_ref().is_some_and(|wait| {
-                wait.wait_id == existing_wait.id && wait.generation == existing_wait.generation
-            });
-            if !target_preserves_generation {
-                if let Some(wait) = next.waits.get_mut(wait_id) {
-                    if let Some(generation) = wait.generations.get_mut(&existing_wait.generation) {
-                        if matches!(generation.state, WaitState::Active | WaitState::Triggered) {
-                            generation.state = WaitState::Resolved;
-                            generation.trigger = None;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    next.work
-        .insert(command.work_item_id.clone(), command.demand.clone());
-    if let Some(wait) = &command.wait {
-        let target_generation = WaitGenerationRecord {
-            owner: SchedulerOwner::WorkItem {
-                work_item_id: wait.owner_work_item_id.clone(),
-            },
-            state: WaitState::Active,
-            trigger: None,
-            consuming_activation_id: None,
-        };
-        if source_dispatch_wait
-            .as_ref()
-            .is_some_and(|source| source.id == wait.wait_id)
-        {
-            let record = next
-                .waits
-                .get_mut(&wait.wait_id)
-                .expect("source dispatch wait exists");
-            record.current_generation = wait.generation;
-            record
-                .generations
-                .insert(wait.generation, target_generation);
-        } else {
-            next.waits.insert(
-                wait.wait_id.clone(),
-                WaitRecord {
-                    current_generation: wait.generation,
-                    generations: BTreeMap::from([(wait.generation, target_generation)]),
-                },
-            );
-        }
-        if command.reserve_dispatch || source_dispatch_wait.is_some() {
-            set_dispatch_state(
-                &mut next,
-                AgentDispatchState::Awaiting {
-                    wait: WaitIdentity {
-                        id: wait.wait_id.clone(),
-                        generation: wait.generation,
-                    },
-                },
-            );
-        }
-    } else if source_dispatch_wait.is_some() {
-        set_dispatch_state(&mut next, AgentDispatchState::Open);
-    }
-    // Terminalize the replaced old focus demand if a proof was provided and validated.
     let mut transitions = vec![format!(
         "work:{}:legacy_state_adopted:generation:{}",
         command.work_item_id, command.demand.scheduling_generation
     )];
+    let resolutions = snapshot
+        .work
+        .get(&command.work_item_id)
+        .and_then(|existing| match &existing.status {
+            WorkStatus::Waiting { wait_id } => Some(WaitIdentity {
+                id: wait_id.clone(),
+                generation: existing.scheduling_generation,
+            }),
+            _ => None,
+        })
+        .filter(|existing_wait| {
+            !command.wait.as_ref().is_some_and(|target| {
+                target.wait_id == existing_wait.id && target.generation == existing_wait.generation
+            })
+        })
+        .and_then(|existing_wait| {
+            snapshot
+                .waits
+                .get(&existing_wait.id)
+                .and_then(|wait| wait.generations.get(&existing_wait.generation))
+                .filter(|generation| {
+                    matches!(generation.state, WaitState::Active | WaitState::Triggered)
+                })
+                .cloned()
+                .map(|expected| LaneWaitResolution {
+                    wait: existing_wait,
+                    expected,
+                    reason: "resolved_by_legacy_adoption",
+                })
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    let arm = command.wait.as_ref().map(|wait| LaneWaitArm {
+        wait: WaitIdentity {
+            id: wait.wait_id.clone(),
+            generation: wait.generation,
+        },
+        owner: SchedulerOwner::WorkItem {
+            work_item_id: wait.owner_work_item_id.clone(),
+        },
+    });
+    let target_dispatch = if let Some(arm) = &arm {
+        if command.reserve_dispatch || source_dispatch_wait.is_some() {
+            AgentDispatchState::Awaiting {
+                wait: arm.wait.clone(),
+            }
+        } else {
+            snapshot.dispatch.clone()
+        }
+    } else if source_dispatch_wait.is_some() {
+        AgentDispatchState::Open
+    } else {
+        snapshot.dispatch.clone()
+    };
+    let mut next = snapshot.clone();
+    if let Err(code) = apply_lane_transition(
+        &mut next,
+        &snapshot.dispatch,
+        &resolutions,
+        arm.as_ref(),
+        target_dispatch,
+        Some(LaneWorkUpdate {
+            work_item_id: command.work_item_id.clone(),
+            demand: command.demand.clone(),
+        }),
+        &mut transitions,
+    ) {
+        return rejected_command(
+            snapshot,
+            command_conflict(ProtocolConflictKind::StateConflict, code),
+        );
+    }
+    // Terminalize the replaced old focus demand if a proof was provided and validated.
     if let Some(proof) = &command.replace_completed_focus {
         if let Some(old_demand) = next.work.get_mut(&proof.work_item_id) {
             old_demand.status = WorkStatus::Terminal;
@@ -2496,24 +2500,19 @@ fn adopt_activation_work_state(
         );
     }
 
-    let mut next = snapshot.clone();
-    let mut transitions = Vec::new();
+    let mut resolutions = Vec::new();
     if let Some(proof) = &command.source_lifecycle_wait {
-        let wait = next
+        let expected = snapshot
             .waits
-            .get_mut(&proof.wait.id)
-            .expect("validated source lifecycle wait exists");
-        let generation = wait
-            .generations
-            .get_mut(&proof.wait.generation)
-            .expect("validated source lifecycle wait generation exists");
-        generation.state = WaitState::Resolved;
-        generation.trigger = None;
-        generation.consuming_activation_id = None;
-        transitions.push(format!(
-            "wait:{}:generation:{}:resolved_by_work_item_handoff",
-            proof.wait.id, proof.wait.generation
-        ));
+            .get(&proof.wait.id)
+            .and_then(|wait| wait.generations.get(&proof.wait.generation))
+            .expect("validated source lifecycle wait generation exists")
+            .clone();
+        resolutions.push(LaneWaitResolution {
+            wait: proof.wait.clone(),
+            expected,
+            reason: "resolved_by_work_item_handoff",
+        });
     }
     if let Some(existing_wait_id) = existing_wait_id {
         if command
@@ -2529,82 +2528,68 @@ fn adopt_activation_work_state(
                 ),
             );
         }
-        if let Some(wait) = next.waits.get_mut(existing_wait_id) {
-            let generation = wait
+        if let Some(wait) = snapshot.waits.get(existing_wait_id) {
+            let expected = wait
                 .generations
-                .get_mut(&wait.current_generation)
+                .get(&wait.current_generation)
                 .expect("current wait generation exists");
-            if matches!(generation.state, WaitState::Active | WaitState::Triggered) {
-                generation.state = WaitState::Resolved;
-                generation.trigger = None;
-                generation.consuming_activation_id = None;
-                transitions.push(format!(
-                    "wait:{existing_wait_id}:generation:{}:resolved_by_activation_rearm",
-                    wait.current_generation
-                ));
+            if matches!(expected.state, WaitState::Active | WaitState::Triggered) {
+                resolutions.push(LaneWaitResolution {
+                    wait: WaitIdentity {
+                        id: existing_wait_id.to_string(),
+                        generation: wait.current_generation,
+                    },
+                    expected: expected.clone(),
+                    reason: "resolved_by_activation_rearm",
+                });
             }
         }
     }
-    next.work.insert(
-        command.work_item_id.clone(),
-        WorkDemand {
-            metadata_revision: command.source_work_item_revision,
-            scheduling_generation: command.wait.generation,
-            status: WorkStatus::Waiting {
-                wait_id: command.wait.wait_id.clone(),
-            },
-            capabilities: Default::default(),
-            locks: Default::default(),
-            locality: "runtime".into(),
-            cost_class: "default".into(),
+    let demand = WorkDemand {
+        metadata_revision: command.source_work_item_revision,
+        scheduling_generation: command.wait.generation,
+        status: WorkStatus::Waiting {
+            wait_id: command.wait.wait_id.clone(),
         },
-    );
-    if let Some(wait) = next.waits.get_mut(&command.wait.wait_id) {
-        wait.current_generation = command.wait.generation;
-        wait.generations.insert(
-            command.wait.generation,
-            WaitGenerationRecord {
-                owner: SchedulerOwner::WorkItem {
-                    work_item_id: command.work_item_id.clone(),
-                },
-                state: WaitState::Active,
-                trigger: None,
-                consuming_activation_id: None,
-            },
-        );
-    } else {
-        next.waits.insert(
-            command.wait.wait_id.clone(),
-            WaitRecord {
-                current_generation: command.wait.generation,
-                generations: BTreeMap::from([(
-                    command.wait.generation,
-                    WaitGenerationRecord {
-                        owner: SchedulerOwner::WorkItem {
-                            work_item_id: command.work_item_id.clone(),
-                        },
-                        state: WaitState::Active,
-                        trigger: None,
-                        consuming_activation_id: None,
-                    },
-                )]),
-            },
-        );
-    }
-    if command.reserve_dispatch {
-        let dispatch = AgentDispatchState::Awaiting {
-            wait: WaitIdentity {
-                id: command.wait.wait_id.clone(),
-                generation: command.wait.generation,
-            },
-        };
-        if next.dispatch != dispatch {
-            next.dispatch = dispatch;
-            next.dispatch_revision += 1;
+        capabilities: Default::default(),
+        locks: Default::default(),
+        locality: "runtime".into(),
+        cost_class: "default".into(),
+    };
+    let arm = LaneWaitArm {
+        wait: WaitIdentity {
+            id: command.wait.wait_id.clone(),
+            generation: command.wait.generation,
+        },
+        owner: SchedulerOwner::WorkItem {
+            work_item_id: command.work_item_id.clone(),
+        },
+    };
+    let target_dispatch = if command.reserve_dispatch {
+        AgentDispatchState::Awaiting {
+            wait: arm.wait.clone(),
         }
-    } else if next.dispatch != AgentDispatchState::Open {
-        next.dispatch = AgentDispatchState::Open;
-        next.dispatch_revision += 1;
+    } else {
+        AgentDispatchState::Open
+    };
+    let mut next = snapshot.clone();
+    let mut transitions = Vec::new();
+    if let Err(code) = apply_lane_transition(
+        &mut next,
+        &snapshot.dispatch,
+        &resolutions,
+        Some(&arm),
+        target_dispatch,
+        Some(LaneWorkUpdate {
+            work_item_id: command.work_item_id.clone(),
+            demand,
+        }),
+        &mut transitions,
+    ) {
+        return rejected_command(
+            snapshot,
+            command_conflict(ProtocolConflictKind::StateConflict, code),
+        );
     }
     if command.focus {
         next.focus = Some(command.work_item_id.clone());
@@ -3862,10 +3847,6 @@ fn settle_work_item(
     }
     let mut next = snapshot.clone();
     let next_generation = current_work.scheduling_generation + 1;
-    next.work
-        .get_mut(work_item_id)
-        .expect("running work item exists")
-        .scheduling_generation = next_generation;
 
     let mut transitions = vec![
         format!("activation:{activation_id}:settled"),
@@ -3877,23 +3858,59 @@ fn settle_work_item(
 
     match settlement {
         Settlement::Continue | Settlement::Yield => {
-            resolve_consumed_wait(&mut next, consumed_wait_id.as_deref(), &mut transitions);
-            next.work
-                .get_mut(work_item_id)
-                .expect("running work item exists")
-                .status = WorkStatus::Runnable;
-            set_dispatch_state(&mut next, AgentDispatchState::Open);
+            let mut demand = current_work.clone();
+            demand.scheduling_generation = next_generation;
+            demand.status = WorkStatus::Runnable;
+            let resolutions = current_lane_resolution(
+                snapshot,
+                consumed_wait_id.as_deref(),
+                "consumed->resolved",
+            )
+            .into_iter()
+            .collect::<Vec<_>>();
+            if let Err(code) = apply_lane_transition(
+                &mut next,
+                &snapshot.dispatch,
+                &resolutions,
+                None,
+                AgentDispatchState::Open,
+                Some(LaneWorkUpdate {
+                    work_item_id: work_item_id.to_string(),
+                    demand,
+                }),
+                &mut transitions,
+            ) {
+                return rejected(snapshot, code);
+            }
             transitions.push(format!("work:{work_item_id}:runnable"));
         }
         Settlement::TargetedYield { continuation } => {
-            resolve_consumed_wait(&mut next, consumed_wait_id.as_deref(), &mut transitions);
-            next.work
-                .get_mut(work_item_id)
-                .expect("running work item exists")
-                .status = WorkStatus::Yielded {
+            let mut demand = current_work.clone();
+            demand.scheduling_generation = next_generation;
+            demand.status = WorkStatus::Yielded {
                 continuation: continuation.clone(),
             };
-            set_dispatch_state(&mut next, AgentDispatchState::Open);
+            let resolutions = current_lane_resolution(
+                snapshot,
+                consumed_wait_id.as_deref(),
+                "consumed->resolved",
+            )
+            .into_iter()
+            .collect::<Vec<_>>();
+            if let Err(code) = apply_lane_transition(
+                &mut next,
+                &snapshot.dispatch,
+                &resolutions,
+                None,
+                AgentDispatchState::Open,
+                Some(LaneWorkUpdate {
+                    work_item_id: work_item_id.to_string(),
+                    demand,
+                }),
+                &mut transitions,
+            ) {
+                return rejected(snapshot, code);
+            }
             next.focus = Some(continuation.target_work_item_id.clone());
             transitions.push(format!(
                 "work:{work_item_id}:yielded:{}:{}",
@@ -3917,7 +3934,7 @@ fn settle_work_item(
                 id: wait.id.clone(),
                 generation: wait_generation,
             };
-            if let Some(existing_wait) = next.waits.get(&wait.id) {
+            if let Some(existing_wait) = snapshot.waits.get(&wait.id) {
                 let current_generation = existing_wait
                     .generations
                     .get(&existing_wait.current_generation)
@@ -3952,84 +3969,66 @@ fn settle_work_item(
                     return rejected(snapshot, "wait_id_consumed_by_other_activation");
                 }
             }
-            next.work
-                .get_mut(work_item_id)
-                .expect("running work item exists")
-                .status = WorkStatus::Waiting {
+            let mut demand = current_work.clone();
+            demand.scheduling_generation = next_generation;
+            demand.status = WorkStatus::Waiting {
                 wait_id: wait.id.clone(),
             };
-            if consumed_wait_id.as_deref().is_some_and(|id| id != wait.id) {
-                resolve_consumed_wait(&mut next, consumed_wait_id.as_deref(), &mut transitions);
-            }
-            let previous_generation = next
-                .waits
-                .get(&wait.id)
-                .map(|record| record.current_generation);
-            if let Some(record) = next.waits.get_mut(&wait.id) {
-                let previous = record
-                    .generations
-                    .get_mut(&record.current_generation)
-                    .expect("current wait generation exists");
-                if previous.state == WaitState::Consumed {
-                    previous.state = WaitState::Resolved;
-                    previous.consuming_activation_id = None;
-                    transitions.push(format!(
-                        "wait:{}:generation:{}:consumed->resolved",
-                        wait.id, record.current_generation
-                    ));
-                }
-                record.current_generation = next_generation;
-                record.generations.insert(
-                    next_generation,
-                    WaitGenerationRecord {
-                        owner: owner.clone(),
-                        state: WaitState::Active,
-                        trigger: None,
-                        consuming_activation_id: None,
-                    },
-                );
-            } else {
-                next.waits.insert(
-                    wait.id.clone(),
-                    WaitRecord {
-                        current_generation: next_generation,
-                        generations: BTreeMap::from([(
-                            next_generation,
-                            WaitGenerationRecord {
-                                owner: owner.clone(),
-                                state: WaitState::Active,
-                                trigger: None,
-                                consuming_activation_id: None,
-                            },
-                        )]),
-                    },
-                );
-            }
-            let dispatch = match mode {
+            let resolutions = current_lane_resolution(
+                snapshot,
+                consumed_wait_id.as_deref(),
+                "consumed->resolved",
+            )
+            .into_iter()
+            .collect::<Vec<_>>();
+            let arm = LaneWaitArm {
+                wait: wait.clone(),
+                owner: owner.clone(),
+            };
+            let target_dispatch = match mode {
                 WaitMode::AwaitThis => AgentDispatchState::Awaiting { wait: wait.clone() },
                 WaitMode::AcceptScheduling => AgentDispatchState::Open,
             };
-            set_dispatch_state(&mut next, dispatch);
-            transitions.push(match previous_generation {
-                Some(generation) => {
-                    format!(
-                        "wait:{}:generation:{generation}->{next_generation}:active",
-                        wait.id
-                    )
-                }
-                None => format!(
-                    "wait:{}:generation:{next_generation}:created:active",
-                    wait.id
-                ),
-            });
+            if let Err(code) = apply_lane_transition(
+                &mut next,
+                &snapshot.dispatch,
+                &resolutions,
+                Some(&arm),
+                target_dispatch,
+                Some(LaneWorkUpdate {
+                    work_item_id: work_item_id.to_string(),
+                    demand,
+                }),
+                &mut transitions,
+            ) {
+                return rejected(snapshot, code);
+            }
         }
         Settlement::Complete { continuation } => {
-            resolve_consumed_wait(&mut next, consumed_wait_id.as_deref(), &mut transitions);
-            next.work
-                .get_mut(work_item_id)
-                .expect("running work item exists")
-                .status = WorkStatus::Terminal;
-            set_dispatch_state(&mut next, AgentDispatchState::Open);
+            let mut demand = current_work.clone();
+            demand.scheduling_generation = next_generation;
+            demand.status = WorkStatus::Terminal;
+            let resolutions = current_lane_resolution(
+                snapshot,
+                consumed_wait_id.as_deref(),
+                "consumed->resolved",
+            )
+            .into_iter()
+            .collect::<Vec<_>>();
+            if let Err(code) = apply_lane_transition(
+                &mut next,
+                &snapshot.dispatch,
+                &resolutions,
+                None,
+                AgentDispatchState::Open,
+                Some(LaneWorkUpdate {
+                    work_item_id: work_item_id.to_string(),
+                    demand,
+                }),
+                &mut transitions,
+            ) {
+                return rejected(snapshot, code);
+            }
             transitions.push(format!("work:{work_item_id}:terminal"));
             let restored_focus = continuation
                 .as_ref()
@@ -4164,8 +4163,24 @@ fn settle_lifecycle(
     match settlement {
         Settlement::Continue | Settlement::Yield | Settlement::Complete { continuation: None } => {
             if !lifecycle_nudge {
-                resolve_consumed_wait(&mut next, consumed_wait_id.as_deref(), &mut transitions);
-                set_dispatch_state(&mut next, AgentDispatchState::Open);
+                let resolutions = current_lane_resolution(
+                    snapshot,
+                    consumed_wait_id.as_deref(),
+                    "consumed->resolved",
+                )
+                .into_iter()
+                .collect::<Vec<_>>();
+                if let Err(code) = apply_lane_transition(
+                    &mut next,
+                    &snapshot.dispatch,
+                    &resolutions,
+                    None,
+                    AgentDispatchState::Open,
+                    None,
+                    &mut transitions,
+                ) {
+                    return rejected(snapshot, code);
+                }
             }
         }
         Settlement::Wait {
@@ -4188,7 +4203,7 @@ fn settle_lifecycle(
                 id: wait.id.clone(),
                 generation: wait_generation,
             };
-            if let Some(existing_wait) = next.waits.get(&wait.id) {
+            if let Some(existing_wait) = snapshot.waits.get(&wait.id) {
                 let current = existing_wait
                     .generations
                     .get(&existing_wait.current_generation)
@@ -4203,90 +4218,55 @@ fn settle_lifecycle(
                     return rejected(snapshot, "wait_generation_not_advanced");
                 }
             }
-            if consumed_wait_id.as_deref().is_some_and(|id| id != wait.id) {
-                resolve_consumed_wait(&mut next, consumed_wait_id.as_deref(), &mut transitions);
-            }
+            let mut resolutions = current_lane_resolution(
+                snapshot,
+                consumed_wait_id.as_deref(),
+                "consumed->resolved",
+            )
+            .into_iter()
+            .collect::<Vec<_>>();
             if lifecycle_nudge {
-                for (existing_wait_id, record) in &mut next.waits {
+                for (existing_wait_id, record) in &snapshot.waits {
                     if existing_wait_id == &wait.id {
                         continue;
                     }
                     let generation = record
                         .generations
-                        .get_mut(&record.current_generation)
+                        .get(&record.current_generation)
                         .expect("current wait generation exists");
                     if generation.owner == owner
                         && matches!(generation.state, WaitState::Active | WaitState::Triggered)
                     {
-                        generation.state = WaitState::Resolved;
-                        generation.trigger = None;
-                        generation.consuming_activation_id = None;
-                        transitions.push(format!(
-                            "wait:{existing_wait_id}:generation:{}:resolved_by_lifecycle_rearm",
-                            record.current_generation
-                        ));
+                        resolutions.push(LaneWaitResolution {
+                            wait: WaitIdentity {
+                                id: existing_wait_id.clone(),
+                                generation: record.current_generation,
+                            },
+                            expected: generation.clone(),
+                            reason: "resolved_by_lifecycle_rearm",
+                        });
                     }
                 }
             }
-            let previous_generation = next
-                .waits
-                .get(&wait.id)
-                .map(|record| record.current_generation);
-            if let Some(record) = next.waits.get_mut(&wait.id) {
-                let previous = record
-                    .generations
-                    .get_mut(&record.current_generation)
-                    .expect("current wait generation exists");
-                if previous.state == WaitState::Consumed {
-                    previous.state = WaitState::Resolved;
-                    previous.consuming_activation_id = None;
-                }
-                record.current_generation = next_generation;
-                record.generations.insert(
-                    next_generation,
-                    WaitGenerationRecord {
-                        owner: owner.clone(),
-                        state: WaitState::Active,
-                        trigger: None,
-                        consuming_activation_id: None,
-                    },
-                );
-            } else {
-                next.waits.insert(
-                    wait.id.clone(),
-                    WaitRecord {
-                        current_generation: next_generation,
-                        generations: BTreeMap::from([(
-                            next_generation,
-                            WaitGenerationRecord {
-                                owner: owner.clone(),
-                                state: WaitState::Active,
-                                trigger: None,
-                                consuming_activation_id: None,
-                            },
-                        )]),
-                    },
-                );
-            }
-            set_dispatch_state(
+            let arm = LaneWaitArm {
+                wait: wait.clone(),
+                owner: owner.clone(),
+            };
+            let target_dispatch = match mode {
+                WaitMode::AwaitThis => AgentDispatchState::Awaiting { wait: wait.clone() },
+                WaitMode::AcceptScheduling => AgentDispatchState::Open,
+            };
+            if let Err(code) = apply_lane_transition(
                 &mut next,
-                match mode {
-                    WaitMode::AwaitThis => AgentDispatchState::Awaiting { wait: wait.clone() },
-                    WaitMode::AcceptScheduling => AgentDispatchState::Open,
-                },
-            );
-            transitions.push(match previous_generation {
-                Some(generation) => {
-                    format!(
-                        "wait:{}:generation:{generation}->{next_generation}:active",
-                        wait.id
-                    )
-                }
-                None => format!(
-                    "wait:{}:generation:{next_generation}:created:active",
-                    wait.id
-                ),
-            });
+                &snapshot.dispatch,
+                &resolutions,
+                Some(&arm),
+                target_dispatch,
+                None,
+                &mut transitions,
+            ) {
+                return rejected(snapshot, code);
+            }
         }
         Settlement::TargetedYield { .. }
         | Settlement::Complete {
@@ -4307,28 +4287,158 @@ fn settle_lifecycle(
     }
 }
 
-fn resolve_consumed_wait(
-    snapshot: &mut Snapshot,
+#[derive(Debug, Clone)]
+struct LaneWaitResolution {
+    wait: WaitIdentity,
+    expected: WaitGenerationRecord,
+    reason: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct LaneWaitArm {
+    wait: WaitIdentity,
+    owner: SchedulerOwner,
+}
+
+#[derive(Debug, Clone)]
+struct LaneWorkUpdate {
+    work_item_id: String,
+    demand: WorkDemand,
+}
+
+fn current_lane_resolution(
+    snapshot: &Snapshot,
     wait_id: Option<&str>,
+    reason: &'static str,
+) -> Option<LaneWaitResolution> {
+    let wait_id = wait_id?;
+    let wait = snapshot.waits.get(wait_id)?;
+    let expected = wait.generations.get(&wait.current_generation)?.clone();
+    Some(LaneWaitResolution {
+        wait: WaitIdentity {
+            id: wait_id.to_string(),
+            generation: wait.current_generation,
+        },
+        expected,
+        reason,
+    })
+}
+
+fn apply_lane_transition(
+    snapshot: &mut Snapshot,
+    expected_dispatch: &AgentDispatchState,
+    resolutions: &[LaneWaitResolution],
+    arm: Option<&LaneWaitArm>,
+    target_dispatch: AgentDispatchState,
+    work_update: Option<LaneWorkUpdate>,
     transitions: &mut Vec<String>,
-) {
-    let Some(wait_id) = wait_id else {
-        return;
-    };
-    let wait = snapshot
-        .waits
-        .get_mut(wait_id)
-        .expect("consumed wait exists");
-    let generation = wait
-        .generations
-        .get_mut(&wait.current_generation)
-        .expect("current wait generation exists");
-    generation.state = WaitState::Resolved;
-    generation.consuming_activation_id = None;
-    transitions.push(format!(
-        "wait:{wait_id}:generation:{}:consumed->resolved",
-        wait.current_generation
-    ));
+) -> Result<(), &'static str> {
+    if &snapshot.dispatch != expected_dispatch {
+        return Err("lane_transition_source_dispatch_changed");
+    }
+    for resolution in resolutions {
+        let Some(wait) = snapshot.waits.get(&resolution.wait.id) else {
+            return Err("lane_transition_source_wait_missing");
+        };
+        if wait.current_generation != resolution.wait.generation
+            || wait.generations.get(&resolution.wait.generation) != Some(&resolution.expected)
+        {
+            return Err("lane_transition_source_wait_changed");
+        }
+    }
+    if let Some(arm) = arm {
+        if let Some(wait) = snapshot.waits.get(&arm.wait.id) {
+            let Some(current) = wait.generations.get(&wait.current_generation) else {
+                return Err("lane_transition_target_wait_missing_generation");
+            };
+            let current_is_resolved_by_transition = resolutions.iter().any(|resolution| {
+                resolution.wait.id == arm.wait.id
+                    && resolution.wait.generation == wait.current_generation
+            });
+            if current.owner != arm.owner
+                || wait.current_generation >= arm.wait.generation
+                || wait.generations.contains_key(&arm.wait.generation)
+                || wait
+                    .generations
+                    .keys()
+                    .any(|generation| *generation > wait.current_generation)
+                || (current.state != WaitState::Resolved && !current_is_resolved_by_transition)
+            {
+                return Err("lane_transition_target_wait_conflict");
+            }
+        }
+    }
+    if let AgentDispatchState::Awaiting { wait } = &target_dispatch {
+        if !arm.is_some_and(|arm| arm.wait == *wait) {
+            return Err("lane_transition_target_dispatch_mismatch");
+        }
+    }
+    if let (Some(arm), Some(work_update)) = (arm, work_update.as_ref()) {
+        if let SchedulerOwner::WorkItem { work_item_id } = &arm.owner {
+            if work_item_id != &work_update.work_item_id
+                || work_update.demand.scheduling_generation != arm.wait.generation
+                || work_update.demand.status
+                    != (WorkStatus::Waiting {
+                        wait_id: arm.wait.id.clone(),
+                    })
+            {
+                return Err("lane_transition_work_projection_mismatch");
+            }
+        }
+    }
+
+    for resolution in resolutions {
+        let generation = snapshot
+            .waits
+            .get_mut(&resolution.wait.id)
+            .expect("validated lane source wait exists")
+            .generations
+            .get_mut(&resolution.wait.generation)
+            .expect("validated lane source wait generation exists");
+        generation.state = WaitState::Resolved;
+        generation.trigger = None;
+        generation.consuming_activation_id = None;
+        transitions.push(format!(
+            "wait:{}:generation:{}:{}",
+            resolution.wait.id, resolution.wait.generation, resolution.reason
+        ));
+    }
+    if let Some(work_update) = work_update {
+        snapshot
+            .work
+            .insert(work_update.work_item_id, work_update.demand);
+    }
+    if let Some(arm) = arm {
+        let generation = WaitGenerationRecord {
+            owner: arm.owner.clone(),
+            state: WaitState::Active,
+            trigger: None,
+            consuming_activation_id: None,
+        };
+        if let Some(wait) = snapshot.waits.get_mut(&arm.wait.id) {
+            let previous_generation = wait.current_generation;
+            wait.current_generation = arm.wait.generation;
+            wait.generations.insert(arm.wait.generation, generation);
+            transitions.push(format!(
+                "wait:{}:generation:{previous_generation}->{}:active",
+                arm.wait.id, arm.wait.generation
+            ));
+        } else {
+            snapshot.waits.insert(
+                arm.wait.id.clone(),
+                WaitRecord {
+                    current_generation: arm.wait.generation,
+                    generations: BTreeMap::from([(arm.wait.generation, generation)]),
+                },
+            );
+            transitions.push(format!(
+                "wait:{}:generation:{}:created:active",
+                arm.wait.id, arm.wait.generation
+            ));
+        }
+    }
+    set_dispatch_state(snapshot, target_dispatch);
+    Ok(())
 }
 
 fn set_dispatch_state(snapshot: &mut Snapshot, dispatch: AgentDispatchState) {
@@ -4469,7 +4579,6 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
     }
     let mut settled_activations = BTreeSet::new();
     let mut terminal_records = BTreeMap::<String, usize>::new();
-    let mut current_awaiting_settlements = BTreeSet::<(String, u64)>::new();
     let mut expected_continuation_admissions =
         BTreeMap::<String, ContinuationAdmissionRecord>::new();
     let mut continuation_prestate_fences = BTreeSet::<(String, u64)>::new();
@@ -4511,7 +4620,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                 | Settlement::Complete { continuation: None } => {}
                 Settlement::Wait {
                     wait,
-                    mode,
+                    mode: _,
                     legacy_wait_id,
                 } => {
                     if legacy_wait_id || wait.generation != settlement_generation {
@@ -4531,11 +4640,6 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                     };
                     if generation.owner != activation.owner {
                         return Err("canonical lifecycle wait settlement owner mismatch".into());
-                    }
-                    if mode == WaitMode::AwaitThis
-                        && matches!(generation.state, WaitState::Active | WaitState::Triggered)
-                    {
-                        current_awaiting_settlements.insert((wait.id, wait.generation));
                     }
                 }
                 Settlement::TargetedYield { .. }
@@ -4596,7 +4700,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
             }
             Settlement::Wait {
                 wait,
-                mode,
+                mode: _,
                 legacy_wait_id,
             } => {
                 if legacy_wait_id {
@@ -4628,12 +4732,6 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                     return Err(
                         "canonical wait settlement disagrees with authoritative work state".into(),
                     );
-                }
-                if projects_current_work_state
-                    && mode == WaitMode::AwaitThis
-                    && matches!(generation.state, WaitState::Active | WaitState::Triggered)
-                {
-                    current_awaiting_settlements.insert((wait.id, wait.generation));
                 }
             }
             Settlement::Complete {
@@ -4827,42 +4925,6 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
         {
             return Err(
                 "settlement-missing activation has no canonical missing-settlement record".into(),
-            );
-        }
-    }
-    if current_awaiting_settlements.len() > 1 {
-        return Err("multiple canonical settlements reserve the single agent lane".into());
-    }
-    if let Some((wait_id, generation)) = current_awaiting_settlements.iter().next() {
-        if snapshot.dispatch
-            != (AgentDispatchState::Awaiting {
-                wait: WaitIdentity {
-                    id: wait_id.clone(),
-                    generation: *generation,
-                },
-            })
-        {
-            return Err(
-                "canonical settlement dispatch disagrees with authoritative lane state".into(),
-            );
-        }
-    } else if !snapshot.settlements.is_empty() && snapshot.dispatch != AgentDispatchState::Open {
-        // Settlement may atomically adopt an activation's WorkItem-owned wait,
-        // so the preserved authoritative lane is not limited to lifecycle-owned
-        // waits. It must still identify an active canonical wait generation.
-        let active_wait_is_preserved = match &snapshot.dispatch {
-            AgentDispatchState::Awaiting { wait } => snapshot
-                .waits
-                .get(&wait.id)
-                .and_then(|record| record.generations.get(&wait.generation))
-                .is_some_and(|generation| {
-                    matches!(generation.state, WaitState::Active | WaitState::Triggered)
-                }),
-            AgentDispatchState::Open => false,
-        };
-        if !active_wait_is_preserved {
-            return Err(
-                "canonical settlement dispatch disagrees with authoritative lane state".into(),
             );
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1327,34 +1327,151 @@ pub fn scheduler_recovery_report(
 }
 
 pub fn apply_scheduler_recovery_plan(
-    _storage: &AppStorage,
+    storage: &AppStorage,
     runtime_db: &RuntimeDb,
     agent_id: &str,
     report: &SchedulerRecoveryReport,
 ) -> Result<(usize, Option<std::path::PathBuf>)> {
-    let mut commands = report
+    let legacy_adoptions = report
         .legacy_adoptions
         .iter()
         .filter(|candidate| candidate.eligible)
-        .filter_map(|candidate| candidate.proposed_command.clone())
+        .filter_map(|candidate| {
+            candidate
+                .proposed_command
+                .as_ref()
+                .map(|command| (candidate, command))
+        })
         .collect::<Vec<_>>();
-    if let Some(candidate) = report.candidates.iter().find(|candidate| {
-        candidate.kind == SchedulerRecoveryCandidateKind::NeedsSettlement && candidate.eligible
-    }) {
-        commands.extend(candidate.proposed_commands.clone());
-    }
-    if commands.is_empty() {
+    let settlement_recovery = report
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.kind == SchedulerRecoveryCandidateKind::NeedsSettlement && candidate.eligible
+        })
+        .map(|candidate| candidate.proposed_commands.as_slice())
+        .unwrap_or_default();
+    if legacy_adoptions.is_empty() && settlement_recovery.is_empty() {
         return Ok((0, None));
     }
+    if let Some(snapshot) = runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+    {
+        crate::domain::scheduler_protocol::assert_invariants(&snapshot)
+            .map_err(|error| anyhow!("invalid canonical scheduler recovery prestate: {error}"))?;
+    }
     let backup_path = runtime_db.create_verified_backup("scheduler-recovery")?;
-    Ok((
-        usize::from(
-            runtime_db
-                .transitions()
-                .commit_scheduler_recovery_plan(agent_id, &commands)?,
-        ),
-        Some(backup_path),
-    ))
+    let mut applied = false;
+    for (candidate, command) in legacy_adoptions {
+        if let Some(reason) =
+            preflight_legacy_adoption(runtime_db, agent_id, &candidate.work_item_id, command)?
+        {
+            record_legacy_adoption_rejection(storage, agent_id, &candidate.work_item_id, reason)?;
+            continue;
+        }
+        match runtime_db
+            .transitions()
+            .commit_scheduler_recovery_plan(agent_id, std::slice::from_ref(command))
+        {
+            Ok(changed) => applied |= changed,
+            Err(error) => {
+                let Some(reason) = isolated_legacy_adoption_rejection(&error) else {
+                    return Err(error);
+                };
+                record_legacy_adoption_rejection(
+                    storage,
+                    agent_id,
+                    &candidate.work_item_id,
+                    reason,
+                )?;
+            }
+        }
+    }
+    if !settlement_recovery.is_empty() {
+        applied |= runtime_db
+            .transitions()
+            .commit_scheduler_recovery_plan(agent_id, settlement_recovery)?;
+    }
+    Ok((usize::from(applied), Some(backup_path)))
+}
+
+fn preflight_legacy_adoption(
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    work_item_id: &str,
+    command: &crate::domain::scheduler_protocol::ProtocolCommand,
+) -> Result<Option<String>> {
+    let current = runtime_db
+        .transitions()
+        .legacy_scheduler_adoption_candidates(agent_id)?
+        .into_iter()
+        .find(|candidate| candidate.work_item_id == work_item_id);
+    let Some(current) = current else {
+        return Ok(Some("source_work_item_missing_or_closed".into()));
+    };
+    if !current.eligible || current.command.as_ref() != Some(command) {
+        return Ok(Some(format!(
+            "source_changed:{agent_id}:{work_item_id}:{}",
+            current.reason
+        )));
+    }
+    let Some(snapshot) = runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+    else {
+        return Ok(None);
+    };
+    let outcome = crate::domain::scheduler_protocol::reduce_command(&snapshot, command);
+    if let Err(error) =
+        crate::domain::scheduler_protocol::assert_invariants(&outcome.outcome.snapshot)
+    {
+        return Ok(Some(format!(
+            "scheduler protocol reducer produced invalid state: {error}"
+        )));
+    }
+    if outcome.outcome.decision == crate::domain::scheduler_protocol::Decision::Rejected {
+        return Ok(Some(
+            outcome
+                .conflict
+                .map(|conflict| conflict.code)
+                .or_else(|| outcome.outcome.diagnostics.into_iter().next())
+                .unwrap_or_else(|| "rejected_without_diagnostic".into()),
+        ));
+    }
+    Ok(None)
+}
+
+fn record_legacy_adoption_rejection(
+    storage: &AppStorage,
+    agent_id: &str,
+    work_item_id: &str,
+    reason: String,
+) -> Result<()> {
+    storage.append_event(&scheduler::scheduler_invariant_diagnostic_event(
+        agent_id,
+        "legacy_adoption_rejected",
+        Some(work_item_id.to_string()),
+        None,
+        vec![reason],
+    )?)
+}
+
+fn isolated_legacy_adoption_rejection(error: &anyhow::Error) -> Option<String> {
+    error.chain().find_map(|source| {
+        source
+            .downcast_ref::<
+                crate::runtime_db::transitions::scheduler_protocol_repository::LegacySchedulerAdoptionRejected,
+            >()
+            .map(|error| error.reason.clone())
+            .or_else(|| {
+                source
+                    .downcast_ref::<
+                        crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerProtocolReducerRejected,
+                    >()
+                    .map(|error| error.reason.clone())
+            })
+    })
 }
 
 fn runtime_error_queue_settlement(

--- a/src/runtime/scheduler_acceptance.rs
+++ b/src/runtime/scheduler_acceptance.rs
@@ -1902,6 +1902,7 @@ async fn seed_scheduler_legacy_adoption_restart_fixture(
                 eligible.len()
             ));
         }
+        let valid_work_item_id = eligible[0].work_item_id.clone();
         let stale_work_item_id = eligible[1].work_item_id.clone();
         let stale = runtime
             .inner
@@ -1919,39 +1920,57 @@ async fn seed_scheduler_legacy_adoption_restart_fixture(
                 None,
             )
             .await?;
-        let error = super::apply_scheduler_recovery_plan(
+        let applied = super::apply_scheduler_recovery_plan(
             &runtime.inner.storage,
             &runtime.inner.runtime_db,
             agent_id,
             &report,
-        )
-        .expect_err("stale legacy adoption report must be rejected");
-        if !error.to_string().contains("legacy adoption source changed") {
-            return Err(error).context("unexpected legacy adoption rollback failure");
+        )?;
+        if applied.0 != 1 {
+            return Err(anyhow!(
+                "scheduler legacy adoption did not apply the valid isolated candidate"
+            ));
         }
-        let partition_initialized = runtime
+        let snapshot = runtime
             .inner
             .runtime_db
             .transitions()
             .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
-            .is_some();
-        if partition_initialized {
+            .ok_or_else(|| anyhow!("valid isolated adoption did not initialize partition"))?;
+        if !snapshot.work.contains_key(&valid_work_item_id)
+            || snapshot.work.contains_key(&stale_work_item_id)
+        {
             return Err(anyhow!(
-                "stale legacy adoption report left partial canonical state"
+                "legacy adoption candidate isolation changed the wrong WorkItems"
+            ));
+        }
+        let isolated_diagnostic = runtime
+            .inner
+            .storage
+            .read_recent_events(32)?
+            .into_iter()
+            .any(|event| {
+                event.kind == "scheduler_diagnostic"
+                    && event.data["reason"] == "legacy_adoption_rejected"
+                    && event.data["work_item_id"] == stale_work_item_id
+            });
+        if !isolated_diagnostic {
+            return Err(anyhow!(
+                "stale legacy adoption did not emit an isolation diagnostic"
             ));
         }
         return Ok(SchedulerLegacyAdoptionRestartFixture {
             checkpoint: "legacy_adoption_atomicity".into(),
             stage: stage.into(),
-            cut_kind: "atomic_rollback".into(),
+            cut_kind: "candidate_isolation".into(),
             agent_id: agent_id.into(),
             work_item_id: stale_work_item_id,
             precommit_fault_rolled_back: true,
             replay_applied: false,
             replay_exactly_once: false,
-            partition_initialized,
+            partition_initialized: true,
             work_status: None,
-            focus_work_item_id: None,
+            focus_work_item_id: snapshot.focus,
         });
     }
     if stage != "replay" && stage != "verify" {
@@ -2019,7 +2038,7 @@ async fn seed_scheduler_legacy_adoption_restart_fixture(
     Ok(SchedulerLegacyAdoptionRestartFixture {
         checkpoint: "legacy_adoption_atomicity".into(),
         stage: stage.into(),
-        cut_kind: "atomic_rollback".into(),
+        cut_kind: "candidate_isolation".into(),
         agent_id: agent_id.into(),
         work_item_id: stale.id.clone(),
         precommit_fault_rolled_back: stage == "verify",

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -853,6 +853,110 @@ async fn legacy_recovery_plan_reconciles_an_existing_dispatch_reservation() {
 }
 
 #[tokio::test]
+async fn legacy_recovery_isolates_a_stale_candidate_and_keeps_other_work_available() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let first = runtime
+        .create_work_item(
+            "legacy recovery first".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let stale = runtime
+        .create_work_item(
+            "legacy recovery stale".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let stale_report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    runtime
+        .update_work_item_fields(
+            stale.id.clone(),
+            Some("legacy recovery stale updated".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        apply_scheduler_recovery_plan(
+            &runtime.inner.storage,
+            &runtime.inner.runtime_db,
+            "default",
+            &stale_report,
+        )
+        .unwrap()
+        .0,
+        1
+    );
+    let isolated = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(isolated.work.contains_key(&first.id));
+    assert!(!isolated.work.contains_key(&stale.id));
+    assert!(runtime
+        .storage()
+        .read_recent_events(32)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_diagnostic"
+                && event.data["reason"] == "legacy_adoption_rejected"
+                && event.data["work_item_id"] == stale.id
+        }));
+
+    let fresh_report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert_eq!(
+        apply_scheduler_recovery_plan(
+            &runtime.inner.storage,
+            &runtime.inner.runtime_db,
+            "default",
+            &fresh_report,
+        )
+        .unwrap()
+        .0,
+        1
+    );
+    let recovered = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(recovered.work.contains_key(&first.id));
+    assert!(recovered.work.contains_key(&stale.id));
+}
+
+#[tokio::test]
 async fn bootstrap_diagnostics_report_cross_model_scheduler_invariant_failures() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -130,6 +130,32 @@ impl fmt::Display for SchedulerProtocolCommandIdentityConflict {
 
 impl StdError for SchedulerProtocolCommandIdentityConflict {}
 
+#[derive(Debug)]
+pub(crate) struct LegacySchedulerAdoptionRejected {
+    pub reason: String,
+}
+
+impl fmt::Display for LegacySchedulerAdoptionRejected {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "legacy adoption rejected: {}", self.reason)
+    }
+}
+
+impl StdError for LegacySchedulerAdoptionRejected {}
+
+#[derive(Debug)]
+pub(crate) struct SchedulerProtocolReducerRejected {
+    pub reason: String,
+}
+
+impl fmt::Display for SchedulerProtocolReducerRejected {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.reason)
+    }
+}
+
+impl StdError for SchedulerProtocolReducerRejected {}
+
 #[derive(Debug, Serialize)]
 struct SnapshotFence<'a> {
     slot: &'a ActivationSlot,
@@ -210,7 +236,9 @@ pub(super) fn validate_protocol_commands_tx(
         let pre_state_fence = snapshot_fence(&snapshot)?;
         let outcome = scheduler_protocol::reduce_command(&snapshot, command);
         scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
-            anyhow!("scheduler protocol reducer produced invalid state: {error}")
+            SchedulerProtocolReducerRejected {
+                reason: format!("scheduler protocol reducer produced invalid state: {error}"),
+            }
         })?;
         if outcome.outcome.decision == Decision::Rejected {
             let code = outcome
@@ -219,7 +247,10 @@ pub(super) fn validate_protocol_commands_tx(
                 .map(|conflict| conflict.code.as_str())
                 .or_else(|| outcome.outcome.diagnostics.first().map(String::as_str))
                 .unwrap_or("rejected_without_diagnostic");
-            bail!("canonical scheduler command {command_kind} rejected: {code}");
+            return Err(SchedulerProtocolReducerRejected {
+                reason: format!("canonical scheduler command {command_kind} rejected: {code}"),
+            }
+            .into());
         }
         let post_state_fence = snapshot_fence(&outcome.outcome.snapshot)?;
         let decision = outcome.outcome.decision.clone();
@@ -508,7 +539,9 @@ impl RuntimeTransitionRepository<'_> {
             }
             let outcome = scheduler_protocol::reduce_command(&snapshot, command);
             scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
-                anyhow!("scheduler protocol reducer produced invalid state: {error}")
+                SchedulerProtocolReducerRejected {
+                    reason: format!("scheduler protocol reducer produced invalid state: {error}"),
+                }
             })?;
             inject_fault(fault, TransitionFaultPoint::AfterValidation)?;
 
@@ -858,18 +891,21 @@ fn validate_legacy_adoption_source_tx(
         .optional()?
         .map(|payload| crate::runtime_db::repositories::decode_work_item_payload(&payload))
         .transpose()?
-        .ok_or_else(|| anyhow!("legacy adoption source WorkItem is missing or closed"))?;
+        .ok_or_else(|| LegacySchedulerAdoptionRejected {
+            reason: "source_work_item_missing_or_closed".into(),
+        })?;
     let candidate = legacy_scheduler_adoption_candidate_tx(tx, &work_item)?;
     if !candidate.eligible
         || candidate.command.as_ref()
             != Some(&ProtocolCommand::AdoptLegacyWorkState(command.clone()))
     {
-        bail!(
-            "legacy adoption source changed for {}:{} ({})",
-            agent_id,
-            command.work_item_id,
-            candidate.reason
-        );
+        return Err(LegacySchedulerAdoptionRejected {
+            reason: format!(
+                "source_changed:{}:{}:{}",
+                agent_id, command.work_item_id, candidate.reason
+            ),
+        }
+        .into());
     }
     Ok(())
 }

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -2856,7 +2856,8 @@ fn canonical_typed_records_must_match_authoritative_activation_and_wait_facts() 
     let waiting_snapshot = waiting.outcome.snapshot;
     let mut waiting_with_open_lane = waiting_snapshot.clone();
     waiting_with_open_lane.dispatch = AgentDispatchState::Open;
-    assert!(assert_invariants(&waiting_with_open_lane).is_err());
+    assert_invariants(&waiting_with_open_lane)
+        .expect("historical settlement disposition must not control the current lane");
 
     let mut waiting_with_resolved_current_generation = waiting_snapshot;
     waiting_with_resolved_current_generation.dispatch = AgentDispatchState::Open;
@@ -3052,6 +3053,97 @@ fn legacy_recovery_adoption_reconciles_the_work_items_dispatch_reservation() {
     assert_eq!(released.outcome.snapshot.dispatch, AgentDispatchState::Open);
     assert_eq!(released.outcome.snapshot.dispatch_revision, 9);
     assert_invariants(&released.outcome.snapshot).expect("released recovery state is canonical");
+}
+
+#[test]
+fn historical_wait_settlement_does_not_override_recovered_lane_state() {
+    let admitted = reduce_command(
+        &minimal_snapshot(3),
+        &ProtocolCommand::AdmitActivation(typed_admission("a-history", "key-history", 3)),
+    );
+    let old_wait = WaitIdentity {
+        id: "wait-history".into(),
+        generation: 4,
+    };
+    let mut settlement = typed_settlement(
+        "s-history",
+        "a-history",
+        ActivationDisposition::WorkWaits {
+            wait: old_wait.clone(),
+        },
+    );
+    settlement.agent_dispatch = AgentDispatchDisposition::Awaiting {
+        wait: old_wait.clone(),
+    };
+    let settled = reduce_command(
+        &admitted.outcome.snapshot,
+        &ProtocolCommand::SettleActivation(SettleActivationCommand { settlement }),
+    );
+    assert_invariants(&settled.outcome.snapshot).expect("historical wait settlement prestate");
+
+    let rearm = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "w1".into(),
+        source_work_item_revision: 5,
+        demand: WorkDemand {
+            metadata_revision: 5,
+            scheduling_generation: 5,
+            status: WorkStatus::Waiting {
+                wait_id: old_wait.id.clone(),
+            },
+            capabilities: BTreeSet::new(),
+            locks: BTreeSet::new(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: Some(LegacyWaitAdoption {
+            wait_id: old_wait.id.clone(),
+            generation: 5,
+            owner_work_item_id: "w1".into(),
+            source_updated_at: "2026-08-01T00:00:01Z".into(),
+        }),
+        focus: true,
+        reserve_dispatch: false,
+        replace_completed_focus: None,
+    });
+    let rearmed = reduce_command(&settled.outcome.snapshot, &rearm);
+    assert_eq!(rearmed.outcome.decision, Decision::LegacyWorkStateAdopted);
+    assert_eq!(
+        rearmed.outcome.snapshot.settlements["s-history"].agent_dispatch,
+        AgentDispatchDisposition::Awaiting { wait: old_wait }
+    );
+    assert_eq!(
+        rearmed.outcome.snapshot.dispatch,
+        AgentDispatchState::Awaiting {
+            wait: WaitIdentity {
+                id: "wait-history".into(),
+                generation: 5,
+            },
+        }
+    );
+    assert_invariants(&rearmed.outcome.snapshot)
+        .expect("historical settlement must not reject the recovered wait generation");
+
+    let release = ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+        work_item_id: "w1".into(),
+        source_work_item_revision: 6,
+        demand: WorkDemand {
+            metadata_revision: 6,
+            scheduling_generation: 6,
+            status: WorkStatus::Runnable,
+            capabilities: BTreeSet::new(),
+            locks: BTreeSet::new(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        },
+        wait: None,
+        focus: true,
+        reserve_dispatch: false,
+        replace_completed_focus: None,
+    });
+    let released = reduce_command(&rearmed.outcome.snapshot, &release);
+    assert_eq!(released.outcome.snapshot.dispatch, AgentDispatchState::Open);
+    assert_invariants(&released.outcome.snapshot)
+        .expect("historical settlement must not reject the released lane");
 }
 
 fn typed_admission(


### PR DESCRIPTION
## Summary

- stop treating historical settlement dispatch records as authority for the current scheduler lane
- centralize fenced lane updates for legacy adoption, activation adoption, and settlement paths
- isolate stale legacy WorkItem adoption candidates while keeping canonical recovery failures fail-closed
- add diagnostics, restart-drill coverage, regression tests, and contract documentation

## Runtime contract

Settlement dispatch remains immutable attempt evidence. The current lane is derived from authoritative live work and wait state, so a historical Awaiting record can no longer contradict a correctly recovered Open lane.

Legacy migration is handled one candidate at a time. A stale or reducer-rejected legacy candidate is skipped with a scheduler diagnostic, while storage failures and invalid canonical state still stop recovery.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test scheduler_workitem_mvp` (41 passed)
- `cargo test --lib legacy_recovery_isolates_a_stale_candidate_and_keeps_other_work_available`
- `cargo test --test runtime_tasks -- --test-threads=1` (45 passed)
- scheduler restart drill prepare/replay/verify fixture

## Test note

A full parallel `cargo test --all-targets` run reached `runtime_tasks` and hit four timeout failures under resource contention. Each timed-out test passed individually, and the complete `runtime_tasks` target passed serially (45/45).
