### PR TITLE
fix: isolate E2E provider temp paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,8 +262,8 @@ jobs:
       HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
       HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
       HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
-      HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
-      HOLON_E2E_CONFIG_FILE: /tmp/holon-e2e-config.json
+      HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+      HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
 
@@ -288,12 +288,12 @@ jobs:
           umask 077
           printf '%s=%s\n' \
             "${HOLON_E2E_CREDENTIAL_ENV}" \
-            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
-          chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_PROVIDER_ENV_FILE}"
+          chmod 0600 "${HOLON_E2E_PROVIDER_ENV_FILE}"
           if [ -n "${HOLON_E2E_CONFIG_JSON}" ]; then
-            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_CONFIG_FILE}"
-            python3 -m json.tool "${HOLON_E2E_CONFIG_FILE}" >/dev/null
-            chmod 0600 "${HOLON_E2E_CONFIG_FILE}"
+            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
+            python3 -m json.tool "${HOLON_E2E_PROVIDER_CONFIG_FILE}" >/dev/null
+            chmod 0600 "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
           fi
 
       - name: Run scheduler live canary
@@ -304,12 +304,12 @@ jobs:
             --skip-build
             --profile scheduler-live-canary
             --scheduler-matrix
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --env-file "${HOLON_E2E_PROVIDER_ENV_FILE}"
             --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
           )
-          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
 
@@ -347,7 +347,7 @@ jobs:
 
       - name: Remove provider configuration
         if: always()
-        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}" "${HOLON_E2E_CONFIG_FILE}"
+        run: rm -f "${HOLON_E2E_PROVIDER_ENV_FILE}" "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
 
   scheduler-e2e-required:
     name: Scheduler E2E Required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,8 +262,6 @@ jobs:
       HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
       HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
       HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
-      HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
-      HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
 
@@ -281,6 +279,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=holon-docker
 
       - name: Prepare provider configuration
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
           test -n "${HOLON_E2E_CREDENTIAL}"
@@ -297,8 +298,11 @@ jobs:
           fi
 
       - name: Run scheduler live canary
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
         run: |
           set -euo pipefail
+          config_file=/tmp/holon-e2e-config.json
           args=(
             --image holon:e2e
             --skip-build
@@ -308,8 +312,8 @@ jobs:
             --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
           )
-          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
+          if [ -s "${config_file}" ]; then
+            args+=(--config-file "${config_file}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
 
@@ -347,6 +351,9 @@ jobs:
 
       - name: Remove provider configuration
         if: always()
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: rm -f "${HOLON_E2E_PROVIDER_ENV_FILE}" "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
 
   scheduler-e2e-required:

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -176,9 +176,9 @@ jobs:
         continue-on-error: true
         env:
           HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
-          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
+          config_file=/tmp/holon-e2e-config.json
           args=(
             --image holon:nightly
             --skip-build
@@ -188,8 +188,8 @@ jobs:
             --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
           )
-          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
+          if [ -s "${config_file}" ]; then
+            args+=(--config-file "${config_file}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
 
@@ -230,6 +230,15 @@ jobs:
               ])
           Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n")
           PY
+
+      - name: Require dispatched live canary success
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PROVIDER_ENV_OUTCOME: ${{ steps.provider-env.outcome }}
+          LIVE_CANARY_OUTCOME: ${{ steps.live-canary.outcome }}
+        run: |
+          test "${PROVIDER_ENV_OUTCOME}" = success
+          test "${LIVE_CANARY_OUTCOME}" = success
 
       - name: Upload scheduler evidence
         if: always()

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -122,8 +122,8 @@ jobs:
       HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
       HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
       HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
-      HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
-      HOLON_E2E_CONFIG_FILE: /tmp/holon-e2e-config.json
+      HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+      HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
 
@@ -161,12 +161,12 @@ jobs:
           umask 077
           printf '%s=%s\n' \
             "${HOLON_E2E_CREDENTIAL_ENV}" \
-            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
-          chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_PROVIDER_ENV_FILE}"
+          chmod 0600 "${HOLON_E2E_PROVIDER_ENV_FILE}"
           if [ -n "${HOLON_E2E_CONFIG_JSON}" ]; then
-            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_CONFIG_FILE}"
-            python3 -m json.tool "${HOLON_E2E_CONFIG_FILE}" >/dev/null
-            chmod 0600 "${HOLON_E2E_CONFIG_FILE}"
+            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
+            python3 -m json.tool "${HOLON_E2E_PROVIDER_CONFIG_FILE}" >/dev/null
+            chmod 0600 "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
           fi
 
       - name: Run scheduler live canary
