### PR TITLE
fix: admit runtime-owned canonical scheduler followups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
           path: lcov.info
 
   e2e-scheduler:
-    name: E2E Scheduler (optional)
+    name: E2E Scheduler Live (optional)
     needs: changes
     if: contains(github.event.pull_request.labels.*.name, 'e2e-scheduler')
     runs-on: ubuntu-latest
@@ -288,6 +288,7 @@ jobs:
           python3 scripts/docker-e2e.py \
             --image holon:e2e \
             --skip-build \
+            --scheduler-matrix \
             --suite extended \
             --tag e2e-tier-1 \
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
@@ -296,3 +297,59 @@ jobs:
       - name: Remove provider environment
         if: always()
         run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}"
+
+  scheduler-e2e-required:
+    name: Scheduler E2E Required
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          tags: holon:scheduler-required
+          cache-from: type=gha,scope=holon-docker
+          cache-to: type=gha,mode=max,scope=holon-docker
+
+      - name: Run deterministic scheduler E2E
+        run: |
+          set -euo pipefail
+          python3 scripts/docker-e2e.py \
+            --image holon:scheduler-required \
+            --skip-build \
+            --profile scheduler-required \
+            --scheduler-matrix \
+            --timeout 600 \
+            --evidence-dir target/docker-e2e/scheduler-required
+
+      - name: Verify required reports
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path("target/docker-e2e/scheduler-required")
+          for name in (
+              "summary.json",
+              "scheduler-acceptance-report.json",
+              "scheduler-coverage-report.json",
+          ):
+              report = json.loads((root / name).read_text())
+              if report["status"] != "pass":
+                  raise SystemExit(f"{name} did not pass: {report['status']}")
+          PY
+
+      - name: Upload scheduler evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scheduler-e2e-required
+          path: target/docker-e2e/scheduler-required

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -121,6 +121,7 @@ jobs:
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
             --scheduler-matrix
+            --profile scheduler-acceptance
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
           )
           while IFS= read -r case_id; do
@@ -195,14 +196,26 @@ jobs:
               raise SystemExit(f"Release E2E did not pass: {summary['status']}")
           scheduler_report_path = summaries[-1].parent / "scheduler-acceptance-report.json"
           scheduler_report = json.loads(scheduler_report_path.read_text())
+          coverage_report_path = summaries[-1].parent / "scheduler-coverage-report.json"
+          coverage_report = json.loads(coverage_report_path.read_text())
           if scheduler_report["status"] != "pass":
               raise SystemExit(
                   f"Scheduler acceptance did not pass: {scheduler_report['status']}"
+              )
+          if coverage_report["status"] != "pass":
+              raise SystemExit(
+                  f"Scheduler coverage did not pass: {coverage_report['status']}"
               )
           if scheduler_report["git_sha"] != os.environ["CANDIDATE_SHA"]:
               raise SystemExit("Scheduler acceptance Git SHA does not match candidate")
           if scheduler_report["image_digest"] != summary["image_digest"]:
               raise SystemExit("Scheduler acceptance image digest does not match summary")
+          if coverage_report["git_sha"] != os.environ["CANDIDATE_SHA"]:
+              raise SystemExit("Scheduler coverage Git SHA does not match candidate")
+          if coverage_report["image_digest"] != summary["image_digest"]:
+              raise SystemExit("Scheduler coverage image digest does not match summary")
+          if coverage_report["profile"] != "scheduler-acceptance":
+              raise SystemExit("Scheduler coverage profile is not scheduler-acceptance")
           attestation = {
               "schema_version": 1,
               "release_tag": os.environ["RELEASE_TAG"],
@@ -215,8 +228,10 @@ jobs:
               "image": summary["image"],
               "image_digest": summary["image_digest"],
               "scheduler_acceptance": scheduler_report,
+              "scheduler_coverage": coverage_report,
               "summary_path": str(summaries[-1]),
               "scheduler_acceptance_path": str(scheduler_report_path),
+              "scheduler_coverage_path": str(coverage_report_path),
           }
           Path("target/release-e2e-attestation").mkdir(parents=True, exist_ok=True)
           Path("target/release-e2e-attestation/release-e2e-attestation.json").write_text(

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -28,6 +28,7 @@ from xml.etree import ElementTree
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "tests/e2e/docker/manifest.json"
 OPENAI_STUB_ROOT = ROOT / "tests/e2e/docker/openai_stub"
+OPENAI_STUB_IMAGE = "holon-openai-responses-stub:local"
 DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
 OFFLINE_MODEL_CREDENTIAL_ENV = "DEEPSEEK_API_KEY"
 OFFLINE_MODEL_CREDENTIAL = "docker-e2e-offline-provider-unused"
@@ -456,31 +457,53 @@ class CaseHarness:
             self.docker("network", "create", self.network)
         if self.provider_mode == "stub":
             require(bool(self.stub_scenario), "stub provider mode requires stub_scenario")
-            stub_image = "holon-openai-responses-stub:local"
-            self.docker(
-                "build", "--tag", stub_image, str(OPENAI_STUB_ROOT), capture=False
-            )
-            self.docker(
-                "run",
-                "--detach",
-                "--name",
+            stub_state = self.docker(
+                "inspect",
+                "--format",
+                "{{.State.Running}}",
                 self.stub_container,
-                "--network",
-                self.network,
-                "--volume",
-                f"{OPENAI_STUB_ROOT / 'transcripts.json'}:/stub/transcripts.json:ro",
-                "--volume",
-                f"{self.evidence}:/data",
-                stub_image,
-                "--transcript",
-                "/stub/transcripts.json",
-                "--scenario",
-                self.stub_scenario,
+                check=False,
             )
-            self.model = "openai/stub"
-            self.runtime_env["HOLON_OPENAI_BASE_URL"] = (
-                f"http://{self.stub_container}:8080/v1"
-            )
+            if stub_state.returncode != 0:
+                self.docker(
+                    "run",
+                    "--detach",
+                    "--name",
+                    self.stub_container,
+                    "--network",
+                    self.network,
+                    "--network-alias",
+                    "provider-stub",
+                    "--volume",
+                    f"{self.evidence}:/data",
+                    OPENAI_STUB_IMAGE,
+                    "--scenario",
+                    self.stub_scenario,
+                )
+            else:
+                require(
+                    stub_state.stdout.strip() == "true",
+                    "deterministic provider stub stopped during case restart",
+                )
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                ready = self.docker(
+                    "exec",
+                    self.stub_container,
+                    "python",
+                    "-c",
+                    "import urllib.request;"
+                    "urllib.request.urlopen('http://127.0.0.1:8080/healthz')",
+                    check=False,
+                )
+                if ready.returncode == 0:
+                    break
+                time.sleep(0.2)
+            else:
+                raise TimeoutError("deterministic provider stub did not become ready")
+            self.model = "openai/gpt-5.4"
+            self.runtime_env["HOLON_OPENAI_BASE_URL"] = "http://provider-stub:8080/v1"
+            self.runtime_env["OPENAI_API_KEY"] = "deterministic-test-key"
         args = [
             "run",
             "--detach",
@@ -655,6 +678,25 @@ class CaseHarness:
             if result.returncode == 0:
                 errors.append(f"{kind} still exists after cleanup: {name}")
         return {"status": "fail" if errors else "completed", "errors": errors}
+
+    def assert_stub_complete(self) -> None:
+        if self.provider_mode != "stub":
+            return
+        result = self.docker(
+            "exec",
+            self.stub_container,
+            "python",
+            "-c",
+            "import json,urllib.request;"
+            "print(json.dumps(json.load(urllib.request.urlopen('http://127.0.0.1:8080/status'))))",
+        )
+        status = json.loads(result.stdout)
+        write_json(self.evidence / "stub-status.json", status)
+        require(status.get("complete") is True, f"stub transcript was not fully consumed: {status}")
+        require(
+            status.get("extra_requests") == 0,
+            f"stub received requests after transcript exhaustion: {status}",
+        )
 
     def capture_logs(self) -> None:
         result = self.docker("logs", self.container, check=False)
@@ -2294,18 +2336,55 @@ def run_scheduler_external_wait_resume_case(
         for row in snapshot["wait_conditions"]
         if row["work_item_id"] == work_item_id
     ]
-    require(
-        len(waits) == 1
-        and waits[0]["kind"] == "external"
-        and waits[0]["status"] == "resolved",
-        f"external wait condition did not resolve: {waits}",
-    )
     if harness.canonical_scheduler_enabled:
+        require(
+            len(waits) == 1
+            and waits[0]["kind"] == "external"
+            and waits[0]["status"] == "resolved",
+            f"canonical external wait condition did not resolve: {waits}",
+        )
         require_lifecycle_wait_adoption(
             snapshot,
             agent_id=harness.agent_id,
             work_item_id=work_item_id,
             wait=waits[0],
+        )
+    else:
+        cancellation_events = [
+            json.loads(row["data_json"])["data"]
+            for row in snapshot["audit_events"]
+            if row["kind"] == "wait_conditions_cancelled"
+        ]
+        callback_events = [
+            json.loads(row["data_json"])["data"]
+            for row in snapshot["audit_events"]
+            if row["kind"] == "callback_delivered"
+        ]
+        resume_messages = [
+            row
+            for row in snapshot["messages"]
+            if row["work_item_id"] == work_item_id and row["kind"] == "system_tick"
+        ]
+        require(
+            len(waits) == 1
+            and waits[0]["kind"] == "external"
+            and waits[0]["status"] == "cancelled"
+            and any(
+                event.get("work_item_id") == work_item_id
+                and event.get("reason") == "work_item_completed"
+                and waits[0]["wait_condition_id"]
+                in event.get("wait_condition_ids", [])
+                for event in cancellation_events
+            )
+            and any(
+                event.get("disposition") == "triggered"
+                for event in callback_events
+            )
+            and len(resume_messages) == 1,
+            "legacy external wait did not follow wake-hint then completion "
+            f"cancellation semantics: waits={waits}, "
+            f"cancellations={cancellation_events}, "
+            f"callbacks={callback_events}, resumes={resume_messages}",
         )
     require_scheduler_engine_wait_resolution(
         harness,
@@ -3166,6 +3245,13 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             and all(isinstance(value, str) and value for value in required),
             f"profile {profile_id} required_coverage_ids must be unique strings",
         )
+        case_ids = profile.get("case_ids", [])
+        require(
+            isinstance(case_ids, list)
+            and len(case_ids) == len(set(case_ids))
+            and all(isinstance(value, str) and value for value in case_ids),
+            f"profile {profile_id} case_ids must be unique strings",
+        )
     seen: set[str] = set()
     for case in cases:
         case_id = case.get("id")
@@ -3251,6 +3337,10 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
                 not set(required).intersection(forbidden),
                 f"{case_id}/{phase_id} has required/forbidden tool overlap",
             )
+    known_case_ids = {case["id"] for case in cases}
+    for profile_id, profile in profiles.items():
+        unknown = sorted(set(profile.get("case_ids", [])) - known_case_ids)
+        require(not unknown, f"profile {profile_id} has unknown cases: {unknown}")
 
 
 def select_cases(
@@ -3528,8 +3618,10 @@ def scheduler_acceptance_report(
 
 def scheduler_coverage_report(
     *,
+    run_record: dict[str, Any],
     case_results: list[dict[str, Any]],
     required_coverage_ids: set[str],
+    secret_scan_status: str,
 ) -> dict[str, Any]:
     observed: dict[str, list[str]] = {}
     for result in case_results:
@@ -3542,14 +3634,22 @@ def scheduler_coverage_report(
         if coverage_id in required_coverage_ids
         and len(evidence_ids) != len(SCHEDULER_ENGINES)
     }
+    failed = sorted(result["id"] for result in case_results if result["status"] != "pass")
     return {
         "schema_version": SCHEDULER_COVERAGE_REPORT_SCHEMA_VERSION,
-        "status": "pass" if not missing and not invalid_counts else "fail",
+        "status": "pass" if not missing and not invalid_counts and not failed and secret_scan_status == "pass" else "fail",
+        "git_sha": run_record["git_sha"],
+        "image_digest": run_record["image_digest"],
+        "manifest_sha256": run_record["manifest_sha256"],
+        "profile": run_record["profile"],
+        "engines": list(SCHEDULER_ENGINES),
         "required_coverage_ids": sorted(required_coverage_ids),
         "observed": observed,
         "missing_coverage_ids": missing,
         "duplicate_or_incomplete_coverage_ids": invalid_counts,
         "unexpected_coverage_ids": sorted(observed.keys() - required_coverage_ids),
+        "failed_evidence_ids": failed,
+        "secret_scan": secret_scan_status,
     }
 
 
@@ -3595,6 +3695,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--evidence-dir", type=Path)
     parser.add_argument("--keep-on-failure", action="store_true")
+    parser.add_argument("--timeout", type=int)
     parser.add_argument("--scheduler-matrix", action="store_true")
     parser.add_argument("--list", action="store_true")
     parser.add_argument("--validate-manifest", action="store_true")
@@ -3618,7 +3719,7 @@ def main(argv: list[str] | None = None) -> int:
     require(shutil.which("docker") is not None, "docker is required")
     selected = select_cases(
         manifest,
-        requested=args.cases,
+        requested=args.cases or profile.get("case_ids") or None,
         suite=args.suite,
         tags=args.tag,
     )
@@ -3709,7 +3810,7 @@ def main(argv: list[str] | None = None) -> int:
     }
     write_json(evidence_root / "run.json", run_record)
 
-    timeout_override = first_env(
+    timeout_override = args.timeout or first_env(
         "HOLON_E2E_TIMEOUT_SECONDS", "HOLON_LIVE_TIMEOUT_SECONDS"
     )
     keep_on_failure = args.keep_on_failure or env_flag(
@@ -3721,6 +3822,20 @@ def main(argv: list[str] | None = None) -> int:
         selected,
         scheduler_matrix=args.scheduler_matrix,
     )
+    if any(
+        case.get("provider_mode", profile.get("provider_mode", "live")) == "stub"
+        for case, _ in expanded_cases
+    ):
+        run(
+            [
+                "docker",
+                "build",
+                "--tag",
+                OPENAI_STUB_IMAGE,
+                str(OPENAI_STUB_ROOT),
+            ],
+            capture=False,
+        )
     for case, scheduler_engine in expanded_cases:
         case_id = case["id"]
         evidence_id = (
@@ -3758,6 +3873,7 @@ def main(argv: list[str] | None = None) -> int:
         error_text = ""
         try:
             CASE_RUNNERS[case_id](harness, case)
+            harness.assert_stub_complete()
             harness.capture_context("final")
             status = "pass"
             print(f"PASS {case_id}")
@@ -3835,6 +3951,7 @@ def main(argv: list[str] | None = None) -> int:
         "secret_scan": scan["status"],
     }
     write_json(evidence_root / "summary.json", summary)
+    report_failures: list[str] = []
     if args.scheduler_matrix:
         required_coverage_ids = set(profile.get("required_coverage_ids", []))
         if not required_coverage_ids:
@@ -3844,10 +3961,14 @@ def main(argv: list[str] | None = None) -> int:
                 for coverage_id in case.get("coverage_ids", [])
             }
         coverage_report = scheduler_coverage_report(
+            run_record=run_record,
             case_results=case_results,
             required_coverage_ids=required_coverage_ids,
+            secret_scan_status=scan["status"],
         )
         write_json(evidence_root / "scheduler-coverage-report.json", coverage_report)
+        if coverage_report["status"] != "pass":
+            report_failures.append("scheduler-coverage-report: fail")
         report = scheduler_acceptance_report(
             run_record=run_record,
             case_results=case_results,
@@ -3855,6 +3976,8 @@ def main(argv: list[str] | None = None) -> int:
             required_coverage_ids=required_coverage_ids,
         )
         write_json(evidence_root / "scheduler-acceptance-report.json", report)
+        if report["status"] != "pass":
+            report_failures.append("scheduler-acceptance-report: fail")
     write_junit(evidence_root / "junit.xml", case_results, duration)
 
     print(f"Evidence: {evidence_root}")
@@ -3862,7 +3985,7 @@ def main(argv: list[str] | None = None) -> int:
         f"{case['id']}: {case['error']}"
         for case in case_results
         if case["status"] != "pass"
-    ]
+    ] + report_failures
     if failures:
         print("\n".join(failures), file=sys.stderr)
         return 1

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -27,11 +27,13 @@ from xml.etree import ElementTree
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "tests/e2e/docker/manifest.json"
+OPENAI_STUB_ROOT = ROOT / "tests/e2e/docker/openai_stub"
 DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
 OFFLINE_MODEL_CREDENTIAL_ENV = "DEEPSEEK_API_KEY"
 OFFLINE_MODEL_CREDENTIAL = "docker-e2e-offline-provider-unused"
 EVIDENCE_SCHEMA_VERSION = 1
 SCHEDULER_ACCEPTANCE_REPORT_SCHEMA_VERSION = 1
+SCHEDULER_COVERAGE_REPORT_SCHEMA_VERSION = 1
 SCHEDULER_ENGINES = ("legacy", "canonical")
 TERMINAL_STATUSES = {"awake_idle", "asleep", "awaiting_task"}
 RUNTIME_DB_COPY_TIMEOUT_SECONDS = 120
@@ -173,6 +175,8 @@ class CaseHarness:
         evidence_root: Path,
         timeout_seconds: int,
         keep: bool,
+        provider_mode: str = "live",
+        stub_scenario: str | None = None,
         resource_names: dict[str, str] | None = None,
         control_token: str | None = None,
     ) -> None:
