### PR TITLE
fix: preserve canonical scheduler liveness under contention

### DIFF
--- a/src/domain/scheduler_protocol.rs
+++ b/src/domain/scheduler_protocol.rs
@@ -3189,6 +3189,7 @@ fn reducer_conflict(code: &str) -> ProtocolConflict {
         | "wait_owner_mismatch"
         | "missing_settlement_owner_mismatch"
         | "agent_lane_reserved"
+        | "agent_lane_reserved_by_other_owner"
         | "agent_lane_reserved_for_other_wait"
         | "wait_id_owner_mismatch"
         | "wait_id_consumed_by_other_activation"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1822,6 +1822,16 @@ pub fn apply_scheduler_recovery_plan(
     agent_id: &str,
     report: &SchedulerRecoveryReport,
 ) -> Result<(usize, Option<std::path::PathBuf>)> {
+    apply_scheduler_recovery_plan_with_hook(storage, runtime_db, agent_id, report, |_| Ok(()))
+}
+
+fn apply_scheduler_recovery_plan_with_hook(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    report: &SchedulerRecoveryReport,
+    mut before_legacy_adoption_commit: impl FnMut(&str) -> Result<()>,
+) -> Result<(usize, Option<std::path::PathBuf>)> {
     let legacy_adoptions = report
         .legacy_adoptions
         .iter()
@@ -1860,15 +1870,21 @@ pub fn apply_scheduler_recovery_plan(
             record_legacy_adoption_rejection(storage, agent_id, &candidate.work_item_id, reason)?;
             continue;
         }
+        before_legacy_adoption_commit(&candidate.work_item_id)?;
         match runtime_db
             .transitions()
             .commit_scheduler_recovery_plan(agent_id, std::slice::from_ref(command))
         {
-            Ok(changed) => applied |= changed,
-            Err(error) => {
-                let Some(reason) = isolated_legacy_adoption_rejection(&error) else {
-                    return Err(error);
-                };
+            Ok(
+                crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Applied(
+                    changed,
+                ),
+            ) => applied |= changed,
+            Ok(
+                crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Rejected {
+                    reason,
+                },
+            ) => {
                 record_legacy_adoption_rejection(
                     storage,
                     agent_id,
@@ -1876,12 +1892,25 @@ pub fn apply_scheduler_recovery_plan(
                     reason,
                 )?;
             }
+            Err(error) => return Err(error),
         }
     }
     if !settlement_recovery.is_empty() {
-        applied |= runtime_db
+        match runtime_db
             .transitions()
-            .commit_scheduler_recovery_plan(agent_id, settlement_recovery)?;
+            .commit_scheduler_recovery_plan(agent_id, settlement_recovery)?
+        {
+            crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Applied(
+                changed,
+            ) => applied |= changed,
+            crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Rejected {
+                reason,
+            } => {
+                return Err(anyhow!(
+                    "scheduler settlement recovery unexpectedly rejected: {reason}"
+                ));
+            }
+        }
     }
     Ok((usize::from(applied), Some(backup_path)))
 }
@@ -1945,23 +1974,6 @@ fn record_legacy_adoption_rejection(
         None,
         vec![reason],
     )?)
-}
-
-fn isolated_legacy_adoption_rejection(error: &anyhow::Error) -> Option<String> {
-    error.chain().find_map(|source| {
-        source
-            .downcast_ref::<
-                crate::runtime_db::transitions::scheduler_protocol_repository::LegacySchedulerAdoptionRejected,
-            >()
-            .map(|error| error.reason.clone())
-            .or_else(|| {
-                source
-                    .downcast_ref::<
-                        crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerProtocolReducerRejected,
-                    >()
-                    .map(|error| error.reason.clone())
-            })
-    })
 }
 
 fn runtime_error_queue_settlement(

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -39,9 +39,21 @@ impl RuntimeHandle {
         } else {
             None
         };
+        let message_work_item_id = match message.work_item_id.as_deref() {
+            Some(work_item_id)
+                if self
+                    .inner
+                    .storage
+                    .latest_work_item(work_item_id)?
+                    .is_some_and(|work_item| work_item.state == WorkItemState::Completed) =>
+            {
+                None
+            }
+            work_item_id => work_item_id,
+        };
         let continuation_work_item_id = matching_wait_work_item_id
             .as_deref()
-            .or(message.work_item_id.as_deref())
+            .or(message_work_item_id)
             .or(scheduler_state.current_turn_work_item_id.as_deref())
             .or(scheduler_state.current_work_item_id.as_deref());
         let continuation_resolution = continuation_trigger.as_ref().map(|trigger| {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -841,6 +841,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 ));
             }
         };
