### PR TITLE
test: split deterministic scheduler gate from live canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - "scripts/docker-live-acceptance.py"
       - "scripts/docker_e2e/**"
       - ".github/workflows/e2e-scheduler-nightly.yml"
+      - ".github/workflows/release-e2e.yml"
       - "tests/e2e/scheduler/**"
   pull_request:
     branches: [main]
@@ -46,6 +47,7 @@ on:
       - "scripts/docker-live-acceptance.py"
       - "scripts/docker_e2e/**"
       - ".github/workflows/e2e-scheduler-nightly.yml"
+      - ".github/workflows/release-e2e.yml"
       - "tests/e2e/scheduler/**"
   workflow_dispatch:
 
@@ -81,6 +83,8 @@ jobs:
               - 'scripts/docker-e2e.py'
               - 'scripts/docker-live-acceptance.py'
               - 'scripts/docker_e2e/**'
+              - '.github/workflows/e2e-scheduler-nightly.yml'
+              - '.github/workflows/release-e2e.yml'
             rust:
               - '.github/workflows/ci.yml'
               - 'src/**'
@@ -247,7 +251,7 @@ jobs:
           path: lcov.info
 
   e2e-scheduler:
-    name: E2E Scheduler Live (optional)
+    name: Scheduler Live Canary (optional)
     needs: changes
     if: contains(github.event.pull_request.labels.*.name, 'e2e-scheduler')
     runs-on: ubuntu-latest
@@ -282,17 +286,49 @@ jobs:
           printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
           chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
 
-      - name: Run scheduler Tier-1 E2E
+      - name: Run scheduler live canary
         run: |
           set -euo pipefail
           python3 scripts/docker-e2e.py \
             --image holon:e2e \
             --skip-build \
+            --profile scheduler-live-canary \
             --scheduler-matrix \
-            --suite extended \
-            --tag e2e-tier-1 \
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
-            --timeout 600
+            --timeout 120 \
+            --evidence-dir target/docker-e2e/scheduler-live-canary
+
+      - name: Publish live canary summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          report_path = Path(
+              "target/docker-e2e/scheduler-live-canary/"
+              "scheduler-live-canary-report.json"
+          )
+          if not report_path.is_file():
+              raise SystemExit(0)
+          report = json.loads(report_path.read_text())
+          lines = [
+              "# Scheduler Live Canary",
+              "",
+              f"- Status: **{report['status']}**",
+              f"- Model: `{report['model_route']}`",
+              f"- Provider retries: `{report['provider_retries']}`",
+              f"- Tool counts: `{json.dumps(report['cases'][0]['tool_counts'], sort_keys=True)}`",
+              f"- Behavioral variance: `{json.dumps(report['behavioral_variances'], sort_keys=True)}`",
+          ]
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n")
+          PY
+
+      - name: Upload live canary evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scheduler-live-canary
+          path: target/docker-e2e/scheduler-live-canary
 
       - name: Remove provider environment
         if: always()
@@ -303,7 +339,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -328,7 +364,7 @@ jobs:
             --skip-build \
             --profile scheduler-required \
             --scheduler-matrix \
-            --timeout 600 \
+            --timeout 120 \
             --evidence-dir target/docker-e2e/scheduler-required
 
       - name: Verify required reports

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -39,7 +39,20 @@ jobs:
           cache-from: type=gha,scope=holon-docker
           cache-to: type=gha,mode=max,scope=holon-docker
 
+      - name: Run deterministic scheduler matrix
+        run: |
+          set -euo pipefail
+          python3 scripts/docker-e2e.py \
+            --image holon:nightly \
+            --skip-build \
+            --profile scheduler-required \
+            --scheduler-matrix \
+            --timeout 120 \
+            --evidence-dir target/docker-e2e/scheduler-required
+
       - name: Prepare provider environment
+        id: provider-env
+        continue-on-error: true
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: |
@@ -49,29 +62,20 @@ jobs:
           printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
           chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
 
-      - name: Run scheduler Tier-1 E2E
+      - name: Run scheduler live canary
+        id: live-canary
+        if: steps.provider-env.outcome == 'success'
+        continue-on-error: true
         run: |
           set -euo pipefail
           python3 scripts/docker-e2e.py \
             --image holon:nightly \
             --skip-build \
+            --profile scheduler-live-canary \
             --scheduler-matrix \
-            --suite extended \
-            --tag e2e-tier-1 \
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
-            --timeout 900
-
-      - name: Run scheduler Tier-2 E2E
-        run: |
-          set -euo pipefail
-          python3 scripts/docker-e2e.py \
-            --image holon:nightly \
-            --skip-build \
-            --scheduler-matrix \
-            --suite extended \
-            --tag e2e-tier-2 \
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
-            --timeout 900
+            --timeout 120 \
+            --evidence-dir target/docker-e2e/scheduler-live-canary
 
       - name: Publish run summary
         if: always()
@@ -79,26 +83,46 @@ jobs:
           python3 - <<'PY'
           import json, os
           from pathlib import Path
-          summaries = sorted(Path("target/docker-e2e").glob("*/summary.json"))
-          if not summaries:
-              raise SystemExit("No Docker E2E summary was produced")
-          summary = json.loads(summaries[-1].read_text())
+          required = json.loads(
+              Path("target/docker-e2e/scheduler-required/summary.json").read_text()
+          )
+          canary_path = Path(
+              "target/docker-e2e/scheduler-live-canary/"
+              "scheduler-live-canary-report.json"
+          )
+          canary = json.loads(canary_path.read_text()) if canary_path.is_file() else None
           lines = [
               "# Scheduler E2E Nightly",
               "",
-              f"- Status: **{summary['status']}**",
-              f"- Model: `{summary['model_route']}`",
-              f"- Duration: `{summary['duration_seconds']}s`",
+              f"- Deterministic gate: **{required['status']}**",
+              f"- Live canary: **{canary['status'] if canary else 'missing'}**",
+              f"- Live model: `{canary['model_route'] if canary else 'unknown'}`",
+              f"- Live provider retries: `{canary['provider_retries'] if canary else 'unknown'}`",
               "",
-              "| Case | Result | Duration |",
+              "| Deterministic case | Result | Duration |",
               "| --- | --- | ---: |",
           ]
-          for case in summary["case_results"]:
+          for case in required["case_results"]:
               lines.append(
                   f"| `{case['id']}` | {case['status']} | {case['duration_seconds']}s |"
               )
+          if canary:
+              lines.extend([
+                  "",
+                  f"- Live tool counts: `{json.dumps(canary['cases'][0]['tool_counts'], sort_keys=True)}`",
+                  f"- Live behavioral variance: `{json.dumps(canary['behavioral_variances'], sort_keys=True)}`",
+              ])
           Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n")
           PY
