### PR TITLE
fix: make scheduler nightly canary configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,8 +258,12 @@ jobs:
     continue-on-error: true
     timeout-minutes: 20
     env:
-      HOLON_E2E_MODEL: ${{ vars.HOLON_E2E_SCHEDULER_MODEL || 'deepseek/deepseek-v4-flash' }}
+      HOLON_E2E_MODEL: ${{ vars.HOLON_E2E_SCHEDULER_MODEL || 'dashscope-token-plan/qwen-3.7' }}
+      HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
+      HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
+      HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
       HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
+      HOLON_E2E_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
 
@@ -276,27 +280,38 @@ jobs:
           cache-from: type=gha,scope=holon-docker
           cache-to: type=gha,mode=max,scope=holon-docker
 
-      - name: Prepare provider environment
-        env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      - name: Prepare provider configuration
         run: |
           set -euo pipefail
-          test -n "${DEEPSEEK_API_KEY}"
+          test -n "${HOLON_E2E_CREDENTIAL}"
+          [[ "${HOLON_E2E_CREDENTIAL_ENV}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
           umask 077
-          printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
+          printf '%s=%s\n' \
+            "${HOLON_E2E_CREDENTIAL_ENV}" \
+            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
           chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+          if [ -n "${HOLON_E2E_CONFIG_JSON}" ]; then
+            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_CONFIG_FILE}"
+            python3 -m json.tool "${HOLON_E2E_CONFIG_FILE}" >/dev/null
+            chmod 0600 "${HOLON_E2E_CONFIG_FILE}"
+          fi
 
       - name: Run scheduler live canary
         run: |
           set -euo pipefail
-          python3 scripts/docker-e2e.py \
-            --image holon:e2e \
-            --skip-build \
-            --profile scheduler-live-canary \
-            --scheduler-matrix \
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
-            --timeout 120 \
+          args=(
+            --image holon:e2e
+            --skip-build
+            --profile scheduler-live-canary
+            --scheduler-matrix
+            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
+          )
+          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          fi
+          python3 scripts/docker-e2e.py "${args[@]}"
 
       - name: Publish live canary summary
         if: always()
@@ -330,9 +345,9 @@ jobs:
           name: scheduler-live-canary
           path: target/docker-e2e/scheduler-live-canary
 
-      - name: Remove provider environment
+      - name: Remove provider configuration
         if: always()
-        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}"
+        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}" "${HOLON_E2E_CONFIG_FILE}"
 
   scheduler-e2e-required:
     name: Scheduler E2E Required

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -60,13 +60,26 @@ jobs:
               await core.summary.write();
               return;
             }
-            const comparison = await github.rest.repos.compareCommitsWithBasehead({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              basehead: `${previous.head_sha}...${context.sha}`,
-              per_page: 100,
-            });
+            let comparison;
+            try {
+              comparison = await github.rest.repos.compareCommitsWithBasehead({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                basehead: `${previous.head_sha}...${context.sha}`,
+                per_page: 100,
+              });
+            } catch (error) {
+              core.warning(`Unable to compare commits: ${error.message}`);
+              core.setOutput("should-run", "true");
+              core.summary.addRaw(
+                `Unable to compare with scheduled run ${previous.id}; running E2E.\n`
+              );
+              await core.summary.write();
+              return;
+            }
             const files = comparison.data.files || [];
