### PR TITLE
fix: bind provider fallback to recovery messages

### DIFF
--- a/docs/implementation-decisions/027-provider-retry-classification.md
+++ b/docs/implementation-decisions/027-provider-retry-classification.md
@@ -5,8 +5,18 @@ Decision:
 - classify transport failures into retryable and fail-fast buckets
 - retry transient failures at most two times before moving to the next fallback
 - keep retry policy visible in diagnostics
+- classify a successfully completed wire response with no content/output items as
+  `empty_response + retryable`
+- keep non-empty responses whose items cannot be mapped to supported model blocks
+  as `invalid_response + fail_fast`
+- preserve token usage reported by failed responses in the provider attempt
+  timeline
 
 Reason:
 
 - some provider failures are recoverable on the same path
 - deterministic contract or auth failures should not burn retries
+- an empty completed response is an upstream availability failure, not evidence
+  that the response contract is unsupported
+- wire-item presence, rather than the final mapped block count alone, preserves
+  the distinction between transient emptiness and deterministic incompatibility

--- a/docs/rfcs/turn-model-lineage-and-recovery.md
+++ b/docs/rfcs/turn-model-lineage-and-recovery.md
@@ -157,10 +157,18 @@ This covers retryable failures such as:
 - rate limits
 - transient transport failures
 - provider service failures
+- completed provider responses that contain no wire content/output items
 
 Retry must not advance to a different model lineage inside the same turn.
 Cross-lineage fallback is a scheduling decision for the next turn, not a
 continuation of the current turn.
+
+A response is `empty_response + retryable` only when the wire response
+successfully completes but contains no content/output items. A non-empty wire
+response whose items are unknown or unsupported remains
+`invalid_response + fail_fast`. Token usage reported by an empty response is
+failure evidence and is included in the provider attempt timeline; it does not
+change the classification.
 
 ### 5.3 Cross-Lineage Fallback Defers To The Next Turn
 
@@ -234,6 +242,31 @@ and surface the failure to the operator instead of creating an infinite recovery
 loop. Holon must also prevent fallback loops where each new turn retries the
 same failed primary model instead of promoting the next candidate.
 
+### 5.6 Recovery Selection Is Message-Bound
+
+The fallback route is carried by a typed directive on the runtime-owned recovery
+message. It is accepted only when all provenance fields identify a runtime
+instruction emitted by the `model_lineage_recovery` subsystem. Operator,
+external, task, or ordinary internal metadata cannot select a fallback model.
+
+The claimed message is resolved once into a turn-local selection snapshot before
+the provider, context policy, tool surface, and prompt are built. Those surfaces
+all use the same snapshot. `AgentState.pending_fallback_model` remains readable
+for state-schema compatibility, but it is not a model-routing source and new
+execution paths do not write it.
+
+Recovery audit lifecycle is explicit:
+
+- `recovery_enqueued` means the recovery message and queue entry are durable.
+- `recovery_turn_started` is emitted only after that exact message is claimed
+  and its turn/run binding exists.
+- `recovery_superseded` means a still-queued recovery was atomically dropped
+  because a later successful turn for the same owner produced accepted
+  continuation progress.
+
+An unrelated, failed, empty, or no-op turn does not supersede recovery. A
+recovery that is already dequeued is never cancelled by this reconciliation.
+
 ## 6. Provider State Rules
 
 ### 6.1 Continuation State Is Lineage-Scoped
@@ -283,7 +316,9 @@ The runtime should make lineage reset explicit so diagnostics can say:
 - `pending_model_promoted`
 - `lineage_retry_exhausted`
 - `deferred_to_fallback`
+- `recovery_enqueued`
 - `recovery_turn_started`
+- `recovery_superseded`
 
 instead of only reporting a low-level request-shape mismatch.
 
@@ -363,14 +398,20 @@ first-class identity and reset reason.
    next-turn fallback/recovery.
 5. Add terminal kinds for retry exhaustion that distinguish
    `deferred_to_fallback` from `provider_failed_needs_recovery`.
-6. Add bounded recovery/fallback-turn enqueueing with loop prevention.
+6. Add bounded recovery/fallback-turn enqueueing with loop prevention and bind
+   the fallback route to the recovery message identity.
 7. Reset provider continuation explicitly when pending model or fallback
    selection is promoted at the next turn.
-8. Add tests for:
+8. Reconcile legacy `pending_fallback_model` state at bootstrap by discarding
+   the global slot; a durable typed recovery message, when present, remains the
+   only authoritative fallback selection.
+9. Add tests for:
    - retry stays on the same lineage inside a turn
    - pre-output cross-lineage fallback terminates the turn and queues a new one
    - post-output cross-lineage fallback terminates as recovery
    - recovery turn starts as a new turn
+   - ordinary queued messages cannot consume a recovery fallback
+   - enqueue, actual start, and supersession are distinct audit transitions
    - encrypted remote compaction is not replayed across lineage change
    - user model switch does not affect an already-running turn
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3042,6 +3042,40 @@ fn generate_image_selection_auto_uses_turn_chain() {
 }
 
 #[test]