+        if work_item.state == crate::types::WorkItemState::Completed
+            && matches!(
+                scenario,
+                scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. }
+            )
+        {
+            return Ok(CanonicalClaimOutcome::ReduceOnly);
+        }
         let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
         let work_projection = work_queue
             .items

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1015,6 +1015,381 @@ async fn legacy_recovery_isolates_a_stale_candidate_and_keeps_other_work_availab
 }
 
 #[tokio::test]
+async fn legacy_recovery_commit_returns_typed_rejection_when_source_changes_after_report() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "legacy recovery commit race".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    let command = report
+        .legacy_adoptions
+        .iter()
+        .find(|candidate| candidate.work_item_id == work_item.id)
+        .and_then(|candidate| candidate.proposed_command.clone())
+        .expect("eligible legacy adoption command");
+
+    runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            Some("legacy recovery source changed".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let outcome = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .commit_scheduler_recovery_plan("default", &[command])
+        .unwrap();
+    let crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Rejected {
+        reason,
+    } = outcome
+    else {
+        panic!("stale recovery source should return a typed rejection");
+    };
+    assert!(reason.contains("source_changed"));
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot_if_initialized("default")
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn legacy_recovery_commit_race_is_diagnostic_and_fresh_retry_converges() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "legacy recovery commit race converges".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let stale_report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    let runtime_for_hook = runtime.clone();
+    let (applied, _) = apply_scheduler_recovery_plan_with_hook(
+        &runtime.inner.storage,
+        &runtime.inner.runtime_db,
+        "default",
+        &stale_report,
+        move |candidate_work_item_id| {
+            let existing = runtime_for_hook
+                .storage()
+                .latest_work_item(candidate_work_item_id)?
+                .expect("race source WorkItem");
+            let mut changed = existing.clone();
+            changed.objective = "legacy recovery source changed at commit".into();
+            changed.revision += 1;
+            changed.updated_at = Utc::now();
+            runtime_for_hook
+                .inner
+                .runtime_db
+                .work_items()
+                .update_expected(&changed, existing.revision)?;
+            Ok(())
+        },
+    )
+    .unwrap();
+    assert_eq!(applied, 0);
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_diagnostic"
+                && event.data["reason"] == "legacy_adoption_rejected"
+                && event.data["work_item_id"] == work_item.id
+        }));
+
+    let fresh_report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert_eq!(
+        apply_scheduler_recovery_plan(
+            &runtime.inner.storage,
+            &runtime.inner.runtime_db,
+            "default",
+            &fresh_report,
+        )
+        .unwrap()
+        .0,
+        1
+    );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap()
+        .work
+        .contains_key(&work_item.id));
+}
+
+#[tokio::test]
+async fn canonical_claim_contention_retains_queue_head_without_failing_poll() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "canonical claim contention".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#claim-contention".into()),
+            "hold the WorkItem lane".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let wait = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.work_item_id.as_deref() == Some(work_item.id.as_str()))
+        .expect("active WorkItem wait");
+    let waiting = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem");
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition(
+            "default",
+            &canonical_waiting_snapshot(&waiting, &wait.id, waiting.revision),
+        )
+        .unwrap();
+    let reserved = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(matches!(
+        reserved.dispatch,
+        AgentDispatchState::Awaiting { ref wait }
+            if reserved.waits[&wait.id].generations[&wait.generation].owner
+                == SchedulerOwner::WorkItem {
+                    work_item_id: work_item.id.clone(),
+                }
+    ));
+
+    let message = runtime
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::InternalFollowup,
+                MessageOrigin::System {
+                    subsystem: "claim-contention".into(),
+                },
+                AuthorityClass::RuntimeInstruction,
+                Priority::Next,
+                MessageBody::Text {
+                    text: "lifecycle nudge while another owner holds the lane".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::RuntimeSystem,
+                AdmissionContext::RuntimeOwned,
+            ),
+        )
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Queued)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_claim_contended"
+                && event.data["conflict_code"] == "agent_lane_reserved_by_other_owner"
+                && event.data["queue_disposition"] == "retained_queued"
+        }));
+}
+
+#[tokio::test]
+async fn late_terminal_task_result_for_completed_work_item_settles_without_model_reentry() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(CountingProvider {
+        calls: Mutex::new(0),
+        reply: "unused",
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "completed parent with late child result".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    append_completed_rejoin_task(
+        &runtime,
+        "task-late-child-result",
+        &work_item.id,
+        "turn-parent-completed",
+    );
+    runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let mut result = task_result_message("task-late-child-result").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    result.metadata = Some(serde_json::json!({
+        "task_id": "task-late-child-result",
+        "task_kind": "child_agent_task",
+        "task_status": "completed",
+        "task_result_id": "result-late-child",
+        "work_item_id": work_item.id,
+    }));
+    let result = runtime.enqueue(result).await.unwrap();
+    let mut runner = tokio::spawn(runtime.clone().run());
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if runner.is_finished() {
+            panic!(
+                "runtime exited while settling late terminal task result: {:?}",
+                (&mut runner).await
+            );
+        }
+        let processed = runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == result.id)
+            .is_some_and(|entry| entry.status == QueueEntryStatus::Processed);
+        if processed {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+            panic!("late task result did not settle: {events:#?}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    runner.abort();
+
+    assert_eq!(provider.call_count().await, 0);
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "task_result_received" && event.data["task_id"] == "task-late-child-result"
+    }));
+    assert!(!events.iter().any(|event| {
+        event.kind == "scheduler_authority_hard_blocker" && event.data["message_id"] == result.id
+    }));
+}
+
+#[tokio::test]
 async fn bootstrap_diagnostics_report_cross_model_scheduler_invariant_failures() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -3112,12 +3487,17 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .await
         .unwrap();
     assert!(replay_commands.is_empty());