+            const truncated =
+              comparison.data.truncation === true || files.length >= 100;
             const exact = new Set([
               ".dockerignore",
               "Cargo.toml",
@@ -89,10 +102,12 @@ jobs:
               file => exact.has(file.filename)
                 || prefixes.some(prefix => file.filename.startsWith(prefix))
             );
-            const shouldRun = files.length >= 300 || changed.length > 0;
+            const shouldRun = truncated || changed.length > 0;
             core.setOutput("should-run", shouldRun ? "true" : "false");
             core.summary.addRaw(
-              shouldRun
+              truncated
+                ? `Commit comparison since run ${previous.id} was truncated; running E2E.\n`
+                : shouldRun
                 ? `Scheduler-relevant changes found since run ${previous.id}; running E2E.\n`
                 : `Only non-code changes found since run ${previous.id}; skipping E2E.\n`
             );

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -9,20 +9,108 @@ on:
       model:
         description: Real model route for E2E.
         required: false
-        default: deepseek/deepseek-v4-flash
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
 jobs:
+  changes:
+    name: Detect scheduler code changes
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.detect.outputs.should-run }}
+    steps:
+      - name: Compare with previous scheduled run
+        id: detect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName !== "schedule") {
+              core.setOutput("should-run", "true");
+              core.summary.addRaw("Manual dispatch: running scheduler E2E.\n");
+              await core.summary.write();
+              return;
+            }
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "e2e-scheduler-nightly.yml",
+                event: "schedule",
+                per_page: 100,
+              }
+            );
+            const previous = runs.find(
+              run => run.id !== context.runId && run.status === "completed"
+            );
+            if (!previous) {
+              core.setOutput("should-run", "true");
+              core.summary.addRaw("No previous scheduled run: running scheduler E2E.\n");
+              await core.summary.write();
+              return;
+            }
+            if (previous.head_sha === context.sha) {
+              core.setOutput("should-run", "false");
+              core.summary.addRaw(
+                `No commits since scheduled run ${previous.id}; skipping scheduler E2E.\n`
+              );
+              await core.summary.write();
+              return;
+            }
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${previous.head_sha}...${context.sha}`,
+              per_page: 100,
+            });
+            const files = comparison.data.files || [];
+            const exact = new Set([
+              ".dockerignore",
+              "Cargo.toml",
+              "Cargo.lock",
+              "Dockerfile",
+              "Makefile",
+              "build.rs",
+              "scripts/docker-e2e.py",
+              ".github/workflows/e2e-scheduler-nightly.yml",
+              ".github/workflows/release-e2e.yml",
+            ]);
+            const prefixes = [
+              "src/",
+              "tests/",
+              "agent_templates/",
+              "builtin_templates/",
+              "scripts/docker_e2e/",
+            ];
+            const changed = files.filter(
+              file => exact.has(file.filename)
+                || prefixes.some(prefix => file.filename.startsWith(prefix))
+            );
+            const shouldRun = files.length >= 300 || changed.length > 0;
+            core.setOutput("should-run", shouldRun ? "true" : "false");
+            core.summary.addRaw(
+              shouldRun
+                ? `Scheduler-relevant changes found since run ${previous.id}; running E2E.\n`
+                : `Only non-code changes found since run ${previous.id}; skipping E2E.\n`
+            );
+            await core.summary.write();
+
   nightly:
     name: Scheduler E2E Nightly
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      HOLON_E2E_MODEL: ${{ inputs.model || 'deepseek/deepseek-v4-flash' }}
+      HOLON_E2E_MODEL: ${{ inputs.model || vars.HOLON_E2E_SCHEDULER_MODEL || 'dashscope-token-plan/qwen-3.7' }}
+      HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
+      HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
+      HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
       HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
+      HOLON_E2E_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
 
@@ -50,17 +138,23 @@ jobs:
             --timeout 120 \
             --evidence-dir target/docker-e2e/scheduler-required
 
-      - name: Prepare provider environment
+      - name: Prepare provider configuration
         id: provider-env
         continue-on-error: true
-        env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: |
           set -euo pipefail
-          test -n "${DEEPSEEK_API_KEY}"
+          test -n "${HOLON_E2E_CREDENTIAL}"
+          [[ "${HOLON_E2E_CREDENTIAL_ENV}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
           umask 077
-          printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
+          printf '%s=%s\n' \
+            "${HOLON_E2E_CREDENTIAL_ENV}" \
+            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
           chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+          if [ -n "${HOLON_E2E_CONFIG_JSON}" ]; then
+            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_CONFIG_FILE}"
+            python3 -m json.tool "${HOLON_E2E_CONFIG_FILE}" >/dev/null
+            chmod 0600 "${HOLON_E2E_CONFIG_FILE}"
+          fi
 
       - name: Run scheduler live canary
         id: live-canary
@@ -68,14 +162,19 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          python3 scripts/docker-e2e.py \
-            --image holon:nightly \
-            --skip-build \
-            --profile scheduler-live-canary \
-            --scheduler-matrix \
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
-            --timeout 120 \
+          args=(
+            --image holon:nightly
+            --skip-build
+            --profile scheduler-live-canary
+            --scheduler-matrix
+            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
+          )
+          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          fi
+          python3 scripts/docker-e2e.py "${args[@]}"
 
       - name: Publish run summary
         if: always()
@@ -145,6 +244,6 @@ jobs:
               await github.rest.issues.create(issueParams);
             }
 
-      - name: Remove provider environment
+      - name: Remove provider configuration
         if: always()
-        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}"
+        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}" "${HOLON_E2E_CONFIG_FILE}"

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -33,85 +33,83 @@ jobs:
               await core.summary.write();
               return;
             }
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "e2e-scheduler-nightly.yml",
-                event: "schedule",
-                per_page: 100,
-              }
-            );
-            const previous = runs.find(
-              run => run.id !== context.runId && run.status === "completed"
-            );
-            if (!previous) {
-              core.setOutput("should-run", "true");
-              core.summary.addRaw("No previous scheduled run: running scheduler E2E.\n");
-              await core.summary.write();
-              return;
-            }
-            if (previous.head_sha === context.sha) {
-              core.setOutput("should-run", "false");
-              core.summary.addRaw(
-                `No commits since scheduled run ${previous.id}; skipping scheduler E2E.\n`
-              );
-              await core.summary.write();
-              return;
-            }
-            let comparison;
             try {
-              comparison = await github.rest.repos.compareCommitsWithBasehead({
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: "e2e-scheduler-nightly.yml",
+                  event: "schedule",
+                  per_page: 100,
+                }
+              );
+              const previous = runs.find(
+                run => run.id !== context.runId && run.status === "completed"
+              );
+              if (!previous) {
+                core.setOutput("should-run", "true");
+                core.summary.addRaw("No previous scheduled run: running scheduler E2E.\n");
+                await core.summary.write();
+                return;
+              }
+              if (previous.head_sha === context.sha) {
+                core.setOutput("should-run", "false");
+                core.summary.addRaw(
+                  `No commits since scheduled run ${previous.id}; skipping scheduler E2E.\n`
+                );
+                await core.summary.write();
+                return;
+              }
+              const comparison = await github.rest.repos.compareCommitsWithBasehead({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 basehead: `${previous.head_sha}...${context.sha}`,
                 per_page: 100,
               });
-            } catch (error) {
-              core.warning(`Unable to compare commits: ${error.message}`);
-              core.setOutput("should-run", "true");
+              const files = comparison.data.files || [];
+              const truncated =
+                comparison.data.truncation === true || files.length >= 300;
+              const exact = new Set([
+                ".dockerignore",
+                "Cargo.toml",
+                "Cargo.lock",
+                "Dockerfile",
+                "Makefile",
+                "build.rs",
+                "scripts/docker-e2e.py",
+                ".github/workflows/e2e-scheduler-nightly.yml",
+                ".github/workflows/release-e2e.yml",
+              ]);
+              const prefixes = [
+                "src/",
+                "tests/",
+                "agent_templates/",
+                "builtin_templates/",
+                "scripts/docker_e2e/",
+              ];
+              const changed = files.filter(
+                file => exact.has(file.filename)
+                  || prefixes.some(prefix => file.filename.startsWith(prefix))
+              );
+              const shouldRun = truncated || changed.length > 0;
+              core.setOutput("should-run", shouldRun ? "true" : "false");
               core.summary.addRaw(
-                `Unable to compare with scheduled run ${previous.id}; running E2E.\n`
+                truncated
+                  ? `Commit comparison since run ${previous.id} was truncated; running E2E.\n`
+                  : shouldRun
+                  ? `Scheduler-relevant changes found since run ${previous.id}; running E2E.\n`
+                  : `Only non-code changes found since run ${previous.id}; skipping E2E.\n`
               );
               await core.summary.write();
-              return;
+            } catch (error) {
+              core.warning(`Unable to detect scheduler code changes: ${error.message}`);
+              core.setOutput("should-run", "true");
+              core.summary.addRaw(
+                "Unable to detect scheduler code changes; running E2E.\n"
+              );
+              await core.summary.write();
             }
-            const files = comparison.data.files || [];
-            const truncated =
-              comparison.data.truncation === true || files.length >= 100;
-            const exact = new Set([
-              ".dockerignore",
-              "Cargo.toml",
-              "Cargo.lock",
-              "Dockerfile",
-              "Makefile",
-              "build.rs",
-              "scripts/docker-e2e.py",
-              ".github/workflows/e2e-scheduler-nightly.yml",
-              ".github/workflows/release-e2e.yml",
-            ]);
-            const prefixes = [
-              "src/",
-              "tests/",
-              "agent_templates/",
-              "builtin_templates/",
-              "scripts/docker_e2e/",
-            ];
-            const changed = files.filter(
-              file => exact.has(file.filename)
-                || prefixes.some(prefix => file.filename.startsWith(prefix))
-            );
-            const shouldRun = truncated || changed.length > 0;
-            core.setOutput("should-run", shouldRun ? "true" : "false");
-            core.summary.addRaw(
-              truncated
-                ? `Commit comparison since run ${previous.id} was truncated; running E2E.\n`
-                : shouldRun
-                ? `Scheduler-relevant changes found since run ${previous.id}; running E2E.\n`
-                : `Only non-code changes found since run ${previous.id}; skipping E2E.\n`
-            );
-            await core.summary.write();
 
   nightly:
     name: Scheduler E2E Nightly

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -15,7 +15,6 @@ on:
       model:
         description: Real model route.
         required: false
-        default: deepseek/deepseek-v4-flash
 
 permissions:
   contents: read
@@ -82,8 +81,12 @@ jobs:
       packages: read
     env:
       CANDIDATE_IMAGE: ${{ needs.candidate.outputs.image }}@${{ needs.candidate.outputs.digest }}
-      HOLON_E2E_MODEL: ${{ inputs.model }}
+      HOLON_E2E_MODEL: ${{ inputs.model || vars.HOLON_E2E_SCHEDULER_MODEL || 'dashscope-token-plan/qwen-3.7' }}
+      HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
+      HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
+      HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
       HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
+      HOLON_E2E_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -96,15 +99,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare protected provider environment
-        env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      - name: Prepare protected provider configuration
         run: |
           set -euo pipefail
-          test -n "${DEEPSEEK_API_KEY}"
+          test -n "${HOLON_E2E_CREDENTIAL}"
+          [[ "${HOLON_E2E_CREDENTIAL_ENV}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
           umask 077
-          printf 'DEEPSEEK_API_KEY=%s\n' "${DEEPSEEK_API_KEY}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
+          printf '%s=%s\n' \
+            "${HOLON_E2E_CREDENTIAL_ENV}" \
+            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
           chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+          if [ -n "${HOLON_E2E_CONFIG_JSON}" ]; then
+            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_CONFIG_FILE}"
+            python3 -m json.tool "${HOLON_E2E_CONFIG_FILE}" >/dev/null
+            chmod 0600 "${HOLON_E2E_CONFIG_FILE}"
+          fi
 
       - name: Pull and smoke candidate digest
         run: |
@@ -124,6 +133,9 @@ jobs:
             --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
             --evidence-dir target/docker-e2e/release-core
           )
+          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          fi
           if [ -n "${HOLON_E2E_PREVIOUS_IMAGE}" ]; then
             args+=(--previous-image "${HOLON_E2E_PREVIOUS_IMAGE}")
           fi
@@ -144,14 +156,19 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          python3 scripts/docker-e2e.py \
-            --image-digest "${CANDIDATE_IMAGE}" \
-            --skip-build \
-            --profile scheduler-live-canary \
-            --scheduler-matrix \
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}" \
-            --timeout 120 \
+          args=(
+            --image-digest "${CANDIDATE_IMAGE}"
+            --skip-build
+            --profile scheduler-live-canary
+            --scheduler-matrix
+            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
+          )
+          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          fi
+          python3 scripts/docker-e2e.py "${args[@]}"
 
       - name: Publish run summary
         if: always()
@@ -343,6 +360,6 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      - name: Remove provider environment
+      - name: Remove provider configuration
         if: always()
-        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}"
+        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}" "${HOLON_E2E_CONFIG_FILE}"

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ passed for the exact tag commit and intended release tag. That workflow builds
 one candidate image after protected-environment approval, records its immutable
 digest, runs the production image smoke test, executes the real-LLM core suite
 against that exact digest, and uploads a machine-readable attestation. The
-default model route is `deepseek/deepseek-v4-flash`.
+default model route is `dashscope-token-plan/qwen-3.7`.
 
 ## Versioning
 

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -81,6 +81,21 @@ credential variable names and whether a file was used. It never records the
 file path or values. Existing `HOLON_LIVE_*` variables remain accepted during
 the compatibility period.
 
+Pass `--config-file` or set `HOLON_E2E_CONFIG_FILE` to seed a non-secret Holon
+`config.json` into each case volume. Keep credentials in the env file rather
+than the config file. The protected CI, nightly, and release workflows expose
+the same split through repository configuration:
+
+- `HOLON_E2E_SCHEDULER_MODEL`: model route; defaults to the same
+  `dashscope-token-plan/qwen-3.7` route used by `holon-trigger`.
+- `HOLON_E2E_SCHEDULER_CREDENTIAL_ENV`: provider credential variable name.
+- `HOLON_E2E_SCHEDULER_CONFIG_JSON`: optional non-secret `config.json` content.
+- `HOLON_E2E_SCHEDULER_CREDENTIAL`: Secret containing the credential value.
+
+The scheduled scheduler workflow compares the current revision with the
+previous scheduled run and skips the expensive Docker matrix when no
+scheduler-relevant code changed. Manual dispatch always runs.
+
 The checked-in case definitions live in
 `tests/e2e/docker/manifest.json`. The stable runner is
 `scripts/docker-e2e.py`; `scripts/docker-live-acceptance.py` remains a

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import os
@@ -139,6 +140,30 @@ def normalize_model_route(model: str) -> str:
     return f"{provider}/{name}"
 
 
+def load_runtime_config(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    require(path.is_file(), f"config file does not exist: {path}")
+    value = json.loads(path.read_text())
+    require(isinstance(value, dict), "config file must contain a JSON object")
+    return value
+
+
+def merged_runtime_config(
+    config: dict[str, Any],
+    model: str,
+    model_runtime_override: dict[str, int] | None,
+) -> dict[str, Any]:
+    merged = copy.deepcopy(config)
+    if model_runtime_override:
+        models = merged.setdefault("models", {})
+        require(isinstance(models, dict), "config models must be a JSON object")
+        catalog = models.setdefault("catalog", {})
+        require(isinstance(catalog, dict), "config models.catalog must be a JSON object")
+        catalog[model] = dict(model_runtime_override)
+    return merged
+
+
 def provider_base_url_env(model: str) -> str:
     route = model.split("/", 1)[0]
     provider, separator, endpoint = route.partition("@")
@@ -177,6 +202,7 @@ class CaseHarness:
         evidence_root: Path,
         timeout_seconds: int,
         keep: bool,
+        runtime_config: dict[str, Any] | None = None,
         provider_mode: str = "live",
         stub_scenario: str | None = None,
         model_runtime_override: dict[str, int] | None = None,
@@ -194,6 +220,7 @@ class CaseHarness:
         )
         self.credential_envs = credential_envs if requires_model else []
         self.env_file = env_file if requires_model else None
+        self.runtime_config = copy.deepcopy(runtime_config or {})
         self.runtime_env = dict(runtime_env)
         if not requires_model:
             self.runtime_env.setdefault(
@@ -514,14 +541,15 @@ class CaseHarness:
                 self.stub_provider_base_url or "http://provider-stub:8080/v1"
             )
             self.runtime_env["OPENAI_API_KEY"] = "deterministic-test-key"
-        if self.model_runtime_override and not self._model_runtime_override_seeded:
-            config = {
-                "models": {
-                    "catalog": {
-                        self.model: self.model_runtime_override,
-                    }
-                }
-            }
+        if (
+            (self.runtime_config or self.model_runtime_override)
+            and not self._model_runtime_override_seeded
+        ):
+            config = merged_runtime_config(
+                self.runtime_config,
+                self.model,
+                self.model_runtime_override,
+            )
             self.docker(
                 "run",
                 "--rm",
@@ -4634,6 +4662,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--profile")
     parser.add_argument("--env-file", type=Path)
+    parser.add_argument("--config-file", type=Path)
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--evidence-dir", type=Path)
     parser.add_argument("--keep-on-failure", action="store_true")
@@ -4686,6 +4715,9 @@ def main(argv: list[str] | None = None) -> int:
         "HOLON_E2E_DOCKER_ENV_FILE", "HOLON_LIVE_DOCKER_ENV_FILE"
     )
     env_file = Path(env_file_value).resolve() if env_file_value else None
+    config_file_value = args.config_file or first_env("HOLON_E2E_CONFIG_FILE")
+    config_file = Path(config_file_value).resolve() if config_file_value else None
+    runtime_config = load_runtime_config(config_file)
     if requires_model and not credential_envs and env_file is None:
         inferred = inferred_credential_env(model)
         require(
@@ -4745,6 +4777,7 @@ def main(argv: list[str] | None = None) -> int:
         "cases": [case["id"] for case in selected],
         "credential_env_names": credential_envs,
         "env_file_used": env_file is not None,
+        "config_file_used": config_file is not None,
         "manifest_sha256": hashlib.sha256(args.manifest.read_bytes()).hexdigest(),
         "scheduler_matrix": args.scheduler_matrix,
         "profile": args.profile,
@@ -4800,6 +4833,7 @@ def main(argv: list[str] | None = None) -> int:
             requires_model=case.get("requires_model", True),
             credential_envs=credential_envs,
             env_file=env_file,
+            runtime_config=runtime_config,
             runtime_env=runtime_env,
             evidence_root=evidence_root,
             timeout_seconds=(

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -228,9 +228,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn("name: scheduler-e2e-nightly", nightly)
         self.assertIn("Detect scheduler code changes", nightly)
         self.assertIn("needs.changes.outputs.should-run == 'true'", nightly)
-        self.assertIn("Unable to compare commits", nightly)
+        self.assertIn("Unable to detect scheduler code changes", nightly)
         self.assertIn("comparison.data.truncation === true", nightly)
-        self.assertIn("files.length >= 100", nightly)
+        self.assertIn("files.length >= 300", nightly)
 
     def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -228,6 +228,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn("name: scheduler-e2e-nightly", nightly)
         self.assertIn("Detect scheduler code changes", nightly)
         self.assertIn("needs.changes.outputs.should-run == 'true'", nightly)
+        self.assertIn("Unable to compare commits", nightly)
+        self.assertIn("comparison.data.truncation === true", nightly)
+        self.assertIn("files.length >= 100", nightly)
 
     def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -70,6 +70,27 @@ class DockerE2ERunnerTests(unittest.TestCase):
             "ANTHROPIC_BASE_URL",
         )
 
+    def test_runtime_config_merges_model_override_without_mutating_source(self) -> None:
+        source = {"providers": {"custom": {"base_url": "https://example.invalid"}}}
+        merged = runner.merged_runtime_config(
+            source,
+            "custom/model",
+            {"max_output_tokens": 4096},
+        )
+
+        self.assertEqual(
+            merged["models"]["catalog"]["custom/model"]["max_output_tokens"],
+            4096,
+        )
+        self.assertNotIn("models", source)
+
+    def test_load_runtime_config_requires_json_object(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "config.json"
+            path.write_text("[]")
+            with self.assertRaisesRegex(AssertionError, "JSON object"):
+                runner.load_runtime_config(path)
+
     def test_work_queue_message_evidence_extracts_retry_identity(self) -> None:
         snapshot = {
             "messages": [
@@ -192,7 +213,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
 
         self.assertLess(
             nightly.index("Run deterministic scheduler matrix"),
-            nightly.index("Prepare provider environment"),
+            nightly.index("Prepare provider configuration"),
         )
         self.assertIn("if: steps.provider-env.outcome == 'success'", nightly)
         self.assertIn("continue-on-error: true", nightly)
@@ -200,8 +221,13 @@ class DockerE2ERunnerTests(unittest.TestCase):
             self.assertIn("scheduler-live-canary-report.json", workflow)
             self.assertIn("behavioral_variances", workflow)
             self.assertIn("tool_counts", workflow)
+            self.assertIn("HOLON_E2E_SCHEDULER_CREDENTIAL", workflow)
+            self.assertIn("HOLON_E2E_SCHEDULER_CONFIG_JSON", workflow)
+            self.assertIn("--config-file", workflow)
         self.assertIn("name: scheduler-live-canary", ci)
         self.assertIn("name: scheduler-e2e-nightly", nightly)
+        self.assertIn("Detect scheduler code changes", nightly)
+        self.assertIn("needs.changes.outputs.should-run == 'true'", nightly)
 
     def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")


### PR DESCRIPTION
## Summary

- make scheduler live-model canaries configurable across CI, nightly, and release workflows instead of requiring a hard-coded DeepSeek credential
- inject the selected credential through a generic protected secret and allow an optional non-sensitive Holon config file to be mounted into Docker E2E runs
- skip scheduled nightly execution when `main` has no commits newer than the previous scheduled run, while keeping manual dispatch available
- document the repository variable/secret contract and extend runner coverage for config-file injection

## Configuration

The workflows now support:

- `HOLON_E2E_SCHEDULER_MODEL` repository variable
- `HOLON_E2E_SCHEDULER_CREDENTIAL_ENV` repository variable
- `HOLON_E2E_SCHEDULER_CREDENTIAL` repository secret
- optional `HOLON_E2E_CONFIG_FILE` repository variable containing non-sensitive Holon JSON configuration

Raw credentials remain in GitHub Secrets and are written only to a permission-restricted temporary env file. The config file may reference credential profiles or provider routing but must not contain secrets.

## Nightly behavior

- `schedule`: run only when the current `main` SHA differs from the newest prior scheduled run SHA
- `workflow_dispatch`: always run, so operators can explicitly validate a model/configuration
- deterministic scheduler coverage remains independent of whether live-model credentials are configured

## Verification

- `python -m unittest tests.test_docker_e2e_runner`
- `actionlint .github/workflows/ci.yml .github/workflows/e2e-scheduler-nightly.yml .github/workflows/release-e2e.yml`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2470
Closes #2482
Closes #2483
Closes #2485