+fn generate_image_selection_uses_current_turn_fallback_model() {
+    let mut fixture = test_app_config("openai/gpt-image-2", &["openai/recovery-image"]);
+    let recovery_model = ModelRef::parse("openai/recovery-image").unwrap();
+    let recovery_override = ModelRuntimeOverride {
+        capabilities: Some(ModelCapabilityOverride {
+            image_generation: Some(true),
+            ..ModelCapabilityOverride::default()
+        }),
+        ..ModelRuntimeOverride::default()
+    };
+    fixture
+        .config
+        .validated_model_overrides
+        .insert(recovery_model.clone(), recovery_override.clone());
+    fixture
+        .config
+        .stored_config
+        .models
+        .catalog
+        .insert(recovery_model.as_string(), recovery_override);
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let selected = catalog
+        .select_generate_image_model(
+            &ContextConfig::default(),
+            None,
+            Some(&route_ref("openai/recovery-image")),
+        )
+        .unwrap();
+
+    assert_eq!(selected.as_string(), "openai@default/recovery-image");
+}
+
+#[test]
 fn generate_image_selection_uses_explicit_image_generation_model() {
     let mut fixture = test_app_config("openai@default/gpt-image-2", &[]);
     fixture.config.image_generation_model = Some(route_ref("openai-codex@default/gpt-5.5"));

--- a/src/host.rs
+++ b/src/host.rs
@@ -1942,10 +1942,7 @@ impl RuntimeHost {
         let config = self.config();
         let model_catalog = RuntimeModelCatalog::from_config(&config);
         let model_ref = model_catalog
-            .provider_chain_for_turn(
-                state.model_override.as_ref(),
-                state.pending_fallback_model.as_ref(),
-            )
+            .provider_chain(state.model_override.as_ref())
             .into_iter()
             .next()
             .unwrap_or_else(|| {

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 use super::{
     aggregate_attempt_token_usage,
     catalog::ProviderCandidate,
-    provider_transport_diagnostics, provider_turn_error,
+    provider_error_token_usage, provider_transport_diagnostics, provider_turn_error,
     retry::{
         classify_provider_error, format_provider_failure, provider_max_attempts,
         provider_retry_backoff, RetryDisposition,
@@ -583,7 +583,7 @@ impl AgentProvider for FallbackProvider {
                             outcome: ProviderAttemptOutcome::Retrying,
                             advanced_to_fallback: false,
                             backoff_ms: Some(backoff.as_millis() as u64),
-                            token_usage: None,
+                            token_usage: provider_error_token_usage(&error).cloned(),
                             transport_diagnostics: provider_transport_diagnostics(&error).cloned(),
                         });
                         warn!(
@@ -618,7 +618,7 @@ impl AgentProvider for FallbackProvider {
                         },
                         advanced_to_fallback: has_fallback,
                         backoff_ms: None,
-                        token_usage: None,
+                        token_usage: provider_error_token_usage(&error).cloned(),
                         transport_diagnostics: provider_transport_diagnostics(&error).cloned(),
                     });
                     last_error = Some(error);
@@ -655,6 +655,20 @@ impl AgentProvider for FallbackProvider {
             },
             source,
         ))
+    }
+
+    fn select_model_lineage(
+        &self,
+        model_ref: &ModelRouteRef,
+    ) -> Option<std::sync::Arc<dyn AgentProvider>> {
+        let model_ref = model_ref.as_string();
+        let index = self
+            .candidates
+            .iter()
+            .position(|candidate| candidate.model_ref == model_ref)?;
+        Some(std::sync::Arc::new(Self {
+            candidates: self.candidates[index..].to_vec(),
+        }))
     }
 
     #[cfg(test)]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::{prompt::PromptStability, tool::ToolError, tool::ToolSpec, types::TokenUsage};
+use crate::{
+    config::ModelRouteRef, prompt::PromptStability, tool::ToolError, tool::ToolSpec,
+    types::TokenUsage,
+};
 
 mod catalog;
 mod diagnostics;
@@ -460,6 +463,13 @@ pub struct ToolResultBlock {
 pub trait AgentProvider: Send + Sync {
     async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse>;
 
+    fn select_model_lineage(
+        &self,
+        _model_ref: &ModelRouteRef,
+    ) -> Option<std::sync::Arc<dyn AgentProvider>> {
+        None
+    }
+
     async fn generate_image(
         &self,
         _request: ProviderGenerateImageRequest,
@@ -700,6 +710,13 @@ pub fn provider_error_code(error: &anyhow::Error) -> Option<&str> {
         .chain()
         .find_map(|source| source.downcast_ref::<retry::ProviderTransportError>())
         .and_then(|error| error.code.as_deref())
+}
+
+pub(crate) fn provider_error_token_usage(error: &anyhow::Error) -> Option<&TokenUsage> {
+    error
+        .chain()
+        .find_map(|source| source.downcast_ref::<retry::ProviderTransportError>())
+        .and_then(|error| error.token_usage.as_ref())
 }
 
 pub fn provider_error_is_context_length_exceeded(error: &anyhow::Error) -> bool {

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -9,6 +9,7 @@ use tokio::time::Duration;
 use super::{
     http_trace::ProviderHttpTraceRequest, ProviderTransportDiagnostics, ReqwestTransportDiagnostics,
 };
+use crate::types::TokenUsage;
 
 pub(crate) const PROVIDER_MAX_RETRIES: usize = 2;
 const PROVIDER_RETRY_BASE_BACKOFF_MS: u64 = 200;
@@ -20,6 +21,7 @@ pub(crate) enum ProviderFailureKind {
     Connection,
     RateLimited,
     ServerError,
+    EmptyResponse,
     AuthError,
     ContractError,
     InvalidResponse,
@@ -47,6 +49,7 @@ pub(crate) struct ProviderTransportError {
     pub code: Option<String>,
     pub status: Option<u16>,
     pub diagnostics: Option<ProviderTransportDiagnostics>,
+    pub token_usage: Option<TokenUsage>,
     message: String,
 }
 
@@ -57,6 +60,7 @@ impl ProviderFailureKind {
             Self::Connection => "connection",
             Self::RateLimited => "rate_limited",
             Self::ServerError => "server_error",
+            Self::EmptyResponse => "empty_response",
             Self::AuthError => "auth_error",
             Self::ContractError => "contract_error",
             Self::InvalidResponse => "invalid_response",
@@ -85,6 +89,7 @@ pub(crate) fn provider_retry_policy_json() -> Value {
             ProviderFailureKind::Connection.as_str(),
             ProviderFailureKind::RateLimited.as_str(),
             ProviderFailureKind::ServerError.as_str(),
+            ProviderFailureKind::EmptyResponse.as_str(),
         ],
         "fail_fast_failure_kinds": [
             ProviderFailureKind::AuthError.as_str(),
@@ -123,11 +128,12 @@ pub(crate) fn provider_transport_error(
     provider_transport_error_with_code(classification, None, status, diagnostics, message)
 }
 
-pub(crate) fn provider_transport_error_with_code(
+fn provider_transport_error_with_evidence(
     classification: ProviderFailureClassification,
     code: Option<&str>,
     status: Option<u16>,
     diagnostics: Option<ProviderTransportDiagnostics>,
+    token_usage: Option<TokenUsage>,
     message: impl Into<String>,
 ) -> anyhow::Error {
     ProviderTransportError {
@@ -135,9 +141,20 @@ pub(crate) fn provider_transport_error_with_code(
         code: code.map(ToString::to_string),
         status,
         diagnostics,
+        token_usage,
         message: message.into(),
     }
     .into()
+}
+
+pub(crate) fn provider_transport_error_with_code(
+    classification: ProviderFailureClassification,
+    code: Option<&str>,
+    status: Option<u16>,
+    diagnostics: Option<ProviderTransportDiagnostics>,
+    message: impl Into<String>,
+) -> anyhow::Error {
+    provider_transport_error_with_evidence(classification, code, status, diagnostics, None, message)
 }
 
 pub(crate) fn classify_reqwest_transport_error_with_trace(
@@ -351,6 +368,57 @@ pub(crate) fn invalid_response_error_with_trace(
             http_trace: trace.and_then(|trace| trace.diagnostics(None)),
             source_chain: vec![error.clone()],
         }),
+        format!("{context}: {error}"),
+    )
+}
+
+pub(crate) fn empty_response_error(
+    context: &str,
+    error: impl std::fmt::Display,
+    token_usage: TokenUsage,
+) -> anyhow::Error {
+    provider_transport_error_with_evidence(
+        ProviderFailureClassification {
+            kind: ProviderFailureKind::EmptyResponse,
+            disposition: RetryDisposition::Retryable,
+        },
+        None,
+        None,
+        None,
+        Some(token_usage),
+        format!("{context}: {error}"),
+    )
+}
+
+pub(crate) fn empty_response_error_with_trace(
+    context: &str,
+    stage: &str,
+    provider: &str,
+    model_ref: Option<&str>,
+    url: Option<&str>,
+    error: impl std::fmt::Display,
+    trace: Option<&ProviderHttpTraceRequest>,
+    token_usage: TokenUsage,
+) -> anyhow::Error {
+    let error = error.to_string();
+    provider_transport_error_with_evidence(
+        ProviderFailureClassification {
+            kind: ProviderFailureKind::EmptyResponse,
+            disposition: RetryDisposition::Retryable,
+        },
+        None,
+        None,
+        Some(ProviderTransportDiagnostics {
+            stage: stage.to_string(),
+            provider: Some(provider.to_string()),
+            model_ref: model_ref.map(ToString::to_string),
+            url: url.map(sanitize_transport_url),
+            status: None,
+            reqwest: None,
+            http_trace: trace.and_then(|trace| trace.diagnostics(None)),
+            source_chain: vec![error.clone()],
+        }),
+        Some(token_usage),
         format!("{context}: {error}"),
     )
 }

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -9,6 +9,7 @@ use super::support::*;
 use super::*;
 use crate::config::{ModelRef, ProviderId};
 use crate::model_catalog::ModelRuntimeOverride;
+use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
 use crate::provider::transports::set_stream_idle_timeout_override_for_tests;
 use crate::provider::{
     ContinuationScopeId, ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
@@ -114,6 +115,78 @@ fn openai_text_response_with_provider_metadata(response_id: &str, text: &str) ->
             }]
         }]
     })
+}
+
+#[test]
+fn openai_responses_classifies_empty_output_as_retryable_with_usage() {
+    let error = parse_openai_response(json!({
+        "id": "resp_empty",
+        "status": "completed",
+        "usage": { "input_tokens": 4, "output_tokens": 893 },
+        "output": []
+    }))
+    .expect_err("empty output should fail");
+
+    let classification = classify_provider_error(&error);
+    assert_eq!(classification.kind, ProviderFailureKind::EmptyResponse);
+    assert_eq!(classification.disposition, RetryDisposition::Retryable);
+    assert_eq!(
+        crate::provider::provider_error_token_usage(&error)
+            .map(|usage| (usage.input_tokens, usage.output_tokens)),
+        Some((4, 893))
+    );
+}
+
+#[test]
+fn openai_responses_classifies_empty_message_content_as_retryable() {
+    let error = parse_openai_response(json!({
+        "id": "resp_empty_message",
+        "status": "completed",
+        "usage": { "input_tokens": 4, "output_tokens": 0 },
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": []
+        }]
+    }))
+    .expect_err("empty message content should fail");
+
+    let classification = classify_provider_error(&error);
+    assert_eq!(classification.kind, ProviderFailureKind::EmptyResponse);
+    assert_eq!(classification.disposition, RetryDisposition::Retryable);
+}
+
+#[test]
+fn openai_responses_keeps_nonempty_unsupported_items_fail_fast() {
+    let error = parse_openai_response(json!({
+        "id": "resp_unsupported",
+        "status": "completed",
+        "usage": { "input_tokens": 4, "output_tokens": 1 },
+        "output": [{ "type": "unsupported_provider_item" }]
+    }))
+    .expect_err("unsupported wire item should fail");
+
+    let classification = classify_provider_error(&error);
+    assert_eq!(classification.kind, ProviderFailureKind::InvalidResponse);
+    assert_eq!(classification.disposition, RetryDisposition::FailFast);
+}
+
+#[test]
+fn openai_responses_keeps_malformed_message_content_fail_fast() {
+    let error = parse_openai_response(json!({
+        "id": "resp_malformed_message",
+        "status": "completed",
+        "usage": { "input_tokens": 4, "output_tokens": 0 },
+        "output": [{
+            "type": "message",
+            "role": "assistant"
+        }]
+    }))
+    .expect_err("message without content should fail");
+
+    let classification = classify_provider_error(&error);
+    assert_eq!(classification.kind, ProviderFailureKind::InvalidResponse);
+    assert_eq!(classification.disposition, RetryDisposition::FailFast);
 }
 
 fn set_remote_compaction_trigger(config: &mut crate::config::AppConfig, model_ref: &str) {

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -1016,6 +1016,83 @@ async fn openai_provider_retries_transient_server_errors() {
 }
 
 #[tokio::test]
+async fn openai_provider_retries_empty_responses_and_preserves_failure_usage() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let server_attempts = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move || {
+            let attempts = server_attempts.clone();
+            async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Json(json!({
+                        "id": "resp_empty",
+                        "status": "completed",
+                        "usage": { "input_tokens": 4, "output_tokens": 893 },
+                        "output": []
+                    }))
+                } else {
+                    Json(json!({
+                        "id": "resp_ok",
+                        "status": "completed",
+                        "usage": { "input_tokens": 2, "output_tokens": 1 },
+                        "output": [{
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{ "type": "output_text", "text": "retry ok" }]
+                        }]
+                    }))
+                }
+            }
+        }),
+    ))
+    .await;
+
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+
+    let (response, diagnostics) = provider
+        .complete_turn_with_diagnostics(provider_turn_request())
+        .await
+        .expect("empty response should retry and recover");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert!(matches!(
+        &response.blocks[0],
+        ModelBlock::Text { text } if text == "retry ok"
+    ));
+    let timeline = diagnostics.expect("missing attempt timeline");
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("empty_response")
+    );
+    assert_eq!(
+        timeline.attempts[0].disposition.as_deref(),
+        Some("retryable")
+    );
+    assert_eq!(
+        timeline.attempts[0]
+            .token_usage
+            .as_ref()
+            .map(|usage| (usage.input_tokens, usage.output_tokens)),
+        Some((4, 893))
+    );
+    assert_eq!(
+        timeline
+            .aggregated_token_usage
+            .as_ref()
+            .map(|usage| (usage.input_tokens, usage.output_tokens)),
+        Some((6, 894))
+    );
+}
+
+#[tokio::test]
 async fn openai_provider_fails_fast_on_contract_errors() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let server_attempts = attempts.clone();