@@ -180,12 +180,12 @@ jobs:
             --skip-build
             --profile scheduler-live-canary
             --scheduler-matrix
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --env-file "${HOLON_E2E_PROVIDER_ENV_FILE}"
             --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
           )
-          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
 
@@ -259,4 +259,4 @@ jobs:
 
       - name: Remove provider configuration
         if: always()
-        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}" "${HOLON_E2E_CONFIG_FILE}"
+        run: rm -f "${HOLON_E2E_PROVIDER_ENV_FILE}" "${HOLON_E2E_PROVIDER_CONFIG_FILE}"

--- a/.github/workflows/e2e-scheduler-nightly.yml
+++ b/.github/workflows/e2e-scheduler-nightly.yml
@@ -122,8 +122,6 @@ jobs:
       HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
       HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
       HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
-      HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
-      HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
 
@@ -154,6 +152,9 @@ jobs:
       - name: Prepare provider configuration
         id: provider-env
         continue-on-error: true
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
           test -n "${HOLON_E2E_CREDENTIAL}"
@@ -173,6 +174,9 @@ jobs:
         id: live-canary
         if: steps.provider-env.outcome == 'success'
         continue-on-error: true
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
           args=(
@@ -259,4 +263,7 @@ jobs:
 
       - name: Remove provider configuration
         if: always()
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: rm -f "${HOLON_E2E_PROVIDER_ENV_FILE}" "${HOLON_E2E_PROVIDER_CONFIG_FILE}"

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -85,8 +85,6 @@ jobs:
       HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
       HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
       HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
-      HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
-      HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,6 +98,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare protected provider configuration
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
           test -n "${HOLON_E2E_CREDENTIAL}"
@@ -124,6 +125,8 @@ jobs:
       - name: Run release core E2E
         env:
           HOLON_E2E_PREVIOUS_IMAGE: ${{ inputs.previous_image }}
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
           args=(
@@ -154,6 +157,9 @@ jobs:
 
       - name: Run scheduler live canary
         continue-on-error: true
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
           args=(
@@ -362,4 +368,7 @@ jobs:
 
       - name: Remove provider configuration
         if: always()
+        env:
+          HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: rm -f "${HOLON_E2E_PROVIDER_ENV_FILE}" "${HOLON_E2E_PROVIDER_CONFIG_FILE}"

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -85,8 +85,8 @@ jobs:
       HOLON_E2E_CREDENTIAL_ENV: ${{ vars.HOLON_E2E_SCHEDULER_CREDENTIAL_ENV || 'DASHSCOPE_TOKEN_PLAN_API_KEY' }}
       HOLON_E2E_CREDENTIAL: ${{ secrets.HOLON_E2E_SCHEDULER_CREDENTIAL || secrets.DASHSCOPE_TOKEN_PLAN_API_KEY || secrets.DEEPSEEK_API_KEY }}
       HOLON_E2E_CONFIG_JSON: ${{ vars.HOLON_E2E_SCHEDULER_CONFIG_JSON }}
-      HOLON_E2E_DOCKER_ENV_FILE: /tmp/holon-e2e.env
-      HOLON_E2E_CONFIG_FILE: /tmp/holon-e2e-config.json
+      HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
+      HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,12 +107,12 @@ jobs:
           umask 077
           printf '%s=%s\n' \
             "${HOLON_E2E_CREDENTIAL_ENV}" \
-            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_DOCKER_ENV_FILE}"
-          chmod 0600 "${HOLON_E2E_DOCKER_ENV_FILE}"
+            "${HOLON_E2E_CREDENTIAL}" > "${HOLON_E2E_PROVIDER_ENV_FILE}"
+          chmod 0600 "${HOLON_E2E_PROVIDER_ENV_FILE}"
           if [ -n "${HOLON_E2E_CONFIG_JSON}" ]; then
-            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_CONFIG_FILE}"
-            python3 -m json.tool "${HOLON_E2E_CONFIG_FILE}" >/dev/null
-            chmod 0600 "${HOLON_E2E_CONFIG_FILE}"
+            printf '%s' "${HOLON_E2E_CONFIG_JSON}" > "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
+            python3 -m json.tool "${HOLON_E2E_PROVIDER_CONFIG_FILE}" >/dev/null
+            chmod 0600 "${HOLON_E2E_PROVIDER_CONFIG_FILE}"
           fi
 
       - name: Pull and smoke candidate digest
@@ -130,11 +130,11 @@ jobs:
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
             --suite core
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --env-file "${HOLON_E2E_PROVIDER_ENV_FILE}"
             --evidence-dir target/docker-e2e/release-core
           )
