### PR TITLE
fix: make stop/start buttons mutually exclusive based on agent state

### DIFF
--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -114,6 +114,11 @@ export function AgentOverviewPanel({
   const [pendingAction, setPendingAction] = useState<AgentControlAction | "delete" | null>(null);
   const workItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
   const currentWorkItems = workItems.filter((item) => item.current);
+  // Stop and Start are inverse lifecycle transitions: only show the one that
+  // applies to the current state. Delete is always available.
+  const normalizedLifecycle = (agent.lifecycle ?? "").trim().toLowerCase().replace(/[_\s]+/g, "-");
+  const normalizedPosture = (agent.posture ?? "").trim().toLowerCase().replace(/[_\s]+/g, "-");
+  const isStopped = normalizedLifecycle === "stopped" || normalizedLifecycle === "archived" || normalizedPosture === "stopped" || normalizedPosture === "archived";
   const openWorkItems = workItems.filter((item) => !item.current && item.state !== "completed");
   const completedWorkItems = workItems.filter((item) => item.state === "completed");
   const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? t("rightPanel.noCurrentWork");
@@ -183,7 +188,7 @@ export function AgentOverviewPanel({
             ) : (
               <>
                 <div className="lifecycle-buttons">
-                  {onControlAgent ? (
+                  {onControlAgent && !isStopped ? (
                     <button
                       type="button"
                       className="lifecycle-btn lifecycle-stop"
@@ -194,7 +199,7 @@ export function AgentOverviewPanel({
                       {t("agent.stop")}
                     </button>
                   ) : null}
-                  {onControlAgent ? (
+                  {onControlAgent && isStopped ? (
                     <button
                       type="button"
                       className="lifecycle-btn lifecycle-start"


### PR DESCRIPTION
## Problem

The Agent Overview panel showed Stop, Start, and Delete buttons all at once. Since Stop and Start are inverse lifecycle transitions, showing both simultaneously is confusing — the user should only see the action applicable to the current agent state.

## Change

In `AgentOverviewPanel.tsx`:

- Added `isStopped` check based on agent `lifecycle` and `posture` (reusing the same normalization logic from `agent-status.ts`).
- **Running agent (non-stopped)** → only shows the Stop button.
- **Stopped/archived agent** → only shows the Start button.
- **Delete button** remains always available.

This ensures the user sees a single, unambiguous lifecycle action based on the agent's current state.

## Testing

- TypeScript compilation passes (`tsc --noEmit`).
- Manual verification: stop button visible for running agents, start button visible for stopped agents.