@@ -1485,6 +1562,26 @@ fn build_provider_from_config_preserves_order_of_unique_models() {
             "openai@default/gpt-5.4",
             "openai-codex@default/gpt-5.4"
         ]
+    );
+}
+
+#[test]
+fn fallback_provider_selects_requested_recovery_lineage() {
+    let fixture = test_config(
+        "anthropic/claude-sonnet-4-6",
+        &["openai/gpt-5.4", "openai-codex/gpt-5.4"],
+        Some("openai-key"),
+        Some("anthropic-token"),
+        true,
+    );
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+    let recovery = provider
+        .select_model_lineage(&route_ref("openai/gpt-5.4"))
+        .expect("fallback provider should select the requested lineage");
+
+    assert_eq!(
+        recovery.configured_model_refs(),
+        vec!["openai@default/gpt-5.4", "openai-codex@default/gpt-5.4"]
     );
 }
 

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -31,7 +31,7 @@ use crate::{
 use super::{build_http_client, request_send_timeout, response_body_timeout, stream_idle_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
-    invalid_response_error_with_trace, provider_transport_error,
+    empty_response_error_with_trace, invalid_response_error_with_trace, provider_transport_error,
     timeout_transport_error_with_trace, ProviderFailureClassification, ProviderFailureKind,
     RetryDisposition,
 };
@@ -607,6 +607,18 @@ fn anthropic_messages_response_to_turn_response(
         read_input_tokens: usage.cache_read_input_tokens.unwrap_or(0),
         creation_input_tokens: usage.cache_creation_input_tokens.unwrap_or(0),
     });