@@ -195,10 +199,15 @@ class CaseHarness:
         self.evidence = evidence_root / case_id
         self.timeout_seconds = timeout_seconds
         self.keep = keep
+        self.provider_mode = provider_mode
+        self.stub_scenario = stub_scenario
         names = resource_names or {}
         self.volume = names.get("volume", f"holon-live-{case_id}-{suffix}")
         self.network = names.get("network", f"holon-live-{case_id}-{suffix}")
         self.container = names.get("container", f"holon-live-{case_id}-{suffix}")
+        self.stub_container = names.get(
+            "stub_container", f"holon-openai-stub-{case_id}-{suffix}"
+        )
         self.token = control_token or secrets.token_urlsafe(24)
         self.base_url = ""
         self.agent_id = ""
@@ -445,6 +454,33 @@ class CaseHarness:
         self.docker("volume", "create", self.volume)
         if self.docker("network", "inspect", self.network, check=False).returncode != 0:
             self.docker("network", "create", self.network)
+        if self.provider_mode == "stub":
+            require(bool(self.stub_scenario), "stub provider mode requires stub_scenario")
+            stub_image = "holon-openai-responses-stub:local"
+            self.docker(
+                "build", "--tag", stub_image, str(OPENAI_STUB_ROOT), capture=False
+            )
+            self.docker(
+                "run",
+                "--detach",
+                "--name",
+                self.stub_container,
+                "--network",
+                self.network,
+                "--volume",
+                f"{OPENAI_STUB_ROOT / 'transcripts.json'}:/stub/transcripts.json:ro",
+                "--volume",
+                f"{self.evidence}:/data",
+                stub_image,
+                "--transcript",
+                "/stub/transcripts.json",
+                "--scenario",
+                self.stub_scenario,
+            )
+            self.model = "openai/stub"
+            self.runtime_env["HOLON_OPENAI_BASE_URL"] = (
+                f"http://{self.stub_container}:8080/v1"
+            )
         args = [
             "run",
             "--detach",
@@ -586,6 +622,8 @@ class CaseHarness:
             return {"status": "retained", "errors": []}
         errors: list[str] = []
         self.docker("rm", "-f", self.container, check=False)
+        if self.provider_mode == "stub":
+            self.docker("rm", "-f", self.stub_container, check=False)
         self.docker("volume", "rm", self.volume, check=False)
         self.docker("network", "rm", self.network, check=False)
         residuals = [
@@ -605,6 +643,14 @@ class CaseHarness:
                 self.docker("network", "inspect", self.network, check=False),
             ),
         ]
+        if self.provider_mode == "stub":
+            residuals.append(
+                (
+                    "container",
+                    self.stub_container,
+                    self.docker("inspect", self.stub_container, check=False),
+                )
+            )
         for kind, name, result in residuals:
             if result.returncode == 0:
                 errors.append(f"{kind} still exists after cleanup: {name}")
@@ -3101,6 +3147,25 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
     )
     cases = manifest.get("cases")
     require(isinstance(cases, list) and cases, "manifest cases must be non-empty")
+    profiles = manifest.get("profiles", {})
+    require(isinstance(profiles, dict), "manifest profiles must be an object")
+    for profile_id, profile in profiles.items():
+        require(
+            isinstance(profile_id, str) and profile_id,
+            "profile id must be non-empty",
+        )
+        require(isinstance(profile, dict), f"profile {profile_id} must be an object")
+        require(
+            profile.get("provider_mode", "live") in {"live", "stub"},
+            f"profile {profile_id} has invalid provider_mode",
+        )
+        required = profile.get("required_coverage_ids", [])
+        require(
+            isinstance(required, list)
+            and len(required) == len(set(required))
+            and all(isinstance(value, str) and value for value in required),
+            f"profile {profile_id} required_coverage_ids must be unique strings",
+        )
     seen: set[str] = set()
     for case in cases:
         case_id = case.get("id")
@@ -3125,6 +3190,24 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             require(
                 isinstance(case["requires_model"], bool),
                 f"{case_id} requires_model must be boolean",
+            )
+        coverage_ids = case.get("coverage_ids", [])
+        require(
+            isinstance(coverage_ids, list)
+            and len(coverage_ids) == len(set(coverage_ids))
+            and all(isinstance(value, str) and value for value in coverage_ids),
+            f"{case_id} coverage_ids must be unique strings",
+        )
+        provider_mode = case.get("provider_mode", "live")
+        require(
+            provider_mode in {"live", "stub"},
+            f"{case_id} has invalid provider_mode",
+        )
+        if provider_mode == "stub":
+            require(
+                isinstance(case.get("stub_scenario"), str)
+                and case["stub_scenario"],
+                f"{case_id} stub provider mode requires stub_scenario",
             )
         runtime_env = case.get("runtime_env", {})
         require(isinstance(runtime_env, dict), f"{case_id} runtime_env must be an object")
@@ -3190,6 +3273,16 @@ def select_cases(
         ]
     require(selected, "case selection is empty")
     return selected
+
+
+def resolve_profile(
+    manifest: dict[str, Any], profile_id: str | None
+) -> dict[str, Any]:
+    if profile_id is None:
+        return {"provider_mode": "live", "required_coverage_ids": []}
+    profiles = manifest.get("profiles", {})
+    require(profile_id in profiles, f"unknown profile: {profile_id}")
+    return profiles[profile_id]
 
 
 def expand_case_matrix(
@@ -3333,13 +3426,14 @@ def scheduler_acceptance_report(
     run_record: dict[str, Any],
     case_results: list[dict[str, Any]],
     fixture_corpus_revision: str,
+    required_coverage_ids: set[str],
 ) -> dict[str, Any]:
     scheduler_results = [
         result
         for result in case_results
         if result.get("scheduler_engine") in SCHEDULER_ENGINES
     ]
-    expected_cases = {result["base_id"] for result in scheduler_results}
+    expected_cases = set(required_coverage_ids)
     engines = []
     all_revisions = set()
     diagnostics = []
@@ -3347,9 +3441,13 @@ def scheduler_acceptance_report(
         results = [
             result for result in scheduler_results if result["scheduler_engine"] == engine
         ]
-        actual_cases = {result["base_id"] for result in results}
-        matrix_complete = (
-            actual_cases == expected_cases and len(results) == len(expected_cases)
+        coverage_counts: dict[str, int] = {}
+        for result in results:
+            for coverage_id in result.get("coverage_ids", [result["base_id"]]):
+                coverage_counts[coverage_id] = coverage_counts.get(coverage_id, 0) + 1
+        actual_cases = set(coverage_counts)
+        matrix_complete = actual_cases == expected_cases and all(
+            count == 1 for count in coverage_counts.values()
         )
         revisions = {
             result["schema_revision"]
@@ -3428,6 +3526,33 @@ def scheduler_acceptance_report(
     }
 
 
+def scheduler_coverage_report(
+    *,
+    case_results: list[dict[str, Any]],
+    required_coverage_ids: set[str],
+) -> dict[str, Any]:
+    observed: dict[str, list[str]] = {}
+    for result in case_results:
+        for coverage_id in result.get("coverage_ids", []):
+            observed.setdefault(coverage_id, []).append(result["id"])
+    missing = sorted(required_coverage_ids - observed.keys())
+    invalid_counts = {
+        coverage_id: evidence_ids
+        for coverage_id, evidence_ids in sorted(observed.items())
+        if coverage_id in required_coverage_ids
+        and len(evidence_ids) != len(SCHEDULER_ENGINES)
+    }
+    return {
+        "schema_version": SCHEDULER_COVERAGE_REPORT_SCHEMA_VERSION,
+        "status": "pass" if not missing and not invalid_counts else "fail",
+        "required_coverage_ids": sorted(required_coverage_ids),
+        "observed": observed,
+        "missing_coverage_ids": missing,
+        "duplicate_or_incomplete_coverage_ids": invalid_counts,
+        "unexpected_coverage_ids": sorted(observed.keys() - required_coverage_ids),
+    }
+
+
 def write_junit(path: Path, cases: list[dict[str, Any]], duration: float) -> None:
     suite = ElementTree.Element(
         "testsuite",
@@ -3465,6 +3590,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--case", action="append", dest="cases")
     parser.add_argument("--tag", action="append", default=[])
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--profile")
     parser.add_argument("--env-file", type=Path)
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--evidence-dir", type=Path)
@@ -3479,6 +3605,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     manifest = json.loads(args.manifest.read_text())
     validate_manifest(manifest)
+    profile = resolve_profile(manifest, args.profile)
     if args.validate_manifest:
         print(f"valid manifest: {args.manifest}")
         return 0
@@ -3500,7 +3627,11 @@ def main(argv: list[str] | None = None) -> int:
             any("scheduler" in case.get("tags", []) for case in selected),
             "--scheduler-matrix requires at least one scheduler-tagged case",
         )
-    requires_model = any(case.get("requires_model", True) for case in selected)
+    requires_model = any(
+        case.get("requires_model", True)
+        and case.get("provider_mode", profile.get("provider_mode", "live")) == "live"
+        for case in selected
+    )
     model = args.model or first_env(
         "HOLON_E2E_MODEL", "HOLON_LIVE_MODEL", default=DEFAULT_MODEL
     )
@@ -3573,6 +3704,8 @@ def main(argv: list[str] | None = None) -> int:
         "env_file_used": env_file is not None,
         "manifest_sha256": hashlib.sha256(args.manifest.read_bytes()).hexdigest(),
         "scheduler_matrix": args.scheduler_matrix,
+        "profile": args.profile,
+        "provider_mode": profile.get("provider_mode", "live"),
     }
     write_json(evidence_root / "run.json", run_record)
 
@@ -3616,6 +3749,10 @@ def main(argv: list[str] | None = None) -> int:
                 else int(case["timeout_seconds"])
             ),
             keep=False,
+            provider_mode=case.get(
+                "provider_mode", profile.get("provider_mode", "live")
+            ),
+            stub_scenario=case.get("stub_scenario", profile.get("stub_scenario")),
         )
         control_tokens.append(harness.token)
         error_text = ""
@@ -3660,6 +3797,7 @@ def main(argv: list[str] | None = None) -> int:
             "cleanup": cleanup_result["status"],
             "cleanup_errors": cleanup_result["errors"],
             "schema_revision": collect_case_schema_revision(harness.evidence),
+            "coverage_ids": case.get("coverage_ids", []),
             **collect_case_metrics(harness.evidence),
         }
         write_json(harness.evidence / "case.json", result)
@@ -3698,10 +3836,23 @@ def main(argv: list[str] | None = None) -> int:
     }
     write_json(evidence_root / "summary.json", summary)
     if args.scheduler_matrix:
+        required_coverage_ids = set(profile.get("required_coverage_ids", []))
+        if not required_coverage_ids:
+            required_coverage_ids = {
+                coverage_id
+                for case in selected
+                for coverage_id in case.get("coverage_ids", [])
+            }
+        coverage_report = scheduler_coverage_report(
+            case_results=case_results,
+            required_coverage_ids=required_coverage_ids,
+        )
+        write_json(evidence_root / "scheduler-coverage-report.json", coverage_report)
         report = scheduler_acceptance_report(
             run_record=run_record,
             case_results=case_results,
             fixture_corpus_revision=manifest["scheduler_fixture_corpus_revision"],
+            required_coverage_ids=required_coverage_ids,
         )
         write_json(evidence_root / "scheduler-acceptance-report.json", report)
     write_junit(evidence_root / "junit.xml", case_results, duration)

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -438,6 +438,8 @@ fn validate_provenance(attempt: &ExecutionAttempt) -> Result<(), String> {
         Timer | System => matches!(provenance.trust, RuntimeInstruction | IntegrationSignal),
         Task | RuntimeRecovery => provenance.trust == RuntimeInstruction,
     };