-    assert!(!runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .commit_scheduler_recovery_plan("default", &replay_commands)
-        .unwrap());
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .commit_scheduler_recovery_plan("default", &replay_commands)
+            .unwrap(),
+        crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Applied(
+            false
+        )
+    );
 
     drop(runtime);
     let reopened = RuntimeHandle::new(

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -525,7 +525,48 @@ impl RuntimeTransitionRepository<'_> {
                 command.scheduler_protocol_bootstrap.as_ref(),
                 &command.scheduler_protocol_commands,
                 &execution_protocol.commands,
-            )?;
+            );
+            let scheduler_protocol = match scheduler_protocol {
+                Ok(prepared) => prepared,
+                Err(error)
+                    if matches!(
+                        command.operation,
+                        QueueOperation::Claim | QueueOperation::Interject
+                    ) && scheduler_protocol_repository::scheduler_protocol_retryable_conflict(
+                        &error,
+                    )
+                    .is_some() =>
+                {
+                    let conflict =
+                        scheduler_protocol_repository::scheduler_protocol_retryable_conflict(&error)
+                            .expect("guard checked scheduler claim contention");
+                    let event = AuditEvent::legacy(
+                        "scheduler_claim_contended",
+                        serde_json::json!({
+                            "agent_id": command.agent_id,
+                            "conflict_kind": conflict.kind,
+                            "conflict_code": conflict.code,
+                            "queue_operation": format!("{:?}", command.operation).to_lowercase(),
+                            "queue_disposition": "retained_queued",
+                        }),
+                    );
+                    let mut commit = finish_transition_tx(
+                        tx,
+                        true,
+                        &command.agent_id,
+                        &[event],
+                        &[],
+                        command.fault,
+                        PostCommitEffects {
+                            notify_scheduler: command.notify_scheduler,
+                            ..PostCommitEffects::default()
+                        },
+                    )?;
+                    commit.scheduler_authority_blocked = true;
+                    return Ok(commit);
+                }
+                Err(error) => return Err(error),
+            };
             let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
                 tx,
                 &command.agent_id,

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -155,6 +155,7 @@ impl StdError for LegacySchedulerAdoptionRejected {}
 #[derive(Debug)]
 pub(crate) struct SchedulerProtocolReducerRejected {
     pub reason: String,
+    pub conflict: Option<ProtocolConflict>,
 }
 
 impl fmt::Display for SchedulerProtocolReducerRejected {
@@ -164,6 +165,39 @@ impl fmt::Display for SchedulerProtocolReducerRejected {
 }
 
 impl StdError for SchedulerProtocolReducerRejected {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SchedulerRecoveryCommitOutcome {
+    Applied(bool),
+    Rejected { reason: String },
+}
+
+pub(crate) fn scheduler_protocol_retryable_conflict(
+    error: &anyhow::Error,
+) -> Option<ProtocolConflict> {
+    error.chain().find_map(|source| {
+        source
+            .downcast_ref::<SchedulerProtocolReducerRejected>()
+            .and_then(|error| error.conflict.as_ref())
+            .filter(|conflict| {
+                matches!(
+                    conflict.code.as_str(),
+                    "activation_already_running"
+                        | "activation_already_settled"
+                        | "activation_slot_not_idle"
+                        | "agent_lane_reserved"
+                        | "agent_lane_reserved_by_other_owner"
+                        | "agent_lane_reserved_for_other_wait"
+                        | "scheduling_generation_already_admitted"
+                        | "stale_dispatch_revision"
+                        | "stale_scheduling_generation"
+                        | "stale_wait_generation"
+                        | "wait_not_triggered"
+                )
+            })
+            .cloned()
+    })
+}
 
 #[derive(Debug, Serialize)]
 struct SnapshotFence<'a> {
@@ -248,17 +282,19 @@ pub(super) fn validate_protocol_commands_tx(
         scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
             SchedulerProtocolReducerRejected {
                 reason: format!("scheduler protocol reducer produced invalid state: {error}"),
+                conflict: None,
             }
         })?;
         if outcome.outcome.decision == Decision::Rejected {
-            let code = outcome
-                .conflict
+            let conflict = outcome.conflict.clone();
+            let code = conflict
                 .as_ref()
                 .map(|conflict| conflict.code.as_str())
                 .or_else(|| outcome.outcome.diagnostics.first().map(String::as_str))
                 .unwrap_or("rejected_without_diagnostic");
             return Err(SchedulerProtocolReducerRejected {
                 reason: format!("canonical scheduler command {command_kind} rejected: {code}"),
+                conflict,
             }
             .into());
         }
@@ -608,9 +644,9 @@ impl RuntimeTransitionRepository<'_> {
         &self,
         agent_id: &str,
         commands: &[ProtocolCommand],
-    ) -> Result<bool> {
+    ) -> Result<SchedulerRecoveryCommitOutcome> {
         if commands.is_empty() {
-            return Ok(false);
+            return Ok(SchedulerRecoveryCommitOutcome::Applied(false));
         }
         self.db.transaction(|tx| {
             for command in commands {
@@ -631,13 +667,35 @@ impl RuntimeTransitionRepository<'_> {
             }
             let bootstrap = (!scheduler_protocol_partition_exists_tx(tx, agent_id)?)
                 .then(canonical_empty_snapshot);
-            let prepared =
-                validate_protocol_commands_tx(tx, agent_id, bootstrap.as_ref(), commands, &[])?;
+            let prepared = match validate_protocol_commands_tx(
+                tx,
+                agent_id,
+                bootstrap.as_ref(),
+                commands,
+                &[],
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    if let Some(reason) = error.chain().find_map(|source| {
+                        source
+                            .downcast_ref::<LegacySchedulerAdoptionRejected>()
+                            .map(|error| error.reason.clone())
+                    }) {
+                        return Ok(SchedulerRecoveryCommitOutcome::Rejected { reason });
+                    }
+                    if scheduler_protocol_retryable_conflict(&error).is_some() {
+                        return Ok(SchedulerRecoveryCommitOutcome::Rejected {
+                            reason: error.to_string(),
+                        });
+                    }
+                    return Err(error);
+                }
+            };
             let changed = prepared
                 .as_ref()
                 .is_some_and(PreparedProtocolCommands::has_writes);
             persist_protocol_commands_tx(tx, agent_id, prepared)?;
-            Ok(changed)
+            Ok(SchedulerRecoveryCommitOutcome::Applied(changed))
         })
     }
 