+    if parsed.content.is_empty() {
+        return Err(empty_response_error_with_trace(
+            "empty Anthropic response",
+            "response_protocol",
+            "anthropic",
+            Some(model_ref),
+            Some(url),
+            "Anthropic response contained no content blocks",
+            trace,
+            crate::types::TokenUsage::new(input_tokens, output_tokens),
+        ));
+    }
     let tools_available = !request.tools.is_empty();
     for (block_index, block) in parsed.content.iter().enumerate() {
         warn_unsupported_anthropic_response_block(
@@ -2908,6 +2920,93 @@ mod tests {
             response.content[1].input.as_ref(),
             Some(&json!({ "cmd": "echo ok" }))
         );
+    }
+
+    #[test]
+    fn anthropic_empty_completed_stream_is_retryable_and_preserves_usage() {
+        let stream = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":3}}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":893}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+        );
+        let events = SseParser::default()
+            .push(stream.as_bytes())
+            .expect("stream should parse");
+        let mut accumulator = AnthropicStreamAccumulator::default();
+        for event in events {
+            accumulator
+                .apply(event, "anthropic/claude-test", "https://example.test", None)
+                .expect("event should accumulate");
+        }
+        let parsed = accumulator
+            .finish("anthropic/claude-test", "https://example.test", None)
+            .expect("stream should finish");
+        let request = ProviderTurnRequest::plain("system", Vec::new(), Vec::new());
+        let error = anthropic_messages_response_to_turn_response(
+            parsed,
+            None,
+            &request,
+            &[],
+            None,
+            &json!({}),
+            "anthropic",
+            "claude-test",
+            AnthropicCacheStrategy::MessagesNative,
+            &[],
+            "anthropic/claude-test",
+            "https://example.test",
+            None,
+        )
+        .expect_err("empty completed stream should fail");
+
+        let classification = crate::provider::retry::classify_provider_error(&error);
+        assert_eq!(classification.kind, ProviderFailureKind::EmptyResponse);
+        assert_eq!(classification.disposition, RetryDisposition::Retryable);
+        assert_eq!(
+            crate::provider::provider_error_token_usage(&error)
+                .map(|usage| (usage.input_tokens, usage.output_tokens)),
+            Some((3, 893))
+        );
+    }
+
+    #[test]
+    fn anthropic_nonempty_unsupported_block_remains_fail_fast() {
+        let parsed = MessagesResponse {
+            content: vec![ApiResponseBlock {
+                kind: "unsupported_provider_block".into(),
+                ..Default::default()
+            }],
+            usage: Some(ApiUsage {
+                input_tokens: Some(3),
+                output_tokens: Some(1),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let request = ProviderTurnRequest::plain("system", Vec::new(), Vec::new());
+        let error = anthropic_messages_response_to_turn_response(
+            parsed,
+            None,
+            &request,
+            &[],
+            None,
+            &json!({}),
+            "anthropic",
+            "claude-test",
+            AnthropicCacheStrategy::MessagesNative,
+            &[],
+            "anthropic/claude-test",
+            "https://example.test",
+            None,
+        )
+        .expect_err("unsupported block should fail");
+
+        let classification = crate::provider::retry::classify_provider_error(&error);
+        assert_eq!(classification.kind, ProviderFailureKind::InvalidResponse);
+        assert_eq!(classification.disposition, RetryDisposition::FailFast);
     }
 
     #[test]

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -45,8 +45,9 @@ use crate::{
 use super::{build_http_client, request_send_timeout, response_body_timeout, stream_idle_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
-    invalid_response_error, provider_transport_error, timeout_transport_error_with_trace,
-    ProviderFailureClassification, ProviderFailureKind, ProviderTransportError, RetryDisposition,
+    empty_response_error, invalid_response_error, provider_transport_error,
+    timeout_transport_error_with_trace, ProviderFailureClassification, ProviderFailureKind,
+    ProviderTransportError, RetryDisposition,
 };
 
 mod auth;

--- a/src/provider/transports/openai/responses/parse.rs
+++ b/src/provider/transports/openai/responses/parse.rs
@@ -348,13 +348,24 @@ pub(in super::super) fn parse_openai_response_with_transport_state(
         .iter()
         .map(canonicalize_openai_provider_item)
         .collect::<Vec<_>>();
+    let usage = response.get("usage").and_then(Value::as_object);
+    let input_tokens = usage
+        .and_then(|usage| usage.get("input_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let output_tokens = usage
+        .and_then(|usage| usage.get("output_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
     let mut blocks = Vec::new();
+    let mut saw_nonempty_wire_item = false;
 
     for item in output {
         match item.get("type").and_then(Value::as_str) {
             Some("message") => {
                 if let Some(content) = item.get("content").and_then(Value::as_array) {
                     for content_item in content {
+                        saw_nonempty_wire_item = true;
                         match content_item.get("type").and_then(Value::as_str) {
                             Some("output_text") | Some("text") | Some("input_text") => {
                                 if let Some(text) = content_item.get("text").and_then(Value::as_str)
@@ -367,9 +378,12 @@ pub(in super::super) fn parse_openai_response_with_transport_state(
                             _ => {}
                         }
                     }
+                } else {
+                    saw_nonempty_wire_item = true;
                 }
             }
             Some("function_call") => {
+                saw_nonempty_wire_item = true;
                 let id = item
                     .get("call_id")
                     .or_else(|| item.get("id"))
@@ -395,6 +409,7 @@ pub(in super::super) fn parse_openai_response_with_transport_state(
                 });
             }
             Some("custom_tool_call") => {
+                saw_nonempty_wire_item = true;
                 let id = item
                     .get("call_id")
                     .or_else(|| item.get("id"))
@@ -424,18 +439,24 @@ pub(in super::super) fn parse_openai_response_with_transport_state(
                     kind: ModelToolCallKind::Custom,
                 });
             }
-            _ => {}
+            _ => saw_nonempty_wire_item = true,
         }
     }
 
     if blocks.is_empty() {
+        if !saw_nonempty_wire_item {
+            return Err(empty_response_error(
+                "empty OpenAI-style response",
+                "response contained no output/content items",
+                crate::types::TokenUsage::new(input_tokens, output_tokens),
+            ));
+        }
         return Err(invalid_response_error(
             "OpenAI-style response contained no supported content blocks",
             "empty supported block set",
         ));
     }
 
-    let usage = response.get("usage").and_then(Value::as_object);
     let cache_usage = usage.map(|usage| ProviderCacheUsage {
         read_input_tokens: usage
             .get("input_tokens_details")
@@ -472,14 +493,8 @@ pub(in super::super) fn parse_openai_response_with_transport_state(
                         .and_then(Value::as_str)
                         .map(str::to_string)
                 }),
-            input_tokens: usage
-                .and_then(|usage| usage.get("input_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0),
-            output_tokens: usage
-                .and_then(|usage| usage.get("output_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0),
+            input_tokens,
+            output_tokens,
             cache_usage,
             provider_message_id: response_id.clone(),
             provider_request_id: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -77,7 +77,7 @@ use crate::{
     agent_template::discover_agent_templates_catalog,
     agents_md::load_agents_md,
     brief,
-    config::RuntimeModelCatalog,
+    config::{ModelRouteRef, RuntimeModelCatalog},
     context::{sync_agent_message_count, ContextConfig},
     host::RuntimeHostBridge,
     ingress::WakeDisposition,
@@ -126,7 +126,7 @@ use crate::{
         SkillActivationSource, SkillActivationState, SkillCatalogEntry, SkillLoadReason,
         SkillsRuntimeView, TaskKind, TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec,
         TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
-        TranscriptEntryKind, TurnRecord, ViewImageObservation, WaitingReason,
+        TranscriptEntryKind, TurnRecord, TurnTerminalKind, ViewImageObservation, WaitingReason,
         WorkItemExecutionBinding, WorkItemLifecycleAuditEvent, WorkspaceEntry,
         AGENT_HOME_WORKSPACE_ID,
     },
@@ -224,10 +224,7 @@ pub(crate) fn agent_model_state_for_catalog(
         .and_then(|_| state.last_active_model.clone())
         .unwrap_or_else(|| effective_model.clone());
     let fallback_active = active_model != effective_model;
-    let effective_chain = model_catalog.provider_chain_for_turn(
-        state.model_override.as_ref(),
-        state.pending_fallback_model.as_ref(),
-    );
+    let effective_chain = model_catalog.provider_chain(state.model_override.as_ref());
     let resolved_policy =
         model_catalog.resolved_model_policy(base_context_config, state.model_override.as_ref());
     AgentModelState {
@@ -269,7 +266,9 @@ struct RuntimeInner {
     runtime_db: RuntimeDb,
     scheduler_engine: crate::config::SchedulerEngineMode,
     clock: Arc<dyn clock::Clock>,
+    base_provider: Arc<dyn AgentProvider>,
     provider: RwLock<Arc<dyn AgentProvider>>,
+    turn_fallback_model: RwLock<Option<ModelRouteRef>>,
     context_config: RwLock<ContextConfig>,
     config_snapshot: ArcSwap<ConfigSnapshot>,
     builtin_web_search_probe_cache:
@@ -3739,6 +3738,150 @@ impl RuntimeHandle {
         unreachable!("settlement OCC retry loop always returns or errors")
     }
 
+    async fn maybe_supersede_queued_provider_recovery(
+        &self,
+        superseding_message: &MessageEnvelope,
+        terminal_transition: Option<&turn::TurnTerminalTransition>,
+    ) -> Result<usize> {
+        let Some(turn_record) = terminal_transition.map(|transition| &transition.turn_record)
+        else {
+            return Ok(0);
+        };
+        if turn_record
+            .terminal
+            .as_ref()
+            .is_none_or(|terminal| terminal.kind != TurnTerminalKind::Completed)
+        {
+            return Ok(0);
+        }
+        let made_progress = !turn_record.produced_brief_ids.is_empty()
+            || !turn_record.tool_execution_ids.is_empty()
+            || !turn_record.completed_work_item_ids.is_empty()
+            || !turn_record.waiting_condition_ids.is_empty();
+        if !made_progress {
+            return Ok(0);
+        }
+
+        let turns = self
+            .inner
+            .runtime_db
+            .turn_records()
+            .recent_for_agent(&superseding_message.agent_id, usize::MAX)?;
+        let queued = self
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()?
+            .into_iter()
+            .filter(|entry| {
+                entry.agent_id == superseding_message.agent_id
+                    && entry.status == QueueEntryStatus::Queued
+                    && entry.message_id != superseding_message.id
+            })
+            .collect::<Vec<_>>();
+        let mut superseded = 0;
+
+        for expected in queued {
+            let Some(recovery_message) = self
+                .inner
+                .storage
+                .read_message_by_id(&expected.message_id)?
+            else {
+                continue;
+            };
+            let Ok(selection) = turn::TurnModelSelection::from_message(&recovery_message) else {
+                continue;
+            };
+            let Some(recovery) = selection.recovery else {
+                continue;
+            };
+            if recovery_message.work_item_id != turn_record.current_work_item_id {
+                continue;
+            }
+            let source_is_earlier = turns.iter().any(|turn| {
+                turn.turn_id == recovery.source_turn_id && turn.turn_index < turn_record.turn_index
+            });
+            if !source_is_earlier {
+                continue;
+            }
+
+            let mut dropped = expected.clone();
+            dropped.status = QueueEntryStatus::Dropped;
+            dropped.updated_at = self.now();
+            let mut guard = self.inner.agent.lock().await;
+            if guard
+                .queue
+                .peek_next_matching(|message| message.id == recovery_message.id)
+                .is_none()
+            {
+                continue;
+            }
+            let mut next_state = guard.state.clone();
+            next_state.pending = guard.queue.len().saturating_sub(1);
+            let mut commit = self.inner.runtime_db.transitions().commit_queue(
+                &crate::runtime_db::transitions::QueueTransitionCommand {
+                    agent_id: recovery_message.agent_id.clone(),
+                    operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                    mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                        expected,
+                        record: dropped,
+                    },
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(guard.last_persisted_state.clone())),
+                        record: Box::new(next_state.clone()),
+                    }),
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    turn_record: None,
+                    audit_events: vec![
+                        AuditEvent::legacy(
+                            "recovery_superseded",
+                            serde_json::json!({
+                                "agent_id": recovery_message.agent_id,
+                                "recovery_message_id": recovery_message.id,
+                                "fallback_model_ref": recovery.fallback_model_ref,
+                                "source_turn_id": recovery.source_turn_id,
+                                "source_message_id": recovery.source_message_id,
+                                "superseding_message_id": superseding_message.id,
+                                "superseding_turn_id": turn_record.turn_id,
+                                "work_item_id": turn_record.current_work_item_id,
+                            }),
+                        ),
+                        AuditEvent::legacy(
+                            "queue_entry_settled",
+                            serde_json::json!({
+                                "message_id": recovery_message.id,
+                                "message_kind": recovery_message.kind,
+                                "status": QueueEntryStatus::Dropped,
+                                "reason": "provider_recovery_superseded",
+                            }),
+                        ),
+                    ],
+                    notify_scheduler: true,
+                    fault: self.take_transition_fault(),
+                    brief_evidence: Vec::new(),
+                },
+            )?;
+            if !commit.applied {
+                continue;
+            }
+            let _ = guard
+                .queue
+                .pop_next_matching(|message| message.id == recovery_message.id);
+            guard.state = next_state.clone();
+            guard.last_persisted_state = next_state;
+            commit.effects.agent_state = None;
+            drop(guard);
+            self.apply_transition_commit(commit).await;
+            superseded += 1;
+        }
+
+        Ok(superseded)
+    }
+
     async fn canonical_queue_settlement_commands(
         &self,
         record: &QueueEntryRecord,
@@ -4006,16 +4149,6 @@ impl RuntimeHandle {
                         let guard = self.inner.agent.lock().await;
                         let mut state = guard.state.clone();
                         if !matches!(state.status, AgentStatus::Stopped) {
-                            if state.pending_fallback_model.is_some() {
-                                let has_fallback = provider_attempt_timeline(&err)
-                                    .and_then(|timeline| {
-                                        timeline.pending_fallback_model_ref.as_deref()
-                                    })
-                                    .is_some();
-                                if !has_fallback {
-                                    state.pending_fallback_model = None;
-                                }
-                            }
                             scheduler::apply_idle_projection(&mut state, &self.inner.storage)?;
                         }
                         if let Some(artifacts) = failure_artifacts.as_ref() {
@@ -4083,6 +4216,11 @@ impl RuntimeHandle {
                         }),
                     )],
                     true,
+                    terminal_transition.as_ref(),
+                )
+                .await?;
+                self.maybe_supersede_queued_provider_recovery(
+                    &message,
                     terminal_transition.as_ref(),
                 )
                 .await?;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -410,10 +410,9 @@ impl RuntimeHandle {
         }
 
         if let Some(reconfig) = config_snapshot.provider_reconfig.as_ref() {
-            let chain = config_snapshot.model_catalog.provider_chain_for_turn(
-                state.model_override.as_ref(),
-                state.pending_fallback_model.as_ref(),
-            );
+            let chain = config_snapshot
+                .model_catalog
+                .provider_chain(state.model_override.as_ref());
             let mut provider_config = reconfig.config.clone();
             provider_config.runtime_max_output_tokens = config_snapshot
                 .model_catalog
@@ -432,6 +431,7 @@ impl RuntimeHandle {
         } else {
             context_config.clone()
         };
+        let base_provider = provider.clone();
 
         let runtime = Self {
             inner: Arc::new(RuntimeInner {
@@ -448,7 +448,9 @@ impl RuntimeHandle {
                 runtime_db,
                 scheduler_engine,
                 clock,
+                base_provider,
                 provider: RwLock::new(provider),
+                turn_fallback_model: RwLock::new(None),
                 config_snapshot: ArcSwap::from(config_snapshot),
                 context_config: RwLock::new(resolved_context_config),
                 builtin_web_search_probe_cache: Mutex::new(HashMap::new()),
@@ -480,8 +482,33 @@ impl RuntimeHandle {
     }
 
     pub(crate) fn model_state_for(&self, state: &AgentState) -> crate::types::AgentModelState {
+        self.model_state_for_turn(state, None)
+    }
+
+    pub(crate) fn model_state_for_turn(
+        &self,
+        state: &AgentState,
+        fallback_model: Option<&ModelRouteRef>,
+    ) -> crate::types::AgentModelState {
         let snap = self.inner.config_snapshot.load();
-        super::agent_model_state_for_catalog(&snap.model_catalog, &snap.base_context_config, state)
+        let mut selected_state = state.clone();
+        selected_state.pending_fallback_model = None;
+        let mut model_state = super::agent_model_state_for_catalog(
+            &snap.model_catalog,
+            &snap.base_context_config,
+            &selected_state,
+        );
+        if let Some(fallback_model) = fallback_model {
+            model_state.active_model = Some(fallback_model.clone());
+            model_state.fallback_active = model_state.effective_model != *fallback_model;
+            model_state.effective_fallback_models = snap
+                .model_catalog
+                .provider_chain_for_turn(state.model_override.as_ref(), Some(fallback_model))
+                .into_iter()
+                .skip(1)
+                .collect();
+        }
+        model_state
     }
 
     pub(crate) async fn current_apply_patch_surface(&self) -> ApplyPatchSurface {
@@ -499,37 +526,55 @@ impl RuntimeHandle {
     }
 
     pub(crate) fn apply_patch_surface_for_state(&self, state: &AgentState) -> ApplyPatchSurface {
+        self.apply_patch_surface_for_turn(state, None)
+    }
+
+    pub(crate) fn apply_patch_surface_for_turn(
+        &self,
+        state: &AgentState,
+        fallback_model: Option<&ModelRouteRef>,
+    ) -> ApplyPatchSurface {
         let route_ref = self
-            .selected_model_ref_for_state(state)
+            .selected_model_ref_for_state(state, fallback_model)
             .unwrap_or_else(|| self.model_state_for(state).effective_model);
         ApplyPatchSurface::for_model_ref(&route_ref.model_ref().as_string())
     }
 
-    fn selected_model_ref_for_state(&self, state: &AgentState) -> Option<ModelRouteRef> {
+    fn selected_model_ref_for_state(
+        &self,
+        state: &AgentState,
+        fallback_model: Option<&ModelRouteRef>,
+    ) -> Option<ModelRouteRef> {
         let snap = self.inner.config_snapshot.load();
         snap.model_catalog
-            .provider_chain_for_turn(
-                state.model_override.as_ref(),
-                state.pending_fallback_model.as_ref(),
-            )
+            .provider_chain_for_turn(state.model_override.as_ref(), fallback_model)
             .into_iter()
             .next()
     }
 
     pub(crate) async fn reconfigure_provider_for_state(&self, state: &AgentState) -> Result<()> {
+        self.reconfigure_provider_for_state_and_fallback(state, None)
+            .await
+    }
+
+    async fn reconfigure_provider_for_state_and_fallback(
+        &self,
+        state: &AgentState,
+        fallback_model: Option<&ModelRouteRef>,
+    ) -> Result<()> {
         let snap = self.inner.config_snapshot.load();
         let Some(reconfig) = snap.provider_reconfig.as_ref() else {
             return Err(anyhow!(
                 "agent model override is unavailable for runtimes without host-managed provider configuration"
             ));
         };
-        let chain = snap.model_catalog.provider_chain_for_turn(
-            state.model_override.as_ref(),
-            state.pending_fallback_model.as_ref(),
-        );
-        let resolved_context_config = snap
+        let chain = snap
             .model_catalog
-            .resolved_context_config(&snap.base_context_config, state.model_override.as_ref());
+            .provider_chain_for_turn(state.model_override.as_ref(), fallback_model);
+        let resolved_context_config = snap.model_catalog.resolved_context_config(
+            &snap.base_context_config,
+            fallback_model.or(state.model_override.as_ref()),
+        );
         let mut provider_config = reconfig.config.clone();
         if let (Some(primary), Some(reasoning_effort)) = (
             chain.first(),
@@ -549,16 +594,42 @@ impl RuntimeHandle {
         Ok(())
     }
 
-    pub(crate) async fn reconfigure_provider_for_current_state(&self) -> Result<()> {
+    pub(crate) async fn reconfigure_provider_for_turn(
+        &self,
+        fallback_model: Option<&ModelRouteRef>,
+    ) -> Result<()> {
         let snap = self.inner.config_snapshot.load();
         if snap.provider_reconfig.is_none() {
+            match fallback_model {
+                Some(fallback_model) => {
+                    let provider = self
+                        .inner
+                        .base_provider
+                        .select_model_lineage(fallback_model)
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "static provider cannot select recovery model lineage {}",
+                                fallback_model.as_string()
+                            )
+                        })?;
+                    *self.inner.provider.write().await = provider;
+                }
+                None if self.inner.turn_fallback_model.read().await.is_some() => {
+                    *self.inner.provider.write().await = self.inner.base_provider.clone();
+                }
+                None => {}
+            }
+            *self.inner.turn_fallback_model.write().await = fallback_model.cloned();
             return Ok(());
         }
         let state = {
             let guard = self.inner.agent.lock().await;
             guard.state.clone()
         };
-        self.reconfigure_provider_for_state(&state).await
+        self.reconfigure_provider_for_state_and_fallback(&state, fallback_model)
+            .await?;
+        *self.inner.turn_fallback_model.write().await = fallback_model.cloned();
+        Ok(())
     }
 
     /// Hot-reload config-derived runtime fields from a new `AppConfig`.
@@ -594,11 +665,12 @@ impl RuntimeHandle {
         &self,
     ) -> Result<crate::types::ViewImageVisionSelection> {
         let state = self.agent_state().await?;
+        let fallback_model = self.inner.turn_fallback_model.read().await.clone();
         let snap = self.inner.config_snapshot.load();
         Ok(snap.model_catalog.select_view_image_vision_model(
             &snap.base_context_config,
             state.model_override.as_ref(),
-            state.pending_fallback_model.as_ref(),
+            fallback_model.as_ref(),
         ))
     }
 
@@ -697,13 +769,14 @@ impl RuntimeHandle {
         request: ProviderGenerateImageRequest,
     ) -> Result<ProviderGenerateImageResponse> {
         let state = self.agent_state().await?;
+        let fallback_model = self.inner.turn_fallback_model.read().await.clone();
         let snap = self.inner.config_snapshot.load();
         let route = snap
             .model_catalog
             .select_generate_image_route(
                 &snap.base_context_config,
                 state.model_override.as_ref(),
-                state.pending_fallback_model.as_ref(),
+                fallback_model.as_ref(),
             )
             .ok_or_else(|| anyhow!("no configured model supports image_generation"))?;
         let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
@@ -1067,6 +1140,16 @@ fn prepare_runtime_storage(
         .retain(|skill| matches!(skill.activation_state, SkillActivationState::SessionActive));
     for skill in &mut state.active_skills {
         skill.activation_source = SkillActivationSource::Restored;
+    }
+    if let Some(legacy_fallback) = state.pending_fallback_model.take() {
+        storage.append_event(&AuditEvent::legacy(
+            "legacy_pending_fallback_discarded",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "fallback_model_ref": legacy_fallback,
+                "reason": "fallback_selection_is_message_bound",
+            }),
+        ))?;
     }
     state.pending = queue.len();
     state.total_message_count = storage.count_messages().unwrap_or_default();

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -904,7 +904,6 @@ impl RuntimeHandle {
         let mut next_state = self.agent_state().await?;
         next_state.model_override = Some(model_override.clone());
         next_state.model_override_reasoning_effort = reasoning_effort.clone();
-        next_state.pending_fallback_model = None;
         let turn_in_progress = next_state.current_run_id.is_some();
         if !turn_in_progress {
             self.reconfigure_provider_for_state(&next_state).await?;
@@ -915,7 +914,6 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             guard.state.model_override = Some(model_override);
             guard.state.model_override_reasoning_effort = reasoning_effort;
-            guard.state.pending_fallback_model = None;
             guard.persist_state(&self.inner.storage)?;
         }
         self.append_audit_event(
@@ -937,7 +935,6 @@ impl RuntimeHandle {
         let mut next_state = self.agent_state().await?;
         next_state.model_override = None;
         next_state.model_override_reasoning_effort = None;
-        next_state.pending_fallback_model = None;
         let turn_in_progress = next_state.current_run_id.is_some();
         if !turn_in_progress {
             self.reconfigure_provider_for_state(&next_state).await?;
@@ -948,7 +945,6 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             guard.state.model_override = None;
             guard.state.model_override_reasoning_effort = None;
-            guard.state.pending_fallback_model = None;
             guard.persist_state(&self.inner.storage)?;
         }
         self.append_audit_event(

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -184,7 +184,7 @@ impl RuntimeHandle {
                         guard.persist_state(&self.inner.storage)?;
                     }
                     terminal_transition = Some(
-                        self.process_interactive_message_deferred(
+                        self.process_interactive_message_deferred_with_cleanup(
                             &message,
                             continuation_resolution.as_ref(),
                             execution_admission_provenance.clone(),

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::config::ModelRouteRef;
+use crate::runtime::turn::TurnModelSelection;
 use crate::runtime::turn::TurnTerminalTransition;
 use crate::tool::{ApplyPatchSurface, ToolSpec};
 use crate::types::ExecutionAdmissionProvenance;
@@ -12,7 +14,7 @@ impl RuntimeHandle {
         loop_control: LoopControlOptions,
     ) -> Result<()> {
         let terminal_transition = self
-            .process_interactive_message_deferred(
+            .process_interactive_message_deferred_with_cleanup(
                 message,
                 continuation_resolution,
                 self.legacy_execution_admission_provenance(message, continuation_resolution, None)?,
@@ -22,6 +24,32 @@ impl RuntimeHandle {
         self.persist_terminal_transition(&terminal_transition)
             .await?;
         Ok(())
+    }
+
+    pub(super) async fn process_interactive_message_deferred_with_cleanup(
+        &self,
+        message: &MessageEnvelope,
+        continuation_resolution: Option<&ContinuationResolution>,
+        execution_admission_provenance: ExecutionAdmissionProvenance,
+        loop_control: LoopControlOptions,
+    ) -> Result<TurnTerminalTransition> {
+        let result = self
+            .process_interactive_message_deferred(
+                message,
+                continuation_resolution,
+                execution_admission_provenance,
+                loop_control,
+            )
+            .await;
+        let cleanup = self.reconfigure_provider_for_turn(None).await;
+        match (result, cleanup) {
+            (Ok(transition), Ok(())) => Ok(transition),
+            (Ok(_), Err(error)) => Err(error.context("failed to clear turn-local model selection")),
+            (Err(error), Ok(())) => Err(error),
+            (Err(error), Err(cleanup_error)) => Err(error.context(format!(
+                "also failed to clear turn-local model selection: {cleanup_error}"
+            ))),
+        }
     }
 
     pub(super) async fn process_interactive_message_deferred(
@@ -40,6 +68,32 @@ impl RuntimeHandle {
             execution_admission_provenance,
         )
         .await?;
+        let model_selection = TurnModelSelection::from_message(message)?;
+        self.reconfigure_provider_for_turn(model_selection.fallback_model())
+            .await?;
+        if let Some(recovery) = model_selection.recovery.as_ref() {
+            let (turn_id, run_id) = {
+                let guard = self.inner.agent.lock().await;
+                (
+                    guard.state.current_turn_id.clone(),
+                    guard.state.current_run_id.clone(),
+                )
+            };
+            self.inner.storage.append_event(&AuditEvent::legacy(
+                "recovery_turn_started",
+                serde_json::json!({
+                    "agent_id": message.agent_id,
+                    "message_id": message.id,
+                    "turn_id": turn_id,
+                    "run_id": run_id,
+                    "fallback_model_ref": recovery.fallback_model_ref,
+                    "source_turn_id": recovery.source_turn_id,
+                    "source_message_id": recovery.source_message_id,
+                    "source_terminal_kind": recovery.source_terminal_kind,
+                    "source_round": recovery.source_round,
+                }),
+            ))?;
+        }
         self.record_incoming_transcript_entry(message)?;
         self.inner
             .storage
@@ -64,8 +118,9 @@ impl RuntimeHandle {
             }
             let state = guard.state.clone();
             drop(guard);
-            let (provider, available_tools, apply_patch_surface, _, _) =
-                self.provider_tool_selection(&identity).await?;
+            let (provider, available_tools, apply_patch_surface, _, _) = self
+                .provider_tool_selection_for_turn(&identity, model_selection.fallback_model())
+                .await?;
             let prompt_tools = provider.prompt_tool_specs(&available_tools);
             let workspace = self.workspace_view_from_state(&state)?;
             let execution = self.execution_snapshot_for_view(
@@ -119,6 +174,7 @@ impl RuntimeHandle {
                 &message.agent_id,
                 message.authority_class.clone(),
                 built,
+                model_selection,
                 loop_control,
             )
             .await?;
@@ -358,6 +414,20 @@ impl RuntimeHandle {
         Option<ProviderNativeWebSearchRequest>,
         BuiltinWebSearchSelectionDiagnostics,
     )> {
+        self.provider_tool_selection_for_turn(identity, None).await
+    }
+
+    pub(super) async fn provider_tool_selection_for_turn(
+        &self,
+        identity: &AgentIdentityView,
+        fallback_model: Option<&ModelRouteRef>,
+    ) -> Result<(
+        Arc<dyn AgentProvider>,
+        Vec<ToolSpec>,
+        ApplyPatchSurface,
+        Option<ProviderNativeWebSearchRequest>,
+        BuiltinWebSearchSelectionDiagnostics,
+    )> {
         let provider = self.current_provider().await;
         let web_config = self.web_config();
         let native_search_provider = web_config.native_search_provider();
@@ -406,7 +476,7 @@ impl RuntimeHandle {
         let native_web_search = native_web_search_selection.request;
         let apply_patch_surface = {
             let guard = self.inner.agent.lock().await;
-            self.apply_patch_surface_for_state(&guard.state)
+            self.apply_patch_surface_for_turn(&guard.state, fallback_model)
         };
         let available_tools = filter_native_web_search_tools(
             self.filtered_tool_specs_for_apply_patch_surface(identity, apply_patch_surface)?,

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -34,12 +34,12 @@ impl RuntimeHandle {
         loop_control: LoopControlOptions,
     ) -> Result<TurnTerminalTransition> {
         let result = Box::pin(self.process_interactive_message_deferred(
-                message,
-                continuation_resolution,
-                execution_admission_provenance,
-                loop_control,
-            ))
-            .await;
+            message,
+            continuation_resolution,
+            execution_admission_provenance,
+            loop_control,
+        ))
+        .await;
         let cleanup = self.reconfigure_provider_for_turn(None).await;
         match (result, cleanup) {
             (Ok(transition), Ok(())) => Ok(transition),

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -33,13 +33,12 @@ impl RuntimeHandle {
         execution_admission_provenance: ExecutionAdmissionProvenance,
         loop_control: LoopControlOptions,
     ) -> Result<TurnTerminalTransition> {
-        let result = self
-            .process_interactive_message_deferred(
+        let result = Box::pin(self.process_interactive_message_deferred(
                 message,
                 continuation_resolution,
                 execution_admission_provenance,
                 loop_control,
-            )
+            ))
             .await;
         let cleanup = self.reconfigure_provider_for_turn(None).await;
         match (result, cleanup) {

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -427,7 +427,7 @@ impl RuntimeHandle {
                 guard.persist_state(&self.inner.storage)?;
             }
             let transition = self
-                .process_interactive_message_deferred(
+                .process_interactive_message_deferred_with_cleanup(
                     message,
                     continuation_resolution,
                     execution_admission_provenance,

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -1452,14 +1452,7 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
 
     assert_eq!(outcome.terminal_kind, TurnTerminalKind::DeferredToFallback);
     let state = runtime.agent_state().await.unwrap();
-    assert_eq!(
-        state
-            .pending_fallback_model
-            .as_ref()
-            .map(|model| model.as_string())
-            .as_deref(),
-        Some("anthropic@default/claude-sonnet-4-6")
-    );
+    assert!(state.pending_fallback_model.is_none());
     assert_eq!(
         state.last_turn_terminal.as_ref().map(|record| record.kind),
         Some(TurnTerminalKind::DeferredToFallback)
@@ -1474,6 +1467,21 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
         queued.authority_class,
         AuthorityClass::RuntimeInstruction
     ));
+    assert_eq!(
+        queued
+            .metadata
+            .as_ref()
+            .and_then(|metadata| { metadata["provider_recovery"]["fallback_model_ref"].as_str() }),
+        Some("anthropic@default/claude-sonnet-4-6")
+    );
+    assert_eq!(
+        crate::runtime::turn::TurnModelSelection::from_message(&queued)
+            .unwrap()
+            .fallback_model()
+            .map(|model| model.as_string())
+            .as_deref(),
+        Some("anthropic@default/claude-sonnet-4-6")
+    );
 
     let events = wait_for_audit_events(
         &runtime,
@@ -1485,9 +1493,7 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
                 && events
                     .iter()
                     .any(|event| event.kind == "deferred_to_fallback")
-                && events
-                    .iter()
-                    .any(|event| event.kind == "recovery_turn_started")
+                && events.iter().any(|event| event.kind == "recovery_enqueued")
         },
         "provider failure fallback events",
     )
@@ -1509,9 +1515,286 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
     assert!(deferred.data["operator_message"]
         .as_str()
         .is_some_and(|message| message.contains("Queued fallback turn")));
-    assert!(events
+    assert!(events.iter().any(|event| event.kind == "recovery_enqueued"));
+    assert!(!events
         .iter()
         .any(|event| event.kind == "recovery_turn_started"));
+}
+
+#[test]
+fn provider_recovery_directive_requires_runtime_owned_recovery_provenance() {
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "try to select a model".into(),
+        },
+    );
+    message.metadata = Some(serde_json::json!({
+        "provider_recovery": {
+            "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+            "source_turn_id": "turn-source",
+            "source_message_id": "message-source",
+            "source_terminal_kind": "deferred_to_fallback",
+            "source_round": 1
+        }
+    }));
+
+    let selection = crate::runtime::turn::TurnModelSelection::from_message(&message).unwrap();
+    assert!(selection.fallback_model().is_none());
+}
+
+async fn assert_successful_same_owner_turn_supersedes_queued_provider_recovery(
+    mut superseding: MessageEnvelope,
+) {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let mut source_turn = TurnRecord::new("default", "turn-source", 1);
+    source_turn.current_work_item_id = Some("work-1".into());
+    runtime.storage().append_turn(&source_turn).unwrap();
+
+    let mut recovery = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "model_lineage_recovery".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "continue recovery".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        crate::types::AdmissionContext::RuntimeOwned,
+    );
+    recovery.work_item_id = Some("work-1".into());
+    recovery.metadata = Some(serde_json::json!({
+        "provider_recovery": {
+            "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+            "source_turn_id": "turn-source",
+            "source_message_id": "message-source",
+            "source_terminal_kind": "deferred_to_fallback",
+            "source_round": 1
+        }
+    }));
+    let recovery = runtime.enqueue(recovery).await.unwrap();
+
+    superseding.turn_id = Some("turn-success".into());
+    let mut transition = terminal_transition(&superseding, Some("work-1"));
+    transition.terminal.turn_index = 2;
+    transition.turn_record.turn_index = 2;
+    transition.turn_record.produced_brief_ids = vec!["brief-success".into()];
+
+    assert_eq!(
+        runtime
+            .maybe_supersede_queued_provider_recovery(&superseding, Some(&transition))
+            .await
+            .unwrap(),
+        1
+    );
+    let queue_entry = runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest_all()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.message_id == recovery.id)
+        .expect("recovery queue entry");
+    assert_eq!(queue_entry.status, QueueEntryStatus::Dropped);
+    assert!(runtime
+        .inner
+        .agent
+        .lock()
+        .await
+        .queue
+        .peek_next_matching(|message| message.id == recovery.id)
+        .is_none());
+    assert!(runtime
+        .storage()
+        .read_recent_events(20)
+        .unwrap()
+        .iter()
+        .any(|event| event.kind == "recovery_superseded"));
+}
+
+#[tokio::test]
+async fn successful_ordinary_turn_supersedes_queued_provider_recovery() {
+    assert_successful_same_owner_turn_supersedes_queued_provider_recovery(MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "continue successfully".into(),
+        },
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn successful_recovery_turn_supersedes_older_queued_provider_recovery() {
+    let mut superseding = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "model_lineage_recovery".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "continue newer recovery".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        crate::types::AdmissionContext::RuntimeOwned,
+    );
+    superseding.metadata = Some(serde_json::json!({
+        "provider_recovery": {
+            "fallback_model_ref": "openai/gpt-5.4",
+            "source_turn_id": "turn-newer-source",
+            "source_message_id": "message-newer-source",
+            "source_terminal_kind": "deferred_to_fallback",
+            "source_round": 1
+        }
+    }));
+    assert_successful_same_owner_turn_supersedes_queued_provider_recovery(superseding).await;
+}
+
+#[tokio::test]
+async fn view_image_selection_uses_current_turn_fallback_model() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    *runtime.inner.turn_fallback_model.write().await = Some(
+        crate::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6").unwrap(),
+    );
+
+    let selection = runtime.current_view_image_vision_selection().await.unwrap();
+    assert_eq!(selection.primary_provider.as_deref(), Some("anthropic"));
+    assert_eq!(
+        selection.primary_model.as_deref(),
+        Some("claude-sonnet-4-6")
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_discards_legacy_fallback_slot_but_preserves_typed_recovery() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let recovery_id = {
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("unused")),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        {
+            let mut guard = runtime.inner.agent.lock().await;
+            guard.state.pending_fallback_model = Some(
+                crate::config::ModelRouteRef::parse_compatible("anthropic/claude-sonnet-4-6")
+                    .unwrap(),
+            );
+            guard.persist_state(&runtime.inner.storage).unwrap();
+        }
+        let mut recovery = MessageEnvelope::new(
+            "default",
+            MessageKind::InternalFollowup,
+            MessageOrigin::System {
+                subsystem: "model_lineage_recovery".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Next,
+            MessageBody::Text {
+                text: "continue recovery".into(),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            crate::types::AdmissionContext::RuntimeOwned,
+        );
+        recovery.metadata = Some(serde_json::json!({
+            "provider_recovery": {
+                "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+                "source_turn_id": "turn-source",
+                "source_message_id": "message-source",
+                "source_terminal_kind": "deferred_to_fallback",
+                "source_round": 1
+            }
+        }));
+        runtime.enqueue(recovery).await.unwrap().id
+    };
+
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    assert!(reopened
+        .agent_state()
+        .await
+        .unwrap()
+        .pending_fallback_model
+        .is_none());
+    let recovery = reopened
+        .inner
+        .agent
+        .lock()
+        .await
+        .queue
+        .peek_next_matching(|message| message.id == recovery_id)
+        .cloned()
+        .expect("typed recovery should survive bootstrap");
+    assert_eq!(
+        crate::runtime::turn::TurnModelSelection::from_message(&recovery)
+            .unwrap()
+            .fallback_model()
+            .map(|model| model.as_string())
+            .as_deref(),
+        Some("anthropic@default/claude-sonnet-4-6")
+    );
+    assert!(reopened
+        .storage()
+        .read_recent_events(20)
+        .unwrap()
+        .iter()
+        .any(|event| event.kind == "legacy_pending_fallback_discarded"));
 }
 
 #[tokio::test]

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -50,7 +50,8 @@ use super::reminders::{
 };
 use super::{
     append_follow_up_user_texts, render_operator_interjection_text, AgentLoopOutcome,
-    LoopControlOptions, TurnRoundRecord, MAX_OUTPUT_RECOVERY_ATTEMPTS, ROUND_TEXT_PREVIEW_LIMIT,
+    LoopControlOptions, ProviderRecoveryDirective, TurnModelSelection, TurnRoundRecord,
+    MAX_OUTPUT_RECOVERY_ATTEMPTS, ROUND_TEXT_PREVIEW_LIMIT,
     WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
 };
 use super::{truncate_preview, CHECKPOINT_RESUME_PROMPT};
@@ -65,6 +66,36 @@ enum OperatorInterjectionPlan {
         scenario_class: Option<crate::domain::scheduler_protocol::SchedulerScenarioClass>,
         effective_mode: crate::domain::scheduler_protocol::ScenarioMode,
     },
+}
+
+impl TurnModelSelection {
+    pub(crate) fn from_message(message: &MessageEnvelope) -> Result<Self> {
+        let trusted_recovery = message.kind == MessageKind::InternalFollowup
+            && message.authority_class == AuthorityClass::RuntimeInstruction
+            && message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
+            && message.admission_context == Some(AdmissionContext::RuntimeOwned)
+            && matches!(
+                &message.origin,
+                MessageOrigin::System { subsystem } if subsystem == "model_lineage_recovery"
+            );
+        if !trusted_recovery {
+            return Ok(Self::default());
+        }
+        let directive = message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("provider_recovery"))
+            .ok_or_else(|| {
+                anyhow::anyhow!("model lineage recovery message is missing its directive")
+            })
+            .and_then(|value| {
+                serde_json::from_value::<ProviderRecoveryDirective>(value.clone())
+                    .map_err(anyhow::Error::from)
+            })?;
+        Ok(Self {
+            recovery: Some(directive),
+        })
+    }
 }
 
 impl RuntimeHandle {
@@ -184,11 +215,6 @@ impl RuntimeHandle {
         } else {
             TurnTerminalKind::DeferredToFallback
         };
-        {
-            let mut guard = self.inner.agent.lock().await;
-            guard.state.pending_fallback_model = Some(fallback_model.clone());
-            guard.persist_state(&self.inner.storage)?;
-        }
         let error_text = error.to_string();
         let provider_failure_text = provider_lineage_failure_text(&error_text);
         let operator_message = provider_lineage_operator_message(
@@ -268,15 +294,35 @@ impl RuntimeHandle {
                 .or_else(|| guard.state.current_turn_work_item_id.clone())
                 .or_else(|| guard.state.current_work_item_id.clone())
         };
+        let source_message_id = {
+            let guard = self.inner.agent.lock().await;
+            guard
+                .state
+                .current_execution_binding
+                .as_ref()
+                .map(|binding| binding.source_message_id.clone())
+                .unwrap_or_else(|| terminal.turn_id.clone())
+        };
+        message.causation_id = Some(source_message_id.clone());
+        message
+            .source_refs
+            .insert("source_turn_id".into(), terminal.turn_id.clone());
+        message
+            .source_refs
+            .insert("source_message_id".into(), source_message_id.clone());
         message.metadata = Some(serde_json::json!({
-            "fallback_model_ref": fallback_ref,
-            "source_terminal_kind": terminal_kind,
-            "source_round": round,
+            "provider_recovery": ProviderRecoveryDirective {
+                fallback_model_ref: fallback_model,
+                source_turn_id: terminal.turn_id.clone(),
+                source_message_id,
+                source_terminal_kind: terminal_kind,
+                source_round: round,
+            },
             "side_effect_boundary_crossed": side_effect_boundary_crossed,
         }));
         let queued = self.enqueue(message).await?;
         self.inner.storage.append_event(&AuditEvent::legacy(
-            "recovery_turn_started",
+            "recovery_enqueued",
             serde_json::json!({
                 "agent_id": agent_id,
                 "message_id": queued.id,
@@ -713,11 +759,13 @@ impl RuntimeHandle {
         effective_prompt: EffectivePrompt,
         loop_control: LoopControlOptions,
     ) -> Result<AgentLoopOutcome> {
+        self.reconfigure_provider_for_turn(None).await?;
         TurnExecution {
             runtime: self,
             agent_id,
             authority_class,
             effective_prompt,
+            model_selection: TurnModelSelection::default(),
             loop_control,
             persist_terminal: true,
         }
@@ -730,6 +778,7 @@ impl RuntimeHandle {
         agent_id: &str,
         authority_class: AuthorityClass,
         effective_prompt: EffectivePrompt,
+        model_selection: TurnModelSelection,
         loop_control: LoopControlOptions,
     ) -> Result<AgentLoopOutcome> {
         TurnExecution {
@@ -737,6 +786,7 @@ impl RuntimeHandle {
             agent_id,
             authority_class,
             effective_prompt,
+            model_selection,
             loop_control,
             persist_terminal: false,
         }
@@ -863,6 +913,7 @@ pub(super) struct TurnExecution<'a> {
     pub(super) agent_id: &'a str,
     pub(super) authority_class: AuthorityClass,
     pub(super) effective_prompt: EffectivePrompt,
+    pub(super) model_selection: TurnModelSelection,
     pub(super) loop_control: LoopControlOptions,
     pub(super) persist_terminal: bool,
 }
@@ -874,6 +925,7 @@ impl TurnExecution<'_> {
             agent_id,
             authority_class,
             mut effective_prompt,
+            model_selection,
             loop_control,
             persist_terminal,
         } = self;
@@ -892,15 +944,13 @@ impl TurnExecution<'_> {
             let guard = runtime.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
         };
-        let (turn_model_override, turn_pending_fallback_model, turn_model_state) = {
+        let (turn_model_override, turn_model_state) = {
             let guard = runtime.inner.agent.lock().await;
             (
                 guard.state.model_override.clone(),
-                guard.state.pending_fallback_model.clone(),
-                runtime.model_state_for(&guard.state),
+                runtime.model_state_for_turn(&guard.state, model_selection.fallback_model()),
             )
         };
-        runtime.reconfigure_provider_for_current_state().await?;
         let identity = runtime.agent_identity_view().await?;
         let (
             provider,
@@ -908,7 +958,9 @@ impl TurnExecution<'_> {
             _apply_patch_surface,
             native_web_search,
             builtin_web_search_selection,
-        ) = runtime.provider_tool_selection(&identity).await?;
+        ) = runtime
+            .provider_tool_selection_for_turn(&identity, model_selection.fallback_model())
+            .await?;
         let allowed_tool_names = available_tools
             .iter()
             .map(|tool| tool.name.clone())
@@ -918,12 +970,12 @@ impl TurnExecution<'_> {
             serde_json::json!({
                 "agent_id": agent_id,
                 "model_override": turn_model_override,
-                "pending_fallback_model": turn_pending_fallback_model,
+                "recovery_fallback_model": model_selection.fallback_model(),
                 "model": turn_model_state,
                 "builtin_web_search_selection": builtin_web_search_selection,
             }),
         ))?;
-        if let Some(pending) = turn_pending_fallback_model.as_ref() {
+        if let Some(pending) = model_selection.fallback_model() {
             runtime.inner.storage.append_event(&AuditEvent::legacy(
                 "pending_model_promoted",
                 serde_json::json!({
@@ -1060,13 +1112,6 @@ impl TurnExecution<'_> {
                             .await?
                         {
                             return Ok(outcome);
-                        }
-                        {
-                            let mut guard = runtime.inner.agent.lock().await;
-                            if guard.state.pending_fallback_model.is_some() {
-                                guard.state.pending_fallback_model = None;
-                                guard.persist_state(&runtime.inner.storage)?;
-                            }
                         }
                         runtime
                             .persist_turn_terminal_record(
@@ -1410,13 +1455,6 @@ impl TurnExecution<'_> {
                         {
                             return Ok(outcome);
                         }
-                        {
-                            let mut guard = runtime.inner.agent.lock().await;
-                            if guard.state.pending_fallback_model.is_some() {
-                                guard.state.pending_fallback_model = None;
-                                guard.persist_state(&runtime.inner.storage)?;
-                            }
-                        }
                         runtime
                             .persist_turn_terminal_record(
                                 TurnTerminalKind::Aborted,
@@ -1446,7 +1484,6 @@ impl TurnExecution<'_> {
                 ));
                 guard.state.last_requested_model = model_attempt_state.requested_model.clone();
                 guard.state.last_active_model = model_attempt_state.active_model.clone();
-                guard.state.pending_fallback_model = None;
                 guard.persist_state(&runtime.inner.storage)?;
                 (
                     guard.state.turn_index,

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -17,9 +17,10 @@ mod tool_summary;
 mod tests;
 
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::config::ModelRouteRef;
 use crate::provider::{ModelBlock, ToolResultBlock};
 use crate::tool::{spec::ToolResultEnvelope, ToolCall};
 use crate::types::{
@@ -53,6 +54,28 @@ pub(crate) struct TurnTerminalTransition {
 
 pub(crate) struct LoopControlOptions {
     pub(super) max_tool_rounds: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct ProviderRecoveryDirective {
+    pub(super) fallback_model_ref: ModelRouteRef,
+    pub(super) source_turn_id: String,
+    pub(super) source_message_id: String,
+    pub(super) source_terminal_kind: TurnTerminalKind,
+    pub(super) source_round: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TurnModelSelection {
+    pub(super) recovery: Option<ProviderRecoveryDirective>,
+}
+
+impl TurnModelSelection {
+    pub(super) fn fallback_model(&self) -> Option<&ModelRouteRef> {
+        self.recovery
+            .as_ref()
+            .map(|directive| &directive.fallback_model_ref)
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- classify completed provider responses with no wire content/output items as `empty_response + retryable`
- preserve failed-response token usage in provider attempt timelines
- bind fallback routing to a typed, runtime-owned recovery message directive instead of agent-global `pending_fallback_model`
- distinguish `recovery_enqueued`, actual `recovery_turn_started`, and atomic `recovery_superseded`
- discard legacy global fallback slots at bootstrap while preserving durable typed recovery messages

## Runtime contract

A recovery message is the source of truth for its fallback lineage. The directive is accepted only for a runtime-owned `InternalFollowup` from the `model_lineage_recovery` subsystem. Provider chain, context policy, tool/apply-patch surfaces, vision/image selection, diagnostics, and static-provider lineage selection all use the same turn-local fallback. The selection is cleared when model reentry ends.

A successful later turn for the same owner may atomically drop an older still-queued recovery only when it produced accepted brief/tool/WorkItem progress. Dequeued recovery is never superseded.

## Provider behavior

- Anthropic completed `content=[]` responses are retryable and retain trace/usage evidence.
- OpenAI Responses `output=[]` and message `content=[]` are retryable.
- Non-empty unsupported blocks/items and malformed message content remain `invalid_response + fail_fast`.

## Verification

- `cargo test provider::tests --no-fail-fast` — 173 passed
- `cargo test runtime::tests::turns --no-fail-fast` — 26 passed
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2458
Closes #2457