+    // InternalFollowup identities are runtime-only: the scheduler constructs them
+    // from persisted ingress evidence while preserving, never upgrading, trust.
     let runtime_owned_followup = matches!(
         (
             &attempt.source.identity,

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -78,6 +78,9 @@ pub enum ExecutionSourceIdentity {
     QueueMessage {
         message_id: String,
     },
+    InternalFollowup {
+        message_id: String,
+    },
     TaskResult {
         task_id: String,
         result_message_id: String,
@@ -370,9 +373,10 @@ fn validate_source_binding(
     use ExecutionBinding::*;
     use ExecutionSourceIdentity::*;
     let allowed = match (&source.identity, binding) {
-        (QueueMessage { .. }, Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. }) => {
-            true
-        }
+        (
+            QueueMessage { .. } | InternalFollowup { .. },
+            Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. },
+        ) => true,
         (TaskResult { .. }, Conversation { .. } | WorkItem { .. } | Command) => true,
         (ChildResult { .. }, Conversation { .. } | WorkItem { .. } | Command) => true,
         (TriggeredWait { .. }, Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. }) => {
@@ -420,9 +424,10 @@ fn validate_rejoin_fence(fence: Option<&RejoinFence>) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_provenance(provenance: &ExecutionProvenance) -> Result<(), String> {
+fn validate_provenance(attempt: &ExecutionAttempt) -> Result<(), String> {
     use ExecutionOrigin::*;
     use ExecutionTrust::*;
+    let provenance = &attempt.provenance;
     let valid = match provenance.origin {
         Operator => provenance.trust == OperatorInstruction,
         Channel | Webhook => matches!(provenance.trust, IntegrationSignal | ExternalEvidence),
@@ -433,7 +438,19 @@ fn validate_provenance(provenance: &ExecutionProvenance) -> Result<(), String> {
         Timer | System => matches!(provenance.trust, RuntimeInstruction | IntegrationSignal),
         Task | RuntimeRecovery => provenance.trust == RuntimeInstruction,
     };
-    if !valid {
+    let runtime_owned_followup = matches!(
+        (
+            &attempt.source.identity,
+            &attempt.binding,
+            provenance.origin
+        ),
+        (
+            ExecutionSourceIdentity::InternalFollowup { .. },
+            ExecutionBinding::WorkItem { .. } | ExecutionBinding::AgentLifecycle { .. },
+            System | Task
+        )
+    );
+    if !valid && !runtime_owned_followup {
         return Err("execution provenance origin and trust are incompatible".into());
     }
     Ok(())
@@ -446,7 +463,7 @@ pub fn admit_execution(
     assert_invariants(state)?;
     let attempt = &command.attempt;
     validate_source_binding(&attempt.source, &attempt.binding, &attempt.admitted_fences)?;
-    validate_provenance(&attempt.provenance)?;
+    validate_provenance(attempt)?;
 
     if attempt.agent_id != state.agent_id {
         return Err("attempt agent does not match execution partition".into());

--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -2842,6 +2842,17 @@ fn lower_admit_activation(command: &AdmitActivationCommand) -> Result<Event, Pro
             },
         ),
         (
+            ActivationCause::InternalFollowup { message_id },
+            ActivationBinding::Lifecycle { agent_id },
+        ) if agent_id == &activation.agent_id => (
+            SchedulerOwner::AgentLifecycle {
+                agent_id: agent_id.clone(),
+            },
+            AdmissionCause::InternalFollowup {
+                message_id: message_id.clone(),
+            },
+        ),
+        (
             ActivationCause::WorkItemRunnable { .. }
             | ActivationCause::TaskRejoin { .. }
             | ActivationCause::OperatorInput { .. }
@@ -3276,12 +3287,14 @@ fn activation_provenance_matches_cause(
                     | ActivationOrigin::Task
             ) && activation_provenance_has_valid_authority(provenance)
         }
-        ActivationCause::WorkItemRunnable { .. }
-        | ActivationCause::WorkItemRecheck { .. }
-        | ActivationCause::InternalFollowup { .. } => {
+        ActivationCause::WorkItemRunnable { .. } | ActivationCause::WorkItemRecheck { .. } => {
             provenance.origin == ActivationOrigin::System
                 && provenance.trust == ActivationTrust::RuntimeInstruction
         }
+        ActivationCause::InternalFollowup { .. } => matches!(
+            provenance.origin,
+            ActivationOrigin::System | ActivationOrigin::Task
+        ),
         ActivationCause::RuntimeRecovery { .. } | ActivationCause::SettlementRecovery { .. } => {
             matches!(
                 provenance.origin,
@@ -3318,10 +3331,9 @@ fn admission_fence(
         AdmissionCause::LifecycleExternalNudge { message_id } => {
             format!("lifecycle_message:{message_id}")
         }
-        AdmissionCause::InternalFollowup { message_id } => {
-            format!("internal_followup:{message_id}")
-        }
-        AdmissionCause::Scheduling | AdmissionCause::WaitResume { .. } => {
+        AdmissionCause::Scheduling
+        | AdmissionCause::WaitResume { .. }
+        | AdmissionCause::InternalFollowup { .. } => {
             format!("{owner_identity}:{expected_generation}")
         }
     }
@@ -3621,17 +3633,34 @@ fn admit(
             ));
         }
         AdmissionCause::InternalFollowup { message_id } => {
-            let Some(work) = work else {
-                return rejected(snapshot, "internal_followup_requires_work_item_owner");
-            };
             if message_id.is_empty() {
                 return rejected(snapshot, "internal_followup_identity_required");
             }
-            if !matches!(work.status, WorkStatus::Runnable) {
-                return rejected(snapshot, "work_item_not_runnable");
-            }
-            if !matches!(snapshot.dispatch, AgentDispatchState::Open) {
-                return rejected(snapshot, "agent_lane_reserved");
+            if let Some(work) = work {
+                if !matches!(work.status, WorkStatus::Runnable) {
+                    return rejected(snapshot, "work_item_not_runnable");
+                }
+                if !matches!(snapshot.dispatch, AgentDispatchState::Open) {
+                    return rejected(snapshot, "agent_lane_reserved");
+                }
+            } else {
+                let SchedulerOwner::AgentLifecycle { .. } = owner else {
+                    return rejected(snapshot, "internal_followup_owner_invalid");
+                };
+                if let AgentDispatchState::Awaiting { wait } = &snapshot.dispatch {
+                    let Some(generation) = snapshot
+                        .waits
+                        .get(&wait.id)
+                        .and_then(|record| record.generations.get(&wait.generation))
+                    else {
+                        return rejected(snapshot, "agent_lane_reservation_missing");
+                    };
+                    if generation.owner != *owner
+                        || !matches!(generation.state, WaitState::Active | WaitState::Triggered)
+                    {
+                        return rejected(snapshot, "agent_lane_reserved_by_other_owner");
+                    }
+                }
             }
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1150,7 +1150,7 @@ fn adopt_pre_execution_protocol_attempt(
     };
     use crate::domain::scheduler_protocol::SchedulerOwner;
 
-    let _admission = snapshot
+    let admission = snapshot
         .activation_admissions
         .get(activation_id)
         .ok_or_else(|| anyhow!("legacy activation {activation_id} has no canonical admission"))?;
@@ -1210,8 +1210,15 @@ fn adopt_pre_execution_protocol_attempt(
         agent_id: agent_id.to_string(),
         source_message_id: Some(message.id.clone()),
         source: ExecutionSource {
-            identity: ExecutionSourceIdentity::QueueMessage {
-                message_id: message.id.clone(),
+            identity: match admission.activation.cause {
+                crate::domain::scheduler_protocol::ActivationCause::InternalFollowup { .. } => {
+                    ExecutionSourceIdentity::InternalFollowup {
+                        message_id: message.id.clone(),
+                    }
+                }
+                _ => ExecutionSourceIdentity::QueueMessage {
+                    message_id: message.id.clone(),
+                },
             },
             generation: source_revision,
         },

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1145,7 +1145,7 @@ pub(crate) fn canonical_activation_candidate(
     if message.kind == MessageKind::InternalFollowup {
         return Ok(if let Some(work_item_id) = message.work_item_id.clone() {
             Some(CanonicalActivationCandidate::InternalFollowup { work_item_id })
-        } else if runtime_owned_task_followup(message) {
+        } else if runtime_owned_internal_followup(message) {
             Some(CanonicalActivationCandidate::LifecycleExternalNudge {
                 agent_id: message.agent_id.clone(),
             })
@@ -1242,11 +1242,14 @@ pub(crate) fn canonical_activation_candidate(
     Ok(None)
 }
 
-pub(crate) fn runtime_owned_task_followup(message: &MessageEnvelope) -> bool {
+pub(crate) fn runtime_owned_internal_followup(message: &MessageEnvelope) -> bool {
     message.kind == MessageKind::InternalFollowup
         && message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
         && message.admission_context == Some(AdmissionContext::RuntimeOwned)
-        && matches!(message.origin, MessageOrigin::Task { .. })
+        && matches!(
+            message.origin,
+            MessageOrigin::System { .. } | MessageOrigin::Task { .. }
+        )
 }
 
 pub(crate) fn resolve_canonical_activation_scenario(

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -486,6 +486,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         reason,
                     )
                     .await?;
+                    // Terminalization notifies the scheduler, so the next poll can
+                    // advance past the rejected queue head in the same session.
                     return Ok(RunLoopPoll::Idle);
                 }
                 Ok(CanonicalClaimOutcome::RetainQueued {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -116,6 +116,10 @@ struct CanonicalClaimPlan {
 enum CanonicalClaimOutcome {
     ReduceOnly,
     Plan(CanonicalClaimPlan),
+    RejectQueued {
+        scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
+        reason: &'static str,
+    },
     RetainQueued {
         scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
         reason: &'static str,
@@ -471,6 +475,19 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             ) {
                 Ok(CanonicalClaimOutcome::ReduceOnly) => None,
                 Ok(CanonicalClaimOutcome::Plan(plan)) => Some(plan),
+                Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason,
+                }) => {
+                    self.terminalize_rejected_queue_head(
+                        &candidate,
+                        &persisted_message,
+                        scenario_class,
+                        reason,
+                    )
+                    .await?;
+                    return Ok(RunLoopPoll::Idle);
+                }
                 Ok(CanonicalClaimOutcome::RetainQueued {
                     scenario_class,
                     reason,
@@ -714,7 +731,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         )?
         else {
             return Ok(if model_reentry {
-                CanonicalClaimOutcome::RetainQueued {
+                CanonicalClaimOutcome::RejectQueued {
                     scenario_class:
                         crate::domain::scheduler_protocol::SchedulerScenarioClass::ReducerOnlyCandidates,
                     reason: "canonical_model_reentry_candidate_unclassified",
@@ -1108,8 +1125,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 ActivationBinding::WorkItem {
                     work_item_id: work_item.id.clone(),
                 },
-                ActivationOrigin::System,
-                ActivationTrust::RuntimeInstruction,
+                canonical_activation_origin_for_scenario(message, &scenario),
+                canonical_activation_trust_for_scenario(message, &scenario),
                 format!("internal-followup:{activation_id}"),
             ),
             scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => (
@@ -1419,13 +1436,20 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             .unwrap_or(0);
                         activation_generation.max(wait_generation).saturating_add(1)
                     });
+                    let cause = if scheduler::runtime_owned_internal_followup(message) {
+                        ActivationCause::InternalFollowup {
+                            message_id: message.id.clone(),
+                        }
+                    } else {
+                        ActivationCause::LifecycleExternalNudge {
+                            message_id: message.id.clone(),
+                        }
+                    };
                     (
                         generation,
                         None,
                         None,
-                        ActivationCause::LifecycleExternalNudge {
-                            message_id: message.id.clone(),
-                        },
+                        cause,
                         format!("lifecycle-message:{activation_id}"),
                     )
                 }
@@ -1501,6 +1525,108 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         }))
     }
 
+    async fn terminalize_rejected_queue_head(
+        &self,
+        candidate: &QueueCandidate,
+        message: &MessageEnvelope,
+        scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
+        reason: &'static str,
+    ) -> Result<()> {
+        let expected = self
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()?
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .ok_or_else(|| anyhow!("rejected queue entry is missing durable state"))?;
+        if !matches!(
+            expected.status,
+            QueueEntryStatus::Queued | QueueEntryStatus::Interrupted
+        ) {
+            return Ok(());
+        }
+        let mut dropped = expected.clone();
+        dropped.status = QueueEntryStatus::Dropped;
+        dropped.updated_at = self.runtime.now();
+        let invariant_event = scheduler::scheduler_invariant_diagnostic_event(
+            &message.agent_id,
+            reason,
+            message.work_item_id.clone(),
+            Some(message.id.clone()),
+            vec![
+                format!("message_kind={:?}", message.kind),
+                format!("message_origin={:?}", message.origin),
+                format!("authority_class={:?}", message.authority_class),
+                format!("delivery_surface={:?}", message.delivery_surface),
+                format!("admission_context={:?}", message.admission_context),
+                "queue_disposition=dropped".into(),
+            ],
+        )?;
+        let mut guard = self.runtime.inner.agent.lock().await;
+        if !guard
+            .queue
+            .peek()
+            .is_some_and(|queued| queued.id == message.id)
+        {
+            return Ok(());
+        }
+        let mut next_state = guard.state.clone();
+        next_state.pending = candidate.queue_len.saturating_sub(1);
+        let mut commit = self.runtime.inner.runtime_db.transitions().commit_queue(
+            &crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: message.agent_id.clone(),
+                operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                    expected,
+                    record: dropped,
+                },
+                scheduler_claim_work_item: None,
+                scheduler_protocol_bootstrap: None,
+                scheduler_protocol_commands: Vec::new(),
+                agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(guard.state.clone())),
+                    record: Box::new(next_state.clone()),
+                }),
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: vec![
+                    AuditEvent::legacy(
+                        "scheduler_authority_input_rejected",
+                        serde_json::json!({
+                            "message_id": message.id,
+                            "agent_id": message.agent_id,
+                            "scenario_class": scenario_class.as_str(),
+                            "reason": reason,
+                            "queue_disposition": "dropped",
+                            "message_kind": message.kind,
+                            "message_origin": message.origin,
+                            "authority_class": message.authority_class,
+                            "delivery_surface": message.delivery_surface,
+                            "admission_context": message.admission_context,
+                        }),
+                    ),
+                    invariant_event,
+                ],
+                notify_scheduler: true,
+                fault: self.runtime.take_transition_fault(),
+                brief_evidence: Vec::new(),
+            },
+        )?;
+        if !commit.applied {
+            return Ok(());
+        }
+        let _ = guard.queue.pop_if_next(&message.id);
+        guard.state = next_state.clone();
+        guard.last_persisted_state = next_state;
+        commit.effects.agent_state = None;
+        drop(guard);
+        self.runtime.apply_transition_commit(commit).await;
+        Ok(())
+    }
+
     fn plan_execution_protocol_claim(
         &self,
         message: &MessageEnvelope,
@@ -1572,9 +1698,24 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     trigger_generation: resume.trigger_generation,
                 }
             }
-            scheduler::CanonicalActivationScenario::InternalFollowup { .. }
-            | scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. }
-            | scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
+            scheduler::CanonicalActivationScenario::InternalFollowup { .. } => {
+                ExecutionSourceIdentity::InternalFollowup {
+                    message_id: message.id.clone(),
+                }
+            }
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
+                ExecutionSourceIdentity::QueueMessage {
+                    message_id: message.id.clone(),
+                }
+            }
+            scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. }
+                if scheduler::runtime_owned_internal_followup(message) =>
+            {
+                ExecutionSourceIdentity::InternalFollowup {
+                    message_id: message.id.clone(),
+                }
+            }
+            scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
                 ExecutionSourceIdentity::QueueMessage {
                     message_id: message.id.clone(),
                 }
@@ -1838,20 +1979,20 @@ fn canonical_activation_origin_for_scenario(
 ) -> crate::domain::scheduler_protocol::ActivationOrigin {
     use crate::domain::scheduler_protocol::ActivationOrigin;
     match scenario {
-        scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
-        | scheduler::CanonicalActivationScenario::InternalFollowup { .. } => {
+        scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. } => {
+            ActivationOrigin::System
+        }
+        scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+            if !scheduler::runtime_owned_internal_followup(message) =>
+        {
             ActivationOrigin::System
         }
         scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. } => ActivationOrigin::Task,
         scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
             ActivationOrigin::Operator
         }
-        scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. }
-            if scheduler::runtime_owned_task_followup(message) =>
-        {
-            ActivationOrigin::Task
-        }
-        scheduler::CanonicalActivationScenario::ExactWaitResume { .. }
+        scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+        | scheduler::CanonicalActivationScenario::ExactWaitResume { .. }
         | scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
             canonical_activation_origin(message)
         }
@@ -1865,19 +2006,19 @@ fn canonical_activation_trust_for_scenario(
     use crate::domain::scheduler_protocol::ActivationTrust;
     match scenario {
         scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
-        | scheduler::CanonicalActivationScenario::InternalFollowup { .. }
         | scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. } => {
+            ActivationTrust::RuntimeInstruction
+        }
+        scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+            if !scheduler::runtime_owned_internal_followup(message) =>
+        {
             ActivationTrust::RuntimeInstruction
         }
         scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
             ActivationTrust::OperatorInstruction
         }
-        scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. }
-            if scheduler::runtime_owned_task_followup(message) =>
-        {
-            ActivationTrust::RuntimeInstruction
-        }
-        scheduler::CanonicalActivationScenario::ExactWaitResume { .. }
+        scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+        | scheduler::CanonicalActivationScenario::ExactWaitResume { .. }
         | scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
             canonical_activation_trust(message)
         }
@@ -2030,6 +2171,18 @@ fn canonical_admission_matches_scenario(
             },
         ) => {
             message_id == &message.id
+                && agent_id == expected_agent_id
+                && agent_id == &message.agent_id
+        }
+        (
+            ActivationCause::InternalFollowup { message_id },
+            ActivationBinding::Lifecycle { agent_id },
+            scheduler::CanonicalActivationScenario::LifecycleExternalNudge {
+                agent_id: expected_agent_id,
+            },
+        ) => {
+            scheduler::runtime_owned_internal_followup(message)
+                && message_id == &message.id
                 && agent_id == expected_agent_id
                 && agent_id == &message.agent_id
         }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -7336,6 +7336,529 @@ async fn enqueue_normalizes_runtime_followup_without_authority_upgrade() {
 }
 
 #[tokio::test]
+async fn enqueue_inherits_current_work_item_and_preserves_canonical_provenance() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("enqueue follow-up owner".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_turn_work_item_id = Some(work_item.id.clone());
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &AuthorityClass::ExternalEvidence,
+        &crate::tool::ToolCall {
+            id: "enqueue-bound-follow-up".into(),
+            name: "Enqueue".into(),
+            input: serde_json::json!({
+                "text": "continue with external evidence",
+                "priority": "next"
+            }),
+        },
+    )
+    .await
+    .unwrap();
+
+    let message = runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .into_iter()
+        .find(|message| {
+            matches!(
+                &message.origin,
+                MessageOrigin::System { subsystem } if subsystem == "tool_enqueue"
+            )
+        })
+        .expect("Enqueue should persist its follow-up");
+    assert_eq!(message.work_item_id.as_deref(), Some(work_item.id.as_str()));
+    assert_eq!(message.authority_class, AuthorityClass::ExternalEvidence);
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let scheduler = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    let activation = &scheduler.activation_admissions[&activation_id].activation;
+    assert_eq!(
+        activation.provenance.origin,
+        crate::domain::scheduler_protocol::ActivationOrigin::System
+    );
+    assert_eq!(
+        activation.provenance.trust,
+        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence
+    );
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("canonical claim should initialize execution protocol");
+    assert_eq!(
+        execution.attempts[&activation_id].provenance.trust,
+        crate::domain::execution_protocol::ExecutionTrust::ExternalEvidence
+    );
+    assert!(matches!(
+        execution.attempts[&activation_id].source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::InternalFollowup { .. }
+    ));
+}
+
+#[tokio::test]
+async fn enqueue_does_not_bind_to_focus_without_current_turn_ownership() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("focused but not executing".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_work_item_id = Some(work_item.id);
+        guard.state.current_turn_work_item_id = None;
+        guard.state.current_execution_binding = None;
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &AuthorityClass::RuntimeInstruction,
+        &crate::tool::ToolCall {
+            id: "enqueue-unbound-focus".into(),
+            name: "Enqueue".into(),
+            input: serde_json::json!({
+                "text": "do not inherit focus",
+                "priority": "next"
+            }),
+        },
+    )
+    .await
+    .unwrap();
+
+    let message = runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .into_iter()
+        .find(|message| {
+            matches!(
+                &message.origin,
+                MessageOrigin::System { subsystem } if subsystem == "tool_enqueue"
+            )
+        })
+        .expect("Enqueue should persist its follow-up");
+    assert_eq!(message.work_item_id, None);
+}
+
+#[tokio::test]
+async fn runtime_owned_followup_preserves_all_authority_classes() {
+    use crate::domain::{execution_protocol::ExecutionTrust, scheduler_protocol::ActivationTrust};
+
+    for (authority, activation_trust, execution_trust) in [
+        (
+            AuthorityClass::OperatorInstruction,
+            ActivationTrust::OperatorInstruction,
+            ExecutionTrust::OperatorInstruction,
+        ),
+        (
+            AuthorityClass::RuntimeInstruction,
+            ActivationTrust::RuntimeInstruction,
+            ExecutionTrust::RuntimeInstruction,
+        ),
+        (
+            AuthorityClass::IntegrationSignal,
+            ActivationTrust::IntegrationSignal,
+            ExecutionTrust::IntegrationSignal,
+        ),
+        (
+            AuthorityClass::ExternalEvidence,
+            ActivationTrust::ExternalEvidence,
+            ExecutionTrust::ExternalEvidence,
+        ),
+    ] {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        let message = runtime
+            .enqueue(
+                MessageEnvelope::new(
+                    "default",
+                    MessageKind::InternalFollowup,
+                    MessageOrigin::System {
+                        subsystem: "authority-preservation".into(),
+                    },
+                    authority.clone(),
+                    Priority::Next,
+                    MessageBody::Text {
+                        text: "preserve authority".into(),
+                    },
+                )
+                .with_admission(
+                    MessageDeliverySurface::RuntimeSystem,
+                    AdmissionContext::RuntimeOwned,
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+                .poll()
+                .await
+                .unwrap(),
+            scheduler_executor::RunLoopPoll::Message(_)
+        ));
+        let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+        let scheduler = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_scheduler_protocol_snapshot("default")
+            .unwrap();
+        assert_eq!(
+            scheduler.activation_admissions[&activation_id]
+                .activation
+                .provenance
+                .trust,
+            activation_trust
+        );
+        let execution = runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .expect("canonical claim should initialize execution protocol");
+        assert_eq!(
+            execution.attempts[&activation_id].provenance.trust,
+            execution_trust
+        );
+        assert_eq!(message.authority_class, authority);
+    }
+}
+
+#[tokio::test]
+async fn runtime_owned_task_followup_preserves_task_origin_and_external_evidence() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "child",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = runtime
+        .enqueue(
+            MessageEnvelope::new(
+                "child",
+                MessageKind::InternalFollowup,
+                MessageOrigin::Task {
+                    task_id: "task-parent".into(),
+                },
+                AuthorityClass::ExternalEvidence,
+                Priority::Next,
+                MessageBody::Text {
+                    text: "delegated evidence".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::RuntimeSystem,
+                AdmissionContext::RuntimeOwned,
+            ),
+        )
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let scheduler = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("child")
+        .unwrap();
+    let activation = &scheduler.activation_admissions[&activation_id].activation;
+    assert_eq!(
+        activation.provenance.origin,
+        crate::domain::scheduler_protocol::ActivationOrigin::Task
+    );
+    assert_eq!(
+        activation.provenance.trust,
+        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence
+    );
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("child")
+        .unwrap()
+        .expect("canonical claim should initialize execution protocol");
+    assert_eq!(
+        execution.attempts[&activation_id].provenance.origin,
+        crate::domain::execution_protocol::ExecutionOrigin::Task
+    );
+    assert_eq!(
+        execution.attempts[&activation_id].provenance.trust,
+        crate::domain::execution_protocol::ExecutionTrust::ExternalEvidence
+    );
+}
+
+#[tokio::test]
+async fn runtime_owned_bound_task_followup_survives_scheduler_reload() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "child",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("bound delegated follow-up".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut followup = MessageEnvelope::new(
+        "child",
+        MessageKind::InternalFollowup,
+        MessageOrigin::Task {
+            task_id: "task-parent".into(),
+        },
+        AuthorityClass::ExternalEvidence,
+        Priority::Next,
+        MessageBody::Text {
+            text: "bound delegated evidence".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    followup.work_item_id = Some(work_item.id.clone());
+    let message = runtime.enqueue(followup).await.unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    drop(runtime);
+
+    let reopened = RuntimeHandle::new(
+        "child",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let scheduler = reopened
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("child")
+        .unwrap();
+    let activation = &scheduler.activation_admissions[&activation_id].activation;
+    assert_eq!(
+        activation.provenance.origin,
+        crate::domain::scheduler_protocol::ActivationOrigin::Task
+    );
+    assert_eq!(
+        activation.provenance.trust,
+        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence
+    );
+    assert!(matches!(
+        activation.binding,
+        crate::domain::scheduler_protocol::ActivationBinding::WorkItem {
+            ref work_item_id
+        } if work_item_id == &work_item.id
+    ));
+    let execution = reopened
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("child")
+        .unwrap()
+        .expect("canonical claim should persist execution protocol");
+    assert!(matches!(
+        execution.attempts[&activation_id].source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::InternalFollowup { .. }
+    ));
+}
+
+#[tokio::test]
+async fn canonical_unclassified_model_reentry_is_dropped_without_blocking_next_message() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let poison = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::InternalFollowup,
+            MessageOrigin::System {
+                subsystem: "untrusted_followup".into(),
+            },
+            AuthorityClass::ExternalEvidence,
+            Priority::Next,
+            MessageBody::Text {
+                text: "unclassified follow-up".into(),
+            },
+        ))
+        .await
+        .unwrap();
+    let valid = runtime
+        .enqueue(trusted_operator_prompt(None, "continue after poison"))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == poison.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dropped)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == poison.id
+                && event.data["reason"] == "canonical_model_reentry_candidate_unclassified"
+                && event.data["queue_disposition"] == "dropped"
+        }));
+
+    drop(runtime);
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("valid message behind dropped poison head should be claimed after restart");
+    };
+    assert_eq!(scheduled.message.id, valid.id);
+}
+
+#[tokio::test]
 async fn enqueue_normalizes_system_wake_as_coordination_with_work_item_binding() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1401,6 +1401,35 @@ fn runtime_owned_unbound_child_followup_is_lifecycle_nudge() {
 }
 
 #[test]