@@ -720,6 +778,7 @@ impl RuntimeTransitionRepository<'_> {
             scheduler_protocol::assert_invariants(&outcome.outcome.snapshot).map_err(|error| {
                 SchedulerProtocolReducerRejected {
                     reason: format!("scheduler protocol reducer produced invalid state: {error}"),
+                    conflict: None,
                 }
             })?;
             inject_fault(fault, TransitionFaultPoint::AfterValidation)?;


### PR DESCRIPTION
## 概要

修复 canonical scheduler 在合法并发/陈旧状态下的 runtime liveness：

- 将 legacy recovery/adoption 的 commit-time stale rejection 表达为结构化结果，使 runtime 记录诊断并基于最新状态重新 poll，而不是终止 run loop
- 将 canonical claim contention 分类为可重试冲突，保留队头并重新调度；协议损坏仍保持 fatal
- 当 completed parent 收到晚到的 child terminal `TaskResult` 时，走 reducer-only settlement，保留 task provenance，不 reopen work item 或触发重复 model turn
- 补充确定性 Rust 竞态回归，覆盖 typed stale rejection、commit-time race convergence、双 runtime claim contention 和 completed-parent late task-result

## 边界

- 保持 source/owner fencing，不放宽 canonical protocol 校验
- 不修改 Docker E2E oracle、completion 两阶段契约或 CI gate

## 验证

- `cargo test --lib runtime::tests::runtime_state -- --nocapture`（125 passed）
- `cargo check --tests`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