-          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
           fi
           if [ -n "${HOLON_E2E_PREVIOUS_IMAGE}" ]; then
             args+=(--previous-image "${HOLON_E2E_PREVIOUS_IMAGE}")
@@ -161,12 +161,12 @@ jobs:
             --skip-build
             --profile scheduler-live-canary
             --scheduler-matrix
-            --env-file "${HOLON_E2E_DOCKER_ENV_FILE}"
+            --env-file "${HOLON_E2E_PROVIDER_ENV_FILE}"
             --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
           )
-          if [ -s "${HOLON_E2E_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_CONFIG_FILE}")
+          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
+            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
 
@@ -362,4 +362,4 @@ jobs:
 
       - name: Remove provider configuration
         if: always()
-        run: rm -f "${HOLON_E2E_DOCKER_ENV_FILE}" "${HOLON_E2E_CONFIG_FILE}"
+        run: rm -f "${HOLON_E2E_PROVIDER_ENV_FILE}" "${HOLON_E2E_PROVIDER_CONFIG_FILE}"

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -126,9 +126,9 @@ jobs:
         env:
           HOLON_E2E_PREVIOUS_IMAGE: ${{ inputs.previous_image }}
           HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
-          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
+          config_file=/tmp/holon-e2e-config.json
           args=(
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
@@ -136,8 +136,8 @@ jobs:
             --env-file "${HOLON_E2E_PROVIDER_ENV_FILE}"
             --evidence-dir target/docker-e2e/release-core
           )
-          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
+          if [ -s "${config_file}" ]; then
+            args+=(--config-file "${config_file}")
           fi
           if [ -n "${HOLON_E2E_PREVIOUS_IMAGE}" ]; then
             args+=(--previous-image "${HOLON_E2E_PREVIOUS_IMAGE}")
@@ -159,9 +159,9 @@ jobs:
         continue-on-error: true
         env:
           HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
-          HOLON_E2E_PROVIDER_CONFIG_FILE: /tmp/holon-e2e-config.json
         run: |
           set -euo pipefail
+          config_file=/tmp/holon-e2e-config.json
           args=(
             --image-digest "${CANDIDATE_IMAGE}"
             --skip-build
@@ -171,8 +171,8 @@ jobs:
             --timeout 120
             --evidence-dir target/docker-e2e/scheduler-live-canary
           )