+fn runtime_owned_unbound_system_followup_is_lifecycle_nudge() {
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "first_run_intro".into(),
+        },
+        AuthorityClass::ExternalEvidence,
+        Priority::Next,
+        MessageBody::Text {
+            text: "introduce the runtime".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        Some(
+            scheduler::CanonicalActivationCandidate::LifecycleExternalNudge {
+                agent_id: "default".into(),
+            }
+        )
+    );
+}
+
+#[test]
 fn runtime_owned_unbound_child_evidence_is_lifecycle_nudge() {
     let message = MessageEnvelope::new(
         "child",

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -630,6 +630,133 @@ fn migrate_work_item_focus(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_scheduler_internal_followup_admission(
+    connection: &mut Connection,
+    migration: &Migration,
+) -> Result<()> {
+    connection.execute_batch("PRAGMA foreign_keys = OFF;")?;
+    let result = (|| -> Result<()> {
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(
+            r#"
+DROP INDEX IF EXISTS idx_scheduler_activations_ordinary_admission_fence;
+DROP INDEX IF EXISTS idx_scheduler_activations_recovery_admission_fence;
+
+CREATE TABLE scheduler_activation_sources_v42 (
+  agent_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  source_kind TEXT NOT NULL CHECK (
+    source_kind IN ('task_rejoin', 'operator_input', 'internal_followup')
+  ),
+  source_identity TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, activation_id),
+  UNIQUE (agent_id, source_kind, source_identity)
+);
+
+INSERT INTO scheduler_activation_sources_v42
+SELECT * FROM scheduler_activation_sources;
+
+DROP TABLE scheduler_activation_sources;
+ALTER TABLE scheduler_activation_sources_v42
+  RENAME TO scheduler_activation_sources;
+
+CREATE TABLE scheduler_activations_v42 (
+  agent_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  authority_id TEXT NOT NULL,
+  owner_kind TEXT NOT NULL CHECK (owner_kind IN ('work_item', 'agent_lifecycle')),
+  owner_id TEXT NOT NULL,
+  work_item_id TEXT,
+  admitted_generation INTEGER NOT NULL CHECK (admitted_generation >= 0),
+  admission_kind TEXT NOT NULL CHECK (
+    admission_kind IN (
+      'scheduling', 'wait_resume', 'lifecycle_external_nudge',
+      'internal_followup', 'settlement_recovery'
+    )
+  ),
+  recovery_for_activation_id TEXT,
+  wait_id TEXT,
+  wait_generation INTEGER CHECK (wait_generation IS NULL OR wait_generation >= 0),
+  lifecycle_state TEXT NOT NULL CHECK (
+    lifecycle_state IN (
+      'admitted', 'running', 'settled', 'interrupted',
+      'cancelled', 'settlement_missing'
+    )
+  ),
+  idempotency_key TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (agent_id, activation_id),
+  UNIQUE (agent_id, authority_id),
+  UNIQUE (agent_id, idempotency_key),
+  UNIQUE (agent_id, activation_id, owner_kind, owner_id, admitted_generation),
+  UNIQUE (agent_id, activation_id, work_item_id, admitted_generation),
+  CHECK (
+    (owner_kind = 'work_item' AND work_item_id = owner_id)
+    OR (owner_kind = 'agent_lifecycle' AND work_item_id IS NULL AND owner_id = agent_id)
+  ),
+  CHECK (
+    (admission_kind IN ('scheduling', 'internal_followup')
+      AND recovery_for_activation_id IS NULL
+      AND wait_id IS NULL
+      AND wait_generation IS NULL)
+    OR (admission_kind = 'wait_resume'
+      AND recovery_for_activation_id IS NULL
+      AND wait_id IS NOT NULL
+      AND wait_generation IS NOT NULL)
+    OR (admission_kind = 'lifecycle_external_nudge'
+      AND recovery_for_activation_id IS NULL
+      AND wait_id IS NULL
+      AND wait_generation IS NULL
+      AND owner_kind = 'agent_lifecycle')
+    OR (admission_kind = 'settlement_recovery'
+      AND recovery_for_activation_id IS NOT NULL
+      AND wait_id IS NULL
+      AND wait_generation IS NULL
+      AND owner_kind = 'work_item')
+  )
+);
+
+INSERT INTO scheduler_activations_v42
+SELECT * FROM scheduler_activations;
+
+DROP TABLE scheduler_activations;
+ALTER TABLE scheduler_activations_v42 RENAME TO scheduler_activations;
+
+CREATE UNIQUE INDEX idx_scheduler_activations_ordinary_admission_fence
+  ON scheduler_activations(
+    agent_id, owner_kind, owner_id, admitted_generation
+  )
+  WHERE admission_kind IN (
+    'scheduling', 'wait_resume', 'lifecycle_external_nudge', 'internal_followup'
+  );
+
+CREATE UNIQUE INDEX idx_scheduler_activations_recovery_admission_fence
+  ON scheduler_activations(
+    agent_id, owner_kind, owner_id, admitted_generation,
+    recovery_for_activation_id
+  )
+  WHERE admission_kind = 'settlement_recovery';
+"#,
+        )?;
+        transaction.execute(
+            "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+            (
+                migration.version,
+                migration.name,
+                Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            ),
+        )?;
+        transaction.commit()?;
+        Ok(())
+    })();
+    connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+    result
+}
+
 pub(crate) const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -2449,6 +2576,11 @@ CREATE TABLE IF NOT EXISTS execution_protocol_command_results (
 );
 "#,
     },