+
+      - name: Upload scheduler evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scheduler-e2e-nightly
+          path: |
+            target/docker-e2e/scheduler-required
+            target/docker-e2e/scheduler-live-canary
 
       - name: Create issue on failure
         if: failure()

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -120,27 +120,38 @@ jobs:
           args=(
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
-            --scheduler-matrix
-            --profile scheduler-acceptance
+            --suite core
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
-          )
-          while IFS= read -r case_id; do
-            args+=(--case "${case_id}")
-          done < <(
-            python3 -c '
-            import json
-            from pathlib import Path
-            manifest = json.loads(Path("tests/e2e/docker/manifest.json").read_text())
-            print("\n".join(
-                case["id"] for case in manifest["cases"]
-                if case["tier"] == "core" or "scheduler" in case.get("tags", [])
-            ))
-            '
+            --evidence-dir target/docker-e2e/release-core
           )
           if [ -n "${HOLON_E2E_PREVIOUS_IMAGE}" ]; then
             args+=(--previous-image "${HOLON_E2E_PREVIOUS_IMAGE}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
+
+      - name: Run deterministic scheduler release gate
+        run: |
+          set -euo pipefail
+          python3 scripts/docker-e2e.py \
+            --image-digest "${CANDIDATE_IMAGE}" \
+            --skip-build \
+            --profile scheduler-required \
+            --scheduler-matrix \
+            --timeout 120 \
+            --evidence-dir target/docker-e2e/scheduler-required
+
+      - name: Run scheduler live canary
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          python3 scripts/docker-e2e.py \
+            --image-digest "${CANDIDATE_IMAGE}" \
+            --skip-build \
+            --profile scheduler-live-canary \
+            --scheduler-matrix \
+            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
+            --timeout 120 \
+            --evidence-dir target/docker-e2e/scheduler-live-canary
 
       - name: Publish run summary
         if: always()
@@ -149,23 +160,34 @@ jobs:
           import json
           from pathlib import Path
 
-          summaries = sorted(Path("target/docker-e2e").glob("*/summary.json"))
-          if not summaries:
-              raise SystemExit("No Docker E2E summary was produced")
-          summary = json.loads(summaries[-1].read_text())
-          scheduler_report = json.loads(
-              (summaries[-1].parent / "scheduler-acceptance-report.json").read_text()
+          summary = json.loads(
+              Path("target/docker-e2e/release-core/summary.json").read_text()
           )
+          scheduler_report = json.loads(
+              Path(
+                  "target/docker-e2e/scheduler-required/"
+                  "scheduler-acceptance-report.json"
+              ).read_text()
+          )
+          canary_path = Path(
+              "target/docker-e2e/scheduler-live-canary/"
+              "scheduler-live-canary-report.json"
+          )
+          canary = json.loads(canary_path.read_text()) if canary_path.is_file() else None
           lines = [
               "# Release Docker E2E",
               "",
               f"- Status: **{summary['status']}**",
               f"- Candidate: `{summary['image']['ref']}`",
               f"- Git SHA: `{summary['git_sha']}`",
-              f"- Scheduler matrix: **{scheduler_report['status']}**",
+              f"- Deterministic scheduler gate: **{scheduler_report['status']}**",
+              f"- Scheduler live canary: **{canary['status'] if canary else 'missing'}**",
               f"- Runtime schema revision: `{scheduler_report['runtime_schema_revision']}`",
               f"- Fixture corpus: `{scheduler_report['fixture_corpus_revision']}`",
-              f"- Model: `{summary['model_route']}`",
+              f"- Core model: `{summary['model_route']}`",
+              f"- Canary provider retries: `{canary['provider_retries'] if canary else 'unknown'}`",
+              f"- Canary tool counts: `{json.dumps(canary['cases'][0]['tool_counts'], sort_keys=True) if canary else 'unknown'}`",
+              f"- Canary behavioral variance: `{json.dumps(canary['behavioral_variances'], sort_keys=True) if canary else 'unknown'}`",
               f"- Duration: `{summary['duration_seconds']}s`",
               "",
               "| Case | Result | Duration |",
@@ -188,16 +210,24 @@ jobs:
           import os
           from pathlib import Path
 
-          summaries = sorted(Path("target/docker-e2e").glob("*/summary.json"))
-          if not summaries:
-              raise SystemExit("No Docker E2E summary was produced")
-          summary = json.loads(summaries[-1].read_text())
+          summary_path = Path("target/docker-e2e/release-core/summary.json")
+          summary = json.loads(summary_path.read_text())
           if summary["status"] != "pass":
               raise SystemExit(f"Release E2E did not pass: {summary['status']}")
-          scheduler_report_path = summaries[-1].parent / "scheduler-acceptance-report.json"
+          scheduler_root = Path("target/docker-e2e/scheduler-required")
+          scheduler_report_path = scheduler_root / "scheduler-acceptance-report.json"
           scheduler_report = json.loads(scheduler_report_path.read_text())
-          coverage_report_path = summaries[-1].parent / "scheduler-coverage-report.json"
+          coverage_report_path = scheduler_root / "scheduler-coverage-report.json"
           coverage_report = json.loads(coverage_report_path.read_text())
+          canary_report_path = Path(
+              "target/docker-e2e/scheduler-live-canary/"
+              "scheduler-live-canary-report.json"
+          )
+          canary_report = (
+              json.loads(canary_report_path.read_text())
+              if canary_report_path.is_file()
+              else None
+          )
           if scheduler_report["status"] != "pass":
               raise SystemExit(
                   f"Scheduler acceptance did not pass: {scheduler_report['status']}"
@@ -214,8 +244,8 @@ jobs:
               raise SystemExit("Scheduler coverage Git SHA does not match candidate")
           if coverage_report["image_digest"] != summary["image_digest"]:
               raise SystemExit("Scheduler coverage image digest does not match summary")
-          if coverage_report["profile"] != "scheduler-acceptance":
-              raise SystemExit("Scheduler coverage profile is not scheduler-acceptance")
+          if coverage_report["profile"] != "scheduler-required":
+              raise SystemExit("Scheduler coverage profile is not scheduler-required")
           attestation = {
               "schema_version": 1,
               "release_tag": os.environ["RELEASE_TAG"],
@@ -229,9 +259,13 @@ jobs:
               "image_digest": summary["image_digest"],
               "scheduler_acceptance": scheduler_report,
               "scheduler_coverage": coverage_report,
-              "summary_path": str(summaries[-1]),
+              "scheduler_live_canary": canary_report,
+              "summary_path": str(summary_path),
               "scheduler_acceptance_path": str(scheduler_report_path),
               "scheduler_coverage_path": str(coverage_report_path),
+              "scheduler_live_canary_path": (
+                  str(canary_report_path) if canary_report is not None else None
+              ),
           }
           Path("target/release-e2e-attestation").mkdir(parents=True, exist_ok=True)
           Path("target/release-e2e-attestation/release-e2e-attestation.json").write_text(
@@ -254,32 +288,42 @@ jobs:
           import json
           from pathlib import Path
 
-          summaries = sorted(Path("target/docker-e2e").glob("*/summary.json"))
-          if not summaries:
+          evidence_roots = [
+              path
+              for path in (
+                  Path("target/docker-e2e/release-core"),
+                  Path("target/docker-e2e/scheduler-required"),
+                  Path("target/docker-e2e/scheduler-live-canary"),
+              )
+              if (path / "summary.json").is_file()
+          ]
+          if not evidence_roots:
               Path("target/docker-e2e-upload/upload-blocked.txt").write_text(
                   "Raw evidence upload blocked because no secret-scan.json was produced.\n"
               )
               raise SystemExit(0)
-          evidence = summaries[-1].parent
-          if not (evidence / "secret-scan.json").is_file():
-              Path("target/docker-e2e-upload/upload-blocked.txt").write_text(
-                  f"Raw evidence upload blocked because {evidence}/secret-scan.json is missing.\n"
-              )
-              raise SystemExit(0)
-          scan = json.loads((evidence / "secret-scan.json").read_text())
-          if scan.get("status") != "pass":
+          for evidence in evidence_roots:
               destination = Path("target/docker-e2e-upload") / evidence.name
-              destination.mkdir(parents=True, exist_ok=True)
-              for name in ("secret-scan.json", "summary.json", "junit.xml"):
-                  source = evidence / name
-                  if source.is_file():
-                      shutil.copy2(source, destination / name)
-              (destination / "raw-evidence-blocked.txt").write_text(
-                  "Raw evidence upload blocked because the secret scan failed. "
-                  "Only metadata was uploaded.\n"
-              )
-              raise SystemExit(0)
-          shutil.copytree(evidence, Path("target/docker-e2e-upload") / evidence.name)
+              scan_path = evidence / "secret-scan.json"
+              if not scan_path.is_file():
+                  destination.mkdir(parents=True, exist_ok=True)
+                  (destination / "raw-evidence-blocked.txt").write_text(
+                      f"Raw evidence upload blocked because {scan_path} is missing.\n"
+                  )
+                  continue
+              scan = json.loads(scan_path.read_text())
+              if scan.get("status") != "pass":
+                  destination.mkdir(parents=True, exist_ok=True)
+                  for name in ("secret-scan.json", "summary.json", "junit.xml"):
+                      source = evidence / name
+                      if source.is_file():
+                          shutil.copy2(source, destination / name)
+                  (destination / "raw-evidence-blocked.txt").write_text(
+                      "Raw evidence upload blocked because the secret scan failed. "
+                      "Only metadata was uploaded.\n"
+                  )
+                  continue
+              shutil.copytree(evidence, destination)
           PY
 
       - name: Upload E2E evidence

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime docker-build docker-smoke docker-e2e docker-e2e-validate docker-live-acceptance fmt fmt-check lint check ci run clean
+.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime docker-build docker-smoke docker-e2e docker-e2e-scheduler-required docker-e2e-scheduler-live-canary docker-e2e-validate docker-live-acceptance fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
 OPENAPI_TOOLS_DIR := web-gui/openapi-tools
@@ -152,6 +152,12 @@ docker-smoke: docker-build ## Start the image and verify the real service readin
 
 docker-e2e: docker-build ## Run the release core Docker E2E suite with a real LLM
 	python3 scripts/docker-e2e.py --image "$(DOCKER_IMAGE)" --skip-build --suite core
+
+docker-e2e-scheduler-required: docker-build ## Run the deterministic scheduler release gate
+	python3 scripts/docker-e2e.py --image "$(DOCKER_IMAGE)" --skip-build --profile scheduler-required --scheduler-matrix --timeout 120
+
+docker-e2e-scheduler-live-canary: docker-build ## Run the real-model scheduler canary
+	python3 scripts/docker-e2e.py --image "$(DOCKER_IMAGE)" --skip-build --profile scheduler-live-canary --scheduler-matrix --timeout 120
 
 docker-e2e-validate: ## Validate the Docker E2E manifest and runner unit tests
 	python3 scripts/docker-e2e.py --validate-manifest

--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -858,10 +858,12 @@ wait and the turn creates a WorkItem wait, `AdoptActivationWorkStateCommand`
 may carry the exact source wait identity and expected dispatch revision. The
 same transaction must verify that the reservation belongs to the source
 lifecycle owner, settle the activation, resolve the source wait exactly once,
-and install the target WorkItem demand, wait, focus, and dispatch reservation.
-A stale revision or foreign reservation fails closed. After the adoption is
-recorded, settlement replay reuses the stored command result and must not
-reconstruct a different payload from the post-handoff dispatch state.
+and install the target WorkItem demand, wait, and focus while reopening
+dispatch for unrelated runnable WorkItems. The target wait remains fenced by
+its exact owner and generation; it does not reserve the agent lane. A stale
+revision or foreign reservation fails closed. After the adoption is recorded,
+settlement replay reuses the stored command result and must not reconstruct a
+different payload from the post-handoff dispatch state.
 
 Bootstrap reconciliation has the same atomicity requirement when
 `AdoptLegacyWorkStateCommand` refreshes the WorkItem that owns the exact current

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -35,6 +35,7 @@ OFFLINE_MODEL_CREDENTIAL = "docker-e2e-offline-provider-unused"
 EVIDENCE_SCHEMA_VERSION = 1
 SCHEDULER_ACCEPTANCE_REPORT_SCHEMA_VERSION = 1
 SCHEDULER_COVERAGE_REPORT_SCHEMA_VERSION = 1
+SCHEDULER_LIVE_CANARY_REPORT_SCHEMA_VERSION = 1
 SCHEDULER_ENGINES = ("legacy", "canonical")
 TERMINAL_STATUSES = {"awake_idle", "asleep", "awaiting_task"}
 RUNTIME_DB_COPY_TIMEOUT_SECONDS = 120
@@ -178,6 +179,7 @@ class CaseHarness:
         keep: bool,
         provider_mode: str = "live",
         stub_scenario: str | None = None,
+        tool_assertion_mode: str = "strict",
         resource_names: dict[str, str] | None = None,
         control_token: str | None = None,
     ) -> None:
@@ -202,6 +204,7 @@ class CaseHarness:
         self.keep = keep
         self.provider_mode = provider_mode
         self.stub_scenario = stub_scenario
+        self.tool_assertion_mode = tool_assertion_mode
         names = resource_names or {}
         self.volume = names.get("volume", f"holon-live-{case_id}-{suffix}")
         self.network = names.get("network", f"holon-live-{case_id}-{suffix}")
@@ -1265,8 +1268,21 @@ class CaseHarness:
         )
         actual = [event["payload"].get("tool_name") for event in events]
         missing = [name for name in expected if name not in actual]
-        require(not missing, f"{label} missing successful tools {missing}; got {actual}")
         forbidden_actual = [name for name in (forbidden or []) if name in actual]
+        if self.tool_assertion_mode == "observe":
+            write_json(
+                self.evidence / f"{label}-tool-observation.json",
+                {
+                    "mode": "observe",
+                    "expected": expected,
+                    "forbidden": forbidden or [],
+                    "actual": actual,
+                    "missing": missing,
+                    "forbidden_actual": forbidden_actual,
+                },
+            )
+            return events
+        require(not missing, f"{label} missing successful tools {missing}; got {actual}")
         require(
             not forbidden_actual,
             f"{label} used forbidden tools {forbidden_actual}; got {actual}",
@@ -2381,8 +2397,8 @@ def run_scheduler_provider_failure_retry_case(
 ) -> None:
     harness.initialize_workspace()
     base_url_env = provider_base_url_env(harness.model)
-    original_base_url = harness.runtime_env.get(base_url_env)
     harness.start()
+    original_base_url = harness.runtime_env.get(base_url_env)
 
     harness.request(
         "POST",
@@ -3805,6 +3821,23 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             profile.get("provider_mode", "live") in {"live", "stub"},
             f"profile {profile_id} has invalid provider_mode",
         )
+        require(
+            profile.get("gate_kind", "required") in {"required", "live_canary"},
+            f"profile {profile_id} has invalid gate_kind",
+        )
+        require(
+            profile.get("tool_assertion_mode", "strict") in {"strict", "observe"},
+            f"profile {profile_id} has invalid tool_assertion_mode",
+        )
+        if profile.get("gate_kind") == "live_canary":
+            require(
+                profile.get("provider_mode", "live") == "live",
+                f"profile {profile_id} live canary must use live provider mode",
+            )
+            require(
+                profile.get("tool_assertion_mode") == "observe",
+                f"profile {profile_id} live canary must observe tool assertions",
+            )
         required = profile.get("required_coverage_ids", [])
         require(
             isinstance(required, list)
@@ -3905,9 +3938,34 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
                 f"{case_id}/{phase_id} has required/forbidden tool overlap",
             )
     known_case_ids = {case["id"] for case in cases}
+    cases_by_id = {case["id"]: case for case in cases}
+    known_coverage_ids = {
+        coverage_id
+        for case in cases
+        for coverage_id in case.get("coverage_ids", [])
+    }
     for profile_id, profile in profiles.items():
-        unknown = sorted(set(profile.get("case_ids", [])) - known_case_ids)
+        profile_case_ids = profile.get("case_ids", [])
+        unknown = sorted(set(profile_case_ids) - known_case_ids)
         require(not unknown, f"profile {profile_id} has unknown cases: {unknown}")
+        unknown_coverage = sorted(
+            set(profile.get("required_coverage_ids", [])) - known_coverage_ids
+        )
+        require(
+            not unknown_coverage,
+            f"profile {profile_id} has unknown coverage ids: {unknown_coverage}",
+        )
+        if profile.get("provider_mode", "live") == "stub":
+            missing_stub_scenarios = sorted(
+                case_id
+                for case_id in profile_case_ids
+                if not cases_by_id[case_id].get("stub_scenario")
+            )
+            require(
+                not missing_stub_scenarios,
+                f"profile {profile_id} cases require stub_scenario: "
+                f"{missing_stub_scenarios}",
+            )
 
 
 def select_cases(
@@ -3936,7 +3994,12 @@ def resolve_profile(
     manifest: dict[str, Any], profile_id: str | None
 ) -> dict[str, Any]:
     if profile_id is None:
-        return {"provider_mode": "live", "required_coverage_ids": []}
+        return {
+            "gate_kind": "suite",
+            "provider_mode": "live",
+            "tool_assertion_mode": "strict",
+            "required_coverage_ids": [],
+        }
     profiles = manifest.get("profiles", {})
     require(profile_id in profiles, f"unknown profile: {profile_id}")
     return profiles[profile_id]
@@ -4035,7 +4098,10 @@ def image_identity(image: str) -> dict[str, Any]:
 
 def collect_case_metrics(evidence: Path) -> dict[str, Any]:
     tool_counts: dict[str, int] = {}
+    behavioral_variances: list[dict[str, Any]] = []
+    provider_rounds = 0
     provider_attempts = 0
+    seen_event_seqs: set[int] = set()
     token_usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
     for path in evidence.glob("*-events.json"):
         try:
@@ -4043,11 +4109,17 @@ def collect_case_metrics(evidence: Path) -> dict[str, Any]:
         except (OSError, json.JSONDecodeError):
             continue
         for event in events:
+            event_seq = event.get("event_seq")
+            if isinstance(event_seq, int):
+                if event_seq in seen_event_seqs:
+                    continue
+                seen_event_seqs.add(event_seq)
             event_type = event.get("type")
             if event_type == "tool_executed":
                 name = event.get("payload", {}).get("tool_name", "unknown")
                 tool_counts[name] = tool_counts.get(name, 0) + 1
             if event_type == "provider_round_completed":
+                provider_rounds += 1
                 payload = event.get("payload", {})
                 provider_attempts += len(
                     (payload.get("provider_attempt_timeline") or {}).get("attempts") or []
@@ -4055,9 +4127,27 @@ def collect_case_metrics(evidence: Path) -> dict[str, Any]:
                 usage = payload.get("token_usage") or {}
                 for key in token_usage:
                     token_usage[key] += int(usage.get(key) or 0)
+    for path in evidence.glob("*-tool-observation.json"):
+        try:
+            observation = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        missing = list(observation.get("missing") or [])
+        forbidden_actual = list(observation.get("forbidden_actual") or [])
+        if missing or forbidden_actual:
+            behavioral_variances.append(
+                {
+                    "scope": path.name.removesuffix("-tool-observation.json"),
+                    "missing_tools": missing,
+                    "forbidden_tools_used": forbidden_actual,
+                }
+            )
     return {
         "tool_counts": tool_counts,
+        "behavioral_variances": behavioral_variances,
+        "provider_rounds": provider_rounds,
         "provider_attempts": provider_attempts,
+        "provider_retries": max(0, provider_attempts - provider_rounds),
         "token_usage": token_usage,
     }
 
@@ -4250,6 +4340,75 @@ def scheduler_coverage_report(
     }
 
 
+def scheduler_live_canary_report(
+    *,
+    run_record: dict[str, Any],
+    case_results: list[dict[str, Any]],
+    scheduler_acceptance_status: str,
+    scheduler_coverage_status: str,
+    secret_scan_status: str,
+) -> dict[str, Any]:
+    scheduler_results = [
+        result
+        for result in case_results
+        if result.get("scheduler_engine") in SCHEDULER_ENGINES
+    ]
+    return {
+        "schema_version": SCHEDULER_LIVE_CANARY_REPORT_SCHEMA_VERSION,
+        "status": (
+            "pass"
+            if scheduler_results
+            and all(result["status"] == "pass" for result in scheduler_results)
+            and scheduler_acceptance_status == "pass"
+            and scheduler_coverage_status == "pass"
+            and secret_scan_status == "pass"
+            else "fail"
+        ),
+        "git_sha": run_record["git_sha"],
+        "image_digest": run_record["image_digest"],
+        "manifest_sha256": run_record["manifest_sha256"],
+        "profile": run_record["profile"],
+        "provider_mode": run_record["provider_mode"],
+        "model_route": run_record["model_route"],
+        "tool_assertion_mode": run_record["tool_assertion_mode"],
+        "scheduler_acceptance": scheduler_acceptance_status,
+        "scheduler_coverage": scheduler_coverage_status,
+        "secret_scan": secret_scan_status,
+        "provider_rounds": sum(
+            int(result.get("provider_rounds") or 0) for result in scheduler_results
+        ),
+        "provider_attempts": sum(
+            int(result.get("provider_attempts") or 0) for result in scheduler_results
+        ),
+        "provider_retries": sum(
+            int(result.get("provider_retries") or 0) for result in scheduler_results
+        ),
+        "behavioral_variances": [
+            {
+                "case_id": result["id"],
+                **variance,
+            }
+            for result in scheduler_results
+            for variance in result.get("behavioral_variances", [])
+        ],
+        "cases": [
+            {
+                "id": result["id"],
+                "base_id": result["base_id"],
+                "scheduler_engine": result["scheduler_engine"],
+                "status": result["status"],
+                "error": result["error"],
+                "provider_rounds": result.get("provider_rounds", 0),
+                "provider_attempts": result.get("provider_attempts", 0),
+                "provider_retries": result.get("provider_retries", 0),
+                "tool_counts": result.get("tool_counts", {}),
+                "behavioral_variances": result.get("behavioral_variances", []),
+            }
+            for result in scheduler_results
+        ],
+    }
+
+
 def write_junit(path: Path, cases: list[dict[str, Any]], duration: float) -> None:
     suite = ElementTree.Element(
         "testsuite",
@@ -4403,7 +4562,9 @@ def main(argv: list[str] | None = None) -> int:
         "manifest_sha256": hashlib.sha256(args.manifest.read_bytes()).hexdigest(),
         "scheduler_matrix": args.scheduler_matrix,
         "profile": args.profile,
+        "gate_kind": profile.get("gate_kind", "suite"),
         "provider_mode": profile.get("provider_mode", "live"),
+        "tool_assertion_mode": profile.get("tool_assertion_mode", "strict"),
     }
     write_json(evidence_root / "run.json", run_record)
 
@@ -4465,6 +4626,7 @@ def main(argv: list[str] | None = None) -> int:
                 "provider_mode", profile.get("provider_mode", "live")
             ),
             stub_scenario=case.get("stub_scenario", profile.get("stub_scenario")),
+            tool_assertion_mode=profile.get("tool_assertion_mode", "strict"),
         )
         control_tokens.append(harness.token)
         error_text = ""
@@ -4548,7 +4710,10 @@ def main(argv: list[str] | None = None) -> int:
                 "duration_seconds": 0.0,
                 "cleanup": "not-applicable",
                 "tool_counts": {},
+                "behavioral_variances": [],
+                "provider_rounds": 0,
                 "provider_attempts": 0,
+                "provider_retries": 0,
                 "token_usage": {
                     "input_tokens": 0,
                     "output_tokens": 0,
@@ -4594,6 +4759,20 @@ def main(argv: list[str] | None = None) -> int:
         write_json(evidence_root / "scheduler-acceptance-report.json", report)
         if report["status"] != "pass":
             report_failures.append("scheduler-acceptance-report: fail")
+        if profile.get("gate_kind") == "live_canary":
+            canary_report = scheduler_live_canary_report(
+                run_record=run_record,
+                case_results=case_results,
+                scheduler_acceptance_status=report["status"],
+                scheduler_coverage_status=coverage_report["status"],
+                secret_scan_status=scan["status"],
+            )
+            write_json(
+                evidence_root / "scheduler-live-canary-report.json",
+                canary_report,
+            )
+            if canary_report["status"] != "pass":
+                report_failures.append("scheduler-live-canary-report: fail")
     write_junit(evidence_root / "junit.xml", case_results, duration)
 
     print(f"Evidence: {evidence_root}")

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -204,6 +204,7 @@ class CaseHarness:
         self.keep = keep
         self.provider_mode = provider_mode
         self.stub_scenario = stub_scenario
+        self.stub_provider_base_url: str | None = None
         self.tool_assertion_mode = tool_assertion_mode
         names = resource_names or {}
         self.volume = names.get("volume", f"holon-live-{case_id}-{suffix}")
@@ -506,7 +507,9 @@ class CaseHarness:
             else:
                 raise TimeoutError("deterministic provider stub did not become ready")
             self.model = "openai/gpt-5.4"
-            self.runtime_env["HOLON_OPENAI_BASE_URL"] = "http://provider-stub:8080/v1"
+            self.runtime_env["HOLON_OPENAI_BASE_URL"] = (
+                self.stub_provider_base_url or "http://provider-stub:8080/v1"
+            )
             self.runtime_env["OPENAI_API_KEY"] = "deterministic-test-key"
         args = [
             "run",
@@ -1461,22 +1464,51 @@ def require_processed_queue_entries(
     )
 
 
-def require_turn_local_compaction(
+def require_compaction_evidence(
     snapshot: dict[str, Any],
     *,
     label: str,
+    previous_compression_epoch: int = 0,
 ) -> list[dict[str, Any]]:
-    events = [
+    turn_local_events = [
         json.loads(row["data_json"])["data"]
         for row in snapshot["audit_events"]
         if row["kind"] == "turn_local_compaction_applied"
     ]
+    context_events = [
+        json.loads(row["data_json"])["data"]
+        for row in snapshot["audit_events"]
+        if row["kind"] == "provider_round_completed"
+        and int(
+            json.loads(row["data_json"])["data"].get("compression_epoch") or 0
+        )
+        > previous_compression_epoch
+    ]
+    compacted_turn_local_events = [
+        event
+        for event in turn_local_events
+        if int(event.get("compacted_rounds") or 0) > 0
+    ]
     require(
-        events
-        and any(int(event.get("compacted_rounds") or 0) > 0 for event in events),
-        f"{label} compaction stimulus did not produce compacted rounds: {events}",
+        compacted_turn_local_events or context_events,
+        f"{label} compaction stimulus did not produce compaction evidence: "
+        f"turn_local={turn_local_events}, context={context_events}",
     )
-    return events
+    return compacted_turn_local_events or context_events
+
+
+def latest_compression_epoch(snapshot: dict[str, Any]) -> int:
+    return max(
+        (
+            int(
+                json.loads(row["data_json"])["data"].get("compression_epoch")
+                or 0
+            )
+            for row in snapshot["audit_events"]
+            if row["kind"] == "provider_round_completed"
+        ),
+        default=0,
+    )
 
 
 def require_scheduler_engine_activation_chain(
@@ -1575,12 +1607,12 @@ def require_scheduler_wait_terminal(
             wait["status"] == "resolved",
             f"canonical {wait_kind} wait did not resolve: {wait}",
         )
-        return waits
-    require(
-        wait["status"] in {"resolved", "cancelled"},
-        f"legacy {wait_kind} wait did not reach a terminal state: {wait}",
-    )
-    if wait["status"] == "cancelled":
+    else:
+        require(
+            wait["status"] in {"resolved", "cancelled"},
+            f"legacy {wait_kind} wait did not reach a terminal state: {wait}",
+        )
+    if not harness.canonical_scheduler_enabled and wait["status"] == "cancelled":
         cancellation_events = [
             json.loads(row["data_json"])["data"]
             for row in snapshot["audit_events"]
@@ -2399,6 +2431,7 @@ def run_scheduler_provider_failure_retry_case(
     base_url_env = provider_base_url_env(harness.model)
     harness.start()
     original_base_url = harness.runtime_env.get(base_url_env)
+    original_stub_provider_base_url = harness.stub_provider_base_url
 
     harness.request(
         "POST",
@@ -2430,7 +2463,10 @@ def run_scheduler_provider_failure_retry_case(
     write_json(harness.evidence / "provider-retry-picked.json", picked)
     failure_event_cursor = harness.event_cursor()
     harness.stop()
-    harness.runtime_env[base_url_env] = "http://127.0.0.1:9"
+    if harness.provider_mode == "stub":
+        harness.stub_provider_base_url = "http://127.0.0.1:9"
+    else:
+        harness.runtime_env[base_url_env] = "http://127.0.0.1:9"
     harness.start(wait_idle=False)
     harness.request(
         "POST",
@@ -2504,7 +2540,9 @@ def run_scheduler_provider_failure_retry_case(
     )
 
     harness.stop()
-    if original_base_url is None:
+    if harness.provider_mode == "stub":
+        harness.stub_provider_base_url = original_stub_provider_base_url
+    elif original_base_url is None:
         harness.runtime_env.pop(base_url_env, None)
     else:
         harness.runtime_env[base_url_env] = original_base_url
@@ -2979,17 +3017,12 @@ def run_scheduler_concurrent_claim_fencing_case(
         label="scheduler-concurrent-waiting",
     )
     harness.wait_agent_asleep()
-    interject_text = (
-        f"Scheduler Docker E2E case {case['id']} interject. Create exactly one "
-        f"WorkItem whose objective is "
-        f"{json.dumps(objective_b, ensure_ascii=False)}, "
-        f"with plan_status ready and exactly these todos: concurrent-b-seed "
-        f"completed, concurrent-b-complete pending. The expected completion "
-        f"marker is {completion_b}. Do not PickWorkItem, WaitFor, or "
-        "CompleteWorkItem in this turn. After CreateWorkItem succeeds, end "
-        "with a concise acknowledgement."
+    created_b = harness.request(
+        "POST",
+        harness.agent_path("work-items", control=True),
+        {"objective": objective_b},
     )
-    harness.prompt("scheduler-concurrent-interject", interject_text)
+    write_json(harness.evidence / "scheduler-concurrent-created-b.json", created_b)
     item_b = harness.wait_work_item(
         objective_marker=objective_b_marker,
         expected_state="completed",
@@ -3015,17 +3048,12 @@ def run_scheduler_concurrent_claim_fencing_case(
             "message_id"
         ],
     )
-    harness.assert_tools(
-        "scheduler-concurrent-interject",
-        baseline,
-        ["CreateWorkItem"],
-        forbidden + ["PickWorkItem", "WaitFor", "CompleteWorkItem"],
-        message_id=harness.prompt_scope("scheduler-concurrent-interject")[
-            "message_id"
-        ],
-    )
     work_item_a_id = item_a["id"]
     work_item_b_id = item_b["id"]
+    require(
+        created_b.get("id") == work_item_b_id,
+        f"concurrent control-plane WorkItem identity mismatch: {created_b}",
+    )
     require(item_a["state"] == "completed", f"WorkItem A not completed: {item_a}")
     require(item_b["state"] == "completed", f"WorkItem B not completed: {item_b}")
     require(work_item_a_id != work_item_b_id, "WorkItem A and B share the same id")
@@ -3045,15 +3073,22 @@ def run_scheduler_concurrent_claim_fencing_case(
             f"WorkItem {letter} brief mismatch: {brief}",
         )
     snapshot = harness.runtime_db_snapshot("scheduler-concurrent")
+    messages_by_id = {
+        row["message_id"]: row for row in snapshot["messages"]
+    }
     a_turn_ids = {
         row["turn_id"]
         for row in snapshot["turn_records"]
         if row["current_work_item_id"] == work_item_a_id
+        and messages_by_id.get(row["trigger_message_id"], {}).get("work_item_id")
+        == work_item_a_id
     }
     b_turn_ids = {
         row["turn_id"]
         for row in snapshot["turn_records"]
         if row["current_work_item_id"] == work_item_b_id
+        and messages_by_id.get(row["trigger_message_id"], {}).get("work_item_id")
+        == work_item_b_id
     }
     harness.assert_tools(
         "scheduler-concurrent-a-resume",
@@ -3083,9 +3118,7 @@ def run_scheduler_concurrent_claim_fencing_case(
         snapshot,
         work_item_id=work_item_b_id,
         expected_admission_kinds=("scheduling",),
-        lifecycle_message_ids={
-            harness.prompt_scope("scheduler-concurrent-interject")["message_id"]
-        },
+        lifecycle_message_ids=set(),
     )
     waits = require_scheduler_wait_terminal(
         harness,
@@ -3332,6 +3365,8 @@ def run_scheduler_compaction_continuity_case(
         "CompleteWorkItem for the exact current item. Do not wait for more "
         "operator input."
     )
+    before_snapshot = harness.runtime_db_snapshot("scheduler-compaction-before")
+    previous_compression_epoch = latest_compression_epoch(before_snapshot)
     phase = case["phases"][0]
     baseline, _ = harness.prompt(
         "scheduler-compaction-create",
@@ -3349,9 +3384,10 @@ def run_scheduler_compaction_continuity_case(
     stimulus_snapshot = harness.runtime_db_snapshot(
         "scheduler-compaction-stimulus"
     )
-    require_turn_local_compaction(
+    require_compaction_evidence(
         stimulus_snapshot,
         label="scheduler-compaction",
+        previous_compression_epoch=previous_compression_epoch,
     )
     harness.wait_agent_asleep()
     harness.prompt(
@@ -3411,7 +3447,11 @@ def run_scheduler_compaction_continuity_case(
             harness.prompt_scope("scheduler-compaction-create")["message_id"]
         },
     )
-    require_turn_local_compaction(snapshot, label="scheduler-compaction")
+    require_compaction_evidence(
+        snapshot,
+        label="scheduler-compaction",
+        previous_compression_epoch=previous_compression_epoch,
+    )
     waits = require_scheduler_wait_terminal(
         harness,
         snapshot,
@@ -3734,7 +3774,7 @@ def run_scheduler_checkpoint_replay_case(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_admission_kinds=("wait_resume",),
+        expected_admission_kinds=("scheduling", "wait_resume"),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },
@@ -3748,16 +3788,13 @@ def run_scheduler_checkpoint_replay_case(
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },
     )
-    waits = [
-        row
-        for row in snapshot["wait_conditions"]
-        if row["work_item_id"] == work_item_a_id
-    ]
-    require(
-        len(waits) == 1
-        and waits[0]["kind"] == "external"
-        and waits[0]["status"] == "resolved",
-        f"replay external wait did not resolve: {waits}",
+    waits = require_scheduler_wait_terminal(
+        harness,
+        snapshot,
+        work_item_id=work_item_a_id,
+        wait_kind="external",
+        require_callback_trigger=True,
+        callback_external_trigger_id=callback["external_trigger_id"],
     )
     require_scheduler_engine_wait_resolution(
         harness,

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2321,6 +2321,23 @@ def work_queue_message_evidence(
     return evidence
 
 
+def recovered_retry_ticks(
+    failed_ticks: list[dict[str, Any]],
+    recovered_ticks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    failed_keys = {
+        tick["idempotency_key"]
+        for tick in failed_ticks
+        if tick["status"] in {"aborted", "interrupted"}
+    }
+    return [
+        tick
+        for tick in recovered_ticks
+        if tick["status"] == "processed"
+        and tick["idempotency_key"] in failed_keys
+    ]
+
+
 def run_scheduler_task_wait_resume_case(
     harness: CaseHarness, case: dict[str, Any]
 ) -> None:
@@ -2343,6 +2360,7 @@ def run_scheduler_task_wait_resume_case(
         f"{completion_marker} immediately followed by CompleteWorkItem for the "
         "exact current item. Do not create another WorkItem."
     )
+    callback = harness.reset_callback("scheduler-task-wait-callback")
     phase = case["phases"][0]
     baseline, _ = harness.prompt(
         "scheduler-task-wait-seed",
@@ -2366,7 +2384,7 @@ def run_scheduler_task_wait_resume_case(
         external_waiting["id"] == task_waiting["id"],
         "task-result rejoin changed WorkItem identity",
     )
-    callback = harness.reset_callback("scheduler-task-wait-callback")
+    harness.wait_agent_asleep()
     harness.fire_callback(
         "scheduler-task-wait-wake",
         callback["trigger_url"],
@@ -2633,12 +2651,12 @@ def run_scheduler_provider_failure_retry_case(
         work_item_id=work_item_id,
         reason="continue_active",
     )
-    processed_ticks = [
-        tick for tick in recovered_ticks if tick["status"] == "processed"
-    ]
+    processed_ticks = recovered_retry_ticks(failed_ticks, recovered_ticks)
     require(
-        len(recovered_ticks) > len(failed_ticks) and processed_ticks,
-        f"provider recovery did not process a retry tick: {recovered_ticks}",
+        processed_ticks,
+        "provider recovery did not process a stable-idempotency retry after "
+        f"an aborted/interrupted attempt: failed={failed_ticks}, "
+        f"recovered={recovered_ticks}",
     )
     require(
         {tick["idempotency_key"] for tick in recovered_ticks} == failed_keys,

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -179,6 +179,7 @@ class CaseHarness:
         keep: bool,
         provider_mode: str = "live",
         stub_scenario: str | None = None,
+        model_runtime_override: dict[str, int] | None = None,
         tool_assertion_mode: str = "strict",
         resource_names: dict[str, str] | None = None,
         control_token: str | None = None,
@@ -205,6 +206,8 @@ class CaseHarness:
         self.provider_mode = provider_mode
         self.stub_scenario = stub_scenario
         self.stub_provider_base_url: str | None = None
+        self.model_runtime_override = dict(model_runtime_override or {})
+        self._model_runtime_override_seeded = False
         self.tool_assertion_mode = tool_assertion_mode
         names = resource_names or {}
         self.volume = names.get("volume", f"holon-live-{case_id}-{suffix}")
@@ -511,6 +514,29 @@ class CaseHarness:
                 self.stub_provider_base_url or "http://provider-stub:8080/v1"
             )
             self.runtime_env["OPENAI_API_KEY"] = "deterministic-test-key"
+        if self.model_runtime_override and not self._model_runtime_override_seeded:
+            config = {
+                "models": {
+                    "catalog": {
+                        self.model: self.model_runtime_override,
+                    }
+                }
+            }
+            self.docker(
+                "run",
+                "--rm",
+                "--volume",
+                f"{self.volume}:/var/lib/holon",
+                "--entrypoint",
+                "bash",
+                self.image,
+                "-lc",
+                "set -euo pipefail; umask 077; "
+                "printf '%s' \"$1\" > /var/lib/holon/config.json",
+                "bash",
+                json.dumps(config, separators=(",", ":")),
+            )
+            self._model_runtime_override_seeded = True
         args = [
             "run",
             "--detach",
@@ -1464,51 +1490,21 @@ def require_processed_queue_entries(
     )
 
 
-def require_compaction_evidence(
+def require_turn_local_compaction(
     snapshot: dict[str, Any],
     *,
     label: str,
-    previous_compression_epoch: int = 0,
 ) -> list[dict[str, Any]]:
-    turn_local_events = [
+    events = [
         json.loads(row["data_json"])["data"]
         for row in snapshot["audit_events"]
         if row["kind"] == "turn_local_compaction_applied"
     ]
-    context_events = [
-        json.loads(row["data_json"])["data"]
-        for row in snapshot["audit_events"]
-        if row["kind"] == "provider_round_completed"
-        and int(
-            json.loads(row["data_json"])["data"].get("compression_epoch") or 0
-        )
-        > previous_compression_epoch
-    ]
-    compacted_turn_local_events = [
-        event
-        for event in turn_local_events
-        if int(event.get("compacted_rounds") or 0) > 0
-    ]
     require(
-        compacted_turn_local_events or context_events,
-        f"{label} compaction stimulus did not produce compaction evidence: "
-        f"turn_local={turn_local_events}, context={context_events}",
+        events and any(int(event.get("compacted_rounds") or 0) > 0 for event in events),
+        f"{label} compaction stimulus did not produce compacted rounds: {events}",
     )
-    return compacted_turn_local_events or context_events
-
-
-def latest_compression_epoch(snapshot: dict[str, Any]) -> int:
-    return max(
-        (
-            int(
-                json.loads(row["data_json"])["data"].get("compression_epoch")
-                or 0
-            )
-            for row in snapshot["audit_events"]
-            if row["kind"] == "provider_round_completed"
-        ),
-        default=0,
-    )
+    return events
 
 
 def require_scheduler_engine_activation_chain(
@@ -1724,6 +1720,70 @@ def require_scheduler_activation_chain(
         f"canonical activation slot was not released: {slots}",
     )
     return activations
+
+
+def require_checkpoint_restart_activation_lineage(
+    before_restart_snapshot: dict[str, Any],
+    snapshot: dict[str, Any],
+    *,
+    work_item_id: str,
+    wait_id: str,
+) -> None:
+    before_restart_activations = [
+        row
+        for row in before_restart_snapshot["scheduler_activations"]
+        if row["work_item_id"] == work_item_id
+    ]
+    require(
+        len(before_restart_activations) == 1
+        and before_restart_activations[0]["admitted_generation"] == 1
+        and before_restart_activations[0]["admission_kind"] == "scheduling"
+        and str(before_restart_activations[0]["idempotency_key"]).startswith(
+            "work-queue-attempt:"
+        ),
+        "checkpoint replay restart boundary did not preserve exactly the initial "
+        f"scheduling activation: {before_restart_activations}",
+    )
+    activations = sorted(
+        (
+            row
+            for row in snapshot["scheduler_activations"]
+            if row["work_item_id"] == work_item_id
+        ),
+        key=lambda row: row["admitted_generation"],
+    )
+    require(
+        len(activations) == 2,
+        f"checkpoint replay expected exactly two WorkItem activations: {activations}",
+    )
+    scheduling, wait_resume = activations
+    require(
+        scheduling["admitted_generation"] == 1
+        and scheduling["admission_kind"] == "scheduling"
+        and str(scheduling["idempotency_key"]).startswith("work-queue-attempt:"),
+        f"checkpoint replay initial scheduling activation mismatch: {scheduling}",
+    )
+    expected_wait_resume_key = (
+        f"wait-resume:{wait_id}:2:{wait_resume['activation_id']}"
+    )
+    require(
+        wait_resume["admitted_generation"] == 2
+        and wait_resume["admission_kind"] == "wait_resume"
+        and wait_resume["idempotency_key"] == expected_wait_resume_key,
+        f"checkpoint replay wait-resume activation mismatch: {wait_resume}",
+    )
+    wait_generations = [
+        row
+        for row in snapshot["scheduler_wait_generations"]
+        if row["wait_id"] == wait_id
+    ]
+    require(
+        len(wait_generations) == 1
+        and wait_generations[0]["owner_work_item_id"] == work_item_id
+        and wait_generations[0]["generation"] == 2
+        and wait_generations[0]["lifecycle_state"] == "resolved",
+        f"checkpoint replay wait generation mismatch: {wait_generations}",
+    )
 
 
 def require_lifecycle_wait_adoption(
@@ -3365,8 +3425,6 @@ def run_scheduler_compaction_continuity_case(
         "CompleteWorkItem for the exact current item. Do not wait for more "
         "operator input."
     )
-    before_snapshot = harness.runtime_db_snapshot("scheduler-compaction-before")
-    previous_compression_epoch = latest_compression_epoch(before_snapshot)
     phase = case["phases"][0]
     baseline, _ = harness.prompt(
         "scheduler-compaction-create",
@@ -3384,10 +3442,9 @@ def run_scheduler_compaction_continuity_case(
     stimulus_snapshot = harness.runtime_db_snapshot(
         "scheduler-compaction-stimulus"
     )
-    require_compaction_evidence(
+    require_turn_local_compaction(
         stimulus_snapshot,
         label="scheduler-compaction",
-        previous_compression_epoch=previous_compression_epoch,
     )
     harness.wait_agent_asleep()
     harness.prompt(
@@ -3447,10 +3504,9 @@ def run_scheduler_compaction_continuity_case(
             harness.prompt_scope("scheduler-compaction-create")["message_id"]
         },
     )
-    require_compaction_evidence(
+    require_turn_local_compaction(
         snapshot,
         label="scheduler-compaction",
-        previous_compression_epoch=previous_compression_epoch,
     )
     waits = require_scheduler_wait_terminal(
         harness,
@@ -3713,6 +3769,9 @@ def run_scheduler_checkpoint_replay_case(
         expected_state="completed",
         label="scheduler-replay-b-completed",
     )
+    before_restart_snapshot = harness.runtime_db_snapshot(
+        "scheduler-replay-before-restart"
+    )
     harness.restart()
     restarted_items = harness.work_items("scheduler-replay-after-restart")
     restarted_a = next(
@@ -3803,6 +3862,12 @@ def run_scheduler_checkpoint_replay_case(
         wait_ids={wait["wait_condition_id"] for wait in waits},
     )
     if harness.canonical_scheduler_enabled:
+        require_checkpoint_restart_activation_lineage(
+            before_restart_snapshot,
+            snapshot,
+            work_item_id=work_item_a_id,
+            wait_id=waits[0]["wait_condition_id"],
+        )
         demands = [
             row
             for row in snapshot["scheduler_work_demands"]
@@ -3946,6 +4011,41 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
                 for name, value in runtime_env.items()
             ),
             f"{case_id} runtime_env must contain HOLON_ string entries",
+        )
+        model_runtime_override = case.get("model_runtime_override", {})
+        require(
+            isinstance(model_runtime_override, dict)
+            and all(
+                name
+                in {
+                    "prompt_budget_estimated_tokens",
+                    "compaction_trigger_estimated_tokens",
+                    "compaction_keep_recent_estimated_tokens",
+                }
+                and isinstance(value, int)
+                and value > 0
+                for name, value in model_runtime_override.items()
+            ),
+            f"{case_id} model_runtime_override must contain positive supported integers",
+        )
+        prompt_budget = model_runtime_override.get("prompt_budget_estimated_tokens")
+        compaction_trigger = model_runtime_override.get(
+            "compaction_trigger_estimated_tokens"
+        )
+        keep_recent = model_runtime_override.get(
+            "compaction_keep_recent_estimated_tokens"
+        )
+        require(
+            prompt_budget is None
+            or compaction_trigger is None
+            or compaction_trigger <= prompt_budget,
+            f"{case_id} compaction trigger exceeds prompt budget",
+        )
+        require(
+            compaction_trigger is None
+            or keep_recent is None
+            or keep_recent <= compaction_trigger,
+            f"{case_id} compaction keep-recent exceeds trigger",
         )
         phases = case.get("phases")
         require(isinstance(phases, list) and phases, f"{case_id} needs phases")
@@ -4663,6 +4763,7 @@ def main(argv: list[str] | None = None) -> int:
                 "provider_mode", profile.get("provider_mode", "live")
             ),
             stub_scenario=case.get("stub_scenario", profile.get("stub_scenario")),
+            model_runtime_override=case.get("model_runtime_override"),
             tool_assertion_mode=profile.get("tool_assertion_mode", "strict"),
         )
         control_tokens.append(harness.token)

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2486,18 +2486,21 @@ def run_scheduler_task_wait_resume_case(
             "canonical task/wait activation causes did not preserve scheduling, "
             f"task-rejoin, and external-resume provenance: {activation_causes}",
         )
-    waits = [
-        row
-        for row in snapshot["wait_conditions"]
-        if row["work_item_id"] == work_item_id
-    ]
-    require(
-        len(waits) == 2
-        and {row["kind"] for row in waits} == {"task", "external"}
-        and {row["kind"]: row["status"] for row in waits}
-        == {"task": "resolved", "external": "cancelled"},
-        f"task/external waits did not reach terminal states: {waits}",
+    task_waits = require_scheduler_wait_terminal(
+        harness,
+        snapshot,
+        work_item_id=work_item_id,
+        wait_kind="task",
     )
+    external_waits = require_scheduler_wait_terminal(
+        harness,
+        snapshot,
+        work_item_id=work_item_id,
+        wait_kind="external",
+        require_callback_trigger=True,
+        callback_external_trigger_id=callback["external_trigger_id"],
+    )
+    waits = task_waits + external_waits
     require_scheduler_engine_wait_resolution(
         harness,
         snapshot,
@@ -3518,10 +3521,26 @@ def run_scheduler_compaction_continuity_case(
         for row in snapshot["turn_records"]
         if row["current_work_item_id"] == work_item_id
     }
+    stimulus_turn_ids = {
+        row["turn_id"]
+        for row in snapshot["turn_records"]
+        if row["turn_id"] not in resume_turn_ids
+    }
+    harness.assert_tools(
+        "scheduler-compaction-stimulus",
+        baseline,
+        ["ExecCommand"],
+        forbidden,
+        turn_ids=stimulus_turn_ids,
+    )
     harness.assert_tools(
         "scheduler-compaction-resume",
         baseline,
-        [name for name in required if name not in {"CreateWorkItem", "PickWorkItem", "WaitFor"}],
+        [
+            name
+            for name in required
+            if name in {"GetWorkItem", "UpdateWorkItem", "CompleteWorkItem"}
+        ],
         forbidden + ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         turn_ids=resume_turn_ids,
     )

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2469,11 +2469,23 @@ def run_scheduler_task_wait_resume_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=("scheduling", "task_rejoin", "wait_resume"),
+        expected_admission_kinds=("scheduling", "wait_resume", "wait_resume"),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-task-wait-seed")["message_id"]
         },
     )
+    if harness.canonical_scheduler_enabled:
+        activation_causes = [
+            json.loads(row["payload_json"])["activation"]["cause"]["kind"]
+            for row in snapshot["scheduler_activations"]
+            if row["work_item_id"] == work_item_id
+        ]
+        require(
+            sorted(activation_causes)
+            == ["task_rejoin", "wait_resume", "work_item_runnable"],
+            "canonical task/wait activation causes did not preserve scheduling, "
+            f"task-rejoin, and external-resume provenance: {activation_causes}",
+        )
     waits = [
         row
         for row in snapshot["wait_conditions"]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -717,7 +717,7 @@ fn canonical_queue_settlement_commands_from_facts(
                     },
                     source_lifecycle_wait,
                     focus,
-                    reserve_dispatch: focus,
+                    reserve_dispatch: false,
                 },
             ));
         }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1018,8 +1018,34 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             && generation.state == WaitState::Active
                     })
             });
+            let authoritative_wait_matches = compatibility_wait.as_ref().is_some_and(|wait| {
+                authoritative_work.is_some_and(|record| {
+                    matches!(
+                        &record.state,
+                        crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                            generation,
+                            wait: authoritative_wait,
+                        } if *generation == wait.generation
+                            && authoritative_wait.wait_id == wait.wait_id
+                            && authoritative_wait.generation == wait.generation
+                    )
+                })
+            });
             match snapshot.work.get(work_item_id) {
                 Some(existing_demand) if existing_demand == &demand && wait_projection_matches => {
+                    (None, None)
+                }
+                Some(existing_demand)
+                    if authoritative_wait_matches
+                        && wait_projection_matches
+                        && existing_demand.scheduling_generation
+                            == demand.scheduling_generation
+                        && existing_demand.status == demand.status =>
+                {
+                    // Task/external resolution advances the legacy WorkItem revision before the
+                    // queued resume is claimed. The canonical scheduler and execution protocol
+                    // still own the active wait generation, so claim that authority directly
+                    // instead of trying to re-adopt the now-runnable legacy projection.
                     (None, None)
                 }
                 Some(_) | None if compatibility_wait.is_some() => (

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1301,6 +1301,126 @@ async fn canonical_claim_contention_retains_queue_head_without_failing_poll() {
 }
 
 #[tokio::test]
+async fn canonical_work_item_wait_keeps_other_runnable_work_schedulable() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let waiting_work = runtime
+        .create_work_item(
+            "waiting work should not reserve the agent lane".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime
+        .pick_work_item(waiting_work.id.clone())
+        .await
+        .unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            Some(waiting_work.id.clone()),
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#work-item-wait".into()),
+            "wait while another WorkItem runs".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let wait = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.work_item_id.as_deref() == Some(waiting_work.id.as_str()))
+        .expect("active WorkItem wait");
+    let waiting_work = runtime
+        .latest_work_item(&waiting_work.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem");
+    let runnable_work = runtime
+        .create_work_item(
+            "independent runnable work".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut snapshot = canonical_waiting_snapshot(&waiting_work, &wait.id, waiting_work.revision);
+    snapshot.dispatch = AgentDispatchState::Open;
+    snapshot.dispatch_revision = 0;
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition("default", &snapshot)
+        .unwrap();
+
+    assert!(runtime.maybe_emit_pending_system_tick(None).await.unwrap());
+    let tick = runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .into_iter()
+        .find(|message| {
+            matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                    if subsystem == "work_queue"
+            ) && message.work_item_id.as_deref() == Some(runnable_work.id.as_str())
+        })
+        .expect("runnable WorkItem should receive a work queue tick");
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(matches!(
+        claimed.slot,
+        ActivationSlot::Running {
+            owner: SchedulerOwner::WorkItem { ref work_item_id },
+            ..
+        } if work_item_id == &runnable_work.id
+    ));
+    assert_eq!(
+        claimed.work[&waiting_work.id].status,
+        WorkStatus::Waiting {
+            wait_id: wait.id.clone(),
+        }
+    );
+    assert_eq!(claimed.dispatch, AgentDispatchState::Open);
+    assert_eq!(
+        tick.work_item_id.as_deref(),
+        Some(runnable_work.id.as_str())
+    );
+}
+
+#[tokio::test]
 async fn late_terminal_task_result_for_completed_work_item_settles_without_model_reentry() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -3315,6 +3435,7 @@ async fn lifecycle_settlement_adopts_wait_without_work_item_turn_binding() {
             work_item_id: work_item.id.clone(),
         }
     );
+    assert_eq!(settled.dispatch, AgentDispatchState::Open);
     assert!(settled
         .settlements
         .contains_key(&canonical_settlement_id(&message.id)));
@@ -3470,15 +3591,7 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
             work_item_id: work_item.id.clone(),
         }
     );
-    assert_eq!(
-        settled.dispatch,
-        AgentDispatchState::Awaiting {
-            wait: WaitIdentity {
-                id: work_wait.condition.id.clone(),
-                generation: work_generation,
-            },
-        }
-    );
+    assert_eq!(settled.dispatch, AgentDispatchState::Open);
     assert_eq!(settled.focus.as_deref(), Some(work_item.id.as_str()));
     assert!(settled.missing_settlements.is_empty());
 
@@ -3513,12 +3626,38 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         context_config(),
     )
     .unwrap();
-    append_completed_rejoin_task(
-        &reopened,
-        "task-lifecycle-handoff",
-        &work_item.id,
-        "turn-lifecycle-wait-handoff",
-    );
+    let terminal_task = TaskRecord {
+        id: "task-lifecycle-handoff".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: Some(work_item.id.clone()),
+        summary: Some("task-lifecycle-handoff completed".into()),
+        detail: Some(serde_json::json!({
+            "rejoin_obligation_id": "task-lifecycle-handoff",
+            "rejoin_generation": 1,
+            "parent_turn_id": "turn-lifecycle-wait-handoff",
+        })),
+        recovery: None,
+    };
+    reopened
+        .persist_task_transition(&terminal_task, "task_completed")
+        .await
+        .unwrap();
+    assert!(reopened
+        .storage()
+        .active_wait_conditions_for_work_item("default", &work_item.id)
+        .unwrap()
+        .is_empty());
+    let resolved_work_item = reopened
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("task result should retain the WorkItem");
+    assert!(resolved_work_item.revision > work_generation);
     let mut rejoin = task_result_message("task-lifecycle-handoff").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -3546,23 +3685,177 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .transitions()
         .load_scheduler_protocol_snapshot("default")
         .unwrap();
+    let rejoin_generation = resolved_work_item.revision;
     assert!(matches!(
         rejoined.slot,
         ActivationSlot::Running {
             owner: SchedulerOwner::WorkItem { ref work_item_id },
             admitted_generation,
             ..
-        } if work_item_id == &work_item.id && admitted_generation == work_generation
+        } if work_item_id == &work_item.id && admitted_generation == rejoin_generation
     ));
     assert_eq!(
-        rejoined.waits[&work_wait.condition.id].generations[&work_generation].state,
+        rejoined.waits[&work_wait.condition.id].generations[&rejoin_generation].state,
         WaitState::Consumed
     );
     assert_eq!(
-        rejoined.waits[&work_wait.condition.id].generations[&work_generation]
+        rejoined.waits[&work_wait.condition.id].generations[&rejoin_generation]
             .consuming_activation_id
             .as_deref(),
         Some(scheduler_executor::canonical_activation_id(&rejoin.id).as_str())
+    );
+}
+
+#[tokio::test]
+async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "task rejoin with stale legacy projection".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-stale-legacy-rejoin".into()),
+            "waiting for stale legacy rejoin task".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem");
+    let wait_generation = waiting_work.revision;
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition(
+            "default",
+            &canonical_waiting_snapshot(&waiting_work, &registration.condition.id, wait_generation),
+        )
+        .unwrap();
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: work_item.revision.max(1),
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation: wait_generation,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: registration.condition.id.clone(),
+                    generation: wait_generation,
+                },
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+
+    let terminal_task = TaskRecord {
+        id: "task-stale-legacy-rejoin".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: Some(work_item.id.clone()),
+        summary: Some("task-stale-legacy-rejoin completed".into()),
+        detail: Some(serde_json::json!({
+            "rejoin_obligation_id": "task-stale-legacy-rejoin",
+            "rejoin_generation": 1,
+            "parent_turn_id": "turn-stale-legacy-parent",
+        })),
+        recovery: None,
+    };
+    runtime
+        .persist_task_transition(&terminal_task, "task_completed")
+        .await
+        .unwrap();
+    let resolved_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("resolved WorkItem");
+    assert!(resolved_work.revision > wait_generation);
+
+    let mut rejoin = task_result_message("task-stale-legacy-rejoin").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    rejoin.work_item_id = Some(work_item.id.clone());
+    rejoin.metadata = Some(serde_json::json!({
+        "task_id": "task-stale-legacy-rejoin",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-stale-legacy-rejoin",
+        "work_item_id": work_item.id,
+    }));
+    rejoin.turn_id = Some("turn-stale-legacy-rejoin".into());
+    let rejoin = runtime.enqueue(rejoin).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
+    let claimed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_scheduler_protocol_snapshot("default")
+        .unwrap();
+    assert!(matches!(
+        claimed.slot,
+        ActivationSlot::Running {
+            owner: SchedulerOwner::WorkItem { ref work_item_id },
+            admitted_generation,
+            ..
+        } if work_item_id == &work_item.id && admitted_generation == wait_generation
+    ));
+    assert_eq!(
+        claimed.waits[&registration.condition.id].generations[&wait_generation].state,
+        WaitState::Consumed
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == rejoin.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dequeued)
     );
 }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -536,14 +536,13 @@ impl RuntimeTransitionRepository<'_> {
                     if matches!(
                         command.operation,
                         QueueOperation::Claim | QueueOperation::Interject
-                    ) && scheduler_protocol_repository::scheduler_protocol_retryable_conflict(
-                        &error,
-                    )
-                    .is_some() =>
+                    ) =>
                 {
-                    let conflict =
-                        scheduler_protocol_repository::scheduler_protocol_retryable_conflict(&error)
-                            .expect("guard checked scheduler claim contention");
+                    let Some(conflict) =
+                        scheduler_protocol_repository::scheduler_protocol_claim_contention(&error)
+                    else {
+                        return Err(error);
+                    };
                     let event = AuditEvent::legacy(
                         "scheduler_claim_contended",
                         serde_json::json!({
@@ -1254,6 +1253,9 @@ mod tests {
             ExecutionBinding, ExecutionOrigin, ExecutionPriority, ExecutionProtocolCommand,
             ExecutionProtocolState, ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity,
             ExecutionTrust, WorkItemExecutionRecord, WorkItemExecutionState,
+        },
+        domain::scheduler_protocol::{
+            ActivationSlot, AgentDispatchState, ProtocolCommand, Snapshot,
         },
         runtime_db::{RuntimeIndexChange, RuntimeIndexOperation},
         types::{
@@ -2000,6 +2002,90 @@ mod tests {
             .transitions()
             .load_scheduler_protocol_snapshot_if_initialized("agent-a")?
             .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn queue_claim_retains_head_when_legacy_adoption_source_changes() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let work_item = work_item("work-stale-adoption");
+        db.work_items().insert_new(&work_item)?;
+        let adoption = db
+            .transitions()
+            .legacy_scheduler_adoption_candidates("agent-a")?
+            .into_iter()
+            .find(|candidate| candidate.work_item_id == work_item.id)
+            .and_then(|candidate| candidate.command)
+            .expect("eligible legacy adoption command");
+        let mut changed = work_item.clone();
+        changed.revision += 1;
+        changed.updated_at += chrono::Duration::seconds(1);
+        assert!(db
+            .work_items()
+            .update_expected(&changed, work_item.revision)?);
+
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-stale-adoption".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Next,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&queued)?;
+        let mut claimed = queued.clone();
+        claimed.status = QueueEntryStatus::Dequeued;
+        claimed.updated_at += chrono::Duration::seconds(1);
+        let bootstrap = Snapshot {
+            slot: ActivationSlot::Idle,
+            dispatch: AgentDispatchState::Open,
+            dispatch_revision: 0,
+            focus: None,
+            work: Default::default(),
+            waits: Default::default(),
+            activations: Default::default(),
+            activation_admissions: Default::default(),
+            settlements: Default::default(),
+            missing_settlements: Default::default(),
+            admitted_generations: Default::default(),
+            continuation_admissions: Default::default(),
+            activation_inputs: Default::default(),
+        };
+
+        let commit = db.transitions().commit_queue(&QueueTransitionCommand {
+            agent_id: "agent-a".into(),
+            operation: QueueOperation::Claim,
+            mutation: QueueMutation::Consume(claimed),
+            scheduler_claim_work_item: None,
+            scheduler_protocol_bootstrap: Some(bootstrap),
+            scheduler_protocol_commands: vec![adoption.clone()],
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: Vec::new(),
+            notify_scheduler: true,
+            fault: None,
+            brief_evidence: Vec::new(),
+        })?;
+
+        assert!(commit.scheduler_authority_blocked);
+        assert_eq!(db.queue_entries().latest_all()?, vec![queued]);
+        assert!(db
+            .audit_events()
+            .recent(Some("agent-a"), 10)?
+            .iter()
+            .any(|event| {
+                event.kind == "scheduler_claim_contended"
+                    && event.data["conflict_code"] == "legacy_adoption_source_changed"
+                    && event.data["queue_disposition"] == "retained_queued"
+            }));
+        assert!(db
+            .transitions()
+            .load_scheduler_protocol_snapshot_if_initialized("agent-a")?
+            .is_none());
+        assert!(matches!(adoption, ProtocolCommand::AdoptLegacyWorkState(_)));
         Ok(())
     }
 

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -199,6 +199,22 @@ pub(crate) fn scheduler_protocol_retryable_conflict(
     })
 }
 
+pub(crate) fn scheduler_protocol_claim_contention(
+    error: &anyhow::Error,
+) -> Option<ProtocolConflict> {
+    scheduler_protocol_retryable_conflict(error).or_else(|| {
+        error.chain().find_map(|source| {
+            source
+                .downcast_ref::<LegacySchedulerAdoptionRejected>()
+                .filter(|error| error.reason.starts_with("source_changed:"))
+                .map(|_| ProtocolConflict {
+                    kind: ProtocolConflictKind::StateConflict,
+                    code: "legacy_adoption_source_changed".into(),
+                })
+        })
+    })
+}
+
 #[derive(Debug, Serialize)]
 struct SnapshotFence<'a> {
     slot: &'a ActivationSlot,
@@ -3147,6 +3163,26 @@ mod tests {
         let mut elevated = candidate.clone();
         elevated.focus = true;
         assert!(!legacy_adoption_source_matches(&candidate, &elevated));
+    }
+
+    #[test]
+    fn legacy_adoption_source_change_is_retryable_claim_contention() {
+        let error = anyhow::Error::new(LegacySchedulerAdoptionRejected {
+            reason: "source_changed:agent-a:work-a".into(),
+        });
+
+        assert_eq!(
+            scheduler_protocol_claim_contention(&error),
+            Some(ProtocolConflict {
+                kind: ProtocolConflictKind::StateConflict,
+                code: "legacy_adoption_source_changed".into(),
+            })
+        );
+
+        let missing = anyhow::Error::new(LegacySchedulerAdoptionRejected {
+            reason: "source_work_item_missing_or_closed".into(),
+        });
+        assert_eq!(scheduler_protocol_claim_contention(&missing), None);
     }
 
     #[test]

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -364,11 +364,10 @@
       "timeout_seconds": 120,
       "description": "Verify WorkItem state survives compaction triggered during a multi-turn lifecycle and persists across restart.",
       "scheduler_protocol_commands_enabled": true,
-      "runtime_env": {
-        "HOLON_COMPACTION_TRIGGER_MESSAGES": "3",
-        "HOLON_COMPACTION_KEEP_RECENT_MESSAGES": "2",
-        "HOLON_COMPACTION_TRIGGER_ESTIMATED_TOKENS": "1",
-        "HOLON_COMPACTION_KEEP_RECENT_ESTIMATED_TOKENS": "1"
+      "model_runtime_override": {
+        "prompt_budget_estimated_tokens": 80000,
+        "compaction_trigger_estimated_tokens": 70000,
+        "compaction_keep_recent_estimated_tokens": 4000
       },
       "phases": [
         {
@@ -376,14 +375,14 @@
           "required_tools": [
             "CreateWorkItem",
             "PickWorkItem",
+            "ExecCommand",
             "WaitFor",
             "GetWorkItem",
             "UpdateWorkItem",
             "CompleteWorkItem"
           ],
           "forbidden_tools": [
-            "ApplyPatch",
-            "ExecCommand"
+            "ApplyPatch"
           ],
           "prompt": "Scheduler Docker E2E case {case_id}. Create exactly one WorkItem whose objective is {objective}, with plan_status ready and exactly these todos: compaction-wait pending, compaction-complete pending. Pick that WorkItem, then call WaitFor with wake=operator_input and a concrete reason. Do not complete it in this turn. When the operator message later resumes this exact WorkItem, call GetWorkItem, update both todos to completed, then emit a concise completion result containing {completion_marker} immediately followed by CompleteWorkItem for the exact current item. Do not create another WorkItem and do not modify files."
         }

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -365,9 +365,9 @@
       "description": "Verify WorkItem state survives compaction triggered during a multi-turn lifecycle and persists across restart.",
       "scheduler_protocol_commands_enabled": true,
       "model_runtime_override": {
-        "prompt_budget_estimated_tokens": 40000,
-        "compaction_trigger_estimated_tokens": 35000,
-        "compaction_keep_recent_estimated_tokens": 4000
+        "prompt_budget_estimated_tokens": 80000,
+        "compaction_trigger_estimated_tokens": 70000,
+        "compaction_keep_recent_estimated_tokens": 8000
       },
       "phases": [
         {

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -365,8 +365,8 @@
       "description": "Verify WorkItem state survives compaction triggered during a multi-turn lifecycle and persists across restart.",
       "scheduler_protocol_commands_enabled": true,
       "model_runtime_override": {
-        "prompt_budget_estimated_tokens": 80000,
-        "compaction_trigger_estimated_tokens": 70000,
+        "prompt_budget_estimated_tokens": 40000,
+        "compaction_trigger_estimated_tokens": 35000,
         "compaction_keep_recent_estimated_tokens": 4000
       },
       "phases": [

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -1,22 +1,24 @@
 {
   "version": 2,
-  "scheduler_fixture_corpus_revision": "scheduler-release-acceptance-v1",
+  "scheduler_fixture_corpus_revision": "scheduler-release-gate-split-v2",
   "profiles": {
     "scheduler-required": {
+      "gate_kind": "required",
       "provider_mode": "stub",
+      "tool_assertion_mode": "strict",
       "case_ids": [
+        "scheduler-task-wait-resume",
+        "scheduler-provider-failure-work-queue-retry",
         "scheduler-multi-workitem-scheduling",
         "scheduler-external-wait-resume",
-        "scheduler-operator-wait-resume"
+        "scheduler-operator-wait-resume",
+        "scheduler-concurrent-claim-fencing",
+        "scheduler-operator-interject-during-wait",
+        "scheduler-compaction-continuity",
+        "scheduler-worktree-isolation",
+        "scheduler-spawn-agent-supervision",
+        "scheduler-checkpoint-replay"
       ],
-      "required_coverage_ids": [
-        "scheduler-multi-workitem-scheduling",
-        "scheduler-external-wait-resume",
-        "scheduler-operator-wait-resume"
-      ]
-    },
-    "scheduler-acceptance": {
-      "provider_mode": "live",
       "required_coverage_ids": [
         "scheduler-task-wait-resume",
         "scheduler-provider-failure-work-queue-retry",
@@ -29,6 +31,17 @@
         "scheduler-worktree-isolation",
         "scheduler-spawn-agent-supervision",
         "scheduler-checkpoint-replay"
+      ]
+    },
+    "scheduler-live-canary": {
+      "gate_kind": "live_canary",
+      "provider_mode": "live",
+      "tool_assertion_mode": "observe",
+      "case_ids": [
+        "scheduler-external-wait-resume"
+      ],
+      "required_coverage_ids": [
+        "scheduler-external-wait-resume"
       ]
     }
   },
@@ -152,9 +165,10 @@
     {
       "id": "scheduler-task-wait-resume",
       "coverage_ids": ["scheduler-task-wait-resume"],
+      "stub_scenario": "scheduler-task-wait",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "task-result", "yield", "wait", "restart", "replay", "delivery"],
-      "timeout_seconds": 900,
+      "timeout_seconds": 120,
       "description": "Verify one WorkItem crosses autonomous scheduling, promoted task-result rejoin, external wait-resume, exact completion delivery, and process restart.",
       "phases": [
         {
@@ -179,9 +193,10 @@
     {
       "id": "scheduler-provider-failure-work-queue-retry",
       "coverage_ids": ["scheduler-provider-failure-work-queue-retry"],
+      "stub_scenario": "scheduler-provider-retry",
       "tier": "extended",
       "tags": ["scheduler", "provider", "failure", "retry", "workitem", "restart"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Force a real provider transport failure for a current WorkItem, restore the provider endpoint across a serve restart, and verify the same continue-active idempotency key is retried to successful completion.",
       "phases": [
         {
@@ -204,7 +219,7 @@
       "stub_scenario": "scheduler-multi",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "multi", "priority", "e2e-tier-1"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify real-LLM multi-WorkItem scheduling: two WorkItems created in one turn both complete autonomously without conflicts or duplicate settlements.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -234,7 +249,7 @@
       "stub_scenario": "scheduler-external",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "external", "wait", "resume", "e2e-tier-1"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify real-LLM WaitFor(external) + external trigger callback + autonomous resume and completion.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -262,7 +277,7 @@
       "stub_scenario": "scheduler-operator",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "operator", "wait", "resume", "e2e-tier-1"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify real-LLM WaitFor(operator_input) + operator message + autonomous resume and completion.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -287,9 +302,10 @@
     {
       "id": "scheduler-concurrent-claim-fencing",
       "coverage_ids": ["scheduler-concurrent-claim-fencing"],
+      "stub_scenario": "scheduler-concurrent",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "concurrent", "claim", "interject", "e2e-tier-2"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify interject prompt during external wait creates a new WorkItem without disrupting the waiting WorkItem; both complete correctly.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -314,9 +330,10 @@
     {
       "id": "scheduler-operator-interject-during-wait",
       "coverage_ids": ["scheduler-operator-interject-during-wait"],
+      "stub_scenario": "scheduler-interject",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "operator", "interject", "e2e-tier-2"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify operator interject during operator wait creates a new WorkItem; original resumes correctly after interject completes.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -341,9 +358,10 @@
     {
       "id": "scheduler-compaction-continuity",
       "coverage_ids": ["scheduler-compaction-continuity"],
+      "stub_scenario": "scheduler-compaction",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "compaction", "continuity", "e2e-tier-2"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify WorkItem state survives compaction triggered during a multi-turn lifecycle and persists across restart.",
       "scheduler_protocol_commands_enabled": true,
       "runtime_env": {
@@ -374,9 +392,10 @@
     {
       "id": "scheduler-worktree-isolation",
       "coverage_ids": ["scheduler-worktree-isolation"],
+      "stub_scenario": "scheduler-worktree",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "worktree", "isolation", "e2e-tier-2"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify agent creates, inspects, and removes a worktree through real model tool calls with correct execution binding.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -403,9 +422,10 @@
     {
       "id": "scheduler-spawn-agent-supervision",
       "coverage_ids": ["scheduler-spawn-agent-supervision"],
+      "stub_scenario": "scheduler-spawn",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "spawn", "agent", "supervision", "e2e-tier-2"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify agent spawns a private_child agent, inspects task status, and completes the parent WorkItem.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [
@@ -430,9 +450,10 @@
     {
       "id": "scheduler-checkpoint-replay",
       "coverage_ids": ["scheduler-checkpoint-replay"],
+      "stub_scenario": "scheduler-checkpoint",
       "tier": "extended",
       "tags": ["scheduler", "workitem", "checkpoint", "replay", "restart", "e2e-tier-2"],
-      "timeout_seconds": 600,
+      "timeout_seconds": 120,
       "description": "Verify multiple WorkItems in different states survive restart and converge correctly with exactly-once settlement.",
       "scheduler_protocol_commands_enabled": true,
       "phases": [

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -160,9 +160,10 @@ class Scenario:
                 return self.provider_retry()
             if self.name in {"scheduler-external", "scheduler-operator"}:
                 kind = self.name.removeprefix("scheduler-")
-                return self.wait(kind, kind, kind)
+                wake = "operator_input" if kind == "operator" else kind
+                return self.wait(kind, kind, wake)
             if self.name == "scheduler-concurrent":
-                return self.interject("concurrent", "external")
+                return self.concurrent()
             if self.name == "scheduler-interject":
                 return self.interject("interject", "operator_input")
             if self.name == "scheduler-compaction":
@@ -265,10 +266,16 @@ class Scenario:
                     ],
                 },
             )
+        if self.phase == 1:
+            self.phase += 1
+            return 200, response(
+                [text_item("Created deterministic task-wait WorkItem.")],
+                "resp_task_wait_created",
+            )
         if not self.work_ids:
             return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
         wid = self.work_ids[0]
-        if self.phase == 1:
+        if self.phase == 2:
             marker = self.markers.get("task_result", "SCHEDULER-TASK-RESULT")
             return self.call(
                 "ExecCommand",
@@ -278,7 +285,7 @@ class Scenario:
                     "max_output_tokens": 100,
                 },
             )
-        if self.phase == 2:
+        if self.phase == 3:
             if not self.task_ids:
                 return 409, {"error": {"type": "missing_task_id", "message": str(self.phase)}}
             return self.call(
@@ -289,12 +296,12 @@ class Scenario:
                     "reason": "deterministic task completion",
                 },
             )
-        if self.phase in {3, 5}:
+        if self.phase in {4, 6}:
             return self.call(
                 "GetWorkItem",
                 {"work_item_id": wid, "include_todo_list": True},
             )
-        if self.phase == 4:
+        if self.phase == 5:
             return self.call(
                 "WaitFor",
                 {
@@ -303,7 +310,7 @@ class Scenario:
                     "reason": "deterministic external completion",
                 },
             )
-        if self.phase == 6:
+        if self.phase == 7:
             return self.call(
                 "UpdateWorkItem",
                 {
@@ -314,7 +321,7 @@ class Scenario:
                     ],
                 },
             )
-        if self.phase == 7:
+        if self.phase == 8:
             return self.call(
                 "CompleteWorkItem",
                 {"work_item_id": wid},
@@ -337,6 +344,95 @@ class Scenario:
                 {"work_item_id": wid},
                 self.markers.get(
                     "provider_complete", "SCHEDULER-PROVIDER-RETRY-COMPLETE"
+                ),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def concurrent(self) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get("concurrent_a", "concurrent-a"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "concurrent-wait", "state": "pending"},
+                        {"text": "concurrent-complete", "state": "pending"},
+                    ],
+                },
+            )
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        if self.phase == 1:
+            return self.call("PickWorkItem", {"work_item_id": self.work_ids[0]})
+        if self.phase == 2:
+            return self.call(
+                "WaitFor",
+                {
+                    "wake": "external",
+                    "resource": self.markers.get(
+                        "callback", "docker-e2e:deterministic"
+                    ),
+                    "reason": "deterministic concurrent wait",
+                },
+            )
+        if len(self.work_ids) < 2:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        if self.phase == 3:
+            return self.call(
+                "ListWorkItems",
+                {"filter": "current", "include_todo_list": True},
+            )
+        if self.phase == 4:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": self.work_ids[1],
+                    "todo_list": [
+                        {"text": "concurrent-b-seed", "state": "completed"},
+                        {"text": "concurrent-b-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 5:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": self.work_ids[1]},
+                self.markers.get(
+                    "concurrent_complete_b", "concurrent-complete-b"
+                ),
+            )
+        if self.phase == 6:
+            marker = self.markers.get("concurrent_a", "SCHEDULER-CONCURRENT-A")
+            if "[trigger:" not in self.current_input_text or marker not in self.current_input_text:
+                self.phase += 1
+                return 200, response(
+                    [text_item("Completed deterministic concurrent WorkItem B.")],
+                    "resp_concurrent_b_complete",
+                )
+            self.phase += 1
+        if self.phase == 7:
+            return self.call(
+                "GetWorkItem",
+                {"work_item_id": self.work_ids[0], "include_todo_list": True},
+            )
+        if self.phase == 8:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": self.work_ids[0],
+                    "todo_list": [
+                        {"text": "concurrent-wait", "state": "completed"},
+                        {"text": "concurrent-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 9:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": self.work_ids[0]},
+                self.markers.get(
+                    "concurrent_complete_a", "concurrent-complete-a"
                 ),
             )
         return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
@@ -656,12 +752,12 @@ class Scenario:
 
     def expected_phase(self) -> int:
         return {
-            "scheduler-task-wait": 9,
+            "scheduler-task-wait": 10,
             "scheduler-provider-retry": 3,
             "scheduler-multi": 12,
             "scheduler-external": 7,
             "scheduler-operator": 7,
-            "scheduler-concurrent": 13,
+            "scheduler-concurrent": 11,
             "scheduler-interject": 13,
             "scheduler-compaction": 7,
             "scheduler-worktree": 12,

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -459,19 +459,19 @@ class Scenario:
         wid = self.work_ids[0]
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": wid})
-        if self.phase == 2:
+        if self.phase in {2, 3, 4}:
             return self.call(
                 "ExecCommand",
                 {
                     "cmd": (
                         "i=0; while [ \"$i\" -lt 16000 ]; do "
-                        "printf 'compaction-payload-%04d\\n' \"$i\"; "
+                        f"printf 'compaction-payload-{self.phase}-%04d\\n' \"$i\"; "
                         "i=$((i+1)); done"
                     ),
                     "max_output_tokens": 64000,
                 },
             )
-        if self.phase == 3:
+        if self.phase == 5:
             return self.call(
                 "WaitFor",
                 {
@@ -479,12 +479,12 @@ class Scenario:
                     "reason": "deterministic compaction wait",
                 },
             )
-        if self.phase == 4:
+        if self.phase == 6:
             return self.call(
                 "GetWorkItem",
                 {"work_item_id": wid, "include_todo_list": True},
             )
-        if self.phase == 5:
+        if self.phase == 7:
             return self.call(
                 "UpdateWorkItem",
                 {
@@ -495,7 +495,7 @@ class Scenario:
                     ],
                 },
             )
-        if self.phase == 6:
+        if self.phase == 8:
             return self.call(
                 "CompleteWorkItem",
                 {"work_item_id": wid},
@@ -829,7 +829,7 @@ class Scenario:
             "scheduler-operator": 7,
             "scheduler-concurrent": 11,
             "scheduler-interject": 13,
-            "scheduler-compaction": 8,
+            "scheduler-compaction": 10,
             "scheduler-worktree": 12,
             "scheduler-spawn": 7,
             "scheduler-checkpoint": 13,

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -164,10 +164,10 @@ class Scenario:
                 return self.wait(kind, kind, wake)
             if self.name == "scheduler-concurrent":
                 return self.concurrent()
+            if self.name == "scheduler-compaction":
+                return self.compaction()
             if self.name == "scheduler-interject":
                 return self.interject("interject", "operator_input")
-            if self.name == "scheduler-compaction":
-                return self.wait("compaction", "compaction", "operator_input")
             if self.name == "scheduler-worktree":
                 return self.worktree()
             if self.name == "scheduler-spawn":
@@ -436,6 +436,76 @@ class Scenario:
                 ),
             )
         return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def compaction(self) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get(
+                        "compaction", "SCHEDULER-COMPACTION"
+                    ),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "compaction-wait", "state": "pending"},
+                        {"text": "compaction-complete", "state": "pending"},
+                    ],
+                },
+            )
+        if not self.work_ids:
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
+        wid = self.work_ids[0]
+        if self.phase == 1:
+            return self.call("PickWorkItem", {"work_item_id": wid})
+        if self.phase == 2:
+            return self.call(
+                "ExecCommand",
+                {
+                    "cmd": (
+                        "i=0; while [ \"$i\" -lt 16000 ]; do "
+                        "printf 'compaction-payload-%04d\\n' \"$i\"; "
+                        "i=$((i+1)); done"
+                    ),
+                    "max_output_tokens": 64000,
+                },
+            )
+        if self.phase == 3:
+            return self.call(
+                "WaitFor",
+                {
+                    "wake": "operator_input",
+                    "reason": "deterministic compaction wait",
+                },
+            )
+        if self.phase == 4:
+            return self.call(
+                "GetWorkItem",
+                {"work_item_id": wid, "include_todo_list": True},
+            )
+        if self.phase == 5:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": "compaction-wait", "state": "completed"},
+                        {"text": "compaction-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 6:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": wid},
+                self.markers.get(
+                    "compaction_complete", "SCHEDULER-COMPACTION-COMPLETE"
+                ),
+            )
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def interject(self, prefix: str, wake: str) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
@@ -759,7 +829,7 @@ class Scenario:
             "scheduler-operator": 7,
             "scheduler-concurrent": 11,
             "scheduler-interject": 13,
-            "scheduler-compaction": 7,
+            "scheduler-compaction": 8,
             "scheduler-worktree": 12,
             "scheduler-spawn": 7,
             "scheduler-checkpoint": 13,

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -9,7 +9,19 @@ from typing import Any
 CALLBACK_CAPABILITY_PATTERN = re.compile(
     r"(/api/callbacks/(?:wake|enqueue)/)[A-Za-z0-9_-]+"
 )
-SCENARIOS = ("scheduler-multi", "scheduler-external", "scheduler-operator")
+SCENARIOS = (
+    "scheduler-task-wait",
+    "scheduler-provider-retry",
+    "scheduler-multi",
+    "scheduler-external",
+    "scheduler-operator",
+    "scheduler-concurrent",
+    "scheduler-interject",
+    "scheduler-compaction",
+    "scheduler-worktree",
+    "scheduler-spawn",
+    "scheduler-checkpoint",
+)
 
 def redact_evidence(value: Any) -> Any:
     if isinstance(value, dict):
@@ -32,6 +44,9 @@ def call_item(cid: str, name: str, args: dict[str, Any]) -> dict[str, Any]:
 class Scenario:
     def __init__(self, name: str) -> None:
         self.name, self.phase, self.work_ids, self.markers = name, 0, [], {}
+        self.task_ids: list[str] = []
+        self.workspace_ids: list[str] = []
+        self.execution_root_ids: list[str] = []
         self.first_turn_closed = False
         self.current_input_text = ""
         self.extra_requests = 0
@@ -42,11 +57,34 @@ class Scenario:
         for wid in re.findall(r"work_[0-9a-f]{15}", raw):
             if wid not in self.work_ids:
                 self.work_ids.append(wid)
+        for task_id in re.findall(r"task_[0-9a-f]{15}", raw):
+            if task_id not in self.task_ids:
+                self.task_ids.append(task_id)
+        for workspace_id in re.findall(r"ws_[0-9a-f]+", raw):
+            if workspace_id not in self.workspace_ids:
+                self.workspace_ids.append(workspace_id)
+        for execution_root_id in re.findall(r"git_worktree_root:[^\"\\\\]+", raw):
+            if execution_root_id not in self.execution_root_ids:
+                self.execution_root_ids.append(execution_root_id)
         for key, pattern in {
             "multi_a": r"SCHEDULER-MULTI-A-[0-9a-f]+", "multi_b": r"SCHEDULER-MULTI-B-[0-9a-f]+",
             "multi_complete_a": r"SCHEDULER-MULTI-COMPLETE-A-[0-9a-f]+", "multi_complete_b": r"SCHEDULER-MULTI-COMPLETE-B-[0-9a-f]+",
             "external": r"SCHEDULER-EXTERNAL-WAIT-[0-9a-f]+", "external_complete": r"SCHEDULER-EXTERNAL-COMPLETE-[0-9a-f]+",
             "operator": r"SCHEDULER-OPERATOR-WAIT-[0-9a-f]+", "operator_complete": r"SCHEDULER-OPERATOR-COMPLETE-[0-9a-f]+",
+            "task": r"SCHEDULER-TASK-WAIT-[0-9a-f]+", "task_result": r"SCHEDULER-TASK-RESULT-[0-9a-f]+",
+            "task_complete": r"SCHEDULER-TASK-WAIT-COMPLETE-[0-9a-f]+",
+            "provider": r"SCHEDULER-PROVIDER-RETRY-[0-9a-f]+", "provider_complete": r"SCHEDULER-PROVIDER-RETRY-COMPLETE-[0-9a-f]+",
+            "concurrent_a": r"SCHEDULER-CONCURRENT-A-[0-9a-f]+", "concurrent_b": r"SCHEDULER-CONCURRENT-B-[0-9a-f]+",
+            "concurrent_complete_a": r"SCHEDULER-CONCURRENT-COMPLETE-A-[0-9a-f]+", "concurrent_complete_b": r"SCHEDULER-CONCURRENT-COMPLETE-B-[0-9a-f]+",
+            "interject_a": r"SCHEDULER-INTERJECT-A-[0-9a-f]+", "interject_b": r"SCHEDULER-INTERJECT-B-[0-9a-f]+",
+            "interject_complete_a": r"SCHEDULER-INTERJECT-COMPLETE-A-[0-9a-f]+", "interject_complete_b": r"SCHEDULER-INTERJECT-COMPLETE-B-[0-9a-f]+",
+            "compaction": r"SCHEDULER-COMPACTION-[0-9a-f]+", "compaction_complete": r"SCHEDULER-COMPACTION-COMPLETE-[0-9a-f]+",
+            "worktree": r"SCHEDULER-WORKTREE-[0-9a-f]+", "worktree_complete": r"SCHEDULER-WORKTREE-COMPLETE-[0-9a-f]+",
+            "spawn": r"SCHEDULER-SPAWN-[0-9a-f]+", "spawn_complete": r"SCHEDULER-SPAWN-COMPLETE-[0-9a-f]+",
+            "spawn_child": r"SCHEDULER-SPAWN-CHILD-[0-9a-f]+",
+            "checkpoint_a": r"SCHEDULER-REPLAY-A-[0-9a-f]+", "checkpoint_b": r"SCHEDULER-REPLAY-B-[0-9a-f]+",
+            "checkpoint_complete_a": r"SCHEDULER-REPLAY-COMPLETE-A-[0-9a-f]+", "checkpoint_complete_b": r"SCHEDULER-REPLAY-COMPLETE-B-[0-9a-f]+",
+            "branch": r"e2e-worktree-[0-9a-f]+",
             "callback": r"docker-e2e:[0-9a-f]+",
         }.items():
             match = re.search(pattern, raw)
@@ -83,6 +121,18 @@ class Scenario:
             current_input = self.current_input(request)
             self.current_input_text = current_input
             if (
+                self.name == "scheduler-spawn"
+                and "SCHEDULER-SPAWN-CHILD-" in current_input
+                and "Scheduler Docker E2E case" not in current_input
+            ):
+                marker = self.markers.get(
+                    "spawn_child", "SCHEDULER-SPAWN-CHILD-deterministic"
+                )
+                return 200, response(
+                    [text_item(f"Child completed {marker}.")],
+                    "resp_scheduler_spawn_child",
+                )
+            if (
                 "[trigger:internal_followup][runtime_instruction][InternalFollowup]"
                 in current_input
                 and "This is the first run of Holon" in current_input
@@ -104,8 +154,25 @@ class Scenario:
                 }
             if self.name == "scheduler-multi":
                 return self.multi()
+            if self.name == "scheduler-task-wait":
+                return self.task_wait()
+            if self.name == "scheduler-provider-retry":
+                return self.provider_retry()
             if self.name in {"scheduler-external", "scheduler-operator"}:
-                return self.wait(self.name.removeprefix("scheduler-"))
+                kind = self.name.removeprefix("scheduler-")
+                return self.wait(kind, kind, kind)
+            if self.name == "scheduler-concurrent":
+                return self.interject("concurrent", "external")
+            if self.name == "scheduler-interject":
+                return self.interject("interject", "operator_input")
+            if self.name == "scheduler-compaction":
+                return self.wait("compaction", "compaction", "operator_input")
+            if self.name == "scheduler-worktree":
+                return self.worktree()
+            if self.name == "scheduler-spawn":
+                return self.spawn()
+            if self.name == "scheduler-checkpoint":
+                return self.checkpoint()
             return 409, {"error": {"type": "unknown_scenario", "message": self.name}}
 
     def multi(self) -> tuple[int, dict[str, Any]]:
@@ -156,38 +223,450 @@ class Scenario:
             return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
         return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
 
-    def wait(self, kind: str) -> tuple[int, dict[str, Any]]:
+    def wait(
+        self, marker_key: str, todo_prefix: str, wake: str
+    ) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
-            return self.call("CreateWorkItem", {"objective": self.markers.get(kind, f"SCHEDULER-{kind.upper()}-WAIT"), "plan_status": "ready", "todo_list": [{"text": f"{kind}-wait", "state": "pending"}, {"text": f"{kind}-complete", "state": "pending"}]})
+            return self.call("CreateWorkItem", {"objective": self.markers.get(marker_key, f"SCHEDULER-{marker_key.upper()}-WAIT"), "plan_status": "ready", "todo_list": [{"text": f"{todo_prefix}-wait", "state": "pending"}, {"text": f"{todo_prefix}-complete", "state": "pending"}]})
         if not self.work_ids:
             return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
         wid = self.work_ids[0]
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": wid})
         if self.phase == 2:
-            args: dict[str, Any] = {"wake": "external" if kind == "external" else "operator_input", "reason": f"deterministic {kind} wait"}
-            if kind == "external":
+            args: dict[str, Any] = {"wake": wake, "reason": f"deterministic {marker_key} wait"}
+            if wake == "external":
                 args["resource"] = self.markers.get("callback", "docker-e2e:deterministic")
             return self.call("WaitFor", args)
         if self.phase == 3:
             return self.call("GetWorkItem", {"work_item_id": wid, "include_todo_list": True})
         if self.phase == 4:
-            return self.call("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": f"{kind}-wait", "state": "completed"}, {"text": f"{kind}-complete", "state": "completed"}]})
+            return self.call("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": f"{todo_prefix}-wait", "state": "completed"}, {"text": f"{todo_prefix}-complete", "state": "completed"}]})
         if self.phase == 5:
-            completion = self.markers.get(f"{kind}_complete") or self.markers[
-                kind
+            completion = self.markers.get(f"{marker_key}_complete") or self.markers[
+                marker_key
             ].replace(
-                f"SCHEDULER-{kind.upper()}-WAIT-",
-                f"SCHEDULER-{kind.upper()}-COMPLETE-",
+                f"SCHEDULER-{marker_key.upper()}-WAIT-",
+                f"SCHEDULER-{marker_key.upper()}-COMPLETE-",
             )
             return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
         return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
 
+    def task_wait(self) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get("task", "SCHEDULER-TASK-WAIT"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "task-continuation", "state": "pending"},
+                        {"text": "external-continuation", "state": "pending"},
+                    ],
+                },
+            )
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        wid = self.work_ids[0]
+        if self.phase == 1:
+            marker = self.markers.get("task_result", "SCHEDULER-TASK-RESULT")
+            return self.call(
+                "ExecCommand",
+                {
+                    "cmd": f"sleep 15; printf {marker}",
+                    "yield_time_ms": 50,
+                    "max_output_tokens": 100,
+                },
+            )
+        if self.phase == 2:
+            if not self.task_ids:
+                return 409, {"error": {"type": "missing_task_id", "message": str(self.phase)}}
+            return self.call(
+                "WaitFor",
+                {
+                    "wake": "task_result",
+                    "resource": self.task_ids[-1],
+                    "reason": "deterministic task completion",
+                },
+            )
+        if self.phase in {3, 5}:
+            return self.call(
+                "GetWorkItem",
+                {"work_item_id": wid, "include_todo_list": True},
+            )
+        if self.phase == 4:
+            return self.call(
+                "WaitFor",
+                {
+                    "wake": "external",
+                    "resource": self.markers.get("callback", "docker-e2e:deterministic"),
+                    "reason": "deterministic external completion",
+                },
+            )
+        if self.phase == 6:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": "task-continuation", "state": "completed"},
+                        {"text": "external-continuation", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 7:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": wid},
+                self.markers.get("task_complete", "SCHEDULER-TASK-WAIT-COMPLETE"),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def provider_retry(self) -> tuple[int, dict[str, Any]]:
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        wid = self.work_ids[0]
+        if self.phase == 0:
+            return self.call(
+                "ListWorkItems",
+                {"filter": "current", "include_todo_list": True},
+            )
+        if self.phase == 1:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": wid},
+                self.markers.get(
+                    "provider_complete", "SCHEDULER-PROVIDER-RETRY-COMPLETE"
+                ),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def interject(self, prefix: str, wake: str) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get(f"{prefix}_a", prefix),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": f"{prefix}-wait", "state": "pending"},
+                        {"text": f"{prefix}-complete", "state": "pending"},
+                    ],
+                },
+            )
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        if self.phase == 1:
+            return self.call("PickWorkItem", {"work_item_id": self.work_ids[0]})
+        if self.phase == 2:
+            args: dict[str, Any] = {
+                "wake": wake,
+                "reason": f"deterministic {prefix} wait",
+            }
+            if wake == "external":
+                args["resource"] = self.markers.get(
+                    "callback", "docker-e2e:deterministic"
+                )
+            return self.call("WaitFor", args)
+        if self.phase == 3:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get(f"{prefix}_b", f"{prefix}-b"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": f"{prefix}-b-seed", "state": "completed"},
+                        {"text": f"{prefix}-b-complete", "state": "pending"},
+                    ],
+                },
+            )
+        if self.phase == 4:
+            self.phase += 1
+            return 200, response(
+                [text_item("Created deterministic interject WorkItem.")],
+                f"resp_{prefix}_interject_created",
+            )
+        if len(self.work_ids) < 2:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        if self.phase == 5:
+            return self.call(
+                "ListWorkItems",
+                {"filter": "current", "include_todo_list": True},
+            )
+        if self.phase == 6:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": self.work_ids[1],
+                    "todo_list": [
+                        {"text": f"{prefix}-b-seed", "state": "completed"},
+                        {"text": f"{prefix}-b-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 7:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": self.work_ids[1]},
+                self.markers.get(f"{prefix}_complete_b", f"{prefix}-complete-b"),
+            )
+        if self.phase == 8:
+            self.phase += 1
+            return 200, response(
+                [text_item("Completed deterministic interject WorkItem.")],
+                f"resp_{prefix}_interject_complete",
+            )
+        if self.phase == 9:
+            return self.call(
+                "GetWorkItem",
+                {"work_item_id": self.work_ids[0], "include_todo_list": True},
+            )
+        if self.phase == 10:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": self.work_ids[0],
+                    "todo_list": [
+                        {"text": f"{prefix}-wait", "state": "completed"},
+                        {"text": f"{prefix}-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 11:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": self.work_ids[0]},
+                self.markers.get(f"{prefix}_complete_a", f"{prefix}-complete-a"),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def worktree(self) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get("worktree", "SCHEDULER-WORKTREE"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "worktree-create", "state": "pending"},
+                        {"text": "worktree-cleanup", "state": "pending"},
+                    ],
+                },
+            )
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        wid = self.work_ids[0]
+        if self.phase == 1:
+            return self.call("PickWorkItem", {"work_item_id": wid})
+        if self.phase in {2, 4, 6, 8}:
+            return self.call("GetWorkspaceState", {})
+        if self.phase == 3:
+            if not self.workspace_ids:
+                return 409, {"error": {"type": "missing_workspace_id", "message": str(self.phase)}}
+            return self.call(
+                "CreateWorktree",
+                {
+                    "workspace_id": self.workspace_ids[0],
+                    "base_ref": "main",
+                    "branch": self.markers.get("branch", "e2e-worktree-deterministic"),
+                    "activate": True,
+                },
+            )
+        if self.phase == 5:
+            return self.call(
+                "SwitchWorkspace",
+                {"workspace_id": self.workspace_ids[0]},
+            )
+        if self.phase == 7:
+            if not self.execution_root_ids:
+                return 409, {"error": {"type": "missing_execution_root_id", "message": str(self.phase)}}
+            return self.call(
+                "RemoveWorktree",
+                {
+                    "execution_root_id": self.execution_root_ids[-1],
+                    "branch_policy": "keep",
+                },
+            )
+        if self.phase == 9:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": "worktree-create", "state": "completed"},
+                        {"text": "worktree-cleanup", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 10:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": wid},
+                self.markers.get("worktree_complete", "SCHEDULER-WORKTREE-COMPLETE"),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def spawn(self) -> tuple[int, dict[str, Any]]:
+        if self.phase == 0:
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get("spawn", "SCHEDULER-SPAWN"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "spawn-child", "state": "pending"},
+                        {"text": "verify-child", "state": "pending"},
+                    ],
+                },
+            )
+        if not self.work_ids:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        wid = self.work_ids[0]
+        if self.phase == 1:
+            return self.call("PickWorkItem", {"work_item_id": wid})
+        if self.phase == 2:
+            marker = self.markers.get(
+                "spawn_child", "SCHEDULER-SPAWN-CHILD-deterministic"
+            )
+            return self.call(
+                "SpawnAgent",
+                {
+                    "preset": "private_child",
+                    "initial_message": (
+                        f"Respond with one sentence containing the marker {marker} "
+                        "and then stop."
+                    ),
+                },
+            )
+        if self.phase == 3:
+            if not self.task_ids:
+                return 409, {"error": {"type": "missing_task_id", "message": str(self.phase)}}
+            return self.call("TaskStatus", {"task_id": self.task_ids[-1]})
+        if self.phase == 4:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": "spawn-child", "state": "completed"},
+                        {"text": "verify-child", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 5:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": wid},
+                self.markers.get("spawn_complete", "SCHEDULER-SPAWN-COMPLETE"),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
+    def checkpoint(self) -> tuple[int, dict[str, Any]]:
+        if self.phase in {0, 1}:
+            key = "checkpoint_a" if self.phase == 0 else "checkpoint_b"
+            suffix = "a" if self.phase == 0 else "b"
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get(key, f"SCHEDULER-REPLAY-{suffix}"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {
+                            "text": "replay-wait" if suffix == "a" else "replay-seed",
+                            "state": "pending" if suffix == "a" else "completed",
+                        },
+                        {"text": "replay-complete", "state": "pending"},
+                    ],
+                },
+            )
+        if self.phase == 2:
+            return self.call("ListWorkItems", {"include_todo_list": True})
+        if self.phase == 3:
+            self.phase += 1
+            return 200, response(
+                [text_item("Created deterministic checkpoint WorkItems.")],
+                "resp_checkpoint_created",
+            )
+        if len(self.work_ids) < 2:
+            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+        if self.phase == 4:
+            return self.call(
+                "WaitFor",
+                {
+                    "wake": "external",
+                    "resource": self.markers.get("callback", "docker-e2e:deterministic"),
+                    "reason": "deterministic checkpoint wait",
+                },
+            )
+        if self.phase == 5:
+            return self.call(
+                "ListWorkItems",
+                {"filter": "current", "include_todo_list": True},
+            )
+        if self.phase == 6:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": self.work_ids[1],
+                    "todo_list": [
+                        {"text": "replay-seed", "state": "completed"},
+                        {"text": "replay-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 7:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": self.work_ids[1]},
+                self.markers.get(
+                    "checkpoint_complete_b", "SCHEDULER-REPLAY-COMPLETE-B"
+                ),
+            )
+        if self.phase == 8:
+            self.phase += 1
+            return 200, response(
+                [text_item("Completed deterministic checkpoint WorkItem B.")],
+                "resp_checkpoint_b_complete",
+            )
+        if self.phase == 9:
+            return self.call(
+                "GetWorkItem",
+                {"work_item_id": self.work_ids[0], "include_todo_list": True},
+            )
+        if self.phase == 10:
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": self.work_ids[0],
+                    "todo_list": [
+                        {"text": "replay-wait", "state": "completed"},
+                        {"text": "replay-complete", "state": "completed"},
+                    ],
+                },
+            )
+        if self.phase == 11:
+            return self.call(
+                "CompleteWorkItem",
+                {"work_item_id": self.work_ids[0]},
+                self.markers.get(
+                    "checkpoint_complete_a", "SCHEDULER-REPLAY-COMPLETE-A"
+                ),
+            )
+        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+
     def expected_phase(self) -> int:
         return {
+            "scheduler-task-wait": 9,
+            "scheduler-provider-retry": 3,
             "scheduler-multi": 12,
             "scheduler-external": 7,
             "scheduler-operator": 7,
+            "scheduler-concurrent": 13,
+            "scheduler-interject": 13,
+            "scheduler-compaction": 7,
+            "scheduler-worktree": 12,
+            "scheduler-spawn": 7,
+            "scheduler-checkpoint": 13,
         }[self.name]
 
     def status(self) -> dict[str, Any]:

--- a/tests/e2e/scheduler/README.md
+++ b/tests/e2e/scheduler/README.md
@@ -59,32 +59,36 @@ Each case asserts three layers:
 
 ## CI Layering
 
-| Layer | Trigger | Tiers | Timeout | Blocking |
+| Layer | Trigger | Scope | Timeout | Blocking |
 |---|---|---|---|---|
-| PR required | every scheduler/runtime Docker-relevant PR | deterministic Tier-1: multi-WorkItem, external wait, operator wait; legacy + canonical | 20 min | yes (`Scheduler E2E Required`) |
-| PR live optional | `e2e-scheduler` label | real-provider Tier-1 subset; legacy + canonical | 20 min | no (`continue-on-error`) |
-| Nightly | schedule | Tier-1 all + Tier-2 all | 60 min (job) / 15 min (suite `--timeout 900`) | creates issue on failure |
-| Release | release pipeline | Tier-1 + Tier-2 + Tier-3 | 90 min | yes |
+| PR required | every scheduler/runtime Docker-relevant PR | all scheduler invariant cases through the deterministic provider; legacy + canonical | 45 min job / 120s per case | yes (`Scheduler E2E Required`) |
+| PR live canary | `e2e-scheduler` label | real-provider external wait/resume smoke; legacy + canonical | 20 min job / 120s per case | no (`continue-on-error`) |
+| Nightly | schedule | deterministic required matrix plus the independent live canary | 60 min | deterministic only |
+| Release | release pipeline | core real-model suite, deterministic scheduler gate, and independent live canary | 90 min | core + deterministic |
 
-The required profile uses the dependency-free OpenAI Responses stub in
-`tests/e2e/docker/openai_stub/`. It produces `scheduler-coverage-report.json`
-from an explicit required coverage set; omitted cases therefore fail even when
-the selected matrix is internally symmetric. Real-provider runs remain the
-interoperability gate for provider behavior that a scripted transport cannot
-prove.
+The `scheduler-required` profile uses the dependency-free OpenAI Responses stub
+in `tests/e2e/docker/openai_stub/`. It covers task-result, provider retry,
+multi-WorkItem scheduling, wait/resume, claim/interject, compaction, worktree,
+child supervision, and checkpoint/restart invariants in both scheduler engines.
+Its exact tool and turn contract remains strict and its
+`scheduler-coverage-report.json` is release-blocking.
+
+The `scheduler-live-canary` profile uses a real provider and records the model
+route, provider attempt/retry counts, tool counts, and behavioral variance in
+`scheduler-live-canary-report.json`. Tool-order and forbidden-tool differences
+are evidence, not invariant failures; runtime fatal errors, failed tools, and
+failure to complete the smoke lifecycle still fail the canary. Canary failure
+does not replace or override the deterministic gate result.
 
 ### Current Decisions
 
 - **Required CI provider**: local deterministic OpenAI Responses stub, with no
   provider secret or PR label.
-- **Live CI provider**: single low-cost model via env var; multi-provider
-  matrix only in release pipeline (max 2 providers).
+- **Live CI provider**: single low-cost model via env var, reported separately
+  from deterministic runtime invariants.
 - **PR blocking**: the deterministic profile is required; the live provider
   job remains optional and `continue-on-error`.
-- **Phase order**: Phase 1 (infrastructure) → 2 (Tier-1) → 3 (Tier-2) → 4
-  (Tier-3); within Phase 2, crash recovery and provider failure are highest
-  priority.
-- **Case migration**: existing 4 scheduler cases remain in the shared
-  `manifest.json`; new cases are added alongside them.
+- **Case migration**: scheduler invariant cases remain in the shared
+  `manifest.json`; each required case names a deterministic `stub_scenario`.
 - **Drill harness**: `scheduler_drill.py` is reused for Tier-2 checkpoint
   replay; no separate Python module extracted yet.

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -129,19 +129,35 @@ class DockerE2ERunnerTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "no registered runner"):
             runner.validate_manifest(invalid)
 
-    def test_profile_exposes_explicit_scheduler_required_set(self) -> None:
-        profile = runner.resolve_profile(self.manifest, "scheduler-acceptance")
+    def test_scheduler_live_canary_profile_is_observational(self) -> None:
+        profile = runner.resolve_profile(self.manifest, "scheduler-live-canary")
+        self.assertEqual(profile["gate_kind"], "live_canary")
         self.assertEqual(profile["provider_mode"], "live")
+        self.assertEqual(profile["tool_assertion_mode"], "observe")
         self.assertEqual(
-            set(profile["required_coverage_ids"]),
-            {
-                case["id"]
-                for case in self.manifest["cases"]
-                if "scheduler" in case.get("tags", [])
-            },
+            profile["case_ids"],
+            ["scheduler-external-wait-resume"],
         )
 
-    def test_scheduler_required_profile_selects_three_stub_cases(self) -> None:
+    def test_workflows_keep_required_gate_independent_and_publish_canary(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yml").read_text()
+        nightly = (ROOT / ".github/workflows/e2e-scheduler-nightly.yml").read_text()
+        release = (ROOT / ".github/workflows/release-e2e.yml").read_text()
+
+        self.assertLess(
+            nightly.index("Run deterministic scheduler matrix"),
+            nightly.index("Prepare provider environment"),
+        )
+        self.assertIn("if: steps.provider-env.outcome == 'success'", nightly)
+        self.assertIn("continue-on-error: true", nightly)
+        for workflow in (ci, nightly, release):
+            self.assertIn("scheduler-live-canary-report.json", workflow)
+            self.assertIn("behavioral_variances", workflow)
+            self.assertIn("tool_counts", workflow)
+        self.assertIn("name: scheduler-live-canary", ci)
+        self.assertIn("name: scheduler-e2e-nightly", nightly)
+
+    def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")
         selected = runner.select_cases(
             self.manifest,
@@ -149,16 +165,143 @@ class DockerE2ERunnerTests(unittest.TestCase):
             suite="core",
             tags=[],
         )
+        expected = [
+            case["id"]
+            for case in self.manifest["cases"]
+            if "scheduler" in case.get("tags", [])
+        ]
+        self.assertEqual(profile["gate_kind"], "required")
         self.assertEqual(profile["provider_mode"], "stub")
+        self.assertEqual(profile["tool_assertion_mode"], "strict")
+        self.assertEqual([case["id"] for case in selected], expected)
+        self.assertEqual(profile["required_coverage_ids"], expected)
+        self.assertTrue(all(case.get("stub_scenario") for case in selected))
+        self.assertTrue(
+            all(case["timeout_seconds"] <= 120 for case in selected)
+        )
+
+    def test_manifest_rejects_live_canary_with_strict_tools(self) -> None:
+        invalid = json.loads(json.dumps(self.manifest))
+        invalid["profiles"]["scheduler-live-canary"][
+            "tool_assertion_mode"
+        ] = "strict"
+        with self.assertRaisesRegex(
+            AssertionError,
+            "live canary must observe tool assertions",
+        ):
+            runner.validate_manifest(invalid)
+
+    def test_manifest_rejects_required_case_without_stub_scenario(self) -> None:
+        invalid = json.loads(json.dumps(self.manifest))
+        invalid["cases"][-1].pop("stub_scenario")
+        with self.assertRaisesRegex(
+            AssertionError,
+            "cases require stub_scenario",
+        ):
+            runner.validate_manifest(invalid)
+
+    def test_scheduler_live_canary_report_records_model_and_retries(self) -> None:
+        report = runner.scheduler_live_canary_report(
+            run_record={
+                "git_sha": "git-sha",
+                "image_digest": "image@sha256:digest",
+                "manifest_sha256": "manifest-hash",
+                "profile": "scheduler-live-canary",
+                "provider_mode": "live",
+                "model_route": "provider/model",
+                "tool_assertion_mode": "observe",
+            },
+            case_results=[
+                {
+                    "id": "scheduler-external-wait-resume-legacy",
+                    "base_id": "scheduler-external-wait-resume",
+                    "scheduler_engine": "legacy",
+                    "status": "pass",
+                    "error": "",
+                    "provider_rounds": 2,
+                    "provider_attempts": 3,
+                    "provider_retries": 1,
+                    "tool_counts": {"WaitFor": 1},
+                    "behavioral_variances": [
+                        {
+                            "scope": "scheduler-external-resume",
+                            "missing_tools": ["GetWorkItem"],
+                            "forbidden_tools_used": [],
+                        }
+                    ],
+                },
+                {
+                    "id": "scheduler-external-wait-resume-canonical",
+                    "base_id": "scheduler-external-wait-resume",
+                    "scheduler_engine": "canonical",
+                    "status": "pass",
+                    "error": "",
+                    "provider_rounds": 2,
+                    "provider_attempts": 2,
+                    "provider_retries": 0,
+                    "tool_counts": {"WaitFor": 1},
+                    "behavioral_variances": [],
+                },
+            ],
+            scheduler_acceptance_status="pass",
+            scheduler_coverage_status="pass",
+            secret_scan_status="pass",
+        )
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["model_route"], "provider/model")
+        self.assertEqual(report["provider_rounds"], 4)
+        self.assertEqual(report["provider_attempts"], 5)
+        self.assertEqual(report["provider_retries"], 1)
         self.assertEqual(
-            [case["id"] for case in selected],
+            report["behavioral_variances"],
             [
-                "scheduler-multi-workitem-scheduling",
-                "scheduler-external-wait-resume",
-                "scheduler-operator-wait-resume",
+                {
+                    "case_id": "scheduler-external-wait-resume-legacy",
+                    "scope": "scheduler-external-resume",
+                    "missing_tools": ["GetWorkItem"],
+                    "forbidden_tools_used": [],
+                }
             ],
         )
-        self.assertTrue(all(case.get("stub_scenario") for case in selected))
+
+    def test_collect_case_metrics_deduplicates_overlapping_event_snapshots(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory)
+            events = [
+                {
+                    "event_seq": 10,
+                    "type": "tool_executed",
+                    "payload": {"tool_name": "WaitFor"},
+                },
+                {
+                    "event_seq": 11,
+                    "type": "provider_round_completed",
+                    "payload": {
+                        "provider_attempt_timeline": {
+                            "attempts": [{"status": "failed"}, {"status": "success"}]
+                        },
+                        "token_usage": {
+                            "input_tokens": 3,
+                            "output_tokens": 2,
+                            "total_tokens": 5,
+                        },
+                    },
+                },
+            ]
+            (evidence / "first-events.json").write_text(
+                json.dumps({"events": events})
+            )
+            (evidence / "second-events.json").write_text(
+                json.dumps({"events": events})
+            )
+
+            metrics = runner.collect_case_metrics(evidence)
+
+        self.assertEqual(metrics["tool_counts"], {"WaitFor": 1})
+        self.assertEqual(metrics["provider_rounds"], 1)
+        self.assertEqual(metrics["provider_attempts"], 2)
+        self.assertEqual(metrics["provider_retries"], 1)
+        self.assertEqual(metrics["token_usage"]["total_tokens"], 5)
 
     def test_scheduler_coverage_reports_missing_and_duplicate_ids(self) -> None:
         report = runner.scheduler_coverage_report(
@@ -319,6 +462,129 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(response["output"][0]["name"], "GetWorkspaceState")
         self.assertEqual(scenario.phase, 8)
+
+    def test_openai_stub_registers_every_required_scenario(self) -> None:
+        profile = runner.resolve_profile(self.manifest, "scheduler-required")
+        selected = runner.select_cases(
+            self.manifest,
+            requested=profile["case_ids"],
+            suite="core",
+            tags=[],
+        )
+        self.assertEqual(
+            {case["stub_scenario"] for case in selected},
+            set(stub.SCENARIOS),
+        )
+        for case in selected:
+            scenario = stub.Scenario(case["stub_scenario"])
+            self.assertGreater(scenario.expected_phase(), 0)
+
+    def test_openai_stub_required_scenarios_reach_exact_completion(self) -> None:
+        expected_calls = {
+            "scheduler-task-wait": [
+                "CreateWorkItem", "ExecCommand", "WaitFor", "GetWorkItem",
+                "WaitFor", "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-provider-retry": ["ListWorkItems", "CompleteWorkItem"],
+            "scheduler-multi": [
+                "CreateWorkItem", "CreateWorkItem", "AgentGet", "ListWorkItems",
+                "UpdateWorkItem", "CompleteWorkItem", "GetWorkspaceState",
+                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-external": [
+                "CreateWorkItem", "PickWorkItem", "WaitFor", "GetWorkItem",
+                "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-operator": [
+                "CreateWorkItem", "PickWorkItem", "WaitFor", "GetWorkItem",
+                "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-concurrent": [
+                "CreateWorkItem", "PickWorkItem", "WaitFor", "CreateWorkItem",
+                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
+                "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-interject": [
+                "CreateWorkItem", "PickWorkItem", "WaitFor", "CreateWorkItem",
+                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
+                "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-compaction": [
+                "CreateWorkItem", "PickWorkItem", "WaitFor", "GetWorkItem",
+                "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-worktree": [
+                "CreateWorkItem", "PickWorkItem", "GetWorkspaceState",
+                "CreateWorktree", "GetWorkspaceState", "SwitchWorkspace",
+                "GetWorkspaceState", "RemoveWorktree", "GetWorkspaceState",
+                "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-spawn": [
+                "CreateWorkItem", "PickWorkItem", "SpawnAgent", "TaskStatus",
+                "UpdateWorkItem", "CompleteWorkItem",
+            ],
+            "scheduler-checkpoint": [
+                "CreateWorkItem", "CreateWorkItem", "ListWorkItems", "WaitFor",
+                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
+                "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+            ],
+        }
+        transcript = (
+            "## current_input\nCurrent input:\n"
+            "- [system][trigger:system_tick] Scheduler Docker E2E case "
+            "SCHEDULER-TASK-WAIT-abcd SCHEDULER-TASK-RESULT-abcd "
+            "SCHEDULER-TASK-WAIT-COMPLETE-abcd "
+            "SCHEDULER-PROVIDER-RETRY-abcd "
+            "SCHEDULER-PROVIDER-RETRY-COMPLETE-abcd "
+            "SCHEDULER-MULTI-A-abcd SCHEDULER-MULTI-B-abcd "
+            "SCHEDULER-MULTI-COMPLETE-A-abcd "
+            "SCHEDULER-MULTI-COMPLETE-B-abcd "
+            "SCHEDULER-EXTERNAL-WAIT-abcd "
+            "SCHEDULER-EXTERNAL-COMPLETE-abcd "
+            "SCHEDULER-OPERATOR-WAIT-abcd "
+            "SCHEDULER-OPERATOR-COMPLETE-abcd "
+            "SCHEDULER-CONCURRENT-A-abcd SCHEDULER-CONCURRENT-B-abcd "
+            "SCHEDULER-CONCURRENT-COMPLETE-A-abcd "
+            "SCHEDULER-CONCURRENT-COMPLETE-B-abcd "
+            "SCHEDULER-INTERJECT-A-abcd SCHEDULER-INTERJECT-B-abcd "
+            "SCHEDULER-INTERJECT-COMPLETE-A-abcd "
+            "SCHEDULER-INTERJECT-COMPLETE-B-abcd "
+            "SCHEDULER-COMPACTION-abcd "
+            "SCHEDULER-COMPACTION-COMPLETE-abcd "
+            "SCHEDULER-WORKTREE-abcd "
+            "SCHEDULER-WORKTREE-COMPLETE-abcd "
+            "SCHEDULER-SPAWN-abcd SCHEDULER-SPAWN-CHILD-abcd "
+            "SCHEDULER-SPAWN-COMPLETE-abcd "
+            "SCHEDULER-REPLAY-A-abcd SCHEDULER-REPLAY-B-abcd "
+            "SCHEDULER-REPLAY-COMPLETE-A-abcd "
+            "SCHEDULER-REPLAY-COMPLETE-B-abcd "
+            "docker-e2e:abcd e2e-worktree-abcd "
+            "work_0123456789abcde work_fedcba987654321 "
+            "task_0123456789abcde ws_0123456789abcdef "
+            "git_worktree_root:deterministic"
+        )
+        request = {
+            "input": [{
+                "type": "message",
+                "content": [{"type": "input_text", "text": transcript}],
+            }]
+        }
+        for name, expected in expected_calls.items():
+            scenario = stub.Scenario(name)
+            actual = []
+            for _ in range(scenario.expected_phase()):
+                status, value = scenario.consume(request)
+                self.assertEqual(status, 200, name)
+                actual.extend(
+                    item["name"]
+                    for item in value["output"]
+                    if item["type"] == "function_call"
+                )
+            self.assertEqual(actual, expected, name)
+            self.assertTrue(scenario.status()["complete"], name)
+            status, value = scenario.consume(request)
+            self.assertEqual(status, 409, name)
+            self.assertEqual(value["error"]["type"], "transcript_exhausted")
 
     def test_secret_scan_reports_value_without_echoing_it(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -623,8 +623,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
             ],
             "scheduler-compaction": [
-                "CreateWorkItem", "PickWorkItem", "ExecCommand", "WaitFor", "GetWorkItem",
-                "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem", "PickWorkItem", "ExecCommand", "ExecCommand",
+                "ExecCommand", "WaitFor", "GetWorkItem", "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-worktree": [
                 "CreateWorkItem", "PickWorkItem", "GetWorkspaceState",
@@ -1383,9 +1384,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 provider_mode="stub",
                 stub_scenario="scheduler-compaction",
                 model_runtime_override={
-                    "prompt_budget_estimated_tokens": 40_000,
-                    "compaction_trigger_estimated_tokens": 35_000,
-                    "compaction_keep_recent_estimated_tokens": 4_000,
+                    "prompt_budget_estimated_tokens": 80_000,
+                    "compaction_trigger_estimated_tokens": 70_000,
+                    "compaction_keep_recent_estimated_tokens": 8_000,
                 },
             )
             commands: list[tuple[str, ...]] = []
@@ -1538,9 +1539,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(
             compaction["model_runtime_override"],
             {
-                "prompt_budget_estimated_tokens": 40000,
-                "compaction_trigger_estimated_tokens": 35000,
-                "compaction_keep_recent_estimated_tokens": 4000,
+                "prompt_budget_estimated_tokens": 80000,
+                "compaction_trigger_estimated_tokens": 70000,
+                "compaction_keep_recent_estimated_tokens": 8000,
             },
         )
 

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -494,7 +494,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
 
     def test_openai_stub_concurrent_callback_starts_a_resume_tools(self) -> None:
         scenario = stub.Scenario("scheduler-concurrent")
-        scenario.phase = 6
+        scenario.phase = 5
         scenario.work_ids = [
             "work_0123456789abcde",
             "work_fedcba987654321",
@@ -517,6 +517,12 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 }
             ]
         }
+
+        status, response = scenario.consume({"input": []})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][-1]["name"], "CompleteWorkItem")
+        self.assertEqual(scenario.phase, 6)
 
         status, response = scenario.consume(callback)
 
@@ -571,7 +577,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
             ],
             "scheduler-compaction": [
-                "CreateWorkItem", "PickWorkItem", "WaitFor", "GetWorkItem",
+                "CreateWorkItem", "PickWorkItem", "ExecCommand", "WaitFor", "GetWorkItem",
                 "UpdateWorkItem", "CompleteWorkItem",
             ],
             "scheduler-worktree": [
@@ -1314,6 +1320,70 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 docker_run,
             )
 
+    def test_stub_start_forces_endpoint_and_seeds_model_override_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            harness = runner.CaseHarness(
+                case_id="stub-model-override",
+                image="holon:test",
+                model="external/model",
+                credential_envs=[],
+                env_file=None,
+                runtime_env={
+                    "HOLON_OPENAI_BASE_URL": "https://external.invalid/v1",
+                },
+                evidence_root=Path(directory),
+                timeout_seconds=1,
+                keep=True,
+                provider_mode="stub",
+                stub_scenario="scheduler-compaction",
+                model_runtime_override={
+                    "prompt_budget_estimated_tokens": 80_000,
+                    "compaction_trigger_estimated_tokens": 70_000,
+                    "compaction_keep_recent_estimated_tokens": 4_000,
+                },
+            )
+            commands: list[tuple[str, ...]] = []
+
+            def fake_docker(
+                *args: str, **_: object
+            ) -> subprocess.CompletedProcess[str]:
+                commands.append(args)
+                if args[:2] in {
+                    ("network", "inspect"),
+                    ("inspect", "--format"),
+                }:
+                    return subprocess.CompletedProcess(["docker", *args], 1, "", "")
+                if args[:2] == ("port", harness.container):
+                    return subprocess.CompletedProcess(
+                        ["docker", *args], 0, "127.0.0.1:49152\n", ""
+                    )
+                return subprocess.CompletedProcess(["docker", *args], 0, "", "")
+
+            harness.docker = fake_docker
+            harness.wait_readiness = lambda: None
+            harness.wait_agent_idle = lambda: None
+
+            harness.start()
+            harness.start()
+
+            self.assertEqual(harness.model, "openai/gpt-5.4")
+            self.assertEqual(
+                harness.runtime_env["HOLON_OPENAI_BASE_URL"],
+                "http://provider-stub:8080/v1",
+            )
+            seed_runs = [
+                command
+                for command in commands
+                if command[0] == "run"
+                and "/var/lib/holon/config.json" in " ".join(command)
+            ]
+            self.assertEqual(len(seed_runs), 1)
+            seeded = json.loads(seed_runs[0][-1])
+            self.assertEqual(
+                seeded["models"]["catalog"]["openai/gpt-5.4"],
+                harness.model_runtime_override,
+            )
+
     def test_scheduler_extended_cases_use_real_lifecycle_fixtures(self) -> None:
         selected = runner.select_cases(
             self.manifest, requested=None, suite="extended", tags=["scheduler"]
@@ -1420,12 +1490,11 @@ class DockerE2ERunnerTests(unittest.TestCase):
             if case["id"] == "scheduler-compaction-continuity"
         )
         self.assertEqual(
-            compaction["runtime_env"],
+            compaction["model_runtime_override"],
             {
-                "HOLON_COMPACTION_TRIGGER_MESSAGES": "3",
-                "HOLON_COMPACTION_KEEP_RECENT_MESSAGES": "2",
-                "HOLON_COMPACTION_TRIGGER_ESTIMATED_TOKENS": "1",
-                "HOLON_COMPACTION_KEEP_RECENT_ESTIMATED_TOKENS": "1",
+                "prompt_budget_estimated_tokens": 80000,
+                "compaction_trigger_estimated_tokens": 70000,
+                "compaction_keep_recent_estimated_tokens": 4000,
             },
         )
 
@@ -1842,7 +1911,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 {"data": {"compacted_rounds": 2, "exact_tail_rounds": 1}}
             ),
         }
-        events = runner.require_compaction_evidence(
+        events = runner.require_turn_local_compaction(
             {"audit_events": [event]},
             label="test",
         )
@@ -1851,25 +1920,83 @@ class DockerE2ERunnerTests(unittest.TestCase):
         event["data_json"] = json.dumps(
             {"data": {"compacted_rounds": 0, "exact_tail_rounds": 3}}
         )
-        context_event = {
-            "kind": "provider_round_completed",
-            "data_json": json.dumps({"data": {"compression_epoch": 1}}),
-        }
-        events = runner.require_compaction_evidence(
-            {"audit_events": [event, context_event]},
-            label="test",
-            previous_compression_epoch=0,
-        )
-        self.assertEqual(events[0]["compression_epoch"], 1)
-
         with self.assertRaisesRegex(
             AssertionError,
-            "compaction stimulus did not produce compaction evidence",
+            "compaction stimulus did not produce compacted rounds",
         ):
-            runner.require_compaction_evidence(
-                {"audit_events": [event, context_event]},
+            runner.require_turn_local_compaction(
+                {
+                    "audit_events": [
+                        event,
+                        {
+                            "kind": "provider_round_completed",
+                            "data_json": json.dumps(
+                                {"data": {"compression_epoch": 1}}
+                            ),
+                        },
+                    ]
+                },
                 label="test",
-                previous_compression_epoch=1,
+            )
+
+    def test_checkpoint_restart_lineage_binds_wait_generation(self) -> None:
+        before_restart_snapshot = {
+            "scheduler_activations": [
+                {
+                    "activation_id": "activation:schedule",
+                    "work_item_id": "work-1",
+                    "admitted_generation": 1,
+                    "admission_kind": "scheduling",
+                    "idempotency_key": "work-queue-attempt:activation:schedule",
+                }
+            ]
+        }
+        snapshot = {
+            "scheduler_activations": [
+                {
+                    "activation_id": "activation:schedule",
+                    "work_item_id": "work-1",
+                    "admitted_generation": 1,
+                    "admission_kind": "scheduling",
+                    "idempotency_key": "work-queue-attempt:activation:schedule",
+                },
+                {
+                    "activation_id": "activation:resume",
+                    "work_item_id": "work-1",
+                    "admitted_generation": 2,
+                    "admission_kind": "wait_resume",
+                    "idempotency_key": "wait-resume:wait-1:2:activation:resume",
+                },
+            ],
+            "scheduler_wait_generations": [
+                {
+                    "wait_id": "wait-1",
+                    "owner_work_item_id": "work-1",
+                    "generation": 2,
+                    "lifecycle_state": "resolved",
+                }
+            ],
+        }
+
+        runner.require_checkpoint_restart_activation_lineage(
+            before_restart_snapshot,
+            snapshot,
+            work_item_id="work-1",
+            wait_id="wait-1",
+        )
+
+        snapshot["scheduler_activations"][1]["idempotency_key"] = (
+            "wait-resume:other-wait:2:activation:resume"
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            "wait-resume activation mismatch",
+        ):
+            runner.require_checkpoint_restart_activation_lineage(
+                before_restart_snapshot,
+                snapshot,
+                work_item_id="work-1",
+                wait_id="wait-1",
             )
 
     def test_wait_work_item_fails_fast_on_duplicate_objective_marker(self) -> None:

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -123,6 +123,52 @@ class DockerE2ERunnerTests(unittest.TestCase):
             ],
         )
 
+    def test_recovered_retry_ticks_accepts_existing_interrupted_tick(self) -> None:
+        key = "work_queue:continue_active:work-1:1"
+        failed = [
+            {
+                "message_id": "message-1",
+                "idempotency_key": key,
+                "status": "aborted",
+            },
+            {
+                "message_id": "message-2",
+                "idempotency_key": key,
+                "status": "interrupted",
+            },
+        ]
+        recovered = [
+            failed[0],
+            {
+                "message_id": "message-2",
+                "idempotency_key": key,
+                "status": "processed",
+            },
+        ]
+
+        self.assertEqual(
+            runner.recovered_retry_ticks(failed, recovered),
+            [recovered[1]],
+        )
+
+    def test_recovered_retry_ticks_rejects_changed_idempotency(self) -> None:
+        failed = [
+            {
+                "message_id": "message-1",
+                "idempotency_key": "work_queue:continue_active:work-1:1",
+                "status": "aborted",
+            }
+        ]
+        recovered = [
+            {
+                "message_id": "message-2",
+                "idempotency_key": "work_queue:continue_active:work-1:2",
+                "status": "processed",
+            }
+        ]
+
+        self.assertEqual(runner.recovered_retry_ticks(failed, recovered), [])
+
     def test_manifest_rejects_unregistered_case(self) -> None:
         invalid = json.loads(json.dumps(self.manifest))
         invalid["cases"][0]["id"] = "not-implemented"
@@ -1337,8 +1383,8 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 provider_mode="stub",
                 stub_scenario="scheduler-compaction",
                 model_runtime_override={
-                    "prompt_budget_estimated_tokens": 80_000,
-                    "compaction_trigger_estimated_tokens": 70_000,
+                    "prompt_budget_estimated_tokens": 40_000,
+                    "compaction_trigger_estimated_tokens": 35_000,
                     "compaction_keep_recent_estimated_tokens": 4_000,
                 },
             )
@@ -1492,8 +1538,8 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(
             compaction["model_runtime_override"],
             {
-                "prompt_budget_estimated_tokens": 80000,
-                "compaction_trigger_estimated_tokens": 70000,
+                "prompt_budget_estimated_tokens": 40000,
+                "compaction_trigger_estimated_tokens": 35000,
                 "compaction_keep_recent_estimated_tokens": 4000,
             },
         )

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -463,6 +463,67 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(response["output"][0]["name"], "GetWorkspaceState")
         self.assertEqual(scenario.phase, 8)
 
+    def test_openai_stub_operator_wait_uses_operator_input_wake(self) -> None:
+        scenario = stub.Scenario("scheduler-operator")
+        scenario.phase = 2
+        scenario.work_ids = ["work_0123456789abcde"]
+
+        status, response = scenario.consume({"input": []})
+
+        self.assertEqual(status, 200)
+        call = response["output"][0]
+        self.assertEqual(call["name"], "WaitFor")
+        self.assertEqual(json.loads(call["arguments"])["wake"], "operator_input")
+
+    def test_openai_stub_task_wait_closes_creation_turn(self) -> None:
+        scenario = stub.Scenario("scheduler-task-wait")
+        scenario.phase = 1
+        scenario.work_ids = ["work_0123456789abcde"]
+        scenario.markers = {"task_result": "SCHEDULER-TASK-RESULT-abcd"}
+
+        status, response = scenario.consume({"input": []})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["type"], "message")
+        self.assertEqual(scenario.phase, 2)
+
+        status, response = scenario.consume({"input": []})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["name"], "ExecCommand")
+
+    def test_openai_stub_concurrent_callback_starts_a_resume_tools(self) -> None:
+        scenario = stub.Scenario("scheduler-concurrent")
+        scenario.phase = 6
+        scenario.work_ids = [
+            "work_0123456789abcde",
+            "work_fedcba987654321",
+        ]
+        scenario.markers = {"concurrent_a": "SCHEDULER-CONCURRENT-A-abcd"}
+        callback = {
+            "input": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": (
+                                "## current_input\nCurrent input:\n"
+                                "- [system][trigger:system_tick] "
+                                "SCHEDULER-CONCURRENT-A-abcd"
+                            ),
+                        }
+                    ],
+                }
+            ]
+        }
+
+        status, response = scenario.consume(callback)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["output"][0]["name"], "GetWorkItem")
+        self.assertEqual(scenario.phase, 8)
+
     def test_openai_stub_registers_every_required_scenario(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")
         selected = runner.select_cases(
@@ -500,7 +561,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "UpdateWorkItem", "CompleteWorkItem",
             ],
             "scheduler-concurrent": [
-                "CreateWorkItem", "PickWorkItem", "WaitFor", "CreateWorkItem",
+                "CreateWorkItem", "PickWorkItem", "WaitFor",
                 "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
                 "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
             ],
@@ -573,7 +634,17 @@ class DockerE2ERunnerTests(unittest.TestCase):
             scenario = stub.Scenario(name)
             actual = []
             for _ in range(scenario.expected_phase()):
-                status, value = scenario.consume(request)
+                phase_request = request
+                if name == "scheduler-concurrent" and scenario.phase == 6:
+                    phase_request = {
+                        "input": [
+                            {
+                                "type": "function_call_output",
+                                "output": "{}",
+                            }
+                        ]
+                    }
+                status, value = scenario.consume(phase_request)
                 self.assertEqual(status, 200, name)
                 actual.extend(
                     item["name"]
@@ -1649,6 +1720,60 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 callback_external_trigger_id="trigger-target",
             )
 
+    def test_canonical_wait_terminal_requires_callback_evidence(self) -> None:
+        harness = type(
+            "CanonicalHarness",
+            (),
+            {"canonical_scheduler_enabled": True},
+        )()
+        snapshot = {
+            "wait_conditions": [
+                {
+                    "wait_condition_id": "wait-1",
+                    "work_item_id": "work-1",
+                    "kind": "external",
+                    "status": "resolved",
+                }
+            ],
+            "audit_events": [],
+        }
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "lacked callback trigger evidence",
+        ):
+            runner.require_scheduler_wait_terminal(
+                harness,
+                snapshot,
+                work_item_id="work-1",
+                wait_kind="external",
+                require_callback_trigger=True,
+                callback_external_trigger_id="trigger-target",
+            )
+
+        snapshot["audit_events"] = [
+            {
+                "kind": "callback_delivered",
+                "data_json": json.dumps(
+                    {
+                        "data": {
+                            "disposition": "triggered",
+                            "external_trigger_id": "trigger-target",
+                        }
+                    }
+                ),
+            }
+        ]
+        waits = runner.require_scheduler_wait_terminal(
+            harness,
+            snapshot,
+            work_item_id="work-1",
+            wait_kind="external",
+            require_callback_trigger=True,
+            callback_external_trigger_id="trigger-target",
+        )
+        self.assertEqual(waits[0]["status"], "resolved")
+
     def test_canonical_activation_oracle_distinguishes_lifecycle_and_work_item(self) -> None:
         harness = type(
             "CanonicalHarness",
@@ -1710,14 +1835,14 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 lifecycle_message_ids={"message-create"},
             )
 
-    def test_compaction_oracle_requires_actual_compacted_rounds(self) -> None:
+    def test_compaction_oracle_requires_actual_compaction_evidence(self) -> None:
         event = {
             "kind": "turn_local_compaction_applied",
             "data_json": json.dumps(
                 {"data": {"compacted_rounds": 2, "exact_tail_rounds": 1}}
             ),
         }
-        events = runner.require_turn_local_compaction(
+        events = runner.require_compaction_evidence(
             {"audit_events": [event]},
             label="test",
         )
@@ -1726,13 +1851,25 @@ class DockerE2ERunnerTests(unittest.TestCase):
         event["data_json"] = json.dumps(
             {"data": {"compacted_rounds": 0, "exact_tail_rounds": 3}}
         )
+        context_event = {
+            "kind": "provider_round_completed",
+            "data_json": json.dumps({"data": {"compression_epoch": 1}}),
+        }
+        events = runner.require_compaction_evidence(
+            {"audit_events": [event, context_event]},
+            label="test",
+            previous_compression_epoch=0,
+        )
+        self.assertEqual(events[0]["compression_epoch"], 1)
+
         with self.assertRaisesRegex(
             AssertionError,
-            "compaction stimulus did not produce compacted rounds",
+            "compaction stimulus did not produce compaction evidence",
         ):
-            runner.require_turn_local_compaction(
-                {"audit_events": [event]},
+            runner.require_compaction_evidence(
+                {"audit_events": [event, context_event]},
                 label="test",
+                previous_compression_epoch=1,
             )
 
     def test_wait_work_item_fails_fast_on_duplicate_objective_marker(self) -> None:

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2431,7 +2431,7 @@ export interface components {
                 agent_id: string;
                 blocked_by?: string | null;
                 /** @enum {string} */
-                candidate_class: "current_runnable" | "triggered_blocked" | "queued_runnable" | "waiting_for_operator" | "yielded" | "blocked" | "completed_recent";
+                candidate_class: "current_runnable" | "triggered_blocked" | "queued_runnable" | "waiting_for_operator" | "yielded" | "blocked" | "completing" | "completed_recent";
                 /** Format: date-time */
                 created_at: string;
                 current_todo?: {
@@ -2440,7 +2440,7 @@ export interface components {
                     text: string;
                 } | null;
                 /** @enum {string} */
-                focus: "current" | "queued" | "yielded" | "blocked" | "completed";
+                focus: "current" | "queued" | "yielded" | "blocked" | "completing" | "completed";
                 id: string;
                 is_current: boolean;
                 is_runnable: boolean;
@@ -2448,9 +2448,9 @@ export interface components {
                 /** @enum {string} */
                 plan_status: "draft" | "ready" | "needs_input";
                 /** @enum {string} */
-                readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed";
+                readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completing" | "completed";
                 /** @enum {string} */
-                reason_code: "completed" | "continuation_yielded" | "active_task_wait" | "active_operator_wait" | "active_timer_wait" | "active_external_wait" | "active_system_wait" | "manual_blocker" | "plan_needs_input" | "runnable";
+                reason_code: "completing" | "completed" | "continuation_yielded" | "active_task_wait" | "active_operator_wait" | "active_timer_wait" | "active_external_wait" | "active_system_wait" | "manual_blocker" | "plan_needs_input" | "runnable";
                 /** Format: date-time */
                 recheck_at?: string | null;
                 result_brief_id?: string | null;
@@ -2458,9 +2458,9 @@ export interface components {
                 /** Format: uint64 */
                 revision: number;
                 /** @enum {string} */
-                scheduling_state: "runnable" | "yielded_to_work_item" | "waiting_operator" | "waiting_task" | "waiting_external" | "waiting_timer" | "waiting_system" | "blocked" | "completed";
+                scheduling_state: "runnable" | "yielded_to_work_item" | "waiting_operator" | "waiting_task" | "waiting_external" | "waiting_timer" | "waiting_system" | "blocked" | "completing" | "completed";
                 /** @enum {string} */
-                state: "open" | "completed";
+                state: "open" | "completing" | "completed";
                 turn_id?: string | null;
                 /** Format: date-time */
                 updated_at: string;
@@ -2592,6 +2592,7 @@ export interface components {
         CompleteWorkItemRequest: {
             /** @enum {string|null} */
             authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+            report_text: string;
         };
         /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
         ControlPromptRequest: {
@@ -3008,7 +3009,7 @@ export interface components {
                  */
                 revision: number;
                 /** @enum {string} */
-                state: "open" | "completed";
+                state: "open" | "completing" | "completed";
                 todo_list?: {
                     /** @enum {string} */
                     state: "pending" | "in_progress" | "completed";
@@ -3091,7 +3092,7 @@ export interface components {
                  */
                 revision: number;
                 /** @enum {string} */
-                state: "open" | "completed";
+                state: "open" | "completing" | "completed";
                 todo_list?: {
                     /** @enum {string} */
                     state: "pending" | "in_progress" | "completed";
@@ -3123,10 +3124,10 @@ export interface components {
                 cancelled_wait_condition_ids?: string[];
                 current_focus_mode: string;
                 /** @enum {string} */
-                current_readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed";
+                current_readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completing" | "completed";
                 current_work_item_id: string;
                 /** @enum {string|null} */
-                previous_readiness?: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed" | null;
+                previous_readiness?: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completing" | "completed" | null;
                 previous_work_item_id?: string | null;
                 reason?: string | null;
                 switch_kind: string;
@@ -3524,7 +3525,7 @@ export interface components {
             agent_id: string;
             blocked_by?: string | null;
             /** @enum {string} */
-            candidate_class: "current_runnable" | "triggered_blocked" | "queued_runnable" | "waiting_for_operator" | "yielded" | "blocked" | "completed_recent";
+            candidate_class: "current_runnable" | "triggered_blocked" | "queued_runnable" | "waiting_for_operator" | "yielded" | "blocked" | "completing" | "completed_recent";
             /** Format: date-time */
             created_at: string;
             current_todo?: {
@@ -3533,7 +3534,7 @@ export interface components {
                 text: string;
             } | null;
             /** @enum {string} */
-            focus: "current" | "queued" | "yielded" | "blocked" | "completed";
+            focus: "current" | "queued" | "yielded" | "blocked" | "completing" | "completed";
             id: string;
             is_current: boolean;
             is_runnable: boolean;
@@ -3541,9 +3542,9 @@ export interface components {
             /** @enum {string} */
             plan_status: "draft" | "ready" | "needs_input";
             /** @enum {string} */
-            readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completed";
+            readiness: "runnable" | "yielded" | "waiting_for_operator" | "blocked" | "completing" | "completed";
             /** @enum {string} */
-            reason_code: "completed" | "continuation_yielded" | "active_task_wait" | "active_operator_wait" | "active_timer_wait" | "active_external_wait" | "active_system_wait" | "manual_blocker" | "plan_needs_input" | "runnable";
+            reason_code: "completing" | "completed" | "continuation_yielded" | "active_task_wait" | "active_operator_wait" | "active_timer_wait" | "active_external_wait" | "active_system_wait" | "manual_blocker" | "plan_needs_input" | "runnable";
             /** Format: date-time */
             recheck_at?: string | null;
             result_brief_id?: string | null;
@@ -3551,9 +3552,9 @@ export interface components {
             /** Format: uint64 */
             revision: number;
             /** @enum {string} */
-            scheduling_state: "runnable" | "yielded_to_work_item" | "waiting_operator" | "waiting_task" | "waiting_external" | "waiting_timer" | "waiting_system" | "blocked" | "completed";
+            scheduling_state: "runnable" | "yielded_to_work_item" | "waiting_operator" | "waiting_task" | "waiting_external" | "waiting_timer" | "waiting_system" | "blocked" | "completing" | "completed";
             /** @enum {string} */
-            state: "open" | "completed";
+            state: "open" | "completing" | "completed";
             turn_id?: string | null;
             /** Format: date-time */
             updated_at: string;
@@ -4220,7 +4221,7 @@ export interface components {
              */
             revision: number;
             /** @enum {string} */
-            state: "open" | "completed";
+            state: "open" | "completing" | "completed";
             todo_list?: {
                 /** @enum {string} */
                 state: "pending" | "in_progress" | "completed";


### PR DESCRIPTION
## 概要

将 Docker scheduler E2E 从 live-model release acceptance 拆成两个相互独立的契约：

- `scheduler-required`：本地 deterministic OpenAI Responses stub 驱动全部 11 个 scheduler invariant case，并在 `legacy` / `canonical` 双引擎上形成阻塞 required matrix。
- `scheduler-live-canary`：只运行一个真实 provider/model smoke case，以观察模式记录 model route、provider attempts/retries、tool counts 与 behavioral variance；失败不覆盖 deterministic gate 结果。

## 主要改动

- 为原先必须依赖 live model 的 8 个 scheduler case 增加 deterministic stub transcript，并校验全部 required scenario 能精确消费到 completion。
- manifest 明确 `gate_kind`、`provider_mode`、`tool_assertion_mode`、case/coverage 集合，并把单 case timeout 收敛到 120 秒。
- runner 增加 live canary report，按事件序号去重 provider/tool metrics，保留严格 runtime invariant 与 secret/schema/coverage 检查。
- PR、nightly、release workflow 分离 deterministic gate 与 optional live canary；nightly 在没有 provider secret 时仍先执行 required matrix。
- PR/nightly/release summary 与 artifact 均保留 canary provider/model/retry/tool variance evidence。
- 更新 Makefile、scheduler E2E 文档与 workflow/profile/reporting 单测。

## 验证

- `python3 -m unittest tests.test_docker_e2e_runner tests.test_scheduler_drill`（72 tests）
- `make docker-e2e-validate`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- workflow YAML parse、Python `py_compile`、`git diff --check`
