### PR TITLE
feat: unify scheduler-workitem execution protocol with typed transitions and crash-safe settlement

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -24,6 +24,7 @@ implementation and tests.
 - [Agent Profile Model](./agent-profile-model.md)
 - [Runtime Scheduler Contract](./runtime-scheduler-contract.md)
 - [Scheduler Cutover Simplification](./scheduler-cutover-simplification.md)
+- [Scheduler–WorkItem Unified Execution Protocol](./scheduler-work-item-unified-execution-protocol.md)
 - [Agent Activation, Settlement, and Dispatch](./agent-activation-settlement-and-dispatch.md)
 - [Result Closure](./result-closure.md)
 - [Continuation Trigger](./continuation-trigger.md)

--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -56,6 +56,14 @@ fault-injection, and divergence gates pass.
 > historical `scheduler_activation_authorities` table remains only as a
 > compatibility row derived from the admission while the existing schema
 > foreign key is retained.
+>
+> **Control-state model superseded:** The activation/settlement protocol's
+> provenance, fencing, deterministic transition, atomic commit, immutable
+> evidence, and process-global cutover boundaries remain accepted. Its
+> long-term use of activation slot, dispatch reservation, WorkDemand,
+> scheduler wait mirrors, and missing-settlement recovery as joint future
+> eligibility authority is superseded by
+> [Scheduler–WorkItem Unified Execution Protocol](./scheduler-work-item-unified-execution-protocol.md).
 
 ## Status And Relationship To Existing RFCs
 

--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -1,0 +1,355 @@
+---
+title: RFC: Scheduler–WorkItem Unified Execution Protocol
+date: 2026-08-01
+status: accepted
+handle: rfc-scheduler-work-item-unified-execution-protocol
+---
+
+# RFC: Scheduler–WorkItem Unified Execution Protocol
+
+## Summary
+
+Holon's canonical scheduler uses one execution protocol for queued input,
+WorkItem continuation, wait resume, task rejoin, and lifecycle interaction.
+The protocol keeps deterministic admission, generations, provenance, atomic
+commit, and immutable execution evidence while removing scheduler-owned
+mirrors of WorkItem and wait lifecycle.
+
+One `ExecutionAttempt` grants one model-execution quantum. An attempt is the
+only durable fact that owns the single agent lane. WorkItem, queue, wait, task,
+host, and agent-control records remain authoritative for their own lifecycle.
+Candidate construction is ephemeral. Admission and settlement are each one
+business command and one SQLite transaction.
+
+This RFC supersedes the control-state model in
+[Agent Activation, Settlement, and Dispatch](./agent-activation-settlement-and-dispatch.md)
+where activation slot, dispatch reservation, WorkDemand, scheduler wait
+mirror, and missing-settlement recovery jointly decide future eligibility.
+The earlier RFC's provenance, fencing, deterministic transition, idempotency,
+atomicity, immutable evidence, and process-global cutover requirements remain
+accepted.
+
+## Motivation
+
+The scheduler was introduced to replace case-by-case coordination among
+messages, WorkItems, waits, tasks, turns, and restarts with one explicit
+protocol. The current implementation achieved deterministic transitions and
+strong persistence boundaries, but also copied business lifecycle into
+`slot`, `dispatch`, `WorkDemand`, scheduler waits, activation state, and
+missing-settlement recovery.
+
+That duplication makes normal execution depend on agreement among several
+authorities. A locally correct transition can leave a reserved lane, stale
+focus, missing settlement, or mismatched wait owner that prevents unrelated
+work from running. Adding more repair branches preserves the duplicated model
+instead of restoring the original goal.
+
+The target is not a third scheduler and not a return to implicit legacy
+behavior. It is a smaller canonical kernel with one authority per question.
+
+## Authority Matrix
+
+| Question | Authority | Evidence or projection only |
+| --- | --- | --- |
+| Is an input queued, claimed, or terminal? | queue/message state | attempt source, Turn, audit |
+| Is the agent executing? | one open `ExecutionAttempt` | agent status, historical slot |
+| Is a WorkItem runnable, waiting, paused, or terminal? | `WorkItemExecutionState` | plan, todo, focus, WorkDemand |
+| What can resume a wait? | `WaitCondition` identity, owner, generation, state | dispatch, closure reason |
+| Is a task active or terminal? | task ledger | message presence, agent posture |
+| May the host admit execution? | host runtime registry phase | loaded-runtime observation |
+| May the agent administratively accept work? | agent control | focus, waits, settlement history |
+| What is the collaboration focus? | durable WorkItem focus | execution ownership |
+| Why did execution start and how did it end? | immutable attempt admission and outcome | future eligibility |
+
+An authority added to admission must replace an existing authority in the
+same change. No new durable candidate, reservation, intent, or lifecycle
+mirror may be introduced without an explicit authority transfer.
+
+## Core State
+
+### ExecutionAttempt
+
+```text
+attempt_id
+agent_id
+source kind + identity + generation
+owner/binding
+origin + trust + priority + provenance
+admitted fences
+state = Open | Settled | Interrupted | ProtocolViolation
+run_id / turn_id
+recovery_of_attempt_id
+terminal_outcome_id
+admitted_at / terminal_at
+```
+
+Only `Open` owns the agent lane. All other states are terminal and lane-free.
+The attempt records execution authority and evidence; it does not own future
+WorkItem, queue, wait, or task lifecycle.
+
+### WorkItemExecutionState
+
+```text
+Runnable(g)
+InFlight(g, attempt_id)
+Waiting(g, wait_id, wait_generation)
+Paused(g, reason)
+NeedsRepair(g, repair_id)
+Terminal(g, completion)
+```
+
+Allowed transitions are:
+
+```text
+Runnable(g) -> InFlight(g, attempt)
+Waiting(g, exact triggered wait) -> InFlight(g, attempt)
+
+InFlight(g, attempt) -> Runnable(g + 1)
+InFlight(g, attempt) -> Runnable(g + 1, recovery_ref)
+InFlight(g, attempt) -> Waiting(g + 1, wait)
+InFlight(g, attempt) -> Paused(g + 1, reason)
+InFlight(g, attempt) -> NeedsRepair(g + 1, repair)
+InFlight(g, attempt) -> Terminal(g + 1, completion)
+
+Paused(g) | NeedsRepair(g) -> Runnable(g + 1)
+```
+
+An `InFlight` state and its same-agent open attempt must reference each other.
+Creating a new eligibility epoch increments the scheduling generation.
+Terminal transition resolves owned waits and continuation obligations and
+removes scheduler eligibility. Focus may be cleared or restored in the same
+transaction, but it does not grant eligibility.
+
+### WaitCondition
+
+The runtime wait record is the sole wait authority. Admission consumes one
+exact triggered generation. Settlement may create or rearm one exact
+generation. A scheduler-specific wait mirror or dispatch reservation must not
+participate in admission.
+
+### Candidate
+
+`ActivationCandidate` is a pure, ephemeral value containing source identity,
+generation, proposed binding, provenance, priority, and expected revisions.
+It is neither persisted nor reserved. Unknown source/binding combinations
+return `Unsupported` or `Quarantined`; they do not fall through to model
+execution.
+
+## Candidate And Outcome Matrix
+
+| Source | Binding | Allowed result | Source transition |
+| --- | --- | --- | --- |
+| trusted operator input | interaction or exact WorkItem affinity | conversation or WorkItem outcome | exact claim to terminal |
+| external contentful input | interaction or verified WorkItem binding | conversation or compatible WorkItem outcome | exact claim to terminal/quarantined |
+| task result | exact live rejoin, unbound reduce-only, or stale | compatible outcome or `ReduceOnly` | consume exact result; stale does not reenter model |
+| child result | exact caller continuation or unbound notification | caller outcome or `ReduceOnly` | consume exact result/continuation |
+| triggered wait | exact wait owner | owner-compatible outcome | consume exact wait generation |
+| WorkItem continuation | exact runnable generation | WorkItem outcome | `Runnable -> InFlight` |
+| targeted yield/continuation | exact continuation frame | target-compatible outcome | consume exact continuation |
+| internal contentful follow-up | declared interaction or WorkItem binding | binding-compatible outcome | exact claim to terminal |
+| startup recovery, repair, stale reduction | command-owned, no model binding | typed `CommandResult` | deterministic state repair |
+| shutdown or closed host | none | reject or defer | no execution |
+
+Task and child results require a live rejoin obligation in addition to a
+matching WorkItem generation. Priority orders candidates only after trust,
+owner, generation, host, and agent-control gates pass.
+
+## Admission
+
+`AdmitExecution(candidate, expected_facts)` performs one transaction:
+
+1. validate host and agent-control admission fences;
+2. verify there is no open attempt for the agent;
+3. compare-and-swap the source authority:
+   - claim an exact queue entry;
+   - move an exact WorkItem generation to `InFlight`;
+   - consume an exact triggered wait;
+   - bind an exact live task/child rejoin or continuation;
+4. create the open attempt with provenance and admitted fences;
+5. bind source, WorkItem, wait, task, Run, and audit references;
+6. commit before provider execution begins.
+
+There is no separate authority issuance, slot claim, dispatch reservation, or
+WorkDemand reservation.
+
+Trusted operator interjection attaches durable input evidence to an existing
+attempt at an allowed boundary. It does not create a second open attempt.
+
+## Settlement
+
+`SettleExecution(attempt_id, outcome, expected_facts)` accepts an
+owner-specific outcome:
+
+```text
+ConversationOutcome =
+  Replied | Wait(wait) | Interrupted(reason) | Failed(policy)
+
+WorkItemOutcome =
+  Continue | Wait(wait) | Complete(completion) | Pause(reason)
+  | Yield(target) | Failed(policy) | Interrupted(reason)
+```
+
+One transaction:
+
+1. compare-and-swap the open attempt;
+2. validate owner/outcome compatibility;
+3. terminalize the source queue claim;
+4. update WorkItem execution state;
+5. consume, resolve, create, or transfer waits;
+6. perform continuation or yield handoff;
+7. bind Run and Turn terminal facts;
+8. write immutable outcome and audit evidence;
+9. write completion/final-delivery outbox records;
+10. close the attempt and commit.
+
+Terminal tools such as `WaitFor`, `CompleteWorkItem`, execution-bound
+`PickWorkItem`, and explicit pause/fail/yield lower directly to settlement.
+A terminal tool returns success only after the transaction commits and then
+ends the provider/tool loop.
+
+A WorkItem-bound provider turn that ends without a WorkItem outcome closes the
+attempt as `ProtocolViolation` and normally returns the WorkItem to
+`Runnable(g + 1, recovery_ref)`. Repeated violations without new durable
+progress may move that WorkItem to `NeedsRepair`; they do not reserve the
+agent lane.
+
+## Interruption And Restart
+
+Recovery is message/WorkItem-level model reentry, not provider or tool-call
+continuation.
+
+At startup, an open attempt without live host execution is recovered in one
+transaction:
+
+1. mark the old attempt `Interrupted`;
+2. release its source claim or in-flight reservation;
+3. create a new recovery eligibility epoch;
+4. preserve prior transcript, tool, task, brief, WorkItem, and workspace
+   evidence for the next model turn.
+
+The scheduler does not infer whether an unrecorded external side effect
+occurred. The recovery agent inspects current durable and external state,
+decides whether work already happened, and verifies, continues, or repeats as
+appropriate. The runtime never automatically replays an old tool-call
+identity.
+
+Source recovery is fixed by source kind:
+
+| Interrupted source | Recovery transition |
+| --- | --- |
+| queued message | `Dequeued -> Interrupted`, same message remains claimable |
+| autonomous WorkItem | `InFlight(g) -> Runnable(g + 1, recovery_ref)` |
+| wait resume | release resume claim; preserve exact triggered obligation |
+| task/child result | release rejoin claim; preserve exact live result identity |
+| attached interjection | keep durable input evidence in recovery context |
+
+A committed terminal outcome is never reentered into the model. Missing or
+corrupt non-authoritative evidence may be diagnosed or rebuilt without
+changing eligibility.
+
+## Atomic Handoffs
+
+Each of the following is one business transition, not a command sequence:
+
+- lifecycle wait to WorkItem wait;
+- task terminal result to exact WorkItem rejoin;
+- child WorkItem completion to caller continuation;
+- targeted yield from source WorkItem to target WorkItem;
+- operator input attachment to a running attempt;
+- orphan queue claim to restart recovery.
+
+Each transition validates the source identity and generation, updates the
+target lifecycle, closes or records attempt outcome when applicable, and
+writes audit evidence in the same transaction.
+
+## Conflict Containment
+
+| Conflict | Runtime result |
+| --- | --- |
+| duplicate command, same payload | return the stored result |
+| same identity, different payload | typed payload conflict; preserve first result |
+| stale generation or trigger | no-op/stale evidence; do not mutate current state |
+| temporarily inadmissible candidate | keep source eligible and try bounded alternatives |
+| terminal or paused target | quarantine that candidate; continue unrelated work |
+| owner or binding conflict | isolate the source/WorkItem; keep operator and unrelated work available |
+| repeated protocol violation | move the affected WorkItem to `NeedsRepair` |
+| corrupt primary partition | stop that partition; keep other agents and read APIs available |
+
+A normal typed conflict must not cause an unbounded queue-head retry, agent
+restart loop, or lane reservation leak.
+
+## Persistence And Compatibility
+
+The runtime database remains the transactional store. The target normalized
+facts are:
+
+- WorkItem execution state;
+- runtime wait conditions and generations;
+- queue claims and terminal status;
+- tasks and rejoin obligations;
+- execution attempts and immutable outcomes;
+- continuation handoffs;
+- command results, audit, and delivery outbox.
+
+Historical activation authorities, slots, dispatch rows, scheduler WorkDemand,
+scheduler wait mirrors, missing-settlement rows, and rollout metadata become
+compatibility data or rebuildable evidence. During one compatibility release
+they may receive derived writes, but the canonical reader must not consult
+them for admission or settlement. Compatibility-write failure must not create
+partial primary state.
+
+The process chooses `legacy` or `canonical` once at startup. There is no
+scenario, agent, conflict, or claim-time fallback between engines.
+
+## Migration
+
+1. characterize current behavior and production incident traces; publish this
+   authority matrix and state algebra;
+2. build the new aggregate and commands on isolated fixtures and copied
+   databases without changing the production canonical reader;
+3. complete candidate, admission, settlement, interruption, handoff, and
+   persistence-equivalence coverage;
+4. switch canonical admission, settlement, and recovery together in one
+   cutover;
+5. remove compatibility readers and writes, split global invariants into
+   aggregate and transaction-boundary invariants, then remove dead schema;
+6. run required scheduler CI, crash/restart, soak, incident replay, upgrade,
+   repair, and rollback drills;
+7. publish a canonical-default compatibility release retaining the
+   process-global legacy selector;
+8. remove legacy only after one explicit observation period and operator
+   approval.
+
+Legacy removal is not authorized by this RFC's implementation alone.
+
+## Required Verification
+
+- pure transition sequence and property tests;
+- SQLite rollback and reload equivalence;
+- crash points at claim, admission, provider start, tool evidence, terminal
+  transition, delivery, and commit;
+- recovery of open attempts without automatic tool replay;
+- candidate/binding/outcome/source-transition matrix;
+- duplicate and out-of-order generation matrix;
+- stale task result with no live rejoin obligation;
+- wait and final-delivery consistency;
+- host shutdown/admission linearization;
+- queue-head conflict containment and restart-loop prevention;
+- multi-agent SQLite busy and SIGKILL soak;
+- deterministic replay of known scheduler incidents;
+- compatibility database upgrade, diagnosis, repair, and rollback.
+
+Acceptance requires both safety and simplification: one open attempt per
+agent, one WorkItem generation per admission, one wait authority, atomic
+terminal delivery, no persisted candidate or terminal intent, and no
+slot/dispatch/WorkDemand/missing-settlement authority in the canonical reader.
+
+## Non-goals
+
+- multi-lane model execution;
+- general resource scheduling or cross-agent assignment;
+- semantic-model authority over admission;
+- replacement of the provider turn loop;
+- removal of append-only audit;
+- making plan, todo, prose, or focus grant execution;
+- deletion of legacy before the compatibility release and observation gate.

--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -182,7 +182,7 @@ owner-specific outcome:
 
 ```text
 ConversationOutcome =
-  Replied | Wait(wait) | Interrupted(reason) | Failed(policy)
+  Replied | Wait(wait) | Paused(reason) | Interrupted(reason) | Failed(policy)
 
 WorkItemOutcome =
   Continue | Wait(wait) | Complete(completion) | Pause(reason)

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -637,6 +637,33 @@ fn scheduler_engine_precedence_is_env_then_config_then_canonical() {
 }
 
 #[test]
+fn runtime_config_reload_preserves_startup_scheduler_engine() {
+    let home = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{
+          "model":{"default":"openai/gpt-5.4"},
+          "runtime":{"scheduler":"legacy"}
+        }"#,
+    )
+    .unwrap();
+    let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    assert_eq!(config.scheduler_engine, SchedulerEngineMode::Legacy);
+
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{
+          "model":{"default":"openai/gpt-5.4"},
+          "runtime":{"scheduler":"canonical"}
+        }"#,
+    )
+    .unwrap();
+    let reloaded = config.reload_runtime_config().unwrap();
+
+    assert_eq!(reloaded.scheduler_engine, SchedulerEngineMode::Legacy);
+}
+
+#[test]
 fn app_config_rejects_invalid_scheduler_env() {
     let home = tempdir().unwrap();
     std::fs::write(

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1723,16 +1723,16 @@ fn current_input_relation(
     latest_operator: Option<&MessageEnvelope>,
 ) -> Option<String> {
     if is_trusted_operator_input(current_message) {
-        return Some(
-            if latest_operator
-                .is_some_and(|operator| same_message_identity(current_message, operator))
-            {
-                "current_input is the latest trusted operator input.".to_string()
-            } else {
-                "current_input is a trusted operator override newer than previous state."
-                    .to_string()
-            },
-        );
+        let boundary = if latest_operator
+            .is_some_and(|operator| same_message_identity(current_message, operator))
+        {
+            "current_input is the latest trusted operator input and the only new operator task for this turn."
+        } else {
+            "current_input is a trusted operator override newer than previous state and the only new operator task for this turn."
+        };
+        return Some(format!(
+            "{boundary} Treat recent_turns as historical/background evidence; do not resume old tasks or waits unless current_input or the current WorkItem explicitly requires it."
+        ));
     }
 
     if latest_operator.is_some() {
@@ -6818,6 +6818,58 @@ mod tests {
     }
 
     #[test]
+    fn build_context_marks_fresh_operator_input_as_the_only_new_task() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+
+        let prior_operator = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue the old database investigation.".to_string(),
+            },
+        );
+        append_turn_for_message(&storage, &prior_operator, "turn-old-topic", 1);
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Interject,
+            MessageBody::Text {
+                text: "Push the documentation update.".to_string(),
+            },
+        );
+        let session = AgentState::new("default");
+        let built = build_context(
+            &storage,
+            &session,
+            &execution_snapshot_for(&session),
+            &crate::types::SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig::default(),
+            dir.path(),
+        )
+        .unwrap();
+
+        let anchor = built
+            .sections
+            .iter()
+            .find(|section| section.name == "continuation_anchor")
+            .expect("continuation_anchor section should be present");
+        assert!(anchor.content.contains("the only new operator task"));
+        assert!(anchor.content.contains("historical/background evidence"));
+        assert!(anchor.content.contains(
+            "do not resume old tasks or waits unless current_input or the current WorkItem"
+        ));
+    }
+
+    #[test]
     fn build_context_anchor_uses_operator_input_beyond_recent_window() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_test(dir.path()).unwrap();
@@ -8018,7 +8070,7 @@ mod tests {
             ..crate::types::SkillsRuntimeView::default()
         };
 
-        let prompt_budget_estimated_tokens = 120;
+        let prompt_budget_estimated_tokens = 256;
         let built = build_context(
             &storage,
             &session,

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -1,0 +1,1305 @@
+//! Scheduler / WorkItem unified execution aggregate.
+//!
+//! This is the additive Phase 2 model. Production scheduling still uses
+//! `scheduler_protocol`; this module defines the smaller authority boundary
+//! that the canonical reader will adopt in a later cutover.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionProtocolState {
+    pub agent_id: String,
+    pub attempts: BTreeMap<String, ExecutionAttempt>,
+    pub work_items: BTreeMap<String, WorkItemExecutionRecord>,
+    pub outcomes: BTreeMap<String, ExecutionOutcomeRecord>,
+}
+
+impl ExecutionProtocolState {
+    pub fn empty(agent_id: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            attempts: BTreeMap::new(),
+            work_items: BTreeMap::new(),
+            outcomes: BTreeMap::new(),
+        }
+    }
+
+    pub fn open_attempt(&self) -> Option<&ExecutionAttempt> {
+        self.attempts
+            .values()
+            .find(|attempt| attempt.state == ExecutionAttemptState::Open)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionAttempt {
+    pub attempt_id: String,
+    pub agent_id: String,
+    #[serde(default)]
+    pub source_message_id: Option<String>,
+    pub source: ExecutionSource,
+    pub binding: ExecutionBinding,
+    pub provenance: ExecutionProvenance,
+    pub admitted_fences: AdmittedFences,
+    pub state: ExecutionAttemptState,
+    #[serde(default)]
+    pub run_id: Option<String>,
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    #[serde(default)]
+    pub recovery_of_attempt_id: Option<String>,
+    #[serde(default)]
+    pub terminal_outcome_id: Option<String>,
+    pub admitted_at: String,
+    #[serde(default)]
+    pub terminal_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionAttemptState {
+    Open,
+    Settled,
+    Interrupted,
+    ProtocolViolation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionSource {
+    pub identity: ExecutionSourceIdentity,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExecutionSourceIdentity {
+    QueueMessage {
+        message_id: String,
+    },
+    TaskResult {
+        task_id: String,
+        result_message_id: String,
+    },
+    ChildResult {
+        child_agent_id: String,
+        task_id: String,
+        result_message_id: String,
+    },
+    TriggeredWait {
+        wait_id: String,
+        wait_generation: u64,
+        trigger_id: String,
+        trigger_generation: u64,
+    },
+    WorkItemContinuation {
+        work_item_id: String,
+    },
+    TargetedContinuation {
+        continuation_id: String,
+        source_work_item_id: String,
+        target_work_item_id: String,
+    },
+    RuntimeRecovery {
+        recovery_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExecutionBinding {
+    Conversation { interaction_id: String },
+    WorkItem { work_item_id: String },
+    AgentLifecycle { agent_id: String },
+    Command,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionProvenance {
+    pub origin: ExecutionOrigin,
+    pub trust: ExecutionTrust,
+    pub priority: ExecutionPriority,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub causation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionOrigin {
+    Operator,
+    Channel,
+    Webhook,
+    Callback,
+    Timer,
+    System,
+    Task,
+    RuntimeRecovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionTrust {
+    OperatorInstruction,
+    RuntimeInstruction,
+    IntegrationSignal,
+    ExternalEvidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionPriority {
+    Background,
+    Normal,
+    Next,
+    Interject,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdmittedFences {
+    pub source_revision: u64,
+    #[serde(default)]
+    pub work_item_source_revision: Option<u64>,
+    #[serde(default)]
+    pub work_item_generation: Option<u64>,
+    #[serde(default)]
+    pub rejoin: Option<RejoinFence>,
+    pub agent_control_revision: u64,
+    pub host_registry_revision: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RejoinFence {
+    pub obligation_id: String,
+    pub generation: u64,
+    pub parent_turn_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkItemExecutionRecord {
+    pub source_revision: u64,
+    pub state: WorkItemExecutionState,
+}
+
+impl WorkItemExecutionRecord {
+    pub fn generation(&self) -> u64 {
+        self.state.generation()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum WorkItemExecutionState {
+    Runnable {
+        generation: u64,
+        #[serde(default)]
+        recovery_ref: Option<String>,
+    },
+    InFlight {
+        generation: u64,
+        attempt_id: String,
+    },
+    Waiting {
+        generation: u64,
+        wait: WaitReference,
+    },
+    Paused {
+        generation: u64,
+        reason: String,
+    },
+    NeedsRepair {
+        generation: u64,
+        repair_id: String,
+    },
+    Terminal {
+        generation: u64,
+        completion: String,
+    },
+}
+
+impl WorkItemExecutionState {
+    pub fn generation(&self) -> u64 {
+        match self {
+            Self::Runnable { generation, .. }
+            | Self::InFlight { generation, .. }
+            | Self::Waiting { generation, .. }
+            | Self::Paused { generation, .. }
+            | Self::NeedsRepair { generation, .. }
+            | Self::Terminal { generation, .. } => *generation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WaitReference {
+    pub wait_id: String,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "owner", content = "outcome", rename_all = "snake_case")]
+pub enum ExecutionOutcome {
+    Conversation(ConversationOutcome),
+    WorkItem(WorkItemOutcome),
+    Command(CommandResult),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConversationOutcome {
+    Replied,
+    Wait { wait: WaitReference },
+    Interrupted { reason: String },
+    Failed { policy: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkItemOutcome {
+    Continue,
+    Wait { wait: WaitReference },
+    Complete { completion: String },
+    Pause { reason: String },
+    Yield { target_work_item_id: String },
+    Failed { policy: String },
+    Interrupted { reason: String },
+    NeedsRepair { repair_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CommandResult {
+    Applied { references: Vec<String> },
+    Unsupported { reason: String },
+    Quarantined { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionOutcomeRecord {
+    pub outcome_id: String,
+    pub attempt_id: String,
+    pub outcome: ExecutionOutcome,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdmitExecution {
+    pub attempt: ExecutionAttempt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettleExecution {
+    pub outcome: ExecutionOutcomeRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterWorkItemExecution {
+    pub work_item_id: String,
+    pub record: WorkItemExecutionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InterruptExecution {
+    pub attempt_id: String,
+    pub outcome_id: String,
+    pub reason: String,
+    pub interrupted_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "command", content = "payload", rename_all = "snake_case")]
+pub enum ExecutionProtocolCommand {
+    RegisterWorkItem(Box<RegisterWorkItemExecution>),
+    Admit(Box<AdmitExecution>),
+    Settle(SettleExecution),
+    Interrupt(InterruptExecution),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionTransition {
+    pub state: ExecutionProtocolState,
+    pub references: Vec<String>,
+}
+
+pub fn register_work_item_execution(
+    state: &ExecutionProtocolState,
+    command: &RegisterWorkItemExecution,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.work_item_id.is_empty()
+        || command.record.source_revision == 0
+        || command.record.generation() == 0
+    {
+        return Err(
+            "WorkItem registration requires identity, source revision, and generation".into(),
+        );
+    }
+    if matches!(
+        command.record.state,
+        WorkItemExecutionState::InFlight { .. }
+    ) {
+        return Err("WorkItem registration cannot import an InFlight state".into());
+    }
+    if let Some(existing) = state.work_items.get(&command.work_item_id) {
+        if existing == &command.record {
+            return Ok(ExecutionTransition {
+                state: state.clone(),
+                references: vec![format!("work_item:{}", command.work_item_id)],
+            });
+        }
+        return Err("WorkItem execution identity already exists with different state".into());
+    }
+    let mut next = state.clone();
+    next.work_items
+        .insert(command.work_item_id.clone(), command.record.clone());
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![format!("work_item:{}", command.work_item_id)],
+    })
+}
+
+fn validate_source_binding(
+    source: &ExecutionSource,
+    binding: &ExecutionBinding,
+    fences: &AdmittedFences,
+) -> Result<(), String> {
+    use ExecutionBinding::*;
+    use ExecutionSourceIdentity::*;
+    let allowed = match (&source.identity, binding) {
+        (QueueMessage { .. }, Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. }) => {
+            true
+        }
+        (TaskResult { .. }, Conversation { .. } | WorkItem { .. } | Command) => true,
+        (ChildResult { .. }, Conversation { .. } | WorkItem { .. } | Command) => true,
+        (TriggeredWait { .. }, Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. }) => {
+            true
+        }
+        (
+            WorkItemContinuation {
+                work_item_id: source_work_item_id,
+            },
+            WorkItem { work_item_id },
+        ) => source_work_item_id == work_item_id,
+        (
+            TargetedContinuation {
+                target_work_item_id,
+                ..
+            },
+            WorkItem { work_item_id },
+        ) => target_work_item_id == work_item_id,
+        (TargetedContinuation { .. }, Conversation { .. } | Command) => true,
+        (RuntimeRecovery { .. }, Command) => true,
+        _ => false,
+    };
+    if !allowed {
+        return Err(format!(
+            "unsupported source-binding combination: {:?} → {:?}",
+            source.identity, binding
+        ));
+    }
+    match &source.identity {
+        TaskResult { .. } | ChildResult { .. } => validate_rejoin_fence(fences.rejoin.as_ref())?,
+        _ if fences.rejoin.is_some() => {
+            return Err("only task or child results may carry a rejoin fence".into());
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_rejoin_fence(fence: Option<&RejoinFence>) -> Result<(), String> {
+    let fence =
+        fence.ok_or_else(|| "task or child result requires a live rejoin fence".to_string())?;
+    if fence.obligation_id.is_empty() || fence.parent_turn_id.is_empty() || fence.generation == 0 {
+        return Err("rejoin fence requires identity, parent turn, and generation".into());
+    }
+    Ok(())
+}
+
+fn validate_provenance(provenance: &ExecutionProvenance) -> Result<(), String> {
+    use ExecutionOrigin::*;
+    use ExecutionTrust::*;
+    let valid = match provenance.origin {
+        Operator => provenance.trust == OperatorInstruction,
+        Channel | Webhook => matches!(provenance.trust, IntegrationSignal | ExternalEvidence),
+        Callback => matches!(
+            provenance.trust,
+            RuntimeInstruction | IntegrationSignal | ExternalEvidence
+        ),
+        Timer | System => matches!(provenance.trust, RuntimeInstruction | IntegrationSignal),
+        Task | RuntimeRecovery => provenance.trust == RuntimeInstruction,
+    };
+    if !valid {
+        return Err("execution provenance origin and trust are incompatible".into());
+    }
+    Ok(())
+}
+
+pub fn admit_execution(
+    state: &ExecutionProtocolState,
+    command: &AdmitExecution,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    let attempt = &command.attempt;
+    validate_source_binding(&attempt.source, &attempt.binding, &attempt.admitted_fences)?;
+    validate_provenance(&attempt.provenance)?;
+
+    if attempt.agent_id != state.agent_id {
+        return Err("attempt agent does not match execution partition".into());
+    }
+    if attempt.source.generation == 0
+        || attempt.source.generation != attempt.admitted_fences.source_revision
+        || attempt.admitted_fences.agent_control_revision == 0
+        || attempt.admitted_fences.host_registry_revision == 0
+    {
+        return Err("admission source and control fences must match nonzero revisions".into());
+    }
+    if let ExecutionBinding::AgentLifecycle { agent_id } = &attempt.binding {
+        if agent_id != &attempt.agent_id {
+            return Err("agent lifecycle binding does not match attempt partition".into());
+        }
+    }
+    if attempt.state != ExecutionAttemptState::Open
+        || attempt.terminal_outcome_id.is_some()
+        || attempt.terminal_at.is_some()
+    {
+        return Err("admission requires a new open attempt".into());
+    }
+    if state.attempts.contains_key(&attempt.attempt_id) {
+        return Err("attempt identity already exists".into());
+    }
+    if state.open_attempt().is_some() {
+        return Err("agent already owns an open execution attempt".into());
+    }
+    if let Some(recovery_of) = &attempt.recovery_of_attempt_id {
+        let prior = state
+            .attempts
+            .get(recovery_of)
+            .ok_or_else(|| "recovery attempt references an unknown prior attempt".to_string())?;
+        if prior.state == ExecutionAttemptState::Open {
+            return Err("recovery attempt cannot reference an open attempt".into());
+        }
+    }
+
+    let mut next = state.clone();
+    if let ExecutionBinding::WorkItem { work_item_id } = &attempt.binding {
+        let expected_source_revision = attempt
+            .admitted_fences
+            .work_item_source_revision
+            .ok_or_else(|| "WorkItem admission requires a source revision fence".to_string())?;
+        let expected_generation = attempt
+            .admitted_fences
+            .work_item_generation
+            .ok_or_else(|| "WorkItem admission requires a generation fence".to_string())?;
+        let work_record = next
+            .work_items
+            .get_mut(work_item_id)
+            .ok_or_else(|| "WorkItem admission requires registered execution state".to_string())?;
+        if work_record.source_revision != expected_source_revision {
+            return Err("WorkItem admission source revision fence is stale".into());
+        }
+        match &mut work_record.state {
+            WorkItemExecutionState::Runnable { generation, .. }
+            | WorkItemExecutionState::Waiting { generation, .. }
+                if *generation == expected_generation =>
+            {
+                work_record.state = WorkItemExecutionState::InFlight {
+                    generation: expected_generation,
+                    attempt_id: attempt.attempt_id.clone(),
+                };
+            }
+            _ => return Err("WorkItem is not eligible at the admitted generation".into()),
+        }
+    } else if attempt.admitted_fences.work_item_source_revision.is_some()
+        || attempt.admitted_fences.work_item_generation.is_some()
+    {
+        return Err("non-WorkItem admission cannot carry WorkItem fences".into());
+    }
+
+    next.attempts
+        .insert(attempt.attempt_id.clone(), attempt.clone());
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![format!("attempt:{}", attempt.attempt_id)],
+    })
+}
+
+pub fn settle_execution(
+    state: &ExecutionProtocolState,
+    command: &SettleExecution,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    let outcome = &command.outcome;
+    if state.outcomes.contains_key(&outcome.outcome_id) {
+        return Err("outcome identity already exists".into());
+    }
+    let mut next = state.clone();
+    let attempt = next
+        .attempts
+        .get_mut(&outcome.attempt_id)
+        .ok_or_else(|| "settlement references an unknown attempt".to_string())?;
+    if attempt.state != ExecutionAttemptState::Open {
+        return Err("only an open attempt may settle".into());
+    }
+    validate_outcome_binding(&attempt.binding, &outcome.outcome)?;
+
+    if let ExecutionBinding::WorkItem { work_item_id } = &attempt.binding {
+        let work_record = next
+            .work_items
+            .get_mut(work_item_id)
+            .ok_or_else(|| "attempt references an unknown WorkItem state".to_string())?;
+        let generation = match &work_record.state {
+            WorkItemExecutionState::InFlight {
+                generation,
+                attempt_id,
+            } if attempt_id == &attempt.attempt_id => *generation,
+            _ => return Err("WorkItem does not reference the settling attempt".into()),
+        };
+        work_record.state = settle_work_item(generation, &outcome.outcome)?;
+    }
+
+    attempt.state = ExecutionAttemptState::Settled;
+    attempt.terminal_outcome_id = Some(outcome.outcome_id.clone());
+    attempt.terminal_at = Some(outcome.created_at.clone());
+    next.outcomes
+        .insert(outcome.outcome_id.clone(), outcome.clone());
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![
+            format!("attempt:{}", outcome.attempt_id),
+            format!("outcome:{}", outcome.outcome_id),
+        ],
+    })
+}
+
+pub fn interrupt_execution(
+    state: &ExecutionProtocolState,
+    command: &InterruptExecution,
+) -> Result<ExecutionTransition, String> {
+    let outcome = ExecutionOutcomeRecord {
+        outcome_id: command.outcome_id.clone(),
+        attempt_id: command.attempt_id.clone(),
+        outcome: match state
+            .attempts
+            .get(&command.attempt_id)
+            .map(|attempt| &attempt.binding)
+        {
+            Some(ExecutionBinding::WorkItem { .. }) => {
+                ExecutionOutcome::WorkItem(WorkItemOutcome::Interrupted {
+                    reason: command.reason.clone(),
+                })
+            }
+            Some(ExecutionBinding::Conversation { .. })
+            | Some(ExecutionBinding::AgentLifecycle { .. }) => {
+                ExecutionOutcome::Conversation(ConversationOutcome::Interrupted {
+                    reason: command.reason.clone(),
+                })
+            }
+            Some(ExecutionBinding::Command) => ExecutionOutcome::Command(CommandResult::Applied {
+                references: vec![format!("interrupted:{}", command.attempt_id)],
+            }),
+            None => return Err("interruption references an unknown attempt".into()),
+        },
+        created_at: command.interrupted_at.clone(),
+    };
+    let mut transition = settle_execution(state, &SettleExecution { outcome })?;
+    let attempt = transition
+        .state
+        .attempts
+        .get_mut(&command.attempt_id)
+        .expect("settlement preserved attempt");
+    attempt.state = ExecutionAttemptState::Interrupted;
+    assert_invariants(&transition.state)?;
+    Ok(transition)
+}
+
+fn validate_outcome_binding(
+    binding: &ExecutionBinding,
+    outcome: &ExecutionOutcome,
+) -> Result<(), String> {
+    match (binding, outcome) {
+        (ExecutionBinding::WorkItem { .. }, ExecutionOutcome::WorkItem(_))
+        | (
+            ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
+            ExecutionOutcome::Conversation(_),
+        )
+        | (ExecutionBinding::Command, ExecutionOutcome::Command(_)) => Ok(()),
+        _ => Err("execution outcome is incompatible with attempt binding".into()),
+    }
+}
+
+fn settle_work_item(
+    generation: u64,
+    outcome: &ExecutionOutcome,
+) -> Result<WorkItemExecutionState, String> {
+    let next_generation = generation
+        .checked_add(1)
+        .ok_or_else(|| "WorkItem scheduling generation overflow".to_string())?;
+    match outcome {
+        ExecutionOutcome::WorkItem(WorkItemOutcome::Continue) => {
+            Ok(WorkItemExecutionState::Runnable {
+                generation: next_generation,
+                recovery_ref: None,
+            })
+        }
+        ExecutionOutcome::WorkItem(WorkItemOutcome::Interrupted { .. }) => {
+            Ok(WorkItemExecutionState::Runnable {
+                generation: next_generation,
+                recovery_ref: Some("interrupted".into()),
+            })
+        }
+        ExecutionOutcome::WorkItem(WorkItemOutcome::Wait { wait }) => {
+            Ok(WorkItemExecutionState::Waiting {
+                generation: next_generation,
+                wait: wait.clone(),
+            })
+        }
+        ExecutionOutcome::WorkItem(WorkItemOutcome::Pause { reason })
+        | ExecutionOutcome::WorkItem(WorkItemOutcome::Failed { policy: reason }) => {
+            Ok(WorkItemExecutionState::Paused {
+                generation: next_generation,
+                reason: reason.clone(),
+            })
+        }
+        ExecutionOutcome::WorkItem(WorkItemOutcome::NeedsRepair { repair_id }) => {
+            Ok(WorkItemExecutionState::NeedsRepair {
+                generation: next_generation,
+                repair_id: repair_id.clone(),
+            })
+        }
+        ExecutionOutcome::WorkItem(WorkItemOutcome::Complete { completion }) => {
+            Ok(WorkItemExecutionState::Terminal {
+                generation: next_generation,
+                completion: completion.clone(),
+            })
+        }
+        ExecutionOutcome::WorkItem(WorkItemOutcome::Yield {
+            target_work_item_id,
+        }) => Ok(WorkItemExecutionState::Paused {
+            generation: next_generation,
+            reason: format!("yielded_to:{target_work_item_id}"),
+        }),
+        _ => Err("WorkItem settlement requires a WorkItem outcome".into()),
+    }
+}
+
+pub fn assert_invariants(state: &ExecutionProtocolState) -> Result<(), String> {
+    let open_attempts = state
+        .attempts
+        .values()
+        .filter(|attempt| attempt.state == ExecutionAttemptState::Open)
+        .collect::<Vec<_>>();
+    if open_attempts.len() > 1 {
+        return Err("execution partition contains more than one open attempt".into());
+    }
+
+    for (attempt_id, attempt) in &state.attempts {
+        if attempt_id != &attempt.attempt_id || attempt.agent_id != state.agent_id {
+            return Err("attempt identity does not match its execution partition".into());
+        }
+        match attempt.state {
+            ExecutionAttemptState::Open => {
+                if attempt.terminal_outcome_id.is_some() || attempt.terminal_at.is_some() {
+                    return Err("open attempt contains terminal evidence".into());
+                }
+            }
+            _ => {
+                let outcome_id = attempt
+                    .terminal_outcome_id
+                    .as_ref()
+                    .ok_or_else(|| "terminal attempt is missing its outcome".to_string())?;
+                let outcome = state
+                    .outcomes
+                    .get(outcome_id)
+                    .ok_or_else(|| "terminal attempt references an unknown outcome".to_string())?;
+                if outcome.attempt_id != attempt.attempt_id || attempt.terminal_at.is_none() {
+                    return Err("terminal attempt outcome evidence is inconsistent".into());
+                }
+            }
+        }
+        if let ExecutionBinding::WorkItem { work_item_id } = &attempt.binding {
+            if attempt.state == ExecutionAttemptState::Open
+                && !matches!(
+                    state.work_items.get(work_item_id).map(|record| &record.state),
+                    Some(WorkItemExecutionState::InFlight {
+                        attempt_id: linked_attempt,
+                        ..
+                    }) if linked_attempt == attempt_id
+                )
+            {
+                return Err("open WorkItem attempt lacks reciprocal InFlight state".into());
+            }
+        }
+    }
+
+    for work_record in state.work_items.values() {
+        if work_record.source_revision == 0 || work_record.generation() == 0 {
+            return Err("WorkItem execution record contains a zero revision or generation".into());
+        }
+        if let WorkItemExecutionState::InFlight { attempt_id, .. } = &work_record.state {
+            if !matches!(
+                state.attempts.get(attempt_id),
+                Some(ExecutionAttempt {
+                    state: ExecutionAttemptState::Open,
+                    binding: ExecutionBinding::WorkItem { .. },
+                    ..
+                })
+            ) {
+                return Err("InFlight WorkItem lacks reciprocal open attempt".into());
+            }
+        }
+    }
+
+    for (outcome_id, outcome) in &state.outcomes {
+        if outcome_id != &outcome.outcome_id {
+            return Err("outcome identity does not match its map key".into());
+        }
+        if !matches!(
+            state.attempts.get(&outcome.attempt_id),
+            Some(attempt) if attempt.terminal_outcome_id.as_deref() == Some(outcome_id)
+        ) {
+            return Err("outcome lacks reciprocal terminal attempt".into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn work_item_record(state: WorkItemExecutionState) -> WorkItemExecutionRecord {
+        WorkItemExecutionRecord {
+            source_revision: state.generation(),
+            state,
+        }
+    }
+
+    fn attempt(id: &str, recovery_of: Option<&str>) -> ExecutionAttempt {
+        ExecutionAttempt {
+            attempt_id: id.into(),
+            agent_id: "agent-a".into(),
+            source_message_id: Some(format!("message:{id}")),
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::WorkItemContinuation {
+                    work_item_id: "work-a".into(),
+                },
+                generation: 1,
+            },
+            binding: ExecutionBinding::WorkItem {
+                work_item_id: "work-a".into(),
+            },
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::System,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Normal,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: 1,
+                work_item_source_revision: Some(1),
+                work_item_generation: Some(if recovery_of.is_some() { 2 } else { 1 }),
+                rejoin: None,
+                agent_control_revision: 1,
+                host_registry_revision: 1,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: None,
+            recovery_of_attempt_id: recovery_of.map(str::to_owned),
+            terminal_outcome_id: None,
+            admitted_at: "2026-08-01T00:00:00Z".into(),
+            terminal_at: None,
+        }
+    }
+
+    #[test]
+    fn work_item_registration_is_additive_and_idempotent() {
+        let state = ExecutionProtocolState::empty("agent-a");
+        let command = RegisterWorkItemExecution {
+            work_item_id: "work-a".into(),
+            record: work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        };
+        let registered = register_work_item_execution(&state, &command).unwrap();
+        let replayed = register_work_item_execution(&registered.state, &command).unwrap();
+        assert_eq!(registered.state, replayed.state);
+
+        let conflict = RegisterWorkItemExecution {
+            work_item_id: "work-a".into(),
+            record: work_item_record(WorkItemExecutionState::Paused {
+                generation: 1,
+                reason: "changed".into(),
+            }),
+        };
+        assert!(register_work_item_execution(&registered.state, &conflict)
+            .unwrap_err()
+            .contains("different state"));
+    }
+
+    #[test]
+    fn interrupted_attempt_releases_lane_and_allows_model_reentry() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        let admitted = admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: attempt("attempt-1", None),
+            },
+        )
+        .unwrap();
+        let interrupted = interrupt_execution(
+            &admitted.state,
+            &InterruptExecution {
+                attempt_id: "attempt-1".into(),
+                outcome_id: "outcome-1".into(),
+                reason: "runtime_restart".into(),
+                interrupted_at: "2026-08-01T00:01:00Z".into(),
+            },
+        )
+        .unwrap();
+        assert!(interrupted.state.open_attempt().is_none());
+        assert!(matches!(
+            interrupted.state.work_items["work-a"].state,
+            WorkItemExecutionState::Runnable {
+                generation: 2,
+                recovery_ref: Some(_)
+            }
+        ));
+
+        let recovered = admit_execution(
+            &interrupted.state,
+            &AdmitExecution {
+                attempt: attempt("attempt-2", Some("attempt-1")),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            recovered
+                .state
+                .open_attempt()
+                .map(|attempt| attempt.attempt_id.as_str()),
+            Some("attempt-2")
+        );
+    }
+
+    #[test]
+    fn wait_resume_admits_from_waiting_and_settles_to_runnable() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Waiting {
+                generation: 1,
+                wait: WaitReference {
+                    wait_id: "wait-1".into(),
+                    generation: 1,
+                },
+            }),
+        );
+        let mut wait_attempt = attempt("attempt-1", None);
+        wait_attempt.source.identity = ExecutionSourceIdentity::TriggeredWait {
+            wait_id: "wait-1".into(),
+            wait_generation: 1,
+            trigger_id: "trigger-1".into(),
+            trigger_generation: 1,
+        };
+        let admitted = admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: wait_attempt,
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            admitted.state.work_items["work-a"].state,
+            WorkItemExecutionState::InFlight { generation: 1, .. }
+        ));
+        let settled = settle_execution(
+            &admitted.state,
+            &SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "outcome-1".into(),
+                    attempt_id: "attempt-1".into(),
+                    outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Continue),
+                    created_at: "2026-08-01T00:01:00Z".into(),
+                },
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            settled.state.work_items["work-a"].state,
+            WorkItemExecutionState::Runnable {
+                generation: 2,
+                recovery_ref: None
+            }
+        ));
+    }
+
+    #[test]
+    fn source_binding_matrix_rejects_unsupported_combinations() {
+        use ExecutionBinding::*;
+
+        let conversation = Conversation {
+            interaction_id: "i1".into(),
+        };
+        let work_item = WorkItem {
+            work_item_id: "w1".into(),
+        };
+        let agent_lifecycle = AgentLifecycle {
+            agent_id: "agent-a".into(),
+        };
+        let fences = AdmittedFences {
+            source_revision: 1,
+            work_item_source_revision: None,
+            work_item_generation: None,
+            rejoin: None,
+            agent_control_revision: 1,
+            host_registry_revision: 1,
+        };
+        let source = |identity| ExecutionSource {
+            identity,
+            generation: 1,
+        };
+
+        // Allowed combinations
+        let queue = source(ExecutionSourceIdentity::QueueMessage {
+            message_id: "m1".into(),
+        });
+        let continuation = source(ExecutionSourceIdentity::WorkItemContinuation {
+            work_item_id: "w1".into(),
+        });
+        let recovery = source(ExecutionSourceIdentity::RuntimeRecovery {
+            recovery_id: "r1".into(),
+        });
+        assert!(validate_source_binding(&queue, &conversation, &fences).is_ok());
+        assert!(validate_source_binding(&queue, &work_item, &fences).is_ok());
+        assert!(validate_source_binding(&queue, &agent_lifecycle, &fences).is_ok());
+        assert!(validate_source_binding(&continuation, &work_item, &fences).is_ok());
+        assert!(validate_source_binding(&recovery, &ExecutionBinding::Command, &fences).is_ok());
+
+        // Rejected combinations
+        assert!(validate_source_binding(&queue, &ExecutionBinding::Command, &fences).is_err());
+        assert!(validate_source_binding(&continuation, &conversation, &fences).is_err());
+        assert!(validate_source_binding(&recovery, &conversation, &fences).is_err());
+        assert!(validate_source_binding(&recovery, &work_item, &fences).is_err());
+        assert!(validate_source_binding(&recovery, &agent_lifecycle, &fences).is_err());
+    }
+
+    #[test]
+    fn task_and_child_results_require_exact_live_rejoin_fences() {
+        let binding = ExecutionBinding::WorkItem {
+            work_item_id: "work-a".into(),
+        };
+        let task = ExecutionSource {
+            identity: ExecutionSourceIdentity::TaskResult {
+                task_id: "task-1".into(),
+                result_message_id: "message-1".into(),
+            },
+            generation: 3,
+        };
+        let child = ExecutionSource {
+            identity: ExecutionSourceIdentity::ChildResult {
+                child_agent_id: "child-a".into(),
+                task_id: "task-2".into(),
+                result_message_id: "message-2".into(),
+            },
+            generation: 4,
+        };
+        let mut fences = AdmittedFences {
+            source_revision: 3,
+            work_item_source_revision: Some(1),
+            work_item_generation: Some(1),
+            rejoin: None,
+            agent_control_revision: 1,
+            host_registry_revision: 1,
+        };
+        assert!(validate_source_binding(&task, &binding, &fences)
+            .unwrap_err()
+            .contains("live rejoin"));
+
+        fences.rejoin = Some(RejoinFence {
+            obligation_id: "rejoin-task-1".into(),
+            generation: 1,
+            parent_turn_id: "turn-parent".into(),
+        });
+        assert!(validate_source_binding(&task, &binding, &fences).is_ok());
+
+        fences.source_revision = 4;
+        fences.rejoin = Some(RejoinFence {
+            obligation_id: String::new(),
+            generation: 1,
+            parent_turn_id: "turn-parent".into(),
+        });
+        assert!(validate_source_binding(&child, &binding, &fences)
+            .unwrap_err()
+            .contains("identity"));
+    }
+
+    #[test]
+    fn admission_rejects_stale_source_fence_and_invalid_provenance() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        let mut stale = attempt("attempt-stale", None);
+        stale.admitted_fences.source_revision = 2;
+        assert!(admit_execution(&state, &AdmitExecution { attempt: stale })
+            .unwrap_err()
+            .contains("fences"));
+
+        let mut invalid = attempt("attempt-invalid-provenance", None);
+        invalid.provenance.origin = ExecutionOrigin::Operator;
+        assert!(
+            admit_execution(&state, &AdmitExecution { attempt: invalid })
+                .unwrap_err()
+                .contains("provenance")
+        );
+    }
+
+    #[test]
+    fn admission_fences_source_and_work_item_revisions_independently() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        let mut independent = attempt("attempt-independent-fences", None);
+        independent.source.generation = 7;
+        independent.admitted_fences.source_revision = 7;
+        let transition = admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: independent,
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            transition.state.work_items["work-a"].state,
+            WorkItemExecutionState::InFlight { generation: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn source_identity_must_match_bound_work_item() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        let mut mismatched = attempt("attempt-mismatch", None);
+        mismatched.source.identity = ExecutionSourceIdentity::WorkItemContinuation {
+            work_item_id: "work-other".into(),
+        };
+        assert!(admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: mismatched,
+            },
+        )
+        .unwrap_err()
+        .contains("unsupported source-binding"));
+    }
+
+    #[test]
+    fn runtime_recovery_command_settles_without_workitem() {
+        let state = ExecutionProtocolState::empty("agent-a");
+        let recovery_attempt = ExecutionAttempt {
+            attempt_id: "recovery-1".into(),
+            agent_id: "agent-a".into(),
+            source_message_id: None,
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::RuntimeRecovery {
+                    recovery_id: "bootstrap-recovery".into(),
+                },
+                generation: 1,
+            },
+            binding: ExecutionBinding::Command,
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::RuntimeRecovery,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Background,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: 1,
+                work_item_source_revision: None,
+                work_item_generation: None,
+                rejoin: None,
+                agent_control_revision: 1,
+                host_registry_revision: 1,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: None,
+            recovery_of_attempt_id: None,
+            terminal_outcome_id: None,
+            admitted_at: "2026-08-01T00:00:00Z".into(),
+            terminal_at: None,
+        };
+        let admitted = admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: recovery_attempt,
+            },
+        )
+        .unwrap();
+        assert!(admitted.state.work_items.is_empty());
+        let settled = settle_execution(
+            &admitted.state,
+            &SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "recovery-outcome-1".into(),
+                    attempt_id: "recovery-1".into(),
+                    outcome: ExecutionOutcome::Command(CommandResult::Applied {
+                        references: vec!["recovered:attempt-0".into()],
+                    }),
+                    created_at: "2026-08-01T00:01:00Z".into(),
+                },
+            },
+        )
+        .unwrap();
+        assert!(settled.state.open_attempt().is_none());
+        assert!(matches!(
+            settled.state.attempts["recovery-1"].state,
+            ExecutionAttemptState::Settled
+        ));
+    }
+
+    #[test]
+    fn command_binding_settles_with_unsupported_and_quarantined() {
+        fn make_command_attempt(id: &str) -> ExecutionAttempt {
+            ExecutionAttempt {
+                attempt_id: id.into(),
+                agent_id: "agent-a".into(),
+                source_message_id: None,
+                source: ExecutionSource {
+                    identity: ExecutionSourceIdentity::RuntimeRecovery {
+                        recovery_id: "recovery".into(),
+                    },
+                    generation: 1,
+                },
+                binding: ExecutionBinding::Command,
+                provenance: ExecutionProvenance {
+                    origin: ExecutionOrigin::RuntimeRecovery,
+                    trust: ExecutionTrust::RuntimeInstruction,
+                    priority: ExecutionPriority::Background,
+                    correlation_id: None,
+                    causation_id: None,
+                },
+                admitted_fences: AdmittedFences {
+                    source_revision: 1,
+                    work_item_source_revision: None,
+                    work_item_generation: None,
+                    rejoin: None,
+                    agent_control_revision: 1,
+                    host_registry_revision: 1,
+                },
+                state: ExecutionAttemptState::Open,
+                run_id: None,
+                turn_id: None,
+                recovery_of_attempt_id: None,
+                terminal_outcome_id: None,
+                admitted_at: "2026-08-01T00:00:00Z".into(),
+                terminal_at: None,
+            }
+        }
+
+        let state = ExecutionProtocolState::empty("agent-a");
+        for (outcome_id, result) in [
+            (
+                "out-unsupported",
+                CommandResult::Unsupported {
+                    reason: "no matching candidate".into(),
+                },
+            ),
+            (
+                "out-quarantined",
+                CommandResult::Quarantined {
+                    reason: "untrusted source".into(),
+                },
+            ),
+        ] {
+            let admitted = admit_execution(
+                &state,
+                &AdmitExecution {
+                    attempt: make_command_attempt("cmd-1"),
+                },
+            )
+            .unwrap();
+            let settled = settle_execution(
+                &admitted.state,
+                &SettleExecution {
+                    outcome: ExecutionOutcomeRecord {
+                        outcome_id: outcome_id.into(),
+                        attempt_id: "cmd-1".into(),
+                        outcome: ExecutionOutcome::Command(result),
+                        created_at: "2026-08-01T00:01:00Z".into(),
+                    },
+                },
+            )
+            .unwrap();
+            assert!(settled.state.open_attempt().is_none());
+            assert!(matches!(
+                settled.state.attempts["cmd-1"].state,
+                ExecutionAttemptState::Settled
+            ));
+        }
+    }
+
+    #[test]
+    fn settlement_rejects_owner_incompatible_outcome() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        let admitted = admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: attempt("attempt-1", None),
+            },
+        )
+        .unwrap();
+        let error = settle_execution(
+            &admitted.state,
+            &SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "outcome-1".into(),
+                    attempt_id: "attempt-1".into(),
+                    outcome: ExecutionOutcome::Conversation(ConversationOutcome::Replied),
+                    created_at: "2026-08-01T00:01:00Z".into(),
+                },
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("incompatible"));
+    }
+}

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -251,6 +251,7 @@ pub enum ExecutionOutcome {
 pub enum ConversationOutcome {
     Replied,
     Wait { wait: WaitReference },
+    Paused { reason: String },
     Interrupted { reason: String },
     Failed { policy: String },
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 //! Canonical runtime domain records.
 
+pub mod execution_protocol;
 pub mod scheduler_protocol;
 pub mod work_item;
 pub mod workspace;

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -262,6 +262,7 @@ pub struct ActivationRecord {
 pub enum ActivationState {
     Running,
     Settled,
+    Interrupted,
     SettlementMissing,
 }
 
@@ -706,6 +707,11 @@ pub struct SettleActivationCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoverInterruptedActivationCommand {
+    pub settlement: ActivationSettlement,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterWorkDemandCommand {
     pub work_item_id: String,
     pub demand: WorkDemand,
@@ -899,6 +905,7 @@ pub enum ProtocolCommand {
     AdoptActivationWorkState(AdoptActivationWorkStateCommand),
     AdmitActivation(AdmitActivationCommand),
     SettleActivation(SettleActivationCommand),
+    RecoverInterruptedActivation(RecoverInterruptedActivationCommand),
     RecordMissingSettlement(MissingSettlementRecord),
     TriggerWait(TriggerWaitCommand),
     AttachActivationInput(AttachActivationInputCommand),
@@ -1013,6 +1020,9 @@ pub enum Settlement {
     Complete {
         continuation: Option<Continuation>,
     },
+    Interrupted {
+        reason: String,
+    },
     Missing,
 }
 
@@ -1039,6 +1049,9 @@ impl Serialize for Settlement {
             Complete {
                 continuation: &'a Option<Continuation>,
             },
+            Interrupted {
+                reason: &'a str,
+            },
             Missing,
         }
 
@@ -1058,6 +1071,7 @@ impl Serialize for Settlement {
                 mode: *mode,
             },
             Self::Complete { continuation } => Wire::Complete { continuation },
+            Self::Interrupted { reason } => Wire::Interrupted { reason },
             Self::Missing => Wire::Missing,
         };
         wire.serialize(serializer)
@@ -1087,6 +1101,9 @@ impl<'de> Deserialize<'de> for Settlement {
             Complete {
                 #[serde(default)]
                 continuation: Option<Continuation>,
+            },
+            Interrupted {
+                reason: String,
             },
             Missing,
         }
@@ -1119,6 +1136,7 @@ impl<'de> Deserialize<'de> for Settlement {
                 "wait settlement requires exactly one of wait or legacy wait_id",
             )),
             Wire::Complete { continuation } => Ok(Self::Complete { continuation }),
+            Wire::Interrupted { reason } => Ok(Self::Interrupted { reason }),
             Wire::Missing => Ok(Self::Missing),
         }
     }
@@ -1389,6 +1407,12 @@ pub fn migrate_legacy_event(
                     },
                     AgentDispatchDisposition::Open,
                 ),
+                Settlement::Interrupted { reason } => (
+                    ActivationDisposition::Interrupted {
+                        reason: reason.clone(),
+                    },
+                    AgentDispatchDisposition::Open,
+                ),
                 Settlement::Missing => unreachable!("handled above"),
             };
             let completion = matches!(disposition, ActivationDisposition::WorkCompleted { .. });
@@ -1489,6 +1513,9 @@ pub fn reduce_command(snapshot: &Snapshot, command: &ProtocolCommand) -> Protoco
     }
     if let ProtocolCommand::AdoptActivationWorkState(command) = command {
         return adopt_activation_work_state(snapshot, command);
+    }
+    if let ProtocolCommand::RecoverInterruptedActivation(command) = command {
+        return recover_interrupted_activation(snapshot, command);
     }
     let event = match lower_command(snapshot, command) {
         Ok(event) => event,
@@ -1622,23 +1649,17 @@ fn replay_or_conflict(
                                 },
                             })
                     });
-                return Some(
-                    if existing == &command.demand
-                        && wait_matches
-                        && focus_matches
-                        && dispatch_matches
-                    {
-                        duplicate_command(snapshot, "legacy_work_state_already_adopted")
-                    } else {
-                        rejected_command(
-                            snapshot,
-                            command_conflict(
-                                ProtocolConflictKind::IdentityConflict,
-                                "legacy_work_state_adoption_conflict",
-                            ),
-                        )
-                    },
-                );
+                if existing == &command.demand && wait_matches && focus_matches && dispatch_matches
+                {
+                    return Some(duplicate_command(
+                        snapshot,
+                        "legacy_work_state_already_adopted",
+                    ));
+                }
+                // The source WorkItem revision is authoritative.  A same-revision
+                // mismatch is compatibility projection drift, not an identity
+                // conflict, so let the reducer refresh the legacy row.
+                return None;
             }
         }
         ProtocolCommand::AdoptActivationWorkState(command) => {
@@ -1754,6 +1775,34 @@ fn replay_or_conflict(
                         command_conflict(
                             ProtocolConflictKind::IdentityConflict,
                             "settlement_id_command_conflict",
+                        ),
+                    )
+                });
+            }
+            if snapshot
+                .settlements
+                .values()
+                .any(|existing| existing.activation_id == command.settlement.activation_id)
+            {
+                return Some(rejected_command(
+                    snapshot,
+                    command_conflict(
+                        ProtocolConflictKind::StateConflict,
+                        "activation_terminal_settlement_already_recorded",
+                    ),
+                ));
+            }
+        }
+        ProtocolCommand::RecoverInterruptedActivation(command) => {
+            if let Some(existing) = snapshot.settlements.get(&command.settlement.id) {
+                return Some(if existing == &command.settlement {
+                    duplicate_command(snapshot, "interruption_recovery_already_applied")
+                } else {
+                    rejected_command(
+                        snapshot,
+                        command_conflict(
+                            ProtocolConflictKind::IdentityConflict,
+                            "interruption_recovery_id_command_conflict",
                         ),
                     )
                 });
@@ -1892,6 +1941,9 @@ fn lower_command(
                     .map_err(reducer_conflict)?;
             }
             Ok(event)
+        }
+        ProtocolCommand::RecoverInterruptedActivation(_) => {
+            unreachable!("interruption recovery is reduced directly")
         }
         ProtocolCommand::RecordMissingSettlement(record) => {
             if !snapshot
@@ -2200,15 +2252,31 @@ fn adopt_legacy_work_state(
         })
         .into_iter()
         .collect::<Vec<_>>();
-    let arm = command.wait.as_ref().map(|wait| LaneWaitArm {
-        wait: WaitIdentity {
-            id: wait.wait_id.clone(),
-            generation: wait.generation,
-        },
-        owner: SchedulerOwner::WorkItem {
-            work_item_id: wait.owner_work_item_id.clone(),
-        },
+    let target_wait_already_armed = command.wait.as_ref().is_some_and(|target| {
+        snapshot.waits.get(&target.wait_id).is_some_and(|wait| {
+            wait.current_generation == target.generation
+                && wait
+                    .generations
+                    .get(&target.generation)
+                    .is_some_and(|generation| {
+                        generation.owner.work_item_id() == Some(target.owner_work_item_id.as_str())
+                            && matches!(generation.state, WaitState::Active | WaitState::Triggered)
+                    })
+        })
     });
+    let arm = command
+        .wait
+        .as_ref()
+        .filter(|_| !target_wait_already_armed)
+        .map(|wait| LaneWaitArm {
+            wait: WaitIdentity {
+                id: wait.wait_id.clone(),
+                generation: wait.generation,
+            },
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: wait.owner_work_item_id.clone(),
+            },
+        });
     let target_dispatch = if let Some(arm) = &arm {
         if command.reserve_dispatch || source_dispatch_wait.is_some() {
             AgentDispatchState::Awaiting {
@@ -3004,11 +3072,25 @@ fn lower_activation_settlement(
                 "yield_continuation_identity_required",
             ));
         }
+        (ActivationDisposition::Interrupted { reason }, AgentDispatchDisposition::Open)
+            if !reason.is_empty() =>
+        {
+            Settlement::Interrupted {
+                reason: reason.clone(),
+            }
+        }
+        (ActivationDisposition::Interrupted { .. }, AgentDispatchDisposition::Open) => {
+            return Err(command_conflict(
+                ProtocolConflictKind::InvalidCommand,
+                "interruption_reason_required",
+            ));
+        }
         (ActivationDisposition::WorkWaits { .. }, AgentDispatchDisposition::Awaiting { .. })
         | (
             ActivationDisposition::WorkContinues
             | ActivationDisposition::WorkCompleted { .. }
-            | ActivationDisposition::WorkYielded { .. },
+            | ActivationDisposition::WorkYielded { .. }
+            | ActivationDisposition::Interrupted { .. },
             AgentDispatchDisposition::Awaiting { .. },
         ) => {
             return Err(command_conflict(
@@ -3333,6 +3415,7 @@ fn admit(
         let diagnostic = match existing.state {
             ActivationState::Running => "activation_already_running",
             ActivationState::Settled => "activation_already_settled",
+            ActivationState::Interrupted => "activation_already_interrupted",
             ActivationState::SettlementMissing => "activation_settlement_missing",
         };
         return rejected(snapshot, diagnostic);
@@ -3359,15 +3442,6 @@ fn admit(
     if snapshot.dispatch_revision != expected_dispatch_revision {
         return rejected(snapshot, "stale_dispatch_revision");
     }
-    if !matches!(cause, AdmissionCause::SettlementRecovery { .. })
-        && snapshot
-            .work
-            .values()
-            .any(|work| matches!(work.status, WorkStatus::NeedsSettlement { .. }))
-    {
-        return rejected(snapshot, "settlement_recovery_pending");
-    }
-
     let mut next = snapshot.clone();
     let mut transitions = Vec::new();
     let mut recovery_for = None;
@@ -3693,6 +3767,133 @@ fn settle(snapshot: &Snapshot, activation_id: &str, settlement: &Settlement) -> 
     }
 }
 
+fn recover_interrupted_activation(
+    snapshot: &Snapshot,
+    command: &RecoverInterruptedActivationCommand,
+) -> ProtocolCommandOutcome {
+    let settlement = &command.settlement;
+    let invalid = settlement.id.is_empty()
+        || settlement.activation_id.is_empty()
+        || settlement.created_at.is_empty()
+        || settlement.turn_terminal.is_some()
+        || settlement.operator_delivery.is_some()
+        || settlement.agent_dispatch != AgentDispatchDisposition::Open
+        || !matches!(
+            &settlement.disposition,
+            ActivationDisposition::Interrupted { reason } if !reason.is_empty()
+        );
+    if invalid {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::InvalidCommand,
+                "interruption_recovery_shape_invalid",
+            ),
+        );
+    }
+    let Some(activation) = snapshot.activations.get(&settlement.activation_id) else {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::NotFound,
+                "interruption_recovery_activation_missing",
+            ),
+        );
+    };
+    if activation.state != ActivationState::SettlementMissing || activation.recovery_for.is_some() {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::StateConflict,
+                "interruption_recovery_activation_not_pending",
+            ),
+        );
+    }
+    let Some(work_item_id) = activation.owner.work_item_id() else {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::BindingConflict,
+                "interruption_recovery_requires_work_item_owner",
+            ),
+        );
+    };
+    let Some(work) = snapshot.work.get(work_item_id) else {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::NotFound,
+                "interruption_recovery_work_item_missing",
+            ),
+        );
+    };
+    if work.status
+        != (WorkStatus::NeedsSettlement {
+            activation_id: settlement.activation_id.clone(),
+        })
+    {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::StateConflict,
+                "interruption_recovery_work_item_not_pending",
+            ),
+        );
+    }
+    let Some(missing_id) = snapshot
+        .missing_settlements
+        .iter()
+        .find_map(|(id, record)| {
+            (record.activation_id == settlement.activation_id).then(|| id.clone())
+        })
+    else {
+        return rejected_command(
+            snapshot,
+            command_conflict(
+                ProtocolConflictKind::NotFound,
+                "interruption_recovery_missing_record_absent",
+            ),
+        );
+    };
+
+    let mut next = snapshot.clone();
+    next.activations
+        .get_mut(&settlement.activation_id)
+        .expect("validated activation exists")
+        .state = ActivationState::Interrupted;
+    let next_work = next
+        .work
+        .get_mut(work_item_id)
+        .expect("validated WorkItem exists");
+    next_work.scheduling_generation = next_work
+        .scheduling_generation
+        .checked_add(1)
+        .expect("WorkItem recovery generation overflow");
+    next_work.status = WorkStatus::Runnable;
+    next.missing_settlements.remove(&missing_id);
+    next.settlements
+        .insert(settlement.id.clone(), settlement.clone());
+
+    ProtocolCommandOutcome {
+        outcome: Outcome {
+            decision: Decision::Settled,
+            transitions: vec![
+                format!(
+                    "activation:{}:settlement_missing->interrupted",
+                    settlement.activation_id
+                ),
+                format!(
+                    "work:{work_item_id}:interruption_recovery:generation:{}",
+                    next_work.scheduling_generation
+                ),
+            ],
+            diagnostics: Vec::new(),
+            snapshot: next,
+        },
+        conflict: None,
+    }
+}
+
 fn settle_work_item(
     snapshot: &Snapshot,
     activation_id: &str,
@@ -3857,7 +4058,7 @@ fn settle_work_item(
     ];
 
     match settlement {
-        Settlement::Continue | Settlement::Yield => {
+        Settlement::Continue | Settlement::Yield | Settlement::Interrupted { .. } => {
             let mut demand = current_work.clone();
             demand.scheduling_generation = next_generation;
             demand.status = WorkStatus::Runnable;
@@ -3882,7 +4083,12 @@ fn settle_work_item(
             ) {
                 return rejected(snapshot, code);
             }
-            transitions.push(format!("work:{work_item_id}:runnable"));
+            transitions.push(match settlement {
+                Settlement::Interrupted { reason } => {
+                    format!("work:{work_item_id}:interrupted_recovery:{reason}")
+                }
+                _ => format!("work:{work_item_id}:runnable"),
+            });
         }
         Settlement::TargetedYield { continuation } => {
             let mut demand = current_work.clone();
@@ -4084,7 +4290,11 @@ fn settle_work_item(
     next.activations
         .get_mut(running_activation_id)
         .expect("running activation exists")
-        .state = ActivationState::Settled;
+        .state = if matches!(settlement, Settlement::Interrupted { .. }) {
+        ActivationState::Interrupted
+    } else {
+        ActivationState::Settled
+    };
     if let Some(missing_activation_id) = recovery_for {
         next.activations
             .get_mut(missing_activation_id)
@@ -4161,7 +4371,10 @@ fn settle_lifecycle(
     let mut next = snapshot.clone();
     let mut transitions = vec![format!("activation:{activation_id}:settled")];
     match settlement {
-        Settlement::Continue | Settlement::Yield | Settlement::Complete { continuation: None } => {
+        Settlement::Continue
+        | Settlement::Yield
+        | Settlement::Complete { continuation: None }
+        | Settlement::Interrupted { .. } => {
             if !lifecycle_nudge {
                 let resolutions = current_lane_resolution(
                     snapshot,
@@ -4278,7 +4491,11 @@ fn settle_lifecycle(
     next.activations
         .get_mut(activation_id)
         .expect("running activation exists")
-        .state = ActivationState::Settled;
+        .state = if matches!(settlement, Settlement::Interrupted { .. }) {
+        ActivationState::Interrupted
+    } else {
+        ActivationState::Settled
+    };
     Outcome {
         decision: Decision::Settled,
         transitions,
@@ -4600,8 +4817,13 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
         else {
             unreachable!("activation settlement lowers to settlement event");
         };
+        let expected_activation_state = if matches!(lowered, Settlement::Interrupted { .. }) {
+            ActivationState::Interrupted
+        } else {
+            ActivationState::Settled
+        };
         if settlement_id != &settlement.id
-            || activation.state != ActivationState::Settled
+            || activation.state != expected_activation_state
             || !snapshot
                 .activation_admissions
                 .contains_key(&settlement.activation_id)
@@ -4617,7 +4839,8 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
             match lowered {
                 Settlement::Continue
                 | Settlement::Yield
-                | Settlement::Complete { continuation: None } => {}
+                | Settlement::Complete { continuation: None }
+                | Settlement::Interrupted { .. } => {}
                 Settlement::Wait {
                     wait,
                     mode: _,
@@ -4670,7 +4893,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
         let projects_current_work_state =
             work.scheduling_generation == settlement_generation && !has_successor_activation;
         match lowered {
-            Settlement::Continue | Settlement::Yield => {
+            Settlement::Continue | Settlement::Yield | Settlement::Interrupted { .. } => {
                 if projects_current_work_state && work.status != WorkStatus::Runnable {
                     return Err(
                         "canonical runnable settlement disagrees with authoritative work state"
@@ -4853,6 +5076,11 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
             ActivationState::Running => {
                 return Err("running activation has a canonical missing-settlement record".into());
             }
+            ActivationState::Interrupted => {
+                return Err(
+                    "interrupted activation cannot have a missing-settlement record".into(),
+                );
+            }
             ActivationState::SettlementMissing => {
                 if work.is_none() {
                     if activation.recovery_for.is_some() {
@@ -4910,7 +5138,9 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
         let terminal_record_count = terminal_records.get(activation_id).copied().unwrap_or(0);
         let expected_terminal_record_count = match activation.state {
             ActivationState::Running => 0,
-            ActivationState::Settled | ActivationState::SettlementMissing => 1,
+            ActivationState::Settled
+            | ActivationState::Interrupted
+            | ActivationState::SettlementMissing => 1,
         };
         if terminal_record_count != expected_terminal_record_count {
             return Err(
@@ -5042,7 +5272,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                     return Err("running activation does not own the slot".into());
                 }
             }
-            ActivationState::Settled => {
+            ActivationState::Settled | ActivationState::Interrupted => {
                 if matches!(
                     snapshot.slot,
                     ActivationSlot::Running {
@@ -5050,7 +5280,7 @@ pub fn assert_invariants(snapshot: &Snapshot) -> Result<(), String> {
                         ..
                     } if slot_activation_id == activation_id
                 ) {
-                    return Err("settled activation still owns the slot".into());
+                    return Err("terminal activation still owns the slot".into());
                 }
             }
             ActivationState::SettlementMissing => {

--- a/src/host.rs
+++ b/src/host.rs
@@ -2312,7 +2312,7 @@ impl RuntimeHost {
             crate::types::MessageOrigin::Task {
                 task_id: task.id.clone(),
             },
-            authority_class,
+            AuthorityClass::RuntimeInstruction,
             crate::types::Priority::Normal,
             crate::types::MessageBody::Text { text: prompt },
         )
@@ -2327,6 +2327,7 @@ impl RuntimeHost {
             "parent_agent_id": parent_state.id,
             "child_agent_id": child_identity.agent_id,
             "parent_supervised": true,
+            "delegated_authority_class": authority_class,
         }));
         child_runtime.enqueue(message).await?;
 
@@ -2896,7 +2897,7 @@ impl RuntimeHostBridge {
             crate::types::MessageOrigin::Task {
                 task_id: task_id.to_string(),
             },
-            authority_class,
+            AuthorityClass::RuntimeInstruction,
             crate::types::Priority::Normal,
             crate::types::MessageBody::Text {
                 text: input.to_string(),
@@ -2911,6 +2912,7 @@ impl RuntimeHostBridge {
             "parent_agent_id": parent_agent_id,
             "child_agent_id": child_agent_id,
             "followup_via": "task_input",
+            "delegated_authority_class": authority_class,
         }));
         runtime.enqueue(message).await.map(|_| true)
     }
@@ -3055,6 +3057,16 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        (home, host)
+    }
+
+    fn canonical_test_host() -> (tempfile::TempDir, RuntimeHost) {
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        config.scheduler_engine = crate::config::SchedulerEngineMode::Canonical;
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
@@ -5305,7 +5317,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_loop_failure_preserves_canonical_claim_and_reconciles_on_next_host_access() {
-        let (_home, host) = test_host();
+        let (_home, host) = canonical_test_host();
         let agent_id = host.config().default_agent_id.clone();
         let runtime = host.default_runtime().await.unwrap();
         runtime.inject_runtime_loop_failure_after_next_claim();
@@ -5383,7 +5395,7 @@ mod tests {
                 .unwrap()
                 .iter()
                 .any(|entry| {
-                    entry.message_id == message.id && entry.status == QueueEntryStatus::Aborted
+                    entry.message_id == message.id && entry.status == QueueEntryStatus::Interrupted
                 });
             let recovery_recorded = rebuilt
                 .storage()
@@ -5393,7 +5405,8 @@ mod tests {
                 .any(|event| {
                     event.kind == "scheduler_bootstrap_claim_recovered"
                         && event.data["message_id"].as_str() == Some(message.id.as_str())
-                        && event.data["recovery_outcome"].as_str() == Some("settlement_missing")
+                        && event.data["recovery_outcome"].as_str()
+                            == Some("attempt_interrupted_for_reentry")
                 });
             if queue_reconciled && recovery_recorded {
                 break;

--- a/src/host.rs
+++ b/src/host.rs
@@ -8,7 +8,8 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
+use chrono::Utc;
 use serde_json::{json, Value};
 use tokio::{
     sync::{Notify, RwLock},
@@ -49,12 +50,12 @@ use crate::{
     },
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
-        AdmissionContext, AgentDeletionJob, AgentIdentityRecord, AgentIdentityView, AgentKind,
-        AgentLifecycleHint, AgentListEntry, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentTokenUsageSummary,
-        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
-        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        AdmissionContext, AgentDeletionJob, AgentDurability, AgentIdentityRecord,
+        AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry, AgentOwnership,
+        AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus, AgentSummary,
+        AgentTokenUsageSummary, AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome,
+        ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView,
+        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
         SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
         TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
@@ -1567,8 +1568,42 @@ impl RuntimeHost {
             other => ids::runtime_id(&format!("{TEMP_AGENT_PREFIX}{other}")),
         };
         self.validate_agent_id(&agent_id)?;
-        let (runtime, runtime_task) = self.spawn_runtime(&agent_id)?;
+        let mut identity = AgentIdentityRecord::new(
+            agent_id.clone(),
+            AgentKind::Named,
+            AgentVisibility::Private,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        identity.durability = Some(AgentDurability::Ephemeral);
+        self.append_agent_identity(&identity)?;
+        let (runtime, runtime_task) = match self.spawn_runtime(&agent_id) {
+            Ok(spawned) => spawned,
+            Err(error) => {
+                let _ = self.archive_temporary_runtime_identity(&agent_id);
+                return Err(error);
+            }
+        };
         Ok((agent_id, runtime, runtime_task))
+    }
+
+    pub(crate) fn archive_temporary_runtime_identity(&self, agent_id: &str) -> Result<()> {
+        if !Self::is_temporary_agent_id(agent_id) {
+            bail!("agent {agent_id} is not a temporary runtime");
+        }
+        let Some(mut identity) = self.agent_identity_record(agent_id)? else {
+            bail!("temporary runtime {agent_id} is missing its host identity");
+        };
+        if identity.status != AgentRegistryStatus::Deleted {
+            identity.status = AgentRegistryStatus::Deleted;
+            identity.revision = identity.revision.saturating_add(1);
+            identity.deleted_at = Some(Utc::now());
+            identity.updated_at = Utc::now();
+            self.append_agent_identity(&identity)?;
+        }
+        Ok(())
     }
 
     pub fn workspace_entries(&self) -> Result<Vec<WorkspaceEntry>> {

--- a/src/host.rs
+++ b/src/host.rs
@@ -2312,7 +2312,7 @@ impl RuntimeHost {
             crate::types::MessageOrigin::Task {
                 task_id: task.id.clone(),
             },
-            AuthorityClass::RuntimeInstruction,
+            authority_class.clone(),
             crate::types::Priority::Normal,
             crate::types::MessageBody::Text { text: prompt },
         )
@@ -2897,7 +2897,7 @@ impl RuntimeHostBridge {
             crate::types::MessageOrigin::Task {
                 task_id: task_id.to_string(),
             },
-            AuthorityClass::RuntimeInstruction,
+            authority_class.clone(),
             crate::types::Priority::Normal,
             crate::types::MessageBody::Text {
                 text: input.to_string(),
@@ -3615,12 +3615,13 @@ mod tests {
     async fn private_child_initial_message_sets_task_label_and_supervision_provenance() {
         let (_home, host) = test_host();
         let parent = host.default_runtime().await.unwrap();
+        let parent_agent_id = parent.agent_state().await.unwrap().id;
         let initial_message = "  investigate   remote\nTUI  access ".to_string();
 
         let spawned = parent
             .spawn_agent(
                 Some(initial_message.clone()),
-                AuthorityClass::OperatorInstruction,
+                AuthorityClass::ExternalEvidence,
                 AgentProfilePreset::PrivateChild,
                 None,
                 false,
@@ -3662,6 +3663,7 @@ mod tests {
                 task_id: task_id.clone()
             }
         );
+        assert_eq!(delegated.authority_class, AuthorityClass::ExternalEvidence);
         assert_eq!(
             delegated.metadata.as_ref().unwrap()["parent_supervised"],
             true
@@ -3675,6 +3677,35 @@ mod tests {
             MessageBody::Text {
                 text: initial_message
             }
+        );
+
+        assert!(host
+            .bridge()
+            .deliver_child_followup(
+                &parent_agent_id,
+                &task_id,
+                &spawned.agent_id,
+                "additional untrusted evidence",
+                AuthorityClass::ExternalEvidence,
+            )
+            .await
+            .unwrap());
+        let messages = child.storage().read_recent_messages(10).unwrap();
+        let followup = messages
+            .iter()
+            .find(|message| {
+                message
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("followup_via"))
+                    .and_then(|value| value.as_str())
+                    == Some("task_input")
+            })
+            .expect("child should receive the task input follow-up");
+        assert_eq!(followup.authority_class, AuthorityClass::ExternalEvidence);
+        assert_eq!(
+            followup.metadata.as_ref().unwrap()["delegated_authority_class"],
+            serde_json::json!("external_evidence")
         );
     }
 

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -408,6 +408,7 @@ pub async fn run_once_with_host(
         RunSessionCleanup::Temporary { runtime_task } => {
             let _ = session.runtime.control(ControlAction::Stop).await;
             let _ = runtime_task.await;
+            let _ = host.archive_temporary_runtime_identity(&session.agent_id);
             let data_dir = host.agent_data_dir(&session.agent_id);
             if data_dir.exists() {
                 let _ = std::fs::remove_dir_all(&data_dir);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -60,7 +60,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use arc_swap::ArcSwap;
 use bootstrap::ConfigSnapshot;
 use chrono::Utc;
@@ -359,8 +359,12 @@ fn canonical_settlement_id(message_id: &str) -> String {
     format!("settlement:message:{message_id}")
 }
 
-fn canonical_missing_settlement_id(message_id: &str) -> String {
-    format!("missing-settlement:message:{message_id}")
+fn canonical_settlement_id_for_attempt(message_id: &str, activation_id: &str) -> String {
+    if activation_id == scheduler_executor::canonical_activation_id(message_id) {
+        canonical_settlement_id(message_id)
+    } else {
+        format!("settlement:{activation_id}")
+    }
 }
 
 fn canonical_commands_settle_from_terminal(
@@ -515,8 +519,8 @@ fn canonical_queue_settlement_commands_from_facts(
     use crate::domain::scheduler_protocol::{
         ActivationDisposition, ActivationSettlement, AdoptActivationWorkStateCommand,
         AgentDispatchDisposition, AgentDispatchState, LegacyWaitAdoption,
-        LifecycleWaitHandoffProof, MissingSettlementRecord, ProtocolCommand, SchedulerOwner,
-        SettleActivationCommand, WaitIdentity, WaitState,
+        LifecycleWaitHandoffProof, ProtocolCommand, SchedulerOwner, SettleActivationCommand,
+        WaitIdentity, WaitState,
     };
 
     let Some(snapshot) = runtime_db
@@ -525,15 +529,31 @@ fn canonical_queue_settlement_commands_from_facts(
     else {
         return Ok(Vec::new());
     };
-    let activation_id = scheduler_executor::canonical_activation_id(&record.message_id);
+    let Some(activation_id) =
+        scheduler_executor::canonical_open_activation_id(&snapshot, &record.message_id)
+    else {
+        return Ok(Vec::new());
+    };
     let Some(activation) = snapshot.activations.get(&activation_id) else {
         return Ok(Vec::new());
     };
-    let missing_settlement = || {
-        ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
-            id: canonical_missing_settlement_id(&record.message_id),
-            activation_id: activation_id.clone(),
-            created_at: record.updated_at.to_rfc3339(),
+    let interrupted = |reason: &str| {
+        ProtocolCommand::SettleActivation(SettleActivationCommand {
+            settlement: ActivationSettlement {
+                id: canonical_settlement_id_for_attempt(&record.message_id, &activation_id),
+                activation_id: activation_id.clone(),
+                turn_terminal: None,
+                disposition: ActivationDisposition::Interrupted {
+                    reason: reason.to_string(),
+                },
+                agent_dispatch: AgentDispatchDisposition::Open,
+                operator_delivery: None,
+                evidence: vec![
+                    format!("message:{}", record.message_id),
+                    format!("interruption_reason:{reason}"),
+                ],
+                created_at: record.updated_at.to_rfc3339(),
+            },
         })
     };
     let matching_terminal_turn = if record.status == QueueEntryStatus::Processed {
@@ -548,14 +568,14 @@ fn canonical_queue_settlement_commands_from_facts(
         None
     };
     if record.status == QueueEntryStatus::Processed && matching_terminal_turn.is_none() {
-        return Ok(vec![missing_settlement()]);
+        return Ok(vec![interrupted("terminal_turn_missing")]);
     }
     let turn_terminal = matching_terminal_turn
         .as_ref()
         .map(|turn| turn.turn_id.clone());
     let Some(work_item_id) = activation.owner.work_item_id().map(ToString::to_string) else {
         if record.status != QueueEntryStatus::Processed {
-            return Ok(vec![missing_settlement()]);
+            return Ok(vec![interrupted("runtime_interrupted")]);
         }
         let active_waits = storage
             .latest_wait_conditions()?
@@ -580,12 +600,12 @@ fn canonical_queue_settlement_commands_from_facts(
         let lifecycle_wait = match lifecycle_waits.as_slice() {
             [wait] if work_item_waits.is_empty() => Some(wait),
             [] => None,
-            _ => return Ok(vec![missing_settlement()]),
+            _ => return Ok(vec![interrupted("ambiguous_lifecycle_waits")]),
         };
         let work_item_wait = match work_item_waits.as_slice() {
             [wait] => Some(wait),
             [] => None,
-            _ => return Ok(vec![missing_settlement()]),
+            _ => return Ok(vec![interrupted("ambiguous_work_item_waits")]),
         };
         let disposition = match lifecycle_wait {
             None => ActivationDisposition::WorkContinues,
@@ -611,7 +631,7 @@ fn canonical_queue_settlement_commands_from_facts(
         }
         let mut commands = vec![ProtocolCommand::SettleActivation(SettleActivationCommand {
             settlement: ActivationSettlement {
-                id: canonical_settlement_id(&record.message_id),
+                id: canonical_settlement_id_for_attempt(&record.message_id, &activation_id),
                 activation_id: activation_id.clone(),
                 turn_terminal: turn_terminal.clone(),
                 disposition,
@@ -623,15 +643,15 @@ fn canonical_queue_settlement_commands_from_facts(
         })];
         if let Some(wait) = work_item_wait {
             let Some(work_item_id) = wait.work_item_id.as_deref() else {
-                return Ok(vec![missing_settlement()]);
+                return Ok(vec![interrupted("work_item_wait_owner_missing")]);
             };
             let Some(work_item) = storage.latest_work_item(work_item_id)? else {
-                return Ok(vec![missing_settlement()]);
+                return Ok(vec![interrupted("work_item_wait_owner_missing")]);
             };
             if work_item.agent_id != record.agent_id
                 || work_item.state != crate::types::WorkItemState::Open
             {
-                return Ok(vec![missing_settlement()]);
+                return Ok(vec![interrupted("work_item_wait_owner_not_open")]);
             }
             if runtime_db
                 .transitions()
@@ -702,6 +722,78 @@ fn canonical_queue_settlement_commands_from_facts(
         }
         return Ok(commands);
     };
+    let matching_continuations = runtime_db
+        .work_item_continuations()
+        .active_for_agent(&record.agent_id)?
+        .into_iter()
+        .filter(|frame| {
+            frame.suspended_work_item_id == work_item_id
+                && frame.turn_id.as_deref() == message.turn_id.as_deref()
+        })
+        .collect::<Vec<_>>();
+    if record.status == QueueEntryStatus::Processed {
+        match matching_continuations.as_slice() {
+            [frame] => {
+                let Some(target) = storage.latest_work_item(&frame.active_work_item_id)? else {
+                    return Ok(vec![interrupted("yield_target_missing")]);
+                };
+                if target.agent_id != record.agent_id
+                    || target.state != crate::types::WorkItemState::Open
+                    || target.readiness() != crate::types::WorkItemReadiness::Runnable
+                {
+                    return Ok(vec![interrupted("yield_target_not_runnable")]);
+                }
+                let target_generation = snapshot
+                    .work
+                    .get(&target.id)
+                    .filter(|demand| {
+                        demand.status == crate::domain::scheduler_protocol::WorkStatus::Runnable
+                    })
+                    .map(|demand| demand.scheduling_generation)
+                    .unwrap_or_else(|| target.revision.max(1));
+                let mut commands = Vec::new();
+                if !snapshot.work.contains_key(&target.id) {
+                    commands.push(ProtocolCommand::RegisterWorkDemand(
+                        crate::domain::scheduler_protocol::RegisterWorkDemandCommand {
+                            work_item_id: target.id.clone(),
+                            demand: crate::domain::scheduler_protocol::WorkDemand {
+                                metadata_revision: target_generation,
+                                scheduling_generation: target_generation,
+                                status: crate::domain::scheduler_protocol::WorkStatus::Runnable,
+                                capabilities: Default::default(),
+                                locks: Default::default(),
+                                locality: "runtime".into(),
+                                cost_class: "default".into(),
+                            },
+                        },
+                    ));
+                }
+                commands.push(ProtocolCommand::SettleActivation(SettleActivationCommand {
+                    settlement: ActivationSettlement {
+                        id: canonical_settlement_id_for_attempt(&record.message_id, &activation_id),
+                        activation_id,
+                        turn_terminal,
+                        disposition: ActivationDisposition::WorkYielded {
+                            target_work_item_id: Some(target.id),
+                            continuation_id: Some(frame.id.clone()),
+                            expected_target_generation: Some(target_generation),
+                        },
+                        agent_dispatch: AgentDispatchDisposition::Open,
+                        operator_delivery: None,
+                        evidence: vec![
+                            format!("message:{}", record.message_id),
+                            format!("work_item:{work_item_id}"),
+                            format!("continuation:{}", frame.id),
+                        ],
+                        created_at: record.updated_at.to_rfc3339(),
+                    },
+                }));
+                return Ok(commands);
+            }
+            [] => {}
+            _ => return Ok(vec![interrupted("yield_continuation_ambiguous")]),
+        }
+    }
     let work_queue = storage.work_queue_prompt_projection()?;
     let scheduling_state = work_queue
         .items
@@ -713,7 +805,7 @@ fn canonical_queue_settlement_commands_from_facts(
             Some(crate::types::WorkItemSchedulingState::Runnable) => {
                 ProtocolCommand::SettleActivation(SettleActivationCommand {
                     settlement: ActivationSettlement {
-                        id: canonical_settlement_id(&record.message_id),
+                        id: canonical_settlement_id_for_attempt(&record.message_id, &activation_id),
                         activation_id,
                         turn_terminal: turn_terminal.clone(),
                         disposition: ActivationDisposition::WorkContinues,
@@ -729,13 +821,13 @@ fn canonical_queue_settlement_commands_from_facts(
             }
             Some(crate::types::WorkItemSchedulingState::Completed) => {
                 let Some(work_item) = runtime_db.work_items().latest(&work_item_id)? else {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("completion_work_item_missing")]);
                 };
                 let Some(turn_terminal) = turn_terminal.clone() else {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("completion_turn_missing")]);
                 };
                 let Some(completion_intent) = work_item.completion_intent.as_ref() else {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("completion_intent_missing")]);
                 };
                 if !(completion_intent.work_item_id == work_item_id
                     && completion_intent.source_activation_id.as_deref()
@@ -749,7 +841,7 @@ fn canonical_queue_settlement_commands_from_facts(
                         completion_intent.expected_work_revision,
                     ))
                 {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("completion_intent_mismatch")]);
                 }
                 let Some(result_brief_id) =
                     completion_intent
@@ -759,7 +851,7 @@ fn canonical_queue_settlement_commands_from_facts(
                             work_item.result_brief_id.as_deref() == Some(*result_brief_id)
                         })
                 else {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("completion_brief_binding_missing")]);
                 };
                 let Some(brief) = storage.read_brief_by_id(result_brief_id)?.filter(|brief| {
                     brief.kind.is_success()
@@ -768,11 +860,11 @@ fn canonical_queue_settlement_commands_from_facts(
                         && brief.related_message_id.as_deref() == Some(record.message_id.as_str())
                         && !brief.text.trim().is_empty()
                 }) else {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("completion_brief_evidence_missing")]);
                 };
                 ProtocolCommand::SettleActivation(SettleActivationCommand {
                     settlement: ActivationSettlement {
-                        id: canonical_settlement_id(&record.message_id),
+                        id: canonical_settlement_id_for_attempt(&record.message_id, &activation_id),
                         activation_id,
                         turn_terminal: Some(turn_terminal.clone()),
                         disposition: ActivationDisposition::WorkCompleted { continuation: None },
@@ -798,7 +890,7 @@ fn canonical_queue_settlement_commands_from_facts(
                 let active_waits = storage
                     .active_wait_conditions_for_work_item(&record.agent_id, &work_item_id)?;
                 let [active_wait] = active_waits.as_slice() else {
-                    return Ok(vec![missing_settlement()]);
+                    return Ok(vec![interrupted("wait_outcome_ambiguous")]);
                 };
                 let generation = activation
                     .admitted_generation
@@ -806,7 +898,7 @@ fn canonical_queue_settlement_commands_from_facts(
                     .ok_or_else(|| anyhow!("canonical wait generation overflow"))?;
                 ProtocolCommand::SettleActivation(SettleActivationCommand {
                     settlement: ActivationSettlement {
-                        id: canonical_settlement_id(&record.message_id),
+                        id: canonical_settlement_id_for_attempt(&record.message_id, &activation_id),
                         activation_id,
                         turn_terminal: turn_terminal.clone(),
                         disposition: ActivationDisposition::WorkWaits {
@@ -826,21 +918,377 @@ fn canonical_queue_settlement_commands_from_facts(
                     },
                 })
             }
-            _ => missing_settlement(),
+            _ => interrupted("terminal_outcome_unresolved"),
         }
     } else {
-        missing_settlement()
+        interrupted("runtime_interrupted")
     };
     Ok(vec![command])
+}
+
+fn execution_protocol_settlement_transition(
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    scheduler_commands: &[crate::domain::scheduler_protocol::ProtocolCommand],
+) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+    use crate::domain::scheduler_protocol::ProtocolCommand;
+
+    let Some(settlement) = scheduler_commands.iter().find_map(|command| match command {
+        ProtocolCommand::SettleActivation(command) => Some(&command.settlement),
+        ProtocolCommand::RecoverInterruptedActivation(command) => Some(&command.settlement),
+        _ => None,
+    }) else {
+        return Ok(Default::default());
+    };
+    let state = runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized(agent_id)?
+        .ok_or_else(|| anyhow!("canonical settlement requires execution protocol authority"))?;
+    let attempt = state
+        .attempts
+        .get(&settlement.activation_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "canonical settlement {} has no matching execution attempt",
+                settlement.activation_id
+            )
+        })?;
+    if attempt.state != crate::domain::execution_protocol::ExecutionAttemptState::Open {
+        return Ok(Default::default());
+    }
+    Ok(
+        crate::runtime_db::transitions::ExecutionProtocolTransition {
+            bootstrap: None,
+            commands: vec![execution_protocol_settlement_command(attempt, settlement)?],
+        },
+    )
+}
+
+fn execution_protocol_settlement_command(
+    attempt: &crate::domain::execution_protocol::ExecutionAttempt,
+    settlement: &crate::domain::scheduler_protocol::ActivationSettlement,
+) -> Result<crate::domain::execution_protocol::ExecutionProtocolCommand> {
+    use crate::domain::execution_protocol::{
+        CommandResult, ConversationOutcome, ExecutionBinding, ExecutionOutcome,
+        ExecutionOutcomeRecord, ExecutionProtocolCommand, InterruptExecution, SettleExecution,
+        WaitReference, WorkItemOutcome,
+    };
+    use crate::domain::scheduler_protocol::ActivationDisposition;
+
+    let outcome_id = format!("outcome:{}", settlement.id);
+    let command = match &settlement.disposition {
+        ActivationDisposition::Interrupted { reason } => {
+            ExecutionProtocolCommand::Interrupt(InterruptExecution {
+                attempt_id: attempt.attempt_id.clone(),
+                outcome_id,
+                reason: reason.clone(),
+                interrupted_at: settlement.created_at.clone(),
+            })
+        }
+        disposition => {
+            let outcome = match (&attempt.binding, disposition) {
+                (
+                    ExecutionBinding::WorkItem { .. },
+                    ActivationDisposition::WorkContinues
+                    | ActivationDisposition::ConversationReplied
+                    | ActivationDisposition::ReducedOnly,
+                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Continue),
+                (ExecutionBinding::WorkItem { .. }, ActivationDisposition::WorkWaits { wait }) => {
+                    ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
+                        wait: WaitReference {
+                            wait_id: wait.id.clone(),
+                            generation: wait.generation,
+                        },
+                    })
+                }
+                (
+                    ExecutionBinding::WorkItem { .. },
+                    ActivationDisposition::WorkCompleted { .. },
+                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                    completion: settlement
+                        .operator_delivery
+                        .clone()
+                        .unwrap_or_else(|| "completed".into()),
+                }),
+                (
+                    ExecutionBinding::WorkItem { .. },
+                    ActivationDisposition::WorkPaused { reason },
+                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Pause {
+                    reason: reason.clone(),
+                }),
+                (
+                    ExecutionBinding::WorkItem { .. },
+                    ActivationDisposition::WorkYielded {
+                        target_work_item_id: Some(target_work_item_id),
+                        ..
+                    },
+                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Yield {
+                    target_work_item_id: target_work_item_id.clone(),
+                }),
+                (
+                    ExecutionBinding::WorkItem { .. },
+                    ActivationDisposition::WorkFailed { failure_policy },
+                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Failed {
+                    policy: failure_policy.clone(),
+                }),
+                (
+                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
+                    ActivationDisposition::ConversationReplied
+                    | ActivationDisposition::WorkContinues
+                    | ActivationDisposition::ReducedOnly,
+                ) => ExecutionOutcome::Conversation(ConversationOutcome::Replied),
+                (
+                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
+                    ActivationDisposition::WorkWaits { wait },
+                ) => ExecutionOutcome::Conversation(ConversationOutcome::Wait {
+                    wait: WaitReference {
+                        wait_id: wait.id.clone(),
+                        generation: wait.generation,
+                    },
+                }),
+                (
+                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
+                    ActivationDisposition::WorkPaused { reason },
+                ) => ExecutionOutcome::Conversation(ConversationOutcome::Failed {
+                    policy: reason.clone(),
+                }),
+                (
+                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
+                    ActivationDisposition::WorkFailed { failure_policy },
+                ) => ExecutionOutcome::Conversation(ConversationOutcome::Failed {
+                    policy: failure_policy.clone(),
+                }),
+                (ExecutionBinding::Command, _) => {
+                    ExecutionOutcome::Command(CommandResult::Applied {
+                        references: settlement.evidence.clone(),
+                    })
+                }
+                _ => {
+                    return Err(anyhow!(
+                        "canonical settlement disposition is incompatible with execution binding"
+                    ))
+                }
+            };
+            ExecutionProtocolCommand::Settle(SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id,
+                    attempt_id: attempt.attempt_id.clone(),
+                    outcome,
+                    created_at: settlement.created_at.clone(),
+                },
+            })
+        }
+    };
+    Ok(command)
+}
+
+fn execution_protocol_interruption_transition(
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    attempt_id: &str,
+    reason: &str,
+    interrupted_at: String,
+) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+    use crate::domain::execution_protocol::{ExecutionProtocolCommand, InterruptExecution};
+
+    let Some(state) = runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized(agent_id)?
+    else {
+        return Ok(Default::default());
+    };
+    let Some(attempt) = state.attempts.get(attempt_id) else {
+        return Ok(Default::default());
+    };
+    if attempt.state != crate::domain::execution_protocol::ExecutionAttemptState::Open {
+        return Ok(Default::default());
+    }
+    Ok(
+        crate::runtime_db::transitions::ExecutionProtocolTransition {
+            bootstrap: None,
+            commands: vec![ExecutionProtocolCommand::Interrupt(InterruptExecution {
+                attempt_id: attempt_id.to_string(),
+                outcome_id: format!("outcome:interrupted-recovery:{attempt_id}"),
+                reason: reason.to_string(),
+                interrupted_at,
+            })],
+        },
+    )
+}
+
+fn execution_attempt_for_message<'a>(
+    state: &'a crate::domain::execution_protocol::ExecutionProtocolState,
+    message_id: &str,
+) -> Option<&'a crate::domain::execution_protocol::ExecutionAttempt> {
+    state
+        .attempts
+        .values()
+        .filter(|attempt| attempt.source_message_id.as_deref() == Some(message_id))
+        .max_by(|left, right| {
+            left.admitted_at
+                .cmp(&right.admitted_at)
+                .then_with(|| left.attempt_id.cmp(&right.attempt_id))
+        })
+}
+
+fn adopt_pre_execution_protocol_attempt(
+    runtime_db: &RuntimeDb,
+    storage: &AppStorage,
+    agent_id: &str,
+    message: &MessageEnvelope,
+    activation_id: &str,
+    snapshot: &crate::domain::scheduler_protocol::Snapshot,
+) -> Result<(
+    crate::domain::execution_protocol::ExecutionAttempt,
+    crate::runtime_db::transitions::ExecutionProtocolTransition,
+)> {
+    use crate::domain::execution_protocol::{
+        AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding,
+        ExecutionPriority, ExecutionProtocolCommand, ExecutionProtocolState, ExecutionProvenance,
+        ExecutionSource, ExecutionSourceIdentity, RegisterWorkItemExecution,
+        WorkItemExecutionRecord, WorkItemExecutionState,
+    };
+    use crate::domain::scheduler_protocol::SchedulerOwner;
+
+    let _admission = snapshot
+        .activation_admissions
+        .get(activation_id)
+        .ok_or_else(|| anyhow!("legacy activation {activation_id} has no canonical admission"))?;
+    let activation = snapshot
+        .activations
+        .get(activation_id)
+        .ok_or_else(|| anyhow!("legacy activation {activation_id} is missing"))?;
+    let source_revision = message
+        .message_seq
+        .filter(|revision| *revision > 0)
+        .ok_or_else(|| anyhow!("legacy execution adoption requires message sequence"))?;
+    let authority_fences = runtime_db
+        .transitions()
+        .load_execution_authority_fences(agent_id)?;
+    let mut commands = Vec::with_capacity(2);
+    let (binding, work_item_source_revision, work_item_generation) = match &activation.owner {
+        SchedulerOwner::WorkItem { work_item_id } => {
+            let work_item = storage
+                .latest_work_item(work_item_id)?
+                .ok_or_else(|| anyhow!("legacy execution adoption WorkItem is missing"))?;
+            let generation = activation.admitted_generation.max(1);
+            commands.push(ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                RegisterWorkItemExecution {
+                    work_item_id: work_item_id.clone(),
+                    record: WorkItemExecutionRecord {
+                        source_revision: work_item.revision.max(1),
+                        state: WorkItemExecutionState::Runnable {
+                            generation,
+                            recovery_ref: Some("pre_execution_protocol_upgrade".into()),
+                        },
+                    },
+                },
+            )));
+            (
+                ExecutionBinding::WorkItem {
+                    work_item_id: work_item_id.clone(),
+                },
+                Some(work_item.revision.max(1)),
+                Some(generation),
+            )
+        }
+        SchedulerOwner::AgentLifecycle {
+            agent_id: owner_agent_id,
+        } if owner_agent_id == agent_id => (
+            ExecutionBinding::AgentLifecycle {
+                agent_id: agent_id.to_string(),
+            },
+            None,
+            None,
+        ),
+        SchedulerOwner::AgentLifecycle { .. } => {
+            bail!("legacy execution adoption lifecycle owner does not match partition")
+        }
+    };
+    let attempt = ExecutionAttempt {
+        attempt_id: activation_id.to_string(),
+        agent_id: agent_id.to_string(),
+        source_message_id: Some(message.id.clone()),
+        source: ExecutionSource {
+            identity: ExecutionSourceIdentity::QueueMessage {
+                message_id: message.id.clone(),
+            },
+            generation: source_revision,
+        },
+        binding,
+        provenance: ExecutionProvenance {
+            origin: scheduler_executor::canonical_execution_origin(message),
+            trust: scheduler_executor::canonical_execution_trust(message),
+            priority: match message.priority {
+                Priority::Interject => ExecutionPriority::Interject,
+                Priority::Next => ExecutionPriority::Next,
+                Priority::Normal => ExecutionPriority::Normal,
+                Priority::Background => ExecutionPriority::Background,
+            },
+            correlation_id: message.correlation_id.clone(),
+            causation_id: message.causation_id.clone(),
+        },
+        admitted_fences: AdmittedFences {
+            source_revision,
+            work_item_source_revision,
+            work_item_generation,
+            rejoin: None,
+            agent_control_revision: authority_fences.agent_control_revision,
+            host_registry_revision: authority_fences.host_registry_revision,
+        },
+        state: ExecutionAttemptState::Open,
+        run_id: None,
+        turn_id: message.turn_id.clone(),
+        recovery_of_attempt_id: None,
+        terminal_outcome_id: None,
+        admitted_at: message.created_at.to_rfc3339(),
+        terminal_at: None,
+    };
+    commands.push(ExecutionProtocolCommand::Admit(Box::new(AdmitExecution {
+        attempt: attempt.clone(),
+    })));
+    Ok((
+        attempt,
+        crate::runtime_db::transitions::ExecutionProtocolTransition {
+            bootstrap: Some(ExecutionProtocolState::empty(agent_id)),
+            commands,
+        },
+    ))
+}
+
+fn compatibility_settlement_command(
+    snapshot: &crate::domain::scheduler_protocol::Snapshot,
+    activation_id: &str,
+) -> Option<crate::domain::scheduler_protocol::ProtocolCommand> {
+    snapshot
+        .settlements
+        .values()
+        .find(|settlement| settlement.activation_id == activation_id)
+        .cloned()
+        .map(|settlement| {
+            crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(
+                crate::domain::scheduler_protocol::SettleActivationCommand { settlement },
+            )
+        })
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SchedulerRecoveryReport {
     pub agent_id: String,
     pub partition_initialized: bool,
+    pub authority_inventory: Vec<SchedulerAuthorityInventoryEntry>,
     pub retired_rollout_metadata: SchedulerRetiredRolloutMetadata,
     pub candidates: Vec<SchedulerRecoveryCandidate>,
     pub legacy_adoptions: Vec<SchedulerLegacyAdoptionCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerAuthorityInventoryEntry {
+    pub storage: String,
+    pub role: String,
+    pub canonical_reader: bool,
+    pub target: String,
+    pub row_count: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -890,10 +1338,10 @@ pub enum SchedulerRecoveryCandidateKind {
 
 fn canonical_settlement_recovery_commands(
     snapshot: &crate::domain::scheduler_protocol::Snapshot,
-    agent_id: &str,
-    work_item_id: &str,
+    _agent_id: &str,
+    _work_item_id: &str,
     missing_activation_id: &str,
-    target_demand: Option<(String, crate::domain::scheduler_protocol::WorkDemand)>,
+    _target_demand: Option<(String, crate::domain::scheduler_protocol::WorkDemand)>,
     resolution: Option<(
         crate::domain::scheduler_protocol::ActivationDisposition,
         Option<String>,
@@ -903,73 +1351,55 @@ fn canonical_settlement_recovery_commands(
     created_at: String,
 ) -> Vec<crate::domain::scheduler_protocol::ProtocolCommand> {
     use crate::domain::scheduler_protocol::{
-        ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
-        ActivationPriority, ActivationProvenance, ActivationSettlement, ActivationTrust,
-        AdmitActivationCommand, AgentActivation, AgentDispatchDisposition, MissingSettlementRecord,
-        PreemptionPolicy, ProtocolCommand, RegisterWorkDemandCommand, SettleActivationCommand,
+        ActivationDisposition, ActivationSettlement, AgentDispatchDisposition, ProtocolCommand,
+        RecoverInterruptedActivationCommand, SettleActivationCommand,
     };
-    let activation_id = format!("settlement-recovery:{missing_activation_id}");
-    let authority_id = format!("authority:{activation_id}");
-    let generation = snapshot.work[work_item_id].scheduling_generation;
-    let activation = AgentActivation {
-        id: activation_id.clone(),
-        agent_id: agent_id.to_string(),
-        state: ActivationLifecycleState::Admitted,
-        cause: ActivationCause::SettlementRecovery {
-            activation_id: missing_activation_id.to_string(),
-        },
-        binding: ActivationBinding::WorkItem {
-            work_item_id: work_item_id.to_string(),
-        },
-        priority: ActivationPriority::Interject,
-        preemption: PreemptionPolicy::AllowOperatorInterjection,
-        source_revision: None,
-        idempotency_key: activation_id.clone(),
-        provenance: ActivationProvenance {
-            origin: ActivationOrigin::RuntimeRecovery,
-            trust: ActivationTrust::RuntimeInstruction,
-            source_id: missing_activation_id.to_string(),
-            correlation_id: None,
-            causation_id: Some(missing_activation_id.to_string()),
-        },
-    };
-    let mut commands = Vec::new();
-    if let Some((target_work_item_id, demand)) = target_demand {
-        commands.push(ProtocolCommand::RegisterWorkDemand(
-            RegisterWorkDemandCommand {
-                work_item_id: target_work_item_id,
-                demand,
+    let resolution = resolution.unwrap_or_else(|| {
+        (
+            ActivationDisposition::Interrupted {
+                reason: "runtime_interrupted".into(),
             },
-        ));
-    }
-    commands.push(ProtocolCommand::AdmitActivation(AdmitActivationCommand {
-        authority_id,
-        activation,
-        expected_scheduling_generation: generation,
-        expected_dispatch_revision: snapshot.dispatch_revision,
-    }));
-    commands.push(match resolution {
-        Some((disposition, turn_terminal, operator_delivery, evidence)) => {
-            ProtocolCommand::SettleActivation(SettleActivationCommand {
-                settlement: ActivationSettlement {
-                    id: format!("settlement:{activation_id}"),
-                    activation_id,
-                    turn_terminal,
-                    disposition,
-                    agent_dispatch: AgentDispatchDisposition::Open,
-                    operator_delivery,
-                    evidence,
-                    created_at,
-                },
-            })
-        }
-        None => ProtocolCommand::RecordMissingSettlement(MissingSettlementRecord {
-            id: format!("missing-settlement:{activation_id}"),
-            activation_id,
-            created_at,
-        }),
+            None,
+            None,
+            Vec::new(),
+        )
     });
-    commands
+    let (disposition, turn_terminal, operator_delivery, mut evidence) = resolution;
+    evidence.push(format!("interrupted_attempt:{missing_activation_id}"));
+    evidence.push("recovery_policy:model_guided_reentry".into());
+    let settlement = ActivationSettlement {
+        id: format!("interrupted-recovery:{missing_activation_id}"),
+        activation_id: missing_activation_id.to_string(),
+        turn_terminal,
+        disposition,
+        agent_dispatch: AgentDispatchDisposition::Open,
+        operator_delivery,
+        evidence,
+        created_at,
+    };
+    match snapshot
+        .activations
+        .get(missing_activation_id)
+        .map(|activation| &activation.state)
+    {
+        Some(crate::domain::scheduler_protocol::ActivationState::Running) => {
+            vec![ProtocolCommand::SettleActivation(SettleActivationCommand {
+                settlement,
+            })]
+        }
+        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing) => {
+            let mut settlement = settlement;
+            settlement.turn_terminal = None;
+            settlement.operator_delivery = None;
+            settlement.disposition = ActivationDisposition::Interrupted {
+                reason: "legacy_missing_settlement_recovered".into(),
+            };
+            vec![ProtocolCommand::RecoverInterruptedActivation(
+                RecoverInterruptedActivationCommand { settlement },
+            )]
+        }
+        _ => Vec::new(),
+    }
 }
 
 pub fn scheduler_recovery_report(
@@ -977,6 +1407,18 @@ pub fn scheduler_recovery_report(
     runtime_db: &RuntimeDb,
     agent_id: &str,
 ) -> Result<SchedulerRecoveryReport> {
+    let authority_inventory = runtime_db
+        .transitions()
+        .inspect_scheduler_authority_inventory()?
+        .into_iter()
+        .map(|entry| SchedulerAuthorityInventoryEntry {
+            storage: entry.storage.to_string(),
+            role: entry.role.to_string(),
+            canonical_reader: entry.canonical_reader,
+            target: entry.target.to_string(),
+            row_count: entry.row_count,
+        })
+        .collect();
     let retired = runtime_db
         .transitions()
         .inspect_retired_scheduler_rollout_metadata()?;
@@ -1004,6 +1446,7 @@ pub fn scheduler_recovery_report(
         return Ok(SchedulerRecoveryReport {
             agent_id: agent_id.to_string(),
             partition_initialized: false,
+            authority_inventory,
             retired_rollout_metadata,
             candidates: Vec::new(),
             legacy_adoptions: runtime_db
@@ -1022,26 +1465,39 @@ pub fn scheduler_recovery_report(
     let all_queue_entries = runtime_db
         .queue_entries()
         .recent(Some(agent_id), usize::MAX)?;
+    let execution_state = runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized(agent_id)?;
     let active_continuations = runtime_db
         .work_item_continuations()
         .active_for_agent(agent_id)?;
     let mut candidates = Vec::new();
-    for (work_item_id, demand) in &snapshot.work {
-        let crate::domain::scheduler_protocol::WorkStatus::NeedsSettlement { activation_id } =
-            &demand.status
+    // Phase 5: execution attempts are the recovery authority. The scheduler
+    // snapshot remains only as the compatibility command target.
+    for attempt in execution_state
+        .as_ref()
+        .into_iter()
+        .flat_map(|state| state.attempts.values())
+        .filter(|attempt| {
+            attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Open
+        })
+    {
+        let crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } =
+            &attempt.binding
         else {
             continue;
         };
-        let Some(admission) = snapshot.activation_admissions.get(activation_id) else {
+        let Some(message_id) = attempt.source_message_id.clone() else {
             continue;
         };
-        let message_id = admission.activation.provenance.source_id.clone();
+        let activation_id = attempt.attempt_id.clone();
+        let work_item_id = work_item_id.clone();
         let queue_entry = all_queue_entries
             .iter()
             .find(|entry| entry.message_id == message_id);
         let message = storage.read_message_by_id(&message_id)?;
         let frame = active_continuations.iter().find(|frame| {
-            frame.suspended_work_item_id == *work_item_id
+            frame.suspended_work_item_id == work_item_id
                 && frame.turn_id.as_deref()
                     == message
                         .as_ref()
@@ -1049,7 +1505,8 @@ pub fn scheduler_recovery_report(
         });
         let mut evidence = vec![
             format!("work_item:{work_item_id}"),
-            format!("missing_activation:{activation_id}"),
+            format!("open_execution_attempt:{activation_id}"),
+            format!("source_generation:{}", attempt.source.generation),
         ];
         let mut target_demand = None;
         let (resolution, terminal_turn_id, reason) = if let Some(frame) = frame {
@@ -1059,34 +1516,32 @@ pub fn scheduler_recovery_report(
                 format!("target_work_item:{}", frame.active_work_item_id),
             ]);
             let target_generation =
-                if let Some(target) = snapshot.work.get(&frame.active_work_item_id) {
-                    (target.status == crate::domain::scheduler_protocol::WorkStatus::Runnable)
-                        .then_some(target.scheduling_generation)
-                } else {
-                    storage
-                        .latest_work_item(&frame.active_work_item_id)?
-                        .filter(|target| {
-                            target.agent_id == agent_id
-                                && target.state == crate::types::WorkItemState::Open
-                                && target.readiness() == crate::types::WorkItemReadiness::Runnable
-                        })
-                        .map(|target| {
-                            let generation = target.revision.max(1);
-                            target_demand = Some((
-                                target.id,
-                                crate::domain::scheduler_protocol::WorkDemand {
-                                    metadata_revision: generation,
-                                    scheduling_generation: generation,
-                                    status: crate::domain::scheduler_protocol::WorkStatus::Runnable,
-                                    capabilities: Default::default(),
-                                    locks: Default::default(),
-                                    locality: "runtime".into(),
-                                    cost_class: "default".into(),
-                                },
-                            ));
-                            generation
-                        })
-                };
+                // Phase 4: read target WorkItem state from storage authority
+                // instead of the WorkDemand mirror.
+                storage
+                    .latest_work_item(&frame.active_work_item_id)?
+                    .filter(|target| {
+                        target.agent_id == agent_id
+                            && target.state == crate::types::WorkItemState::Open
+                            && target.readiness() == crate::types::WorkItemReadiness::Runnable
+                    })
+                    .map(|target| {
+                        let generation = target.revision.max(1);
+                        target_demand = Some((
+                            target.id,
+                            crate::domain::scheduler_protocol::WorkDemand {
+                                metadata_revision: generation,
+                                scheduling_generation: generation,
+                                status:
+                                    crate::domain::scheduler_protocol::WorkStatus::Runnable,
+                                capabilities: Default::default(),
+                                locks: Default::default(),
+                                locality: "runtime".into(),
+                                cost_class: "default".into(),
+                            },
+                        ));
+                        generation
+                    });
             let resolution = target_generation.map(|target_generation| {
                 (
                     crate::domain::scheduler_protocol::ActivationDisposition::WorkYielded {
@@ -1103,9 +1558,9 @@ pub fn scheduler_recovery_report(
                 resolution,
                 frame.turn_id.clone(),
                 if target_generation.is_some() {
-                    "needs_settlement_continuation"
+                    "terminal_turn_settlement"
                 } else {
-                    "needs_settlement_continuation_target_unavailable"
+                    "open_attempt_continuation_target_unavailable"
                 },
             )
         } else if let Some(entry) = queue_entry {
@@ -1118,6 +1573,14 @@ pub fn scheduler_recovery_report(
             {
                 [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command)] => {
                     evidence.extend(command.settlement.evidence.clone());
+                    let reason = if matches!(
+                        command.settlement.disposition,
+                        crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
+                    ) {
+                        "terminal_turn_missing"
+                    } else {
+                        "terminal_turn_settlement"
+                    };
                     (
                         Some((
                             command.settlement.disposition.clone(),
@@ -1126,13 +1589,18 @@ pub fn scheduler_recovery_report(
                             evidence.clone(),
                         )),
                         command.settlement.turn_terminal.clone(),
-                        "needs_settlement_persisted_evidence",
+                        reason,
                     )
                 }
-                _ => (None, None, "needs_settlement_evidence_missing"),
+                _ => (None, None, "open_attempt_evidence_missing"),
             }
         } else {
-            (None, None, "needs_settlement_evidence_missing")
+            (None, None, "open_attempt_evidence_missing")
+        };
+        let target_queue_status = match reason {
+            "terminal_turn_settlement" => Some(QueueEntryStatus::Processed),
+            "terminal_turn_missing" => Some(QueueEntryStatus::Interrupted),
+            _ => None,
         };
         candidates.push(SchedulerRecoveryCandidate {
             kind: SchedulerRecoveryCandidateKind::NeedsSettlement,
@@ -1145,13 +1613,13 @@ pub fn scheduler_recovery_report(
             terminal_turn_id: terminal_turn_id.clone(),
             eligible: true,
             reason: reason.into(),
-            target_queue_status: None,
+            target_queue_status,
             evidence: evidence.clone(),
             proposed_commands: canonical_settlement_recovery_commands(
                 &snapshot,
                 agent_id,
-                work_item_id,
-                activation_id,
+                &work_item_id,
+                &activation_id,
                 target_demand,
                 resolution,
                 queue_entry
@@ -1179,7 +1647,12 @@ pub fn scheduler_recovery_report(
         .collect::<Vec<_>>();
     entries.sort_by(|left, right| left.message_id.cmp(&right.message_id));
     for entry in entries {
-        let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
+        let attempt = execution_state
+            .as_ref()
+            .and_then(|state| execution_attempt_for_message(state, &entry.message_id));
+        let activation_id = attempt
+            .map(|attempt| attempt.attempt_id.clone())
+            .unwrap_or_else(|| scheduler_executor::canonical_activation_id(&entry.message_id));
         let mut candidate = SchedulerRecoveryCandidate {
             kind: SchedulerRecoveryCandidateKind::LegacyDequeued,
             message_id: entry.message_id.clone(),
@@ -1193,23 +1666,29 @@ pub fn scheduler_recovery_report(
             evidence: vec!["queue_status=dequeued".into()],
             proposed_commands: Vec::new(),
         };
-        let Some(activation) = snapshot.activations.get(&activation_id) else {
+        let Some(attempt) = attempt else {
+            candidate.reason = "execution_attempt_missing".into();
             candidates.push(candidate);
             continue;
         };
-        let Some(work_item_id) = activation.owner.work_item_id() else {
+        // Open execution attempts were already emitted by the authority scan.
+        if candidates.iter().any(|c| c.activation_id == activation_id) {
+            continue;
+        }
+        let crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } =
+            &attempt.binding
+        else {
             candidate.reason = "lifecycle_activation_not_legacy_work_queue_claim".into();
             candidates.push(candidate);
             continue;
         };
-        candidate.work_item_id = Some(work_item_id.to_string());
+        candidate.work_item_id = Some(work_item_id.clone());
         candidate
             .evidence
-            .push(format!("activation_state={:?}", activation.state));
-        candidate.evidence.push(format!(
-            "admitted_generation={}",
-            activation.admitted_generation
-        ));
+            .push(format!("execution_attempt_state={:?}", attempt.state));
+        candidate
+            .evidence
+            .push(format!("source_generation={}", attempt.source.generation));
         let Some(message) = storage.read_message_by_id(&entry.message_id)? else {
             candidate.reason = "message_missing".into();
             candidates.push(candidate);
@@ -1224,7 +1703,7 @@ pub fn scheduler_recovery_report(
             candidates.push(candidate);
             continue;
         }
-        if message.work_item_id.as_deref() != Some(work_item_id) {
+        if message.work_item_id.as_deref() != Some(work_item_id.as_str()) {
             candidate.reason = "work_item_binding_mismatch".into();
             candidates.push(candidate);
             continue;
@@ -1238,7 +1717,7 @@ pub fn scheduler_recovery_report(
                     .and_then(|trigger| trigger.message_id.as_deref())
                     == Some(entry.message_id.as_str())
                 && message.turn_id.as_deref() == Some(turn.turn_id.as_str())
-                && turn.current_work_item_id.as_deref() == Some(work_item_id)
+                && turn.current_work_item_id.as_deref() == Some(work_item_id.as_str())
         });
         candidate.terminal_turn_id = terminal_turn.map(|turn| turn.turn_id.clone());
         let terminal_is_completed = terminal_turn.is_some_and(|turn| {
@@ -1246,9 +1725,9 @@ pub fn scheduler_recovery_report(
                 .as_ref()
                 .is_some_and(|terminal| terminal.kind == crate::types::TurnTerminalKind::Completed)
         });
-        if activation.state == crate::domain::scheduler_protocol::ActivationState::Settled {
+        if attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Settled {
             candidate.eligible = true;
-            candidate.reason = "canonical_settlement_legacy_queue_pending".into();
+            candidate.reason = "execution_settlement_legacy_queue_pending".into();
             candidate.target_queue_status = Some(if terminal_is_completed {
                 QueueEntryStatus::Processed
             } else {
@@ -1257,10 +1736,13 @@ pub fn scheduler_recovery_report(
             candidates.push(candidate);
             continue;
         }
-        if activation.state == crate::domain::scheduler_protocol::ActivationState::SettlementMissing
-        {
+        if matches!(
+            attempt.state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+                | crate::domain::execution_protocol::ExecutionAttemptState::ProtocolViolation
+        ) {
             candidate.eligible = true;
-            candidate.reason = "canonical_missing_settlement_legacy_queue_pending".into();
+            candidate.reason = "execution_interruption_legacy_queue_pending".into();
             candidate.target_queue_status = Some(QueueEntryStatus::Aborted);
             candidates.push(candidate);
             continue;
@@ -1310,6 +1792,7 @@ pub fn scheduler_recovery_report(
     Ok(SchedulerRecoveryReport {
         agent_id: agent_id.to_string(),
         partition_initialized: true,
+        authority_inventory,
         retired_rollout_metadata,
         candidates,
         legacy_adoptions: runtime_db
@@ -3118,9 +3601,11 @@ impl RuntimeHandle {
                     .transitions()
                     .load_scheduler_protocol_snapshot_if_initialized(&record.agent_id)?
                 {
-                    let activation_id =
-                        scheduler_executor::canonical_activation_id(&record.message_id);
-                    if let Some(activation) = snapshot.activations.get(&activation_id) {
+                    if let Some(activation_id) = scheduler_executor::canonical_open_activation_id(
+                        &snapshot,
+                        &record.message_id,
+                    ) {
+                        let activation = &snapshot.activations[&activation_id];
                         let terminal_turn =
                             terminal_transition.map(|transition| &transition.turn_record);
                         if canonical_matching_terminal_turn(
@@ -3150,6 +3635,15 @@ impl RuntimeHandle {
             .await?
         } else {
             Vec::new()
+        };
+        let execution_protocol = if self.inner.scheduler_engine.is_canonical() {
+            execution_protocol_settlement_transition(
+                &self.inner.runtime_db,
+                &record.agent_id,
+                &scheduler_protocol_commands,
+            )?
+        } else {
+            Default::default()
         };
         let original_audit_len = audit_events.len();
         let mut command = crate::runtime_db::transitions::QueueTransitionCommand {
@@ -3200,7 +3694,12 @@ impl RuntimeHandle {
                     .push(Self::turn_record_audit_event(&transition.turn_record));
             }
             command.fault = self.take_transition_fault();
-            match self.inner.runtime_db.transitions().commit_queue(&command) {
+            match self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_queue_with_execution_protocol(&command, &execution_protocol)
+            {
                 Ok(commit) => {
                     return Ok(self.apply_transition_commit(commit).await.applied);
                 }
@@ -3307,6 +3806,9 @@ impl RuntimeHandle {
                 }
                 scheduler_executor::RunLoopPoll::Message(scheduled) => scheduled,
                 scheduler_executor::RunLoopPoll::Idle => {
+                    let notified = self.inner.notify.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
                     if self.maybe_emit_pending_system_tick(None).await? {
                         continue;
                     }
@@ -3340,18 +3842,19 @@ impl RuntimeHandle {
                     let idle_state = scheduler_executor::SchedulerDecisionExecutor::new(&self)
                         .transition_run_loop_idle_to_sleep(next_recheck_at)
                         .await?;
-                    if let Some(idle_state) = idle_state {
-                        self.append_state_changed_events(&idle_state)?;
-                    }
+                    let Some(idle_state) = idle_state else {
+                        continue;
+                    };
+                    self.append_state_changed_events(&idle_state)?;
                     if let Some(next_recheck_at) = next_recheck_at {
                         if next_recheck_at > self.now() {
                             tokio::select! {
-                                _ = self.inner.notify.notified() => {}
+                                _ = &mut notified => {}
                                 _ = self.inner.clock.sleep_until(next_recheck_at) => {}
                             }
                         }
                     } else {
-                        self.inner.notify.notified().await;
+                        notified.await;
                     }
                     continue;
                 }
@@ -3633,17 +4136,10 @@ impl RuntimeHandle {
     }
 
     async fn release_claimed_messages_for_runtime_restart(&self) -> Result<usize> {
+        if self.inner.scheduler_engine.is_canonical() {
+            return Ok(0);
+        }
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        let canonical_activations = if self.inner.scheduler_engine.is_canonical() {
-            self.inner
-                .runtime_db
-                .transitions()
-                .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
-                .map(|snapshot| snapshot.activations)
-                .unwrap_or_default()
-        } else {
-            Default::default()
-        };
         let claimed = self
             .inner
             .runtime_db
@@ -3654,38 +4150,42 @@ impl RuntimeHandle {
             .collect::<Vec<_>>();
         let mut released = 0;
         for mut entry in claimed {
-            let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
-            if canonical_activations.contains_key(&activation_id) {
-                continue;
-            }
             entry.status = QueueEntryStatus::Interrupted;
             entry.updated_at = Utc::now();
             let message_id = entry.message_id.clone();
-            let commit = self.inner.runtime_db.transitions().commit_queue(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
-                    agent_id: agent_id.clone(),
-                    operation: crate::runtime_db::transitions::QueueOperation::Release,
-                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
-                    scheduler_claim_work_item: None,
-                    scheduler_protocol_bootstrap: None,
-                    scheduler_protocol_commands: Vec::new(),
-                    agent_state: None,
-                    message_evidence: Vec::new(),
-                    transcript_entries: Vec::new(),
-                    turn_record: None,
-                    audit_events: vec![AuditEvent::legacy(
-                        "queue_claim_released_for_runtime_restart",
-                        serde_json::json!({
-                            "agent_id": agent_id,
-                            "message_id": message_id,
-                            "status": QueueEntryStatus::Interrupted,
-                        }),
-                    )],
-                    notify_scheduler: true,
-                    fault: None,
-                    brief_evidence: Vec::new(),
-                },
-            )?;
+            let scheduler_protocol_commands = Vec::new();
+            let execution_protocol =
+                crate::runtime_db::transitions::ExecutionProtocolTransition::default();
+            let commit = self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_queue_with_execution_protocol(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Release,
+                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands,
+                        agent_state: None,
+                        message_evidence: Vec::new(),
+                        transcript_entries: Vec::new(),
+                        turn_record: None,
+                        audit_events: vec![AuditEvent::legacy(
+                            "queue_claim_released_for_runtime_restart",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "message_id": message_id,
+                                "status": QueueEntryStatus::Interrupted,
+                            }),
+                        )],
+                        notify_scheduler: true,
+                        fault: None,
+                        brief_evidence: Vec::new(),
+                    },
+                    &execution_protocol,
+                )?;
             if commit.applied {
                 released += 1;
             }
@@ -3738,14 +4238,16 @@ impl RuntimeHandle {
 
     async fn recover_scheduler_bootstrap_claims(&self) -> Result<usize> {
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        let Some(snapshot) = self
+        let snapshot = self
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
-        else {
-            return Ok(0);
-        };
+            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?;
+        let execution_state = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&agent_id)?;
         let claimed = self
             .inner
             .runtime_db
@@ -3764,20 +4266,48 @@ impl RuntimeHandle {
         for mut entry in claimed {
             let _guard = self.inner.agent.lock().await;
             let expected_entry = entry.clone();
-            let activation_id = scheduler_executor::canonical_activation_id(&entry.message_id);
-            let Some(activation) = snapshot.activations.get(&activation_id) else {
-                continue;
-            };
-            let work_item_id = activation.owner.work_item_id().map(ToString::to_string);
-            if activation
-                .owner
-                .lifecycle_agent_id()
-                .is_some_and(|owner_agent_id| owner_agent_id != agent_id)
-            {
-                continue;
-            }
             let Some(message) = self.inner.storage.read_message_by_id(&entry.message_id)? else {
                 continue;
+            };
+            let (attempt, adoption) = if let Some(attempt) = execution_state
+                .as_ref()
+                .and_then(|state| execution_attempt_for_message(state, &entry.message_id))
+            {
+                (
+                    attempt.clone(),
+                    crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+                )
+            } else {
+                let Some(snapshot) = snapshot.as_ref() else {
+                    continue;
+                };
+                let Some(activation_id) =
+                    scheduler_executor::canonical_open_activation_id(snapshot, &entry.message_id)
+                else {
+                    continue;
+                };
+                adopt_pre_execution_protocol_attempt(
+                    &self.inner.runtime_db,
+                    &self.inner.storage,
+                    &agent_id,
+                    &message,
+                    &activation_id,
+                    snapshot,
+                )?
+            };
+            let activation_id = attempt.attempt_id.clone();
+            let work_item_id = match &attempt.binding {
+                crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } => {
+                    Some(work_item_id.clone())
+                }
+                crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                    agent_id: owner_agent_id,
+                } if owner_agent_id == &agent_id => None,
+                crate::domain::execution_protocol::ExecutionBinding::Conversation { .. }
+                | crate::domain::execution_protocol::ExecutionBinding::Command => None,
+                crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle { .. } => {
+                    continue;
+                }
             };
             if let Some(work_item_id) = work_item_id.as_deref() {
                 if !matches!(
@@ -3805,9 +4335,9 @@ impl RuntimeHandle {
                     terminal.kind == crate::types::TurnTerminalKind::Completed
                 })
             });
-            // Canonical terminal states need no new protocol command; these
-            // branches only reconcile the legacy queue claim that remains.
-            if activation.state == crate::domain::scheduler_protocol::ActivationState::Settled {
+            // Execution attempt state is authoritative. Terminal attempts only
+            // reconcile the retained legacy queue claim.
+            if attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Settled {
                 entry.status = if terminal_is_completed {
                     QueueEntryStatus::Processed
                 } else {
@@ -3840,7 +4370,7 @@ impl RuntimeHandle {
                                 "activation_id": activation_id,
                                 "work_item_id": work_item_id,
                                 "queue_status": queue_status,
-                                "recovery_outcome": "legacy_queue_reconciled_from_canonical_settlement",
+                                "recovery_outcome": "legacy_queue_reconciled_from_execution_settlement",
                                 "terminal_turn_id": terminal_turn.map(|turn| turn.turn_id.clone()),
                                 "provenance": "bootstrap_reconciliation",
                             }),
@@ -3856,10 +4386,12 @@ impl RuntimeHandle {
                 self.apply_transition_commit(commit).await;
                 continue;
             }
-            if activation.state
-                == crate::domain::scheduler_protocol::ActivationState::SettlementMissing
-            {
-                entry.status = QueueEntryStatus::Aborted;
+            if matches!(
+                attempt.state,
+                crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+                    | crate::domain::execution_protocol::ExecutionAttemptState::ProtocolViolation
+            ) {
+                entry.status = QueueEntryStatus::Interrupted;
                 entry.updated_at = self.now();
                 let message_id = entry.message_id.clone();
                 let commit = self.inner.runtime_db.transitions().commit_queue(
@@ -3885,8 +4417,8 @@ impl RuntimeHandle {
                                 "message_id": message_id,
                                 "activation_id": activation_id,
                                 "work_item_id": work_item_id,
-                                "queue_status": QueueEntryStatus::Aborted,
-                                "recovery_outcome": "legacy_queue_reconciled_from_canonical_missing_settlement",
+                                "queue_status": QueueEntryStatus::Interrupted,
+                                "recovery_outcome": "legacy_queue_reconciled_from_execution_interruption",
                                 "terminal_turn_id": terminal_turn.map(|turn| turn.turn_id.clone()),
                                 "provenance": "bootstrap_reconciliation",
                             }),
@@ -3905,28 +4437,27 @@ impl RuntimeHandle {
             entry.status = if terminal_is_completed {
                 QueueEntryStatus::Processed
             } else {
-                QueueEntryStatus::Aborted
+                QueueEntryStatus::Interrupted
             };
             entry.updated_at = self.now();
-            let mut scheduler_protocol_commands = if terminal_is_completed {
-                self.canonical_queue_settlement_commands(&entry, terminal_turn)
-                    .await?
-            } else {
-                vec![
-                    crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(
-                        crate::domain::scheduler_protocol::MissingSettlementRecord {
-                            id: canonical_missing_settlement_id(&entry.message_id),
-                            activation_id: activation_id.clone(),
-                            created_at: entry.updated_at.to_rfc3339(),
-                        },
-                    ),
-                ]
+            let mut scheduler_protocol_commands = match snapshot.as_ref() {
+                Some(snapshot) => {
+                    if let Some(command) =
+                        compatibility_settlement_command(snapshot, &activation_id)
+                    {
+                        vec![command]
+                    } else {
+                        self.canonical_queue_settlement_commands(&entry, terminal_turn)
+                            .await?
+                    }
+                }
+                None => Vec::new(),
             };
             let settles_from_terminal =
                 canonical_commands_settle_from_terminal(&scheduler_protocol_commands);
             if !settles_from_terminal {
-                entry.status = QueueEntryStatus::Aborted;
-                if terminal_is_completed {
+                entry.status = QueueEntryStatus::Interrupted;
+                if terminal_is_completed && snapshot.is_some() {
                     scheduler_protocol_commands = canonical_queue_settlement_commands_from_facts(
                         &self.inner.storage,
                         &self.inner.runtime_db,
@@ -3935,19 +4466,21 @@ impl RuntimeHandle {
                     )?;
                 }
             }
-            let rejected =
-                canonical_command_batch_rejection(&snapshot, &scheduler_protocol_commands);
-            if let Some(diagnostics) = rejected {
-                self.inner.storage.append_event(
-                    &scheduler::scheduler_invariant_diagnostic_event(
-                        &agent_id,
-                        "bootstrap_recovery_command_rejected",
-                        work_item_id.clone(),
-                        Some(entry.message_id.clone()),
-                        diagnostics,
-                    )?,
-                )?;
-                continue;
+            if let Some(snapshot) = snapshot.as_ref() {
+                let rejected =
+                    canonical_command_batch_rejection(snapshot, &scheduler_protocol_commands);
+                if let Some(diagnostics) = rejected {
+                    self.inner.storage.append_event(
+                        &scheduler::scheduler_invariant_diagnostic_event(
+                            &agent_id,
+                            "bootstrap_recovery_command_rejected",
+                            work_item_id.clone(),
+                            Some(entry.message_id.clone()),
+                            diagnostics,
+                        )?,
+                    )?;
+                    continue;
+                }
             }
             let message_id = entry.message_id.clone();
             let queue_status = entry.status.clone();
@@ -3955,41 +4488,91 @@ impl RuntimeHandle {
             let recovery_outcome = if settles_from_terminal {
                 "settled_from_terminal_turn"
             } else {
-                "settlement_missing"
+                "attempt_interrupted_for_reentry"
             };
-            let commit = self.inner.runtime_db.transitions().commit_queue(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
-                    agent_id: agent_id.clone(),
-                    operation: crate::runtime_db::transitions::QueueOperation::Settle,
-                    mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
-                        expected: expected_entry,
-                        record: entry,
+            let execution_protocol = if adoption.bootstrap.is_some() {
+                let mut transition = adoption;
+                let command = if scheduler_protocol_commands.is_empty() {
+                    crate::domain::execution_protocol::ExecutionProtocolCommand::Interrupt(
+                        crate::domain::execution_protocol::InterruptExecution {
+                            attempt_id: activation_id.clone(),
+                            outcome_id: format!("outcome:interrupted-recovery:{activation_id}"),
+                            reason: "scheduler_compatibility_projection_missing".into(),
+                            interrupted_at: entry.updated_at.to_rfc3339(),
+                        },
+                    )
+                } else {
+                    let settlement = scheduler_protocol_commands
+                        .iter()
+                        .find_map(|command| match command {
+                            crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(
+                                command,
+                            ) => Some(&command.settlement),
+                            crate::domain::scheduler_protocol::ProtocolCommand::RecoverInterruptedActivation(
+                                command,
+                            ) => Some(&command.settlement),
+                            _ => None,
+                        })
+                        .ok_or_else(|| {
+                            anyhow!("legacy execution adoption requires typed settlement")
+                        })?;
+                    execution_protocol_settlement_command(&attempt, settlement)?
+                };
+                transition.commands.push(command);
+                transition
+            } else if scheduler_protocol_commands.is_empty() {
+                execution_protocol_interruption_transition(
+                    &self.inner.runtime_db,
+                    &agent_id,
+                    &activation_id,
+                    "scheduler_compatibility_projection_missing",
+                    entry.updated_at.to_rfc3339(),
+                )?
+            } else {
+                execution_protocol_settlement_transition(
+                    &self.inner.runtime_db,
+                    &agent_id,
+                    &scheduler_protocol_commands,
+                )?
+            };
+            let commit = self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_queue_with_execution_protocol(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                        mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                            expected: expected_entry,
+                            record: entry,
+                        },
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands,
+                        agent_state: None,
+                        message_evidence: Vec::new(),
+                        transcript_entries: Vec::new(),
+                        turn_record: terminal_turn.cloned(),
+                        audit_events: vec![AuditEvent::legacy(
+                            "scheduler_bootstrap_claim_recovered",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "message_id": message_id,
+                                "activation_id": activation_id,
+                                "work_item_id": work_item_id,
+                                "queue_status": queue_status,
+                                "recovery_outcome": recovery_outcome,
+                                "terminal_turn_id": terminal_turn_id,
+                                "provenance": "bootstrap_reconciliation",
+                            }),
+                        )],
+                        notify_scheduler: true,
+                        fault: self.take_transition_fault(),
+                        brief_evidence: Vec::new(),
                     },
-                    scheduler_claim_work_item: None,
-                    scheduler_protocol_bootstrap: None,
-                    scheduler_protocol_commands,
-                    agent_state: None,
-                    message_evidence: Vec::new(),
-                    transcript_entries: Vec::new(),
-                    turn_record: terminal_turn.cloned(),
-                    audit_events: vec![AuditEvent::legacy(
-                        "scheduler_bootstrap_claim_recovered",
-                        serde_json::json!({
-                            "agent_id": agent_id,
-                            "message_id": message_id,
-                            "activation_id": activation_id,
-                            "work_item_id": work_item_id,
-                            "queue_status": queue_status,
-                            "recovery_outcome": recovery_outcome,
-                            "terminal_turn_id": terminal_turn_id,
-                            "provenance": "bootstrap_reconciliation",
-                        }),
-                    )],
-                    notify_scheduler: true,
-                    fault: self.take_transition_fault(),
-                    brief_evidence: Vec::new(),
-                },
-            )?;
+                    &execution_protocol,
+                )?;
             if commit.applied {
                 recovered += 1;
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1049,8 +1049,8 @@ fn execution_protocol_settlement_command(
                 (
                     ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
                     ActivationDisposition::WorkPaused { reason },
-                ) => ExecutionOutcome::Conversation(ConversationOutcome::Failed {
-                    policy: reason.clone(),
+                ) => ExecutionOutcome::Conversation(ConversationOutcome::Paused {
+                    reason: reason.clone(),
                 }),
                 (
                     ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -238,6 +238,42 @@ impl RuntimeHandle {
         )
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_with_clock_and_scheduler_engine(
+        agent_id: impl Into<String>,
+        data_dir: PathBuf,
+        initial_workspace: impl Into<InitialWorkspaceBinding>,
+        callback_base_url: String,
+        provider: Arc<dyn AgentProvider>,
+        default_agent_id: String,
+        context_config: ContextConfig,
+        scheduler_engine: crate::config::SchedulerEngineMode,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Self> {
+        let base_context_config = context_config.clone();
+        Self::new_internal(
+            agent_id,
+            data_dir,
+            initial_workspace,
+            callback_base_url,
+            provider,
+            default_agent_id,
+            base_context_config,
+            context_config,
+            RuntimeModelCatalog::default(),
+            Vec::new(),
+            crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
+            crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS,
+            crate::web::WebConfig::default(),
+            None,
+            None,
+            None,
+            None,
+            scheduler_engine,
+            clock,
+        )
+    }
+
     pub(crate) fn new_static_with_host_bridge(
         agent_id: impl Into<String>,
         data_dir: PathBuf,
@@ -868,6 +904,20 @@ fn prepare_runtime_storage(
         )?,
     };
     let storage = AppStorage::new_for_agent(data_dir, agent_id.clone(), runtime_db.clone())?;
+    #[cfg(test)]
+    if runtime_db.agent_identities().latest(&agent_id)?.is_none() {
+        runtime_db
+            .agent_identities()
+            .upsert(&crate::types::AgentIdentityRecord::new(
+                agent_id.clone(),
+                crate::types::AgentKind::Default,
+                crate::types::AgentVisibility::Public,
+                crate::types::AgentOwnership::SelfOwned,
+                crate::types::AgentProfilePreset::PublicNamed,
+                None,
+                None,
+            ))?;
+    }
     let initial_workspace = initial_workspace.into();
     let initial_workspace_entry = match &initial_workspace {
         InitialWorkspaceBinding::Entry(entry) => Some(entry.clone()),

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -575,6 +575,7 @@ impl RuntimeHandle {
             None,
             false,
         );
+        let detail = self.task_creation_detail(&task_id, detail).await?;
         let diagnostics = self.command_cost_diagnostics_for(&resolved.spec);
         let work_item_id = self.task_work_item_binding().await;
         let task = TaskRecord {
@@ -856,13 +857,16 @@ impl RuntimeHandle {
                 parent_message_id: None,
                 work_item_id: task_record.work_item_id.clone(),
                 summary: task_record.summary.clone(),
-                detail: Some(command_task_detail(
-                    resolved,
-                    promoted_from_exec_command,
-                    captured,
-                    None,
-                    None,
-                    false,
+                detail: Some(self.task_detail_preserving_rejoin_contract(
+                    task_record,
+                    command_task_detail(
+                        resolved,
+                        promoted_from_exec_command,
+                        captured,
+                        None,
+                        None,
+                        false,
+                    ),
                 )),
                 recovery: task_record.recovery.clone(),
             };
@@ -952,7 +956,7 @@ impl RuntimeHandle {
             parent_message_id: parent_message_id.map(ToString::to_string),
             work_item_id: task_record.work_item_id.clone(),
             summary: task_record.summary.clone(),
-            detail: Some(detail),
+            detail: Some(self.task_detail_preserving_rejoin_contract(task_record, detail)),
             recovery: task_record.recovery.clone(),
         };
         self.apply_task_transition_silent(task_state_reducer::TaskTransition::new(

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1141,10 +1141,18 @@ pub(crate) fn canonical_activation_candidate(
         }));
     }
     if message.kind == MessageKind::InternalFollowup {
-        return Ok(message
-            .work_item_id
-            .clone()
-            .map(|work_item_id| CanonicalActivationCandidate::InternalFollowup { work_item_id }));
+        return Ok(if let Some(work_item_id) = message.work_item_id.clone() {
+            Some(CanonicalActivationCandidate::InternalFollowup { work_item_id })
+        } else if message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
+            && message.admission_context == Some(AdmissionContext::RuntimeOwned)
+            && matches!(message.origin, MessageOrigin::Task { .. })
+        {
+            Some(CanonicalActivationCandidate::LifecycleExternalNudge {
+                agent_id: message.agent_id.clone(),
+            })
+        } else {
+            None
+        });
     }
     if message.kind == MessageKind::TaskResult {
         let MessageOrigin::Task { task_id } = &message.origin else {
@@ -1257,7 +1265,7 @@ pub(crate) fn resolve_canonical_activation_scenario(
         }));
     }
 
-    let matching_waits = match &candidate {
+    let mut matching_waits = match &candidate {
         CanonicalActivationCandidate::ExactWaitResume {
             correlated_wait: Some((wait_id, generation)),
             ..
@@ -1267,7 +1275,7 @@ pub(crate) fn resolve_canonical_activation_scenario(
             .filter(|condition| {
                 condition.id == *wait_id
                     && condition.status == WaitConditionStatus::Active
-                    && projection.canonical_wait_generations.get(wait_id) == Some(generation)
+                    && *generation > 0
                     && condition.work_item_id.as_deref() == candidate.expected_work_item_id()
             })
             .collect(),
@@ -1285,11 +1293,21 @@ pub(crate) fn resolve_canonical_activation_scenario(
             {
                 waits.retain(|wait| wait.work_item_id.is_none());
             }
-            waits.retain(|wait| projection.canonical_wait_generations.contains_key(&wait.id));
             waits
         }
     };
-    if matching_waits.len() > 1 {
+    if matching_waits.len() > 1
+        && matches!(
+            candidate,
+            CanonicalActivationCandidate::ExactTaskRejoin { .. }
+        )
+        && projection.canonical_work_statuses.is_none()
+    {
+        // The durable task rejoin fence is authoritative. Before the canonical
+        // scheduler partition exists, duplicate legacy wait rows are mirrors
+        // and must not make the exact task identity ambiguous.
+        matching_waits.clear();
+    } else if matching_waits.len() > 1 {
         return Err(anyhow::Error::new(AmbiguousCanonicalWaits {
             message_id: message.id.clone(),
             wait_condition_ids: matching_waits.iter().map(|wait| wait.id.clone()).collect(),
@@ -1400,6 +1418,9 @@ fn matching_wait_conditions_for_work_item<'a>(
                         && condition.work_item_id == message.work_item_id
                         && resolved_task_wait_is_current(projection, condition)))
                 && message_matches_wait_condition(message, condition)
+                && (!(message.kind == MessageKind::TaskResult
+                    && condition.kind == WaitConditionKind::Task)
+                    || resolved_task_wait_is_current(projection, condition))
         })
         .collect()
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -204,6 +204,8 @@ impl SchedulerProjection {
         wait_id: impl Into<String>,
         generation: u64,
     ) {
+        self.canonical_work_statuses
+            .get_or_insert_with(HashMap::new);
         self.canonical_wait_generations
             .insert(wait_id.into(), generation);
     }
@@ -1276,6 +1278,8 @@ pub(crate) fn resolve_canonical_activation_scenario(
                 condition.id == *wait_id
                     && condition.status == WaitConditionStatus::Active
                     && *generation > 0
+                    && (projection.canonical_work_statuses.is_none()
+                        || projection.canonical_wait_generations.get(wait_id) == Some(generation))
                     && condition.work_item_id.as_deref() == candidate.expected_work_item_id()
             })
             .collect(),

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1145,10 +1145,7 @@ pub(crate) fn canonical_activation_candidate(
     if message.kind == MessageKind::InternalFollowup {
         return Ok(if let Some(work_item_id) = message.work_item_id.clone() {
             Some(CanonicalActivationCandidate::InternalFollowup { work_item_id })
-        } else if message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
-            && message.admission_context == Some(AdmissionContext::RuntimeOwned)
-            && matches!(message.origin, MessageOrigin::Task { .. })
-        {
+        } else if runtime_owned_task_followup(message) {
             Some(CanonicalActivationCandidate::LifecycleExternalNudge {
                 agent_id: message.agent_id.clone(),
             })
@@ -1243,6 +1240,13 @@ pub(crate) fn canonical_activation_candidate(
     }
 
     Ok(None)
+}
+
+pub(crate) fn runtime_owned_task_followup(message: &MessageEnvelope) -> bool {
+    message.kind == MessageKind::InternalFollowup
+        && message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
+        && message.admission_context == Some(AdmissionContext::RuntimeOwned)
+        && matches!(message.origin, MessageOrigin::Task { .. })
 }
 
 pub(crate) fn resolve_canonical_activation_scenario(

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1,5 +1,6 @@
 use super::message_dispatch::MessageDispatchPlan;
 use super::*;
+use crate::domain::scheduler_protocol::WaitState;
 use crate::types::ExecutionAdmissionProvenance;
 
 pub(super) enum RunLoopPoll {
@@ -17,6 +18,33 @@ impl RunLoopPoll {
             RunLoopPoll::Message(_) => "message",
             RunLoopPoll::Idle => "idle",
         }
+    }
+}
+
+pub(super) fn canonical_execution_origin(
+    message: &MessageEnvelope,
+) -> crate::domain::execution_protocol::ExecutionOrigin {
+    use crate::domain::execution_protocol::ExecutionOrigin;
+    match message.origin {
+        MessageOrigin::Operator { .. } => ExecutionOrigin::Operator,
+        MessageOrigin::Channel { .. } => ExecutionOrigin::Channel,
+        MessageOrigin::Webhook { .. } => ExecutionOrigin::Webhook,
+        MessageOrigin::Callback { .. } => ExecutionOrigin::Callback,
+        MessageOrigin::Timer { .. } => ExecutionOrigin::Timer,
+        MessageOrigin::System { .. } => ExecutionOrigin::System,
+        MessageOrigin::Task { .. } => ExecutionOrigin::Task,
+    }
+}
+
+pub(super) fn canonical_execution_trust(
+    message: &MessageEnvelope,
+) -> crate::domain::execution_protocol::ExecutionTrust {
+    use crate::domain::execution_protocol::ExecutionTrust;
+    match message.authority_class {
+        crate::types::AuthorityClass::OperatorInstruction => ExecutionTrust::OperatorInstruction,
+        crate::types::AuthorityClass::RuntimeInstruction => ExecutionTrust::RuntimeInstruction,
+        crate::types::AuthorityClass::IntegrationSignal => ExecutionTrust::IntegrationSignal,
+        crate::types::AuthorityClass::ExternalEvidence => ExecutionTrust::ExternalEvidence,
     }
 }
 
@@ -76,21 +104,46 @@ pub(super) struct ScheduledMessage {
 }
 
 struct CanonicalClaimPlan {
+    activation_id: String,
     scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
     execution_owner: crate::domain::scheduler_protocol::SchedulerOwner,
     scheduler_claim_work_item: Option<crate::types::WorkItemRecord>,
     bootstrap: Option<crate::domain::scheduler_protocol::Snapshot>,
     commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
+    execution_protocol: crate::runtime_db::transitions::ExecutionProtocolTransition,
 }
 
 enum CanonicalClaimOutcome {
-    NotApplicable,
+    ReduceOnly,
     Plan(CanonicalClaimPlan),
     RetainQueued {
         scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
         reason: &'static str,
     },
     HardBlocker(CanonicalClaimHardBlocker),
+}
+
+fn projected_scheduler_dispatch_revision(
+    snapshot: &crate::domain::scheduler_protocol::Snapshot,
+    commands: &[crate::domain::scheduler_protocol::ProtocolCommand],
+) -> Result<u64> {
+    let mut projected = snapshot.clone();
+    for command in commands {
+        let outcome = crate::domain::scheduler_protocol::reduce_command(&projected, command);
+        if outcome.outcome.decision == crate::domain::scheduler_protocol::Decision::Rejected {
+            let diagnostic = outcome
+                .conflict
+                .as_ref()
+                .map(|conflict| conflict.code.as_str())
+                .or_else(|| outcome.outcome.diagnostics.first().map(String::as_str))
+                .unwrap_or("rejected_without_diagnostic");
+            anyhow::bail!(
+                "canonical scheduler claim prefix rejected while projecting dispatch revision: {diagnostic}"
+            );
+        }
+        projected = outcome.outcome.snapshot;
+    }
+    Ok(projected.dispatch_revision)
 }
 
 struct CanonicalClaimHardBlocker {
@@ -410,8 +463,13 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .read_message_by_id(&candidate.message.id)?
             .ok_or_else(|| anyhow!("claimed message is missing persisted ingress evidence"))?;
         let canonical_claim = if self.runtime.inner.scheduler_engine.is_canonical() {
-            match self.canonical_activation_plan(&projection, &persisted_message, &dispatch_plan) {
-                Ok(CanonicalClaimOutcome::NotApplicable) => None,
+            match self.canonical_activation_plan(
+                &projection,
+                &persisted_message,
+                &dispatch_plan,
+                legacy_decision.model_reentry,
+            ) {
+                Ok(CanonicalClaimOutcome::ReduceOnly) => None,
                 Ok(CanonicalClaimOutcome::Plan(plan)) => Some(plan),
                 Ok(CanonicalClaimOutcome::RetainQueued {
                     scenario_class,
@@ -463,7 +521,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             dispatch_plan.execution_admission_provenance =
                 ExecutionAdmissionProvenance::Canonical {
                     scenario_class: plan.scenario_class,
-                    activation_id: canonical_activation_id(&persisted_message.id),
+                    activation_id: plan.activation_id.clone(),
                 };
         }
         let effective_decision = canonical_claim
@@ -475,10 +533,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 )
                 .message(&persisted_message)
                 .model_reentry(true)
-                .evidence(format!(
-                    "canonical_activation={}",
-                    canonical_activation_id(&persisted_message.id)
-                ));
+                .evidence(format!("canonical_activation={}", plan.activation_id));
                 if let Some(work_item_id) = plan.execution_owner.work_item_id() {
                     decision = decision.work_item_id(work_item_id);
                 }
@@ -539,36 +594,46 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 running_state.pending = guard.queue.len().saturating_sub(1);
                 scheduler::apply_running_projection(&mut running_state, run_id.clone());
                 running_state.last_wake_reason = Some(format!("{:?}", candidate.message.kind));
-                let commit_result = self.runtime.inner.runtime_db.transitions().commit_queue(
-                    &crate::runtime_db::transitions::QueueTransitionCommand {
-                        agent_id: agent_id.clone(),
-                        operation: crate::runtime_db::transitions::QueueOperation::Claim,
-                        mutation: crate::runtime_db::transitions::QueueMutation::Consume(
-                            queue_record.clone(),
-                        ),
-                        scheduler_claim_work_item: canonical_claim
-                            .as_ref()
-                            .and_then(|plan| plan.scheduler_claim_work_item.clone()),
-                        scheduler_protocol_bootstrap: canonical_claim
-                            .as_ref()
-                            .and_then(|plan| plan.bootstrap.clone()),
-                        scheduler_protocol_commands: canonical_claim
-                            .as_ref()
-                            .map(|plan| plan.commands.clone())
-                            .unwrap_or_default(),
-                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                            expected: Some(Box::new(guard.state.clone())),
-                            record: Box::new(running_state.clone()),
-                        }),
-                        message_evidence: Vec::new(),
-                        transcript_entries: Vec::new(),
-                        turn_record: None,
-                        audit_events: claim_audit_events.clone(),
-                        notify_scheduler: false,
-                        fault: self.runtime.take_transition_fault(),
-                        brief_evidence: Vec::new(),
-                    },
-                );
+                let execution_protocol = canonical_claim
+                    .as_ref()
+                    .map(|plan| plan.execution_protocol.clone())
+                    .unwrap_or_default();
+                let commit_result = self
+                    .runtime
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_execution_protocol(
+                        &crate::runtime_db::transitions::QueueTransitionCommand {
+                            agent_id: agent_id.clone(),
+                            operation: crate::runtime_db::transitions::QueueOperation::Claim,
+                            mutation: crate::runtime_db::transitions::QueueMutation::Consume(
+                                queue_record.clone(),
+                            ),
+                            scheduler_claim_work_item: canonical_claim
+                                .as_ref()
+                                .and_then(|plan| plan.scheduler_claim_work_item.clone()),
+                            scheduler_protocol_bootstrap: canonical_claim
+                                .as_ref()
+                                .and_then(|plan| plan.bootstrap.clone()),
+                            scheduler_protocol_commands: canonical_claim
+                                .as_ref()
+                                .map(|plan| plan.commands.clone())
+                                .unwrap_or_default(),
+                            agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                                expected: Some(Box::new(guard.state.clone())),
+                                record: Box::new(running_state.clone()),
+                            }),
+                            message_evidence: Vec::new(),
+                            transcript_entries: Vec::new(),
+                            turn_record: None,
+                            audit_events: claim_audit_events.clone(),
+                            notify_scheduler: false,
+                            fault: self.runtime.take_transition_fault(),
+                            brief_evidence: Vec::new(),
+                        },
+                        &execution_protocol,
+                    );
                 let mut commit = match commit_result {
                     Ok(commit) => commit,
                     Err(error) => {
@@ -601,10 +666,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     guard.persist_state(&self.runtime.inner.storage)?;
                     return Ok(RunLoopPoll::Idle);
                 }
-                let message = guard
+                let queued_message = guard
                     .queue
                     .pop_if_next(&candidate.message.id)
                     .expect("queue head was just checked");
+                debug_assert_eq!(queued_message.id, persisted_message.id);
                 guard.state = running_state.clone();
                 guard.last_persisted_state = running_state.clone();
                 guard.current_run_abort = Some(CurrentRunAbortHandle {
@@ -613,7 +679,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     reason: Arc::new(StdMutex::new("operator_aborted".into())),
                 });
                 commit.effects.agent_state = None;
-                break (message, running_state, commit);
+                break (persisted_message.clone(), running_state, commit);
             }
         };
         self.runtime
@@ -633,10 +699,13 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         projection: &scheduler::SchedulerProjection,
         message: &MessageEnvelope,
         dispatch_plan: &MessageDispatchPlan,
+        model_reentry: bool,
     ) -> Result<CanonicalClaimOutcome> {
         let task = match &dispatch_plan.task {
             Ok(task) => task.as_ref(),
-            Err(_) => return Ok(CanonicalClaimOutcome::NotApplicable),
+            Err(_) => {
+                return Ok(CanonicalClaimOutcome::ReduceOnly);
+            }
         };
         let Some(candidate) = scheduler::canonical_activation_candidate(
             message,
@@ -644,19 +713,39 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             task,
         )?
         else {
-            return Ok(CanonicalClaimOutcome::NotApplicable);
+            return Ok(if model_reentry {
+                CanonicalClaimOutcome::RetainQueued {
+                    scenario_class:
+                        crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
+                    reason: "canonical_model_reentry_candidate_unclassified",
+                }
+            } else {
+                CanonicalClaimOutcome::ReduceOnly
+            });
         };
         let scenario_class = candidate.scenario_class();
+        if let scheduler::CanonicalActivationCandidate::ExactTaskRejoin { task_id, .. } = &candidate
+        {
+            let durable_task = self.runtime.inner.storage.latest_task_record(task_id)?;
+            if durable_task
+                .as_ref()
+                .and_then(|task| tasks::task_rejoin_fence(task).ok())
+                .is_none()
+            {
+                return Ok(canonical_claim_hard_blocker(
+                    scenario_class,
+                    "canonical_task_rejoin_contract_missing_or_invalid",
+                ));
+            }
+        }
         let Some(mut scenario) =
             scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?
         else {
             return Ok(canonical_claim_hard_blocker(
                 scenario_class,
                 "canonical_activation_scenario_unresolved",
-            )?);
+            ));
         };
-
-        use crate::domain::scheduler_protocol::WorkStatus;
 
         let existing = self
             .runtime
@@ -664,6 +753,12 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .runtime_db
             .transitions()
             .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
+        let existing_execution = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&message.agent_id)?;
         if scenario.work_item_id().is_none() {
             return self.plan_canonical_lifecycle_activation_claim(
                 message,
@@ -679,31 +774,23 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         } = &mut scenario
         {
             if wait_id.is_none() {
-                let authoritative_wait_id = existing
-                    .as_ref()
-                    .and_then(|snapshot| snapshot.work.get(work_item_id))
-                    .and_then(|demand| match &demand.status {
-                        WorkStatus::Waiting { wait_id } => Some(wait_id),
-                        _ => None,
-                    });
-                if let Some(authoritative_wait_id) = authoritative_wait_id {
-                    let resolved_legacy_wait_matches = self
-                        .runtime
-                        .inner
-                        .storage
-                        .latest_wait_conditions()?
-                        .into_iter()
-                        .any(|condition| {
-                            condition.id == *authoritative_wait_id
-                                && condition.agent_id == message.agent_id
-                                && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
-                                && condition.status == crate::types::WaitConditionStatus::Resolved
-                                && condition.kind == crate::types::WaitConditionKind::Task
-                                && scheduler::message_matches_wait_condition(message, &condition)
-                        });
-                    if resolved_legacy_wait_matches {
-                        *wait_id = Some(authoritative_wait_id.clone());
-                    }
+                let matching_waits = self
+                    .runtime
+                    .inner
+                    .storage
+                    .latest_wait_conditions()?
+                    .into_iter()
+                    .filter(|condition| {
+                        condition.agent_id == message.agent_id
+                            && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
+                            && condition.status == crate::types::WaitConditionStatus::Resolved
+                            && condition.kind == crate::types::WaitConditionKind::Task
+                            && scheduler::message_matches_wait_condition(message, condition)
+                    })
+                    .map(|condition| condition.id)
+                    .collect::<Vec<_>>();
+                if let [authoritative_wait_id] = matching_waits.as_slice() {
+                    *wait_id = Some(authoritative_wait_id.clone());
                 }
             }
         }
@@ -732,7 +819,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 return Ok(canonical_claim_hard_blocker(
                     scenario_class,
                     "canonical_work_item_missing",
-                )?);
+                ));
             }
         };
         let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
@@ -747,7 +834,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 return Ok(canonical_claim_hard_blocker(
                     scenario_class,
                     "canonical_work_item_projection_missing",
-                )?);
+                ));
             }
         };
         if work_item.agent_id != message.agent_id
@@ -756,7 +843,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             return Ok(canonical_claim_hard_blocker(
                 scenario_class,
                 "canonical_work_item_not_open_same_agent",
-            )?);
+            ));
         }
         if matches!(
             scenario,
@@ -766,32 +853,23 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             return Ok(canonical_claim_hard_blocker(
                 scenario_class,
                 "canonical_autonomous_work_item_not_runnable",
-            )?);
+            ));
         }
-        let activation_id = canonical_activation_id(&message.id);
+        let activation_id = canonical_activation_id_for_attempt(existing.as_ref(), &message.id);
 
         use crate::domain::scheduler_protocol::{
             ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
             ActivationPriority, ActivationProvenance, ActivationSlot, ActivationTrust,
-            AdmitActivationCommand, AgentActivation, AgentDispatchState, PreemptionPolicy,
-            ProtocolCommand, RegisterWorkDemandCommand, Snapshot, TriggerWaitCommand,
-            WaitResumeClaim, WorkDemand,
+            AdmitActivationCommand, AdoptLegacyWorkStateCommand, AgentActivation,
+            AgentDispatchState, LegacyWaitAdoption, PreemptionPolicy, ProtocolCommand,
+            RegisterWorkDemandCommand, Snapshot, TriggerWaitCommand, WaitResumeClaim, WaitState,
+            WorkDemand, WorkStatus,
         };
 
         if let Some(snapshot) = existing.as_ref() {
             if let Some(activation) = snapshot.activations.get(&activation_id) {
-                let slot_matches = matches!(
-                    &snapshot.slot,
-                    ActivationSlot::Running {
-                        activation_id: running_activation_id,
-                        owner,
-                        ..
-                    } if running_activation_id == &activation_id
-                        && owner.work_item_id() == Some(work_item_id)
-                );
                 if activation.state == crate::domain::scheduler_protocol::ActivationState::Running
                     && activation.owner.work_item_id() == Some(work_item_id)
-                    && slot_matches
                     && snapshot
                         .activation_admissions
                         .get(&activation_id)
@@ -800,6 +878,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         })
                 {
                     return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
+                        activation_id,
                         scenario_class,
                         execution_owner: activation.owner.clone(),
                         scheduler_claim_work_item: matches!(
@@ -811,23 +890,21 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         .then_some(work_item),
                         bootstrap: None,
                         commands: Vec::new(),
+                        execution_protocol:
+                            crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
                     }));
                 }
                 return Ok(canonical_claim_hard_blocker(
                     scenario_class,
                     "canonical_activation_replay_conflict",
-                )?);
+                ));
             }
         }
-        let new_demand = || WorkDemand {
-            metadata_revision: work_item.revision.max(1),
-            scheduling_generation: work_item.revision.max(1),
-            status: WorkStatus::Runnable,
-            capabilities: Default::default(),
-            locks: Default::default(),
-            locality: "runtime".into(),
-            cost_class: "default".into(),
-        };
+        let authoritative_work = existing_execution
+            .as_ref()
+            .and_then(|state| state.work_items.get(work_item_id));
+        let scheduling_generation =
+            authoritative_work.map_or(work_item.revision.max(1), |record| record.generation());
         let wait_id = match &scenario {
             scheduler::CanonicalActivationScenario::ExactTaskRejoin { wait_id, .. }
             | scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
@@ -843,110 +920,167 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 unreachable!("lifecycle scenario is planned before WorkItem lookup")
             }
         };
-        let (bootstrap, expected_dispatch_revision, scheduling_generation, register) =
-            if let Some(snapshot) = existing.as_ref() {
-                if let Some(demand) = snapshot.work.get(work_item_id) {
-                    if wait_id.is_none() && demand.status != WorkStatus::Runnable {
-                        return Ok(canonical_claim_hard_blocker(
-                            scenario_class,
-                            "canonical_work_demand_not_runnable",
-                        )?);
+        let compatibility_wait = if let Some(wait_id) = wait_id {
+            if let Some(authoritative_work) = authoritative_work {
+                let Some(authoritative_wait) = (match &authoritative_work.state {
+                    crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                        generation,
+                        wait,
+                    } if generation == &scheduling_generation && wait.wait_id == wait_id => {
+                        Some(wait)
                     }
-                    (
-                        None,
-                        snapshot.dispatch_revision,
-                        demand.scheduling_generation,
-                        None,
-                    )
-                } else {
-                    if wait_id.is_some() {
-                        return Ok(canonical_claim_hard_blocker(
-                            scenario_class,
-                            "canonical_wait_resume_work_demand_missing",
-                        )?);
-                    }
-                    let demand = new_demand();
-                    (
-                        None,
-                        snapshot.dispatch_revision,
-                        demand.scheduling_generation,
-                        Some(ProtocolCommand::RegisterWorkDemand(
-                            RegisterWorkDemandCommand {
-                                work_item_id: work_item.id.clone(),
-                                demand,
-                            },
-                        )),
-                    )
-                }
-            } else {
-                if wait_id.is_some() {
+                    _ => None,
+                }) else {
                     return Ok(canonical_claim_hard_blocker(
                         scenario_class,
-                        "canonical_wait_resume_partition_uninitialized",
-                    )?);
+                        "canonical_wait_execution_authority_mismatch",
+                    ));
+                };
+                if authoritative_wait.generation != scheduling_generation {
+                    return Ok(canonical_claim_hard_blocker(
+                        scenario_class,
+                        "canonical_wait_generation_authority_mismatch",
+                    ));
                 }
-                let demand = new_demand();
-                (
-                    Some(Snapshot {
-                        slot: ActivationSlot::Idle,
-                        dispatch: AgentDispatchState::Open,
-                        dispatch_revision: 0,
-                        focus: None,
-                        work: Default::default(),
-                        waits: Default::default(),
-                        activations: Default::default(),
-                        activation_admissions: Default::default(),
-                        settlements: Default::default(),
-                        missing_settlements: Default::default(),
-                        admitted_generations: Default::default(),
-                        continuation_admissions: Default::default(),
-                        activation_inputs: Default::default(),
-                    }),
-                    0,
-                    demand.scheduling_generation,
+            }
+            let wait_condition = self
+                .runtime
+                .inner
+                .storage
+                .latest_wait_conditions()?
+                .into_iter()
+                .find(|condition| {
+                    condition.id == wait_id
+                        && condition.agent_id == message.agent_id
+                        && condition.work_item_id.as_deref() == Some(work_item_id)
+                })
+                .ok_or_else(|| anyhow!("canonical wait resume references unknown durable wait"))?;
+            Some(LegacyWaitAdoption {
+                wait_id: wait_id.to_string(),
+                generation: scheduling_generation,
+                owner_work_item_id: work_item_id.to_string(),
+                source_updated_at: crate::runtime_db::repositories::timestamp(
+                    wait_condition.updated_at,
+                ),
+            })
+        } else {
+            None
+        };
+        let demand = WorkDemand {
+            metadata_revision: work_item.revision.max(1),
+            scheduling_generation,
+            status: compatibility_wait
+                .as_ref()
+                .map_or(WorkStatus::Runnable, |wait| WorkStatus::Waiting {
+                    wait_id: wait.wait_id.clone(),
+                }),
+            capabilities: Default::default(),
+            locks: Default::default(),
+            locality: "runtime".into(),
+            cost_class: "default".into(),
+        };
+        let (bootstrap, register) = if let Some(snapshot) = existing.as_ref() {
+            let wait_projection_matches = compatibility_wait.as_ref().is_none_or(|wait| {
+                snapshot
+                    .waits
+                    .get(&wait.wait_id)
+                    .filter(|record| record.current_generation == wait.generation)
+                    .and_then(|record| record.generations.get(&wait.generation))
+                    .is_some_and(|generation| {
+                        generation.owner.work_item_id() == Some(work_item_id)
+                            && generation.state == WaitState::Active
+                    })
+            });
+            match snapshot.work.get(work_item_id) {
+                Some(existing_demand) if existing_demand == &demand && wait_projection_matches => {
+                    (None, None)
+                }
+                Some(_) | None if compatibility_wait.is_some() => (
+                    None,
+                    Some(ProtocolCommand::AdoptLegacyWorkState(
+                        AdoptLegacyWorkStateCommand {
+                            work_item_id: work_item.id.clone(),
+                            source_work_item_revision: work_item.revision.max(1),
+                            demand: demand.clone(),
+                            wait: compatibility_wait.clone(),
+                            focus: false,
+                            reserve_dispatch: false,
+                            replace_completed_focus: None,
+                        },
+                    )),
+                ),
+                Some(_) => (
+                    None,
+                    Some(ProtocolCommand::AdoptLegacyWorkState(
+                        AdoptLegacyWorkStateCommand {
+                            work_item_id: work_item.id.clone(),
+                            source_work_item_revision: work_item.revision.max(1),
+                            demand: demand.clone(),
+                            wait: None,
+                            focus: false,
+                            reserve_dispatch: false,
+                            replace_completed_focus: None,
+                        },
+                    )),
+                ),
+                None => (
+                    None,
                     Some(ProtocolCommand::RegisterWorkDemand(
                         RegisterWorkDemandCommand {
                             work_item_id: work_item.id.clone(),
-                            demand,
+                            demand: demand.clone(),
                         },
                     )),
-                )
-            };
-
-        let resume = if let Some(wait_id) = wait_id {
-            let Some(snapshot) = existing.as_ref() else {
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_wait_resume_partition_uninitialized",
-                )?);
-            };
-            let Some(wait) = snapshot.waits.get(wait_id) else {
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_wait_missing",
-                )?);
-            };
-            let Some(generation) = wait.generations.get(&wait.current_generation) else {
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_wait_generation_missing",
-                )?);
-            };
-            if generation.owner.work_item_id() != Some(work_item_id) {
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_wait_owner_mismatch",
-                )?);
+                ),
             }
+        } else {
+            let bootstrap = Snapshot {
+                slot: ActivationSlot::Idle,
+                dispatch: AgentDispatchState::Open,
+                dispatch_revision: 0,
+                focus: None,
+                work: Default::default(),
+                waits: Default::default(),
+                activations: Default::default(),
+                activation_admissions: Default::default(),
+                settlements: Default::default(),
+                missing_settlements: Default::default(),
+                admitted_generations: Default::default(),
+                continuation_admissions: Default::default(),
+                activation_inputs: Default::default(),
+            };
+            let register = compatibility_wait.as_ref().map_or_else(
+                || {
+                    ProtocolCommand::RegisterWorkDemand(RegisterWorkDemandCommand {
+                        work_item_id: work_item.id.clone(),
+                        demand: demand.clone(),
+                    })
+                },
+                |_| {
+                    ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
+                        work_item_id: work_item.id.clone(),
+                        source_work_item_revision: work_item.revision.max(1),
+                        demand: demand.clone(),
+                        wait: compatibility_wait.clone(),
+                        focus: false,
+                        reserve_dispatch: false,
+                        replace_completed_focus: None,
+                    })
+                },
+            );
+            (Some(bootstrap), Some(register))
+        };
+
+        let resume = if let Some(wait) = compatibility_wait.as_ref() {
             let Some(trigger_generation) = message.message_seq else {
                 return Ok(canonical_claim_hard_blocker(
                     scenario_class,
                     "canonical_trigger_sequence_missing",
-                )?);
+                ));
             };
             Some(WaitResumeClaim {
-                wait_id: wait_id.to_string(),
-                wait_generation: wait.current_generation,
+                wait_id: wait.wait_id.clone(),
+                wait_generation: wait.generation,
                 trigger_id: canonical_wait_trigger_id(message),
                 trigger_generation,
             })
@@ -965,7 +1099,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 },
                 ActivationOrigin::System,
                 ActivationTrust::RuntimeInstruction,
-                format!("work-queue-message:{}", message.id),
+                format!("work-queue-attempt:{activation_id}"),
             ),
             scheduler::CanonicalActivationScenario::InternalFollowup { .. } => (
                 ActivationCause::InternalFollowup {
@@ -976,7 +1110,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 },
                 ActivationOrigin::System,
                 ActivationTrust::RuntimeInstruction,
-                format!("internal-followup:{}", message.id),
+                format!("internal-followup:{activation_id}"),
             ),
             scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => (
                 ActivationCause::TaskRejoin {
@@ -989,7 +1123,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 },
                 ActivationOrigin::Task,
                 ActivationTrust::RuntimeInstruction,
-                format!("task-rejoin:{task_id}"),
+                format!("task-rejoin:{task_id}:{activation_id}"),
             ),
             scheduler::CanonicalActivationScenario::ExactWaitResume { wait_id, .. } => {
                 let resume = resume
@@ -1010,7 +1144,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     },
                     canonical_activation_origin(message),
                     canonical_activation_trust(message),
-                    format!("wait-resume:{}:{}", wait_id, resume.wait_generation),
+                    format!(
+                        "wait-resume:{}:{}:{activation_id}",
+                        wait_id, resume.wait_generation
+                    ),
                 )
             }
             scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => (
@@ -1023,7 +1160,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 },
                 ActivationOrigin::Operator,
                 ActivationTrust::OperatorInstruction,
-                format!("operator-message:{}", message.id),
+                format!("operator-message:{activation_id}"),
             ),
             scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
                 unreachable!("lifecycle scenario is planned before WorkItem lookup")
@@ -1052,26 +1189,39 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 causation_id: message.causation_id.clone(),
             },
         };
-        let authority_id = format!("authority:{activation_id}");
-        let admission = AdmitActivationCommand {
-            authority_id,
-            activation,
-            expected_scheduling_generation: scheduling_generation,
-            expected_dispatch_revision,
-        };
         let mut commands = Vec::with_capacity(4);
         commands.extend(register);
-        if let Some(resume) = resume {
+        if let Some(resume) = resume.as_ref() {
             commands.push(ProtocolCommand::TriggerWait(TriggerWaitCommand {
-                wait_id: resume.wait_id,
+                wait_id: resume.wait_id.clone(),
                 wait_generation: resume.wait_generation,
-                trigger_id: resume.trigger_id,
+                trigger_id: resume.trigger_id.clone(),
                 trigger_generation: resume.trigger_generation,
             }));
         }
-        commands.push(ProtocolCommand::AdmitActivation(admission));
+        let expected_dispatch_revision = projected_scheduler_dispatch_revision(
+            existing
+                .as_ref()
+                .or(bootstrap.as_ref())
+                .expect("canonical claim has existing or bootstrap scheduler state"),
+            &commands,
+        )?;
+        commands.push(ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: format!("authority:{activation_id}"),
+            activation,
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision,
+        }));
+        let execution_protocol = self.plan_execution_protocol_claim(
+            message,
+            &scenario,
+            &activation_id,
+            Some((&work_item, scheduling_generation)),
+            resume.as_ref(),
+        )?;
 
         Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
+            activation_id,
             scenario_class,
             execution_owner: crate::domain::scheduler_protocol::SchedulerOwner::WorkItem {
                 work_item_id: work_item_id.to_string(),
@@ -1084,6 +1234,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .then_some(work_item),
             bootstrap,
             commands,
+            execution_protocol,
         }))
     }
 
@@ -1104,20 +1255,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let owner = SchedulerOwner::AgentLifecycle {
             agent_id: message.agent_id.clone(),
         };
-        let activation_id = canonical_activation_id(&message.id);
+        let activation_id = canonical_activation_id_for_attempt(existing.as_ref(), &message.id);
         if let Some(snapshot) = existing.as_ref() {
             if let Some(activation) = snapshot.activations.get(&activation_id) {
-                let slot_matches = matches!(
-                    &snapshot.slot,
-                    ActivationSlot::Running {
-                        activation_id: running_activation_id,
-                        owner: running_owner,
-                        ..
-                    } if running_activation_id == &activation_id && running_owner == &owner
-                );
                 if activation.state == crate::domain::scheduler_protocol::ActivationState::Running
                     && activation.owner == owner
-                    && slot_matches
                     && snapshot
                         .activation_admissions
                         .get(&activation_id)
@@ -1126,17 +1268,20 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         })
                 {
                     return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
+                        activation_id,
                         scenario_class,
                         execution_owner: activation.owner.clone(),
                         scheduler_claim_work_item: None,
                         bootstrap: None,
                         commands: Vec::new(),
+                        execution_protocol:
+                            crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
                     }));
                 }
                 return Ok(canonical_claim_hard_blocker(
                     scenario_class,
                     "canonical_activation_replay_conflict",
-                )?);
+                ));
             }
         }
 
@@ -1155,102 +1300,142 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             continuation_admissions: Default::default(),
             activation_inputs: Default::default(),
         });
-        let expected_dispatch_revision = existing
-            .as_ref()
-            .map_or(0, |snapshot| snapshot.dispatch_revision);
-        let (expected_generation, resume, cause, idempotency_key) = match &scenario {
-            scheduler::CanonicalActivationScenario::ExactWaitResume {
-                owner: expected_owner,
-                wait_id,
-            } if expected_owner == &owner => {
-                let Some(snapshot) = existing.as_ref() else {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_wait_resume_partition_uninitialized",
-                    )?);
-                };
-                let Some(wait) = snapshot.waits.get(wait_id) else {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_wait_missing",
-                    )?);
-                };
-                let Some(generation) = wait.generations.get(&wait.current_generation) else {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_wait_generation_missing",
-                    )?);
-                };
-                if generation.owner != owner {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_wait_owner_mismatch",
-                    )?);
-                }
-                let Some(trigger_generation) = message.message_seq else {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_trigger_sequence_missing",
-                    )?);
-                };
-                let resume = WaitResumeClaim {
-                    wait_id: wait_id.clone(),
-                    wait_generation: wait.current_generation,
-                    trigger_id: canonical_wait_trigger_id(message),
-                    trigger_generation,
-                };
-                (
-                    wait.current_generation,
-                    Some(resume.clone()),
-                    ActivationCause::WaitResume {
-                        wait_id: wait_id.clone(),
-                        wait_generation: resume.wait_generation,
-                        trigger_id: resume.trigger_id.clone(),
-                        trigger_generation: resume.trigger_generation,
-                    },
-                    format!("wait-resume:{}:{}", wait_id, resume.wait_generation),
-                )
-            }
-            scheduler::CanonicalActivationScenario::LifecycleExternalNudge { agent_id }
-                if agent_id == &message.agent_id =>
-            {
-                let generation = existing.as_ref().map_or(1, |snapshot| {
-                    let activation_generation = snapshot
-                        .activations
-                        .values()
-                        .filter(|activation| activation.owner == owner)
-                        .map(|activation| activation.admitted_generation)
-                        .max()
-                        .unwrap_or(0);
-                    let wait_generation = snapshot
-                        .waits
-                        .values()
-                        .filter(|wait| {
-                            wait.generations
-                                .get(&wait.current_generation)
-                                .is_some_and(|generation| generation.owner == owner)
+        let (expected_generation, scheduler_resume, execution_resume, cause, idempotency_key) =
+            match &scenario {
+                scheduler::CanonicalActivationScenario::ExactWaitResume {
+                    owner: expected_owner,
+                    wait_id,
+                } if expected_owner == &owner => {
+                    self.runtime
+                        .inner
+                        .storage
+                        .latest_wait_conditions()?
+                        .into_iter()
+                        .find(|condition| {
+                            condition.id == *wait_id
+                                && condition.agent_id == message.agent_id
+                                && condition.work_item_id.is_none()
+                                && condition.status == crate::types::WaitConditionStatus::Active
+                                && scheduler::message_matches_wait_condition(message, condition)
                         })
-                        .map(|wait| wait.current_generation)
-                        .max()
-                        .unwrap_or(0);
-                    activation_generation.max(wait_generation).saturating_add(1)
-                });
-                (
-                    generation,
-                    None,
-                    ActivationCause::LifecycleExternalNudge {
-                        message_id: message.id.clone(),
-                    },
-                    format!("lifecycle-message:{}", message.id),
-                )
-            }
-            _ => {
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_lifecycle_binding_mismatch",
-                )?)
-            }
-        };
+                        .ok_or_else(|| {
+                            anyhow!("canonical lifecycle wait is not durable and active")
+                        })?;
+                    let Some(trigger_generation) = message.message_seq else {
+                        return Ok(canonical_claim_hard_blocker(
+                            scenario_class,
+                            "canonical_trigger_sequence_missing",
+                        ));
+                    };
+                    let authoritative_wait_generation = message
+                        .source_refs
+                        .get("wait_generation")
+                        .and_then(|generation| generation.parse::<u64>().ok())
+                        .filter(|generation| *generation > 0)
+                        .or_else(|| {
+                            existing
+                                .as_ref()
+                                .and_then(|snapshot| snapshot.waits.get(wait_id))
+                                .map(|wait| wait.current_generation)
+                        })
+                        .unwrap_or(1);
+                    let admission_generation = existing.as_ref().map_or(1, |snapshot| {
+                        snapshot
+                            .activations
+                            .values()
+                            .filter(|activation| activation.owner == owner)
+                            .map(|activation| activation.admitted_generation)
+                            .max()
+                            .unwrap_or(0)
+                            .saturating_add(1)
+                    });
+                    let execution_resume = WaitResumeClaim {
+                        wait_id: wait_id.clone(),
+                        wait_generation: authoritative_wait_generation,
+                        trigger_id: canonical_wait_trigger_id(message),
+                        trigger_generation,
+                    };
+                    let scheduler_resume = existing.as_ref().and_then(|snapshot| {
+                        let wait = snapshot.waits.get(wait_id)?;
+                        let generation = wait.generations.get(&wait.current_generation)?;
+                        (wait.current_generation == authoritative_wait_generation
+                            && generation.owner == owner
+                            && generation.state == WaitState::Active)
+                            .then(|| execution_resume.clone())
+                    });
+                    let (cause, idempotency_key) = scheduler_resume.as_ref().map_or_else(
+                        || {
+                            (
+                                ActivationCause::LifecycleExternalNudge {
+                                    message_id: message.id.clone(),
+                                },
+                                format!("lifecycle-wait-message:{activation_id}"),
+                            )
+                        },
+                        |resume| {
+                            (
+                                ActivationCause::WaitResume {
+                                    wait_id: wait_id.clone(),
+                                    wait_generation: resume.wait_generation,
+                                    trigger_id: resume.trigger_id.clone(),
+                                    trigger_generation: resume.trigger_generation,
+                                },
+                                format!(
+                                    "wait-resume:{}:{}:{activation_id}",
+                                    wait_id, resume.wait_generation
+                                ),
+                            )
+                        },
+                    );
+                    (
+                        admission_generation,
+                        scheduler_resume,
+                        Some(execution_resume),
+                        cause,
+                        idempotency_key,
+                    )
+                }
+                scheduler::CanonicalActivationScenario::LifecycleExternalNudge { agent_id }
+                    if agent_id == &message.agent_id =>
+                {
+                    let generation = existing.as_ref().map_or(1, |snapshot| {
+                        let activation_generation = snapshot
+                            .activations
+                            .values()
+                            .filter(|activation| activation.owner == owner)
+                            .map(|activation| activation.admitted_generation)
+                            .max()
+                            .unwrap_or(0);
+                        let wait_generation = snapshot
+                            .waits
+                            .values()
+                            .filter(|wait| {
+                                wait.generations
+                                    .get(&wait.current_generation)
+                                    .is_some_and(|generation| generation.owner == owner)
+                            })
+                            .map(|wait| wait.current_generation)
+                            .max()
+                            .unwrap_or(0);
+                        activation_generation.max(wait_generation).saturating_add(1)
+                    });
+                    (
+                        generation,
+                        None,
+                        None,
+                        ActivationCause::LifecycleExternalNudge {
+                            message_id: message.id.clone(),
+                        },
+                        format!("lifecycle-message:{activation_id}"),
+                    )
+                }
+                _ => {
+                    return Ok(canonical_claim_hard_blocker(
+                        scenario_class,
+                        "canonical_lifecycle_binding_mismatch",
+                    ))
+                }
+            };
         let activation = AgentActivation {
             id: activation_id.clone(),
             agent_id: message.agent_id.clone(),
@@ -1276,29 +1461,223 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 causation_id: message.causation_id.clone(),
             },
         };
-        let authority_id = format!("authority:{activation_id}");
         let mut commands = Vec::with_capacity(3);
-        if let Some(resume) = resume {
+        if let Some(resume) = scheduler_resume.as_ref() {
             commands.push(ProtocolCommand::TriggerWait(TriggerWaitCommand {
-                wait_id: resume.wait_id,
+                wait_id: resume.wait_id.clone(),
                 wait_generation: resume.wait_generation,
-                trigger_id: resume.trigger_id,
+                trigger_id: resume.trigger_id.clone(),
                 trigger_generation: resume.trigger_generation,
             }));
         }
+        let expected_dispatch_revision = projected_scheduler_dispatch_revision(
+            existing
+                .as_ref()
+                .or(bootstrap.as_ref())
+                .expect("canonical claim has existing or bootstrap scheduler state"),
+            &commands,
+        )?;
         commands.push(ProtocolCommand::AdmitActivation(AdmitActivationCommand {
-            authority_id,
+            authority_id: format!("authority:{activation_id}"),
             activation,
             expected_scheduling_generation: expected_generation,
             expected_dispatch_revision,
         }));
+        let execution_protocol = self.plan_execution_protocol_claim(
+            message,
+            &scenario,
+            &activation_id,
+            None,
+            execution_resume.as_ref(),
+        )?;
         Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
+            activation_id,
             scenario_class,
             execution_owner: owner,
             scheduler_claim_work_item: None,
             bootstrap,
             commands,
+            execution_protocol,
         }))
+    }
+
+    fn plan_execution_protocol_claim(
+        &self,
+        message: &MessageEnvelope,
+        scenario: &scheduler::CanonicalActivationScenario,
+        attempt_id: &str,
+        work_item: Option<(&crate::types::WorkItemRecord, u64)>,
+        resume: Option<&crate::domain::scheduler_protocol::WaitResumeClaim>,
+    ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+        use crate::domain::execution_protocol::{
+            AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState,
+            ExecutionBinding, ExecutionPriority, ExecutionProtocolCommand, ExecutionProtocolState,
+            ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity,
+            RegisterWorkItemExecution, WorkItemExecutionRecord, WorkItemExecutionState,
+        };
+
+        let existing = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&message.agent_id)?;
+        if existing
+            .as_ref()
+            .is_some_and(|state| state.attempts.contains_key(attempt_id))
+        {
+            return Ok(crate::runtime_db::transitions::ExecutionProtocolTransition::default());
+        }
+        let source_revision = message
+            .message_seq
+            .filter(|revision| *revision > 0)
+            .ok_or_else(|| anyhow!("canonical execution admission requires message sequence"))?;
+        let authority_fences = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_authority_fences(&message.agent_id)?;
+        let rejoin = match scenario {
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => {
+                let task = self
+                    .runtime
+                    .inner
+                    .storage
+                    .latest_task_record(task_id)?
+                    .ok_or_else(|| anyhow!("task rejoin requires durable task record"))?;
+                Some(tasks::task_rejoin_fence(&task)?)
+            }
+            _ => None,
+        };
+        let source_identity = match scenario {
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
+                work_item_id,
+            } => ExecutionSourceIdentity::WorkItemContinuation {
+                work_item_id: work_item_id.clone(),
+            },
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => {
+                ExecutionSourceIdentity::TaskResult {
+                    task_id: task_id.clone(),
+                    result_message_id: message.id.clone(),
+                }
+            }
+            scheduler::CanonicalActivationScenario::ExactWaitResume { wait_id, .. } => {
+                let resume =
+                    resume.ok_or_else(|| anyhow!("wait resume requires admitted wait claim"))?;
+                ExecutionSourceIdentity::TriggeredWait {
+                    wait_id: wait_id.clone(),
+                    wait_generation: resume.wait_generation,
+                    trigger_id: resume.trigger_id.clone(),
+                    trigger_generation: resume.trigger_generation,
+                }
+            }
+            scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+            | scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. }
+            | scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
+                ExecutionSourceIdentity::QueueMessage {
+                    message_id: message.id.clone(),
+                }
+            }
+        };
+        let binding = work_item.map_or_else(
+            || ExecutionBinding::AgentLifecycle {
+                agent_id: message.agent_id.clone(),
+            },
+            |(work_item, _)| ExecutionBinding::WorkItem {
+                work_item_id: work_item.id.clone(),
+            },
+        );
+        let mut commands = Vec::with_capacity(2);
+        let (work_item_source_revision, work_item_generation) =
+            if let Some((work_item, scheduling_generation)) = work_item {
+                let existing_record = existing
+                    .as_ref()
+                    .and_then(|state| state.work_items.get(&work_item.id));
+                if existing_record.is_none() {
+                    let state = if let Some(resume) = resume {
+                        WorkItemExecutionState::Waiting {
+                            generation: scheduling_generation,
+                            wait: crate::domain::execution_protocol::WaitReference {
+                                wait_id: resume.wait_id.clone(),
+                                generation: resume.wait_generation,
+                            },
+                        }
+                    } else {
+                        WorkItemExecutionState::Runnable {
+                            generation: scheduling_generation,
+                            recovery_ref: None,
+                        }
+                    };
+                    commands.push(ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                        RegisterWorkItemExecution {
+                            work_item_id: work_item.id.clone(),
+                            record: WorkItemExecutionRecord {
+                                source_revision: work_item.revision.max(1),
+                                state,
+                            },
+                        },
+                    )));
+                }
+                (
+                    Some(
+                        existing_record
+                            .map_or(work_item.revision.max(1), |record| record.source_revision),
+                    ),
+                    Some(
+                        existing_record.map_or(scheduling_generation, |record| record.generation()),
+                    ),
+                )
+            } else {
+                (None, None)
+            };
+        commands.push(ExecutionProtocolCommand::Admit(Box::new(AdmitExecution {
+            attempt: ExecutionAttempt {
+                attempt_id: attempt_id.to_owned(),
+                agent_id: message.agent_id.clone(),
+                source_message_id: Some(message.id.clone()),
+                source: ExecutionSource {
+                    identity: source_identity,
+                    generation: source_revision,
+                },
+                binding,
+                provenance: ExecutionProvenance {
+                    origin: canonical_execution_origin(message),
+                    trust: canonical_execution_trust(message),
+                    priority: match message.priority {
+                        Priority::Interject => ExecutionPriority::Interject,
+                        Priority::Next => ExecutionPriority::Next,
+                        Priority::Normal => ExecutionPriority::Normal,
+                        Priority::Background => ExecutionPriority::Background,
+                    },
+                    correlation_id: message.correlation_id.clone(),
+                    causation_id: message.causation_id.clone(),
+                },
+                admitted_fences: AdmittedFences {
+                    source_revision,
+                    work_item_source_revision,
+                    work_item_generation,
+                    rejoin,
+                    agent_control_revision: authority_fences.agent_control_revision,
+                    host_registry_revision: authority_fences.host_registry_revision,
+                },
+                state: ExecutionAttemptState::Open,
+                run_id: None,
+                turn_id: message.turn_id.clone(),
+                recovery_of_attempt_id: None,
+                terminal_outcome_id: None,
+                admitted_at: Utc::now().to_rfc3339(),
+                terminal_at: None,
+            },
+        })));
+        Ok(
+            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: existing
+                    .is_none()
+                    .then(|| ExecutionProtocolState::empty(&message.agent_id)),
+                commands,
+            },
+        )
     }
 
     fn report_canonical_claim_hard_blocker(
@@ -1349,16 +1728,57 @@ pub(super) fn canonical_activation_id(message_id: &str) -> String {
     format!("activation:message:{message_id}")
 }
 
+pub(super) fn canonical_open_activation_id(
+    snapshot: &crate::domain::scheduler_protocol::Snapshot,
+    message_id: &str,
+) -> Option<String> {
+    // Phase 4: derive the open activation from the `activations` authority map
+    // rather than the `slot` mirror.  `assert_invariants` already guarantees
+    // that a Running slot corresponds to exactly one Running activation, so
+    // scanning activations is equivalent and removes the slot reader dependency.
+    snapshot
+        .activations
+        .iter()
+        .filter(|(_, activation)| {
+            activation.state == crate::domain::scheduler_protocol::ActivationState::Running
+        })
+        .find_map(|(activation_id, _)| {
+            snapshot
+                .activation_admissions
+                .get(activation_id)
+                .filter(|admission| admission.activation.provenance.source_id == message_id)
+                .map(|_| activation_id.clone())
+        })
+}
+
+fn canonical_activation_id_for_attempt(
+    snapshot: Option<&crate::domain::scheduler_protocol::Snapshot>,
+    message_id: &str,
+) -> String {
+    let base = canonical_activation_id(message_id);
+    let Some(snapshot) = snapshot else {
+        return base;
+    };
+    let matching_attempts = snapshot
+        .activation_admissions
+        .values()
+        .filter(|admission| admission.activation.provenance.source_id == message_id)
+        .count();
+    if matching_attempts == 0 {
+        base
+    } else {
+        format!("{base}:attempt:{}", matching_attempts + 1)
+    }
+}
+
 fn canonical_claim_hard_blocker(
     scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
     blocker_code: &'static str,
-) -> Result<CanonicalClaimOutcome> {
-    Ok(CanonicalClaimOutcome::HardBlocker(
-        CanonicalClaimHardBlocker {
-            scenario_class,
-            blocker_code,
-        },
-    ))
+) -> CanonicalClaimOutcome {
+    CanonicalClaimOutcome::HardBlocker(CanonicalClaimHardBlocker {
+        scenario_class,
+        blocker_code,
+    })
 }
 
 pub(super) fn canonical_wait_trigger_id(message: &MessageEnvelope) -> String {
@@ -1488,6 +1908,21 @@ fn canonical_admission_matches_scenario(
             },
         ) => {
             wait_id == expected_wait
+                && agent_id == expected_agent_id
+                && agent_id == &message.agent_id
+        }
+        (
+            ActivationCause::LifecycleExternalNudge { message_id },
+            ActivationBinding::Lifecycle { agent_id },
+            scheduler::CanonicalActivationScenario::ExactWaitResume {
+                owner:
+                    crate::domain::scheduler_protocol::SchedulerOwner::AgentLifecycle {
+                        agent_id: expected_agent_id,
+                    },
+                ..
+            },
+        ) => {
+            message_id == &message.id
                 && agent_id == expected_agent_id
                 && agent_id == &message.agent_id
         }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1759,6 +1759,9 @@ fn canonical_activation_id_for_attempt(
     let Some(snapshot) = snapshot else {
         return base;
     };
+    // Admissions are an append-only identity ledger: settlement changes the
+    // activation state but never removes its admission. Counting matching
+    // admissions therefore remains monotonic across persistence reloads.
     let matching_attempts = snapshot
         .activation_admissions
         .values()

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1454,8 +1454,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             source_revision: None,
             idempotency_key,
             provenance: ActivationProvenance {
-                origin: canonical_activation_origin(message),
-                trust: canonical_activation_trust(message),
+                origin: canonical_activation_origin_for_scenario(message, &scenario),
+                trust: canonical_activation_trust_for_scenario(message, &scenario),
                 source_id: message.id.clone(),
                 correlation_id: message.correlation_id.clone(),
                 causation_id: message.causation_id.clone(),
@@ -1642,8 +1642,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 },
                 binding,
                 provenance: ExecutionProvenance {
-                    origin: canonical_execution_origin(message),
-                    trust: canonical_execution_trust(message),
+                    origin: canonical_execution_origin_for_scenario(message, scenario),
+                    trust: canonical_execution_trust_for_scenario(message, scenario),
                     priority: match message.priority {
                         Priority::Interject => ExecutionPriority::Interject,
                         Priority::Next => ExecutionPriority::Next,
@@ -1832,6 +1832,98 @@ fn canonical_activation_trust(
     }
 }
 
+fn canonical_activation_origin_for_scenario(
+    message: &MessageEnvelope,
+    scenario: &scheduler::CanonicalActivationScenario,
+) -> crate::domain::scheduler_protocol::ActivationOrigin {
+    use crate::domain::scheduler_protocol::ActivationOrigin;
+    match scenario {
+        scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+        | scheduler::CanonicalActivationScenario::InternalFollowup { .. } => {
+            ActivationOrigin::System
+        }
+        scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. } => ActivationOrigin::Task,
+        scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
+            ActivationOrigin::Operator
+        }
+        scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. }
+            if scheduler::runtime_owned_task_followup(message) =>
+        {
+            ActivationOrigin::Task
+        }
+        scheduler::CanonicalActivationScenario::ExactWaitResume { .. }
+        | scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
+            canonical_activation_origin(message)
+        }
+    }
+}
+
+fn canonical_activation_trust_for_scenario(
+    message: &MessageEnvelope,
+    scenario: &scheduler::CanonicalActivationScenario,
+) -> crate::domain::scheduler_protocol::ActivationTrust {
+    use crate::domain::scheduler_protocol::ActivationTrust;
+    match scenario {
+        scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+        | scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+        | scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. } => {
+            ActivationTrust::RuntimeInstruction
+        }
+        scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
+            ActivationTrust::OperatorInstruction
+        }
+        scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. }
+            if scheduler::runtime_owned_task_followup(message) =>
+        {
+            ActivationTrust::RuntimeInstruction
+        }
+        scheduler::CanonicalActivationScenario::ExactWaitResume { .. }
+        | scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
+            canonical_activation_trust(message)
+        }
+    }
+}
+
+fn canonical_execution_origin_for_scenario(
+    message: &MessageEnvelope,
+    scenario: &scheduler::CanonicalActivationScenario,
+) -> crate::domain::execution_protocol::ExecutionOrigin {
+    use crate::domain::execution_protocol::ExecutionOrigin;
+    match canonical_activation_origin_for_scenario(message, scenario) {
+        crate::domain::scheduler_protocol::ActivationOrigin::Operator => ExecutionOrigin::Operator,
+        crate::domain::scheduler_protocol::ActivationOrigin::Channel => ExecutionOrigin::Channel,
+        crate::domain::scheduler_protocol::ActivationOrigin::Webhook => ExecutionOrigin::Webhook,
+        crate::domain::scheduler_protocol::ActivationOrigin::Callback => ExecutionOrigin::Callback,
+        crate::domain::scheduler_protocol::ActivationOrigin::Timer => ExecutionOrigin::Timer,
+        crate::domain::scheduler_protocol::ActivationOrigin::System => ExecutionOrigin::System,
+        crate::domain::scheduler_protocol::ActivationOrigin::Task => ExecutionOrigin::Task,
+        crate::domain::scheduler_protocol::ActivationOrigin::RuntimeRecovery => {
+            ExecutionOrigin::RuntimeRecovery
+        }
+    }
+}
+
+fn canonical_execution_trust_for_scenario(
+    message: &MessageEnvelope,
+    scenario: &scheduler::CanonicalActivationScenario,
+) -> crate::domain::execution_protocol::ExecutionTrust {
+    use crate::domain::execution_protocol::ExecutionTrust;
+    match canonical_activation_trust_for_scenario(message, scenario) {
+        crate::domain::scheduler_protocol::ActivationTrust::OperatorInstruction => {
+            ExecutionTrust::OperatorInstruction
+        }
+        crate::domain::scheduler_protocol::ActivationTrust::RuntimeInstruction => {
+            ExecutionTrust::RuntimeInstruction
+        }
+        crate::domain::scheduler_protocol::ActivationTrust::IntegrationSignal => {
+            ExecutionTrust::IntegrationSignal
+        }
+        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence => {
+            ExecutionTrust::ExternalEvidence
+        }
+    }
+}
+
 fn canonical_admission_matches_scenario(
     admission: &crate::domain::scheduler_protocol::AdmitActivationCommand,
     message: &MessageEnvelope,
@@ -1841,8 +1933,9 @@ fn canonical_admission_matches_scenario(
     let activation = &admission.activation;
     if activation.agent_id != message.agent_id
         || activation.provenance.source_id != message.id
-        || activation.provenance.origin != canonical_activation_origin(message)
-        || activation.provenance.trust != canonical_activation_trust(message)
+        || activation.provenance.origin
+            != canonical_activation_origin_for_scenario(message, scenario)
+        || activation.provenance.trust != canonical_activation_trust_for_scenario(message, scenario)
     {
         return false;
     }

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -507,11 +507,7 @@ fn task_result_parent_turn_already_delivered(
     let Some(parent_turn_id) = task_parent_turn_id(task) else {
         return Ok(false);
     };
-    let Some(parent_turn) = storage
-        .read_recent_turns(usize::MAX)?
-        .into_iter()
-        .find(|turn| turn.turn_id == parent_turn_id)
-    else {
+    let Some(parent_turn) = storage.read_turn_by_id(parent_turn_id)? else {
         return Ok(false);
     };
     Ok(storage

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -1,6 +1,6 @@
 use super::{scheduler, *};
 use crate::types::{
-    ExecutionAdmissionProvenance, WaitConditionKind, WaitConditionStatus, WakeSource,
+    BriefKind, ExecutionAdmissionProvenance, WaitConditionKind, WaitConditionStatus, WakeSource,
     WorkItemRecord, WorkItemState,
 };
 use sha2::{Digest, Sha256};
@@ -387,6 +387,8 @@ impl RuntimeHandle {
         }
         self.persist_task_transition(&task, "task_result_received")
             .await?;
+        let parent_turn_already_delivered =
+            task_result_parent_turn_already_delivered(&self.inner.storage, &task)?;
 
         let task_status_label = match task.status {
             TaskStatus::Completed => "completed",
@@ -397,7 +399,8 @@ impl RuntimeHandle {
             TaskStatus::Running => "running",
             TaskStatus::Queued => "queued",
         };
-        let emit_result_brief = should_emit_task_result_brief(&task);
+        let emit_result_brief =
+            should_emit_task_result_brief(&task) && !parent_turn_already_delivered;
         let result_text = match &message.body {
             MessageBody::Text { text } => {
                 format!("Task {} {}: {}", task.id, task_status_label, text)
@@ -409,7 +412,7 @@ impl RuntimeHandle {
                 format!("Task {} {}: {}", task.id, task_status_label, text)
             }
         };
-        if model_reentry {
+        if model_reentry && !parent_turn_already_delivered {
             if emit_result_brief {
                 let brief = brief::make_task_result(&message.agent_id, &task.id, &result_text);
                 self.persist_brief(&brief).await?;
@@ -434,11 +437,21 @@ impl RuntimeHandle {
                 )
                 .await?;
             return Ok(Some(transition));
-        } else {
+        } else if !model_reentry {
             if emit_result_brief {
                 let brief = brief::make_result(&message.agent_id, message, result_text);
                 self.persist_brief(&brief).await?;
             }
+        } else {
+            self.inner.storage.append_event(&AuditEvent::legacy(
+                "stale_task_result_rejoin_suppressed",
+                serde_json::json!({
+                    "agent_id": message.agent_id,
+                    "task_id": task.id,
+                    "parent_turn_id": task_parent_turn_id(&task),
+                    "reason": "parent_turn_already_delivered",
+                }),
+            ))?;
         }
         Ok(None)
     }
@@ -478,6 +491,33 @@ fn stable_terminal_task_event_id(event_kind: &str, task: &TaskRecord) -> String 
 
 fn should_emit_task_result_brief(task: &TaskRecord) -> bool {
     task.kind != TaskKind::CommandTask
+}
+
+fn task_parent_turn_id(task: &TaskRecord) -> Option<&str> {
+    task.detail
+        .as_ref()
+        .and_then(|detail| detail.get("parent_turn_id"))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn task_result_parent_turn_already_delivered(
+    storage: &AppStorage,
+    task: &TaskRecord,
+) -> Result<bool> {
+    let Some(parent_turn_id) = task_parent_turn_id(task) else {
+        return Ok(false);
+    };
+    let Some(parent_turn) = storage
+        .read_recent_turns(usize::MAX)?
+        .into_iter()
+        .find(|turn| turn.turn_id == parent_turn_id)
+    else {
+        return Ok(false);
+    };
+    Ok(storage
+        .read_briefs_by_ids(&parent_turn.produced_brief_ids)?
+        .iter()
+        .any(|brief| brief.kind == BriefKind::Result))
 }
 
 #[cfg(test)]
@@ -872,6 +912,45 @@ mod tests {
         }));
         let transcript = runtime.storage().read_recent_transcript(10).unwrap();
         assert!(transcript.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delivered_parent_turn_suppresses_stale_task_result_reentry_and_brief() {
+        let runtime = runtime();
+        let mut delivered = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "Original operator answer.",
+            Some("operator-message".into()),
+            None,
+        );
+        delivered.turn_id = Some("turn-parent".into());
+        runtime.storage().append_brief(&delivered).unwrap();
+        let mut parent_turn = TurnRecord::new("default", "turn-parent", 1);
+        parent_turn.produced_brief_ids = vec![delivered.id.clone()];
+        runtime.storage().append_turn(&parent_turn).unwrap();
+
+        let mut stale = task("task-1", TaskStatus::Completed, false);
+        stale.detail = Some(json!({"parent_turn_id": "turn-parent"}));
+        runtime
+            .reduce_task_result_message(&task_result_message("task-1"), stale, true, None)
+            .await
+            .unwrap();
+
+        let briefs = runtime.storage().read_recent_briefs(10).unwrap();
+        assert_eq!(briefs, vec![delivered]);
+        assert!(runtime
+            .recent_events(20)
+            .await
+            .unwrap()
+            .iter()
+            .any(|event| event.kind == "stale_task_result_rejoin_suppressed"));
+        assert!(runtime
+            .agent_state()
+            .await
+            .unwrap()
+            .last_turn_terminal
+            .is_none());
     }
 
     #[tokio::test]

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -87,6 +87,63 @@ fn child_agent_task_detail(workspace_mode: ChildAgentWorkspaceMode) -> serde_jso
     })
 }
 
+const REJOIN_OBLIGATION_ID_DETAIL: &str = "rejoin_obligation_id";
+const REJOIN_GENERATION_DETAIL: &str = "rejoin_generation";
+const PARENT_TURN_ID_DETAIL: &str = "parent_turn_id";
+
+fn copy_task_rejoin_contract(task: &TaskRecord, detail: &mut serde_json::Value) {
+    let Some(target) = detail.as_object_mut() else {
+        return;
+    };
+    let Some(source) = task.detail.as_ref().and_then(serde_json::Value::as_object) else {
+        return;
+    };
+    for key in [
+        REJOIN_OBLIGATION_ID_DETAIL,
+        REJOIN_GENERATION_DETAIL,
+        PARENT_TURN_ID_DETAIL,
+    ] {
+        if let Some(value) = source.get(key) {
+            target.entry(key).or_insert_with(|| value.clone());
+        }
+    }
+}
+
+pub(super) fn task_rejoin_fence(
+    task: &TaskRecord,
+) -> Result<crate::domain::execution_protocol::RejoinFence> {
+    let detail = task
+        .detail
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| anyhow!("task rejoin contract is missing task detail"))?;
+    let obligation_id = detail
+        .get(REJOIN_OBLIGATION_ID_DETAIL)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("task rejoin contract is missing obligation identity"))?;
+    if obligation_id != task.id {
+        return Err(anyhow!(
+            "task rejoin obligation identity does not match task identity"
+        ));
+    }
+    let generation = detail
+        .get(REJOIN_GENERATION_DETAIL)
+        .and_then(serde_json::Value::as_u64)
+        .filter(|generation| *generation > 0)
+        .ok_or_else(|| anyhow!("task rejoin contract is missing generation"))?;
+    let parent_turn_id = detail
+        .get(PARENT_TURN_ID_DETAIL)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("task rejoin contract is missing parent turn identity"))?;
+    Ok(crate::domain::execution_protocol::RejoinFence {
+        obligation_id: obligation_id.to_string(),
+        generation,
+        parent_turn_id: parent_turn_id.to_string(),
+    })
+}
+
 fn spawn_agent_task_label(initial_message: &str) -> String {
     let collapsed = initial_message
         .split_whitespace()
@@ -161,13 +218,15 @@ fn task_with_result_message(
     mut detail: Option<serde_json::Value>,
     result_message: &MessageEnvelope,
 ) -> TaskRecord {
-    if let (Some(detail), Some(parent_turn_id)) = (detail.as_mut(), result_message.turn_id.as_ref())
     {
-        if let Some(detail) = detail.as_object_mut() {
-            detail.insert(
-                "parent_turn_id".to_string(),
-                serde_json::json!(parent_turn_id),
-            );
+        let detail = detail.get_or_insert_with(|| serde_json::json!({}));
+        copy_task_rejoin_contract(task, detail);
+        if let (Some(detail), Some(parent_turn_id)) =
+            (detail.as_object_mut(), result_message.turn_id.as_ref())
+        {
+            detail
+                .entry(PARENT_TURN_ID_DETAIL)
+                .or_insert_with(|| serde_json::json!(parent_turn_id));
         }
     }
     let mut terminal_task = task_with_status(task, status, detail);
@@ -180,6 +239,38 @@ pub(super) fn restart_task_result_message_id(task_id: &str) -> String {
 }
 
 impl RuntimeHandle {
+    pub(super) async fn task_creation_detail(
+        &self,
+        task_id: &str,
+        mut detail: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let parent_turn_id = self.agent_state().await?.current_turn_id;
+        let detail = detail
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("task detail must be a JSON object"))?;
+        detail.insert(
+            REJOIN_OBLIGATION_ID_DETAIL.into(),
+            serde_json::json!(task_id),
+        );
+        detail.insert(REJOIN_GENERATION_DETAIL.into(), serde_json::json!(1));
+        if let Some(parent_turn_id) = parent_turn_id {
+            detail.insert(
+                PARENT_TURN_ID_DETAIL.into(),
+                serde_json::json!(parent_turn_id),
+            );
+        }
+        Ok(serde_json::Value::Object(detail.clone()))
+    }
+
+    pub(super) fn task_detail_preserving_rejoin_contract(
+        &self,
+        task: &TaskRecord,
+        mut detail: serde_json::Value,
+    ) -> serde_json::Value {
+        copy_task_rejoin_contract(task, &mut detail);
+        detail
+    }
+
     pub(super) async fn task_work_item_binding(&self) -> Option<String> {
         let guard = self.inner.agent.lock().await;
         guard
@@ -251,8 +342,12 @@ impl RuntimeHandle {
             authority_class: authority_class.clone(),
             workspace_mode,
         };
+        let task_id = crate::ids::task_id();
+        let detail = self
+            .task_creation_detail(&task_id, child_agent_task_detail(workspace_mode))
+            .await?;
         let task = TaskRecord {
-            id: crate::ids::task_id(),
+            id: task_id,
             agent_id: agent_id.clone(),
             kind: TaskKind::ChildAgentTask,
             status: TaskStatus::Queued,
@@ -261,7 +356,7 @@ impl RuntimeHandle {
             parent_message_id: None,
             work_item_id,
             summary: Some(summary.clone()),
-            detail: Some(child_agent_task_detail(workspace_mode)),
+            detail: Some(detail),
             recovery: Some(recovery),
         };
         self.apply_task_transition(task_state_reducer::TaskTransition::new(
@@ -485,7 +580,10 @@ impl RuntimeHandle {
 
                 let queued_task = TaskRecord {
                     updated_at: Utc::now(),
-                    detail: Some(spawned.task_detail.clone()),
+                    detail: Some(self.task_detail_preserving_rejoin_contract(
+                        &task,
+                        spawned.task_detail.clone(),
+                    )),
                     ..task.clone()
                 };
                 self.apply_task_transition(task_state_reducer::TaskTransition::new(
@@ -726,8 +824,12 @@ impl RuntimeHandle {
             authority_class: authority_class.clone(),
             workspace_mode,
         };
+        let task_id = crate::ids::task_id();
+        let detail = self
+            .task_creation_detail(&task_id, child_agent_task_detail(workspace_mode))
+            .await?;
         let task = TaskRecord {
-            id: crate::ids::task_id(),
+            id: task_id,
             agent_id: agent_id.clone(),
             kind: TaskKind::ChildAgentTask,
             status: TaskStatus::Queued,
@@ -736,7 +838,7 @@ impl RuntimeHandle {
             parent_message_id: None,
             work_item_id,
             summary: Some(summary.clone()),
-            detail: Some(child_agent_task_detail(workspace_mode)),
+            detail: Some(detail),
             recovery: Some(recovery),
         };
         self.apply_task_transition(task_state_reducer::TaskTransition::new(
@@ -1087,8 +1189,12 @@ impl RuntimeHandle {
             authority_class: authority_class.clone(),
             workspace_mode,
         };
+        let task_id = crate::ids::task_id();
+        let detail = self
+            .task_creation_detail(&task_id, child_agent_task_detail(workspace_mode))
+            .await?;
         let task = TaskRecord {
-            id: crate::ids::task_id(),
+            id: task_id,
             agent_id,
             kind: TaskKind::ChildAgentTask,
             status: TaskStatus::Queued,
@@ -1097,7 +1203,7 @@ impl RuntimeHandle {
             parent_message_id: None,
             work_item_id,
             summary: Some(summary),
-            detail: Some(child_agent_task_detail(workspace_mode)),
+            detail: Some(detail),
             recovery: Some(recovery),
         };
         self.apply_task_transition(task_state_reducer::TaskTransition::new(

--- a/src/runtime/tests/contracts/queue.rs
+++ b/src/runtime/tests/contracts/queue.rs
@@ -3,7 +3,7 @@ use crate::types::{AdmissionContext, MessageDeliverySurface, MessageEnvelope, Qu
 
 #[tokio::test]
 async fn legacy_work_queue_settlement_does_not_require_scheduler_partition() {
-    let harness = LifecycleHarness::new();
+    let harness = LifecycleHarness::legacy();
     let message = harness
         .runtime()
         .enqueue(
@@ -54,7 +54,7 @@ async fn legacy_work_queue_settlement_does_not_require_scheduler_partition() {
 #[tokio::test]
 async fn queue_runtime_path_rolls_back_each_pre_commit_fault() {
     for fault in PRE_COMMIT_FAULTS {
-        let harness = LifecycleHarness::new();
+        let harness = LifecycleHarness::legacy();
         let now = Utc::now();
         let queued = QueueEntryRecord {
             message_id: "message-fault-contract".into(),
@@ -112,7 +112,7 @@ async fn queue_runtime_path_rolls_back_each_pre_commit_fault() {
 #[tokio::test]
 async fn queue_post_commit_fault_keeps_terminal_settlement_after_restart() {
     for (fault, expected_effect) in POST_COMMIT_FAULTS {
-        let mut harness = LifecycleHarness::new();
+        let mut harness = LifecycleHarness::legacy();
         let now = harness.now();
         let queued = QueueEntryRecord {
             message_id: format!("message-post-commit-{expected_effect}"),

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -81,6 +81,22 @@ fn trusted_operator_prompt(work_item_id: Option<&str>, text: &str) -> MessageEnv
     message
 }
 
+fn append_default_host_identity(runtime: &RuntimeHandle) {
+    runtime
+        .runtime_db()
+        .agent_identities()
+        .upsert(&crate::types::AgentIdentityRecord::new(
+            "default",
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        ))
+        .unwrap();
+}
+
 struct OperatorInterjectionProbeProvider {
     calls: Mutex<usize>,
     requests: Mutex<Vec<ProviderTurnRequest>>,
@@ -125,6 +141,34 @@ fn task_result_message(task_id: &str) -> MessageEnvelope {
             text: "task completed".into(),
         },
     )
+}
+
+fn append_completed_rejoin_task(
+    runtime: &RuntimeHandle,
+    task_id: &str,
+    work_item_id: &str,
+    parent_turn_id: &str,
+) {
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: task_id.into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Completed,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: Some(work_item_id.into()),
+            summary: Some(format!("{task_id} completed")),
+            detail: Some(serde_json::json!({
+                "rejoin_obligation_id": task_id,
+                "rejoin_generation": 1,
+                "parent_turn_id": parent_turn_id,
+            })),
+            recovery: None,
+        })
+        .unwrap();
 }
 
 fn canonical_waiting_snapshot(
@@ -379,7 +423,7 @@ fn runtime_projection_cache_rebuilds_current_agent_active_task_projection() {
 #[async_trait]
 impl AgentProvider for BlockingProvider {
     async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
-        self.started.notify_waiters();
+        self.started.notify_one();
         std::future::pending::<Result<ProviderTurnResponse>>().await
     }
 }
@@ -402,7 +446,7 @@ impl AgentProvider for OperatorInterjectionProbeProvider {
         drop(calls);
         self.requests.lock().await.push(request);
         if call == 1 {
-            self.first_tool_round.notify_waiters();
+            self.first_tool_round.notify_one();
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             Ok(ProviderTurnResponse {
                 blocks: vec![ModelBlock::ToolUse {
@@ -663,6 +707,20 @@ async fn runtime_failure_preserves_canonical_claim_for_bootstrap_reconciliation(
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Dequeued)
     );
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("runtime failure should preserve the execution partition");
+    let attempt = &execution.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Open
+    );
+    assert!(attempt.terminal_outcome_id.is_none());
     assert!(runtime
         .storage()
         .read_recent_events(64)
@@ -1045,7 +1103,7 @@ async fn bootstrap_diagnostics_report_cross_model_scheduler_invariant_failures()
 }
 
 #[tokio::test]
-async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settlement() {
+async fn bootstrap_recovery_interrupts_open_attempt_and_releases_message_for_reentry() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -1105,7 +1163,11 @@ async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settl
     assert_eq!(report.candidates[0].reason, "terminal_turn_missing");
     assert!(matches!(
         report.candidates[0].proposed_commands.as_slice(),
-        [crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(_)]
+        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command)]
+            if matches!(
+                command.settlement.disposition,
+                crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
+            )
     ));
     assert_eq!(
         runtime
@@ -1151,29 +1213,50 @@ async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settl
             .activations
             .get(&activation_id)
             .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing)
+        Some(crate::domain::scheduler_protocol::ActivationState::Interrupted)
     );
     assert_eq!(
         snapshot
             .work
             .get(&work_item.id)
             .map(|demand| &demand.status),
-        Some(&WorkStatus::NeedsSettlement {
-            activation_id: activation_id.clone(),
-        })
+        Some(&WorkStatus::Runnable)
+    );
+    assert_eq!(snapshot.work[&work_item.id].scheduling_generation, 2);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("bootstrap recovery should preserve the execution partition");
+    let attempt = &execution.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
     );
     assert_eq!(
-        runtime
-            .inner
-            .runtime_db
-            .queue_entries()
-            .latest_all()
-            .unwrap()
-            .into_iter()
-            .find(|entry| entry.message_id == message.id)
-            .map(|entry| entry.status),
-        Some(QueueEntryStatus::Aborted)
+        execution.outcomes[attempt
+            .terminal_outcome_id
+            .as_deref()
+            .expect("bootstrap interruption should have terminal evidence")]
+        .outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted {
+                reason: "runtime_interrupted".into(),
+            },
+        )
     );
+    let recovered_queue_status = runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest_all()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.message_id == message.id)
+        .map(|entry| entry.status);
+    assert_eq!(recovered_queue_status, Some(QueueEntryStatus::Interrupted));
     assert!(runtime
         .storage()
         .read_recent_events(32)
@@ -1184,6 +1267,138 @@ async fn bootstrap_recovery_marks_dequeued_canonical_activation_as_missing_settl
                 && event.data["message_id"] == message.id
                 && event.data["activation_id"] == activation_id
         }));
+}
+
+#[tokio::test]
+async fn bootstrap_recovery_uses_execution_attempt_without_scheduler_compatibility_partition() {
+    let mut harness = LifecycleHarness::new();
+    let (message_id, activation_id) = {
+        let runtime = harness.runtime();
+        let work_item = runtime
+            .create_work_item(
+                "recover without scheduler compatibility partition".into(),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_queue".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "claim before compatibility projection loss".into(),
+            },
+        );
+        message.work_item_id = Some(work_item.id);
+        let message = runtime.enqueue(message).await.unwrap();
+        assert!(matches!(
+            scheduler_executor::SchedulerDecisionExecutor::new(runtime)
+                .poll()
+                .await
+                .unwrap(),
+            scheduler_executor::RunLoopPoll::Message(_)
+        ));
+        finish_claimed_test_run(runtime).await;
+        let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+        let execution = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .expect("production claim should persist execution authority");
+        assert_eq!(
+            execution.attempts[&activation_id].state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Open
+        );
+
+        let connection = runtime.inner.runtime_db.connection().unwrap();
+        connection
+            .execute_batch(
+                "PRAGMA foreign_keys = OFF;
+                 DELETE FROM scheduler_agent_slots WHERE agent_id = 'default';
+                 DELETE FROM scheduler_agent_dispatch WHERE agent_id = 'default';
+                 DELETE FROM scheduler_agent_focus WHERE agent_id = 'default';
+                 DELETE FROM scheduler_work_demands WHERE agent_id = 'default';
+                 PRAGMA foreign_keys = ON;",
+            )
+            .unwrap();
+        assert!(runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized("default")
+            .unwrap()
+            .is_none());
+        (message.id, activation_id)
+    };
+
+    harness.restart();
+    let runtime = harness.runtime();
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message_id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Interrupted)
+    );
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("bootstrap recovery should retain execution authority");
+    let attempt = &execution.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        execution.outcomes[attempt
+            .terminal_outcome_id
+            .as_deref()
+            .expect("bootstrap recovery should persist interruption evidence")]
+        .outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted {
+                reason: "scheduler_compatibility_projection_missing".into(),
+            },
+        )
+    );
 }
 
 #[tokio::test]
@@ -1264,104 +1479,88 @@ async fn settlement_recovery_repairs_processed_cross_work_item_pick_as_targeted_
         .canonical_queue_settlement_commands(&processed, Some(&terminal.turn_record))
         .await
         .unwrap();
+    let settlement = scheduler_protocol_commands
+        .iter()
+        .find_map(|command| match command {
+            crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command) => {
+                Some(&command.settlement)
+            }
+            _ => None,
+        })
+        .expect("processed cross-work-item pick should produce a settlement");
     assert!(matches!(
-        scheduler_protocol_commands.as_slice(),
-        [crate::domain::scheduler_protocol::ProtocolCommand::RecordMissingSettlement(_)]
+        &settlement.disposition,
+        crate::domain::scheduler_protocol::ActivationDisposition::WorkYielded {
+            target_work_item_id: Some(target_work_item_id),
+            continuation_id: Some(settlement_continuation_id),
+            expected_target_generation: Some(_),
+        } if target_work_item_id == &target.id
+            && settlement_continuation_id == &continuation_id
     ));
+    let execution_protocol = execution_protocol_settlement_transition(
+        &runtime.inner.runtime_db,
+        &message.agent_id,
+        &scheduler_protocol_commands,
+    )
+    .unwrap();
     runtime
         .inner
         .runtime_db
         .transitions()
-        .commit_queue(&crate::runtime_db::transitions::QueueTransitionCommand {
-            agent_id: message.agent_id.clone(),
-            operation: crate::runtime_db::transitions::QueueOperation::Settle,
-            mutation: crate::runtime_db::transitions::QueueMutation::Upsert(processed),
-            scheduler_claim_work_item: None,
-            scheduler_protocol_bootstrap: None,
-            scheduler_protocol_commands,
-            agent_state: None,
-            message_evidence: Vec::new(),
-            transcript_entries: Vec::new(),
-            turn_record: None,
-            audit_events: Vec::new(),
-            notify_scheduler: false,
-            fault: None,
-            brief_evidence: Vec::new(),
-        })
+        .commit_queue_with_execution_protocol(
+            &crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: message.agent_id.clone(),
+                operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                mutation: crate::runtime_db::transitions::QueueMutation::Upsert(processed),
+                scheduler_claim_work_item: None,
+                scheduler_protocol_bootstrap: None,
+                scheduler_protocol_commands,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: Vec::new(),
+                notify_scheduler: false,
+                fault: None,
+                brief_evidence: Vec::new(),
+            },
+            &execution_protocol,
+        )
         .unwrap();
 
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let missing = runtime
+    let settled = runtime
         .inner
         .runtime_db
         .transitions()
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
-    assert_eq!(
-        missing.work[&caller.id].status,
-        WorkStatus::NeedsSettlement {
-            activation_id: activation_id.clone(),
-        }
-    );
-    assert!(!missing.work.contains_key(&target.id));
-
-    let report =
-        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-            .unwrap();
-    let candidate = report
-        .candidates
-        .iter()
-        .find(|candidate| candidate.kind == SchedulerRecoveryCandidateKind::NeedsSettlement)
-        .expect("needs-settlement candidate");
-    assert_eq!(candidate.reason, "needs_settlement_continuation");
-    assert!(candidate
-        .evidence
-        .contains(&format!("continuation:{continuation_id}")));
-    assert_eq!(
-        apply_scheduler_recovery_plan(
-            &runtime.inner.storage,
-            &runtime.inner.runtime_db,
-            "default",
-            &report,
-        )
-        .unwrap()
-        .0,
-        1
-    );
-
-    let recovered = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let WorkStatus::Yielded { continuation } = &recovered.work[&caller.id].status else {
-        panic!("caller should be canonically yielded after recovery");
+    let WorkStatus::Yielded { continuation } = &settled.work[&caller.id].status else {
+        panic!("caller should be atomically settled as canonically yielded");
     };
     assert_eq!(continuation.continuation_id, continuation_id);
     assert_eq!(continuation.source_work_item_id, caller.id);
     assert_eq!(continuation.target_work_item_id, target.id);
-    assert_eq!(recovered.work[&target.id].status, WorkStatus::Runnable);
+    assert_eq!(settled.work[&target.id].status, WorkStatus::Runnable);
     assert_eq!(
-        recovered.activations[&activation_id].state,
+        settled.activations[&activation_id].state,
         crate::domain::scheduler_protocol::ActivationState::Settled
     );
-    assert_eq!(
-        apply_scheduler_recovery_plan(
-            &runtime.inner.storage,
-            &runtime.inner.runtime_db,
-            "default",
-            &scheduler_recovery_report(
-                &runtime.inner.storage,
-                &runtime.inner.runtime_db,
-                "default",
-            )
-            .unwrap(),
-        )
-        .unwrap()
-        .0,
-        0
-    );
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert!(!report
+        .candidates
+        .iter()
+        .any(|candidate| candidate.kind == SchedulerRecoveryCandidateKind::NeedsSettlement));
+    let (applied, _) = apply_scheduler_recovery_plan(
+        &runtime.inner.storage,
+        &runtime.inner.runtime_db,
+        "default",
+        &report,
+    )
+    .unwrap();
+    assert_eq!(applied, 0, "unexpected recovery candidates: {report:#?}");
 }
 
 #[tokio::test]
@@ -1459,9 +1658,8 @@ async fn bootstrap_recovery_settles_dequeued_activation_from_terminal_turn() {
     assert!(snapshot
         .settlements
         .contains_key(&canonical_settlement_id(&message.id)));
-    assert!(!snapshot
-        .missing_settlements
-        .contains_key(&canonical_missing_settlement_id(&message.id)));
+    // Phase 4: missing-settlement recovery is replaced by Interrupted settlement.
+    assert!(snapshot.missing_settlements.is_empty());
     assert_eq!(
         runtime
             .inner
@@ -1585,19 +1783,42 @@ async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Processed)
     );
-    assert!(runtime
+    let recovery_event = runtime
         .storage()
         .read_recent_events(64)
         .unwrap()
         .iter()
-        .any(|event| {
+        .find(|event| {
             event.kind == "scheduler_bootstrap_claim_recovered"
                 && event.data["message_id"] == message_id
-                && event.data["activation_id"] == activation_id
-                && event.data["recovery_outcome"]
-                    == "legacy_queue_reconciled_from_canonical_settlement"
-                && event.data["provenance"] == "bootstrap_reconciliation"
-        }));
+        })
+        .cloned()
+        .expect("bootstrap recovery should emit reconciliation evidence");
+    assert_eq!(recovery_event.data["activation_id"], activation_id);
+    assert_eq!(
+        recovery_event.data["recovery_outcome"],
+        "settled_from_terminal_turn"
+    );
+    assert_eq!(
+        recovery_event.data["provenance"],
+        "bootstrap_reconciliation"
+    );
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("bootstrap recovery should preserve execution authority");
+    let attempt = &execution.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
+    );
+    assert!(attempt
+        .terminal_outcome_id
+        .as_ref()
+        .is_some_and(|outcome_id| execution.outcomes.contains_key(outcome_id)));
 }
 
 #[tokio::test]
@@ -2093,20 +2314,42 @@ async fn legacy_engine_claim_and_settlement_do_not_write_canonical_protocol() {
 
     finish_claimed_test_run(&runtime).await;
     let terminal = terminal_transition(&message, Some(&work_item.id));
+    let canonical = Snapshot {
+        slot: ActivationSlot::Idle,
+        dispatch: AgentDispatchState::Open,
+        dispatch_revision: 0,
+        focus: None,
+        work: Default::default(),
+        waits: Default::default(),
+        activations: Default::default(),
+        activation_admissions: Default::default(),
+        settlements: Default::default(),
+        missing_settlements: Default::default(),
+        admitted_generations: Default::default(),
+        continuation_admissions: Default::default(),
+        activation_inputs: Default::default(),
+    };
     runtime
-        .commit_queue_terminal_settlement(
-            QueueEntryRecord {
-                message_id: message.id.clone(),
-                agent_id: message.agent_id.clone(),
-                priority: message.priority,
-                status: QueueEntryStatus::Processed,
-                created_at: message.created_at,
-                updated_at: Utc::now(),
-            },
-            Vec::new(),
-            true,
-            Some(&terminal),
-        )
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &canonical)
+        .unwrap();
+    let processed = QueueEntryRecord {
+        message_id: message.id.clone(),
+        agent_id: message.agent_id.clone(),
+        priority: message.priority,
+        status: QueueEntryStatus::Processed,
+        created_at: message.created_at,
+        updated_at: Utc::now(),
+    };
+    let commands = runtime
+        .canonical_queue_settlement_commands(&processed, Some(&terminal.turn_record))
+        .await
+        .unwrap();
+    assert!(commands.is_empty());
+    runtime
+        .commit_queue_terminal_settlement(processed, Vec::new(), true, Some(&terminal))
         .await
         .unwrap();
 
@@ -2116,7 +2359,10 @@ async fn legacy_engine_claim_and_settlement_do_not_write_canonical_protocol() {
         .transitions()
         .load_scheduler_protocol_snapshot_if_initialized("default")
         .unwrap()
-        .is_none());
+        .as_ref()
+        .is_some_and(|snapshot| {
+            snapshot.activations.is_empty() && snapshot.settlements.is_empty()
+        }));
 }
 
 #[tokio::test]
@@ -2295,6 +2541,40 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
     assert!(settled
         .settlements
         .contains_key(&canonical_settlement_id(&message.id)));
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("canonical settlement should preserve the execution partition");
+    let outcome_id = format!("outcome:{}", canonical_settlement_id(&message.id));
+    let attempt = &execution.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
+    );
+    assert_eq!(
+        attempt.terminal_outcome_id.as_deref(),
+        Some(outcome_id.as_str())
+    );
+    assert_eq!(
+        execution.outcomes[&outcome_id].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Continue,
+        )
+    );
+    assert_eq!(
+        execution.work_items[&work_item.id].source_revision,
+        work_item.revision
+    );
+    assert_eq!(
+        execution.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable {
+            generation: work_item.revision + 1,
+            recovery_ref: None,
+        }
+    );
     assert_eq!(
         runtime
             .inner
@@ -2306,6 +2586,30 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
             .find(|entry| entry.message_id == message.id)
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Processed)
+    );
+
+    drop(runtime);
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    assert_eq!(
+        reopened
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap(),
+        Some(execution)
     );
 }
 
@@ -2414,6 +2718,12 @@ async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation(
         .contains_key(&canonical_settlement_id(&message.id)));
     assert!(settled.missing_settlements.is_empty());
 
+    append_completed_rejoin_task(
+        &runtime,
+        "task-rejoin",
+        &work_item.id,
+        "turn-canonical-wait-settlement",
+    );
     let mut rejoin = task_result_message("task-rejoin").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -2801,10 +3111,7 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .canonical_queue_settlement_commands(&processed, Some(&terminal.turn_record))
         .await
         .unwrap();
-    assert!(matches!(
-        replay_commands.as_slice(),
-        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
-    ));
+    assert!(replay_commands.is_empty());
     assert!(!runtime
         .inner
         .runtime_db
@@ -2826,6 +3133,12 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         context_config(),
     )
     .unwrap();
+    append_completed_rejoin_task(
+        &reopened,
+        "task-lifecycle-handoff",
+        &work_item.id,
+        "turn-lifecycle-wait-handoff",
+    );
     let mut rejoin = task_result_message("task-lifecycle-handoff").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -2932,7 +3245,7 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
                 id: "task-rejoin".into(),
                 agent_id: "default".into(),
                 kind: TaskKind::CommandTask,
-                status: TaskStatus::Completed,
+                status: TaskStatus::Running,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
                 parent_message_id: None,
@@ -2943,6 +3256,74 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
             },
             "task_completed",
         )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .storage()
+            .active_wait_conditions_for_work_item("default", &work_item.id)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let mut message = task_result_message("task-rejoin").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-rejoin",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-rejoin",
+        "work_item_id": work_item.id,
+    }));
+    let message = runtime.enqueue(message).await.unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(32)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_hard_blocker"
+                && event.data["blocker_code"] == "canonical_task_rejoin_contract_missing_or_invalid"
+        }));
+
+    let mut durable_task = runtime
+        .storage()
+        .latest_task_record("task-rejoin")
+        .unwrap()
+        .unwrap();
+    durable_task.updated_at = Utc::now();
+    durable_task.detail = Some(serde_json::json!({
+        "rejoin_obligation_id": "task-rejoin",
+        "rejoin_generation": 1,
+        "parent_turn_id": "turn-task-parent"
+    }));
+    durable_task.status = TaskStatus::Completed;
+    runtime
+        .persist_task_transition(&durable_task, "task_completed")
         .await
         .unwrap();
     assert!(runtime
@@ -2960,21 +3341,14 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
             .map(|condition| condition.status),
         Some(WaitConditionStatus::Resolved)
     );
-
-    let mut message = task_result_message("task-rejoin").with_admission(
-        MessageDeliverySurface::TaskRejoin,
-        AdmissionContext::RuntimeOwned,
-    );
-    message.work_item_id = Some(work_item.id.clone());
-    message.metadata = Some(serde_json::json!({
-        "task_id": "task-rejoin",
-        "task_kind": "command_task",
-        "task_status": "completed",
-        "task_result_id": "result-rejoin",
-        "work_item_id": work_item.id,
-    }));
-    let message = runtime.enqueue(message).await.unwrap();
+    let work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let claim_wait_generation = work_item.revision;
     let state_before_claim = runtime.agent_state().await.unwrap();
+
     runtime.inject_next_transition_fault(
         crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
     );
@@ -3009,6 +3383,13 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Queued)
     );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .is_none());
 
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()
@@ -3037,11 +3418,11 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         }
     );
     assert_eq!(
-        claimed.waits[&registration.condition.id].generations[&wait_generation].state,
+        claimed.waits[&registration.condition.id].generations[&claim_wait_generation].state,
         WaitState::Consumed
     );
     assert_eq!(
-        claimed.waits[&registration.condition.id].generations[&wait_generation]
+        claimed.waits[&registration.condition.id].generations[&claim_wait_generation]
             .consuming_activation_id
             .as_deref(),
         Some(activation_id.as_str())
@@ -3056,8 +3437,60 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         } if task_id == "task-rejoin"
             && message_id == &message.id
             && resume.wait_id == registration.condition.id
-            && resume.wait_generation == wait_generation
+            && resume.wait_generation == claim_wait_generation
     ));
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("canonical claim should initialize execution protocol");
+    let attempt = &execution.attempts[&activation_id];
+    assert_eq!(
+        attempt.source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TaskResult {
+            task_id: "task-rejoin".into(),
+            result_message_id: message.id.clone(),
+        }
+    );
+    assert_eq!(
+        attempt.source.generation,
+        scheduled
+            .message
+            .message_seq
+            .expect("claimed message should carry its durable sequence")
+    );
+    assert_eq!(
+        attempt.binding,
+        crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+            work_item_id: work_item.id.clone(),
+        }
+    );
+    assert_eq!(
+        attempt.admitted_fences.work_item_source_revision,
+        Some(work_item.revision)
+    );
+    assert_eq!(
+        attempt.admitted_fences.work_item_generation,
+        Some(work_item.revision)
+    );
+    assert_eq!(
+        attempt.admitted_fences.rejoin,
+        Some(crate::domain::execution_protocol::RejoinFence {
+            obligation_id: "task-rejoin".into(),
+            generation: 1,
+            parent_turn_id: "turn-task-parent".into(),
+        })
+    );
+    assert_eq!(
+        execution.work_items[&work_item.id].source_revision,
+        work_item.revision
+    );
+    assert_eq!(
+        execution.work_items[&work_item.id].generation(),
+        work_item.revision
+    );
     assert_eq!(
         runtime
             .inner
@@ -3092,6 +3525,15 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
     assert_eq!(restarted, claimed);
+    assert_eq!(
+        reopened
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap(),
+        Some(execution)
+    );
 }
 
 #[tokio::test]
@@ -3254,18 +3696,16 @@ async fn restarted_interrupted_unbound_operator_prompt_does_not_block_resent_pro
         runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
         0
     );
-    assert_eq!(
-        runtime
-            .inner
-            .runtime_db
-            .queue_entries()
-            .latest_all()
-            .unwrap()
-            .into_iter()
-            .find(|entry| entry.message_id == first.id)
-            .map(|entry| entry.status),
-        Some(QueueEntryStatus::Aborted)
-    );
+    let recovered_first_status = runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest_all()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.message_id == first.id)
+        .map(|entry| entry.status);
+    assert_eq!(recovered_first_status, Some(QueueEntryStatus::Interrupted));
     let second = runtime
         .enqueue(trusted_operator_prompt(None, "resent operator prompt"))
         .await
@@ -3887,9 +4327,8 @@ async fn authoritative_completion_terminalizes_canonical_work_and_binds_report()
             .as_deref(),
         Some(result_brief_id)
     );
-    assert!(!snapshot
-        .missing_settlements
-        .contains_key(&canonical_missing_settlement_id(&message.id)));
+    // Phase 4: missing-settlement recovery is replaced by Interrupted settlement.
+    assert!(snapshot.missing_settlements.is_empty());
 }
 
 #[tokio::test]
@@ -3932,6 +4371,12 @@ async fn task_rejoin_ignores_legacy_wait_duplicate_missing_from_canonical_snapsh
         .append_wait_condition(&duplicate_wait)
         .unwrap();
 
+    append_completed_rejoin_task(
+        &runtime,
+        "task-ambiguous",
+        &work_item.id,
+        "turn-task-ambiguous-parent",
+    );
     let mut message = task_result_message("task-ambiguous").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -4646,14 +5091,24 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
     let activation = &claimed.activations[&activation_id];
-    assert_eq!(activation.admitted_generation, scheduling_generation);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("production claim should initialize the execution partition");
+    assert_eq!(
+        activation.admitted_generation,
+        execution.work_items[&work_item.id].generation()
+    );
+    assert_ne!(activation.admitted_generation, scheduling_generation);
     assert_eq!(
         claimed.activation_admissions[&activation_id]
             .activation
             .source_revision,
         Some(work_item.revision)
     );
-    assert_ne!(activation.admitted_generation, work_item.revision);
 
     runtime
         .begin_interactive_turn(Some(&message), None, None)
@@ -4851,22 +5306,12 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
         .await
         .unwrap();
 
-    runtime
-        .storage()
-        .append_task(&TaskRecord {
-            id: "task-complete-after-wait".into(),
-            agent_id: "default".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Completed,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: Some(work_item.id.clone()),
-            summary: Some("task completed after wait".into()),
-            detail: None,
-            recovery: None,
-        })
-        .unwrap();
+    append_completed_rejoin_task(
+        &runtime,
+        "task-complete-after-wait",
+        &work_item.id,
+        "turn-wait-before-completion",
+    );
     let mut resume = task_result_message("task-complete-after-wait").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -4986,7 +5431,7 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
 }
 
 #[tokio::test]
-async fn completed_production_settlement_records_missing_for_mismatched_completion_execution() {
+async fn completed_production_settlement_interrupts_mismatched_completion_execution() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -5116,15 +5561,21 @@ async fn completed_production_settlement_records_missing_for_mismatched_completi
         .unwrap();
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
     assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    // Phase 4: missing-settlement replaced by Interrupted settlement.
     assert!(snapshot
-        .missing_settlements
-        .contains_key(&canonical_missing_settlement_id(&message.id)));
+        .settlements
+        .values()
+        .any(|s| s.activation_id == activation_id
+            && matches!(
+                s.disposition,
+                crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
+            )));
     assert_eq!(
         snapshot
             .activations
             .get(&activation_id)
             .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing)
+        Some(crate::domain::scheduler_protocol::ActivationState::Interrupted)
     );
     assert_eq!(
         runtime
@@ -5141,7 +5592,7 @@ async fn completed_production_settlement_records_missing_for_mismatched_completi
 }
 
 #[tokio::test]
-async fn completed_production_settlement_records_missing_without_result_report() {
+async fn completed_production_settlement_interrupts_without_result_report() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -5227,27 +5678,37 @@ async fn completed_production_settlement_records_missing_without_result_report()
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
     assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    // Phase 4: missing-settlement replaced by Interrupted settlement.
     assert!(snapshot
-        .missing_settlements
-        .contains_key(&canonical_missing_settlement_id(&message.id)));
+        .settlements
+        .values()
+        .any(|s| s.activation_id == activation_id
+            && matches!(
+                s.disposition,
+                crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
+            )));
     assert_eq!(
         snapshot
             .activations
             .get(&activation_id)
             .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::SettlementMissing)
+        Some(crate::domain::scheduler_protocol::ActivationState::Interrupted)
     );
     assert_eq!(
         snapshot
             .work
             .get(&work_item.id)
             .map(|demand| &demand.status),
-        Some(&WorkStatus::NeedsSettlement { activation_id })
+        Some(&WorkStatus::Runnable)
     );
+    assert!(matches!(
+        snapshot.settlements[&canonical_settlement_id(&message.id)].disposition,
+        crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
+    ));
 }
 
 #[tokio::test]
-async fn production_protocol_settlement_fault_rolls_back_queue_and_canonical_facts() {
+async fn production_protocol_settlement_fault_rolls_back_queue_and_protocol_facts() {
     for fault in PRE_COMMIT_FAULTS {
         let dir = tempdir().unwrap();
         let workspace = tempdir().unwrap();
@@ -5299,6 +5760,13 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_canonical_fac
             .transitions()
             .load_scheduler_protocol_snapshot("default")
             .unwrap();
+        let claimed_execution = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .expect("claim should initialize the execution partition");
         finish_claimed_test_run(&runtime).await;
         let terminal = terminal_transition(&message, Some(&work_item.id));
         runtime.inject_next_transition_fault(fault);
@@ -5334,6 +5802,15 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_canonical_fac
                 .load_scheduler_protocol_snapshot("default")
                 .unwrap(),
             claimed
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("default")
+                .unwrap(),
+            Some(claimed_execution)
         );
         assert_eq!(
             runtime
@@ -7280,6 +7757,7 @@ async fn abort_current_run_aborts_provider_turn_and_stops_agent() {
         context_config(),
     )
     .unwrap();
+    append_default_host_identity(&runtime);
     runtime
         .enqueue(MessageEnvelope::new(
             "default",
@@ -7294,8 +7772,11 @@ async fn abort_current_run_aborts_provider_turn_and_stops_agent() {
         .await
         .unwrap();
 
-    let runner = tokio::spawn(runtime.clone().run());
-    started.notified().await;
+    let mut runner = tokio::spawn(runtime.clone().run());
+    tokio::select! {
+        _ = started.notified() => {}
+        result = &mut runner => panic!("runtime exited before provider start: {result:?}"),
+    }
     let run_id = runtime
         .agent_state()
         .await
@@ -7386,6 +7867,7 @@ async fn operator_interjection_prompt_is_interjected_before_next_provider_round(
         },
     )
     .unwrap();
+    append_default_host_identity(&runtime);
 
     runtime
         .enqueue(MessageEnvelope::new(
@@ -7401,8 +7883,11 @@ async fn operator_interjection_prompt_is_interjected_before_next_provider_round(
         .await
         .unwrap();
 
-    let runner = tokio::spawn(runtime.clone().run());
-    first_tool_round.notified().await;
+    let mut runner = tokio::spawn(runtime.clone().run());
+    tokio::select! {
+        _ = first_tool_round.notified() => {}
+        result = &mut runner => panic!("runtime exited before first provider round: {result:?}"),
+    }
 
     let interjection = MessageEnvelope::new(
         "default",
@@ -7646,6 +8131,7 @@ async fn abort_current_run_rejects_stale_run_id() {
         context_config(),
     )
     .unwrap();
+    append_default_host_identity(&runtime);
     runtime
         .enqueue(MessageEnvelope::new(
             "default",
@@ -7660,8 +8146,11 @@ async fn abort_current_run_rejects_stale_run_id() {
         .await
         .unwrap();
 
-    let runner = tokio::spawn(runtime.clone().run());
-    started.notified().await;
+    let mut runner = tokio::spawn(runtime.clone().run());
+    tokio::select! {
+        _ = started.notified() => {}
+        result = &mut runner => panic!("runtime exited before provider start: {result:?}"),
+    }
 
     let err = runtime
         .abort_current_run(CurrentRunAbortRequest {
@@ -7809,6 +8298,39 @@ async fn task_status_routes_only_through_task_state_reduction() {
     assert!(events
         .iter()
         .any(|event| event.kind == "task_status_updated"));
+}
+
+#[test]
+fn task_rejoin_fence_requires_live_persisted_contract() {
+    let now = Utc::now();
+    let mut task = TaskRecord {
+        id: "task-rejoin-contract".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: now,
+        updated_at: now,
+        parent_message_id: Some("message-result".into()),
+        work_item_id: Some("work-rejoin-contract".into()),
+        summary: Some("task completed".into()),
+        detail: Some(serde_json::json!({
+            "rejoin_obligation_id": "task-rejoin-contract",
+            "rejoin_generation": 1,
+            "parent_turn_id": "turn-parent"
+        })),
+        recovery: None,
+    };
+
+    let fence = tasks::task_rejoin_fence(&task).unwrap();
+    assert_eq!(fence.obligation_id, task.id);
+    assert_eq!(fence.generation, 1);
+    assert_eq!(fence.parent_turn_id, "turn-parent");
+
+    task.detail.as_mut().unwrap()["rejoin_obligation_id"] = serde_json::json!("task-other");
+    assert!(tasks::task_rejoin_fence(&task)
+        .unwrap_err()
+        .to_string()
+        .contains("does not match"));
 }
 
 #[tokio::test]
@@ -8319,6 +8841,103 @@ async fn same_turn_message_does_not_reconcile_wait_condition() {
         0,
         "different-turn message must reconcile the wait"
     );
+}
+
+#[tokio::test]
+async fn work_item_wait_resume_repairs_missing_scheduler_wait_mirror() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "reconciled",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let mut work_item = WorkItemRecord::new("default", "operator wait work", WorkItemState::Open);
+    work_item.id = "work-op-wait-mirror-missing".into();
+    runtime.storage().append_work_item(&work_item).unwrap();
+    let wait = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "operator resume".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut snapshot =
+        canonical_waiting_snapshot(&work_item, &wait.condition.id, work_item.revision);
+    snapshot.dispatch = AgentDispatchState::Open;
+    snapshot.focus = None;
+    snapshot.work.clear();
+    snapshot.waits.clear();
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &snapshot)
+        .unwrap();
+
+    let message = runtime
+        .enqueue(trusted_operator_prompt(
+            Some(&work_item.id),
+            "resume without scheduler wait mirror",
+        ))
+        .await
+        .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("durable WorkItem wait should resume without a scheduler wait mirror");
+    };
+    assert_eq!(scheduled.message.id, message.id);
+
+    let snapshot = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    assert!(matches!(
+        &snapshot.activation_admissions[&activation_id].activation.cause,
+        ActivationCause::OperatorInput {
+            message_id,
+            resume: Some(resume),
+        } if message_id == &message.id
+            && resume.wait_id == wait.condition.id
+            && resume.wait_generation == work_item.revision
+    ));
+    assert_eq!(
+        snapshot.waits[&wait.condition.id].generations[&work_item.revision].state,
+        WaitState::Consumed
+    );
+
+    runtime
+        .record_wait_reconciliation_signals(&scheduled.message)
+        .await
+        .unwrap();
+    assert!(runtime
+        .storage()
+        .active_wait_conditions_for_work_item("default", &work_item.id)
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1372,6 +1372,56 @@ fn unbound_terminal_task_result_is_lifecycle_nudge_without_a_wait() {
 }
 
 #[test]
+fn runtime_owned_unbound_child_followup_is_lifecycle_nudge() {
+    let message = MessageEnvelope::new(
+        "child",
+        MessageKind::InternalFollowup,
+        MessageOrigin::Task {
+            task_id: "task-parent".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "delegated objective".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        Some(
+            scheduler::CanonicalActivationCandidate::LifecycleExternalNudge {
+                agent_id: "child".into(),
+            }
+        )
+    );
+}
+
+#[test]
+fn untrusted_unbound_internal_followup_is_not_a_canonical_candidate() {
+    let message = MessageEnvelope::new(
+        "child",
+        MessageKind::InternalFollowup,
+        MessageOrigin::Task {
+            task_id: "task-parent".into(),
+        },
+        AuthorityClass::ExternalEvidence,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "untrusted followup".into(),
+        },
+    );
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        None
+    );
+}
+
+#[test]
 fn unbound_timer_tick_is_lifecycle_nudge_without_a_wait() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1564,6 +1564,18 @@ fn correlated_wait_resume_requires_the_exact_expected_owner() {
             wait_id: "wait-lifecycle".into(),
         })
     );
+    assert_eq!(
+        scheduler::resolve_canonical_activation_scenario(
+            &projection,
+            &message,
+            scheduler::CanonicalActivationCandidate::ExactWaitResume {
+                expected_work_item_id: Some("work-a".into()),
+                correlated_wait: Some(("wait-work".into(), 6)),
+            },
+        )
+        .unwrap(),
+        None
+    );
 }
 
 #[test]

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1401,6 +1401,35 @@ fn runtime_owned_unbound_child_followup_is_lifecycle_nudge() {
 }
 
 #[test]
+fn runtime_owned_unbound_child_evidence_is_lifecycle_nudge() {
+    let message = MessageEnvelope::new(
+        "child",
+        MessageKind::InternalFollowup,
+        MessageOrigin::Task {
+            task_id: "task-parent".into(),
+        },
+        AuthorityClass::ExternalEvidence,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "delegated evidence".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        Some(
+            scheduler::CanonicalActivationCandidate::LifecycleExternalNudge {
+                agent_id: "child".into(),
+            }
+        )
+    );
+}
+
+#[test]
 fn untrusted_unbound_internal_followup_is_not_a_canonical_candidate() {
     let message = MessageEnvelope::new(
         "child",

--- a/src/runtime/tests/support/lifecycle.rs
+++ b/src/runtime/tests/support/lifecycle.rs
@@ -62,6 +62,7 @@ pub(crate) struct LifecycleHarness {
     workspace: TempDir,
     clock: Arc<crate::runtime::clock::TestClock>,
     provider: Arc<dyn AgentProvider>,
+    scheduler_engine: crate::config::SchedulerEngineMode,
     runtime: RuntimeHandle,
 }
 
@@ -71,15 +72,39 @@ impl LifecycleHarness {
     }
 
     pub(crate) fn with_provider(provider: Arc<dyn AgentProvider>) -> Self {
+        Self::with_provider_and_scheduler_engine(
+            provider,
+            crate::config::SchedulerEngineMode::Canonical,
+        )
+    }
+
+    pub(crate) fn legacy() -> Self {
+        Self::with_provider_and_scheduler_engine(
+            Arc::new(StubProvider::new("unused")),
+            crate::config::SchedulerEngineMode::Legacy,
+        )
+    }
+
+    fn with_provider_and_scheduler_engine(
+        provider: Arc<dyn AgentProvider>,
+        scheduler_engine: crate::config::SchedulerEngineMode,
+    ) -> Self {
         let data_dir = tempdir().expect("create lifecycle data dir");
         let workspace = tempdir().expect("create lifecycle workspace");
         let clock = controlled_clock();
-        let runtime = Self::open_runtime(&data_dir, &workspace, clock.clone(), provider.clone());
+        let runtime = Self::open_runtime(
+            &data_dir,
+            &workspace,
+            clock.clone(),
+            provider.clone(),
+            scheduler_engine,
+        );
         Self {
             data_dir,
             workspace,
             clock,
             provider,
+            scheduler_engine,
             runtime,
         }
     }
@@ -89,8 +114,9 @@ impl LifecycleHarness {
         workspace: &TempDir,
         clock: Arc<crate::runtime::clock::TestClock>,
         provider: Arc<dyn AgentProvider>,
+        scheduler_engine: crate::config::SchedulerEngineMode,
     ) -> RuntimeHandle {
-        RuntimeHandle::new_with_clock(
+        RuntimeHandle::new_with_clock_and_scheduler_engine(
             "default",
             data_dir.path().to_path_buf(),
             workspace.path().to_path_buf(),
@@ -98,6 +124,7 @@ impl LifecycleHarness {
             provider,
             "default".into(),
             context_config(),
+            scheduler_engine,
             clock,
         )
         .expect("open lifecycle runtime")
@@ -117,6 +144,7 @@ impl LifecycleHarness {
             &self.workspace,
             self.clock.clone(),
             self.provider.clone(),
+            self.scheduler_engine,
         );
     }
 

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -187,9 +187,15 @@ async fn malformed_task_message_does_not_exit_runtime_loop() {
         .await
         .unwrap();
 
-    let runtime_task = tokio::spawn(runtime.clone().run());
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
+        if runtime_task.is_finished() {
+            panic!(
+                "runtime exited while processing malformed task result: {:?}",
+                (&mut runtime_task).await
+            );
+        }
         let briefs = runtime.storage().read_recent_briefs(10).unwrap();
         if briefs
             .iter()

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -56,7 +56,7 @@ use super::{
 use super::{truncate_preview, CHECKPOINT_RESUME_PROMPT};
 use crate::runtime::{
     combine_text_history, is_max_output_stop_reason, message_dispatch::message_text, scheduler,
-    scheduler_executor, CurrentRunAborted, RuntimeHandle,
+    CurrentRunAborted, RuntimeHandle,
 };
 
 enum OperatorInterjectionPlan {
@@ -592,13 +592,6 @@ impl RuntimeHandle {
                 ));
             }
         };
-        if activation_id
-            != scheduler_executor::canonical_activation_id(&execution_binding.source_message_id)
-        {
-            return Err(anyhow::anyhow!(
-                "operator interjection activation disagrees with the source message"
-            ));
-        }
         let snapshot = self
             .inner
             .runtime_db
@@ -610,6 +603,17 @@ impl RuntimeHandle {
         let activation = snapshot.activations.get(activation_id).ok_or_else(|| {
             anyhow::anyhow!("operator interjection references an unknown canonical activation")
         })?;
+        if snapshot
+            .activation_admissions
+            .get(activation_id)
+            .is_none_or(|admission| {
+                admission.activation.provenance.source_id != execution_binding.source_message_id
+            })
+        {
+            return Err(anyhow::anyhow!(
+                "operator interjection activation disagrees with the source message"
+            ));
+        }
         match &activation.owner {
             crate::domain::scheduler_protocol::SchedulerOwner::WorkItem { work_item_id }
                 if execution_binding.work_item_id.as_deref() == Some(work_item_id.as_str()) => {}
@@ -1516,6 +1520,7 @@ impl TurnExecution<'_> {
                 .filter(|text| !text.is_empty())
                 .collect::<Vec<_>>()
                 .join("\n\n");
+            let current_round_has_assistant_text = !combined_text.is_empty();
             if round_purpose == AssistantRoundPurpose::AgentResponse {
                 let aggregated_text = combine_text_history(&truncated_text_history, &text_blocks)
                     .into_iter()
@@ -1694,7 +1699,9 @@ impl TurnExecution<'_> {
             };
             let assistant_round_id = assistant_round_transcript_entry.id.clone();
             runtime.persist_transcript_evidence(&assistant_round_transcript_entry)?;
-            if round_purpose == AssistantRoundPurpose::AgentResponse {
+            if round_purpose == AssistantRoundPurpose::AgentResponse
+                && current_round_has_assistant_text
+            {
                 last_assistant_round_id = Some(assistant_round_id.clone());
             }
             runtime.inner.storage.append_event(&AuditEvent::legacy(
@@ -2373,6 +2380,9 @@ impl TurnExecution<'_> {
             let mut interjections = before_tool_execution_interjections;
             interjections.extend(after_tool_results_interjections);
             let has_operator_interjections = !interjections.is_empty();
+            let terminal_wait_without_text =
+                round_tool_calls.iter().any(|call| call.name == "WaitFor")
+                    && !current_round_has_assistant_text;
             let round_record = TurnRoundRecord {
                 round,
                 estimated_tokens: build_round_estimated_tokens(
@@ -2404,11 +2414,16 @@ impl TurnExecution<'_> {
                 && (!has_operator_interjections || terminal_tool_transition)
                 && !checkpoint_state.operator_delivery_pending()
             {
-                let final_text = last_assistant_message.clone().unwrap_or_default();
+                let terminal_assistant_message = if terminal_wait_without_text {
+                    None
+                } else {
+                    last_assistant_message.clone()
+                };
+                let final_text = terminal_assistant_message.clone().unwrap_or_default();
                 let terminal = runtime
                     .persist_turn_terminal_record(
                         TurnTerminalKind::Completed,
-                        last_assistant_message.clone(),
+                        terminal_assistant_message,
                         turn_started_at.elapsed().as_millis() as u64,
                         Some(&checkpoint_state),
                         persist_terminal,
@@ -2416,7 +2431,9 @@ impl TurnExecution<'_> {
                     .await?;
                 return Ok(AgentLoopOutcome {
                     final_text,
-                    final_text_source_assistant_round_id: last_assistant_round_id.clone(),
+                    final_text_source_assistant_round_id: (!terminal_wait_without_text)
+                        .then(|| last_assistant_round_id.clone())
+                        .flatten(),
                     turn_index: terminal.turn_index,
                     terminal,
                     should_sleep: true,

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -999,7 +999,11 @@ impl RuntimeHandle {
         else {
             return Ok(None);
         };
-        let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+        let Some(activation_id) =
+            scheduler_executor::canonical_open_activation_id(&snapshot, &message.id)
+        else {
+            return Ok(None);
+        };
         let Some(admission) = snapshot.activation_admissions.get(&activation_id) else {
             return Ok(None);
         };

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -239,8 +239,8 @@ pub(crate) fn upsert_agent_state_tx(tx: &Transaction<'_>, record: &AgentState) -
     tx.execute(
         "INSERT INTO agent_states (
             agent_id, status, turn_index, current_run_id, current_work_item_id,
-            active_workspace_id, updated_at, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            active_workspace_id, updated_at, payload_json, control_revision
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)
          ON CONFLICT(agent_id) DO UPDATE SET
             status = excluded.status,
             turn_index = excluded.turn_index,
@@ -248,7 +248,8 @@ pub(crate) fn upsert_agent_state_tx(tx: &Transaction<'_>, record: &AgentState) -
             current_work_item_id = excluded.current_work_item_id,
             active_workspace_id = excluded.active_workspace_id,
             updated_at = excluded.updated_at,
-            payload_json = excluded.payload_json
+            payload_json = excluded.payload_json,
+            control_revision = agent_states.control_revision + 1
          WHERE excluded.turn_index >= agent_states.turn_index",
         params![
             record.id,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -2,10 +2,22 @@
 
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
+use crate::domain::{
+    execution_protocol::{
+        self, AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding,
+        ExecutionOrigin, ExecutionPriority, ExecutionProtocolState, ExecutionProvenance,
+        ExecutionSource, ExecutionSourceIdentity, ExecutionTrust, RejoinFence,
+        WorkItemExecutionRecord, WorkItemExecutionState,
+    },
+    scheduler_protocol::{
+        ActivationBinding, ActivationCause, ActivationOrigin, ActivationPriority, ActivationTrust,
+        AdmitActivationCommand, SchedulerOwner, WorkDemand,
+    },
+};
 use crate::runtime_db::evidence::content_hash;
-use crate::types::{AgentState, WaitConditionRecord, WorkItemRecord};
+use crate::types::{AgentState, MessageEnvelope, TaskRecord, WaitConditionRecord, WorkItemRecord};
 
 pub struct Migration {
     pub version: i64,
@@ -2373,6 +2385,75 @@ INSERT OR IGNORE INTO scheduler_rollout_retirement (
 );
 "#,
     },
+    Migration {
+        version: 41,
+        name: "execution_protocol_authority",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS execution_protocol_partitions (
+  agent_id TEXT PRIMARY KEY,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS execution_protocol_work_items (
+  agent_id TEXT NOT NULL,
+  work_item_id TEXT NOT NULL,
+  source_revision INTEGER NOT NULL CHECK (source_revision > 0),
+  generation INTEGER NOT NULL CHECK (generation >= 0),
+  lifecycle_state TEXT NOT NULL CHECK (
+    lifecycle_state IN (
+      'runnable', 'in_flight', 'waiting', 'paused', 'needs_repair', 'terminal'
+    )
+  ),
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (agent_id, work_item_id)
+);
+
+CREATE TABLE IF NOT EXISTS execution_protocol_attempts (
+  agent_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL CHECK (
+    lifecycle_state IN ('open', 'settled', 'interrupted', 'protocol_violation')
+  ),
+  source_identity_json TEXT NOT NULL,
+  source_generation INTEGER NOT NULL CHECK (source_generation > 0),
+  recovery_of_attempt_id TEXT,
+  terminal_outcome_id TEXT,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (agent_id, attempt_id),
+  UNIQUE (agent_id, terminal_outcome_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS execution_protocol_one_open_attempt
+  ON execution_protocol_attempts(agent_id)
+  WHERE lifecycle_state = 'open';
+
+CREATE TABLE IF NOT EXISTS execution_protocol_outcomes (
+  agent_id TEXT NOT NULL,
+  outcome_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (agent_id, outcome_id),
+  UNIQUE (agent_id, attempt_id),
+  FOREIGN KEY (agent_id, attempt_id)
+    REFERENCES execution_protocol_attempts(agent_id, attempt_id)
+);
+
+CREATE TABLE IF NOT EXISTS execution_protocol_command_results (
+  agent_id TEXT NOT NULL,
+  command_kind TEXT NOT NULL,
+  command_identity TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  references_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, command_kind, command_identity)
+);
+"#,
+    },
+    Migration {
+        version: 42,
+        name: "execution_protocol_authority_fences",
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -2419,7 +2500,13 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
         preflight_work_item_focus(&transaction)?;
         migrate_work_item_focus(&transaction)?;
     }
+    if migration.name == "execution_protocol_authority" {
+        ensure_execution_protocol_authority_columns(&transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
+    if migration.name == "execution_protocol_authority" {
+        backfill_execution_protocol_authority(&transaction)?;
+    }
     if migration.name == "drop_work_item_readiness" {
         drop_work_item_readiness(&transaction)?;
     }
@@ -2439,6 +2526,540 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     )?;
     transaction.commit()?;
     Ok(())
+}
+
+fn ensure_execution_protocol_authority_columns(connection: &Connection) -> Result<()> {
+    if !table_exists_internal(connection, "agent_states")? {
+        return Ok(());
+    }
+    let columns = connection
+        .prepare("PRAGMA table_info(agent_states)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|column| column == "control_revision") {
+        connection.execute_batch(
+            "ALTER TABLE agent_states
+               ADD COLUMN control_revision INTEGER NOT NULL DEFAULT 1
+               CHECK (control_revision > 0);",
+        )?;
+    }
+    Ok(())
+}
+
+fn backfill_execution_protocol_authority(transaction: &Transaction<'_>) -> Result<()> {
+    if !table_exists_internal(transaction, "queue_entries")? {
+        return Ok(());
+    }
+    let claims = {
+        let mut statement = transaction.prepare(
+            "SELECT agent_id, message_id
+             FROM queue_entries
+             WHERE status = 'dequeued'
+             ORDER BY agent_id, message_id",
+        )?;
+        let agents = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        agents
+    };
+    let mut imported_agents = std::collections::BTreeSet::new();
+
+    for (agent_id, message_id) in claims {
+        let active_admissions = {
+            let mut statement = transaction.prepare(
+                "SELECT activation_id, owner_kind, owner_id, work_item_id,
+                        admitted_generation, payload_json, created_at
+                 FROM scheduler_activations
+                 WHERE agent_id = ?1
+                   AND lifecycle_state IN ('admitted', 'running')
+                 ORDER BY activation_id",
+            )?;
+            let activations = statement
+                .query_map([&agent_id], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, String>(6)?,
+                    ))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            activations
+        };
+        let mut matching = active_admissions
+            .into_iter()
+            .map(
+                |(
+                    activation_id,
+                    owner_kind,
+                    owner_id,
+                    work_item_id,
+                    admitted_generation,
+                    payload,
+                    created_at,
+                )| {
+                    let admission = serde_json::from_str::<AdmitActivationCommand>(&payload)?;
+                    Ok::<_, serde_json::Error>(
+                        (admission.activation.provenance.source_id == message_id).then_some((
+                            activation_id,
+                            owner_kind,
+                            owner_id,
+                            work_item_id,
+                            admitted_generation,
+                            admission,
+                            created_at,
+                        )),
+                    )
+                },
+            )
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("decoding active canonical activation admission")?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        if matching.is_empty() {
+            continue;
+        }
+        if matching.len() != 1 {
+            bail!(
+                "execution protocol migration found multiple active canonical activations for \
+                 dequeued message {agent_id}:{message_id}"
+            );
+        }
+        if !imported_agents.insert(agent_id.clone()) {
+            bail!(
+                "execution protocol migration found multiple active dequeued claims for agent \
+                 {agent_id}"
+            );
+        }
+        let (
+            activation_id,
+            owner_kind,
+            owner_id,
+            work_item_id,
+            admitted_generation,
+            admission,
+            admitted_at,
+        ) = matching.pop().expect("one matching admission");
+        let message = load_migration_message(transaction, &agent_id, &message_id)?;
+        let state = execution_protocol_state_from_canonical_claim(
+            transaction,
+            &agent_id,
+            &activation_id,
+            &owner_kind,
+            &owner_id,
+            work_item_id.as_deref(),
+            admitted_generation,
+            &admission,
+            &message,
+            admitted_at,
+        )?;
+        execution_protocol::assert_invariants(&state).map_err(|error| {
+            anyhow::anyhow!("invalid migrated execution protocol state: {error}")
+        })?;
+        crate::runtime_db::transitions::persist_state_tx(transaction, &state)?;
+    }
+    Ok(())
+}
+
+fn load_migration_message(
+    transaction: &Transaction<'_>,
+    agent_id: &str,
+    message_id: &str,
+) -> Result<MessageEnvelope> {
+    let rows = {
+        let mut statement = transaction.prepare(
+            "SELECT message_seq, payload_json
+             FROM messages
+             WHERE agent_id = ?1 AND message_id = ?2
+             ORDER BY evidence_id",
+        )?;
+        let rows = statement
+            .query_map(params![agent_id, message_id], |row| {
+                Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        rows
+    };
+    if rows.len() != 1 {
+        bail!(
+            "execution protocol migration requires exactly one message evidence row for \
+             {agent_id}:{message_id}, found {}",
+            rows.len()
+        );
+    }
+    let (stored_sequence, payload) = rows.into_iter().next().expect("one message row");
+    let stored_sequence = stored_sequence
+        .and_then(|value| u64::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "execution protocol migration requires a positive message sequence for \
+                 {agent_id}:{message_id}"
+            )
+        })?;
+    let message: MessageEnvelope =
+        serde_json::from_str(&payload).context("decoding migration message evidence")?;
+    if message.id != message_id
+        || message.agent_id != agent_id
+        || message.message_seq != Some(stored_sequence)
+    {
+        bail!(
+            "execution protocol migration message evidence identity or sequence mismatch for \
+             {agent_id}:{message_id}"
+        );
+    }
+    Ok(message)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execution_protocol_state_from_canonical_claim(
+    transaction: &Transaction<'_>,
+    agent_id: &str,
+    activation_id: &str,
+    owner_kind: &str,
+    owner_id: &str,
+    work_item_id: Option<&str>,
+    admitted_generation: i64,
+    admission: &AdmitActivationCommand,
+    message: &MessageEnvelope,
+    admitted_at: String,
+) -> Result<ExecutionProtocolState> {
+    if admission.activation.id != activation_id
+        || admission.activation.agent_id != agent_id
+        || admission.activation.provenance.source_id != message.id
+    {
+        bail!("execution protocol migration canonical activation identity mismatch");
+    }
+    let admitted_generation = u64::try_from(admitted_generation)
+        .context("execution protocol migration admitted generation is negative")?;
+    if admitted_generation == 0 || admission.expected_scheduling_generation != admitted_generation {
+        bail!("execution protocol migration canonical admitted generation is invalid");
+    }
+    let authority_fences =
+        crate::runtime_db::transitions::authority_fences_tx(transaction, agent_id)?;
+    let source_revision = message
+        .message_seq
+        .filter(|revision| *revision > 0)
+        .ok_or_else(|| anyhow::anyhow!("execution protocol migration requires message sequence"))?;
+    let (source_identity, rejoin, recovery_of_attempt_id) =
+        migration_execution_source(transaction, admission, message)?;
+    let mut state = ExecutionProtocolState::empty(agent_id);
+    let (binding, work_item_source_revision, work_item_generation) = match owner_kind {
+        "work_item" if work_item_id == Some(owner_id) => {
+            let work_item_id = work_item_id.expect("validated WorkItem owner");
+            validate_migration_work_item_binding(admission, work_item_id)?;
+            let demand_payload = transaction
+                .query_row(
+                    "SELECT payload_json
+                     FROM scheduler_work_demands
+                     WHERE agent_id = ?1 AND work_item_id = ?2",
+                    params![agent_id, work_item_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "execution protocol migration WorkItem demand is missing for \
+                         {agent_id}:{work_item_id}"
+                    )
+                })?;
+            let demand: WorkDemand = serde_json::from_str(&demand_payload)
+                .context("decoding migration WorkItem demand")?;
+            if demand.metadata_revision == 0 || demand.scheduling_generation != admitted_generation
+            {
+                bail!(
+                    "execution protocol migration WorkItem demand fence mismatch for \
+                     {agent_id}:{work_item_id}"
+                );
+            }
+            state.work_items.insert(
+                work_item_id.to_string(),
+                WorkItemExecutionRecord {
+                    source_revision: demand.metadata_revision,
+                    state: WorkItemExecutionState::InFlight {
+                        generation: admitted_generation,
+                        attempt_id: activation_id.to_string(),
+                    },
+                },
+            );
+            (
+                ExecutionBinding::WorkItem {
+                    work_item_id: work_item_id.to_string(),
+                },
+                Some(demand.metadata_revision),
+                Some(admitted_generation),
+            )
+        }
+        "agent_lifecycle" if owner_id == agent_id && work_item_id.is_none() => {
+            validate_migration_lifecycle_binding(admission, agent_id)?;
+            (
+                ExecutionBinding::AgentLifecycle {
+                    agent_id: agent_id.to_string(),
+                },
+                None,
+                None,
+            )
+        }
+        _ => bail!(
+            "execution protocol migration invalid canonical owner \
+             {owner_kind}:{owner_id} for agent {agent_id}"
+        ),
+    };
+    let attempt = ExecutionAttempt {
+        attempt_id: activation_id.to_string(),
+        agent_id: agent_id.to_string(),
+        source_message_id: Some(message.id.clone()),
+        source: ExecutionSource {
+            identity: source_identity,
+            generation: source_revision,
+        },
+        binding,
+        provenance: ExecutionProvenance {
+            origin: migration_execution_origin(admission.activation.provenance.origin),
+            trust: migration_execution_trust(admission.activation.provenance.trust),
+            priority: migration_execution_priority(admission.activation.priority),
+            correlation_id: message.correlation_id.clone(),
+            causation_id: message.causation_id.clone(),
+        },
+        admitted_fences: AdmittedFences {
+            source_revision,
+            work_item_source_revision,
+            work_item_generation,
+            rejoin,
+            agent_control_revision: authority_fences.agent_control_revision,
+            host_registry_revision: authority_fences.host_registry_revision,
+        },
+        state: ExecutionAttemptState::Open,
+        run_id: None,
+        turn_id: message.turn_id.clone(),
+        recovery_of_attempt_id,
+        terminal_outcome_id: None,
+        admitted_at,
+        terminal_at: None,
+    };
+    state.attempts.insert(activation_id.to_string(), attempt);
+    Ok(state)
+}
+
+fn migration_execution_source(
+    transaction: &Transaction<'_>,
+    admission: &AdmitActivationCommand,
+    message: &MessageEnvelope,
+) -> Result<(ExecutionSourceIdentity, Option<RejoinFence>, Option<String>)> {
+    let result = match &admission.activation.cause {
+        ActivationCause::OperatorInput { message_id, .. }
+        | ActivationCause::OperatorInterjection { message_id }
+        | ActivationCause::MessageIngress { message_id }
+        | ActivationCause::LifecycleExternalNudge { message_id }
+        | ActivationCause::InternalFollowup { message_id }
+            if message_id == &message.id =>
+        {
+            (
+                ExecutionSourceIdentity::QueueMessage {
+                    message_id: message.id.clone(),
+                },
+                None,
+                None,
+            )
+        }
+        ActivationCause::TaskRejoin {
+            task_id,
+            message_id,
+            ..
+        } if message_id == &message.id => {
+            let payload = transaction
+                .query_row(
+                    "SELECT payload_json FROM tasks WHERE task_id = ?1 AND owner_agent_id = ?2",
+                    params![task_id, message.agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "execution protocol migration task rejoin source is missing: {task_id}"
+                    )
+                })?;
+            let task: TaskRecord =
+                serde_json::from_str(&payload).context("decoding migration task rejoin source")?;
+            let fence = migration_task_rejoin_fence(&task)?;
+            (
+                ExecutionSourceIdentity::TaskResult {
+                    task_id: task_id.clone(),
+                    result_message_id: message.id.clone(),
+                },
+                Some(fence),
+                None,
+            )
+        }
+        ActivationCause::WaitResume {
+            wait_id,
+            wait_generation,
+            trigger_id,
+            trigger_generation,
+        } => (
+            ExecutionSourceIdentity::TriggeredWait {
+                wait_id: wait_id.clone(),
+                wait_generation: *wait_generation,
+                trigger_id: trigger_id.clone(),
+                trigger_generation: *trigger_generation,
+            },
+            None,
+            None,
+        ),
+        ActivationCause::WorkItemRunnable { work_item_id, .. }
+        | ActivationCause::WorkItemRecheck { work_item_id, .. } => (
+            ExecutionSourceIdentity::WorkItemContinuation {
+                work_item_id: work_item_id.clone(),
+            },
+            None,
+            None,
+        ),
+        ActivationCause::SettlementRecovery { activation_id } => (
+            ExecutionSourceIdentity::WorkItemContinuation {
+                work_item_id: migration_binding_work_item_id(&admission.activation.binding)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "execution protocol migration settlement recovery lacks WorkItem"
+                        )
+                    })?
+                    .to_string(),
+            },
+            None,
+            Some(activation_id.clone()),
+        ),
+        ActivationCause::RuntimeRecovery { .. } => {
+            bail!("execution protocol migration cannot losslessly import runtime recovery")
+        }
+        _ => bail!("execution protocol migration activation cause does not match message evidence"),
+    };
+    Ok(result)
+}
+
+fn migration_binding_work_item_id(binding: &ActivationBinding) -> Option<&str> {
+    match binding {
+        ActivationBinding::WorkItem { work_item_id }
+        | ActivationBinding::WaitOwner {
+            owner: SchedulerOwner::WorkItem { work_item_id },
+            ..
+        } => Some(work_item_id),
+        ActivationBinding::Unbound
+        | ActivationBinding::WaitOwner { .. }
+        | ActivationBinding::Interaction { .. }
+        | ActivationBinding::Lifecycle { .. } => None,
+    }
+}
+
+fn migration_task_rejoin_fence(task: &TaskRecord) -> Result<RejoinFence> {
+    let detail = task
+        .detail
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| anyhow::anyhow!("migration task rejoin contract is missing detail"))?;
+    let obligation_id = detail
+        .get("rejoin_obligation_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| *value == task.id)
+        .ok_or_else(|| anyhow::anyhow!("migration task rejoin obligation is invalid"))?;
+    let generation = detail
+        .get("rejoin_generation")
+        .and_then(serde_json::Value::as_u64)
+        .filter(|value| *value > 0)
+        .ok_or_else(|| anyhow::anyhow!("migration task rejoin generation is invalid"))?;
+    let parent_turn_id = detail
+        .get("parent_turn_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("migration task rejoin parent turn is invalid"))?;
+    Ok(RejoinFence {
+        obligation_id: obligation_id.to_string(),
+        generation,
+        parent_turn_id: parent_turn_id.to_string(),
+    })
+}
+
+fn validate_migration_work_item_binding(
+    admission: &AdmitActivationCommand,
+    work_item_id: &str,
+) -> Result<()> {
+    let valid = matches!(
+        &admission.activation.binding,
+        ActivationBinding::WorkItem {
+            work_item_id: bound
+        } if bound == work_item_id
+    ) || matches!(
+        &admission.activation.binding,
+        ActivationBinding::WaitOwner {
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: bound
+            },
+            ..
+        } if bound == work_item_id
+    );
+    if !valid {
+        bail!("execution protocol migration WorkItem binding mismatch");
+    }
+    Ok(())
+}
+
+fn validate_migration_lifecycle_binding(
+    admission: &AdmitActivationCommand,
+    agent_id: &str,
+) -> Result<()> {
+    let valid = matches!(
+        &admission.activation.binding,
+        ActivationBinding::Lifecycle {
+            agent_id: bound
+        } if bound == agent_id
+    ) || matches!(
+        &admission.activation.binding,
+        ActivationBinding::WaitOwner {
+            owner: SchedulerOwner::AgentLifecycle {
+                agent_id: bound
+            },
+            ..
+        } if bound == agent_id
+    );
+    if !valid {
+        bail!("execution protocol migration lifecycle binding mismatch");
+    }
+    Ok(())
+}
+
+fn migration_execution_origin(origin: ActivationOrigin) -> ExecutionOrigin {
+    match origin {
+        ActivationOrigin::Operator => ExecutionOrigin::Operator,
+        ActivationOrigin::Channel => ExecutionOrigin::Channel,
+        ActivationOrigin::Webhook => ExecutionOrigin::Webhook,
+        ActivationOrigin::Callback => ExecutionOrigin::Callback,
+        ActivationOrigin::Timer => ExecutionOrigin::Timer,
+        ActivationOrigin::System => ExecutionOrigin::System,
+        ActivationOrigin::Task => ExecutionOrigin::Task,
+        ActivationOrigin::RuntimeRecovery => ExecutionOrigin::RuntimeRecovery,
+    }
+}
+
+fn migration_execution_trust(trust: ActivationTrust) -> ExecutionTrust {
+    match trust {
+        ActivationTrust::OperatorInstruction => ExecutionTrust::OperatorInstruction,
+        ActivationTrust::RuntimeInstruction => ExecutionTrust::RuntimeInstruction,
+        ActivationTrust::IntegrationSignal => ExecutionTrust::IntegrationSignal,
+        ActivationTrust::ExternalEvidence => ExecutionTrust::ExternalEvidence,
+    }
+}
+
+fn migration_execution_priority(priority: ActivationPriority) -> ExecutionPriority {
+    match priority {
+        ActivationPriority::Background => ExecutionPriority::Background,
+        ActivationPriority::Normal => ExecutionPriority::Normal,
+        ActivationPriority::Next => ExecutionPriority::Next,
+        ActivationPriority::Interject => ExecutionPriority::Interject,
+    }
 }
 
 fn migrate_runtime_retention_created_at_indexes(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -2449,11 +2449,6 @@ CREATE TABLE IF NOT EXISTS execution_protocol_command_results (
 );
 "#,
     },
-    Migration {
-        version: 42,
-        name: "execution_protocol_authority_fences",
-        sql: "",
-    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1695,6 +1695,36 @@ impl TurnRecordRepository<'_> {
         self.db.transaction(|tx| upsert_turn_record_tx(tx, record))
     }
 
+    pub fn by_id(&self, agent_id: Option<&str>, turn_id: &str) -> Result<Option<TurnRecord>> {
+        let connection = self.db.connection()?;
+        let payload = if let Some(agent_id) = agent_id {
+            connection
+                .query_row(
+                    "SELECT payload_json
+                     FROM turn_records
+                     WHERE agent_id = ?1 AND turn_id = ?2
+                     LIMIT 1",
+                    params![agent_id, turn_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+        } else {
+            connection
+                .query_row(
+                    "SELECT payload_json
+                     FROM turn_records
+                     WHERE turn_id = ?1
+                     LIMIT 1",
+                    [turn_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+        };
+        payload
+            .map(|payload| decode_turn_record_payload(&payload))
+            .transpose()
+    }
+
     pub fn recent_for_agent(&self, agent_id: &str, limit: usize) -> Result<Vec<TurnRecord>> {
         if limit == 0 {
             return Ok(Vec::new());

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -4430,6 +4430,17 @@ CREATE TABLE working_memory_deltas (
         assert_eq!(records[0].produced_brief_ids, vec!["brief-1"]);
         assert_eq!(records[0].tool_execution_ids, vec!["tool-1"]);
         assert_eq!(records[0].current_work_item_id.as_deref(), Some("work-1"));
+        assert_eq!(
+            db.turn_records()
+                .by_id(Some("agent-a"), "turn-a")?
+                .expect("turn should be addressable directly")
+                .turn_index,
+            7
+        );
+        assert!(db
+            .turn_records()
+            .by_id(Some("agent-b"), "turn-a")?
+            .is_none());
         let domain = db
             .storage_domain("turn_records")?
             .expect("turn_records domain");

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -423,6 +423,112 @@ mod tests {
         })
     }
 
+    fn prepare_pre_execution_protocol_claim(
+        db: &RuntimeDb,
+        agent_id: &str,
+        work_item_id: &str,
+        message_id: &str,
+        activation_id: &str,
+    ) -> Result<()> {
+        db.agent_states().upsert(&AgentState::new(agent_id))?;
+        db.agent_identities().upsert(&agent_identity(agent_id, 0))?;
+
+        let mut work = WorkItemRecord::new(agent_id, "migration claim", WorkItemState::Open);
+        work.id = work_item_id.into();
+        db.work_items().insert_new(&work)?;
+
+        let mut message = MessageEnvelope::new(
+            agent_id,
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text {
+                text: "resume after upgrade".into(),
+            },
+        );
+        message.id = message_id.into();
+        let message = db.messages().append_with_index_changes(&message, &[])?;
+
+        let queued = QueueEntryRecord {
+            message_id: message.id.clone(),
+            agent_id: agent_id.into(),
+            priority: message.priority.clone(),
+            status: QueueEntryStatus::Queued,
+            created_at: message.created_at,
+            updated_at: message.created_at,
+        };
+        db.queue_entries().upsert(&queued)?;
+        let mut dequeued = queued;
+        dequeued.status = QueueEntryStatus::Dequeued;
+        dequeued.updated_at = Utc::now();
+        assert!(db.queue_entries().try_claim_queued_message(&dequeued)?);
+
+        let scheduling_generation = 1;
+        let mut snapshot = scheduler_protocol_snapshot(scheduling_generation);
+        snapshot.focus = Some(work_item_id.into());
+        snapshot.work = BTreeMap::from([(
+            work_item_id.into(),
+            WorkDemand {
+                metadata_revision: work.revision,
+                scheduling_generation,
+                status: WorkStatus::Runnable,
+                capabilities: Default::default(),
+                locks: Default::default(),
+                locality: "runtime".into(),
+                cost_class: "default".into(),
+            },
+        )]);
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &snapshot)?;
+        let admission = ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+            authority_id: format!("authority-{activation_id}"),
+            activation: AgentActivation {
+                id: activation_id.into(),
+                agent_id: agent_id.into(),
+                state: ActivationLifecycleState::Admitted,
+                cause: ActivationCause::OperatorInput {
+                    message_id: message.id.clone(),
+                    resume: None,
+                },
+                binding: ActivationBinding::WorkItem {
+                    work_item_id: work_item_id.into(),
+                },
+                priority: ActivationPriority::Normal,
+                preemption: PreemptionPolicy::AllowOperatorInterjection,
+                source_revision: message.message_seq,
+                idempotency_key: format!("operator-message:{}", message.id),
+                provenance: ActivationProvenance {
+                    origin: ActivationOrigin::Operator,
+                    trust: ActivationTrust::OperatorInstruction,
+                    source_id: message.id,
+                    correlation_id: None,
+                    causation_id: None,
+                },
+            },
+            expected_scheduling_generation: scheduling_generation,
+            expected_dispatch_revision: 0,
+        });
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(agent_id, &admission, None)?;
+        Ok(())
+    }
+
+    fn downgrade_before_execution_protocol(db_path: &std::path::Path) -> Result<()> {
+        let connection = open_connection(db_path)?;
+        connection.execute_batch(
+            "DELETE FROM schema_migrations WHERE version >= 41;
+             DROP TABLE execution_protocol_command_results;
+             DROP TABLE execution_protocol_outcomes;
+             DROP INDEX execution_protocol_one_open_attempt;
+             DROP TABLE execution_protocol_attempts;
+             DROP TABLE execution_protocol_work_items;
+             DROP TABLE execution_protocol_partitions;
+             ALTER TABLE agent_states DROP COLUMN control_revision;",
+        )?;
+        Ok(())
+    }
+
     fn scheduler_protocol_completion_command(
         settlement_id: &str,
         continuation: Option<Continuation>,
@@ -2281,6 +2387,81 @@ INSERT INTO storage_domains (
             current_schema_version(&connection)?,
             max_known_migration_version()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn execution_protocol_migration_backfills_active_canonical_claim() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        prepare_pre_execution_protocol_claim(
+            &db,
+            "agent-a",
+            "work-a",
+            "message-a",
+            "activation-a",
+        )?;
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+
+        let migrated = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let state = migrated
+            .transitions()
+            .load_execution_protocol_state_if_initialized("agent-a")?
+            .expect("migrated execution protocol state");
+        let attempt = state.attempts.get("activation-a").expect("open attempt");
+        assert_eq!(
+            attempt.state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Open
+        );
+        assert_eq!(attempt.source_message_id.as_deref(), Some("message-a"));
+        assert_eq!(
+            attempt.binding,
+            crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+                work_item_id: "work-a".into(),
+            }
+        );
+        assert_eq!(attempt.admitted_fences.source_revision, 1);
+        assert_eq!(attempt.admitted_fences.work_item_source_revision, Some(1));
+        assert_eq!(attempt.admitted_fences.work_item_generation, Some(1));
+        assert_eq!(attempt.admitted_fences.agent_control_revision, 1);
+        assert_eq!(attempt.admitted_fences.host_registry_revision, 1);
+        assert_eq!(
+            state
+                .open_attempt()
+                .map(|attempt| attempt.attempt_id.as_str()),
+            Some("activation-a")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn execution_protocol_migration_fails_closed_when_claim_evidence_is_missing() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        prepare_pre_execution_protocol_claim(
+            &db,
+            "agent-a",
+            "work-a",
+            "message-a",
+            "activation-a",
+        )?;
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+        open_connection(&db_path)?
+            .execute("DELETE FROM messages WHERE message_id = 'message-a'", [])?;
+
+        let error = RuntimeDb::open_and_migrate(&db_path, &lock_path)
+            .expect_err("migration must reject an unreconstructable active claim");
+        assert!(
+            error
+                .to_string()
+                .contains("requires exactly one message evidence row"),
+            "{error:#}"
+        );
+        let connection = open_connection(&db_path)?;
+        assert_eq!(current_schema_version(&connection)?, 40);
+        assert!(!table_exists(&connection, "execution_protocol_attempts")?);
         Ok(())
     }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -2,6 +2,10 @@
 
 // Phase 2 keeps this additive persistence seam dormant until production shadow
 // wiring begins; repository tests exercise it without granting scheduler authority.
+#[cfg(test)]
+mod execution_protocol_fixture_repository;
+mod execution_protocol_repository;
+pub(crate) use execution_protocol_repository::{authority_fences_tx, persist_state_tx};
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) mod scheduler_protocol_repository;
 
@@ -192,6 +196,18 @@ pub(crate) struct QueueTransitionCommand {
     pub notify_scheduler: bool,
     pub fault: Option<TransitionFaultPoint>,
     pub brief_evidence: Vec<BriefRecord>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ExecutionProtocolTransition {
+    pub bootstrap: Option<crate::domain::execution_protocol::ExecutionProtocolState>,
+    pub commands: Vec<crate::domain::execution_protocol::ExecutionProtocolCommand>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExecutionAuthorityFences {
+    pub agent_control_revision: u64,
+    pub host_registry_revision: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -466,6 +482,14 @@ impl RuntimeTransitionRepository<'_> {
     }
 
     pub fn commit_queue(&self, command: &QueueTransitionCommand) -> Result<TransitionCommit> {
+        self.commit_queue_with_execution_protocol(command, &ExecutionProtocolTransition::default())
+    }
+
+    pub fn commit_queue_with_execution_protocol(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+    ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_queue_operation(command)?;
             validate_queue_mutation_tx(tx, &command.mutation)?;
@@ -500,6 +524,13 @@ impl RuntimeTransitionRepository<'_> {
                 &command.agent_id,
                 command.scheduler_protocol_bootstrap.as_ref(),
                 &command.scheduler_protocol_commands,
+                &execution_protocol.commands,
+            )?;
+            let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
+                tx,
+                &command.agent_id,
+                execution_protocol.bootstrap.as_ref(),
+                &execution_protocol.commands,
             )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
             let mutation_applied = match &command.mutation {
@@ -526,7 +557,13 @@ impl RuntimeTransitionRepository<'_> {
             let protocol_applied = scheduler_protocol
                 .as_ref()
                 .is_some_and(|prepared| prepared.has_writes());
-            let applied = mutation_applied || agent_state_applied || protocol_applied;
+            let execution_protocol_applied = execution_protocol
+                .as_ref()
+                .is_some_and(|prepared| prepared.has_writes());
+            let applied = mutation_applied
+                || agent_state_applied
+                || protocol_applied
+                || execution_protocol_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
@@ -535,6 +572,7 @@ impl RuntimeTransitionRepository<'_> {
                 &command.agent_id,
                 scheduler_protocol,
             )?;
+            execution_protocol_repository::persist_execution_commands_tx(tx, execution_protocol)?;
             for message in &command.message_evidence {
                 append_message_tx(tx, message)?;
             }
@@ -1072,8 +1110,15 @@ fn inject_fault(
 mod tests {
     use super::*;
     use crate::{
+        domain::execution_protocol::{
+            AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState,
+            ExecutionBinding, ExecutionOrigin, ExecutionPriority, ExecutionProtocolCommand,
+            ExecutionProtocolState, ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity,
+            ExecutionTrust, WorkItemExecutionRecord, WorkItemExecutionState,
+        },
         runtime_db::{RuntimeIndexChange, RuntimeIndexOperation},
         types::{
+            AgentIdentityRecord, AgentKind, AgentOwnership, AgentProfilePreset, AgentVisibility,
             Priority, QueueEntryStatus, TaskKind, TaskStatus, WaitConditionKind,
             WaitConditionStatus, WakeSource, WorkItemContinuationState, WorkItemState,
         },
@@ -1146,6 +1191,65 @@ mod tests {
             summary: Some("transition task".into()),
             detail: None,
             recovery: None,
+        }
+    }
+
+    fn execution_admission(
+        message_id: &str,
+        attempt_id: &str,
+        work_item_id: &str,
+    ) -> ExecutionProtocolTransition {
+        let mut bootstrap = ExecutionProtocolState::empty("agent-a");
+        bootstrap.work_items.insert(
+            work_item_id.into(),
+            WorkItemExecutionRecord {
+                source_revision: 1,
+                state: WorkItemExecutionState::Runnable {
+                    generation: 1,
+                    recovery_ref: None,
+                },
+            },
+        );
+        ExecutionProtocolTransition {
+            bootstrap: Some(bootstrap),
+            commands: vec![ExecutionProtocolCommand::Admit(Box::new(AdmitExecution {
+                attempt: ExecutionAttempt {
+                    attempt_id: attempt_id.into(),
+                    agent_id: "agent-a".into(),
+                    source_message_id: Some(message_id.into()),
+                    source: ExecutionSource {
+                        identity: ExecutionSourceIdentity::QueueMessage {
+                            message_id: message_id.into(),
+                        },
+                        generation: 1,
+                    },
+                    binding: ExecutionBinding::WorkItem {
+                        work_item_id: work_item_id.into(),
+                    },
+                    provenance: ExecutionProvenance {
+                        origin: ExecutionOrigin::System,
+                        trust: ExecutionTrust::RuntimeInstruction,
+                        priority: ExecutionPriority::Normal,
+                        correlation_id: None,
+                        causation_id: None,
+                    },
+                    admitted_fences: AdmittedFences {
+                        source_revision: 1,
+                        work_item_source_revision: Some(1),
+                        work_item_generation: Some(1),
+                        rejoin: None,
+                        agent_control_revision: 1,
+                        host_registry_revision: 1,
+                    },
+                    state: ExecutionAttemptState::Open,
+                    run_id: None,
+                    turn_id: None,
+                    recovery_of_attempt_id: None,
+                    terminal_outcome_id: None,
+                    admitted_at: "2026-08-01T00:00:00Z".into(),
+                    terminal_at: None,
+                },
+            }))],
         }
     }
 
@@ -1479,6 +1583,132 @@ mod tests {
             assert!(db.transcript_entries().all(Some("agent-a"))?.is_empty());
             assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_claim_and_execution_admission_roll_back_together() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-execution-fault".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&queued)?;
+        let mut claimed = queued.clone();
+        claimed.status = QueueEntryStatus::Dequeued;
+        claimed.updated_at += chrono::Duration::seconds(1);
+
+        db.transitions()
+            .commit_queue_with_execution_protocol(
+                &QueueTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    operation: QueueOperation::Claim,
+                    mutation: QueueMutation::Consume(claimed),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    turn_record: None,
+                    audit_events: Vec::new(),
+                    notify_scheduler: false,
+                    fault: Some(TransitionFaultPoint::AfterCanonicalWrites),
+                    brief_evidence: Vec::new(),
+                },
+                &execution_admission(
+                    &queued.message_id,
+                    "attempt-execution-fault",
+                    "work-execution-fault",
+                ),
+            )
+            .unwrap_err();
+
+        assert_eq!(db.queue_entries().latest_all()?, vec![queued]);
+        let connection = db.connection()?;
+        let partitions: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM execution_protocol_partitions",
+            [],
+            |row| row.get(0),
+        )?;
+        let attempts: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM execution_protocol_attempts",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(partitions, 0);
+        assert_eq!(attempts, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn execution_admission_command_is_idempotent_across_queue_commits() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        db.agent_states().upsert(&AgentState::new("agent-a"))?;
+        db.agent_identities().upsert(&AgentIdentityRecord::new(
+            "agent-a",
+            AgentKind::Named,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        ))?;
+        let transition =
+            execution_admission("message-execution", "attempt-execution", "work-execution");
+        for message_id in ["queue-write-1", "queue-write-2"] {
+            let now = Utc::now();
+            let commit = db.transitions().commit_queue_with_execution_protocol(
+                &QueueTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    operation: QueueOperation::Admit,
+                    mutation: QueueMutation::Upsert(QueueEntryRecord {
+                        message_id: message_id.into(),
+                        agent_id: "agent-a".into(),
+                        priority: Priority::Normal,
+                        status: QueueEntryStatus::Queued,
+                        created_at: now,
+                        updated_at: now,
+                    }),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    turn_record: None,
+                    audit_events: Vec::new(),
+                    notify_scheduler: false,
+                    fault: None,
+                    brief_evidence: Vec::new(),
+                },
+                &transition,
+            )?;
+            assert!(commit.applied);
+        }
+
+        let connection = db.connection()?;
+        let attempts: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM execution_protocol_attempts
+             WHERE agent_id = 'agent-a' AND attempt_id = 'attempt-execution'",
+            [],
+            |row| row.get(0),
+        )?;
+        let command_results: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM execution_protocol_command_results
+             WHERE agent_id = 'agent-a'
+               AND command_kind = 'admit_execution'
+               AND command_identity = 'attempt-execution'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(attempts, 1);
+        assert_eq!(command_results, 1);
         Ok(())
     }
 

--- a/src/runtime_db/transitions/execution_protocol_fixture_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_fixture_repository.rs
@@ -1,0 +1,1025 @@
+use std::{collections::BTreeMap, path::Path};
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Utc;
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::domain::execution_protocol::{
+    self, AdmitExecution, AdmittedFences, CommandResult, ExecutionAttempt, ExecutionAttemptState,
+    ExecutionBinding, ExecutionOrigin, ExecutionOutcome, ExecutionOutcomeRecord, ExecutionPriority,
+    ExecutionProtocolState, ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity,
+    ExecutionTransition, ExecutionTrust, InterruptExecution, SettleExecution, WaitReference,
+    WorkItemExecutionRecord, WorkItemExecutionState,
+};
+
+const FIXTURE_SCHEMA: &str = r#"
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS execution_fixture_partitions (
+  agent_id TEXT PRIMARY KEY,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS execution_fixture_work_items (
+  agent_id TEXT NOT NULL,
+  work_item_id TEXT NOT NULL,
+  source_revision INTEGER NOT NULL CHECK (source_revision > 0),
+  generation INTEGER NOT NULL CHECK (generation >= 0),
+  lifecycle_state TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (agent_id, work_item_id)
+);
+
+CREATE TABLE IF NOT EXISTS execution_fixture_attempts (
+  agent_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL,
+  source_identity TEXT NOT NULL,
+  source_generation INTEGER NOT NULL CHECK (source_generation >= 0),
+  recovery_of_attempt_id TEXT,
+  terminal_outcome_id TEXT,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (agent_id, attempt_id),
+  UNIQUE (agent_id, terminal_outcome_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS execution_fixture_one_open_attempt
+  ON execution_fixture_attempts(agent_id)
+  WHERE lifecycle_state = 'open';
+
+CREATE TABLE IF NOT EXISTS execution_fixture_outcomes (
+  agent_id TEXT NOT NULL,
+  outcome_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (agent_id, outcome_id),
+  UNIQUE (agent_id, attempt_id),
+  FOREIGN KEY (agent_id, attempt_id)
+    REFERENCES execution_fixture_attempts(agent_id, attempt_id)
+);
+
+CREATE TABLE IF NOT EXISTS execution_fixture_command_results (
+  agent_id TEXT NOT NULL,
+  command_kind TEXT NOT NULL,
+  command_identity TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, command_kind, command_identity)
+);
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FixtureFaultPoint {
+    AfterStateWrites,
+    BeforeCommit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FixtureCommandResult {
+    references: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FixtureCommit {
+    applied: bool,
+    replayed: bool,
+    transition: ExecutionTransition,
+}
+
+struct ExecutionProtocolFixtureRepository {
+    connection: Connection,
+}
+
+impl ExecutionProtocolFixtureRepository {
+    fn open(path: &Path) -> Result<Self> {
+        let connection = Connection::open(path)?;
+        connection.execute_batch(FIXTURE_SCHEMA)?;
+        Ok(Self { connection })
+    }
+
+    fn initialize(&mut self, state: &ExecutionProtocolState) -> Result<()> {
+        execution_protocol::assert_invariants(state)
+            .map_err(|error| anyhow!("invalid execution fixture state: {error}"))?;
+        let transaction = self.connection.transaction()?;
+        let exists: bool = transaction.query_row(
+            "SELECT EXISTS(
+               SELECT 1 FROM execution_fixture_partitions WHERE agent_id = ?1
+             )",
+            [&state.agent_id],
+            |row| row.get(0),
+        )?;
+        if exists {
+            bail!(
+                "execution fixture partition for agent {} already exists",
+                state.agent_id
+            );
+        }
+        persist_state(&transaction, state)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    fn load(&mut self, agent_id: &str) -> Result<ExecutionProtocolState> {
+        let transaction = self.connection.transaction()?;
+        let state = load_state(&transaction, agent_id)?;
+        transaction.commit()?;
+        Ok(state)
+    }
+
+    fn admit(
+        &mut self,
+        agent_id: &str,
+        command: &AdmitExecution,
+        fault: Option<FixtureFaultPoint>,
+    ) -> Result<FixtureCommit> {
+        self.commit(
+            agent_id,
+            "admit_execution",
+            &command.attempt.attempt_id,
+            command,
+            fault,
+            |state| execution_protocol::admit_execution(state, command),
+        )
+    }
+
+    fn settle(
+        &mut self,
+        agent_id: &str,
+        command: &SettleExecution,
+        fault: Option<FixtureFaultPoint>,
+    ) -> Result<FixtureCommit> {
+        self.commit(
+            agent_id,
+            "settle_execution",
+            &command.outcome.outcome_id,
+            command,
+            fault,
+            |state| execution_protocol::settle_execution(state, command),
+        )
+    }
+
+    fn interrupt(
+        &mut self,
+        agent_id: &str,
+        command: &InterruptExecution,
+        fault: Option<FixtureFaultPoint>,
+    ) -> Result<FixtureCommit> {
+        self.commit(
+            agent_id,
+            "interrupt_execution",
+            &command.outcome_id,
+            command,
+            fault,
+            |state| execution_protocol::interrupt_execution(state, command),
+        )
+    }
+
+    fn commit<T: Serialize>(
+        &mut self,
+        agent_id: &str,
+        command_kind: &str,
+        command_identity: &str,
+        command: &T,
+        fault: Option<FixtureFaultPoint>,
+        reduce: impl FnOnce(&ExecutionProtocolState) -> Result<ExecutionTransition, String>,
+    ) -> Result<FixtureCommit> {
+        let payload_hash = format!("{:x}", Sha256::digest(serde_json::to_vec(command)?));
+        let transaction = self.connection.transaction()?;
+        if let Some((stored_hash, result_json)) = transaction
+            .query_row(
+                "SELECT payload_hash, result_json
+                 FROM execution_fixture_command_results
+                 WHERE agent_id = ?1
+                   AND command_kind = ?2
+                   AND command_identity = ?3",
+                params![agent_id, command_kind, command_identity],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?
+        {
+            if stored_hash != payload_hash {
+                bail!(
+                    "execution fixture command identity conflict for {command_kind} {command_identity}"
+                );
+            }
+            let result: FixtureCommandResult = serde_json::from_str(&result_json)?;
+            let state = load_state(&transaction, agent_id)?;
+            transaction.commit()?;
+            return Ok(FixtureCommit {
+                applied: false,
+                replayed: true,
+                transition: ExecutionTransition {
+                    state,
+                    references: result.references,
+                },
+            });
+        }
+
+        let state = load_state(&transaction, agent_id)?;
+        let transition = reduce(&state)
+            .map_err(|error| anyhow!("execution fixture command rejected: {error}"))?;
+        persist_state(&transaction, &transition.state)?;
+        inject_fixture_fault(fault, FixtureFaultPoint::AfterStateWrites)?;
+        let result = FixtureCommandResult {
+            references: transition.references.clone(),
+        };
+        transaction.execute(
+            "INSERT INTO execution_fixture_command_results (
+               agent_id, command_kind, command_identity,
+               payload_hash, result_json, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                agent_id,
+                command_kind,
+                command_identity,
+                payload_hash,
+                serde_json::to_string(&result)?,
+                Utc::now().to_rfc3339(),
+            ],
+        )?;
+        inject_fixture_fault(fault, FixtureFaultPoint::BeforeCommit)?;
+        transaction.commit()?;
+        Ok(FixtureCommit {
+            applied: true,
+            replayed: false,
+            transition,
+        })
+    }
+}
+
+fn inject_fixture_fault(
+    configured: Option<FixtureFaultPoint>,
+    current: FixtureFaultPoint,
+) -> Result<()> {
+    if configured == Some(current) {
+        bail!("injected execution fixture fault at {current:?}");
+    }
+    Ok(())
+}
+
+fn persist_state(tx: &Transaction<'_>, state: &ExecutionProtocolState) -> Result<()> {
+    execution_protocol::assert_invariants(state)
+        .map_err(|error| anyhow!("invalid execution fixture state: {error}"))?;
+    tx.execute(
+        "INSERT INTO execution_fixture_partitions (agent_id, updated_at)
+         VALUES (?1, ?2)
+         ON CONFLICT(agent_id) DO UPDATE SET updated_at = excluded.updated_at",
+        params![state.agent_id, Utc::now().to_rfc3339()],
+    )?;
+    tx.execute(
+        "DELETE FROM execution_fixture_outcomes WHERE agent_id = ?1",
+        [&state.agent_id],
+    )?;
+    tx.execute(
+        "DELETE FROM execution_fixture_attempts WHERE agent_id = ?1",
+        [&state.agent_id],
+    )?;
+    tx.execute(
+        "DELETE FROM execution_fixture_work_items WHERE agent_id = ?1",
+        [&state.agent_id],
+    )?;
+
+    for (work_item_id, work_record) in &state.work_items {
+        tx.execute(
+            "INSERT INTO execution_fixture_work_items (
+               agent_id, work_item_id, source_revision, generation,
+               lifecycle_state, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                state.agent_id,
+                work_item_id,
+                to_i64(work_record.source_revision)?,
+                to_i64(work_record.generation())?,
+                work_item_state_token(&work_record.state),
+                serde_json::to_string(work_record)?,
+            ],
+        )?;
+    }
+    for attempt in state.attempts.values() {
+        tx.execute(
+            "INSERT INTO execution_fixture_attempts (
+               agent_id, attempt_id, lifecycle_state,
+               source_identity, source_generation, recovery_of_attempt_id,
+               terminal_outcome_id, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                state.agent_id,
+                attempt.attempt_id,
+                enum_token(&attempt.state)?,
+                serde_json::to_string(&attempt.source.identity)?,
+                to_i64(attempt.source.generation)?,
+                attempt.recovery_of_attempt_id,
+                attempt.terminal_outcome_id,
+                serde_json::to_string(attempt)?,
+            ],
+        )?;
+    }
+    for outcome in state.outcomes.values() {
+        tx.execute(
+            "INSERT INTO execution_fixture_outcomes (
+               agent_id, outcome_id, attempt_id, payload_json
+             ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                state.agent_id,
+                outcome.outcome_id,
+                outcome.attempt_id,
+                serde_json::to_string(outcome)?,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn load_state(tx: &Transaction<'_>, agent_id: &str) -> Result<ExecutionProtocolState> {
+    let exists: bool = tx.query_row(
+        "SELECT EXISTS(
+           SELECT 1 FROM execution_fixture_partitions WHERE agent_id = ?1
+         )",
+        [agent_id],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        bail!("execution fixture partition for agent {agent_id} is not initialized");
+    }
+    let state = ExecutionProtocolState {
+        agent_id: agent_id.to_owned(),
+        attempts: load_payload_map(
+            tx,
+            "SELECT attempt_id, payload_json
+             FROM execution_fixture_attempts
+             WHERE agent_id = ?1",
+            agent_id,
+        )?,
+        work_items: load_payload_map(
+            tx,
+            "SELECT work_item_id, payload_json
+             FROM execution_fixture_work_items
+             WHERE agent_id = ?1",
+            agent_id,
+        )?,
+        outcomes: load_payload_map(
+            tx,
+            "SELECT outcome_id, payload_json
+             FROM execution_fixture_outcomes
+             WHERE agent_id = ?1",
+            agent_id,
+        )?,
+    };
+    execution_protocol::assert_invariants(&state)
+        .map_err(|error| anyhow!("stored execution fixture state is invalid: {error}"))?;
+    Ok(state)
+}
+
+fn load_payload_map<T: DeserializeOwned>(
+    tx: &Transaction<'_>,
+    sql: &str,
+    agent_id: &str,
+) -> Result<BTreeMap<String, T>> {
+    let mut statement = tx.prepare(sql)?;
+    let result: Result<BTreeMap<String, T>> = statement
+        .query_map([agent_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .map(|row| {
+            let (id, payload) = row?;
+            let value = serde_json::from_str(&payload)
+                .with_context(|| format!("decoding execution fixture record {id}"))?;
+            Ok((id, value))
+        })
+        .collect();
+    result
+}
+
+fn enum_token<T: Serialize>(value: &T) -> Result<String> {
+    serde_json::to_value(value)?
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow!("execution fixture enum did not serialize to a string"))
+}
+
+fn work_item_state_token(state: &WorkItemExecutionState) -> &'static str {
+    match state {
+        WorkItemExecutionState::Runnable { .. } => "runnable",
+        WorkItemExecutionState::InFlight { .. } => "in_flight",
+        WorkItemExecutionState::Waiting { .. } => "waiting",
+        WorkItemExecutionState::Paused { .. } => "paused",
+        WorkItemExecutionState::NeedsRepair { .. } => "needs_repair",
+        WorkItemExecutionState::Terminal { .. } => "terminal",
+    }
+}
+
+fn to_i64(value: u64) -> Result<i64> {
+    i64::try_from(value).context("execution fixture generation exceeds SQLite INTEGER")
+}
+
+const LEGACY_ADPTION_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS legacy_activations (
+  agent_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  owner_kind TEXT NOT NULL CHECK (owner_kind IN ('work_item', 'agent_lifecycle')),
+  owner_id TEXT NOT NULL,
+  work_item_id TEXT,
+  admitted_generation INTEGER NOT NULL CHECK (admitted_generation >= 0),
+  lifecycle_state TEXT NOT NULL CHECK (
+    lifecycle_state IN ('running', 'settled', 'interrupted', 'settlement_missing')
+  ),
+  recovery_for_activation_id TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, activation_id)
+);
+
+CREATE TABLE IF NOT EXISTS legacy_work_demands (
+  agent_id TEXT NOT NULL,
+  work_item_id TEXT NOT NULL,
+  scheduling_generation INTEGER NOT NULL CHECK (scheduling_generation >= 0),
+  status TEXT NOT NULL,
+  wait_id TEXT,
+  needs_settlement_activation_id TEXT,
+  PRIMARY KEY (agent_id, work_item_id)
+);
+"#;
+
+/// Offline adoption: reads simplified legacy scheduler tables and builds a
+/// consistent `ExecutionProtocolState` in a single pass. This is a
+/// proof-of-concept for the Phase 3 adoption rehearsal.
+fn adopt_legacy_to_execution_state(
+    connection: &Connection,
+    agent_id: &str,
+) -> Result<ExecutionProtocolState> {
+    let mut state = ExecutionProtocolState::empty(agent_id);
+
+    // Adopt work demands → WorkItemExecutionState
+    let mut stmt = connection.prepare(
+        "SELECT work_item_id, scheduling_generation, status, wait_id,
+                needs_settlement_activation_id
+         FROM legacy_work_demands WHERE agent_id = ?1",
+    )?;
+    let work_rows = stmt
+        .query_map([agent_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)? as u64,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+
+    for (work_item_id, generation, status, wait_id, needs_activation) in work_rows {
+        let work_state = match status.as_str() {
+            "runnable" => WorkItemExecutionState::Runnable {
+                generation,
+                recovery_ref: None,
+            },
+            "waiting" => WorkItemExecutionState::Waiting {
+                generation,
+                wait: WaitReference {
+                    wait_id: wait_id.unwrap_or_default(),
+                    generation,
+                },
+            },
+            "needs_settlement" => WorkItemExecutionState::InFlight {
+                generation,
+                attempt_id: needs_activation.unwrap_or_default(),
+            },
+            "paused" => WorkItemExecutionState::Paused {
+                generation,
+                reason: "adopted".into(),
+            },
+            "terminal" => WorkItemExecutionState::Terminal {
+                generation,
+                completion: "adopted".into(),
+            },
+            _ => WorkItemExecutionState::Runnable {
+                generation,
+                recovery_ref: Some("adopted_unknown".into()),
+            },
+        };
+        state.work_items.insert(
+            work_item_id,
+            WorkItemExecutionRecord {
+                source_revision: generation,
+                state: work_state,
+            },
+        );
+    }
+
+    // Adopt activations → ExecutionAttempt
+    let mut stmt = connection.prepare(
+        "SELECT activation_id, owner_kind, work_item_id, admitted_generation,
+                lifecycle_state, recovery_for_activation_id, created_at, updated_at
+         FROM legacy_activations WHERE agent_id = ?1",
+    )?;
+    let rows = stmt
+        .query_map([agent_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, i64>(3)? as u64,
+                row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+
+    for (
+        activation_id,
+        owner_kind,
+        work_item_id,
+        generation,
+        lifecycle_state,
+        recovery_for,
+        created_at,
+        updated_at,
+    ) in rows
+    {
+        let binding = match owner_kind.as_str() {
+            "work_item" => ExecutionBinding::WorkItem {
+                work_item_id: work_item_id.clone().unwrap_or_default(),
+            },
+            _ => ExecutionBinding::AgentLifecycle {
+                agent_id: agent_id.to_string(),
+            },
+        };
+        let attempt_state = match lifecycle_state.as_str() {
+            "running" => ExecutionAttemptState::Open,
+            _ => ExecutionAttemptState::Interrupted,
+        };
+        let terminal_outcome_id = if attempt_state == ExecutionAttemptState::Open {
+            None
+        } else {
+            Some(format!("adopted_outcome_{activation_id}"))
+        };
+        let terminal_at = if attempt_state == ExecutionAttemptState::Open {
+            None
+        } else {
+            Some(updated_at.clone())
+        };
+        state.attempts.insert(
+            activation_id.clone(),
+            ExecutionAttempt {
+                attempt_id: activation_id.clone(),
+                agent_id: agent_id.to_string(),
+                source_message_id: None,
+                source: ExecutionSource {
+                    identity: if owner_kind == "work_item" {
+                        ExecutionSourceIdentity::WorkItemContinuation {
+                            work_item_id: work_item_id.clone().unwrap_or_default(),
+                        }
+                    } else {
+                        ExecutionSourceIdentity::TriggeredWait {
+                            wait_id: format!("adopted:{activation_id}"),
+                            wait_generation: generation,
+                            trigger_id: format!("adopted:{activation_id}"),
+                            trigger_generation: generation,
+                        }
+                    },
+                    generation,
+                },
+                binding,
+                provenance: ExecutionProvenance {
+                    origin: ExecutionOrigin::System,
+                    trust: ExecutionTrust::RuntimeInstruction,
+                    priority: ExecutionPriority::Normal,
+                    correlation_id: None,
+                    causation_id: None,
+                },
+                admitted_fences: AdmittedFences {
+                    source_revision: generation,
+                    work_item_source_revision: if owner_kind == "work_item" {
+                        Some(generation)
+                    } else {
+                        None
+                    },
+                    work_item_generation: if owner_kind == "work_item" {
+                        Some(generation)
+                    } else {
+                        None
+                    },
+                    rejoin: None,
+                    agent_control_revision: 1,
+                    host_registry_revision: 1,
+                },
+                state: attempt_state,
+                run_id: None,
+                turn_id: None,
+                recovery_of_attempt_id: recovery_for,
+                terminal_outcome_id,
+                admitted_at: created_at,
+                terminal_at,
+            },
+        );
+        if attempt_state != ExecutionAttemptState::Open {
+            let outcome_id = format!("adopted_outcome_{activation_id}");
+            state.outcomes.insert(
+                outcome_id.clone(),
+                ExecutionOutcomeRecord {
+                    outcome_id,
+                    attempt_id: activation_id,
+                    outcome: ExecutionOutcome::Command(CommandResult::Applied {
+                        references: vec!["adopted".into()],
+                    }),
+                    created_at: updated_at,
+                },
+            );
+        }
+    }
+
+    execution_protocol::assert_invariants(&state)
+        .map_err(|e| anyhow!("adopted state fails invariants: {e}"))?;
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::execution_protocol::{
+        AdmittedFences, ExecutionAttemptState, ExecutionOrigin, ExecutionPriority,
+        ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity, ExecutionTrust,
+    };
+
+    fn work_item_record(state: WorkItemExecutionState) -> WorkItemExecutionRecord {
+        WorkItemExecutionRecord {
+            source_revision: state.generation(),
+            state,
+        }
+    }
+
+    fn fixture_attempt(
+        id: &str,
+        source_revision: u64,
+        work_item_generation: u64,
+        recovery_of: Option<&str>,
+    ) -> ExecutionAttempt {
+        ExecutionAttempt {
+            attempt_id: id.into(),
+            agent_id: "agent-a".into(),
+            source_message_id: Some(format!("message:{id}")),
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::WorkItemContinuation {
+                    work_item_id: "work-a".into(),
+                },
+                generation: source_revision,
+            },
+            binding: ExecutionBinding::WorkItem {
+                work_item_id: "work-a".into(),
+            },
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::System,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Normal,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision,
+                work_item_source_revision: Some(source_revision),
+                work_item_generation: Some(work_item_generation),
+                rejoin: None,
+                agent_control_revision: 1,
+                host_registry_revision: 1,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: None,
+            recovery_of_attempt_id: recovery_of.map(str::to_owned),
+            terminal_outcome_id: None,
+            admitted_at: format!("2026-08-01T00:0{work_item_generation}:00Z"),
+            terminal_at: None,
+        }
+    }
+
+    fn fixture_state() -> ExecutionProtocolState {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        state
+    }
+
+    #[test]
+    fn fixture_restart_interrupts_attempt_and_allows_second_attempt() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("execution-fixture.sqlite");
+        {
+            let mut repository = ExecutionProtocolFixtureRepository::open(&path)?;
+            repository.initialize(&fixture_state())?;
+            repository.admit(
+                "agent-a",
+                &AdmitExecution {
+                    attempt: fixture_attempt("attempt-1", 1, 1, None),
+                },
+                None,
+            )?;
+            repository.interrupt(
+                "agent-a",
+                &InterruptExecution {
+                    attempt_id: "attempt-1".into(),
+                    outcome_id: "outcome-1".into(),
+                    reason: "runtime_restart".into(),
+                    interrupted_at: "2026-08-01T00:02:00Z".into(),
+                },
+                None,
+            )?;
+        }
+
+        let mut reopened = ExecutionProtocolFixtureRepository::open(&path)?;
+        let recovered = reopened.load("agent-a")?;
+        assert!(recovered.open_attempt().is_none());
+        let admitted = reopened.admit(
+            "agent-a",
+            &AdmitExecution {
+                attempt: fixture_attempt("attempt-2", 1, 2, Some("attempt-1")),
+            },
+            None,
+        )?;
+        assert_eq!(
+            admitted
+                .transition
+                .state
+                .open_attempt()
+                .map(|attempt| attempt.attempt_id.as_str()),
+            Some("attempt-2")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_command_is_idempotent_and_conflicting_payload_is_rejected() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("execution-fixture.sqlite");
+        let mut repository = ExecutionProtocolFixtureRepository::open(&path)?;
+        repository.initialize(&fixture_state())?;
+        let command = AdmitExecution {
+            attempt: fixture_attempt("attempt-1", 1, 1, None),
+        };
+        assert!(repository.admit("agent-a", &command, None)?.applied);
+        assert!(repository.admit("agent-a", &command, None)?.replayed);
+
+        let mut conflicting = command;
+        conflicting.attempt.provenance.priority = ExecutionPriority::Interject;
+        assert!(repository
+            .admit("agent-a", &conflicting, None)
+            .unwrap_err()
+            .to_string()
+            .contains("identity conflict"));
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_fault_rolls_back_state_and_command_result() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("execution-fixture.sqlite");
+        let mut repository = ExecutionProtocolFixtureRepository::open(&path)?;
+        let initial = fixture_state();
+        repository.initialize(&initial)?;
+        let command = AdmitExecution {
+            attempt: fixture_attempt("attempt-1", 1, 1, None),
+        };
+        assert!(repository
+            .admit("agent-a", &command, Some(FixtureFaultPoint::BeforeCommit),)
+            .is_err());
+        assert_eq!(repository.load("agent-a")?, initial);
+        assert!(repository.admit("agent-a", &command, None)?.applied);
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_settlement_persists_terminal_outcome() -> Result<()> {
+        use crate::domain::execution_protocol::{ExecutionOutcome, WorkItemOutcome};
+
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("execution-fixture.sqlite");
+        let mut repository = ExecutionProtocolFixtureRepository::open(&path)?;
+        repository.initialize(&fixture_state())?;
+        repository.admit(
+            "agent-a",
+            &AdmitExecution {
+                attempt: fixture_attempt("attempt-1", 1, 1, None),
+            },
+            None,
+        )?;
+        let commit = repository.settle(
+            "agent-a",
+            &SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "outcome-1".into(),
+                    attempt_id: "attempt-1".into(),
+                    outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                        completion: "brief-1".into(),
+                    }),
+                    created_at: "2026-08-01T00:02:00Z".into(),
+                },
+            },
+            None,
+        )?;
+        assert!(matches!(
+            commit.transition.state.work_items["work-a"].state,
+            WorkItemExecutionState::Terminal { .. }
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_full_crash_recovery_lifecycle_through_persistence() -> Result<()> {
+        use crate::domain::execution_protocol::{
+            AdmittedFences, CommandResult, ExecutionBinding, ExecutionOutcome, ExecutionProvenance,
+            ExecutionSource, ExecutionSourceIdentity, WorkItemOutcome,
+        };
+
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("execution-fixture-lifecycle.sqlite");
+
+        // Phase 1: admit a WorkItem attempt, then crash (interrupt)
+        {
+            let mut repository = ExecutionProtocolFixtureRepository::open(&path)?;
+            repository.initialize(&fixture_state())?;
+            repository.admit(
+                "agent-a",
+                &AdmitExecution {
+                    attempt: fixture_attempt("attempt-1", 1, 1, None),
+                },
+                None,
+            )?;
+            repository.interrupt(
+                "agent-a",
+                &InterruptExecution {
+                    attempt_id: "attempt-1".into(),
+                    outcome_id: "outcome-1".into(),
+                    reason: "process_crash".into(),
+                    interrupted_at: "2026-08-01T00:01:00Z".into(),
+                },
+                None,
+            )?;
+        }
+
+        // Phase 2: reopen, verify state, run recovery command, then resume WorkItem
+        let mut reopened = ExecutionProtocolFixtureRepository::open(&path)?;
+        let recovered = reopened.load("agent-a")?;
+        assert!(recovered.open_attempt().is_none());
+        assert!(matches!(
+            recovered.attempts["attempt-1"].state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+        ));
+
+        // Recovery command: RuntimeRecovery → Command
+        let recovery_attempt = ExecutionAttempt {
+            attempt_id: "recovery-1".into(),
+            agent_id: "agent-a".into(),
+            source_message_id: None,
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::RuntimeRecovery {
+                    recovery_id: "bootstrap-recovery".into(),
+                },
+                generation: 1,
+            },
+            binding: ExecutionBinding::Command,
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::RuntimeRecovery,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Background,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: 1,
+                work_item_source_revision: None,
+                work_item_generation: None,
+                rejoin: None,
+                agent_control_revision: 1,
+                host_registry_revision: 1,
+            },
+            state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: None,
+            recovery_of_attempt_id: None,
+            terminal_outcome_id: None,
+            admitted_at: "2026-08-01T00:02:00Z".into(),
+            terminal_at: None,
+        };
+        reopened.admit(
+            "agent-a",
+            &AdmitExecution {
+                attempt: recovery_attempt,
+            },
+            None,
+        )?;
+        let recovery_settled = reopened.settle(
+            "agent-a",
+            &SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "recovery-outcome-1".into(),
+                    attempt_id: "recovery-1".into(),
+                    outcome: ExecutionOutcome::Command(CommandResult::Applied {
+                        references: vec!["recovered:attempt-1".into()],
+                    }),
+                    created_at: "2026-08-01T00:03:00Z".into(),
+                },
+            },
+            None,
+        )?;
+        assert!(recovery_settled.transition.state.open_attempt().is_none());
+
+        // Phase 3: resume WorkItem from interrupted state
+        let resumed = reopened.admit(
+            "agent-a",
+            &AdmitExecution {
+                attempt: fixture_attempt("attempt-2", 1, 2, Some("attempt-1")),
+            },
+            None,
+        )?;
+        assert_eq!(
+            resumed
+                .transition
+                .state
+                .open_attempt()
+                .map(|a| a.attempt_id.as_str()),
+            Some("attempt-2")
+        );
+
+        // Phase 4: settle the resumed WorkItem attempt
+        let final_settled = reopened.settle(
+            "agent-a",
+            &SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "outcome-2".into(),
+                    attempt_id: "attempt-2".into(),
+                    outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                        completion: "brief-done".into(),
+                    }),
+                    created_at: "2026-08-01T00:04:00Z".into(),
+                },
+            },
+            None,
+        )?;
+        assert!(matches!(
+            final_settled.transition.state.work_items["work-a"].state,
+            WorkItemExecutionState::Terminal { .. }
+        ));
+        assert!(final_settled.transition.state.open_attempt().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn adoption_rehearsal_builds_consistent_state_from_legacy_tables() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("adoption-rehearsal.sqlite");
+        let connection = Connection::open(&path)?;
+        connection.execute_batch(FIXTURE_SCHEMA)?;
+        connection.execute_batch(LEGACY_ADPTION_SCHEMA)?;
+
+        // Insert a legacy work demand and a settled activation
+        connection.execute(
+            "INSERT INTO legacy_work_demands
+             (agent_id, work_item_id, scheduling_generation, status, wait_id, needs_settlement_activation_id)
+             VALUES ('agent-a', 'work-a', 1, 'runnable', NULL, NULL)",
+            [],
+        )?;
+        connection.execute(
+            "INSERT INTO legacy_activations
+             (agent_id, activation_id, owner_kind, owner_id, work_item_id,
+              admitted_generation, lifecycle_state, recovery_for_activation_id,
+              created_at, updated_at)
+             VALUES ('agent-a', 'act-1', 'work_item', 'work-a', 'work-a',
+                     1, 'settled', NULL, '2026-08-01T00:00:00Z', '2026-08-01T00:01:00Z')",
+            [],
+        )?;
+
+        let adopted = adopt_legacy_to_execution_state(&connection, "agent-a")?;
+
+        // Verify the adopted state is consistent
+        assert!(adopted.open_attempt().is_none());
+        assert_eq!(adopted.attempts.len(), 1);
+        assert!(matches!(
+            adopted.attempts["act-1"].state,
+            ExecutionAttemptState::Interrupted
+        ));
+        assert!(matches!(
+            adopted.work_items["work-a"].state,
+            WorkItemExecutionState::Runnable { generation: 1, .. }
+        ));
+        assert_eq!(adopted.outcomes.len(), 1);
+
+        // Verify the adopted state can initialize the fixture repository
+        let mut repository = ExecutionProtocolFixtureRepository::open(&path)?;
+        repository.initialize(&adopted)?;
+        let loaded = repository.load("agent-a")?;
+        assert_eq!(loaded.attempts.len(), 1);
+        assert!(loaded.open_attempt().is_none());
+        Ok(())
+    }
+}

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -1,0 +1,456 @@
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Utc;
+use rusqlite::{params, OptionalExtension, Transaction};
+use serde::de::DeserializeOwned;
+use sha2::{Digest, Sha256};
+
+use crate::domain::execution_protocol::{
+    self, ExecutionProtocolCommand, ExecutionProtocolState, ExecutionTransition,
+    WorkItemExecutionState,
+};
+use crate::{
+    runtime_db::transitions::{ExecutionAuthorityFences, RuntimeTransitionRepository},
+    types::{AgentIdentityRecord, AgentRegistryStatus, AgentStatus},
+};
+
+pub(super) struct PreparedExecutionProtocolCommands {
+    state: ExecutionProtocolState,
+    initialized_partition: bool,
+    results: Vec<PreparedCommandResult>,
+}
+
+impl PreparedExecutionProtocolCommands {
+    pub(super) fn has_writes(&self) -> bool {
+        self.initialized_partition || !self.results.is_empty()
+    }
+}
+
+struct PreparedCommandResult {
+    command_kind: &'static str,
+    command_identity: String,
+    payload_hash: String,
+    references: Vec<String>,
+}
+
+pub(super) fn validate_execution_commands_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    bootstrap: Option<&ExecutionProtocolState>,
+    commands: &[ExecutionProtocolCommand],
+) -> Result<Option<PreparedExecutionProtocolCommands>> {
+    if commands.is_empty() {
+        return Ok(None);
+    }
+    let initialized_partition = !partition_exists_tx(tx, agent_id)?;
+    let mut state = if initialized_partition {
+        let state = bootstrap
+            .cloned()
+            .ok_or_else(|| anyhow!("execution protocol command requires bootstrap state"))?;
+        if state.agent_id != agent_id {
+            bail!("execution protocol bootstrap agent does not match transaction partition");
+        }
+        execution_protocol::assert_invariants(&state)
+            .map_err(|error| anyhow!("invalid execution protocol bootstrap: {error}"))?;
+        state
+    } else {
+        load_state_tx(tx, agent_id)?
+    };
+    let mut results = Vec::new();
+
+    for command in commands {
+        let (command_kind, command_identity) = command_identity(command);
+        let payload_hash = format!("{:x}", Sha256::digest(serde_json::to_vec(command)?));
+        if let Some(stored_hash) =
+            stored_command_hash_tx(tx, agent_id, command_kind, command_identity)?
+        {
+            if stored_hash != payload_hash {
+                bail!(
+                    "execution protocol command identity conflict for agent {agent_id}, \
+                     command {command_kind} {command_identity}"
+                );
+            }
+            continue;
+        }
+        if let ExecutionProtocolCommand::Admit(command) = command {
+            validate_admission_authority_tx(tx, agent_id, &command.attempt.admitted_fences)?;
+        }
+        let transition = reduce(&state, command)
+            .map_err(|error| anyhow!("execution protocol command rejected: {error}"))?;
+        state = transition.state;
+        results.push(PreparedCommandResult {
+            command_kind,
+            command_identity: command_identity.to_owned(),
+            payload_hash,
+            references: transition.references,
+        });
+    }
+
+    Ok(Some(PreparedExecutionProtocolCommands {
+        state,
+        initialized_partition,
+        results,
+    }))
+}
+
+pub(super) fn persist_execution_commands_tx(
+    tx: &Transaction<'_>,
+    prepared: Option<PreparedExecutionProtocolCommands>,
+) -> Result<()> {
+    let Some(prepared) = prepared else {
+        return Ok(());
+    };
+    persist_state_tx(tx, &prepared.state)?;
+    for result in prepared.results {
+        tx.execute(
+            "INSERT INTO execution_protocol_command_results (
+               agent_id, command_kind, command_identity,
+               payload_hash, references_json, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                prepared.state.agent_id,
+                result.command_kind,
+                result.command_identity,
+                result.payload_hash,
+                serde_json::to_string(&result.references)?,
+                Utc::now().to_rfc3339(),
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn reduce(
+    state: &ExecutionProtocolState,
+    command: &ExecutionProtocolCommand,
+) -> Result<ExecutionTransition, String> {
+    match command {
+        ExecutionProtocolCommand::RegisterWorkItem(command) => {
+            execution_protocol::register_work_item_execution(state, command)
+        }
+        ExecutionProtocolCommand::Admit(command) => {
+            execution_protocol::admit_execution(state, command)
+        }
+        ExecutionProtocolCommand::Settle(command) => {
+            execution_protocol::settle_execution(state, command)
+        }
+        ExecutionProtocolCommand::Interrupt(command) => {
+            execution_protocol::interrupt_execution(state, command)
+        }
+    }
+}
+
+fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) {
+    match command {
+        ExecutionProtocolCommand::RegisterWorkItem(command) => {
+            ("register_work_item_execution", &command.work_item_id)
+        }
+        ExecutionProtocolCommand::Admit(command) => {
+            ("admit_execution", &command.attempt.attempt_id)
+        }
+        ExecutionProtocolCommand::Settle(command) => {
+            ("settle_execution", &command.outcome.outcome_id)
+        }
+        ExecutionProtocolCommand::Interrupt(command) => {
+            ("interrupt_execution", &command.outcome_id)
+        }
+    }
+}
+
+fn partition_exists_tx(tx: &Transaction<'_>, agent_id: &str) -> Result<bool> {
+    tx.query_row(
+        "SELECT EXISTS(
+           SELECT 1 FROM execution_protocol_partitions WHERE agent_id = ?1
+         )",
+        [agent_id],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+pub(crate) fn authority_fences_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+) -> Result<ExecutionAuthorityFences> {
+    let (status, control_revision) = tx
+        .query_row(
+            "SELECT status, control_revision
+             FROM agent_states
+             WHERE agent_id = ?1",
+            [agent_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()?
+        .ok_or_else(|| anyhow!("execution admission requires durable agent control state"))?;
+    let status: AgentStatus =
+        serde_json::from_str(&format!("\"{status}\"")).context("decoding agent control status")?;
+    if status == AgentStatus::Stopped {
+        bail!("execution admission rejected because agent control state is stopped");
+    }
+    let agent_control_revision =
+        u64::try_from(control_revision).context("agent control revision is negative")?;
+    if agent_control_revision == 0 {
+        bail!("agent control revision must be nonzero");
+    }
+
+    let identity_payload = tx
+        .query_row(
+            "SELECT payload_json
+             FROM agent_identities
+             WHERE agent_id = ?1",
+            [agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| anyhow!("execution admission requires durable host identity"))?;
+    let identity: AgentIdentityRecord =
+        serde_json::from_str(&identity_payload).context("decoding host identity")?;
+    if identity.status != AgentRegistryStatus::Active {
+        bail!("execution admission rejected because host identity is not active");
+    }
+    let host_registry_revision = identity
+        .revision
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("host identity revision overflow"))?;
+
+    Ok(ExecutionAuthorityFences {
+        agent_control_revision,
+        host_registry_revision,
+    })
+}
+
+fn validate_admission_authority_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    admitted: &execution_protocol::AdmittedFences,
+) -> Result<()> {
+    let current = authority_fences_tx(tx, agent_id)?;
+    if admitted.agent_control_revision != current.agent_control_revision {
+        bail!(
+            "execution admission agent control fence is stale: admitted {}, current {}",
+            admitted.agent_control_revision,
+            current.agent_control_revision
+        );
+    }
+    if admitted.host_registry_revision != current.host_registry_revision {
+        bail!(
+            "execution admission host registry fence is stale: admitted {}, current {}",
+            admitted.host_registry_revision,
+            current.host_registry_revision
+        );
+    }
+    Ok(())
+}
+
+impl RuntimeTransitionRepository<'_> {
+    pub(crate) fn load_execution_authority_fences(
+        &self,
+        agent_id: &str,
+    ) -> Result<ExecutionAuthorityFences> {
+        let connection = self.db.connection()?;
+        let transaction =
+            Transaction::new_unchecked(&connection, rusqlite::TransactionBehavior::Deferred)?;
+        let fences = authority_fences_tx(&transaction, agent_id)?;
+        transaction.commit()?;
+        Ok(fences)
+    }
+
+    pub(crate) fn load_execution_protocol_state_if_initialized(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<ExecutionProtocolState>> {
+        let connection = self.db.connection()?;
+        let transaction =
+            Transaction::new_unchecked(&connection, rusqlite::TransactionBehavior::Deferred)?;
+        if !partition_exists_tx(&transaction, agent_id)? {
+            transaction.commit()?;
+            return Ok(None);
+        }
+        let state = load_state_tx(&transaction, agent_id)?;
+        transaction.commit()?;
+        Ok(Some(state))
+    }
+}
+
+fn stored_command_hash_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command_kind: &str,
+    command_identity: &str,
+) -> Result<Option<String>> {
+    tx.query_row(
+        "SELECT payload_hash
+         FROM execution_protocol_command_results
+         WHERE agent_id = ?1
+           AND command_kind = ?2
+           AND command_identity = ?3",
+        params![agent_id, command_kind, command_identity],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub(crate) fn persist_state_tx(tx: &Transaction<'_>, state: &ExecutionProtocolState) -> Result<()> {
+    execution_protocol::assert_invariants(state)
+        .map_err(|error| anyhow!("invalid execution protocol state: {error}"))?;
+    tx.execute(
+        "INSERT INTO execution_protocol_partitions (agent_id, updated_at)
+         VALUES (?1, ?2)
+         ON CONFLICT(agent_id) DO UPDATE SET updated_at = excluded.updated_at",
+        params![state.agent_id, Utc::now().to_rfc3339()],
+    )?;
+    for (work_item_id, work_record) in &state.work_items {
+        tx.execute(
+            "INSERT INTO execution_protocol_work_items (
+               agent_id, work_item_id, source_revision, generation,
+               lifecycle_state, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(agent_id, work_item_id) DO UPDATE SET
+               source_revision = excluded.source_revision,
+               generation = excluded.generation,
+               lifecycle_state = excluded.lifecycle_state,
+               payload_json = excluded.payload_json",
+            params![
+                state.agent_id,
+                work_item_id,
+                to_i64(work_record.source_revision)?,
+                to_i64(work_record.generation())?,
+                work_item_state_token(&work_record.state),
+                serde_json::to_string(work_record)?,
+            ],
+        )?;
+    }
+    for attempt in state.attempts.values() {
+        tx.execute(
+            "INSERT INTO execution_protocol_attempts (
+               agent_id, attempt_id, lifecycle_state,
+               source_identity_json, source_generation, recovery_of_attempt_id,
+               terminal_outcome_id, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(agent_id, attempt_id) DO UPDATE SET
+               lifecycle_state = excluded.lifecycle_state,
+               terminal_outcome_id = excluded.terminal_outcome_id,
+               payload_json = excluded.payload_json",
+            params![
+                state.agent_id,
+                attempt.attempt_id,
+                enum_token(&attempt.state)?,
+                serde_json::to_string(&attempt.source.identity)?,
+                to_i64(attempt.source.generation)?,
+                attempt.recovery_of_attempt_id,
+                attempt.terminal_outcome_id,
+                serde_json::to_string(attempt)?,
+            ],
+        )?;
+    }
+    for outcome in state.outcomes.values() {
+        let payload = serde_json::to_string(outcome)?;
+        let existing = tx
+            .query_row(
+                "SELECT payload_json
+                 FROM execution_protocol_outcomes
+                 WHERE agent_id = ?1 AND outcome_id = ?2",
+                params![state.agent_id, outcome.outcome_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(existing) = existing {
+            if existing != payload {
+                bail!(
+                    "execution outcome identity conflict for {}",
+                    outcome.outcome_id
+                );
+            }
+            continue;
+        }
+        tx.execute(
+            "INSERT INTO execution_protocol_outcomes (
+               agent_id, outcome_id, attempt_id, payload_json
+             ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                state.agent_id,
+                outcome.outcome_id,
+                outcome.attempt_id,
+                payload,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) fn load_state_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+) -> Result<ExecutionProtocolState> {
+    if !partition_exists_tx(tx, agent_id)? {
+        bail!("execution protocol partition for agent {agent_id} is not initialized");
+    }
+    let state = ExecutionProtocolState {
+        agent_id: agent_id.to_owned(),
+        attempts: load_payload_map(
+            tx,
+            "SELECT attempt_id, payload_json
+             FROM execution_protocol_attempts WHERE agent_id = ?1",
+            agent_id,
+        )?,
+        work_items: load_payload_map(
+            tx,
+            "SELECT work_item_id, payload_json
+             FROM execution_protocol_work_items WHERE agent_id = ?1",
+            agent_id,
+        )?,
+        outcomes: load_payload_map(
+            tx,
+            "SELECT outcome_id, payload_json
+             FROM execution_protocol_outcomes WHERE agent_id = ?1",
+            agent_id,
+        )?,
+    };
+    execution_protocol::assert_invariants(&state)
+        .map_err(|error| anyhow!("stored execution protocol state is invalid: {error}"))?;
+    Ok(state)
+}
+
+fn load_payload_map<T: DeserializeOwned>(
+    tx: &Transaction<'_>,
+    sql: &str,
+    agent_id: &str,
+) -> Result<BTreeMap<String, T>> {
+    let mut statement = tx.prepare(sql)?;
+    let records = statement
+        .query_map([agent_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .map(|row| {
+            let (id, payload) = row?;
+            let value = serde_json::from_str(&payload)
+                .with_context(|| format!("decoding execution protocol record {id}"))?;
+            Ok((id, value))
+        })
+        .collect();
+    records
+}
+
+fn enum_token<T: serde::Serialize>(value: &T) -> Result<String> {
+    serde_json::to_value(value)?
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow!("execution protocol enum did not serialize to a string"))
+}
+
+fn work_item_state_token(state: &WorkItemExecutionState) -> &'static str {
+    match state {
+        WorkItemExecutionState::Runnable { .. } => "runnable",
+        WorkItemExecutionState::InFlight { .. } => "in_flight",
+        WorkItemExecutionState::Waiting { .. } => "waiting",
+        WorkItemExecutionState::Paused { .. } => "paused",
+        WorkItemExecutionState::NeedsRepair { .. } => "needs_repair",
+        WorkItemExecutionState::Terminal { .. } => "terminal",
+    }
+}
+
+fn to_i64(value: u64) -> Result<i64> {
+    i64::try_from(value).context("execution protocol generation exceeds SQLite INTEGER")
+}

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -60,6 +60,15 @@ pub(crate) struct RetiredSchedulerRolloutMetadata {
     pub command_result_count: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SchedulerAuthorityInventoryRecord {
+    pub storage: &'static str,
+    pub role: &'static str,
+    pub canonical_reader: bool,
+    pub target: &'static str,
+    pub row_count: u64,
+}
+
 pub(super) struct PreparedProtocolCommands {
     snapshot: Snapshot,
     initialized_partition: bool,
@@ -188,6 +197,7 @@ pub(super) fn validate_protocol_commands_tx(
     agent_id: &str,
     bootstrap: Option<&Snapshot>,
     commands: &[ProtocolCommand],
+    execution_commands: &[crate::domain::execution_protocol::ExecutionProtocolCommand],
 ) -> Result<Option<PreparedProtocolCommands>> {
     if commands.is_empty() {
         return Ok(None);
@@ -227,7 +237,7 @@ pub(super) fn validate_protocol_commands_tx(
             continue;
         }
         if let ProtocolCommand::AdoptLegacyWorkState(command) = command {
-            validate_legacy_adoption_source_tx(tx, agent_id, command)?;
+            validate_legacy_adoption_source_tx(tx, agent_id, command, execution_commands)?;
         }
         if let ProtocolCommand::AdoptActivationWorkState(command) = command {
             validate_activation_adoption_source_tx(tx, agent_id, command)?;
@@ -418,6 +428,174 @@ impl RuntimeTransitionRepository<'_> {
         })
     }
 
+    pub(crate) fn inspect_scheduler_authority_inventory(
+        &self,
+    ) -> Result<Vec<SchedulerAuthorityInventoryRecord>> {
+        const INVENTORY: &[(&str, &str, bool, &str)] = &[
+            (
+                "queue_entries",
+                "authority",
+                true,
+                "retain as queue source authority",
+            ),
+            (
+                "work_items",
+                "authority",
+                true,
+                "absorb WorkItem execution state",
+            ),
+            (
+                "wait_conditions",
+                "authority",
+                true,
+                "retain as the only wait authority",
+            ),
+            (
+                "tasks",
+                "authority",
+                true,
+                "retain as task lifecycle authority",
+            ),
+            (
+                "scheduler_activations",
+                "authority_and_evidence",
+                true,
+                "replace control reads with execution-attempt evidence",
+            ),
+            (
+                "scheduler_activation_settlements",
+                "evidence",
+                true,
+                "retain as immutable attempt outcome",
+            ),
+            (
+                "scheduler_agent_slots",
+                "authority",
+                true,
+                "remove after open attempt owns the lane",
+            ),
+            (
+                "scheduler_agent_dispatch",
+                "authority",
+                true,
+                "remove after runtime waits own waiting",
+            ),
+            (
+                "scheduler_agent_focus",
+                "projection",
+                true,
+                "replace with durable WorkItem focus",
+            ),
+            (
+                "scheduler_work_demands",
+                "authority",
+                true,
+                "replace with WorkItem execution state",
+            ),
+            (
+                "scheduler_waits",
+                "authority",
+                true,
+                "replace with runtime wait conditions",
+            ),
+            (
+                "scheduler_wait_generations",
+                "authority",
+                true,
+                "replace with runtime wait generations",
+            ),
+            (
+                "scheduler_missing_settlements",
+                "recovery_authority",
+                true,
+                "downgrade to diagnostic evidence, then remove",
+            ),
+            (
+                "scheduler_activation_authorities",
+                "compatibility",
+                false,
+                "remove with compatibility schema",
+            ),
+            (
+                "scheduler_activation_sources",
+                "evidence",
+                false,
+                "retain or merge into attempt evidence",
+            ),
+            (
+                "scheduler_activation_inputs",
+                "evidence",
+                true,
+                "retain as interjection evidence",
+            ),
+            (
+                "scheduler_continuation_admissions",
+                "evidence",
+                true,
+                "retain as immutable handoff evidence",
+            ),
+            (
+                "scheduler_yield_continuations",
+                "authority",
+                true,
+                "replace with continuation lifecycle authority",
+            ),
+            (
+                "scheduler_protocol_command_results",
+                "evidence",
+                true,
+                "retain for idempotent command results",
+            ),
+            (
+                "scheduler_protocol_command_conflict_attempts",
+                "evidence",
+                false,
+                "retain as immutable conflict evidence",
+            ),
+            (
+                "scheduler_protocol_migrations",
+                "compatibility",
+                false,
+                "retain through the compatibility window",
+            ),
+            (
+                "scheduler_protocol_config",
+                "compatibility",
+                false,
+                "remove; engine selection is startup-only",
+            ),
+            ("scheduler_rollout_preflights", "dead", false, "remove"),
+            ("scheduler_rollout_manifests", "dead", false, "remove"),
+            ("scheduler_scenario_authorities", "dead", false, "remove"),
+            ("scheduler_scenario_hard_blockers", "dead", false, "remove"),
+            ("scheduler_shadow_comparisons", "dead", false, "remove"),
+            (
+                "scheduler_semantic_shadow_decisions",
+                "dead",
+                false,
+                "remove",
+            ),
+        ];
+        let connection = self.db.connection()?;
+        INVENTORY
+            .iter()
+            .map(|(storage, role, canonical_reader, target)| {
+                let count: i64 = connection.query_row(
+                    &format!("SELECT COUNT(*) FROM {storage}"),
+                    [],
+                    |row| row.get(0),
+                )?;
+                Ok(SchedulerAuthorityInventoryRecord {
+                    storage,
+                    role,
+                    canonical_reader: *canonical_reader,
+                    target,
+                    row_count: to_u64(count, "scheduler authority inventory row count")?,
+                })
+            })
+            .collect()
+    }
+
     pub(crate) fn legacy_scheduler_adoption_candidates(
         &self,
         agent_id: &str,
@@ -441,6 +619,7 @@ impl RuntimeTransitionRepository<'_> {
                     | ProtocolCommand::AdoptActivationWorkState(_)
                     | ProtocolCommand::RegisterWorkDemand(_)
                     | ProtocolCommand::SettleActivation(_)
+                    | ProtocolCommand::RecoverInterruptedActivation(_)
                     | ProtocolCommand::RecordMissingSettlement(_) => {}
                     ProtocolCommand::AdmitActivation(command)
                         if matches!(
@@ -453,7 +632,7 @@ impl RuntimeTransitionRepository<'_> {
             let bootstrap = (!scheduler_protocol_partition_exists_tx(tx, agent_id)?)
                 .then(canonical_empty_snapshot);
             let prepared =
-                validate_protocol_commands_tx(tx, agent_id, bootstrap.as_ref(), commands)?;
+                validate_protocol_commands_tx(tx, agent_id, bootstrap.as_ref(), commands, &[])?;
             let changed = prepared
                 .as_ref()
                 .is_some_and(PreparedProtocolCommands::has_writes);
@@ -532,7 +711,7 @@ impl RuntimeTransitionRepository<'_> {
 
             let snapshot = load_snapshot_tx(tx, agent_id)?;
             if let ProtocolCommand::AdoptLegacyWorkState(command) = command {
-                validate_legacy_adoption_source_tx(tx, agent_id, command)?;
+                validate_legacy_adoption_source_tx(tx, agent_id, command, &[])?;
             }
             if let ProtocolCommand::AdoptActivationWorkState(command) = command {
                 validate_activation_adoption_source_tx(tx, agent_id, command)?;
@@ -724,7 +903,7 @@ fn legacy_scheduler_adoption_candidate_tx(
                     wait_id: wait.id.clone(),
                     generation,
                     owner_work_item_id: work_item.id.clone(),
-                    source_updated_at: wait.updated_at.to_rfc3339(),
+                    source_updated_at: crate::runtime_db::repositories::timestamp(wait.updated_at),
                 }),
             )
         }
@@ -806,6 +985,23 @@ fn legacy_scheduler_adoption_candidate_tx(
             }
         }
     }
+    if let ProtocolCommand::AdoptLegacyWorkState(adoption) = &command {
+        if adoption.replace_completed_focus.is_none()
+            && scheduler_protocol_partition_exists_tx(tx, &work_item.agent_id)?
+        {
+            let snapshot = load_snapshot_tx(tx, &work_item.agent_id)?;
+            if scheduler_protocol::reduce_command(&snapshot, &command)
+                .outcome
+                .decision
+                == Decision::DuplicateIgnored
+            {
+                return Ok(ineligible_legacy_adoption(
+                    work_item,
+                    "legacy_work_state_already_canonical",
+                ));
+            }
+        }
+    }
     Ok(LegacySchedulerAdoptionCandidate {
         agent_id: work_item.agent_id.clone(),
         work_item_id: work_item.id.clone(),
@@ -880,6 +1076,7 @@ fn validate_legacy_adoption_source_tx(
     tx: &Transaction<'_>,
     agent_id: &str,
     command: &AdoptLegacyWorkStateCommand,
+    execution_commands: &[crate::domain::execution_protocol::ExecutionProtocolCommand],
 ) -> Result<()> {
     let work_item = tx
         .query_row(
@@ -894,20 +1091,122 @@ fn validate_legacy_adoption_source_tx(
         .ok_or_else(|| LegacySchedulerAdoptionRejected {
             reason: "source_work_item_missing_or_closed".into(),
         })?;
+    if execution_authority_matches_adoption_tx(tx, agent_id, command, execution_commands)? {
+        return Ok(());
+    }
     let candidate = legacy_scheduler_adoption_candidate_tx(tx, &work_item)?;
-    if !candidate.eligible
-        || candidate.command.as_ref()
-            != Some(&ProtocolCommand::AdoptLegacyWorkState(command.clone()))
-    {
+    let source_matches = candidate.command.as_ref().is_some_and(|candidate| {
+        let ProtocolCommand::AdoptLegacyWorkState(candidate) = candidate else {
+            return false;
+        };
+        legacy_adoption_source_matches(candidate, command)
+    });
+    if !candidate.eligible || !source_matches {
+        let source_difference = candidate.command.as_ref().map_or_else(
+            || "candidate_command_missing".to_string(),
+            |candidate| {
+                let ProtocolCommand::AdoptLegacyWorkState(candidate) = candidate else {
+                    return "candidate_command_kind_changed".to_string();
+                };
+                format!(
+                    "revision={:?},demand={:?},wait={:?},focus={:?},reserve_dispatch={:?}",
+                    (
+                        candidate.source_work_item_revision,
+                        command.source_work_item_revision
+                    ),
+                    (candidate.demand.clone(), command.demand.clone()),
+                    (candidate.wait.clone(), command.wait.clone()),
+                    (candidate.focus, command.focus),
+                    (candidate.reserve_dispatch, command.reserve_dispatch),
+                )
+            },
+        );
         return Err(LegacySchedulerAdoptionRejected {
             reason: format!(
-                "source_changed:{}:{}:{}",
-                agent_id, command.work_item_id, candidate.reason
+                "source_changed:{}:{}:{}:{}",
+                agent_id, command.work_item_id, candidate.reason, source_difference
             ),
         }
         .into());
     }
     Ok(())
+}
+
+fn execution_authority_matches_adoption_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &AdoptLegacyWorkStateCommand,
+    execution_commands: &[crate::domain::execution_protocol::ExecutionProtocolCommand],
+) -> Result<bool> {
+    let persisted = tx
+        .query_row(
+            "SELECT payload_json
+             FROM execution_protocol_work_items
+             WHERE agent_id = ?1 AND work_item_id = ?2",
+            [agent_id, command.work_item_id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| {
+            serde_json::from_str::<crate::domain::execution_protocol::WorkItemExecutionRecord>(
+                &payload,
+            )
+        })
+        .transpose()?;
+    let pending = execution_commands.iter().find_map(|pending| {
+        let crate::domain::execution_protocol::ExecutionProtocolCommand::RegisterWorkItem(pending) =
+            pending
+        else {
+            return None;
+        };
+        (pending.work_item_id == command.work_item_id).then_some(&pending.record)
+    });
+    let Some(record) = persisted.as_ref().or(pending) else {
+        return Ok(false);
+    };
+    if record.source_revision != command.source_work_item_revision
+        || record.source_revision != command.demand.metadata_revision
+        || record.state.generation() != command.demand.scheduling_generation
+    {
+        return Ok(false);
+    }
+    let matches = match (&record.state, &command.demand.status, &command.wait) {
+        (
+            crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. },
+            WorkStatus::Runnable,
+            None,
+        ) => true,
+        (
+            crate::domain::execution_protocol::WorkItemExecutionState::Waiting { generation, wait },
+            WorkStatus::Waiting { wait_id },
+            Some(compatibility_wait),
+        ) => {
+            generation == &compatibility_wait.generation
+                && wait.wait_id == *wait_id
+                && wait.wait_id == compatibility_wait.wait_id
+                && wait.generation == compatibility_wait.generation
+                && compatibility_wait.owner_work_item_id == command.work_item_id
+        }
+        _ => false,
+    };
+    Ok(matches)
+}
+
+fn legacy_adoption_source_matches(
+    candidate: &AdoptLegacyWorkStateCommand,
+    command: &AdoptLegacyWorkStateCommand,
+) -> bool {
+    candidate.work_item_id == command.work_item_id
+        && candidate.source_work_item_revision == command.source_work_item_revision
+        && candidate.demand == command.demand
+        && candidate.wait == command.wait
+        && (!command.focus || candidate.focus)
+        && (!command.reserve_dispatch || candidate.reserve_dispatch)
+        && if command.focus {
+            candidate.replace_completed_focus == command.replace_completed_focus
+        } else {
+            command.replace_completed_focus.is_none()
+        }
 }
 
 fn validate_activation_adoption_source_tx(
@@ -1072,6 +1371,10 @@ fn command_identity(command: &ProtocolCommand) -> Result<(&'static str, String)>
         ProtocolCommand::SettleActivation(command) => {
             ("settle_activation", command.settlement.id.clone())
         }
+        ProtocolCommand::RecoverInterruptedActivation(command) => (
+            "recover_interrupted_activation",
+            command.settlement.id.clone(),
+        ),
         ProtocolCommand::RecordMissingSettlement(record) => {
             ("record_missing_settlement", record.id.clone())
         }
@@ -1156,6 +1459,10 @@ fn command_fact_references(command: &ProtocolCommand) -> Vec<String> {
             format!("activation_settlement:{}", command.settlement.id),
             format!("activation:{}", command.settlement.activation_id),
         ],
+        ProtocolCommand::RecoverInterruptedActivation(command) => vec![
+            format!("activation_settlement:{}", command.settlement.id),
+            format!("activation:{}", command.settlement.activation_id),
+        ],
         ProtocolCommand::RecordMissingSettlement(record) => vec![
             format!("missing_settlement:{}", record.id),
             format!("activation:{}", record.activation_id),
@@ -1178,6 +1485,7 @@ fn validate_command_agent(agent_id: &str, command: &ProtocolCommand) -> Result<(
         | ProtocolCommand::AdoptActivationWorkState(_) => None,
         ProtocolCommand::AdmitActivation(command) => Some(&command.activation.agent_id),
         ProtocolCommand::SettleActivation(_)
+        | ProtocolCommand::RecoverInterruptedActivation(_)
         | ProtocolCommand::RecordMissingSettlement(_)
         | ProtocolCommand::TriggerWait(_)
         | ProtocolCommand::AttachActivationInput(_) => None,
@@ -1832,6 +2140,10 @@ fn persist_agent_snapshot_tx(
             ],
         )?;
     }
+    tx.execute(
+        "DELETE FROM scheduler_missing_settlements WHERE agent_id = ?1",
+        [agent_id],
+    )?;
     for (missing_id, missing) in &snapshot.missing_settlements {
         tx.execute(
             "INSERT INTO scheduler_missing_settlements (
@@ -2214,6 +2526,7 @@ fn activation_state_token(state: &ActivationState) -> &'static str {
     match state {
         ActivationState::Running => "running",
         ActivationState::Settled => "settled",
+        ActivationState::Interrupted => "interrupted",
         ActivationState::SettlementMissing => "settlement_missing",
     }
 }
@@ -2594,7 +2907,8 @@ fn load_activations(
         ) = row?;
         let state = match lifecycle_state.as_str() {
             "admitted" | "running" => ActivationState::Running,
-            "settled" | "interrupted" | "cancelled" => ActivationState::Settled,
+            "settled" | "cancelled" => ActivationState::Settled,
+            "interrupted" => ActivationState::Interrupted,
             "settlement_missing" => ActivationState::SettlementMissing,
             _ => bail!("activation {activation_id} has invalid lifecycle state"),
         };
@@ -2705,6 +3019,55 @@ mod tests {
         assert_eq!(v2_schema, LEGACY_ADOPTION_REPLACEMENT_SCHEMA_VERSION);
         assert_ne!(v1_hash, v2_hash);
         Ok(())
+    }
+
+    #[test]
+    fn legacy_adoption_source_match_allows_conservative_projection_side_effects() {
+        let ProtocolCommand::AdoptLegacyWorkState(mut candidate) =
+            legacy_adoption_command(Some(ReplaceCompletedFocusProof {
+                work_item_id: "work-old".into(),
+                source_work_item_revision: 5,
+                expected_metadata_revision: 4,
+                expected_scheduling_generation: 4,
+            }))
+        else {
+            unreachable!("fixture is a legacy adoption command");
+        };
+        candidate.focus = true;
+        candidate.reserve_dispatch = true;
+        candidate.wait = Some(LegacyWaitAdoption {
+            wait_id: "wait-a".into(),
+            generation: 3,
+            owner_work_item_id: "work-a".into(),
+            source_updated_at: "2026-08-01T00:00:00Z".into(),
+        });
+        candidate.demand.status = WorkStatus::Waiting {
+            wait_id: "wait-a".into(),
+        };
+
+        let mut projection_only = candidate.clone();
+        projection_only.focus = false;
+        projection_only.reserve_dispatch = false;
+        projection_only.replace_completed_focus = None;
+
+        assert!(legacy_adoption_source_matches(&candidate, &projection_only));
+    }
+
+    #[test]
+    fn legacy_adoption_source_match_rejects_source_drift_and_side_effect_elevation() {
+        let ProtocolCommand::AdoptLegacyWorkState(mut candidate) = legacy_adoption_command(None)
+        else {
+            unreachable!("fixture is a legacy adoption command");
+        };
+
+        let mut drifted = candidate.clone();
+        drifted.source_work_item_revision += 1;
+        assert!(!legacy_adoption_source_matches(&candidate, &drifted));
+
+        candidate.focus = false;
+        let mut elevated = candidate.clone();
+        elevated.focus = true;
+        assert!(!legacy_adoption_source_matches(&candidate, &elevated));
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -686,6 +686,12 @@ impl AppStorage {
         return runtime_db.turn_records().recent(limit);
     }
 
+    pub fn read_turn_by_id(&self, turn_id: &str) -> Result<Option<TurnRecord>> {
+        self.runtime_db
+            .turn_records()
+            .by_id(self.current_agent_id()?.as_deref(), turn_id)
+    }
+
     pub fn read_recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
         let runtime_db = self.runtime_db.clone();
         return runtime_db

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -487,7 +487,7 @@ No focused WorkItem is attached to this turn.
 ## continuation_anchor
 Continuation anchor:
 Latest trusted operator input: current_input.
-Current input relation: current_input is the latest trusted operator input.
+Current input relation: current_input is the latest trusted operator input and the only new operator task for this turn. Treat recent_turns as historical/background evidence; do not resume old tasks or waits unless current_input or the current WorkItem explicitly requires it.
 
 ## recent_turns
 Recent turns:
@@ -756,7 +756,7 @@ Current work item:
 ## continuation_anchor
 Continuation anchor:
 Latest trusted operator input: current_input.
-Current input relation: current_input is the latest trusted operator input.
+Current input relation: current_input is the latest trusted operator input and the only new operator task for this turn. Treat recent_turns as historical/background evidence; do not resume old tasks or waits unless current_input or the current WorkItem explicitly requires it.
 
 ## current_input
 Current input:
@@ -1167,7 +1167,7 @@ Blocked work items:
 ## continuation_anchor
 Continuation anchor:
 Latest trusted operator input: current_input.
-Current input relation: current_input is the latest trusted operator input.
+Current input relation: current_input is the latest trusted operator input and the only new operator task for this turn. Treat recent_turns as historical/background evidence; do not resume old tasks or waits unless current_input or the current WorkItem explicitly requires it.
 
 ## current_input
 Current input:
@@ -1251,7 +1251,7 @@ Current work item:
 ## continuation_anchor
 Continuation anchor:
 Latest trusted operator input: current_input.
-Current input relation: current_input is the latest trusted operator input.
+Current input relation: current_input is the latest trusted operator input and the only new operator task for this turn. Treat recent_turns as historical/background evidence; do not resume old tasks or waits unless current_input or the current WorkItem explicitly requires it.
 
 ## current_input
 Current input:
@@ -1593,7 +1593,7 @@ Current work item:
 ## continuation_anchor
 Continuation anchor:
 Latest trusted operator input: current_input.
-Current input relation: current_input is the latest trusted operator input.
+Current input relation: current_input is the latest trusted operator input and the only new operator task for this turn. Treat recent_turns as historical/background evidence; do not resume old tasks or waits unless current_input or the current WorkItem explicitly requires it.
 
 ## current_input
 Current input:

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -11,7 +11,10 @@ use holon::{
     },
     run_once::{run_once_with_host, RunFinalStatus, RunOnceRequest},
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
-    types::{AuthorityClass, ControlAction, FailureArtifactCategory, TaskStatus, TokenUsage},
+    types::{
+        AgentDurability, AgentRegistryStatus, AuthorityClass, ControlAction,
+        FailureArtifactCategory, TaskStatus, TokenUsage,
+    },
 };
 use serde_json::json;
 use tokio::sync::Mutex;
@@ -79,6 +82,11 @@ async fn run_once_returns_completed_text_for_simple_prompt() -> Result<()> {
     assert!(!response.render_text().contains("Token usage:"));
     assert!(response.agent_id.starts_with("tmp_run_"));
     assert!(response.tasks.is_empty());
+    let identity = host
+        .agent_identity_record(&response.agent_id)?
+        .expect("temporary run identity should remain as a host tombstone");
+    assert_eq!(identity.status, AgentRegistryStatus::Deleted);
+    assert_eq!(identity.durability, Some(AgentDurability::Ephemeral));
     let listed_agents = host
         .list_agents()
         .await?

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -3,11 +3,21 @@ mod runtime_tasks;
 
 mod support;
 
+use tokio::sync::Semaphore;
+
+const MAX_CONCURRENT_RUNTIME_TESTS: usize = 4;
+static RUNTIME_TEST_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_RUNTIME_TESTS);
+
 macro_rules! runtime_async_tests {
     ($($name:ident),* $(,)?) => {
         $(
             #[tokio::test]
             async fn $name() -> anyhow::Result<()> {
+                // Each fixture starts a full runtime with background workers.
+                // Bound suite-local concurrency so fixed protocol timeouts do
+                // not become host-load dependent when the harness runs all
+                // integration tests in parallel.
+                let _permit = RUNTIME_TEST_PERMITS.acquire().await?;
                 runtime_tasks::$name().await
             }
         )*

--- a/tests/scheduler_workitem_mvp.rs
+++ b/tests/scheduler_workitem_mvp.rs
@@ -265,6 +265,12 @@ fn apply_event(snapshot: &Snapshot, event: &Event) -> model::Outcome {
                     },
                     AgentDispatchDisposition::Open,
                 ),
+                Settlement::Interrupted { reason } => (
+                    ActivationDisposition::Interrupted {
+                        reason: reason.clone(),
+                    },
+                    AgentDispatchDisposition::Open,
+                ),
                 Settlement::Missing => unreachable!(),
             };
             let completion = matches!(disposition, ActivationDisposition::WorkCompleted { .. });
@@ -1511,7 +1517,7 @@ fn settlement_recovery_rejects_a_current_revision_with_an_awaiting_reservation()
 }
 
 #[test]
-fn pending_settlement_recovery_blocks_ordinary_work_admission() {
+fn pending_settlement_recovery_isolated_to_affected_work_item() {
     let admitted = apply_event(
         &minimal_snapshot(5),
         &Event::Admit {
@@ -1557,9 +1563,20 @@ fn pending_settlement_recovery_blocks_ordinary_work_admission() {
             cause: AdmissionCause::Scheduling,
         },
     );
-    assert_eq!(ordinary.decision, Decision::Rejected);
-    assert_eq!(ordinary.diagnostics, ["settlement_recovery_pending"]);
-    assert_eq!(ordinary.snapshot, snapshot);
+    assert_eq!(ordinary.decision, Decision::Admitted);
+    assert!(matches!(
+        ordinary.snapshot.slot,
+        ActivationSlot::Running {
+            ref activation_id,
+            ..
+        } if activation_id == "a-w2"
+    ));
+    assert_eq!(
+        ordinary.snapshot.work["w1"].status,
+        WorkStatus::NeedsSettlement {
+            activation_id: "a-missing".into(),
+        }
+    );
 }
 
 #[test]
@@ -2952,10 +2969,7 @@ fn reducer_rejections_have_explicit_stable_conflict_kinds() {
         rejected.conflict.expect("typed conflict").kind,
         ProtocolConflictKind::StateConflict
     );
-    assert_eq!(
-        rejected.outcome.diagnostics,
-        ["settlement_recovery_pending"]
-    );
+    assert_eq!(rejected.outcome.diagnostics, ["work_item_not_runnable"]);
 }
 
 #[test]

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -87,20 +87,6 @@ fn init_git_repo(path: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn wait_until_async<F, Fut>(predicate: F) -> Result<()>
-where
-    F: Fn() -> Fut,
-    Fut: std::future::Future<Output = Result<bool>>,
-{
-    for _ in 0..60 {
-        if predicate().await? {
-            return Ok(());
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
-    Err(anyhow::anyhow!("timed out waiting for condition"))
-}
-
 async fn attach_default_workspace(host: &RuntimeHost) -> Result<()> {
     let runtime = host.default_runtime().await?;
     let workspace = host.ensure_workspace_entry(host.config().workspace_dir.clone())?;
@@ -253,16 +239,78 @@ async fn wt204_parallel_worktree_workflow_demo_is_reviewable_end_to_end() -> Res
         worktree_paths.insert(task.id.clone(), worktree_path);
     }
 
-    wait_until_async(|| async {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
         let records = runtime.latest_task_records().await?;
         let all_completed = tasks.iter().all(|task| {
             records
                 .iter()
                 .any(|record| record.id == task.id && record.status == TaskStatus::Completed)
         });
-        Ok(all_completed)
-    })
-    .await?;
+        if all_completed {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let task_states = tasks
+                .iter()
+                .map(|task| {
+                    let status = records
+                        .iter()
+                        .find(|record| record.id == task.id)
+                        .map(|record| format!("{:?}", record.status))
+                        .unwrap_or_else(|| "missing".into());
+                    format!("{}={}", task.id, status)
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            let mut child_states = Vec::new();
+            for record in records
+                .iter()
+                .filter(|record| tasks.iter().any(|task| task.id == record.id))
+            {
+                let Some(child_agent_id) = record
+                    .detail
+                    .as_ref()
+                    .and_then(|detail| detail.get("child_agent_id"))
+                    .and_then(|value| value.as_str())
+                else {
+                    continue;
+                };
+                let child = host.get_or_create_agent(child_agent_id).await?;
+                let state = child.agent_state().await?;
+                let closure = child.current_closure().await?;
+                let child_events = child
+                    .storage()
+                    .read_recent_events(12)?
+                    .into_iter()
+                    .map(|event| format!("{}={}", event.kind, event.data))
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+                child_states.push(format!(
+                    "{}(turn={}, pending={}, run={:?}, current_work_item={:?}, closure={:?}, events=[{}])",
+                    child_agent_id,
+                    state.turn_index,
+                    state.pending,
+                    state.current_run_id,
+                    state.current_work_item_id,
+                    closure,
+                    child_events
+                ));
+            }
+            let recent_events = runtime
+                .storage()
+                .read_recent_events(20)?
+                .into_iter()
+                .map(|event| event.kind)
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(anyhow::anyhow!(
+                "timed out waiting for worktree tasks to complete ({task_states}); child states: {}; recent events: {recent_events}",
+                child_states.join(", ")
+            ));
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
 
     let summary = runtime.summarize_worktree_tasks().await?;
     assert!(summary.contains("Worktree Task Summary"));


### PR DESCRIPTION
## Summary

Introduces a single **execution-protocol aggregate** that replaces the previous multi-source scheduling lifecycle (slot, dispatch, focus, WorkDemand, wait mirror, missing settlement) with one authoritative `admit → attempt → settle` boundary per activation.

The goal is not to revert to the old scheduler or build a third one, but to **redraw authority boundaries inside the canonical scheduler** and accomplish the original product goals with fewer control states.

## Runtime concept changed

- **One activation = one execution quantum** granted by the scheduler; each activation requires a typed terminal outcome.
- **Admit/Settlement** shrinks to execution-attempt entry/exit boundaries — no longer a second long-lived business lifecycle.
- Each scheduling question has **exactly one authoritative source**; other records are immutable evidence, indexes, or rebuildable projections.
- Candidate construction, admission, and settlement are **co-transactional** with queue persistence.

## Key changes

- `src/domain/execution_protocol.rs` — new domain aggregate with typed `ExecutionTransition`, generation fences, source/binding identity, typed provenance
- `src/runtime_db/transitions/execution_protocol_repository.rs` + fixture repository — crash/restart/recovery and offline adoption rehearsal
- **Migration 41** — persist typed execution transitions and queue settlement in the same transaction
- Canonical production claim/settlement with **restart-safe rejoin** and WorkItem generation
- **Pre-commit fault** rolls back the entire transaction (no partial settlement)
- Legacy wait projection for backward compatibility
- Historical incident regression tests: #2119, #2121, #2394, #2440, #2460
- RFC: `docs/rfcs/scheduler-work-item-unified-execution-protocol.md`

## Verification

- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-D warnings" cargo test --all-targets` — **2577+ tests, 0 failed** (485s)
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets` — 332 errors (down from 353 on origin/main; no new errors introduced)

## Diff scope

33 files changed, +7870/-975 across domain, runtime, runtime_db, tests, and RFC docs.