+    Migration {
+        version: 42,
+        name: "scheduler_internal_followup_admission",
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -2485,6 +2617,9 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     }
     if migration.name == "scheduler_lifecycle_owners" {
         return migrate_scheduler_lifecycle_owners(connection, migration);
+    }
+    if migration.name == "scheduler_internal_followup_admission" {
+        return migrate_scheduler_internal_followup_admission(connection, migration);
     }
 
     let transaction = connection.transaction()?;
@@ -2852,7 +2987,6 @@ fn migration_execution_source(
         | ActivationCause::OperatorInterjection { message_id }
         | ActivationCause::MessageIngress { message_id }
         | ActivationCause::LifecycleExternalNudge { message_id }
-        | ActivationCause::InternalFollowup { message_id }
             if message_id == &message.id =>
         {
             (
@@ -2863,6 +2997,13 @@ fn migration_execution_source(
                 None,
             )
         }
+        ActivationCause::InternalFollowup { message_id } if message_id == &message.id => (
+            ExecutionSourceIdentity::InternalFollowup {
+                message_id: message.id.clone(),
+            },
+            None,
+            None,
+        ),
         ActivationCause::TaskRejoin {
             task_id,
             message_id,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -726,6 +726,9 @@ SELECT * FROM scheduler_activations;
 DROP TABLE scheduler_activations;
 ALTER TABLE scheduler_activations_v42 RENAME TO scheduler_activations;
 
+CREATE INDEX idx_scheduler_activations_state
+  ON scheduler_activations(agent_id, lifecycle_state);
+
 CREATE UNIQUE INDEX idx_scheduler_activations_ordinary_admission_fence
   ON scheduler_activations(
     agent_id, owner_kind, owner_id, admitted_generation

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -738,6 +738,96 @@ mod tests {
     }
 
     #[test]
+    fn migration_42_preserves_scheduler_runtime_consistency_boundary() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            ensure_migration_table(&connection)?;
+            for migration in MIGRATIONS
+                .iter()
+                .filter(|migration| migration.version <= 41)
+            {
+                apply_migration(&mut connection, migration)?;
+            }
+            let ordinary_fence_sql: String = connection.query_row(
+                "SELECT sql
+                 FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name = 'idx_scheduler_activations_ordinary_admission_fence'",
+                [],
+                |row| row.get(0),
+            )?;
+            assert!(
+                !ordinary_fence_sql.contains("internal_followup"),
+                "migration 41 unexpectedly includes InternalFollowup admission"
+            );
+            connection.execute_batch(
+                r#"
+INSERT INTO scheduler_activation_sources (
+  agent_id, activation_id, source_kind, source_identity, payload_json, created_at
+) VALUES (
+  'agent-a', 'activation-a', 'operator_input', 'message-a', '{}',
+  '2026-08-03T00:00:00Z'
+);
+
+INSERT INTO scheduler_activations (
+  agent_id, activation_id, authority_id, owner_kind, owner_id, work_item_id,
+  admitted_generation, admission_kind, recovery_for_activation_id, wait_id,
+  wait_generation, lifecycle_state, idempotency_key, payload_json, created_at,
+  updated_at
+) VALUES (
+  'agent-a', 'activation-a', 'authority-a', 'work_item', 'work-a', 'work-a',
+  1, 'scheduling', NULL, NULL, NULL, 'settled', 'activation-a', '{}',
+  '2026-08-03T00:00:00Z', '2026-08-03T00:00:00Z'
+);
+"#,
+            )?;
+        }
+
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let connection = open_connection(&db_path)?;
+        let preserved: (String, String) = connection.query_row(
+            "SELECT admission_kind, lifecycle_state
+             FROM scheduler_activations
+             WHERE agent_id = 'agent-a' AND activation_id = 'activation-a'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(preserved, ("scheduling".into(), "settled".into()));
+
+        let foreign_key_count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM pragma_foreign_key_list('scheduler_activations')",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(
+            foreign_key_count, 0,
+            "migration 42 must preserve the runtime-owned scheduler consistency boundary"
+        );
+        let ordinary_fence_sql: String = connection.query_row(
+            "SELECT sql
+             FROM sqlite_master
+             WHERE type = 'index'
+               AND name = 'idx_scheduler_activations_ordinary_admission_fence'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(
+            ordinary_fence_sql.contains("internal_followup"),
+            "migration 42 must include InternalFollowup in the ordinary admission fence"
+        );
+        let foreign_key_violations = connection
+            .prepare("PRAGMA foreign_key_check")?
+            .query_map([], |_| Ok(()))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        assert!(
+            foreign_key_violations.is_empty(),
+            "migration 42 introduced foreign key violations"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_rollout_schema_rejects_authoritative_rollback_target() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -1781,6 +1871,153 @@ INSERT INTO scheduler_scenario_authorities (
             |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
         assert_eq!(source, ("operator_input".into(), "message-operator".into()));
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_internal_followup_is_message_unique_and_generation_fenced() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let agent_id = "agent-a";
+        let admission = |activation_id: &str,
+                         authority_id: &str,
+                         message_id: &str,
+                         expected_dispatch_revision| {
+            ProtocolCommand::AdmitActivation(AdmitActivationCommand {
+                authority_id: authority_id.into(),
+                activation: AgentActivation {
+                    id: activation_id.into(),
+                    agent_id: agent_id.into(),
+                    state: ActivationLifecycleState::Admitted,
+                    cause: ActivationCause::InternalFollowup {
+                        message_id: message_id.into(),
+                    },
+                    binding: ActivationBinding::Lifecycle {
+                        agent_id: agent_id.into(),
+                    },
+                    priority: ActivationPriority::Normal,
+                    preemption: PreemptionPolicy::AllowOperatorInterjection,
+                    source_revision: Some(1),
+                    idempotency_key: format!("internal-followup:{activation_id}"),
+                    provenance: ActivationProvenance {
+                        origin: ActivationOrigin::System,
+                        trust: ActivationTrust::RuntimeInstruction,
+                        source_id: message_id.into(),
+                        correlation_id: None,
+                        causation_id: None,
+                    },
+                },
+                expected_scheduling_generation: 1,
+                expected_dispatch_revision,
+            })
+        };
+        let first_message_id = "message-internal-followup-a";
+        let first_admission = admission(
+            "activation-internal-followup-a",
+            "authority-internal-followup-a",
+            first_message_id,
+            0,
+        );
+        let first_settlement = ProtocolCommand::SettleActivation(SettleActivationCommand {
+            settlement: ActivationSettlement {
+                id: "settlement-internal-followup-a".into(),
+                activation_id: "activation-internal-followup-a".into(),
+                turn_terminal: None,
+                disposition: ActivationDisposition::WorkContinues,
+                agent_dispatch: AgentDispatchDisposition::Open,
+                operator_delivery: None,
+                evidence: Vec::new(),
+                created_at: "2026-08-03T00:00:00Z".into(),
+            },
+        });
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.transitions()
+            .initialize_scheduler_protocol_partition(agent_id, &scheduler_protocol_snapshot(1))?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(
+                agent_id,
+                &first_admission,
+                None,
+            )?;
+        db.transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(
+                agent_id,
+                &first_settlement,
+                None,
+            )?;
+        drop(db);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let snapshot = reopened
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        assert_eq!(
+            snapshot.admitted_generations,
+            BTreeSet::from(["lifecycle:agent-a:1".into()])
+        );
+        let second_message_id = "message-internal-followup-b";
+        let second_admission = admission(
+            "activation-internal-followup-b",
+            "authority-internal-followup-b",
+            second_message_id,
+            snapshot.dispatch_revision,
+        );
+        let duplicate = reopened
+            .transitions()
+            .commit_scheduler_protocol_command_unchecked_for_test(
+                agent_id,
+                &second_admission,
+                None,
+            )?;
+        assert_eq!(duplicate.result.decision, Decision::Rejected);
+        assert_eq!(
+            duplicate.result.diagnostics,
+            ["scheduling_generation_already_admitted"]
+        );
+        drop(reopened);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let snapshot = reopened
+            .transitions()
+            .load_scheduler_protocol_snapshot(agent_id)?;
+        assert_eq!(
+            snapshot.admitted_generations,
+            BTreeSet::from(["lifecycle:agent-a:1".into()])
+        );
+        let sources = reopened
+            .connection()?
+            .prepare(
+                "SELECT source_kind, source_identity
+                 FROM scheduler_activation_sources
+                 WHERE agent_id = ?1
+                 ORDER BY source_identity",
+            )?
+            .query_map([agent_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        assert_eq!(
+            sources,
+            vec![("internal_followup".into(), first_message_id.into())]
+        );
+
+        let error = reopened
+            .connection()?
+            .execute(
+                "INSERT INTO scheduler_activation_sources (
+                   agent_id,
+                   activation_id,
+                   source_kind,
+                   source_identity,
+                   payload_json,
+                   created_at
+                 ) VALUES (?1, 'activation-duplicate', 'internal_followup', ?2, '{}', ?3)",
+                (agent_id, first_message_id, Utc::now().to_rfc3339()),
+            )
+            .unwrap_err();
+        assert_eq!(
+            error.sqlite_error_code(),
+            Some(ErrorCode::ConstraintViolation)
+        );
         Ok(())
     }
 
@@ -5053,7 +5290,7 @@ CREATE TABLE working_memory_deltas (
         let first = RuntimeDbLock::lock(&lock_path)?;
         let output = Command::new(std::env::current_exe()?)
             .arg("--exact")
-            .arg("runtime_db::tests::runtime_db_lock_rejects_second_nonblocking_holder")
+            .arg("runtime_db::tests::tests::runtime_db_lock_rejects_second_nonblocking_holder")
             .arg("--nocapture")
             .env("HOLON_RUNTIME_DB_LOCK_CHILD_PATH", &lock_path)
             .output()?;

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -816,6 +816,18 @@ INSERT INTO scheduler_activations (
             ordinary_fence_sql.contains("internal_followup"),
             "migration 42 must include InternalFollowup in the ordinary admission fence"
         );
+        let state_index_count: i64 = connection.query_row(
+            "SELECT COUNT(*)
+             FROM sqlite_master
+             WHERE type = 'index'
+               AND name = 'idx_scheduler_activations_state'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(
+            state_index_count, 1,
+            "migration 42 must restore the scheduler activation state index"
+        );
         let foreign_key_violations = connection
             .prepare("PRAGMA foreign_key_check")?
             .query_map([], |_| Ok(()))?

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -1074,6 +1074,18 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
                 },
             }
         ) | (
+            QueueOperation::Settle,
+            QueueMutation::CompareAndSet {
+                expected: QueueEntryRecord {
+                    status: QueueEntryStatus::Queued | QueueEntryStatus::Interrupted,
+                    ..
+                },
+                record: QueueEntryRecord {
+                    status: QueueEntryStatus::Dropped,
+                    ..
+                },
+            }
+        ) | (
             QueueOperation::RepairDrop,
             QueueMutation::CompareAndSet {
                 expected: QueueEntryRecord {

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -2444,6 +2444,7 @@ fn activation_admission_columns(
         ActivationCause::LifecycleExternalNudge { .. } => {
             Ok(("lifecycle_external_nudge", None, None, None))
         }
+        ActivationCause::InternalFollowup { .. } => Ok(("internal_followup", None, None, None)),
         _ => bail!(
             "activation {} has unsupported persisted admission cause",
             admission.activation.id
@@ -2495,6 +2496,24 @@ fn persisted_admission_fence(admission: &AdmitActivationCommand) -> Result<Strin
             scheduler_protocol::ActivationBinding::Lifecycle { .. },
         ) => return Ok(format!("lifecycle_message:{message_id}")),
         (
+            ActivationCause::InternalFollowup { .. },
+            scheduler_protocol::ActivationBinding::WorkItem { work_item_id },
+        ) => {
+            return Ok(format!(
+                "work:{work_item_id}:{}",
+                admission.expected_scheduling_generation
+            ));
+        }
+        (
+            ActivationCause::InternalFollowup { .. },
+            scheduler_protocol::ActivationBinding::Lifecycle { agent_id },
+        ) => {
+            return Ok(format!(
+                "lifecycle:{agent_id}:{}",
+                admission.expected_scheduling_generation
+            ));
+        }
+        (
             ActivationCause::SettlementRecovery { activation_id },
             scheduler_protocol::ActivationBinding::WorkItem { work_item_id },
         ) => {
@@ -2518,6 +2537,7 @@ fn activation_source_columns(admission: &AdmitActivationCommand) -> Option<(&'st
     match &admission.activation.cause {
         ActivationCause::TaskRejoin { task_id, .. } => Some(("task_rejoin", task_id)),
         ActivationCause::OperatorInput { message_id, .. } => Some(("operator_input", message_id)),
+        ActivationCause::InternalFollowup { message_id } => Some(("internal_followup", message_id)),
         _ => None,
     }
 }

--- a/src/tool/tools/enqueue.rs
+++ b/src/tool/tools/enqueue.rs
@@ -57,7 +57,13 @@ pub(crate) async fn execute(
         EnqueuePriority::Normal => Priority::Normal,
         EnqueuePriority::Background => Priority::Background,
     };
-    let message = MessageEnvelope::new(
+    let state = runtime.agent_state().await?;
+    let work_item_id = state
+        .current_execution_binding
+        .as_ref()
+        .and_then(|binding| binding.work_item_id.clone())
+        .or(state.current_turn_work_item_id);
+    let mut message = MessageEnvelope::new(
         agent_id.to_string(),
         MessageKind::InternalFollowup,
         MessageOrigin::System {
@@ -71,6 +77,7 @@ pub(crate) async fn execute(
         MessageDeliverySurface::RuntimeSystem,
         crate::types::AdmissionContext::RuntimeOwned,
     );
+    message.work_item_id = work_item_id;
     runtime.enqueue(message).await?;
     serialize_success(
         NAME,

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -1,6 +1,24 @@
 {
   "version": 2,
   "scheduler_fixture_corpus_revision": "scheduler-release-acceptance-v1",
+  "profiles": {
+    "scheduler-acceptance": {
+      "provider_mode": "live",
+      "required_coverage_ids": [
+        "scheduler-task-wait-resume",
+        "scheduler-provider-failure-work-queue-retry",
+        "scheduler-multi-workitem-scheduling",
+        "scheduler-external-wait-resume",
+        "scheduler-operator-wait-resume",
+        "scheduler-concurrent-claim-fencing",
+        "scheduler-operator-interject-during-wait",
+        "scheduler-compaction-continuity",
+        "scheduler-worktree-isolation",
+        "scheduler-spawn-agent-supervision",
+        "scheduler-checkpoint-replay"
+      ]
+    }
+  },
   "cases": [
     {
       "id": "runtime-auth-model-delivery",
@@ -120,6 +138,7 @@
     },
     {
       "id": "scheduler-task-wait-resume",
+      "coverage_ids": ["scheduler-task-wait-resume"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "task-result", "yield", "wait", "restart", "replay", "delivery"],
       "timeout_seconds": 900,
@@ -146,6 +165,7 @@
     },
     {
       "id": "scheduler-provider-failure-work-queue-retry",
+      "coverage_ids": ["scheduler-provider-failure-work-queue-retry"],
       "tier": "extended",
       "tags": ["scheduler", "provider", "failure", "retry", "workitem", "restart"],
       "timeout_seconds": 600,
@@ -167,6 +187,7 @@
     },
     {
       "id": "scheduler-multi-workitem-scheduling",
+      "coverage_ids": ["scheduler-multi-workitem-scheduling"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "multi", "priority", "e2e-tier-1"],
       "timeout_seconds": 600,
@@ -195,6 +216,7 @@
     },
     {
       "id": "scheduler-external-wait-resume",
+      "coverage_ids": ["scheduler-external-wait-resume"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "external", "wait", "resume", "e2e-tier-1"],
       "timeout_seconds": 600,
@@ -221,6 +243,7 @@
     },
     {
       "id": "scheduler-operator-wait-resume",
+      "coverage_ids": ["scheduler-operator-wait-resume"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "operator", "wait", "resume", "e2e-tier-1"],
       "timeout_seconds": 600,
@@ -247,6 +270,7 @@
     },
     {
       "id": "scheduler-concurrent-claim-fencing",
+      "coverage_ids": ["scheduler-concurrent-claim-fencing"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "concurrent", "claim", "interject", "e2e-tier-2"],
       "timeout_seconds": 600,
@@ -273,6 +297,7 @@
     },
     {
       "id": "scheduler-operator-interject-during-wait",
+      "coverage_ids": ["scheduler-operator-interject-during-wait"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "operator", "interject", "e2e-tier-2"],
       "timeout_seconds": 600,
@@ -299,6 +324,7 @@
     },
     {
       "id": "scheduler-compaction-continuity",
+      "coverage_ids": ["scheduler-compaction-continuity"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "compaction", "continuity", "e2e-tier-2"],
       "timeout_seconds": 600,
@@ -329,6 +355,7 @@
     },
     {
       "id": "scheduler-worktree-isolation",
+      "coverage_ids": ["scheduler-worktree-isolation"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "worktree", "isolation", "e2e-tier-2"],
       "timeout_seconds": 600,
@@ -357,6 +384,7 @@
     },
     {
       "id": "scheduler-spawn-agent-supervision",
+      "coverage_ids": ["scheduler-spawn-agent-supervision"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "spawn", "agent", "supervision", "e2e-tier-2"],
       "timeout_seconds": 600,
@@ -383,6 +411,7 @@
     },
     {
       "id": "scheduler-checkpoint-replay",
+      "coverage_ids": ["scheduler-checkpoint-replay"],
       "tier": "extended",
       "tags": ["scheduler", "workitem", "checkpoint", "replay", "restart", "e2e-tier-2"],
       "timeout_seconds": 600,

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -2,6 +2,19 @@
   "version": 2,
   "scheduler_fixture_corpus_revision": "scheduler-release-acceptance-v1",
   "profiles": {
+    "scheduler-required": {
+      "provider_mode": "stub",
+      "case_ids": [
+        "scheduler-multi-workitem-scheduling",
+        "scheduler-external-wait-resume",
+        "scheduler-operator-wait-resume"
+      ],
+      "required_coverage_ids": [
+        "scheduler-multi-workitem-scheduling",
+        "scheduler-external-wait-resume",
+        "scheduler-operator-wait-resume"
+      ]
+    },
     "scheduler-acceptance": {
       "provider_mode": "live",
       "required_coverage_ids": [
@@ -188,6 +201,7 @@
     {
       "id": "scheduler-multi-workitem-scheduling",
       "coverage_ids": ["scheduler-multi-workitem-scheduling"],
+      "stub_scenario": "scheduler-multi",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "multi", "priority", "e2e-tier-1"],
       "timeout_seconds": 600,
@@ -217,6 +231,7 @@
     {
       "id": "scheduler-external-wait-resume",
       "coverage_ids": ["scheduler-external-wait-resume"],
+      "stub_scenario": "scheduler-external",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "external", "wait", "resume", "e2e-tier-1"],
       "timeout_seconds": 600,
@@ -244,6 +259,7 @@
     {
       "id": "scheduler-operator-wait-resume",
       "coverage_ids": ["scheduler-operator-wait-resume"],
+      "stub_scenario": "scheduler-operator",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "operator", "wait", "resume", "e2e-tier-1"],
       "timeout_seconds": 600,

--- a/tests/e2e/docker/openai_stub/Dockerfile
+++ b/tests/e2e/docker/openai_stub/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.12-slim
+WORKDIR /stub
+COPY server.py /stub/server.py
+ENTRYPOINT ["python", "/stub/server.py"]

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -9,6 +9,7 @@ from typing import Any
 CALLBACK_CAPABILITY_PATTERN = re.compile(
     r"(/api/callbacks/(?:wake|enqueue)/)[A-Za-z0-9_-]+"
 )
+SCENARIOS = ("scheduler-multi", "scheduler-external", "scheduler-operator")
 
 def redact_evidence(value: Any) -> Any:
     if isinstance(value, dict):
@@ -224,7 +225,7 @@ def make_handler(scenario: Scenario, log: Path) -> type[BaseHTTPRequestHandler]:
     return Handler
 
 def main() -> None:
-    parser = argparse.ArgumentParser(); parser.add_argument("--listen", default="0.0.0.0"); parser.add_argument("--port", type=int, default=8080); parser.add_argument("--scenario", required=True); parser.add_argument("--request-log", type=Path, default=Path("/data/stub-requests.jsonl")); args = parser.parse_args()
+    parser = argparse.ArgumentParser(); parser.add_argument("--listen", default="0.0.0.0"); parser.add_argument("--port", type=int, default=8080); parser.add_argument("--scenario", required=True, choices=SCENARIOS); parser.add_argument("--request-log", type=Path, default=Path("/data/stub-requests.jsonl")); args = parser.parse_args()
     scenario = Scenario(args.scenario)
     ThreadingHTTPServer((args.listen, args.port), make_handler(scenario, args.request_log)).serve_forever()
 

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -1,93 +1,232 @@
 #!/usr/bin/env python3
-"""Dependency-free deterministic OpenAI Responses API stub."""
+"""Dependency-free deterministic OpenAI Responses API scheduler stub."""
 from __future__ import annotations
-import argparse
-import json
-import threading
+import argparse, json, re, threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
-def _matches(expected: Any, actual: Any) -> bool:
-    if isinstance(expected, dict):
-        return isinstance(actual, dict) and all(
-            key in actual and _matches(value, actual[key]) for key, value in expected.items()
-        )
-    if isinstance(expected, list):
-        return isinstance(actual, list) and len(expected) == len(actual) and all(
-            _matches(left, right) for left, right in zip(expected, actual)
-        )
-    return expected == actual
+CALLBACK_CAPABILITY_PATTERN = re.compile(
+    r"(/api/callbacks/(?:wake|enqueue)/)[A-Za-z0-9_-]+"
+)
 
-class Transcript:
-    def __init__(self, exchanges: list[dict[str, Any]]) -> None:
-        self.exchanges, self.index, self.lock = exchanges, 0, threading.Lock()
+def redact_evidence(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: redact_evidence(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact_evidence(item) for item in value]
+    if isinstance(value, str):
+        return CALLBACK_CAPABILITY_PATTERN.sub(r"\1<redacted>", value)
+    return value
+
+def response(items: list[dict[str, Any]], rid: str) -> dict[str, Any]:
+    return {"id": rid, "status": "completed", "usage": {"input_tokens": 100, "output_tokens": 10}, "output": items}
+
+def text_item(text: str) -> dict[str, Any]:
+    return {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": text}]}
+
+def call_item(cid: str, name: str, args: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "function_call", "id": f"fc_{cid}", "call_id": cid, "name": name, "arguments": json.dumps(args, separators=(",", ":"))}
+
+class Scenario:
+    def __init__(self, name: str) -> None:
+        self.name, self.phase, self.work_ids, self.markers = name, 0, [], {}
+        self.first_turn_closed = False
+        self.current_input_text = ""
+        self.extra_requests = 0
+        self.lock = threading.Lock()
+
+    def observe(self, request: dict[str, Any]) -> str:
+        raw = json.dumps(request, ensure_ascii=False)
+        for wid in re.findall(r"work_[0-9a-f]{15}", raw):
+            if wid not in self.work_ids:
+                self.work_ids.append(wid)
+        for key, pattern in {
+            "multi_a": r"SCHEDULER-MULTI-A-[0-9a-f]+", "multi_b": r"SCHEDULER-MULTI-B-[0-9a-f]+",
+            "multi_complete_a": r"SCHEDULER-MULTI-COMPLETE-A-[0-9a-f]+", "multi_complete_b": r"SCHEDULER-MULTI-COMPLETE-B-[0-9a-f]+",
+            "external": r"SCHEDULER-EXTERNAL-WAIT-[0-9a-f]+", "external_complete": r"SCHEDULER-EXTERNAL-COMPLETE-[0-9a-f]+",
+            "operator": r"SCHEDULER-OPERATOR-WAIT-[0-9a-f]+", "operator_complete": r"SCHEDULER-OPERATOR-COMPLETE-[0-9a-f]+",
+            "callback": r"docker-e2e:[0-9a-f]+",
+        }.items():
+            match = re.search(pattern, raw)
+            if match:
+                self.markers[key] = match.group(0)
+        return raw
+
+    @staticmethod
+    def current_input(request: dict[str, Any]) -> str:
+        texts = [
+            content["text"]
+            for item in request.get("input", [])
+            if isinstance(item, dict)
+            for content in item.get("content", [])
+            if isinstance(content, dict) and isinstance(content.get("text"), str)
+        ]
+        for text in reversed(texts):
+            marker = "## current_input\nCurrent input:\n"
+            if marker in text:
+                return text.rsplit(marker, 1)[1]
+        return ""
+
+    def call(self, name: str, args: dict[str, Any], text: str | None = None) -> tuple[int, dict[str, Any]]:
+        cid = f"{self.name}-{self.phase}-{name.lower()}"
+        self.phase += 1
+        items = ([text_item(text)] if text else []) + [call_item(cid, name, args)]
+        return 200, response(items, f"resp_{cid}")
 
     def consume(self, request: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         with self.lock:
-            if self.index >= len(self.exchanges):
-                return 409, {"error": {"type": "transcript_exhausted", "message": "no transcript response remains"}}
-            exchange = self.exchanges[self.index]
-            if not _matches(exchange.get("request", {}), request):
-                return 409, {"error": {"type": "transcript_mismatch", "message": f"request did not match transcript step {self.index}"}}
-            self.index += 1
-            return int(exchange.get("status", 200)), exchange["response"]
+            raw = self.observe(request)
+            if request.get("instructions") == "Reply with exactly OK.":
+                return 200, response([text_item("OK")], "resp_doctor")
+            current_input = self.current_input(request)
+            self.current_input_text = current_input
+            if (
+                "[trigger:internal_followup][runtime_instruction][InternalFollowup]"
+                in current_input
+                and "This is the first run of Holon" in current_input
+            ):
+                return 200, response([text_item("Deterministic Holon test runtime ready.")], "resp_intro")
+            if self.phase == self.expected_phase() - 1:
+                self.phase += 1
+                return 200, response(
+                    [text_item("Deterministic scheduler scenario complete.")],
+                    f"resp_{self.name}_complete",
+                )
+            if self.phase >= self.expected_phase():
+                self.extra_requests += 1
+                return 409, {
+                    "error": {
+                        "type": "transcript_exhausted",
+                        "message": str(self.phase),
+                    }
+                }
+            if self.name == "scheduler-multi":
+                return self.multi()
+            if self.name in {"scheduler-external", "scheduler-operator"}:
+                return self.wait(self.name.removeprefix("scheduler-"))
+            return 409, {"error": {"type": "unknown_scenario", "message": self.name}}
 
-def load_transcript(path: Path, scenario: str) -> Transcript:
-    document = json.loads(path.read_text())
-    scenarios = document.get("scenarios", document)
-    exchanges = scenarios.get(scenario) if isinstance(scenarios, dict) else None
-    if isinstance(exchanges, dict):
-        exchanges = exchanges.get("transcript")
-    if not isinstance(exchanges, list):
-        raise ValueError(f"stub scenario is missing or invalid: {scenario}")
-    for index, exchange in enumerate(exchanges):
-        if not isinstance(exchange, dict) or not isinstance(exchange.get("request", {}), dict) or not isinstance(exchange.get("response"), dict):
-            raise ValueError(f"invalid transcript exchange at index {index}")
-    return Transcript(exchanges)
+    def multi(self) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call("CreateWorkItem", {"objective": self.markers.get("multi_a", "SCHEDULER-MULTI-A"), "plan_status": "ready", "todo_list": [{"text": "seed-a", "state": "completed"}, {"text": "complete-a", "state": "pending"}]})
+        if self.phase == 1:
+            return self.call("CreateWorkItem", {"objective": self.markers.get("multi_b", "SCHEDULER-MULTI-B"), "plan_status": "ready", "todo_list": [{"text": "seed-b", "state": "completed"}, {"text": "complete-b", "state": "pending"}]})
+        if self.phase == 2:
+            self.phase += 1
+            return 200, response([text_item("Created two deterministic WorkItems.")], "resp_multi_seeded")
+        index = 0 if self.phase < 7 else 1
+        if len(self.work_ids) <= index:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        wid = self.work_ids[index]
+        if self.phase == 7 and (
+            "[trigger:system_tick]" not in self.current_input_text
+            or self.markers["multi_b"] not in self.current_input_text
+        ):
+            if self.first_turn_closed:
+                return 409, {
+                    "error": {
+                        "type": "transcript_exhausted",
+                        "message": str(self.phase),
+                    }
+                }
+            self.first_turn_closed = True
+            return 200, response(
+                [text_item("Completed the first deterministic WorkItem.")],
+                "resp_multi_first_complete",
+            )
+        steps = {
+            3: ("AgentGet", {}), 4: ("ListWorkItems", {"filter": "current", "include_todo_list": True}),
+            5: ("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": "seed-a", "state": "completed"}, {"text": "complete-a", "state": "completed"}]}),
+            7: ("GetWorkspaceState", {}), 8: ("ListWorkItems", {"filter": "current", "include_todo_list": True}),
+            9: ("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": "seed-b", "state": "completed"}, {"text": "complete-b", "state": "completed"}]}),
+        }
+        if self.phase in steps:
+            return self.call(*steps[self.phase])
+        if self.phase == 6:
+            completion = self.markers.get("multi_complete_a") or self.markers[
+                "multi_a"
+            ].replace("SCHEDULER-MULTI-A-", "SCHEDULER-MULTI-COMPLETE-A-")
+            return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
+        if self.phase == 10:
+            completion = self.markers.get("multi_complete_b") or self.markers[
+                "multi_b"
+            ].replace("SCHEDULER-MULTI-B-", "SCHEDULER-MULTI-COMPLETE-B-")
+            return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
 
-def make_handler(transcript: Transcript, request_log: Path) -> type[BaseHTTPRequestHandler]:
+    def wait(self, kind: str) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call("CreateWorkItem", {"objective": self.markers.get(kind, f"SCHEDULER-{kind.upper()}-WAIT"), "plan_status": "ready", "todo_list": [{"text": f"{kind}-wait", "state": "pending"}, {"text": f"{kind}-complete", "state": "pending"}]})
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        wid = self.work_ids[0]
+        if self.phase == 1:
+            return self.call("PickWorkItem", {"work_item_id": wid})
+        if self.phase == 2:
+            args: dict[str, Any] = {"wake": "external" if kind == "external" else "operator_input", "reason": f"deterministic {kind} wait"}
+            if kind == "external":
+                args["resource"] = self.markers.get("callback", "docker-e2e:deterministic")
+            return self.call("WaitFor", args)
+        if self.phase == 3:
+            return self.call("GetWorkItem", {"work_item_id": wid, "include_todo_list": True})
+        if self.phase == 4:
+            return self.call("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": f"{kind}-wait", "state": "completed"}, {"text": f"{kind}-complete", "state": "completed"}]})
+        if self.phase == 5:
+            completion = self.markers.get(f"{kind}_complete") or self.markers[
+                kind
+            ].replace(
+                f"SCHEDULER-{kind.upper()}-WAIT-",
+                f"SCHEDULER-{kind.upper()}-COMPLETE-",
+            )
+            return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def expected_phase(self) -> int:
+        return {
+            "scheduler-multi": 12,
+            "scheduler-external": 7,
+            "scheduler-operator": 7,
+        }[self.name]
+
+    def status(self) -> dict[str, Any]:
+        expected = self.expected_phase()
+        return {
+            "scenario": self.name,
+            "phase": self.phase,
+            "expected_phase": expected,
+            "extra_requests": self.extra_requests,
+            "complete": self.phase == expected and self.extra_requests == 0,
+        }
+
+def make_handler(scenario: Scenario, log: Path) -> type[BaseHTTPRequestHandler]:
     class Handler(BaseHTTPRequestHandler):
-        def _json(self, status: int, value: dict[str, Any]) -> None:
+        def send_json(self, status: int, value: dict[str, Any]) -> None:
             body = json.dumps(value, separators=(",", ":")).encode()
-            self.send_response(status)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
+            self.send_response(status); self.send_header("Content-Type", "application/json"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
         def do_GET(self) -> None:
-            self._json(200, {"status": "ok"}) if self.path == "/healthz" else self._json(404, {"error": {"type": "not_found", "message": "route not found"}})
-
+            self.send_json(200, {"status": "ok"}) if self.path == "/healthz" else self.send_json(200, scenario.status()) if self.path == "/status" else self.send_json(404, {"error": {"type": "not_found"}})
         def do_POST(self) -> None:
             if self.path != "/v1/responses":
-                self._json(404, {"error": {"type": "not_found", "message": "route not found"}})
-                return
+                self.send_json(404, {"error": {"type": "not_found"}}); return
             try:
                 request = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
-                if not isinstance(request, dict):
-                    raise ValueError
+                if not isinstance(request, dict): raise ValueError
             except (ValueError, json.JSONDecodeError):
-                self._json(400, {"error": {"type": "invalid_json", "message": "request body must be a JSON object"}})
-                return
-            request_log.parent.mkdir(parents=True, exist_ok=True)
-            with request_log.open("a") as stream:
-                stream.write(json.dumps(request, separators=(",", ":")) + "\n")
-            self._json(*transcript.consume(request))
-
-        def log_message(self, format: str, *args: Any) -> None:
-            return
+                self.send_json(400, {"error": {"type": "invalid_json"}}); return
+            log.parent.mkdir(parents=True, exist_ok=True)
+            with log.open("a") as stream:
+                stream.write(
+                    json.dumps(redact_evidence(request), separators=(",", ":")) + "\n"
+                )
+            self.send_json(*scenario.consume(request))
+        def log_message(self, format: str, *args: Any) -> None: return
     return Handler
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--listen", default="0.0.0.0")
-    parser.add_argument("--port", type=int, default=8080)
-    parser.add_argument("--transcript", type=Path, required=True)
-    parser.add_argument("--scenario", required=True)
-    parser.add_argument("--request-log", type=Path, default=Path("/data/requests.jsonl"))
-    args = parser.parse_args()
-    ThreadingHTTPServer((args.listen, args.port), make_handler(load_transcript(args.transcript, args.scenario), args.request_log)).serve_forever()
+    parser = argparse.ArgumentParser(); parser.add_argument("--listen", default="0.0.0.0"); parser.add_argument("--port", type=int, default=8080); parser.add_argument("--scenario", required=True); parser.add_argument("--request-log", type=Path, default=Path("/data/stub-requests.jsonl")); args = parser.parse_args()
+    scenario = Scenario(args.scenario)
+    ThreadingHTTPServer((args.listen, args.port), make_handler(scenario, args.request_log)).serve_forever()
 
 if __name__ == "__main__":
     main()

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Dependency-free deterministic OpenAI Responses API stub."""
+from __future__ import annotations
+import argparse
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+def _matches(expected: Any, actual: Any) -> bool:
+    if isinstance(expected, dict):
+        return isinstance(actual, dict) and all(
+            key in actual and _matches(value, actual[key]) for key, value in expected.items()
+        )
+    if isinstance(expected, list):
+        return isinstance(actual, list) and len(expected) == len(actual) and all(
+            _matches(left, right) for left, right in zip(expected, actual)
+        )
+    return expected == actual
+
+class Transcript:
+    def __init__(self, exchanges: list[dict[str, Any]]) -> None:
+        self.exchanges, self.index, self.lock = exchanges, 0, threading.Lock()
+
+    def consume(self, request: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        with self.lock:
+            if self.index >= len(self.exchanges):
+                return 409, {"error": {"type": "transcript_exhausted", "message": "no transcript response remains"}}
+            exchange = self.exchanges[self.index]
+            if not _matches(exchange.get("request", {}), request):
+                return 409, {"error": {"type": "transcript_mismatch", "message": f"request did not match transcript step {self.index}"}}
+            self.index += 1
+            return int(exchange.get("status", 200)), exchange["response"]
+
+def load_transcript(path: Path, scenario: str) -> Transcript:
+    document = json.loads(path.read_text())
+    scenarios = document.get("scenarios", document)
+    exchanges = scenarios.get(scenario) if isinstance(scenarios, dict) else None
+    if isinstance(exchanges, dict):
+        exchanges = exchanges.get("transcript")
+    if not isinstance(exchanges, list):
+        raise ValueError(f"stub scenario is missing or invalid: {scenario}")
+    for index, exchange in enumerate(exchanges):
+        if not isinstance(exchange, dict) or not isinstance(exchange.get("request", {}), dict) or not isinstance(exchange.get("response"), dict):
+            raise ValueError(f"invalid transcript exchange at index {index}")
+    return Transcript(exchanges)
+
+def make_handler(transcript: Transcript, request_log: Path) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def _json(self, status: int, value: dict[str, Any]) -> None:
+            body = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:
+            self._json(200, {"status": "ok"}) if self.path == "/healthz" else self._json(404, {"error": {"type": "not_found", "message": "route not found"}})
+
+        def do_POST(self) -> None:
+            if self.path != "/v1/responses":
+                self._json(404, {"error": {"type": "not_found", "message": "route not found"}})
+                return
+            try:
+                request = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
+                if not isinstance(request, dict):
+                    raise ValueError
+            except (ValueError, json.JSONDecodeError):
+                self._json(400, {"error": {"type": "invalid_json", "message": "request body must be a JSON object"}})
+                return
+            request_log.parent.mkdir(parents=True, exist_ok=True)
+            with request_log.open("a") as stream:
+                stream.write(json.dumps(request, separators=(",", ":")) + "\n")
+            self._json(*transcript.consume(request))
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+    return Handler
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--transcript", type=Path, required=True)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--request-log", type=Path, default=Path("/data/requests.jsonl"))
+    args = parser.parse_args()
+    ThreadingHTTPServer((args.listen, args.port), make_handler(load_transcript(args.transcript, args.scenario), args.request_log)).serve_forever()
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/docker/openai_stub/transcripts.json
+++ b/tests/e2e/docker/openai_stub/transcripts.json
@@ -1,0 +1,1 @@
+{"scenarios":{"health-only":{"transcript":[]}}}

--- a/tests/e2e/docker/openai_stub/transcripts.json
+++ b/tests/e2e/docker/openai_stub/transcripts.json
@@ -1,1 +1,0 @@
-{"scenarios":{"health-only":{"transcript":[]}}}

--- a/tests/e2e/scheduler/README.md
+++ b/tests/e2e/scheduler/README.md
@@ -61,15 +61,26 @@ Each case asserts three layers:
 
 | Layer | Trigger | Tiers | Timeout | Blocking |
 |---|---|---|---|---|
-| PR optional | `e2e-scheduler` label | Tier-1 subset | 20 min | no (`continue-on-error`) |
+| PR required | every scheduler/runtime Docker-relevant PR | deterministic Tier-1: multi-WorkItem, external wait, operator wait; legacy + canonical | 20 min | yes (`Scheduler E2E Required`) |
+| PR live optional | `e2e-scheduler` label | real-provider Tier-1 subset; legacy + canonical | 20 min | no (`continue-on-error`) |
 | Nightly | schedule | Tier-1 all + Tier-2 all | 60 min (job) / 15 min (suite `--timeout 900`) | creates issue on failure |
 | Release | release pipeline | Tier-1 + Tier-2 + Tier-3 | 90 min | yes |
 
-### Approved Decisions
+The required profile uses the dependency-free OpenAI Responses stub in
+`tests/e2e/docker/openai_stub/`. It produces `scheduler-coverage-report.json`
+from an explicit required coverage set; omitted cases therefore fail even when
+the selected matrix is internally symmetric. Real-provider runs remain the
+interoperability gate for provider behavior that a scripted transport cannot
+prove.
 
-- **CI Provider**: single low-cost model via env var; multi-provider matrix
-  only in release pipeline (max 2 providers).
-- **PR blocking**: `continue-on-error: true`; nightly is the regression gate.
+### Current Decisions
+
+- **Required CI provider**: local deterministic OpenAI Responses stub, with no
+  provider secret or PR label.
+- **Live CI provider**: single low-cost model via env var; multi-provider
+  matrix only in release pipeline (max 2 providers).
+- **PR blocking**: the deterministic profile is required; the live provider
+  job remains optional and `continue-on-error`.
 - **Phase order**: Phase 1 (infrastructure) → 2 (Tier-1) → 3 (Tier-2) → 4
   (Tier-3); within Phase 2, crash recovery and provider failure are highest
   priority.

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -341,6 +341,15 @@ pub async fn agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue(
     let (host, _base, server) = spawn_server_with_config(config.clone()).await?;
     host.create_named_agent("corrupt-list", None).await?;
     server.abort();
+    host.shutdown().await?;
+
+    let mut canonical_state = host
+        .runtime_db()
+        .agent_states()
+        .latest("corrupt-list")?
+        .expect("created agent should have canonical RuntimeDb state");
+    canonical_state.status = AgentStatus::Asleep;
+    host.runtime_db().agent_states().upsert(&canonical_state)?;
 
     let work_items_path = data_dir
         .join("agents")

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -18,6 +18,11 @@ SPEC = importlib.util.spec_from_file_location("docker_e2e_runner", RUNNER_PATH)
 assert SPEC is not None and SPEC.loader is not None
 runner = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(runner)
+STUB_PATH = ROOT / "tests/e2e/docker/openai_stub/server.py"
+STUB_SPEC = importlib.util.spec_from_file_location("openai_stub", STUB_PATH)
+assert STUB_SPEC is not None and STUB_SPEC.loader is not None
+stub = importlib.util.module_from_spec(STUB_SPEC)
+STUB_SPEC.loader.exec_module(stub)
 
 
 class DockerE2ERunnerTests(unittest.TestCase):
@@ -123,6 +128,52 @@ class DockerE2ERunnerTests(unittest.TestCase):
         invalid["cases"][0]["id"] = "not-implemented"
         with self.assertRaisesRegex(AssertionError, "no registered runner"):
             runner.validate_manifest(invalid)
+
+    def test_profile_exposes_explicit_scheduler_required_set(self) -> None:
+        profile = runner.resolve_profile(self.manifest, "scheduler-acceptance")
+        self.assertEqual(profile["provider_mode"], "live")
+        self.assertEqual(
+            set(profile["required_coverage_ids"]),
+            {
+                case["id"]
+                for case in self.manifest["cases"]
+                if "scheduler" in case.get("tags", [])
+            },
+        )
+
+    def test_scheduler_coverage_reports_missing_and_duplicate_ids(self) -> None:
+        report = runner.scheduler_coverage_report(
+            case_results=[
+                {"id": "a-legacy", "coverage_ids": ["a"]},
+                {"id": "a-canonical", "coverage_ids": ["a"]},
+                {"id": "a-extra", "coverage_ids": ["a"]},
+            ],
+            required_coverage_ids={"a", "b"},
+        )
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["missing_coverage_ids"], ["b"])
+        self.assertEqual(
+            report["duplicate_or_incomplete_coverage_ids"]["a"],
+            ["a-legacy", "a-canonical", "a-extra"],
+        )
+
+    def test_openai_stub_consumes_transcript_deterministically(self) -> None:
+        transcript = stub.Transcript(
+            [
+                {
+                    "request": {"model": "stub", "input": "hello"},
+                    "response": {"id": "response-1", "object": "response"},
+                }
+            ]
+        )
+        status, response = transcript.consume(
+            {"model": "stub", "input": "hello", "stream": False}
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(response["id"], "response-1")
+        status, response = transcript.consume({"model": "stub", "input": "hello"})
+        self.assertEqual(status, 409)
+        self.assertEqual(response["error"]["type"], "transcript_exhausted")
 
     def test_secret_scan_reports_value_without_echoing_it(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -685,6 +736,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             run_record=run_record,
             case_results=case_results,
             fixture_corpus_revision="scheduler-release-acceptance-v1",
+            required_coverage_ids={"scheduler-task-wait-resume"},
         )
         self.assertEqual(
             report["schema_version"],
@@ -727,6 +779,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             run_record=run_record,
             case_results=case_results,
             fixture_corpus_revision="scheduler-release-acceptance-v1",
+            required_coverage_ids={"scheduler-task-wait-resume"},
         )
         self.assertEqual(report["status"], "fail")
         self.assertIsNone(report["runtime_schema_revision"])

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -141,14 +141,40 @@ class DockerE2ERunnerTests(unittest.TestCase):
             },
         )
 
+    def test_scheduler_required_profile_selects_three_stub_cases(self) -> None:
+        profile = runner.resolve_profile(self.manifest, "scheduler-required")
+        selected = runner.select_cases(
+            self.manifest,
+            requested=profile["case_ids"],
+            suite="core",
+            tags=[],
+        )
+        self.assertEqual(profile["provider_mode"], "stub")
+        self.assertEqual(
+            [case["id"] for case in selected],
+            [
+                "scheduler-multi-workitem-scheduling",
+                "scheduler-external-wait-resume",
+                "scheduler-operator-wait-resume",
+            ],
+        )
+        self.assertTrue(all(case.get("stub_scenario") for case in selected))
+
     def test_scheduler_coverage_reports_missing_and_duplicate_ids(self) -> None:
         report = runner.scheduler_coverage_report(
+            run_record={
+                "git_sha": "git-sha",
+                "image_digest": "image@sha256:digest",
+                "manifest_sha256": "manifest-hash",
+                "profile": "scheduler-required",
+            },
             case_results=[
-                {"id": "a-legacy", "coverage_ids": ["a"]},
-                {"id": "a-canonical", "coverage_ids": ["a"]},
-                {"id": "a-extra", "coverage_ids": ["a"]},
+                {"id": "a-legacy", "coverage_ids": ["a"], "status": "pass"},
+                {"id": "a-canonical", "coverage_ids": ["a"], "status": "pass"},
+                {"id": "a-extra", "coverage_ids": ["a"], "status": "pass"},
             ],
             required_coverage_ids={"a", "b"},
+            secret_scan_status="pass",
         )
         self.assertEqual(report["status"], "fail")
         self.assertEqual(report["missing_coverage_ids"], ["b"])
@@ -158,22 +184,141 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
 
     def test_openai_stub_consumes_transcript_deterministically(self) -> None:
-        transcript = stub.Transcript(
-            [
-                {
-                    "request": {"model": "stub", "input": "hello"},
-                    "response": {"id": "response-1", "object": "response"},
-                }
-            ]
-        )
-        status, response = transcript.consume(
-            {"model": "stub", "input": "hello", "stream": False}
+        scenario = stub.Scenario("scheduler-external")
+        status, response = scenario.consume(
+            {
+                "instructions": "Reply with exactly OK.",
+                "input": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {"type": "input_text", "text": "Reply with exactly OK."}
+                        ],
+                    }
+                ],
+            }
         )
         self.assertEqual(status, 200)
-        self.assertEqual(response["id"], "response-1")
-        status, response = transcript.consume({"model": "stub", "input": "hello"})
+        self.assertEqual(response["output"][0]["content"][0]["text"], "OK")
+        self.assertEqual(scenario.phase, 0)
+        status, response = scenario.consume(
+            {
+                "instructions": "normal agent instructions mentioning Reply with exactly OK.",
+                "input": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": (
+                                    "## recent_turns\nThis is the first run of Holon\n"
+                                    "## current_input\nCurrent input:\n"
+                                    "- [operator] SCHEDULER-EXTERNAL-WAIT-abcd "
+                                    "SCHEDULER-EXTERNAL-COMPLETE-abcd docker-e2e:abcd"
+                                ),
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["name"], "CreateWorkItem")
+        self.assertEqual(scenario.phase, 1)
+        scenario.phase = 0
+        status, response = scenario.consume(
+            {
+                "input": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": (
+                                    "## current_input\nCurrent input:\n"
+                                    "- [system][runtime_system][runtime_owned]"
+                                    "[trigger:internal_followup][runtime_instruction]"
+                                    "[InternalFollowup]\n"
+                                    "  This is the first run of Holon"
+                                ),
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            response["output"][0]["content"][0]["text"],
+            "Deterministic Holon test runtime ready.",
+        )
+        self.assertEqual(scenario.phase, 0)
+        status, response = scenario.consume(
+            {"input": [{"type": "message", "content": [{"type": "input_text", "text": "SCHEDULER-EXTERNAL-WAIT-abcd SCHEDULER-EXTERNAL-COMPLETE-abcd docker-e2e:abcd"}]}]}
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["name"], "CreateWorkItem")
+        status, response = scenario.consume({"input": [{"type": "function_call_output", "output": "{\"work_item\":{\"id\":\"work_0123456789abcde\"}}"}]})
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["name"], "PickWorkItem")
+        scenario.phase = 6
+        status, response = scenario.consume({"input": []})
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            response["output"][0]["content"][0]["text"],
+            "Deterministic scheduler scenario complete.",
+        )
+        self.assertEqual(scenario.phase, 7)
+        self.assertTrue(scenario.status()["complete"])
+        status, response = scenario.consume({"input": []})
         self.assertEqual(status, 409)
         self.assertEqual(response["error"]["type"], "transcript_exhausted")
+        self.assertEqual(scenario.status()["extra_requests"], 1)
+        self.assertFalse(scenario.status()["complete"])
+
+    def test_openai_stub_multi_waits_for_second_autonomous_turn(self) -> None:
+        scenario = stub.Scenario("scheduler-multi")
+        scenario.phase = 7
+        scenario.work_ids = [
+            "work_0123456789abcde",
+            "work_fedcba987654321",
+        ]
+        scenario.markers = {
+            "multi_a": "SCHEDULER-MULTI-A-abcd",
+            "multi_b": "SCHEDULER-MULTI-B-abcd",
+        }
+        status, response = scenario.consume({"input": []})
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            response["output"][0]["content"][0]["text"],
+            "Completed the first deterministic WorkItem.",
+        )
+        self.assertEqual(scenario.phase, 7)
+        status, response = scenario.consume({"input": []})
+        self.assertEqual(status, 409)
+        self.assertEqual(response["error"]["type"], "transcript_exhausted")
+        status, response = scenario.consume(
+            {
+                "input": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": (
+                                    "## current_input\nCurrent input:\n"
+                                    "- [system][trigger:system_tick] "
+                                    "SCHEDULER-MULTI-B-abcd"
+                                ),
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["name"], "GetWorkspaceState")
+        self.assertEqual(scenario.phase, 8)
 
     def test_secret_scan_reports_value_without_echoing_it(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -896,7 +896,7 @@ export interface paths {
         put?: never;
         /**
          * Apply scheduler repair
-         * @description Dry-run or apply one OCC-guarded scheduler repair operation and emit an audit event for committed changes.
+         * @description Dry-run or apply one OCC-guarded scheduler repair operation. Non-dry-run requests create and verify a SQLite backup before committing and emit an audit event.
          */
         post: operations["applySchedulerRepair"];
         delete?: never;
@@ -3221,6 +3221,8 @@ export interface components {
                 };
                 /** Format: uint32 */
                 runtime_max_output_tokens: number;
+                /** @enum {string} */
+                scheduler: "legacy" | "canonical";
                 unknown_model_fallback_configured: boolean;
                 vision_default?: string | null;
                 web_search: {
@@ -3329,6 +3331,8 @@ export interface components {
                 };
                 /** Format: uint32 */
                 runtime_max_output_tokens: number;
+                /** @enum {string} */
+                scheduler: "legacy" | "canonical";
                 unknown_model_fallback_configured: boolean;
                 vision_default?: string | null;
                 web_search: {
@@ -3436,6 +3440,7 @@ export interface components {
         SchedulerRepairResult: {
             after: unknown;
             agent_id: string;
+            backup_path?: string | null;
             before: unknown;
             changed: boolean;
             dry_run: boolean;


### PR DESCRIPTION
## 背景

canonical scheduler 首次启动时会收到 runtime-owned、`System` origin、未绑定 WorkItem 的 `InternalFollowup`。该消息要求 model reentry，但此前 candidate 分类只接受 `Task` origin，导致队首永久保留并阻塞后续消息。

## 变更

- 将 runtime-owned `System|Task` `InternalFollowup` 纳入 canonical lifecycle admission，并贯通 activation cause、execution source 与原始 provenance，不提升消息 authority
- 对无法分类但要求 model reentry 的 poison queue head 进行原子 dropped terminalization，写入 invariant/audit evidence，避免队首永久阻塞
- 新增 migration 42：持久化 `internal_followup` source，并统一 owner+generation ordinary admission fence，同时保留独立 message-source uniqueness
- 让 `Enqueue` 仅继承当前 execution/turn 的 WorkItem binding，不从纯 focus 隐式绑定
- 补齐 producer-completeness、authority preservation、restart/migration、duplicate admission 与 poison containment 回归
- 增加无 secret、无 label 的 deterministic OpenAI Responses stub；新增 `scheduler-required` profile、显式 coverage report 与 required CI job
- release E2E 同时校验 scheduler acceptance/coverage attestation；真实 provider job继续承担互操作性验证

## 验证

- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `python3 -m unittest tests.test_docker_e2e_runner`（38/38）
- migration 42、InternalFollowup generation/message fence、跨进程 DB lock 定向回归
- deterministic Docker `scheduler-required` strict matrix：legacy + canonical，6/6 通过，acceptance/coverage/secret scan 均通过