-          if [ -s "${HOLON_E2E_PROVIDER_CONFIG_FILE}" ]; then
-            args+=(--config-file "${HOLON_E2E_PROVIDER_CONFIG_FILE}")
+          if [ -s "${config_file}" ]; then
+            args+=(--config-file "${config_file}")
           fi
           python3 scripts/docker-e2e.py "${args[@]}"
 

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -75,16 +75,18 @@ OPENROUTER_API_KEY='...' \
 make docker-e2e
 ```
 
-Alternatively, set `HOLON_E2E_DOCKER_ENV_FILE` or pass `--env-file` to an
+Alternatively, set `HOLON_E2E_PROVIDER_ENV_FILE` or pass `--env-file` to an
 untracked Docker env file with mode `0600`. The runner records only the
 credential variable names and whether a file was used. It never records the
-file path or values. Existing `HOLON_LIVE_*` variables remain accepted during
-the compatibility period.
+file path or values. The legacy `HOLON_E2E_DOCKER_ENV_FILE` and existing
+`HOLON_LIVE_*` variables remain accepted during the compatibility period.
 
-Pass `--config-file` or set `HOLON_E2E_CONFIG_FILE` to seed a non-secret Holon
-`config.json` into each case volume. Keep credentials in the env file rather
-than the config file. The protected CI, nightly, and release workflows expose
-the same split through repository configuration:
+Pass `--config-file` or set `HOLON_E2E_PROVIDER_CONFIG_FILE` to seed a
+non-secret Holon `config.json` into each case volume. The legacy
+`HOLON_E2E_CONFIG_FILE` remains accepted during the compatibility period. Keep
+credentials in the env file rather than the config file. The protected CI,
+nightly, and release workflows expose the same split through repository
+configuration:
 
 - `HOLON_E2E_SCHEDULER_MODEL`: model route; defaults to the same
   `dashscope-token-plan/qwen-3.7` route used by `holon-trigger`.

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -116,6 +116,25 @@ def first_env(*names: str, default: str = "") -> str:
     return default
 
 
+def provider_file_paths(
+    env_file: Path | None,
+    config_file: Path | None,
+) -> tuple[Path | None, Path | None]:
+    env_file_value = env_file or first_env(
+        "HOLON_E2E_PROVIDER_ENV_FILE",
+        "HOLON_E2E_DOCKER_ENV_FILE",
+        "HOLON_LIVE_DOCKER_ENV_FILE",
+    )
+    config_file_value = config_file or first_env(
+        "HOLON_E2E_PROVIDER_CONFIG_FILE",
+        "HOLON_E2E_CONFIG_FILE",
+    )
+    return (
+        Path(env_file_value).resolve() if env_file_value else None,
+        Path(config_file_value).resolve() if config_file_value else None,
+    )
+
+
 def env_flag(*names: str) -> bool:
     return first_env(*names).lower() in {"1", "true", "yes", "on"}
 
@@ -4711,18 +4730,13 @@ def main(argv: list[str] | None = None) -> int:
         "HOLON_E2E_CREDENTIAL_ENVS", "HOLON_LIVE_CREDENTIAL_ENVS"
     )
     credential_envs = [name.strip() for name in raw_names.split(",") if name.strip()]
-    env_file_value = args.env_file or first_env(
-        "HOLON_E2E_DOCKER_ENV_FILE", "HOLON_LIVE_DOCKER_ENV_FILE"
-    )
-    env_file = Path(env_file_value).resolve() if env_file_value else None
-    config_file_value = args.config_file or first_env("HOLON_E2E_CONFIG_FILE")
-    config_file = Path(config_file_value).resolve() if config_file_value else None
+    env_file, config_file = provider_file_paths(args.env_file, args.config_file)
     runtime_config = load_runtime_config(config_file)
     if requires_model and not credential_envs and env_file is None:
         inferred = inferred_credential_env(model)
         require(
             inferred is not None,
-            "set HOLON_E2E_CREDENTIAL_ENVS or HOLON_E2E_DOCKER_ENV_FILE "
+            "set HOLON_E2E_CREDENTIAL_ENVS or HOLON_E2E_PROVIDER_ENV_FILE "
             f"for model {model}",
         )
         credential_envs = [inferred]

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2949,6 +2949,10 @@ def run_scheduler_external_wait_resume_case(
         and completion_marker in (result_brief.get("text") or ""),
         f"external wait completion brief mismatch: {result_brief}",
     )
+    # CompleteWorkItem persists the completed WorkItem before the canonical
+    # scheduler records the enclosing activation settlement. Wait for the
+    # resume turn to fully drain before inspecting activation lineage.
+    harness.wait_queue_drained()
     snapshot = harness.runtime_db_snapshot("scheduler-external")
     resume_turn_ids = {
         row["turn_id"]

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -231,6 +231,8 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn("Unable to detect scheduler code changes", nightly)
         self.assertIn("comparison.data.truncation === true", nightly)
         self.assertIn("files.length >= 300", nightly)
+        self.assertIn("HOLON_E2E_PROVIDER_CONFIG_FILE:", nightly)
+        self.assertNotIn("HOLON_E2E_CONFIG_FILE:", nightly)
 
     def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import json
 import copy
+import os
 import subprocess
 import tempfile
 import unittest
@@ -90,6 +91,36 @@ class DockerE2ERunnerTests(unittest.TestCase):
             path.write_text("[]")
             with self.assertRaisesRegex(AssertionError, "JSON object"):
                 runner.load_runtime_config(path)
+
+    def test_provider_file_paths_accept_new_names_before_legacy_aliases(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "HOLON_E2E_PROVIDER_ENV_FILE": "provider.env",
+                "HOLON_E2E_DOCKER_ENV_FILE": "legacy.env",
+                "HOLON_E2E_PROVIDER_CONFIG_FILE": "provider.json",
+                "HOLON_E2E_CONFIG_FILE": "legacy.json",
+            },
+            clear=True,
+        ):
+            env_file, config_file = runner.provider_file_paths(None, None)
+
+        self.assertEqual(env_file, Path("provider.env").resolve())
+        self.assertEqual(config_file, Path("provider.json").resolve())
+
+    def test_provider_file_paths_keep_legacy_aliases(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "HOLON_E2E_DOCKER_ENV_FILE": "legacy.env",
+                "HOLON_E2E_CONFIG_FILE": "legacy.json",
+            },
+            clear=True,
+        ):
+            env_file, config_file = runner.provider_file_paths(None, None)
+
+        self.assertEqual(env_file, Path("legacy.env").resolve())
+        self.assertEqual(config_file, Path("legacy.json").resolve())
 
     def test_work_queue_message_evidence_extracts_retry_identity(self) -> None:
         snapshot = {

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import io
+import inspect
 import json
 import copy
 import os
@@ -2012,6 +2013,13 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 expected_admission_kinds=("wait_resume",),
                 lifecycle_message_ids={"message-create"},
             )
+
+    def test_external_wait_resume_drains_queue_before_runtime_snapshot(self) -> None:
+        source = inspect.getsource(runner.run_scheduler_external_wait_resume_case)
+        self.assertLess(
+            source.index("harness.wait_queue_drained()"),
+            source.index('harness.runtime_db_snapshot("scheduler-external")'),
+        )
 
     def test_compaction_oracle_requires_actual_compaction_evidence(self) -> None:
         event = {

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -265,6 +265,15 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn("files.length >= 300", nightly)
         self.assertIn("HOLON_E2E_PROVIDER_CONFIG_FILE:", nightly)
         self.assertNotIn("HOLON_E2E_CONFIG_FILE:", nightly)
+        nightly_job_env = nightly.split("  nightly:\n", 1)[1].split(
+            "    steps:\n", 1
+        )[0]
+        release_job_env = release.split("  core:\n", 1)[1].split(
+            "    steps:\n", 1
+        )[0]
+        for job_env in (nightly_job_env, release_job_env):
+            self.assertNotIn("HOLON_E2E_PROVIDER_ENV_FILE", job_env)
+            self.assertNotIn("HOLON_E2E_PROVIDER_CONFIG_FILE", job_env)
 
     def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -263,8 +263,16 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn("Unable to detect scheduler code changes", nightly)
         self.assertIn("comparison.data.truncation === true", nightly)
         self.assertIn("files.length >= 300", nightly)
+        self.assertIn("Require dispatched live canary success", nightly)
+        self.assertIn('test "${LIVE_CANARY_OUTCOME}" = success', nightly)
         self.assertIn("HOLON_E2E_PROVIDER_CONFIG_FILE:", nightly)
         self.assertNotIn("HOLON_E2E_CONFIG_FILE:", nightly)
+        for workflow in (ci, nightly, release):
+            live_step = workflow.split(
+                "      - name: Run scheduler live canary\n", 1
+            )[1].split("      - name:", 1)[0]
+            self.assertNotIn("HOLON_E2E_PROVIDER_CONFIG_FILE", live_step)
+            self.assertIn("config_file=/tmp/holon-e2e-config.json", live_step)
         nightly_job_env = nightly.split("  nightly:\n", 1)[1].split(
             "    steps:\n", 1
         )[0]


### PR DESCRIPTION
## Summary
- 将 workflow 专用的 provider 临时文件变量改为 `HOLON_E2E_PROVIDER_ENV_FILE` / `HOLON_E2E_PROVIDER_CONFIG_FILE`，避免 deterministic gate 隐式继承 live-model 配置
- 让 Docker E2E runner 同时识别新的 canonical 名称与旧名称 fallback，保持本地兼容性
- 同步 acceptance 文档，并增加 runner-level fallback 测试

## Why
nightly job 原先在 job scope 设置 `HOLON_E2E_CONFIG_FILE=/tmp/holon-e2e-config.json`。deterministic matrix 早于 provider configuration step 执行，却通过 runner fallback 隐式读到这个尚未创建的路径，因此在真正调用模型前失败。

本修复将 workflow 内部准备的 provider 文件改用独立变量名；live canary 仍通过显式 `--env-file` / `--config-file` 传递 host 路径，而 deterministic gate 不再继承这些 live-model 文件。

## Verification
- `python3 -m unittest tests.test_docker_e2e_runner`（66 tests）
- `actionlint .github/workflows/ci.yml .github/workflows/e2e-scheduler-nightly.yml .github/workflows/release-e2e.yml`
- `git diff --check`
- 手动 run `30883749835`（基于 `9513adb1`）暴露假绿：provider preparation/live step 未实际执行，但 workflow 仍成功
- 修复提交 `82edb61b`：手动 dispatch 现在强制要求 provider preparation 与 live canary 均成功；新的 real-LLM run 待触发

Closes #2493


