### PR TITLE
fix: unify canonical execution protocol

### DIFF
--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -29,6 +29,15 @@ The earlier RFC's provenance, fencing, deterministic transition, idempotency,
 atomicity, immutable evidence, and process-global cutover requirements remain
 accepted.
 
+## Implementation Status
+
+As of 2026-08-05, canonical admission, turn binding, terminal settlement,
+operator interjection, exact wait reconciliation, and startup recovery read
+only the unified execution protocol and their owning business ledgers.
+Historical scheduler control tables remain available to the explicitly
+selected legacy engine and to explicit recovery diagnostics during the
+observation period; they do not grant or settle canonical execution.
+
 ## Motivation
 
 The scheduler was introduced to replace case-by-case coordination among
@@ -54,7 +63,7 @@ behavior. It is a smaller canonical kernel with one authority per question.
 | Is an input queued, claimed, or terminal? | queue/message state | attempt source, Turn, audit |
 | Is the agent executing? | one open `ExecutionAttempt` | agent status, historical slot |
 | Is a WorkItem runnable, waiting, paused, or terminal? | `WorkItemExecutionState` | plan, todo, focus, WorkDemand |
-| What can resume a wait? | `WaitCondition` identity, owner, generation, state | dispatch, closure reason |
+| What can resume a wait? | `WaitCondition` identity, owner, source, state | dispatch, closure reason |
 | Is a task active or terminal? | task ledger | message presence, agent posture |
 | May the host admit execution? | host runtime registry phase | loaded-runtime observation |
 | May the agent administratively accept work? | agent control | focus, waits, settlement history |
@@ -92,7 +101,7 @@ WorkItem, queue, wait, or task lifecycle.
 ```text
 Runnable(g)
 InFlight(g, attempt_id)
-Waiting(g, wait_id, wait_generation)
+Waiting(g, wait_id)
 Paused(g, reason)
 NeedsRepair(g, repair_id)
 Terminal(g, completion)
@@ -106,7 +115,7 @@ Waiting(g, exact triggered wait) -> InFlight(g, attempt)
 
 InFlight(g, attempt) -> Runnable(g + 1)
 InFlight(g, attempt) -> Runnable(g + 1, recovery_ref)
-InFlight(g, attempt) -> Waiting(g + 1, wait)
+InFlight(g, attempt) -> Waiting(g + 1, wait_id)
 InFlight(g, attempt) -> Paused(g + 1, reason)
 InFlight(g, attempt) -> NeedsRepair(g + 1, repair)
 InFlight(g, attempt) -> Terminal(g + 1, completion)
@@ -122,10 +131,32 @@ transaction, but it does not grant eligibility.
 
 ### WaitCondition
 
-The runtime wait record is the sole wait authority. Admission consumes one
-exact triggered generation. Settlement may create or rearm one exact
-generation. A scheduler-specific wait mirror or dispatch reservation must not
-participate in admission.
+The runtime wait record is the sole wait authority. Every `WaitFor` creates a
+new globally unique `wait_id`; that identity is the wait incarnation token.
+Rearming cancels the prior unresolved wait and creates a different `wait_id`.
+WorkItem record revision, WorkItem execution generation, message sequence, and
+task generation keep their own meanings and are never reused as wait identity.
+
+The wait state machine is:
+
+```text
+Active
+  -> Triggered(trigger_message_id)
+  -> Resolved(consuming_attempt_id)
+
+Active | Triggered
+  -> Cancelled | Expired
+```
+
+Ingress performs `Active -> Triggered` and enqueues the exact trigger message
+in one transaction. Admission performs `Triggered -> Resolved` while opening
+the consuming attempt. Duplicate, cancelled, expired, unknown, or legacy wait
+correlations are typed terminal no-ops. A scheduler-specific wait mirror,
+generation, or dispatch reservation must not participate in admission.
+
+Each agent-lifecycle owner and each WorkItem owner has at most one unresolved
+wait (`Active` or `Triggered`). This is enforced by database uniqueness, not
+only by runtime scans.
 
 ### Candidate
 
@@ -143,7 +174,7 @@ execution.
 | external contentful input | interaction or verified WorkItem binding | conversation or compatible WorkItem outcome | exact claim to terminal/quarantined |
 | task result | exact live rejoin, unbound reduce-only, or stale | compatible outcome or `ReduceOnly` | consume exact result; stale does not reenter model |
 | child result | exact caller continuation or unbound notification | caller outcome or `ReduceOnly` | consume exact result/continuation |
-| triggered wait | exact wait owner | owner-compatible outcome | consume exact wait generation |
+| triggered wait | exact wait owner | owner-compatible outcome | consume exact `wait_id` and trigger message |
 | WorkItem continuation | exact runnable generation | WorkItem outcome | `Runnable -> InFlight` |
 | targeted yield/continuation | exact continuation frame | target-compatible outcome | consume exact continuation |
 | internal contentful follow-up | declared interaction or WorkItem binding | binding-compatible outcome | exact claim to terminal |
@@ -204,8 +235,25 @@ One transaction:
 
 Terminal tools such as `WaitFor`, `CompleteWorkItem`, execution-bound
 `PickWorkItem`, and explicit pause/fail/yield lower directly to settlement.
-A terminal tool returns success only after the transaction commits and then
-ends the provider/tool loop.
+The provider/tool loop may prepare a terminal intent, but it must not publish a
+successful terminal tool result until the transaction containing the source
+queue terminal state, Turn terminal record, attempt outcome, owner state, and
+wait/continuation mutations commits. A terminal tool returns success only
+after that commit and then ends the provider/tool loop.
+
+`WaitFor(task_result)` reads the task and rejoin authority inside the same
+transaction:
+
+- if the task is non-terminal, create a new Active wait and settle to Waiting;
+- if the task is terminal with an unconsumed result obligation, do not create a
+  wait; settle to Continue/Runnable and ensure the exact result message is
+  queued idempotently;
+- if the terminal result obligation was already consumed, return a typed
+  stale/already-consumed result without sleeping;
+- if the task is unknown or belongs to another owner, reject validation without
+  mutating wait or execution state.
+
+Task-result-before-wait is therefore a normal transition, not recovery.
 
 A WorkItem-bound provider turn that ends without a WorkItem outcome closes the
 attempt as `ProtocolViolation` and normally returns the WorkItem to
@@ -278,13 +326,21 @@ writes audit evidence in the same transaction.
 A normal typed conflict must not cause an unbounded queue-head retry, agent
 restart loop, or lane reservation leak.
 
+The run loop may terminalize a bounded number of provably stale or reduce-only
+queue heads in one poll and continue to the next candidate. Wake-only timer,
+callback, system, or legacy wait-trigger envelopes with no exact current
+`wait_id` are dropped. Trusted operator input remains trusted operator input
+even when historical wait correlation is absent or stale. Contentful external
+input keeps its original ingress trust but loses stale correlation; a
+wait-trigger-only envelope is dropped as a whole.
+
 ## Persistence And Compatibility
 
 The runtime database remains the transactional store. The target normalized
 facts are:
 
 - WorkItem execution state;
-- runtime wait conditions and generations;
+- runtime wait conditions and exact trigger relationships;
 - queue claims and terminal status;
 - tasks and rejoin obligations;
 - execution attempts and immutable outcomes;
@@ -301,18 +357,32 @@ partial primary state.
 The process chooses `legacy` or `canonical` once at startup. There is no
 scenario, agent, conflict, or claim-time fallback between engines.
 
+The canonical cutover does not semantically migrate historical unresolved
+waits. A protocol-version migration cancels every pre-cutover unresolved wait
+with reason `protocol_cutover`. It clears a WorkItem blocker only when the
+blocker is still provably owned by that exact `WaitFor`; otherwise it preserves
+the newer blocker rather than guessing. Legacy wake envelopes are subsequently
+dropped by normal stale-source reduction. Task results are judged only by the
+task/rejoin ledger, never by a legacy wait generation. The same migration may
+normalize historical terminal execution payloads to the current structural
+shape, but only from identity already present on the attempt itself; this does
+not revive, rebind, or trigger any historical wait.
+
 ## Migration
 
 1. characterize current behavior and production incident traces; publish this
    authority matrix and state algebra;
-2. build the new aggregate and commands on isolated fixtures and copied
-   databases without changing the production canonical reader;
+2. build exact wait identity/state and terminal business commands on isolated
+   fixtures and copied databases without changing the production canonical
+   reader;
 3. complete candidate, admission, settlement, interruption, handoff, and
    persistence-equivalence coverage;
-4. switch canonical admission, settlement, and recovery together in one
-   cutover;
-5. remove compatibility readers and writes, split global invariants into
-   aggregate and transaction-boundary invariants, then remove dead schema;
+4. switch canonical admission, settlement, restart, and recovery together in
+   one cutover; do not operate two production authorities in shadow;
+5. retain old control tables only as read-only diagnostic evidence for one
+   observation period, then remove compatibility readers and writes, split
+   global invariants into aggregate and transaction-boundary invariants, and
+   remove dead schema;
 6. run required scheduler CI, crash/restart, soak, incident replay, upgrade,
    repair, and rollback drills;
 7. publish a canonical-default compatibility release retaining the
@@ -331,6 +401,10 @@ Legacy removal is not authorized by this RFC's implementation alone.
 - recovery of open attempts without automatic tool replay;
 - candidate/binding/outcome/source-transition matrix;
 - duplicate and out-of-order generation matrix;
+- duplicate, stale, and out-of-order exact wait trigger matrix;
+- task terminal before, during, and after `WaitFor(task_result)`;
+- WorkItem metadata revision changes that do not change execution generation;
+- bounded stale queue-head reduction followed by operator input;
 - stale task result with no live rejoin obligation;
 - wait and final-delivery consistency;
 - host shutdown/admission linearization;
@@ -340,8 +414,8 @@ Legacy removal is not authorized by this RFC's implementation alone.
 - compatibility database upgrade, diagnosis, repair, and rollback.
 
 Acceptance requires both safety and simplification: one open attempt per
-agent, one WorkItem generation per admission, one wait authority, atomic
-terminal delivery, no persisted candidate or terminal intent, and no
+agent, one WorkItem generation per admission, one unresolved wait per owner,
+atomic terminal delivery, no persisted candidate or terminal intent, and no
 slot/dispatch/WorkDemand/missing-settlement authority in the canonical reader.
 
 ## Non-goals

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5008,6 +5008,7 @@
                 "status": {
                   "enum": [
                     "active",
+                    "triggered",
                     "resolved",
                     "cancelled",
                     "expired"
@@ -5015,6 +5016,19 @@
                   "type": "string"
                 },
                 "subject_ref": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "trigger_message_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "triggered_at": {
+                  "format": "date-time",
                   "type": [
                     "string",
                     "null"
@@ -5220,6 +5234,7 @@
                   "expected_status": {
                     "enum": [
                       "active",
+                      "triggered",
                       "resolved",
                       "cancelled",
                       "expired"

--- a/docs/website/reference/runtime-status-enum-inventory.json
+++ b/docs/website/reference/runtime-status-enum-inventory.json
@@ -59,6 +59,7 @@
       "name": "WaitConditionStatus",
       "serialized_values": [
         "active",
+        "triggered",
         "resolved",
         "cancelled",
         "expired"

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -1465,8 +1465,28 @@ class CaseHarness:
                 "wait_conditions": sqlite_rows(
                     connection,
                     "SELECT wait_condition_id, agent_id, work_item_id, status, kind, "
-                    "subject_ref, waiting_for, last_turn_id, payload_json "
+                    "subject_ref, waiting_for, last_turn_id, trigger_message_id, "
+                    "payload_json "
                     "FROM wait_conditions ORDER BY created_at",
+                ),
+                "execution_protocol_attempts": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, attempt_id, lifecycle_state, terminal_outcome_id, "
+                    "payload_json FROM execution_protocol_attempts "
+                    "ORDER BY agent_id, attempt_id",
+                ),
+                "execution_protocol_work_items": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, work_item_id, source_revision, generation, "
+                    "lifecycle_state, payload_json "
+                    "FROM execution_protocol_work_items "
+                    "ORDER BY agent_id, work_item_id",
+                ),
+                "execution_protocol_outcomes": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, outcome_id, attempt_id, payload_json "
+                    "FROM execution_protocol_outcomes "
+                    "ORDER BY agent_id, outcome_id",
                 ),
                 "scheduler_work_demands": sqlite_rows(
                     connection,
@@ -1559,15 +1579,15 @@ def require_scheduler_engine_activation_chain(
     snapshot: dict[str, Any],
     *,
     work_item_id: str,
-    expected_admission_kinds: tuple[str, ...],
+    expected_source_kinds: tuple[str, ...],
     lifecycle_message_ids: set[str] | None = None,
 ) -> None:
     if harness.canonical_scheduler_enabled:
-        require_scheduler_activation_chain(
+        require_execution_attempt_chain(
             snapshot,
             agent_id=harness.agent_id,
             work_item_id=work_item_id,
-            expected_admission_kinds=expected_admission_kinds,
+            expected_source_kinds=expected_source_kinds,
             lifecycle_message_ids=lifecycle_message_ids or set(),
         )
         return
@@ -1607,19 +1627,28 @@ def require_scheduler_engine_wait_resolution(
     work_item_id: str,
     wait_ids: set[str],
 ) -> None:
+    if harness.canonical_scheduler_enabled:
+        waits = [
+            row
+            for row in snapshot["wait_conditions"]
+            if row["wait_condition_id"] in wait_ids
+        ]
+        require(
+            len(waits) == len(wait_ids)
+            and all(
+                row["agent_id"] == harness.agent_id
+                and row["work_item_id"] == work_item_id
+                and row["status"] == "resolved"
+                for row in waits
+            ),
+            f"canonical waits did not resolve exactly once: {waits}",
+        )
+        return
     canonical_waits = [
         row
         for row in snapshot["scheduler_wait_generations"]
         if row["wait_id"] in wait_ids or row["owner_work_item_id"] == work_item_id
     ]
-    if harness.canonical_scheduler_enabled:
-        require(
-            len(canonical_waits) == len(wait_ids)
-            and all(row["lifecycle_state"] == "resolved" for row in canonical_waits)
-            and all(row["consuming_activation_id"] is None for row in canonical_waits),
-            f"canonical waits did not resolve exactly once: {canonical_waits}",
-        )
-        return
     require(
         not canonical_waits,
         f"legacy scheduler wrote canonical wait generations: {canonical_waits}",
@@ -1697,76 +1726,116 @@ def require_scheduler_wait_terminal(
     return waits
 
 
-def require_scheduler_activation_chain(
+def execution_attempt(row: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(row["payload_json"])
+
+
+def execution_outcome(row: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(row["payload_json"])
+
+
+def execution_binding_work_item(attempt: dict[str, Any]) -> str | None:
+    binding = attempt.get("binding", {})
+    if binding.get("kind") == "work_item":
+        return binding.get("work_item_id")
+    return None
+
+
+def require_execution_work_items_terminal(
+    snapshot: dict[str, Any],
+    *,
+    agent_id: str,
+    work_item_ids: set[str],
+    label: str,
+) -> None:
+    records = [
+        row
+        for row in snapshot["execution_protocol_work_items"]
+        if row["agent_id"] == agent_id and row["work_item_id"] in work_item_ids
+    ]
+    require(
+        len(records) == len(work_item_ids)
+        and all(row["lifecycle_state"] == "terminal" for row in records),
+        f"{label} execution WorkItems did not converge: {records}",
+    )
+
+
+def require_execution_attempt_chain(
     snapshot: dict[str, Any],
     *,
     agent_id: str,
     work_item_id: str,
-    expected_admission_kinds: tuple[str, ...],
+    expected_source_kinds: tuple[str, ...],
     lifecycle_message_ids: set[str],
 ) -> list[dict[str, Any]]:
-    work_item_activations = [
-        row
-        for row in snapshot["scheduler_activations"]
-        if row["work_item_id"] == work_item_id
+    attempts = [
+        (row, execution_attempt(row))
+        for row in snapshot["execution_protocol_attempts"]
+        if row["agent_id"] == agent_id
     ]
-    lifecycle_activation_ids = {
-        f"activation:message:{message_id}" for message_id in lifecycle_message_ids
-    }
-    lifecycle_activations = [
-        row
-        for row in snapshot["scheduler_activations"]
-        if row["activation_id"] in lifecycle_activation_ids
+    work_item_attempts = [
+        (row, attempt)
+        for row, attempt in attempts
+        if execution_binding_work_item(attempt) == work_item_id
+    ]
+    lifecycle_attempts = [
+        (row, attempt)
+        for row, attempt in attempts
+        if attempt.get("source_message_id") in lifecycle_message_ids
+        and attempt.get("binding")
+        == {"kind": "agent_lifecycle", "agent_id": agent_id}
     ]
     require(
-        len(lifecycle_activations) == len(lifecycle_activation_ids)
-        and all(
-            row["work_item_id"] is None
-            and row["lifecycle_state"] == "settled"
-            for row in lifecycle_activations
-        ),
-        "canonical lifecycle activations did not settle without claiming a "
-        f"WorkItem: {lifecycle_activations}",
-    )
-    require(
-        sorted(row["admission_kind"] for row in work_item_activations)
-        == sorted(expected_admission_kinds)
+        len(lifecycle_attempts) == len(lifecycle_message_ids)
         and all(
             row["lifecycle_state"] == "settled"
-            for row in work_item_activations
+            and row["terminal_outcome_id"] is not None
+            for row, _ in lifecycle_attempts
         ),
-        "canonical WorkItem activation lineage did not match the expected "
-        f"admission kinds {expected_admission_kinds}: {work_item_activations}",
+        "canonical lifecycle attempts did not settle without claiming a "
+        f"WorkItem: {[attempt for _, attempt in lifecycle_attempts]}",
     )
-    activations = work_item_activations + lifecycle_activations
-    activation_ids = {row["activation_id"] for row in activations}
-    settlements = [
-        row
-        for row in snapshot["scheduler_activation_settlements"]
-        if row["activation_id"] in activation_ids
-    ]
     require(
-        len(settlements) == len(activations),
-        f"canonical settlements are missing or duplicated: {settlements}",
+        sorted(
+            attempt.get("source", {}).get("identity", {}).get("kind")
+            for _, attempt in work_item_attempts
+        )
+        == sorted(expected_source_kinds)
+        and all(
+            row["lifecycle_state"] == "settled"
+            and row["terminal_outcome_id"] is not None
+            for row, _ in work_item_attempts
+        ),
+        "canonical WorkItem attempt lineage did not match the expected "
+        f"source kinds {expected_source_kinds}: "
+        f"{[attempt for _, attempt in work_item_attempts]}",
+    )
+    terminal_attempts = work_item_attempts + lifecycle_attempts
+    outcome_by_id = {
+        row["outcome_id"]: execution_outcome(row)
+        for row in snapshot["execution_protocol_outcomes"]
+        if row["agent_id"] == agent_id
+    }
+    require(
+        all(
+            row["terminal_outcome_id"] in outcome_by_id
+            and outcome_by_id[row["terminal_outcome_id"]]["attempt_id"]
+            == row["attempt_id"]
+            for row, _ in terminal_attempts
+        ),
+        "canonical execution outcomes are missing or mismatched: "
+        f"attempts={[attempt for _, attempt in terminal_attempts]}, "
+        f"outcomes={outcome_by_id}",
     )
     require(
         not [
             row
-            for row in snapshot["scheduler_missing_settlements"]
-            if row["activation_id"] in activation_ids
+            for row in snapshot["execution_protocol_attempts"]
+            if row["agent_id"] == agent_id and row["lifecycle_state"] == "open"
         ],
-        "canonical activation chain retained missing settlement evidence",
+        "canonical execution lane retained an open attempt",
     )
-    slots = [
-        row for row in snapshot["scheduler_agent_slots"] if row["agent_id"] == agent_id
-    ]
-    require(
-        len(slots) == 1
-        and slots[0]["slot_kind"] == "idle"
-        and slots[0]["activation_id"] is None,
-        f"canonical activation slot was not released: {slots}",
-    )
-    return activations
+    return [attempt for _, attempt in terminal_attempts]
 
 
 def require_checkpoint_restart_activation_lineage(
@@ -1776,60 +1845,57 @@ def require_checkpoint_restart_activation_lineage(
     work_item_id: str,
     wait_id: str,
 ) -> None:
-    before_restart_activations = [
-        row
-        for row in before_restart_snapshot["scheduler_activations"]
-        if row["work_item_id"] == work_item_id
+    before_restart_attempts = [
+        execution_attempt(row)
+        for row in before_restart_snapshot["execution_protocol_attempts"]
+        if execution_binding_work_item(execution_attempt(row)) == work_item_id
     ]
     require(
-        len(before_restart_activations) == 1
-        and before_restart_activations[0]["admitted_generation"] == 1
-        and before_restart_activations[0]["admission_kind"] == "scheduling"
-        and str(before_restart_activations[0]["idempotency_key"]).startswith(
-            "work-queue-attempt:"
-        ),
+        len(before_restart_attempts) == 1
+        and before_restart_attempts[0]["source"]["identity"]["kind"]
+        == "work_item_continuation"
+        and before_restart_attempts[0]["admitted_fences"]["work_item_generation"] == 1,
         "checkpoint replay restart boundary did not preserve exactly the initial "
-        f"scheduling activation: {before_restart_activations}",
+        f"scheduling attempt: {before_restart_attempts}",
     )
-    activations = sorted(
+    attempts = sorted(
         (
-            row
-            for row in snapshot["scheduler_activations"]
-            if row["work_item_id"] == work_item_id
+            execution_attempt(row)
+            for row in snapshot["execution_protocol_attempts"]
+            if execution_binding_work_item(execution_attempt(row)) == work_item_id
         ),
-        key=lambda row: row["admitted_generation"],
+        key=lambda attempt: attempt["admitted_fences"]["work_item_generation"],
     )
     require(
-        len(activations) == 2,
-        f"checkpoint replay expected exactly two WorkItem activations: {activations}",
+        len(attempts) == 2,
+        f"checkpoint replay expected exactly two WorkItem attempts: {attempts}",
     )
-    scheduling, wait_resume = activations
+    scheduling, wait_resume = attempts
     require(
-        scheduling["admitted_generation"] == 1
-        and scheduling["admission_kind"] == "scheduling"
-        and str(scheduling["idempotency_key"]).startswith("work-queue-attempt:"),
-        f"checkpoint replay initial scheduling activation mismatch: {scheduling}",
-    )
-    expected_wait_resume_key = (
-        f"wait-resume:{wait_id}:2:{wait_resume['activation_id']}"
+        scheduling["admitted_fences"]["work_item_generation"] == 1
+        and scheduling["source"]["identity"]["kind"] == "work_item_continuation",
+        f"checkpoint replay initial scheduling attempt mismatch: {scheduling}",
     )
     require(
-        wait_resume["admitted_generation"] == 2
-        and wait_resume["admission_kind"] == "wait_resume"
-        and wait_resume["idempotency_key"] == expected_wait_resume_key,
-        f"checkpoint replay wait-resume activation mismatch: {wait_resume}",
+        wait_resume["admitted_fences"]["work_item_generation"] == 2
+        and wait_resume["source"]["identity"]
+        == {
+            "kind": "triggered_wait",
+            "wait_id": wait_id,
+            "trigger_message_id": wait_resume["source_message_id"],
+        },
+        f"checkpoint replay wait-resume attempt mismatch: {wait_resume}",
     )
-    wait_generations = [
+    waits = [
         row
-        for row in snapshot["scheduler_wait_generations"]
-        if row["wait_id"] == wait_id
+        for row in snapshot["wait_conditions"]
+        if row["wait_condition_id"] == wait_id
     ]
     require(
-        len(wait_generations) == 1
-        and wait_generations[0]["owner_work_item_id"] == work_item_id
-        and wait_generations[0]["generation"] == 2
-        and wait_generations[0]["lifecycle_state"] == "resolved",
-        f"checkpoint replay wait generation mismatch: {wait_generations}",
+        len(waits) == 1
+        and waits[0]["work_item_id"] == work_item_id
+        and waits[0]["status"] == "resolved",
+        f"checkpoint replay wait identity mismatch: {waits}",
     )
 
 
@@ -1855,64 +1921,39 @@ def require_lifecycle_wait_adoption(
         f"adopted wait source turn is missing or duplicated: {source_turns}",
     )
     source_message_id = source_turns[0]["trigger_message_id"]
-    activation_id = f"activation:message:{source_message_id}"
-    activations = [
-        row
-        for row in snapshot["scheduler_activations"]
-        if row["agent_id"] == agent_id and row["activation_id"] == activation_id
-    ]
-    require(
-        len(activations) == 1
-        and activations[0]["work_item_id"] is None
-        and activations[0]["lifecycle_state"] == "settled"
-        and activations[0]["admitted_generation"] > 0,
-        f"lifecycle adoption source activation is invalid: {activations}",
-    )
-    settlements = [
-        row
-        for row in snapshot["scheduler_activation_settlements"]
-        if row["agent_id"] == agent_id and row["activation_id"] == activation_id
-    ]
-    settlement = json.loads(settlements[0]["payload_json"]) if len(settlements) == 1 else {}
-    require(
-        len(settlements) == 1
-        and settlement.get("turn_terminal") == source_turn_id
-        and settlement.get("disposition") == {"kind": "work_continues"}
-        and settlement.get("agent_dispatch") == {"kind": "open"}
-        and settlement.get("operator_delivery") is None,
-        f"lifecycle adoption source did not settle WorkContinues: {settlements}",
-    )
-    adoption_rows = [
-        row
-        for row in snapshot["scheduler_protocol_command_results"]
+    attempts = [
+        (row, execution_attempt(row))
+        for row in snapshot["execution_protocol_attempts"]
         if row["agent_id"] == agent_id
-        and row["command_kind"] == "adopt_activation_work_state"
-        and row["command_identity"] == f"{activation_id}:{work_item_id}"
+        and execution_attempt(row).get("source_message_id") == source_message_id
     ]
     require(
-        len(adoption_rows) == 1
-        and adoption_rows[0]["decision"] == "legacy_work_state_adopted"
-        and adoption_rows[0]["conflict_kind"] is None
-        and adoption_rows[0]["conflict_code"] is None,
-        f"lifecycle wait adoption command is missing or conflicted: {adoption_rows}",
+        len(attempts) == 1
+        and attempts[0][0]["lifecycle_state"] == "settled"
+        and attempts[0][1].get("binding")
+        == {"kind": "agent_lifecycle", "agent_id": agent_id},
+        f"lifecycle handoff source attempt is invalid: {attempts}",
     )
-    post_state = json.loads(adoption_rows[0]["post_state_fence_json"])
-    adopted_work = post_state.get("work", {}).get(work_item_id, {})
-    adopted_generation = adopted_work.get("scheduling_generation")
-    references = json.loads(adoption_rows[0]["result_references_json"])
+    terminal_outcome_id = attempts[0][0]["terminal_outcome_id"]
+    outcomes = [
+        row
+        for row in snapshot["execution_protocol_outcomes"]
+        if row["agent_id"] == agent_id and row["outcome_id"] == terminal_outcome_id
+    ]
+    outcome = execution_outcome(outcomes[0]) if len(outcomes) == 1 else {}
     require(
-        isinstance(adopted_generation, int)
-        and adopted_generation > 0
-        and adopted_work.get("metadata_revision") == adopted_generation
-        and adopted_work.get("status")
-        == {"kind": "waiting", "wait_id": wait["wait_condition_id"]}
-        and set(references)
+        len(outcomes) == 1
+        and outcome.get("attempt_id") == attempts[0][0]["attempt_id"]
+        and outcome.get("outcome")
         == {
-            f"activation:{activation_id}",
-            f"work:{work_item_id}",
-            f"wait:{wait['wait_condition_id']}:generation:{adopted_generation}",
+            "owner": "conversation",
+            "outcome": {
+                "kind": "handoff_to_work_item_wait",
+                "work_item_id": work_item_id,
+                "wait": {"wait_id": wait["wait_condition_id"]},
+            },
         },
-        f"lifecycle adoption did not preserve wait ownership/generation: {adoption_rows}",
+        f"lifecycle wait handoff outcome is missing or mismatched: {outcomes}",
     )
 
 
@@ -2516,22 +2557,22 @@ def run_scheduler_task_wait_resume_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=("scheduling", "wait_resume", "wait_resume"),
+        expected_source_kinds=("work_item_continuation", "task_result", "triggered_wait"),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-task-wait-seed")["message_id"]
         },
     )
     if harness.canonical_scheduler_enabled:
         activation_causes = [
-            json.loads(row["payload_json"])["activation"]["cause"]["kind"]
-            for row in snapshot["scheduler_activations"]
-            if row["work_item_id"] == work_item_id
+            execution_attempt(row)["source"]["identity"]["kind"]
+            for row in snapshot["execution_protocol_attempts"]
+            if execution_binding_work_item(execution_attempt(row)) == work_item_id
         ]
         require(
             sorted(activation_causes)
-            == ["task_rejoin", "wait_resume", "work_item_runnable"],
-            "canonical task/wait activation causes did not preserve scheduling, "
-            f"task-rejoin, and external-resume provenance: {activation_causes}",
+            == ["task_result", "triggered_wait", "work_item_continuation"],
+            "canonical task/wait execution sources did not preserve scheduling, "
+            f"task-result, and external-resume provenance: {activation_causes}",
         )
     task_waits = require_scheduler_wait_terminal(
         harness,
@@ -2854,21 +2895,17 @@ def run_scheduler_multi_workitem_case(
             harness,
             snapshot,
             work_item_id=wid,
-            expected_admission_kinds=("scheduling",),
+            expected_source_kinds=("work_item_continuation",),
             lifecycle_message_ids={
                 harness.prompt_scope("scheduler-multi-create")["message_id"]
             },
         )
     if harness.canonical_scheduler_enabled:
-        demands = [
-            row
-            for row in snapshot["scheduler_work_demands"]
-            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-        ]
-        require(
-            len(demands) == 2
-            and all(d["status"] == "terminal" for d in demands),
-            f"multi-WorkItem demands did not converge: {demands}",
+        require_execution_work_items_terminal(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_ids={work_item_a_id, work_item_b_id},
+            label="multi-WorkItem",
         )
     harness.restart()
     restarted_items = harness.work_items("scheduler-multi-after-restart")
@@ -2970,7 +3007,7 @@ def run_scheduler_external_wait_resume_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=("wait_resume",),
+        expected_source_kinds=("triggered_wait",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-external-wait")["message_id"]
         },
@@ -3090,7 +3127,7 @@ def run_scheduler_operator_wait_resume_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=("wait_resume",),
+        expected_source_kinds=("triggered_wait",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-operator-wait")["message_id"]
         },
@@ -3252,7 +3289,7 @@ def run_scheduler_concurrent_claim_fencing_case(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_admission_kinds=("wait_resume",),
+        expected_source_kinds=("triggered_wait",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-concurrent-create")["message_id"]
         },
@@ -3261,7 +3298,7 @@ def run_scheduler_concurrent_claim_fencing_case(
         harness,
         snapshot,
         work_item_id=work_item_b_id,
-        expected_admission_kinds=("scheduling",),
+        expected_source_kinds=("work_item_continuation",),
         lifecycle_message_ids=set(),
     )
     waits = require_scheduler_wait_terminal(
@@ -3279,15 +3316,11 @@ def run_scheduler_concurrent_claim_fencing_case(
         wait_ids={wait["wait_condition_id"] for wait in waits},
     )
     if harness.canonical_scheduler_enabled:
-        demands = [
-            row
-            for row in snapshot["scheduler_work_demands"]
-            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-        ]
-        require(
-            len(demands) == 2
-            and all(d["status"] == "terminal" for d in demands),
-            f"concurrent demands did not converge: {demands}",
+        require_execution_work_items_terminal(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_ids={work_item_a_id, work_item_b_id},
+            label="concurrent",
         )
     harness.restart()
     restarted_items = harness.work_items("scheduler-concurrent-after-restart")
@@ -3441,7 +3474,7 @@ def run_scheduler_operator_interject_during_wait_case(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_admission_kinds=("wait_resume",),
+        expected_source_kinds=("triggered_wait",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-interject-create")["message_id"]
         },
@@ -3450,7 +3483,7 @@ def run_scheduler_operator_interject_during_wait_case(
         harness,
         snapshot,
         work_item_id=work_item_b_id,
-        expected_admission_kinds=("scheduling",),
+        expected_source_kinds=("work_item_continuation",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-interject-b-create")["message_id"]
         },
@@ -3468,15 +3501,11 @@ def run_scheduler_operator_interject_during_wait_case(
         wait_ids={wait["wait_condition_id"] for wait in waits},
     )
     if harness.canonical_scheduler_enabled:
-        demands = [
-            row
-            for row in snapshot["scheduler_work_demands"]
-            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-        ]
-        require(
-            len(demands) == 2
-            and all(d["status"] == "terminal" for d in demands),
-            f"interject demands did not converge: {demands}",
+        require_execution_work_items_terminal(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_ids={work_item_a_id, work_item_b_id},
+            label="interject",
         )
     harness.restart()
     restarted_items = harness.work_items("scheduler-interject-after-restart")
@@ -3599,7 +3628,7 @@ def run_scheduler_compaction_continuity_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=("wait_resume",),
+        expected_source_kinds=("triggered_wait",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-compaction-create")["message_id"]
         },
@@ -3714,7 +3743,7 @@ def run_scheduler_worktree_isolation_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=(),
+        expected_source_kinds=(),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-worktree-lifecycle")["message_id"]
         },
@@ -3804,7 +3833,7 @@ def run_scheduler_spawn_agent_supervision_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_admission_kinds=(),
+        expected_source_kinds=(),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-spawn-and-complete")["message_id"]
         },
@@ -3933,7 +3962,7 @@ def run_scheduler_checkpoint_replay_case(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_admission_kinds=("scheduling", "wait_resume"),
+        expected_source_kinds=("work_item_continuation", "triggered_wait"),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },
@@ -3942,7 +3971,7 @@ def run_scheduler_checkpoint_replay_case(
         harness,
         snapshot,
         work_item_id=work_item_b_id,
-        expected_admission_kinds=("scheduling",),
+        expected_source_kinds=("work_item_continuation",),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },
@@ -3968,15 +3997,11 @@ def run_scheduler_checkpoint_replay_case(
             work_item_id=work_item_a_id,
             wait_id=waits[0]["wait_condition_id"],
         )
-        demands = [
-            row
-            for row in snapshot["scheduler_work_demands"]
-            if row["work_item_id"] in (work_item_a_id, work_item_b_id)
-        ]
-        require(
-            len(demands) == 2
-            and all(d["status"] == "terminal" for d in demands),
-            f"replay demands did not converge: {demands}",
+        require_execution_work_items_terminal(
+            snapshot,
+            agent_id=harness.agent_id,
+            work_item_ids={work_item_a_id, work_item_b_id},
+            label="replay",
         )
 
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -5335,6 +5335,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -5357,6 +5359,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -5815,6 +5819,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -1,8 +1,8 @@
 //! Scheduler / WorkItem unified execution aggregate.
 //!
-//! This is the additive Phase 2 model. Production scheduling still uses
-//! `scheduler_protocol`; this module defines the smaller authority boundary
-//! that the canonical reader will adopt in a later cutover.
+//! Canonical production scheduling uses this aggregate as the sole execution
+//! authority. The older `scheduler_protocol` remains only for the explicitly
+//! selected legacy engine and read-only compatibility diagnostics.
 
 use std::collections::BTreeMap;
 
@@ -14,6 +14,14 @@ pub struct ExecutionProtocolState {
     pub attempts: BTreeMap<String, ExecutionAttempt>,
     pub work_items: BTreeMap<String, WorkItemExecutionRecord>,
     pub outcomes: BTreeMap<String, ExecutionOutcomeRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetWorkItemWaiting {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub expected: Option<WorkItemExecutionRecord>,
+    pub record: WorkItemExecutionRecord,
 }
 
 impl ExecutionProtocolState {
@@ -92,9 +100,7 @@ pub enum ExecutionSourceIdentity {
     },
     TriggeredWait {
         wait_id: String,
-        wait_generation: u64,
-        trigger_id: String,
-        trigger_generation: u64,
+        trigger_message_id: String,
     },
     WorkItemContinuation {
         work_item_id: String,
@@ -238,7 +244,6 @@ impl WorkItemExecutionState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WaitReference {
     pub wait_id: String,
-    pub generation: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -253,10 +258,22 @@ pub enum ExecutionOutcome {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ConversationOutcome {
     Replied,
-    Wait { wait: WaitReference },
-    Paused { reason: String },
-    Interrupted { reason: String },
-    Failed { policy: String },
+    Wait {
+        wait: WaitReference,
+    },
+    HandoffToWorkItemWait {
+        work_item_id: String,
+        wait: WaitReference,
+    },
+    Paused {
+        reason: String,
+    },
+    Interrupted {
+        reason: String,
+    },
+    Failed {
+        policy: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -305,6 +322,14 @@ pub struct RegisterWorkItemExecution {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdvanceWorkItemSourceRevision {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub expected_source_revision: u64,
+    pub source_revision: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InterruptExecution {
     pub attempt_id: String,
     pub outcome_id: String,
@@ -316,6 +341,8 @@ pub struct InterruptExecution {
 #[serde(tag = "command", content = "payload", rename_all = "snake_case")]
 pub enum ExecutionProtocolCommand {
     RegisterWorkItem(Box<RegisterWorkItemExecution>),
+    AdvanceWorkItemSourceRevision(AdvanceWorkItemSourceRevision),
+    SetWorkItemWaiting(Box<SetWorkItemWaiting>),
     Admit(Box<AdmitExecution>),
     Settle(SettleExecution),
     Interrupt(InterruptExecution),
@@ -325,6 +352,73 @@ pub enum ExecutionProtocolCommand {
 pub struct ExecutionTransition {
     pub state: ExecutionProtocolState,
     pub references: Vec<String>,
+}
+
+pub fn set_work_item_waiting(
+    state: &ExecutionProtocolState,
+    command: &SetWorkItemWaiting,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.record.source_revision == 0
+        || command.record.generation() == 0
+        || !matches!(command.record.state, WorkItemExecutionState::Waiting { .. })
+    {
+        return Err("WorkItem waiting transition requires identity and Waiting state".into());
+    }
+    if state.work_items.get(&command.work_item_id) != command.expected.as_ref() {
+        return Err("WorkItem waiting transition fence is stale".into());
+    }
+    if command.expected.as_ref().is_some_and(|record| {
+        matches!(
+            record.state,
+            WorkItemExecutionState::InFlight { .. } | WorkItemExecutionState::Terminal { .. }
+        ) || command.record.generation() <= record.generation()
+    }) {
+        return Err("WorkItem is not eligible for lifecycle wait handoff".into());
+    }
+    let mut next = state.clone();
+    next.work_items
+        .insert(command.work_item_id.clone(), command.record.clone());
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![format!("work_item:{}", command.work_item_id)],
+    })
+}
+
+pub fn advance_work_item_source_revision(
+    state: &ExecutionProtocolState,
+    command: &AdvanceWorkItemSourceRevision,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.expected_source_revision == 0
+        || command.source_revision <= command.expected_source_revision
+    {
+        return Err(
+            "WorkItem source revision advance requires identity and a monotonic revision".into(),
+        );
+    }
+    let mut next = state.clone();
+    let record = next
+        .work_items
+        .get_mut(&command.work_item_id)
+        .ok_or_else(|| "WorkItem source revision advance requires registered state".to_string())?;
+    if record.source_revision != command.expected_source_revision {
+        return Err("WorkItem source revision advance fence is stale".into());
+    }
+    if matches!(record.state, WorkItemExecutionState::InFlight { .. }) {
+        return Err("WorkItem source revision cannot advance while InFlight".into());
+    }
+    record.source_revision = command.source_revision;
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![format!("work_item:{}", command.work_item_id)],
+    })
 }
 
 pub fn register_work_item_execution(
@@ -926,16 +1020,13 @@ mod tests {
                 generation: 1,
                 wait: WaitReference {
                     wait_id: "wait-1".into(),
-                    generation: 1,
                 },
             }),
         );
         let mut wait_attempt = attempt("attempt-1", None);
         wait_attempt.source.identity = ExecutionSourceIdentity::TriggeredWait {
             wait_id: "wait-1".into(),
-            wait_generation: 1,
-            trigger_id: "trigger-1".into(),
-            trigger_generation: 1,
+            trigger_message_id: "trigger-1".into(),
         };
         let admitted = admit_execution(
             &state,

--- a/src/host.rs
+++ b/src/host.rs
@@ -3055,6 +3055,11 @@ mod tests {
 
     use crate::{
         config::{provider_registry_for_tests, ControlAuthMode, ModelRouteRef},
+        domain::execution_protocol::{
+            AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding,
+            ExecutionOrigin, ExecutionPriority, ExecutionProvenance, ExecutionSource,
+            ExecutionSourceIdentity, ExecutionTrust,
+        },
         provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
         runtime::RuntimeHandle,
         runtime_db::RuntimeDb,
@@ -4709,6 +4714,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
 
@@ -4815,6 +4822,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
 
@@ -5944,11 +5953,73 @@ mod tests {
             .append_queue_entry(&make_queue_entry(&msg_a, QueueEntryStatus::Dequeued))
             .unwrap();
 
-        // Has scheduler activation: should NOT be recovered
+        // Has unified execution attempt: should NOT be recovered.
         let msg_b = make_message("msg-activated");
         storage.append_message(&msg_b).unwrap();
         storage
             .append_queue_entry(&make_queue_entry(&msg_b, QueueEntryStatus::Dequeued))
+            .unwrap();
+        let attempt = ExecutionAttempt {
+            attempt_id: format!("activation:message:{}", msg_b.id),
+            agent_id: agent_id.clone(),
+            source_message_id: Some(msg_b.id.clone()),
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::QueueMessage {
+                    message_id: msg_b.id.clone(),
+                },
+                generation: 1,
+            },
+            binding: ExecutionBinding::AgentLifecycle {
+                agent_id: agent_id.clone(),
+            },
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::Operator,
+                trust: ExecutionTrust::OperatorInstruction,
+                priority: ExecutionPriority::Normal,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: 1,
+                work_item_source_revision: None,
+                work_item_generation: None,
+                rejoin: None,
+                agent_control_revision: 1,
+                host_registry_revision: 1,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: None,
+            recovery_of_attempt_id: None,
+            terminal_outcome_id: None,
+            admitted_at: Utc::now().to_rfc3339(),
+            terminal_at: None,
+        };
+        runtime_db
+            .transaction(|tx| {
+                tx.execute(
+                    "INSERT INTO execution_protocol_attempts (
+                       agent_id, attempt_id, lifecycle_state,
+                       source_identity_json, source_generation,
+                       recovery_of_attempt_id, terminal_outcome_id, payload_json
+                     ) VALUES (?1, ?2, 'open', ?3, ?4, NULL, NULL, ?5)",
+                    rusqlite::params![
+                        &agent_id,
+                        &attempt.attempt_id,
+                        serde_json::to_string(&attempt.source.identity)?,
+                        attempt.source.generation as i64,
+                        serde_json::to_string(&attempt)?,
+                    ],
+                )?;
+                Ok(())
+            })
+            .expect("insert execution attempt");
+
+        // A legacy activation without a unified attempt no longer protects a claim.
+        let msg_legacy = make_message("msg-legacy-activation");
+        storage.append_message(&msg_legacy).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_legacy, QueueEntryStatus::Dequeued))
             .unwrap();
         runtime_db
             .transaction(|tx| {
@@ -5961,14 +6032,14 @@ mod tests {
                      VALUES (?, ?, '', 'work_item', 'test-work', 'test-work', 0, 'scheduling', NULL, NULL, NULL, 'running', '', '{}', ?, ?)",
                     rusqlite::params![
                         &agent_id,
-                        format!("activation:message:{}", msg_b.id),
+                        format!("activation:message:{}", msg_legacy.id),
                         Utc::now().timestamp_millis(),
                         Utc::now().timestamp_millis(),
                     ],
                 )?;
                 Ok(())
             })
-            .expect("insert activation");
+            .expect("insert legacy activation");
 
         // Has terminal turn: should NOT be recovered
         let msg_c = make_message("msg-terminal");
@@ -5998,7 +6069,7 @@ mod tests {
         let entries = storage.latest_queue_entries().unwrap();
         for entry in &entries {
             match entry.message_id.as_str() {
-                "msg-orphaned" => assert_eq!(
+                "msg-orphaned" | "msg-legacy-activation" => assert_eq!(
                     entry.status,
                     QueueEntryStatus::Interrupted,
                     "orphaned should be recovered"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -44,7 +44,7 @@ pub use tasks::{
     PickedWorkItem, WorkItemContinuationSummary, WorkItemFocusTransition,
     WorkItemFocusTransitionWarning,
 };
-pub(crate) use waiting::{WaitForScope, WaitForWakeKind};
+pub(crate) use waiting::{WaitForRegistrationOutcome, WaitForScope, WaitForWakeKind};
 pub(crate) use worktree::format_worktree_task_summary;
 
 #[cfg(test)]
@@ -60,7 +60,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use arc_swap::ArcSwap;
 use bootstrap::ConfigSnapshot;
 use chrono::Utc;
@@ -927,191 +927,219 @@ fn canonical_queue_settlement_commands_from_facts(
     Ok(vec![command])
 }
 
-fn execution_protocol_settlement_transition(
+fn execution_protocol_settlement_transition_from_facts(
+    storage: &AppStorage,
     runtime_db: &RuntimeDb,
-    agent_id: &str,
-    scheduler_commands: &[crate::domain::scheduler_protocol::ProtocolCommand],
+    record: &QueueEntryRecord,
+    terminal_turn: Option<&TurnRecord>,
 ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
-    use crate::domain::scheduler_protocol::ProtocolCommand;
-
-    let Some(settlement) = scheduler_commands.iter().find_map(|command| match command {
-        ProtocolCommand::SettleActivation(command) => Some(&command.settlement),
-        ProtocolCommand::RecoverInterruptedActivation(command) => Some(&command.settlement),
-        _ => None,
-    }) else {
-        return Ok(Default::default());
-    };
-    let state = runtime_db
-        .transitions()
-        .load_execution_protocol_state_if_initialized(agent_id)?
-        .ok_or_else(|| anyhow!("canonical settlement requires execution protocol authority"))?;
-    let attempt = state
-        .attempts
-        .get(&settlement.activation_id)
-        .ok_or_else(|| {
-            anyhow!(
-                "canonical settlement {} has no matching execution attempt",
-                settlement.activation_id
-            )
-        })?;
-    if attempt.state != crate::domain::execution_protocol::ExecutionAttemptState::Open {
-        return Ok(Default::default());
-    }
-    Ok(
-        crate::runtime_db::transitions::ExecutionProtocolTransition {
-            bootstrap: None,
-            commands: vec![execution_protocol_settlement_command(attempt, settlement)?],
-        },
-    )
-}
-
-fn execution_protocol_settlement_command(
-    attempt: &crate::domain::execution_protocol::ExecutionAttempt,
-    settlement: &crate::domain::scheduler_protocol::ActivationSettlement,
-) -> Result<crate::domain::execution_protocol::ExecutionProtocolCommand> {
     use crate::domain::execution_protocol::{
-        CommandResult, ConversationOutcome, ExecutionBinding, ExecutionOutcome,
-        ExecutionOutcomeRecord, ExecutionProtocolCommand, InterruptExecution, SettleExecution,
-        WaitReference, WorkItemOutcome,
+        CommandResult, ConversationOutcome, ExecutionAttemptState, ExecutionBinding,
+        ExecutionOutcome, ExecutionOutcomeRecord, ExecutionProtocolCommand, InterruptExecution,
+        SettleExecution, WaitReference, WorkItemOutcome,
     };
-    use crate::domain::scheduler_protocol::ActivationDisposition;
-
-    let outcome_id = format!("outcome:{}", settlement.id);
-    let command = match &settlement.disposition {
-        ActivationDisposition::Interrupted { reason } => {
-            ExecutionProtocolCommand::Interrupt(InterruptExecution {
-                attempt_id: attempt.attempt_id.clone(),
-                outcome_id,
-                reason: reason.clone(),
-                interrupted_at: settlement.created_at.clone(),
-            })
-        }
-        disposition => {
-            let outcome = match (&attempt.binding, disposition) {
-                (
-                    ExecutionBinding::WorkItem { .. },
-                    ActivationDisposition::WorkContinues
-                    | ActivationDisposition::ConversationReplied
-                    | ActivationDisposition::ReducedOnly,
-                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Continue),
-                (ExecutionBinding::WorkItem { .. }, ActivationDisposition::WorkWaits { wait }) => {
-                    ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
-                        wait: WaitReference {
-                            wait_id: wait.id.clone(),
-                            generation: wait.generation,
-                        },
-                    })
-                }
-                (
-                    ExecutionBinding::WorkItem { .. },
-                    ActivationDisposition::WorkCompleted { .. },
-                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
-                    completion: settlement
-                        .operator_delivery
-                        .clone()
-                        .unwrap_or_else(|| "completed".into()),
-                }),
-                (
-                    ExecutionBinding::WorkItem { .. },
-                    ActivationDisposition::WorkPaused { reason },
-                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Pause {
-                    reason: reason.clone(),
-                }),
-                (
-                    ExecutionBinding::WorkItem { .. },
-                    ActivationDisposition::WorkYielded {
-                        target_work_item_id: Some(target_work_item_id),
-                        ..
-                    },
-                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Yield {
-                    target_work_item_id: target_work_item_id.clone(),
-                }),
-                (
-                    ExecutionBinding::WorkItem { .. },
-                    ActivationDisposition::WorkFailed { failure_policy },
-                ) => ExecutionOutcome::WorkItem(WorkItemOutcome::Failed {
-                    policy: failure_policy.clone(),
-                }),
-                (
-                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
-                    ActivationDisposition::ConversationReplied
-                    | ActivationDisposition::WorkContinues
-                    | ActivationDisposition::ReducedOnly,
-                ) => ExecutionOutcome::Conversation(ConversationOutcome::Replied),
-                (
-                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
-                    ActivationDisposition::WorkWaits { wait },
-                ) => ExecutionOutcome::Conversation(ConversationOutcome::Wait {
-                    wait: WaitReference {
-                        wait_id: wait.id.clone(),
-                        generation: wait.generation,
-                    },
-                }),
-                (
-                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
-                    ActivationDisposition::WorkPaused { reason },
-                ) => ExecutionOutcome::Conversation(ConversationOutcome::Paused {
-                    reason: reason.clone(),
-                }),
-                (
-                    ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. },
-                    ActivationDisposition::WorkFailed { failure_policy },
-                ) => ExecutionOutcome::Conversation(ConversationOutcome::Failed {
-                    policy: failure_policy.clone(),
-                }),
-                (ExecutionBinding::Command, _) => {
-                    ExecutionOutcome::Command(CommandResult::Applied {
-                        references: settlement.evidence.clone(),
-                    })
-                }
-                _ => {
-                    return Err(anyhow!(
-                        "canonical settlement disposition is incompatible with execution binding"
-                    ))
-                }
-            };
-            ExecutionProtocolCommand::Settle(SettleExecution {
-                outcome: ExecutionOutcomeRecord {
-                    outcome_id,
-                    attempt_id: attempt.attempt_id.clone(),
-                    outcome,
-                    created_at: settlement.created_at.clone(),
-                },
-            })
-        }
-    };
-    Ok(command)
-}
-
-fn execution_protocol_interruption_transition(
-    runtime_db: &RuntimeDb,
-    agent_id: &str,
-    attempt_id: &str,
-    reason: &str,
-    interrupted_at: String,
-) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
-    use crate::domain::execution_protocol::{ExecutionProtocolCommand, InterruptExecution};
 
     let Some(state) = runtime_db
         .transitions()
-        .load_execution_protocol_state_if_initialized(agent_id)?
+        .load_execution_protocol_state_if_initialized(&record.agent_id)?
     else {
         return Ok(Default::default());
     };
-    let Some(attempt) = state.attempts.get(attempt_id) else {
+    let Some(attempt) = execution_attempt_for_message(&state, &record.message_id) else {
         return Ok(Default::default());
     };
-    if attempt.state != crate::domain::execution_protocol::ExecutionAttemptState::Open {
+    if attempt.state != ExecutionAttemptState::Open {
         return Ok(Default::default());
     }
+    let interrupted = |reason: &str| crate::runtime_db::transitions::ExecutionProtocolTransition {
+        bootstrap: None,
+        commands: vec![ExecutionProtocolCommand::Interrupt(InterruptExecution {
+            attempt_id: attempt.attempt_id.clone(),
+            outcome_id: format!("outcome:interrupted:{}", attempt.attempt_id),
+            reason: reason.to_string(),
+            interrupted_at: record.updated_at.to_rfc3339(),
+        })],
+    };
+    if record.status != QueueEntryStatus::Processed {
+        return Ok(interrupted("runtime_interrupted"));
+    }
+    let Some(message) = storage.read_message_by_id(&record.message_id)? else {
+        return Ok(interrupted("source_message_missing"));
+    };
+    let owner_work_item_id = match &attempt.binding {
+        ExecutionBinding::WorkItem { work_item_id } => Some(work_item_id.as_str()),
+        ExecutionBinding::Conversation { .. }
+        | ExecutionBinding::AgentLifecycle { .. }
+        | ExecutionBinding::Command => None,
+    };
+    let matching_terminal_turn = canonical_matching_terminal_turn(
+        runtime_db,
+        record,
+        &message,
+        owner_work_item_id,
+        terminal_turn,
+    )?;
+    let Some(terminal_turn) = matching_terminal_turn else {
+        return Err(anyhow!(
+            "execution attempt {} cannot settle message {} as processed without a matching \
+             terminal Turn",
+            attempt.attempt_id,
+            record.message_id
+        ));
+    };
+
+    let outcome = match &attempt.binding {
+        ExecutionBinding::WorkItem { work_item_id } => {
+            let matching_continuations = runtime_db
+                .work_item_continuations()
+                .active_for_agent(&record.agent_id)?
+                .into_iter()
+                .filter(|frame| {
+                    frame.suspended_work_item_id == *work_item_id
+                        && frame.turn_id.as_deref() == Some(terminal_turn.turn_id.as_str())
+                })
+                .collect::<Vec<_>>();
+            match matching_continuations.as_slice() {
+                [frame] => {
+                    let Some(target) = storage.latest_work_item(&frame.active_work_item_id)? else {
+                        return Ok(interrupted("yield_target_missing"));
+                    };
+                    if target.agent_id != record.agent_id
+                        || target.state != crate::types::WorkItemState::Open
+                        || target.readiness() != crate::types::WorkItemReadiness::Runnable
+                    {
+                        return Ok(interrupted("yield_target_not_runnable"));
+                    }
+                    ExecutionOutcome::WorkItem(WorkItemOutcome::Yield {
+                        target_work_item_id: target.id,
+                    })
+                }
+                [] => {
+                    let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
+                        return Ok(interrupted("work_item_missing"));
+                    };
+                    let scheduling = storage
+                        .work_queue_prompt_projection()?
+                        .items
+                        .into_iter()
+                        .find(|candidate| candidate.id == *work_item_id)
+                        .map(|candidate| candidate.scheduling_state);
+                    match scheduling {
+                        Some(crate::types::WorkItemSchedulingState::Runnable) => {
+                            ExecutionOutcome::WorkItem(WorkItemOutcome::Continue)
+                        }
+                        Some(crate::types::WorkItemSchedulingState::Completed) => {
+                            let Some(intent) = work_item.completion_intent.as_ref() else {
+                                return Ok(interrupted("completion_intent_missing"));
+                            };
+                            if intent.work_item_id != *work_item_id
+                                || intent.source_activation_id.as_deref()
+                                    != Some(attempt.attempt_id.as_str())
+                                || intent.source_message_id.as_deref()
+                                    != Some(record.message_id.as_str())
+                                || intent.source_turn_id.as_deref()
+                                    != Some(terminal_turn.turn_id.as_str())
+                                || intent.expected_work_revision
+                                    != attempt
+                                        .admitted_fences
+                                        .work_item_source_revision
+                                        .unwrap_or_default()
+                            {
+                                return Ok(interrupted("completion_intent_mismatch"));
+                            }
+                            let Some(brief_id) =
+                                intent.result_brief_id.as_deref().filter(|brief_id| {
+                                    work_item.result_brief_id.as_deref() == Some(*brief_id)
+                                })
+                            else {
+                                return Ok(interrupted("completion_brief_binding_missing"));
+                            };
+                            let Some(brief) = storage.read_brief_by_id(brief_id)?.filter(|brief| {
+                                brief.kind.is_success()
+                                    && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
+                                    && brief.turn_id.as_deref()
+                                        == Some(terminal_turn.turn_id.as_str())
+                                    && brief.related_message_id.as_deref()
+                                        == Some(record.message_id.as_str())
+                                    && !brief.text.trim().is_empty()
+                            }) else {
+                                return Ok(interrupted("completion_brief_evidence_missing"));
+                            };
+                            ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                                completion: brief.id,
+                            })
+                        }
+                        Some(
+                            crate::types::WorkItemSchedulingState::WaitingOperator
+                            | crate::types::WorkItemSchedulingState::WaitingTask
+                            | crate::types::WorkItemSchedulingState::WaitingExternal
+                            | crate::types::WorkItemSchedulingState::WaitingTimer
+                            | crate::types::WorkItemSchedulingState::WaitingSystem,
+                        ) => {
+                            let active_waits = storage.active_wait_conditions_for_work_item(
+                                &record.agent_id,
+                                work_item_id,
+                            )?;
+                            let [wait] = active_waits.as_slice() else {
+                                return Ok(interrupted("wait_outcome_ambiguous"));
+                            };
+                            ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
+                                wait: WaitReference {
+                                    wait_id: wait.id.clone(),
+                                },
+                            })
+                        }
+                        Some(crate::types::WorkItemSchedulingState::YieldedToWorkItem) => {
+                            return Ok(interrupted("yield_continuation_missing"));
+                        }
+                        Some(
+                            crate::types::WorkItemSchedulingState::Blocked
+                            | crate::types::WorkItemSchedulingState::Completing,
+                        )
+                        | None => return Ok(interrupted("terminal_outcome_unresolved")),
+                    }
+                }
+                _ => return Ok(interrupted("yield_continuation_ambiguous")),
+            }
+        }
+        ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. } => {
+            let active_waits = storage
+                .latest_wait_conditions()?
+                .into_iter()
+                .filter(|wait| {
+                    wait.agent_id == record.agent_id
+                        && wait.work_item_id.is_none()
+                        && wait.turn_id.as_deref() == Some(terminal_turn.turn_id.as_str())
+                        && wait.status == crate::types::WaitConditionStatus::Active
+                })
+                .collect::<Vec<_>>();
+            match active_waits.as_slice() {
+                [] => ExecutionOutcome::Conversation(ConversationOutcome::Replied),
+                [wait] => ExecutionOutcome::Conversation(ConversationOutcome::Wait {
+                    wait: WaitReference {
+                        wait_id: wait.id.clone(),
+                    },
+                }),
+                _ => return Ok(interrupted("ambiguous_lifecycle_waits")),
+            }
+        }
+        ExecutionBinding::Command => ExecutionOutcome::Command(CommandResult::Applied {
+            references: vec![
+                format!("message:{}", record.message_id),
+                format!("turn:{}", terminal_turn.turn_id),
+            ],
+        }),
+    };
     Ok(
         crate::runtime_db::transitions::ExecutionProtocolTransition {
             bootstrap: None,
-            commands: vec![ExecutionProtocolCommand::Interrupt(InterruptExecution {
-                attempt_id: attempt_id.to_string(),
-                outcome_id: format!("outcome:interrupted-recovery:{attempt_id}"),
-                reason: reason.to_string(),
-                interrupted_at,
+            commands: vec![ExecutionProtocolCommand::Settle(SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: format!("outcome:message:{}", record.message_id),
+                    attempt_id: attempt.attempt_id.clone(),
+                    outcome,
+                    created_at: record.updated_at.to_rfc3339(),
+                },
             })],
         },
     )
@@ -1129,154 +1157,6 @@ fn execution_attempt_for_message<'a>(
             left.admitted_at
                 .cmp(&right.admitted_at)
                 .then_with(|| left.attempt_id.cmp(&right.attempt_id))
-        })
-}
-
-fn adopt_pre_execution_protocol_attempt(
-    runtime_db: &RuntimeDb,
-    storage: &AppStorage,
-    agent_id: &str,
-    message: &MessageEnvelope,
-    activation_id: &str,
-    snapshot: &crate::domain::scheduler_protocol::Snapshot,
-) -> Result<(
-    crate::domain::execution_protocol::ExecutionAttempt,
-    crate::runtime_db::transitions::ExecutionProtocolTransition,
-)> {
-    use crate::domain::execution_protocol::{
-        AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding,
-        ExecutionPriority, ExecutionProtocolCommand, ExecutionProtocolState, ExecutionProvenance,
-        ExecutionSource, ExecutionSourceIdentity, RegisterWorkItemExecution,
-        WorkItemExecutionRecord, WorkItemExecutionState,
-    };
-    use crate::domain::scheduler_protocol::SchedulerOwner;
-
-    let admission = snapshot
-        .activation_admissions
-        .get(activation_id)
-        .ok_or_else(|| anyhow!("legacy activation {activation_id} has no canonical admission"))?;
-    let activation = snapshot
-        .activations
-        .get(activation_id)
-        .ok_or_else(|| anyhow!("legacy activation {activation_id} is missing"))?;
-    let source_revision = message
-        .message_seq
-        .filter(|revision| *revision > 0)
-        .ok_or_else(|| anyhow!("legacy execution adoption requires message sequence"))?;
-    let authority_fences = runtime_db
-        .transitions()
-        .load_execution_authority_fences(agent_id)?;
-    let mut commands = Vec::with_capacity(2);
-    let (binding, work_item_source_revision, work_item_generation) = match &activation.owner {
-        SchedulerOwner::WorkItem { work_item_id } => {
-            let work_item = storage
-                .latest_work_item(work_item_id)?
-                .ok_or_else(|| anyhow!("legacy execution adoption WorkItem is missing"))?;
-            let generation = activation.admitted_generation.max(1);
-            commands.push(ExecutionProtocolCommand::RegisterWorkItem(Box::new(
-                RegisterWorkItemExecution {
-                    work_item_id: work_item_id.clone(),
-                    record: WorkItemExecutionRecord {
-                        source_revision: work_item.revision.max(1),
-                        state: WorkItemExecutionState::Runnable {
-                            generation,
-                            recovery_ref: Some("pre_execution_protocol_upgrade".into()),
-                        },
-                    },
-                },
-            )));
-            (
-                ExecutionBinding::WorkItem {
-                    work_item_id: work_item_id.clone(),
-                },
-                Some(work_item.revision.max(1)),
-                Some(generation),
-            )
-        }
-        SchedulerOwner::AgentLifecycle {
-            agent_id: owner_agent_id,
-        } if owner_agent_id == agent_id => (
-            ExecutionBinding::AgentLifecycle {
-                agent_id: agent_id.to_string(),
-            },
-            None,
-            None,
-        ),
-        SchedulerOwner::AgentLifecycle { .. } => {
-            bail!("legacy execution adoption lifecycle owner does not match partition")
-        }
-    };
-    let attempt = ExecutionAttempt {
-        attempt_id: activation_id.to_string(),
-        agent_id: agent_id.to_string(),
-        source_message_id: Some(message.id.clone()),
-        source: ExecutionSource {
-            identity: match admission.activation.cause {
-                crate::domain::scheduler_protocol::ActivationCause::InternalFollowup { .. } => {
-                    ExecutionSourceIdentity::InternalFollowup {
-                        message_id: message.id.clone(),
-                    }
-                }
-                _ => ExecutionSourceIdentity::QueueMessage {
-                    message_id: message.id.clone(),
-                },
-            },
-            generation: source_revision,
-        },
-        binding,
-        provenance: ExecutionProvenance {
-            origin: scheduler_executor::canonical_execution_origin(message),
-            trust: scheduler_executor::canonical_execution_trust(message),
-            priority: match message.priority {
-                Priority::Interject => ExecutionPriority::Interject,
-                Priority::Next => ExecutionPriority::Next,
-                Priority::Normal => ExecutionPriority::Normal,
-                Priority::Background => ExecutionPriority::Background,
-            },
-            correlation_id: message.correlation_id.clone(),
-            causation_id: message.causation_id.clone(),
-        },
-        admitted_fences: AdmittedFences {
-            source_revision,
-            work_item_source_revision,
-            work_item_generation,
-            rejoin: None,
-            agent_control_revision: authority_fences.agent_control_revision,
-            host_registry_revision: authority_fences.host_registry_revision,
-        },
-        state: ExecutionAttemptState::Open,
-        run_id: None,
-        turn_id: message.turn_id.clone(),
-        recovery_of_attempt_id: None,
-        terminal_outcome_id: None,
-        admitted_at: message.created_at.to_rfc3339(),
-        terminal_at: None,
-    };
-    commands.push(ExecutionProtocolCommand::Admit(Box::new(AdmitExecution {
-        attempt: attempt.clone(),
-    })));
-    Ok((
-        attempt,
-        crate::runtime_db::transitions::ExecutionProtocolTransition {
-            bootstrap: Some(ExecutionProtocolState::empty(agent_id)),
-            commands,
-        },
-    ))
-}
-
-fn compatibility_settlement_command(
-    snapshot: &crate::domain::scheduler_protocol::Snapshot,
-    activation_id: &str,
-) -> Option<crate::domain::scheduler_protocol::ProtocolCommand> {
-    snapshot
-        .settlements
-        .values()
-        .find(|settlement| settlement.activation_id == activation_id)
-        .cloned()
-        .map(|settlement| {
-            crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(
-                crate::domain::scheduler_protocol::SettleActivationCommand { settlement },
-            )
         })
 }
 
@@ -1486,6 +1366,7 @@ fn canonical_authority_convergence_command(
                 let source_updated_at =
                     crate::runtime_db::repositories::timestamp(condition.updated_at);
                 let authoritative_state = match condition.status {
+                    WaitConditionStatus::Triggered => return Ok(None),
                     WaitConditionStatus::Resolved => {
                         AuthoritativeWaitState::Resolved { source_updated_at }
                     }
@@ -2019,23 +1900,6 @@ pub fn apply_scheduler_recovery_plan_with_backup_policy(
         report,
         backup_policy,
         true,
-        |_| Ok(()),
-    )
-}
-
-fn apply_automatic_scheduler_recovery_plan(
-    storage: &AppStorage,
-    runtime_db: &RuntimeDb,
-    agent_id: &str,
-    report: &SchedulerRecoveryReport,
-) -> Result<(usize, Option<std::path::PathBuf>)> {
-    apply_scheduler_recovery_plan_with_options(
-        storage,
-        runtime_db,
-        agent_id,
-        report,
-        SchedulerRecoveryBackupPolicy::Required,
-        false,
         |_| Ok(()),
     )
 }
@@ -3320,16 +3184,28 @@ impl RuntimeHandle {
                 let message = message.ok_or_else(|| {
                     anyhow!("canonical execution admission requires a source message")
                 })?;
-                let activation = self
+                let attempt = self
                     .inner
                     .runtime_db
                     .transitions()
-                    .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?
-                    .and_then(|snapshot| snapshot.activations.get(activation_id).cloned())
+                    .load_execution_protocol_state_if_initialized(&message.agent_id)?
+                    .and_then(|state| state.attempts.get(activation_id).cloned())
                     .ok_or_else(|| {
-                        anyhow!("canonical execution admission references an unknown activation")
+                        anyhow!("canonical execution admission references an unknown attempt")
                     })?;
-                Some((activation_id.clone(), activation.owner))
+                let work_item_id = match attempt.binding {
+                    crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+                        work_item_id,
+                    } => Some(work_item_id),
+                    crate::domain::execution_protocol::ExecutionBinding::Conversation {
+                        ..
+                    }
+                    | crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                        ..
+                    }
+                    | crate::domain::execution_protocol::ExecutionBinding::Command => None,
+                };
+                Some((activation_id.clone(), work_item_id))
             }
             ExecutionAdmissionProvenance::LegacyCompat { .. } => None,
         };
@@ -3360,8 +3236,8 @@ impl RuntimeHandle {
                     .inner
                     .runtime_db
                     .transitions()
-                    .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?
-                    .is_none_or(|snapshot| !snapshot.activations.contains_key(&activation_id));
+                    .load_execution_protocol_state_if_initialized(&message.agent_id)?
+                    .is_none_or(|state| !state.attempts.contains_key(&activation_id));
             if authoritative_without_activation {
                 self.inner.storage.append_event(&AuditEvent::legacy(
                     "authoritative_work_item_turn_without_activation",
@@ -3383,16 +3259,15 @@ impl RuntimeHandle {
                 .unwrap_or_else(crate::ids::turn_id);
             guard.state.current_turn_id = Some(turn_id.clone());
             guard.state.last_turn_terminal = None;
-            if let Some((_, owner)) = canonical_execution_binding.as_ref() {
-                guard.state.current_turn_work_item_id =
-                    owner.work_item_id().map(ToString::to_string);
+            if let Some((_, work_item_id)) = canonical_execution_binding.as_ref() {
+                guard.state.current_turn_work_item_id = work_item_id.clone();
             } else if guard.state.current_turn_work_item_id.is_none() {
                 guard.state.current_turn_work_item_id = guard.state.current_work_item_id.clone();
             }
             guard.state.current_execution_binding = message.map(|message| {
                 let work_item_id = canonical_execution_binding
                     .as_ref()
-                    .map(|(_, owner)| owner.work_item_id().map(ToString::to_string))
+                    .map(|(_, work_item_id)| work_item_id.clone())
                     .unwrap_or_else(|| {
                         message
                             .work_item_id
@@ -3472,14 +3347,14 @@ impl RuntimeHandle {
     ) -> Result<()> {
         let provenance = if let Some(message) = message {
             let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-            let snapshot = self
+            let execution = self
                 .inner
                 .runtime_db
                 .transitions()
-                .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
-            if snapshot
+                .load_execution_protocol_state_if_initialized(&message.agent_id)?;
+            if execution
                 .as_ref()
-                .is_some_and(|snapshot| snapshot.activations.contains_key(&activation_id))
+                .is_some_and(|state| state.attempts.contains_key(&activation_id))
             {
                 let scenario_class =
                     scheduler::canonical_activation_candidate(message, None, None)?
@@ -3711,10 +3586,7 @@ impl RuntimeHandle {
                 }
                 Err(error) => {
                     let can_retry = attempt + 1 < ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
-                        && retryable_enqueue_agent_state_conflict(
-                            &error,
-                            message.agent_id.as_str(),
-                        );
+                        && retryable_enqueue_conflict(&error, message.agent_id.as_str());
                     if !can_retry
                         || !self
                             .refresh_enqueue_agent_state_baseline(&message.agent_id)
@@ -3729,11 +3601,25 @@ impl RuntimeHandle {
     }
 
     async fn enqueue_attempt(&self, message: &MessageEnvelope) -> Result<TransitionCommit> {
+        let wait_trigger = self.wait_trigger_transition_for_message(message)?;
         let message_is_new = self
             .inner
             .storage
             .read_message_by_id(&message.id)?
             .is_none();
+        let existing_queue_entry = self.inner.runtime_db.queue_entries().latest(&message.id)?;
+        if existing_queue_entry.as_ref().is_some_and(|entry| {
+            matches!(
+                entry.status,
+                QueueEntryStatus::Dequeued
+                    | QueueEntryStatus::Interjected
+                    | QueueEntryStatus::Processed
+                    | QueueEntryStatus::Aborted
+                    | QueueEntryStatus::Dropped
+            )
+        }) {
+            return Ok(TransitionCommit::default());
+        }
         let mut audit_events = vec![
             AuditEvent::legacy(
                 "message_admitted",
@@ -3758,13 +3644,31 @@ impl RuntimeHandle {
                 &MessageLifecycleAuditEvent::from_message(&message),
             )?,
         ];
+        if let Some(wait_trigger) = wait_trigger.as_ref() {
+            audit_events.push(AuditEvent::legacy(
+                "wait_condition_triggered",
+                serde_json::json!({
+                    "agent_id": message.agent_id,
+                    "wait_condition_id": wait_trigger.record.id,
+                    "trigger_message_id": message.id,
+                    "work_item_id": wait_trigger.record.work_item_id,
+                }),
+            ));
+        }
         let commit = {
             let mut guard = self.inner.agent.lock().await;
+            let queue_needs_push = guard
+                .queue
+                .peek_next_matching(|queued| queued.id == message.id)
+                .is_none();
             let expected_persisted_state = guard.last_persisted_state.clone();
             let mut committed_state = guard.state.clone();
             let previous_status = committed_state.status.clone();
             let previous_sleeping_until = committed_state.sleeping_until;
-            committed_state.pending = guard.queue.len().saturating_add(1);
+            committed_state.pending = guard
+                .queue
+                .len()
+                .saturating_add(usize::from(queue_needs_push));
             committed_state.last_wake_reason = Some(format!("{:?}", message.kind));
             committed_state.total_message_count = self
                 .inner
@@ -3787,37 +3691,46 @@ impl RuntimeHandle {
                     }),
                 ));
             }
-            let mut commit = self.inner.runtime_db.transitions().commit_queue(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
-                    agent_id: message.agent_id.clone(),
-                    operation: crate::runtime_db::transitions::QueueOperation::Admit,
-                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
-                        QueueEntryRecord {
-                            message_id: message.id.clone(),
-                            agent_id: message.agent_id.clone(),
-                            priority: message.priority.clone(),
-                            status: QueueEntryStatus::Queued,
-                            created_at: message.created_at,
-                            updated_at: Utc::now(),
-                        },
-                    ),
-                    scheduler_claim_work_item: None,
-                    scheduler_protocol_bootstrap: None,
-                    scheduler_protocol_commands: Vec::new(),
-                    agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(expected_persisted_state)),
-                        record: Box::new(committed_state.clone()),
-                    }),
-                    message_evidence: vec![message.clone()],
-                    transcript_entries: Vec::new(),
-                    turn_record: None,
-                    audit_events,
-                    notify_scheduler: true,
-                    fault: self.take_transition_fault(),
-                    brief_evidence: Vec::new(),
-                },
-            )?;
-            guard.queue.push(message.clone());
+            let mut commit = self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_queue_with_wait_trigger(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: message.agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Admit,
+                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
+                            QueueEntryRecord {
+                                message_id: message.id.clone(),
+                                agent_id: message.agent_id.clone(),
+                                priority: message.priority.clone(),
+                                status: QueueEntryStatus::Queued,
+                                created_at: existing_queue_entry
+                                    .as_ref()
+                                    .map_or(message.created_at, |entry| entry.created_at),
+                                updated_at: Utc::now(),
+                            },
+                        ),
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                            expected: Some(Box::new(expected_persisted_state)),
+                            record: Box::new(committed_state.clone()),
+                        }),
+                        message_evidence: vec![message.clone()],
+                        transcript_entries: Vec::new(),
+                        turn_record: None,
+                        audit_events,
+                        notify_scheduler: true,
+                        fault: self.take_transition_fault(),
+                        brief_evidence: Vec::new(),
+                    },
+                    wait_trigger.as_ref(),
+                )?;
+            if queue_needs_push {
+                guard.queue.push(message.clone());
+            }
             guard.state = committed_state.clone();
             guard.last_persisted_state = committed_state;
             commit.effects.agent_state = None;
@@ -3892,56 +3805,12 @@ impl RuntimeHandle {
         transcript_entries: Vec<TranscriptEntry>,
         brief_evidence: Vec<BriefRecord>,
     ) -> Result<bool> {
-        if self.inner.scheduler_engine.is_canonical()
-            && record.status == QueueEntryStatus::Processed
-        {
-            if let Some(message) = self.inner.storage.read_message_by_id(&record.message_id)? {
-                if let Some(snapshot) = self
-                    .inner
-                    .runtime_db
-                    .transitions()
-                    .load_scheduler_protocol_snapshot_if_initialized(&record.agent_id)?
-                {
-                    if let Some(activation_id) = scheduler_executor::canonical_open_activation_id(
-                        &snapshot,
-                        &record.message_id,
-                    ) {
-                        let activation = &snapshot.activations[&activation_id];
-                        let terminal_turn =
-                            terminal_transition.map(|transition| &transition.turn_record);
-                        if canonical_matching_terminal_turn(
-                            &self.inner.runtime_db,
-                            &record,
-                            &message,
-                            activation.owner.work_item_id(),
-                            terminal_turn,
-                        )?
-                        .is_none()
-                        {
-                            return Err(anyhow!(
-                                "canonical model-turn activation {activation_id} cannot settle \
-                                 message {} as processed without a matching terminal Turn",
-                                record.message_id
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-        let scheduler_protocol_commands = if self.inner.scheduler_engine.is_canonical() {
-            self.canonical_queue_settlement_commands(
+        let execution_protocol = if self.inner.scheduler_engine.is_canonical() {
+            execution_protocol_settlement_transition_from_facts(
+                &self.inner.storage,
+                &self.inner.runtime_db,
                 &record,
                 terminal_transition.map(|transition| &transition.turn_record),
-            )
-            .await?
-        } else {
-            Vec::new()
-        };
-        let execution_protocol = if self.inner.scheduler_engine.is_canonical() {
-            execution_protocol_settlement_transition(
-                &self.inner.runtime_db,
-                &record.agent_id,
-                &scheduler_protocol_commands,
             )?
         } else {
             Default::default()
@@ -3953,7 +3822,7 @@ impl RuntimeHandle {
             mutation: crate::runtime_db::transitions::QueueMutation::Upsert(record.clone()),
             scheduler_claim_work_item: None,
             scheduler_protocol_bootstrap: None,
-            scheduler_protocol_commands: scheduler_protocol_commands.clone(),
+            scheduler_protocol_commands: Vec::new(),
             agent_state: None,
             message_evidence: Vec::new(),
             transcript_entries: transcript_entries.clone(),
@@ -4006,7 +3875,7 @@ impl RuntimeHandle {
                 }
                 Err(error) => {
                     let can_retry = attempt + 1 < ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
-                        && retryable_enqueue_agent_state_conflict(&error, &record.agent_id);
+                        && retryable_enqueue_conflict(&error, &record.agent_id);
                     if !can_retry
                         || !self
                             .refresh_enqueue_agent_state_baseline(&record.agent_id)
@@ -4164,6 +4033,7 @@ impl RuntimeHandle {
         Ok(superseded)
     }
 
+    #[cfg(test)]
     async fn canonical_queue_settlement_commands(
         &self,
         record: &QueueEntryRecord,
@@ -4205,22 +4075,11 @@ impl RuntimeHandle {
             self.validate_legacy_engine_startup(&agent_id)?;
         }
         self.bootstrap_recovery().await?;
-        if self.inner.scheduler_engine.is_canonical() {
-            let recovery =
-                scheduler_recovery_report(&self.inner.storage, &self.inner.runtime_db, &agent_id)?;
-            apply_automatic_scheduler_recovery_plan(
-                &self.inner.storage,
-                &self.inner.runtime_db,
-                &agent_id,
-                &recovery,
-            )?;
-        }
         scheduler_executor::SchedulerDecisionExecutor::new(&self)
             .bootstrap_recovered()
             .await?;
         if self.inner.scheduler_engine.is_canonical() {
             self.recover_scheduler_bootstrap_claims().await?;
-            self.record_scheduler_bootstrap_diagnostics().await?;
         }
 
         loop {
@@ -4602,7 +4461,6 @@ impl RuntimeHandle {
             entry.status = QueueEntryStatus::Interrupted;
             entry.updated_at = Utc::now();
             let message_id = entry.message_id.clone();
-            let scheduler_protocol_commands = Vec::new();
             let execution_protocol =
                 crate::runtime_db::transitions::ExecutionProtocolTransition::default();
             let commit = self
@@ -4616,7 +4474,7 @@ impl RuntimeHandle {
                         mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
                         scheduler_claim_work_item: None,
                         scheduler_protocol_bootstrap: None,
-                        scheduler_protocol_commands,
+                        scheduler_protocol_commands: Vec::new(),
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),
@@ -4644,25 +4502,25 @@ impl RuntimeHandle {
     }
 
     fn validate_legacy_engine_startup(&self, agent_id: &str) -> Result<()> {
-        if let Some(snapshot) = self
+        if let Some(execution) = self
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+            .load_execution_protocol_state_if_initialized(agent_id)?
         {
-            let running = snapshot
-                .activations
+            let open_attempts = execution
+                .attempts
                 .iter()
-                .filter(|(_, activation)| {
-                    activation.state == crate::domain::scheduler_protocol::ActivationState::Running
+                .filter(|(_, attempt)| {
+                    attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Open
                 })
-                .map(|(activation_id, _)| activation_id.as_str())
+                .map(|(attempt_id, _)| attempt_id.as_str())
                 .collect::<Vec<_>>();
-            if !running.is_empty() {
+            if !open_attempts.is_empty() {
                 return Err(anyhow!(
-                    "legacy scheduler startup refused for agent {agent_id}: non-terminal \
-                     canonical activations remain ({})",
-                    running.join(", ")
+                    "legacy scheduler startup refused for agent {agent_id}: open unified \
+                     execution attempts remain ({})",
+                    open_attempts.join(", ")
                 ));
             }
         }
@@ -4687,11 +4545,6 @@ impl RuntimeHandle {
 
     async fn recover_scheduler_bootstrap_claims(&self) -> Result<usize> {
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        let snapshot = self
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?;
         let execution_state = self
             .inner
             .runtime_db
@@ -4718,32 +4571,13 @@ impl RuntimeHandle {
             let Some(message) = self.inner.storage.read_message_by_id(&entry.message_id)? else {
                 continue;
             };
-            let (attempt, adoption) = if let Some(attempt) = execution_state
+            let Some(attempt) = execution_state
                 .as_ref()
                 .and_then(|state| execution_attempt_for_message(state, &entry.message_id))
-            {
-                (
-                    attempt.clone(),
-                    crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
-                )
-            } else {
-                let Some(snapshot) = snapshot.as_ref() else {
-                    continue;
-                };
-                let Some(activation_id) =
-                    scheduler_executor::canonical_open_activation_id(snapshot, &entry.message_id)
-                else {
-                    continue;
-                };
-                adopt_pre_execution_protocol_attempt(
-                    &self.inner.runtime_db,
-                    &self.inner.storage,
-                    &agent_id,
-                    &message,
-                    &activation_id,
-                    snapshot,
-                )?
+            else {
+                continue;
             };
+            let attempt = attempt.clone();
             let activation_id = attempt.attempt_id.clone();
             let work_item_id = match &attempt.binding {
                 crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } => {
@@ -4889,101 +4723,20 @@ impl RuntimeHandle {
                 QueueEntryStatus::Interrupted
             };
             entry.updated_at = self.now();
-            let mut scheduler_protocol_commands = match snapshot.as_ref() {
-                Some(snapshot) => {
-                    if let Some(command) =
-                        compatibility_settlement_command(snapshot, &activation_id)
-                    {
-                        vec![command]
-                    } else {
-                        self.canonical_queue_settlement_commands(&entry, terminal_turn)
-                            .await?
-                    }
-                }
-                None => Vec::new(),
-            };
-            let settles_from_terminal =
-                canonical_commands_settle_from_terminal(&scheduler_protocol_commands);
-            if !settles_from_terminal {
-                entry.status = QueueEntryStatus::Interrupted;
-                if terminal_is_completed && snapshot.is_some() {
-                    scheduler_protocol_commands = canonical_queue_settlement_commands_from_facts(
-                        &self.inner.storage,
-                        &self.inner.runtime_db,
-                        &entry,
-                        terminal_turn,
-                    )?;
-                }
-            }
-            if let Some(snapshot) = snapshot.as_ref() {
-                let rejected =
-                    canonical_command_batch_rejection(snapshot, &scheduler_protocol_commands);
-                if let Some(diagnostics) = rejected {
-                    self.inner.storage.append_event(
-                        &scheduler::scheduler_invariant_diagnostic_event(
-                            &agent_id,
-                            "bootstrap_recovery_command_rejected",
-                            work_item_id.clone(),
-                            Some(entry.message_id.clone()),
-                            diagnostics,
-                        )?,
-                    )?;
-                    continue;
-                }
-            }
             let message_id = entry.message_id.clone();
             let queue_status = entry.status.clone();
             let terminal_turn_id = terminal_turn.map(|turn| turn.turn_id.clone());
-            let recovery_outcome = if settles_from_terminal {
+            let recovery_outcome = if terminal_is_completed {
                 "settled_from_terminal_turn"
             } else {
                 "attempt_interrupted_for_reentry"
             };
-            let execution_protocol = if adoption.bootstrap.is_some() {
-                let mut transition = adoption;
-                let command = if scheduler_protocol_commands.is_empty() {
-                    crate::domain::execution_protocol::ExecutionProtocolCommand::Interrupt(
-                        crate::domain::execution_protocol::InterruptExecution {
-                            attempt_id: activation_id.clone(),
-                            outcome_id: format!("outcome:interrupted-recovery:{activation_id}"),
-                            reason: "scheduler_compatibility_projection_missing".into(),
-                            interrupted_at: entry.updated_at.to_rfc3339(),
-                        },
-                    )
-                } else {
-                    let settlement = scheduler_protocol_commands
-                        .iter()
-                        .find_map(|command| match command {
-                            crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(
-                                command,
-                            ) => Some(&command.settlement),
-                            crate::domain::scheduler_protocol::ProtocolCommand::RecoverInterruptedActivation(
-                                command,
-                            ) => Some(&command.settlement),
-                            _ => None,
-                        })
-                        .ok_or_else(|| {
-                            anyhow!("legacy execution adoption requires typed settlement")
-                        })?;
-                    execution_protocol_settlement_command(&attempt, settlement)?
-                };
-                transition.commands.push(command);
-                transition
-            } else if scheduler_protocol_commands.is_empty() {
-                execution_protocol_interruption_transition(
-                    &self.inner.runtime_db,
-                    &agent_id,
-                    &activation_id,
-                    "scheduler_compatibility_projection_missing",
-                    entry.updated_at.to_rfc3339(),
-                )?
-            } else {
-                execution_protocol_settlement_transition(
-                    &self.inner.runtime_db,
-                    &agent_id,
-                    &scheduler_protocol_commands,
-                )?
-            };
+            let execution_protocol = execution_protocol_settlement_transition_from_facts(
+                &self.inner.storage,
+                &self.inner.runtime_db,
+                &entry,
+                terminal_turn,
+            )?;
             let commit = self
                 .inner
                 .runtime_db
@@ -4998,7 +4751,7 @@ impl RuntimeHandle {
                         },
                         scheduler_claim_work_item: None,
                         scheduler_protocol_bootstrap: None,
-                        scheduler_protocol_commands,
+                        scheduler_protocol_commands: Vec::new(),
                         agent_state: None,
                         message_evidence: Vec::new(),
                         transcript_entries: Vec::new(),
@@ -5028,136 +4781,6 @@ impl RuntimeHandle {
             self.apply_transition_commit(commit).await;
         }
         Ok(recovered)
-    }
-
-    async fn record_scheduler_bootstrap_diagnostics(&self) -> Result<()> {
-        const STUCK_ACTIVATION_AGE: chrono::Duration = chrono::Duration::minutes(5);
-
-        let (agent_id, active_run_id) = {
-            let guard = self.inner.agent.lock().await;
-            (guard.state.id.clone(), guard.state.current_run_id.clone())
-        };
-        let Some(snapshot) = self
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
-        else {
-            return Ok(());
-        };
-        let queue_entries = self
-            .inner
-            .runtime_db
-            .queue_entries()
-            .recent(Some(&agent_id), usize::MAX)?;
-        let turns = self
-            .inner
-            .runtime_db
-            .turn_records()
-            .recent_for_agent(&agent_id, usize::MAX)?;
-        let work_items = self
-            .inner
-            .runtime_db
-            .work_items()
-            .latest_for_agent(&agent_id, usize::MAX)?;
-        let mut events = Vec::new();
-
-        for (activation_id, activation) in snapshot.activations.iter().filter(|(_, activation)| {
-            activation.state == crate::domain::scheduler_protocol::ActivationState::Running
-        }) {
-            let work_item_id = activation.owner.work_item_id().map(ToString::to_string);
-            let message_id = activation_id
-                .strip_prefix("activation:message:")
-                .map(ToString::to_string);
-            let queue_entry = message_id.as_deref().and_then(|message_id| {
-                queue_entries
-                    .iter()
-                    .find(|entry| entry.message_id == message_id)
-            });
-            let terminal_turn = message_id.as_deref().and_then(|message_id| {
-                turns.iter().find(|turn| {
-                    turn.terminal.is_some()
-                        && turn
-                            .trigger
-                            .as_ref()
-                            .and_then(|trigger| trigger.message_id.as_deref())
-                            == Some(message_id)
-                })
-            });
-            let mut base_evidence = vec![
-                format!("activation_id={activation_id}"),
-                format!("owner={:?}", activation.owner),
-                format!("admitted_generation={}", activation.admitted_generation),
-            ];
-            if active_run_id.is_none() {
-                events.push(scheduler::scheduler_invariant_diagnostic_event(
-                    &agent_id,
-                    "running_activation_without_active_run",
-                    work_item_id.clone(),
-                    message_id.clone(),
-                    base_evidence.clone(),
-                )?);
-            }
-            if work_item_id.as_deref().is_some_and(|work_item_id| {
-                work_items.iter().any(|work_item| {
-                    work_item.id == work_item_id
-                        && work_item.state == crate::types::WorkItemState::Completed
-                })
-            }) {
-                events.push(scheduler::scheduler_invariant_diagnostic_event(
-                    &agent_id,
-                    "completed_work_item_has_running_activation",
-                    work_item_id.clone(),
-                    message_id.clone(),
-                    base_evidence.clone(),
-                )?);
-            }
-            if let (Some(queue_entry), Some(turn)) = (queue_entry, terminal_turn) {
-                if queue_entry.status == QueueEntryStatus::Dequeued {
-                    let mut evidence = base_evidence.clone();
-                    evidence.push(format!("turn_id={}", turn.turn_id));
-                    evidence.push("queue_status=dequeued".into());
-                    events.push(scheduler::scheduler_invariant_diagnostic_event(
-                        &agent_id,
-                        "terminal_turn_has_dequeued_queue",
-                        work_item_id.clone(),
-                        message_id.clone(),
-                        evidence,
-                    )?);
-                }
-            }
-            if let Some(queue_entry) = queue_entry {
-                let age = self.now().signed_duration_since(queue_entry.updated_at);
-                if age >= STUCK_ACTIVATION_AGE {
-                    base_evidence.push(format!("age_seconds={}", age.num_seconds()));
-                    events.push(scheduler::scheduler_invariant_diagnostic_event(
-                        &agent_id,
-                        "running_activation_age_exceeded",
-                        work_item_id,
-                        message_id,
-                        base_evidence,
-                    )?);
-                }
-            }
-        }
-
-        if !events.is_empty() {
-            tracing::warn!(
-                agent_id = %agent_id,
-                diagnostic_count = events.len(),
-                "scheduler bootstrap invariants require attention"
-            );
-            let recent_events = self.inner.storage.read_recent_events(128)?;
-            events.retain(|event| {
-                !recent_events
-                    .iter()
-                    .any(|recent| recent.kind == event.kind && recent.data == event.data)
-            });
-        }
-        if !events.is_empty() {
-            self.inner.storage.append_events(&events)?;
-        }
-        Ok(())
     }
 
     async fn bootstrap_recovery(&self) -> Result<()> {
@@ -5330,17 +4953,14 @@ fn normalized_turn_id(turn_id: Option<&str>) -> Option<String> {
         .map(ToString::to_string)
 }
 
-pub(crate) fn retryable_enqueue_agent_state_conflict(
-    error: &anyhow::Error,
-    agent_id: &str,
-) -> bool {
+pub(crate) fn retryable_enqueue_conflict(error: &anyhow::Error, agent_id: &str) -> bool {
     error.chain().any(|source| {
         source
             .downcast_ref::<RuntimeStateTransitionConflict>()
             .is_some_and(|conflict| {
                 conflict.retryable()
-                    && conflict.domain() == "agent_state"
-                    && conflict.record_id() == agent_id
+                    && ((conflict.domain() == "agent_state" && conflict.record_id() == agent_id)
+                        || conflict.domain() == "wait_condition_trigger")
             })
     })
 }

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -668,6 +668,7 @@ impl RuntimeHandle {
                             true,
                         ),
                         None,
+                        None,
                     )
                     .await;
                 runtime
@@ -796,6 +797,7 @@ impl RuntimeHandle {
             terminal.status.clone(),
             detail.clone(),
             Some(&result_message.id),
+            Some(&result_message),
         )
         .await?;
         let enqueue_result = self.enqueue(result_message).await;
@@ -945,6 +947,7 @@ impl RuntimeHandle {
         status: TaskStatus,
         detail: serde_json::Value,
         parent_message_id: Option<&str>,
+        message_evidence: Option<&MessageEnvelope>,
     ) -> Result<()> {
         let fallback = TaskRecord {
             id: task_record.id.clone(),
@@ -959,11 +962,12 @@ impl RuntimeHandle {
             detail: Some(self.task_detail_preserving_rejoin_contract(task_record, detail)),
             recovery: task_record.recovery.clone(),
         };
-        self.apply_task_transition_silent(task_state_reducer::TaskTransition::new(
-            &fallback,
-            "command_task_terminal_persisted",
-        ))
-        .await?;
+        let mut transition =
+            task_state_reducer::TaskTransition::new(&fallback, "command_task_terminal_persisted");
+        if let Some(message_evidence) = message_evidence {
+            transition = transition.with_message_evidence(message_evidence);
+        }
+        self.apply_task_transition_silent(transition).await?;
         Ok(())
     }
 

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -656,14 +656,11 @@ impl RuntimeHandle {
         message.work_item_id = work_item_id;
         message.correlation_id = correlation_id;
         message.causation_id = causation_id;
-        if let Some((wait_id, wait_generation)) = self
+        if let Some(wait_id) = self
             .exact_external_wait_correlation(pending.external_trigger_id.as_deref())
             .await?
         {
             message.source_refs.insert("wait_id".into(), wait_id);
-            message
-                .source_refs
-                .insert("wait_generation".into(), wait_generation.to_string());
         }
         self.inner.storage.append_event(&AuditEvent::legacy(
             "system_tick_emitted",
@@ -836,7 +833,7 @@ impl RuntimeHandle {
                     Ok(commit) => commit,
                     Err(error) => {
                         let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
-                            && super::retryable_enqueue_agent_state_conflict(&error, &agent_id);
+                            && super::retryable_enqueue_conflict(&error, &agent_id);
                         if !can_retry {
                             return Err(error);
                         }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -65,7 +65,7 @@ pub(crate) enum CanonicalActivationCandidate {
     },
     ExactWaitResume {
         expected_work_item_id: Option<String>,
-        correlated_wait: Option<(String, u64)>,
+        correlated_wait: Option<String>,
     },
     LifecycleExternalNudge {
         agent_id: String,
@@ -301,6 +301,7 @@ impl SchedulerProjection {
             .filter(|condition| condition.agent_id == snapshot.id)
             .filter(|condition| {
                 condition.status == WaitConditionStatus::Active
+                    || condition.status == WaitConditionStatus::Triggered
                     || (condition.status == WaitConditionStatus::Resolved
                         && condition.kind == WaitConditionKind::Task)
             })
@@ -1276,17 +1277,16 @@ pub(crate) fn resolve_canonical_activation_scenario(
 
     let mut matching_waits = match &candidate {
         CanonicalActivationCandidate::ExactWaitResume {
-            correlated_wait: Some((wait_id, generation)),
+            correlated_wait: Some(wait_id),
             ..
         } => projection
             .activation_waits
             .iter()
             .filter(|condition| {
                 condition.id == *wait_id
-                    && condition.status == WaitConditionStatus::Active
-                    && *generation > 0
-                    && (projection.canonical_work_statuses.is_none()
-                        || projection.canonical_wait_generations.get(wait_id) == Some(generation))
+                    && (condition.status == WaitConditionStatus::Active
+                        || (condition.status == WaitConditionStatus::Triggered
+                            && condition.trigger_message_id() == Some(message.id.as_str())))
                     && condition.work_item_id.as_deref() == candidate.expected_work_item_id()
             })
             .collect(),
@@ -1379,7 +1379,7 @@ pub(crate) fn resolve_canonical_activation_scenario(
     }))
 }
 
-fn authoritative_wait_correlation(message: &MessageEnvelope) -> Option<(String, u64)> {
+fn authoritative_wait_correlation(message: &MessageEnvelope) -> Option<String> {
     let trusted = matches!(
         (message.delivery_surface, message.admission_context),
         (
@@ -1399,9 +1399,7 @@ fn authoritative_wait_correlation(message: &MessageEnvelope) -> Option<(String, 
     if !trusted {
         return None;
     }
-    let wait_id = message.source_refs.get("wait_id")?.clone();
-    let generation = message.source_refs.get("wait_generation")?.parse().ok()?;
-    Some((wait_id, generation))
+    message.source_refs.get("wait_id").cloned()
 }
 
 fn matching_wait_conditions<'a>(
@@ -1423,6 +1421,8 @@ fn matching_wait_conditions_for_work_item<'a>(
             expected_work_item_id
                 .is_none_or(|work_item_id| condition.work_item_id.as_deref() == Some(work_item_id))
                 && (condition.status == WaitConditionStatus::Active
+                    || (condition.status == WaitConditionStatus::Triggered
+                        && condition.trigger_message_id() == Some(message.id.as_str()))
                     || (message.kind == MessageKind::TaskResult
                         && condition.status == WaitConditionStatus::Resolved
                         && condition.kind == WaitConditionKind::Task

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1,6 +1,5 @@
 use super::message_dispatch::MessageDispatchPlan;
 use super::*;
-use crate::domain::scheduler_protocol::WaitState;
 use crate::types::ExecutionAdmissionProvenance;
 
 pub(super) enum RunLoopPoll {
@@ -20,33 +19,6 @@ impl RunLoopPoll {
             RunLoopPoll::Idle => "idle",
             RunLoopPoll::AuthorityBlocked => "authority_blocked",
         }
-    }
-}
-
-pub(super) fn canonical_execution_origin(
-    message: &MessageEnvelope,
-) -> crate::domain::execution_protocol::ExecutionOrigin {
-    use crate::domain::execution_protocol::ExecutionOrigin;
-    match message.origin {
-        MessageOrigin::Operator { .. } => ExecutionOrigin::Operator,
-        MessageOrigin::Channel { .. } => ExecutionOrigin::Channel,
-        MessageOrigin::Webhook { .. } => ExecutionOrigin::Webhook,
-        MessageOrigin::Callback { .. } => ExecutionOrigin::Callback,
-        MessageOrigin::Timer { .. } => ExecutionOrigin::Timer,
-        MessageOrigin::System { .. } => ExecutionOrigin::System,
-        MessageOrigin::Task { .. } => ExecutionOrigin::Task,
-    }
-}
-
-pub(super) fn canonical_execution_trust(
-    message: &MessageEnvelope,
-) -> crate::domain::execution_protocol::ExecutionTrust {
-    use crate::domain::execution_protocol::ExecutionTrust;
-    match message.authority_class {
-        crate::types::AuthorityClass::OperatorInstruction => ExecutionTrust::OperatorInstruction,
-        crate::types::AuthorityClass::RuntimeInstruction => ExecutionTrust::RuntimeInstruction,
-        crate::types::AuthorityClass::IntegrationSignal => ExecutionTrust::IntegrationSignal,
-        crate::types::AuthorityClass::ExternalEvidence => ExecutionTrust::ExternalEvidence,
     }
 }
 
@@ -108,10 +80,8 @@ pub(super) struct ScheduledMessage {
 struct CanonicalClaimPlan {
     activation_id: String,
     scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
-    execution_owner: crate::domain::scheduler_protocol::SchedulerOwner,
-    scheduler_claim_work_item: Option<crate::types::WorkItemRecord>,
-    bootstrap: Option<crate::domain::scheduler_protocol::Snapshot>,
-    commands: Vec<crate::domain::scheduler_protocol::ProtocolCommand>,
+    work_item_id: Option<String>,
+    work_item_expectation: Option<crate::types::WorkItemRecord>,
     execution_protocol: crate::runtime_db::transitions::ExecutionProtocolTransition,
 }
 
@@ -127,29 +97,6 @@ enum CanonicalClaimOutcome {
         reason: &'static str,
     },
     HardBlocker(CanonicalClaimHardBlocker),
-}
-
-fn projected_scheduler_dispatch_revision(
-    snapshot: &crate::domain::scheduler_protocol::Snapshot,
-    commands: &[crate::domain::scheduler_protocol::ProtocolCommand],
-) -> Result<u64> {
-    let mut projected = snapshot.clone();
-    for command in commands {
-        let outcome = crate::domain::scheduler_protocol::reduce_command(&projected, command);
-        if outcome.outcome.decision == crate::domain::scheduler_protocol::Decision::Rejected {
-            let diagnostic = outcome
-                .conflict
-                .as_ref()
-                .map(|conflict| conflict.code.as_str())
-                .or_else(|| outcome.outcome.diagnostics.first().map(String::as_str))
-                .unwrap_or("rejected_without_diagnostic");
-            anyhow::bail!(
-                "canonical scheduler claim prefix rejected while projecting dispatch revision: {diagnostic}"
-            );
-        }
-        projected = outcome.outcome.snapshot;
-    }
-    Ok(projected.dispatch_revision)
 }
 
 struct CanonicalClaimHardBlocker {
@@ -554,7 +501,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 .message(&persisted_message)
                 .model_reentry(true)
                 .evidence(format!("canonical_activation={}", plan.activation_id));
-                if let Some(work_item_id) = plan.execution_owner.work_item_id() {
+                if let Some(work_item_id) = plan.work_item_id.as_deref() {
                     decision = decision.work_item_id(work_item_id);
                 }
                 decision
@@ -614,16 +561,40 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 running_state.pending = guard.queue.len().saturating_sub(1);
                 scheduler::apply_running_projection(&mut running_state, run_id.clone());
                 running_state.last_wake_reason = Some(format!("{:?}", candidate.message.kind));
-                let execution_protocol = canonical_claim
+                let mut execution_protocol = canonical_claim
                     .as_ref()
                     .map(|plan| plan.execution_protocol.clone())
                     .unwrap_or_default();
+                let wait_transition = canonical_claim
+                    .as_ref()
+                    .map(|_| {
+                        self.runtime
+                            .wait_resolution_transition_for_message(&persisted_message)
+                    })
+                    .transpose()?
+                    .flatten();
+                align_execution_claim_with_wait_transition(
+                    &mut execution_protocol,
+                    wait_transition.as_ref(),
+                )?;
+                let mut attempt_audit_events = claim_audit_events.clone();
+                if let Some(wait_transition) = wait_transition.as_ref() {
+                    attempt_audit_events.push(AuditEvent::legacy(
+                        "wait_conditions_resolved",
+                        serde_json::json!({
+                            "agent_id": persisted_message.agent_id,
+                            "message_id": persisted_message.id,
+                            "reason": "execution_admission",
+                            "wait_condition_ids": [wait_transition.record.id],
+                        }),
+                    ));
+                }
                 let commit_result = self
                     .runtime
                     .inner
                     .runtime_db
                     .transitions()
-                    .commit_queue_with_execution_protocol(
+                    .commit_queue_with_execution_protocol_and_wait_transition(
                         &crate::runtime_db::transitions::QueueTransitionCommand {
                             agent_id: agent_id.clone(),
                             operation: crate::runtime_db::transitions::QueueOperation::Claim,
@@ -632,14 +603,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             ),
                             scheduler_claim_work_item: canonical_claim
                                 .as_ref()
-                                .and_then(|plan| plan.scheduler_claim_work_item.clone()),
-                            scheduler_protocol_bootstrap: canonical_claim
-                                .as_ref()
-                                .and_then(|plan| plan.bootstrap.clone()),
-                            scheduler_protocol_commands: canonical_claim
-                                .as_ref()
-                                .map(|plan| plan.commands.clone())
-                                .unwrap_or_default(),
+                                .and_then(|plan| plan.work_item_expectation.clone()),
+                            scheduler_protocol_bootstrap: None,
+                            scheduler_protocol_commands: Vec::new(),
                             agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                                 expected: Some(Box::new(guard.state.clone())),
                                 record: Box::new(running_state.clone()),
@@ -647,18 +613,19 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             message_evidence: Vec::new(),
                             transcript_entries: Vec::new(),
                             turn_record: None,
-                            audit_events: claim_audit_events.clone(),
+                            audit_events: attempt_audit_events,
                             notify_scheduler: false,
                             fault: self.runtime.take_transition_fault(),
                             brief_evidence: Vec::new(),
                         },
                         &execution_protocol,
+                        wait_transition.as_ref(),
                     );
                 let mut commit = match commit_result {
                     Ok(commit) => commit,
                     Err(error) => {
                         let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
-                            && super::retryable_enqueue_agent_state_conflict(&error, &agent_id);
+                            && super::retryable_enqueue_conflict(&error, &agent_id);
                         if !can_retry {
                             return Err(error);
                         }
@@ -721,7 +688,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
     ) -> Result<bool> {
         let scheduler::CanonicalActivationCandidate::ExactWaitResume {
             expected_work_item_id,
-            correlated_wait: Some((wait_id, generation)),
+            correlated_wait: Some(wait_id),
         } = candidate
         else {
             return Ok(false);
@@ -737,28 +704,15 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     && condition.agent_id == message.agent_id
                     && condition.work_item_id.as_deref() == expected_work_item_id.as_deref()
             });
-        if durable_wait
-            .as_ref()
-            .is_none_or(|condition| condition.status != crate::types::WaitConditionStatus::Active)
-        {
+        if durable_wait.as_ref().is_none_or(|condition| {
+            !matches!(
+                condition.status,
+                crate::types::WaitConditionStatus::Active
+                    | crate::types::WaitConditionStatus::Triggered
+            ) || (condition.status == crate::types::WaitConditionStatus::Triggered
+                && condition.trigger_message_id() != Some(message.id.as_str()))
+        }) {
             return Ok(true);
-        }
-        if let Some(snapshot) = self
-            .runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?
-        {
-            if snapshot.waits.get(wait_id).is_some_and(|wait| {
-                wait.current_generation != *generation
-                    || wait
-                        .generations
-                        .get(generation)
-                        .is_none_or(|generation| generation.state == WaitState::Resolved)
-            }) {
-                return Ok(true);
-            }
         }
         if let Some(work_item_id) = expected_work_item_id {
             if let Some(execution) = self
@@ -772,11 +726,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     !matches!(
                         &work.state,
                         crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
-                            generation: current_generation,
                             wait,
-                        } if current_generation == generation
-                            && wait.wait_id == *wait_id
-                            && wait.generation == *generation
+                            ..
+                        } if wait.wait_id == *wait_id
                     )
                 }) {
                     return Ok(true);
@@ -784,6 +736,65 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
         }
         Ok(false)
+    }
+
+    fn provably_stale_task_rejoin(
+        &self,
+        candidate: &scheduler::CanonicalActivationCandidate,
+        message: &MessageEnvelope,
+    ) -> Result<bool> {
+        let scheduler::CanonicalActivationCandidate::ExactTaskRejoin {
+            task_id,
+            work_item_id,
+        } = candidate
+        else {
+            return Ok(false);
+        };
+        let Some(execution) = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&message.agent_id)?
+        else {
+            return Ok(false);
+        };
+        let Some(crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+            wait, ..
+        }) = execution
+            .work_items
+            .get(work_item_id)
+            .map(|record| &record.state)
+        else {
+            return Ok(false);
+        };
+        let current_wait = self
+            .runtime
+            .inner
+            .storage
+            .latest_wait_conditions()?
+            .into_iter()
+            .find(|condition| {
+                condition.id == wait.wait_id
+                    && condition.agent_id == message.agent_id
+                    && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
+            });
+        Ok(current_wait.is_none_or(|condition| {
+            !matches!(
+                condition.status,
+                crate::types::WaitConditionStatus::Active
+                    | crate::types::WaitConditionStatus::Triggered
+                    | crate::types::WaitConditionStatus::Resolved
+            ) || condition.kind != crate::types::WaitConditionKind::Task
+                || !condition.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        crate::types::WakeSource::TaskResult {
+                            task_id: expected_task_id,
+                        } if expected_task_id == task_id
+                    )
+                })
+        }))
     }
 
     fn canonical_activation_plan(
@@ -795,9 +806,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
     ) -> Result<CanonicalClaimOutcome> {
         let task = match &dispatch_plan.task {
             Ok(task) => task.as_ref(),
-            Err(_) => {
-                return Ok(CanonicalClaimOutcome::ReduceOnly);
-            }
+            Err(_) => return Ok(CanonicalClaimOutcome::ReduceOnly),
         };
         let Some(candidate) = scheduler::canonical_activation_candidate(
             message,
@@ -817,6 +826,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         };
         let scenario_class = candidate.scenario_class();
         let stale_correlated_wait = self.provably_stale_correlated_wait(&candidate, message)?;
+        let stale_task_rejoin = self.provably_stale_task_rejoin(&candidate, message)?;
         if let scheduler::CanonicalActivationCandidate::ExactTaskRejoin { task_id, .. } = &candidate
         {
             let durable_task = self.runtime.inner.storage.latest_task_record(task_id)?;
@@ -825,15 +835,21 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 .and_then(|task| tasks::task_rejoin_fence(task).ok())
                 .is_none()
             {
-                return Ok(canonical_claim_hard_blocker(
+                return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
-                    "canonical_task_rejoin_contract_missing_or_invalid",
-                ));
+                    reason: "canonical_task_rejoin_contract_missing_or_invalid",
+                });
             }
         }
         let Some(mut scenario) =
             scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?
         else {
+            if stale_task_rejoin {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_task_rejoin_stale",
+                });
+            }
             if stale_correlated_wait {
                 return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
@@ -846,12 +862,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             ));
         };
 
-        let existing = self
-            .runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&message.agent_id)?;
         let existing_execution = self
             .runtime
             .inner
@@ -862,7 +872,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             return self.plan_canonical_lifecycle_activation_claim(
                 message,
                 scenario,
-                existing,
+                existing_execution,
                 scenario_class,
             );
         }
@@ -897,121 +907,69 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let work_item_id = scenario
             .work_item_id()
             .expect("WorkItem scenario has a WorkItem owner");
-        let work_item = self
-            .runtime
-            .inner
-            .storage
-            .latest_work_item(work_item_id)?
-            .ok_or_else(|| anyhow!("canonical activation references unknown WorkItem"));
-        let work_item = match work_item {
-            Ok(work_item) => work_item,
-            Err(_) => {
+        let Some(work_item) = self.runtime.inner.storage.latest_work_item(work_item_id)? else {
+            return Ok(
                 if matches!(
                     scenario,
                     scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. }
                 ) {
-                    return Ok(CanonicalClaimOutcome::RetainQueued {
+                    CanonicalClaimOutcome::RetainQueued {
                         scenario_class,
                         reason: "explicit_binding_work_item_missing",
-                    });
-                }
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_work_item_missing",
-                ));
-            }
+                    }
+                } else {
+                    CanonicalClaimOutcome::RejectQueued {
+                        scenario_class,
+                        reason: "canonical_work_item_missing",
+                    }
+                },
+            );
         };
-        if work_item.state != crate::types::WorkItemState::Open
-            && matches!(
+        if work_item.agent_id != message.agent_id {
+            return Ok(CanonicalClaimOutcome::RejectQueued {
+                scenario_class,
+                reason: "canonical_work_item_not_open_same_agent",
+            });
+        }
+        if work_item.state != crate::types::WorkItemState::Open {
+            if matches!(
                 scenario,
                 scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. }
-            )
-        {
-            return Ok(CanonicalClaimOutcome::ReduceOnly);
+            ) && task.is_some_and(|task| {
+                crate::runtime::task_state_reducer::is_terminal_task_status(&task.status)
+            }) {
+                return Ok(CanonicalClaimOutcome::ReduceOnly);
+            }
+            return Ok(CanonicalClaimOutcome::RejectQueued {
+                scenario_class,
+                reason: "canonical_work_item_not_open_same_agent",
+            });
         }
         let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
-        let work_projection = work_queue
+        let Some(work_projection) = work_queue
             .items
             .iter()
             .find(|candidate| candidate.id == work_item.id)
-            .ok_or_else(|| anyhow!("canonical activation has no WorkItem scheduling projection"));
-        let work_projection = match work_projection {
-            Ok(work_projection) => work_projection,
-            Err(_) => {
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_work_item_projection_missing",
-                ));
-            }
-        };
-        if work_item.agent_id != message.agent_id
-            || work_item.state != crate::types::WorkItemState::Open
-        {
+        else {
             return Ok(canonical_claim_hard_blocker(
                 scenario_class,
-                "canonical_work_item_not_open_same_agent",
+                "canonical_work_item_projection_missing",
             ));
-        }
+        };
         if matches!(
             scenario,
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
         ) && work_projection.scheduling_state != crate::types::WorkItemSchedulingState::Runnable
         {
-            return Ok(canonical_claim_hard_blocker(
+            return Ok(CanonicalClaimOutcome::RejectQueued {
                 scenario_class,
-                "canonical_autonomous_work_item_not_runnable",
-            ));
+                reason: "canonical_autonomous_work_item_not_runnable",
+            });
         }
-        let activation_id = canonical_activation_id_for_attempt(existing.as_ref(), &message.id);
 
-        use crate::domain::scheduler_protocol::{
-            ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationOrigin,
-            ActivationPriority, ActivationProvenance, ActivationSlot, ActivationTrust,
-            AdmitActivationCommand, AdoptLegacyWorkStateCommand, AgentActivation,
-            AgentDispatchState, LegacyWaitAdoption, PreemptionPolicy, ProtocolCommand,
-            RegisterWorkDemandCommand, Snapshot, TriggerWaitCommand, WaitResumeClaim, WaitState,
-            WorkDemand, WorkStatus,
-        };
-
-        if let Some(snapshot) = existing.as_ref() {
-            if let Some(activation) = snapshot.activations.get(&activation_id) {
-                if activation.state == crate::domain::scheduler_protocol::ActivationState::Running
-                    && activation.owner.work_item_id() == Some(work_item_id)
-                    && snapshot
-                        .activation_admissions
-                        .get(&activation_id)
-                        .is_some_and(|admission| {
-                            canonical_admission_matches_scenario(admission, message, &scenario)
-                        })
-                {
-                    return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
-                        activation_id,
-                        scenario_class,
-                        execution_owner: activation.owner.clone(),
-                        scheduler_claim_work_item: matches!(
-                            scenario,
-                            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
-                                ..
-                            }
-                        )
-                        .then_some(work_item),
-                        bootstrap: None,
-                        commands: Vec::new(),
-                        execution_protocol:
-                            crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
-                    }));
-                }
-                return Ok(canonical_claim_hard_blocker(
-                    scenario_class,
-                    "canonical_activation_replay_conflict",
-                ));
-            }
-        }
         let authoritative_work = existing_execution
             .as_ref()
             .and_then(|state| state.work_items.get(work_item_id));
-        let scheduling_generation =
-            authoritative_work.map_or(work_item.revision.max(1), |record| record.generation());
         let wait_id = match &scenario {
             scheduler::CanonicalActivationScenario::ExactTaskRejoin { wait_id, .. }
             | scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
@@ -1027,346 +985,77 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 unreachable!("lifecycle scenario is planned before WorkItem lookup")
             }
         };
-        let compatibility_wait = if let Some(wait_id) = wait_id {
-            if let Some(authoritative_work) = authoritative_work {
-                let Some(authoritative_wait) = (match &authoritative_work.state {
-                    crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
-                        generation,
-                        wait,
-                    } if generation == &scheduling_generation && wait.wait_id == wait_id => {
-                        Some(wait)
-                    }
-                    _ => None,
-                }) else {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_wait_execution_authority_mismatch",
-                    ));
-                };
-                if authoritative_wait.generation != scheduling_generation {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_wait_generation_authority_mismatch",
-                    ));
-                }
-            }
-            let wait_condition = self
-                .runtime
-                .inner
-                .storage
-                .latest_wait_conditions()?
-                .into_iter()
-                .find(|condition| {
-                    condition.id == wait_id
-                        && condition.agent_id == message.agent_id
-                        && condition.work_item_id.as_deref() == Some(work_item_id)
-                })
-                .ok_or_else(|| anyhow!("canonical wait resume references unknown durable wait"))?;
-            Some(LegacyWaitAdoption {
-                wait_id: wait_id.to_string(),
-                generation: scheduling_generation,
-                owner_work_item_id: work_item_id.to_string(),
-                source_updated_at: crate::runtime_db::repositories::timestamp(
-                    wait_condition.updated_at,
-                ),
-            })
-        } else {
-            None
-        };
-        let demand = WorkDemand {
-            metadata_revision: work_item.revision.max(1),
-            scheduling_generation,
-            status: compatibility_wait
-                .as_ref()
-                .map_or(WorkStatus::Runnable, |wait| WorkStatus::Waiting {
-                    wait_id: wait.wait_id.clone(),
-                }),
-            capabilities: Default::default(),
-            locks: Default::default(),
-            locality: "runtime".into(),
-            cost_class: "default".into(),
-        };
-        let (bootstrap, register) = if let Some(snapshot) = existing.as_ref() {
-            let wait_projection_matches = compatibility_wait.as_ref().is_none_or(|wait| {
-                snapshot
-                    .waits
-                    .get(&wait.wait_id)
-                    .filter(|record| record.current_generation == wait.generation)
-                    .and_then(|record| record.generations.get(&wait.generation))
-                    .is_some_and(|generation| {
-                        generation.owner.work_item_id() == Some(work_item_id)
-                            && generation.state == WaitState::Active
-                    })
-            });
-            let authoritative_wait_matches = compatibility_wait.as_ref().is_some_and(|wait| {
-                authoritative_work.is_some_and(|record| {
-                    matches!(
-                        &record.state,
-                        crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
-                            generation,
-                            wait: authoritative_wait,
-                        } if *generation == wait.generation
-                            && authoritative_wait.wait_id == wait.wait_id
-                            && authoritative_wait.generation == wait.generation
-                    )
-                })
-            });
-            match snapshot.work.get(work_item_id) {
-                Some(existing_demand) if existing_demand == &demand && wait_projection_matches => {
-                    (None, None)
-                }
-                Some(existing_demand)
-                    if authoritative_wait_matches
-                        && wait_projection_matches
-                        && existing_demand.scheduling_generation
-                            == demand.scheduling_generation
-                        && existing_demand.status == demand.status =>
-                {
-                    // Task/external resolution advances the legacy WorkItem revision before the
-                    // queued resume is claimed. The canonical scheduler and execution protocol
-                    // still own the active wait generation, so claim that authority directly
-                    // instead of trying to re-adopt the now-runnable legacy projection.
-                    (None, None)
-                }
-                Some(_) | None if compatibility_wait.is_some() => (
-                    None,
-                    Some(ProtocolCommand::AdoptLegacyWorkState(
-                        AdoptLegacyWorkStateCommand {
-                            work_item_id: work_item.id.clone(),
-                            source_work_item_revision: work_item.revision.max(1),
-                            demand: demand.clone(),
-                            wait: compatibility_wait.clone(),
-                            focus: false,
-                            reserve_dispatch: false,
-                            replace_completed_focus: None,
-                        },
-                    )),
-                ),
-                Some(_) => (
-                    None,
-                    Some(ProtocolCommand::AdoptLegacyWorkState(
-                        AdoptLegacyWorkStateCommand {
-                            work_item_id: work_item.id.clone(),
-                            source_work_item_revision: work_item.revision.max(1),
-                            demand: demand.clone(),
-                            wait: None,
-                            focus: false,
-                            reserve_dispatch: false,
-                            replace_completed_focus: None,
-                        },
-                    )),
-                ),
-                None => (
-                    None,
-                    Some(ProtocolCommand::RegisterWorkDemand(
-                        RegisterWorkDemandCommand {
-                            work_item_id: work_item.id.clone(),
-                            demand: demand.clone(),
-                        },
-                    )),
-                ),
-            }
-        } else {
-            let bootstrap = Snapshot {
-                slot: ActivationSlot::Idle,
-                dispatch: AgentDispatchState::Open,
-                dispatch_revision: 0,
-                focus: None,
-                work: Default::default(),
-                waits: Default::default(),
-                activations: Default::default(),
-                activation_admissions: Default::default(),
-                settlements: Default::default(),
-                missing_settlements: Default::default(),
-                admitted_generations: Default::default(),
-                continuation_admissions: Default::default(),
-                activation_inputs: Default::default(),
-            };
-            let register = compatibility_wait.as_ref().map_or_else(
-                || {
-                    ProtocolCommand::RegisterWorkDemand(RegisterWorkDemandCommand {
-                        work_item_id: work_item.id.clone(),
-                        demand: demand.clone(),
-                    })
-                },
-                |_| {
-                    ProtocolCommand::AdoptLegacyWorkState(AdoptLegacyWorkStateCommand {
-                        work_item_id: work_item.id.clone(),
-                        source_work_item_revision: work_item.revision.max(1),
-                        demand: demand.clone(),
-                        wait: compatibility_wait.clone(),
-                        focus: false,
-                        reserve_dispatch: false,
-                        replace_completed_focus: None,
-                    })
-                },
-            );
-            (Some(bootstrap), Some(register))
-        };
-
-        let resume = if let Some(wait) = compatibility_wait.as_ref() {
-            let Some(trigger_generation) = message.message_seq else {
-                return Ok(canonical_claim_hard_blocker(
+        if let Some(wait_id) = wait_id {
+            let Some(authoritative_work) = authoritative_work else {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
-                    "canonical_trigger_sequence_missing",
-                ));
+                    reason: "canonical_wait_execution_authority_missing",
+                });
             };
-            Some(WaitResumeClaim {
-                wait_id: wait.wait_id.clone(),
-                wait_generation: wait.generation,
-                trigger_id: canonical_wait_trigger_id(message),
-                trigger_generation,
-            })
-        } else {
-            None
-        };
-        let (cause, binding, provenance_origin, provenance_trust, idempotency_key) = match &scenario
-        {
-            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. } => (
-                ActivationCause::WorkItemRunnable {
-                    work_item_id: work_item.id.clone(),
-                    scheduling_generation,
-                },
-                ActivationBinding::WorkItem {
-                    work_item_id: work_item.id.clone(),
-                },
-                ActivationOrigin::System,
-                ActivationTrust::RuntimeInstruction,
-                format!("work-queue-attempt:{activation_id}"),
-            ),
-            scheduler::CanonicalActivationScenario::InternalFollowup { .. } => (
-                ActivationCause::InternalFollowup {
-                    message_id: message.id.clone(),
-                },
-                ActivationBinding::WorkItem {
-                    work_item_id: work_item.id.clone(),
-                },
-                canonical_activation_origin_for_scenario(message, &scenario),
-                canonical_activation_trust_for_scenario(message, &scenario),
-                format!("internal-followup:{activation_id}"),
-            ),
-            scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => (
-                ActivationCause::TaskRejoin {
-                    task_id: task_id.clone(),
-                    message_id: message.id.clone(),
-                    resume: resume.clone(),
-                },
-                ActivationBinding::WorkItem {
-                    work_item_id: work_item.id.clone(),
-                },
-                ActivationOrigin::Task,
-                ActivationTrust::RuntimeInstruction,
-                format!("task-rejoin:{task_id}:{activation_id}"),
-            ),
-            scheduler::CanonicalActivationScenario::ExactWaitResume { wait_id, .. } => {
-                let resume = resume
-                    .as_ref()
-                    .expect("exact wait resume has a canonical wait claim");
-                (
-                    ActivationCause::WaitResume {
-                        wait_id: wait_id.clone(),
-                        wait_generation: resume.wait_generation,
-                        trigger_id: resume.trigger_id.clone(),
-                        trigger_generation: resume.trigger_generation,
-                    },
-                    ActivationBinding::WaitOwner {
-                        wait_id: wait_id.clone(),
-                        owner: crate::domain::scheduler_protocol::SchedulerOwner::WorkItem {
-                            work_item_id: work_item.id.clone(),
-                        },
-                    },
-                    canonical_activation_origin(message),
-                    canonical_activation_trust(message),
-                    format!(
-                        "wait-resume:{}:{}:{activation_id}",
-                        wait_id, resume.wait_generation
-                    ),
-                )
+            if !matches!(
+                &authoritative_work.state,
+                crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+                    if wait.wait_id == wait_id
+            ) {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_wait_execution_authority_mismatch",
+                });
             }
-            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => (
-                ActivationCause::OperatorInput {
-                    message_id: message.id.clone(),
-                    resume: resume.clone(),
-                },
-                ActivationBinding::WorkItem {
-                    work_item_id: work_item.id.clone(),
-                },
-                ActivationOrigin::Operator,
-                ActivationTrust::OperatorInstruction,
-                format!("operator-message:{activation_id}"),
-            ),
-            scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
-                unreachable!("lifecycle scenario is planned before WorkItem lookup")
-            }
-        };
-        let activation = AgentActivation {
-            id: activation_id.clone(),
-            agent_id: message.agent_id.clone(),
-            state: ActivationLifecycleState::Admitted,
-            cause,
-            binding,
-            priority: match message.priority {
-                Priority::Interject => ActivationPriority::Interject,
-                Priority::Next => ActivationPriority::Next,
-                Priority::Normal => ActivationPriority::Normal,
-                Priority::Background => ActivationPriority::Background,
-            },
-            preemption: PreemptionPolicy::AllowOperatorInterjection,
-            source_revision: Some(work_item.revision),
-            idempotency_key,
-            provenance: ActivationProvenance {
-                origin: provenance_origin,
-                trust: provenance_trust,
-                source_id: message.id.clone(),
-                correlation_id: message.correlation_id.clone(),
-                causation_id: message.causation_id.clone(),
-            },
-        };
-        let mut commands = Vec::with_capacity(4);
-        commands.extend(register);
-        if let Some(resume) = resume.as_ref() {
-            commands.push(ProtocolCommand::TriggerWait(TriggerWaitCommand {
-                wait_id: resume.wait_id.clone(),
-                wait_generation: resume.wait_generation,
-                trigger_id: resume.trigger_id.clone(),
-                trigger_generation: resume.trigger_generation,
-            }));
+        } else if authoritative_work.is_some_and(|record| {
+            !matches!(
+                record.state,
+                crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+            )
+        }) {
+            return Ok(CanonicalClaimOutcome::RejectQueued {
+                scenario_class,
+                reason: "canonical_work_item_execution_not_runnable",
+            });
         }
-        let expected_dispatch_revision = projected_scheduler_dispatch_revision(
-            existing
-                .as_ref()
-                .or(bootstrap.as_ref())
-                .expect("canonical claim has existing or bootstrap scheduler state"),
-            &commands,
-        )?;
-        commands.push(ProtocolCommand::AdmitActivation(AdmitActivationCommand {
-            authority_id: format!("authority:{activation_id}"),
-            activation,
-            expected_scheduling_generation: scheduling_generation,
-            expected_dispatch_revision,
-        }));
+
+        let scheduling_generation =
+            authoritative_work.map_or(work_item.revision.max(1), |record| record.generation());
+        let activation_id =
+            canonical_execution_attempt_id_for_message(existing_execution.as_ref(), &message.id);
+        if let Some(existing_attempt) = existing_execution
+            .as_ref()
+            .and_then(|state| state.attempts.get(&activation_id))
+        {
+            if execution_attempt_matches_scenario(existing_attempt, message, &scenario) {
+                return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
+                    activation_id,
+                    scenario_class,
+                    work_item_id: Some(work_item.id),
+                    work_item_expectation: None,
+                    execution_protocol:
+                        crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+                }));
+            }
+            return Ok(CanonicalClaimOutcome::RejectQueued {
+                scenario_class,
+                reason: "canonical_execution_attempt_replay_conflict",
+            });
+        }
         let execution_protocol = self.plan_execution_protocol_claim(
             message,
             &scenario,
             &activation_id,
             Some((&work_item, scheduling_generation)),
-            resume.as_ref(),
+            wait_id,
         )?;
+        let work_item_expectation = matches!(
+            scenario,
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+                | scheduler::CanonicalActivationScenario::InternalFollowup { .. }
+        )
+        .then_some(work_item.clone());
 
         Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
             activation_id,
             scenario_class,
-            execution_owner: crate::domain::scheduler_protocol::SchedulerOwner::WorkItem {
-                work_item_id: work_item_id.to_string(),
-            },
-            scheduler_claim_work_item: matches!(
-                scenario,
-                scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
-                    | scheduler::CanonicalActivationScenario::InternalFollowup { .. }
-            )
-            .then_some(work_item),
-            bootstrap,
-            commands,
+            work_item_id: Some(work_item.id),
+            work_item_expectation,
             execution_protocol,
         }))
     }
@@ -1375,285 +1064,78 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         &self,
         message: &MessageEnvelope,
         scenario: scheduler::CanonicalActivationScenario,
-        existing: Option<crate::domain::scheduler_protocol::Snapshot>,
+        existing_execution: Option<crate::domain::execution_protocol::ExecutionProtocolState>,
         scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
     ) -> Result<CanonicalClaimOutcome> {
-        use crate::domain::scheduler_protocol::{
-            ActivationBinding, ActivationCause, ActivationLifecycleState, ActivationPriority,
-            ActivationProvenance, ActivationSlot, AdmitActivationCommand, AgentActivation,
-            AgentDispatchState, PreemptionPolicy, ProtocolCommand, SchedulerOwner, Snapshot,
-            TriggerWaitCommand, WaitResumeClaim,
-        };
-
-        let owner = SchedulerOwner::AgentLifecycle {
-            agent_id: message.agent_id.clone(),
-        };
-        let mut projected_existing = existing.clone();
-        let mut authority_repair_commands = Vec::new();
-        if let Some(snapshot) = projected_existing.as_ref() {
-            if let Some(command) = canonical_authority_convergence_command(
-                &self.runtime.inner.storage,
-                snapshot,
-                &message.agent_id,
-            )? {
-                let outcome = crate::domain::scheduler_protocol::reduce_command(snapshot, &command);
-                if outcome.outcome.decision
-                    == crate::domain::scheduler_protocol::Decision::AuthorityConverged
-                {
-                    projected_existing = Some(outcome.outcome.snapshot);
-                    authority_repair_commands.push(command);
-                }
-            }
-        }
-        let activation_id = canonical_activation_id_for_attempt(existing.as_ref(), &message.id);
-        if let Some(snapshot) = existing.as_ref() {
-            if let Some(activation) = snapshot.activations.get(&activation_id) {
-                if activation.state == crate::domain::scheduler_protocol::ActivationState::Running
-                    && activation.owner == owner
-                    && snapshot
-                        .activation_admissions
-                        .get(&activation_id)
-                        .is_some_and(|admission| {
-                            canonical_admission_matches_scenario(admission, message, &scenario)
-                        })
-                {
-                    return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
-                        activation_id,
+        let wait_id = match &scenario {
+            scheduler::CanonicalActivationScenario::ExactWaitResume { owner, wait_id }
+                if owner
+                    == &(crate::domain::scheduler_protocol::SchedulerOwner::AgentLifecycle {
+                        agent_id: message.agent_id.clone(),
+                    }) =>
+            {
+                let matching = self
+                    .runtime
+                    .inner
+                    .storage
+                    .latest_wait_conditions()?
+                    .into_iter()
+                    .find(|condition| {
+                        condition.id == *wait_id
+                            && condition.agent_id == message.agent_id
+                            && condition.work_item_id.is_none()
+                            && condition.status == crate::types::WaitConditionStatus::Triggered
+                            && condition.trigger_message_id() == Some(message.id.as_str())
+                            && scheduler::message_matches_wait_condition(message, condition)
+                    });
+                if matching.is_none() {
+                    return Ok(CanonicalClaimOutcome::RejectQueued {
                         scenario_class,
-                        execution_owner: activation.owner.clone(),
-                        scheduler_claim_work_item: None,
-                        bootstrap: None,
-                        commands: Vec::new(),
-                        execution_protocol:
-                            crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
-                    }));
+                        reason: "canonical_lifecycle_wait_stale",
+                    });
                 }
-                return Ok(canonical_claim_hard_blocker(
+                Some(wait_id.as_str())
+            }
+            scheduler::CanonicalActivationScenario::LifecycleExternalNudge { agent_id }
+                if agent_id == &message.agent_id =>
+            {
+                None
+            }
+            _ => {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
-                    "canonical_activation_replay_conflict",
-                ));
+                    reason: "canonical_lifecycle_binding_mismatch",
+                })
             }
-        }
-
-        let bootstrap = existing.is_none().then(|| Snapshot {
-            slot: ActivationSlot::Idle,
-            dispatch: AgentDispatchState::Open,
-            dispatch_revision: 0,
-            focus: None,
-            work: Default::default(),
-            waits: Default::default(),
-            activations: Default::default(),
-            activation_admissions: Default::default(),
-            settlements: Default::default(),
-            missing_settlements: Default::default(),
-            admitted_generations: Default::default(),
-            continuation_admissions: Default::default(),
-            activation_inputs: Default::default(),
-        });
-        let (expected_generation, scheduler_resume, execution_resume, cause, idempotency_key) =
-            match &scenario {
-                scheduler::CanonicalActivationScenario::ExactWaitResume {
-                    owner: expected_owner,
-                    wait_id,
-                } if expected_owner == &owner => {
-                    self.runtime
-                        .inner
-                        .storage
-                        .latest_wait_conditions()?
-                        .into_iter()
-                        .find(|condition| {
-                            condition.id == *wait_id
-                                && condition.agent_id == message.agent_id
-                                && condition.work_item_id.is_none()
-                                && condition.status == crate::types::WaitConditionStatus::Active
-                                && scheduler::message_matches_wait_condition(message, condition)
-                        })
-                        .ok_or_else(|| {
-                            anyhow!("canonical lifecycle wait is not durable and active")
-                        })?;
-                    let Some(trigger_generation) = message.message_seq else {
-                        return Ok(canonical_claim_hard_blocker(
-                            scenario_class,
-                            "canonical_trigger_sequence_missing",
-                        ));
-                    };
-                    let authoritative_wait_generation = message
-                        .source_refs
-                        .get("wait_generation")
-                        .and_then(|generation| generation.parse::<u64>().ok())
-                        .filter(|generation| *generation > 0)
-                        .or_else(|| {
-                            projected_existing
-                                .as_ref()
-                                .and_then(|snapshot| snapshot.waits.get(wait_id))
-                                .map(|wait| wait.current_generation)
-                        })
-                        .unwrap_or(1);
-                    let admission_generation = projected_existing.as_ref().map_or(1, |snapshot| {
-                        snapshot
-                            .activations
-                            .values()
-                            .filter(|activation| activation.owner == owner)
-                            .map(|activation| activation.admitted_generation)
-                            .max()
-                            .unwrap_or(0)
-                            .saturating_add(1)
-                    });
-                    let execution_resume = WaitResumeClaim {
-                        wait_id: wait_id.clone(),
-                        wait_generation: authoritative_wait_generation,
-                        trigger_id: canonical_wait_trigger_id(message),
-                        trigger_generation,
-                    };
-                    let scheduler_resume = projected_existing.as_ref().and_then(|snapshot| {
-                        let wait = snapshot.waits.get(wait_id)?;
-                        let generation = wait.generations.get(&wait.current_generation)?;
-                        (wait.current_generation == authoritative_wait_generation
-                            && generation.owner == owner
-                            && generation.state == WaitState::Active)
-                            .then(|| execution_resume.clone())
-                    });
-                    let (cause, idempotency_key) = scheduler_resume.as_ref().map_or_else(
-                        || {
-                            (
-                                ActivationCause::LifecycleExternalNudge {
-                                    message_id: message.id.clone(),
-                                },
-                                format!("lifecycle-wait-message:{activation_id}"),
-                            )
-                        },
-                        |resume| {
-                            (
-                                ActivationCause::WaitResume {
-                                    wait_id: wait_id.clone(),
-                                    wait_generation: resume.wait_generation,
-                                    trigger_id: resume.trigger_id.clone(),
-                                    trigger_generation: resume.trigger_generation,
-                                },
-                                format!(
-                                    "wait-resume:{}:{}:{activation_id}",
-                                    wait_id, resume.wait_generation
-                                ),
-                            )
-                        },
-                    );
-                    (
-                        admission_generation,
-                        scheduler_resume,
-                        Some(execution_resume),
-                        cause,
-                        idempotency_key,
-                    )
-                }
-                scheduler::CanonicalActivationScenario::LifecycleExternalNudge { agent_id }
-                    if agent_id == &message.agent_id =>
-                {
-                    let generation = projected_existing.as_ref().map_or(1, |snapshot| {
-                        let activation_generation = snapshot
-                            .activations
-                            .values()
-                            .filter(|activation| activation.owner == owner)
-                            .map(|activation| activation.admitted_generation)
-                            .max()
-                            .unwrap_or(0);
-                        let wait_generation = snapshot
-                            .waits
-                            .values()
-                            .filter(|wait| {
-                                wait.generations
-                                    .get(&wait.current_generation)
-                                    .is_some_and(|generation| generation.owner == owner)
-                            })
-                            .map(|wait| wait.current_generation)
-                            .max()
-                            .unwrap_or(0);
-                        activation_generation.max(wait_generation).saturating_add(1)
-                    });
-                    let cause = if scheduler::runtime_owned_internal_followup(message) {
-                        ActivationCause::InternalFollowup {
-                            message_id: message.id.clone(),
-                        }
-                    } else {
-                        ActivationCause::LifecycleExternalNudge {
-                            message_id: message.id.clone(),
-                        }
-                    };
-                    (
-                        generation,
-                        None,
-                        None,
-                        cause,
-                        format!("lifecycle-message:{activation_id}"),
-                    )
-                }
-                _ => {
-                    return Ok(canonical_claim_hard_blocker(
-                        scenario_class,
-                        "canonical_lifecycle_binding_mismatch",
-                    ))
-                }
-            };
-        let activation = AgentActivation {
-            id: activation_id.clone(),
-            agent_id: message.agent_id.clone(),
-            state: ActivationLifecycleState::Admitted,
-            cause,
-            binding: ActivationBinding::Lifecycle {
-                agent_id: message.agent_id.clone(),
-            },
-            priority: match message.priority {
-                Priority::Interject => ActivationPriority::Interject,
-                Priority::Next => ActivationPriority::Next,
-                Priority::Normal => ActivationPriority::Normal,
-                Priority::Background => ActivationPriority::Background,
-            },
-            preemption: PreemptionPolicy::AllowOperatorInterjection,
-            source_revision: None,
-            idempotency_key,
-            provenance: ActivationProvenance {
-                origin: canonical_activation_origin_for_scenario(message, &scenario),
-                trust: canonical_activation_trust_for_scenario(message, &scenario),
-                source_id: message.id.clone(),
-                correlation_id: message.correlation_id.clone(),
-                causation_id: message.causation_id.clone(),
-            },
         };
-        let mut commands = authority_repair_commands;
-        if let Some(resume) = scheduler_resume.as_ref() {
-            commands.push(ProtocolCommand::TriggerWait(TriggerWaitCommand {
-                wait_id: resume.wait_id.clone(),
-                wait_generation: resume.wait_generation,
-                trigger_id: resume.trigger_id.clone(),
-                trigger_generation: resume.trigger_generation,
-            }));
+        let activation_id =
+            canonical_execution_attempt_id_for_message(existing_execution.as_ref(), &message.id);
+        if let Some(existing_attempt) = existing_execution
+            .as_ref()
+            .and_then(|state| state.attempts.get(&activation_id))
+        {
+            if execution_attempt_matches_scenario(existing_attempt, message, &scenario) {
+                return Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
+                    activation_id,
+                    scenario_class,
+                    work_item_id: None,
+                    work_item_expectation: None,
+                    execution_protocol:
+                        crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+                }));
+            }
+            return Ok(CanonicalClaimOutcome::RejectQueued {
+                scenario_class,
+                reason: "canonical_execution_attempt_replay_conflict",
+            });
         }
-        let expected_dispatch_revision = projected_scheduler_dispatch_revision(
-            existing
-                .as_ref()
-                .or(bootstrap.as_ref())
-                .expect("canonical claim has existing or bootstrap scheduler state"),
-            &commands,
-        )?;
-        commands.push(ProtocolCommand::AdmitActivation(AdmitActivationCommand {
-            authority_id: format!("authority:{activation_id}"),
-            activation,
-            expected_scheduling_generation: expected_generation,
-            expected_dispatch_revision,
-        }));
-        let execution_protocol = self.plan_execution_protocol_claim(
-            message,
-            &scenario,
-            &activation_id,
-            None,
-            execution_resume.as_ref(),
-        )?;
+        let execution_protocol =
+            self.plan_execution_protocol_claim(message, &scenario, &activation_id, None, wait_id)?;
         Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
             activation_id,
             scenario_class,
-            execution_owner: owner,
-            scheduler_claim_work_item: None,
-            bootstrap,
-            commands,
+            work_item_id: None,
+            work_item_expectation: None,
             execution_protocol,
         }))
     }
@@ -1766,7 +1248,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         scenario: &scheduler::CanonicalActivationScenario,
         attempt_id: &str,
         work_item: Option<(&crate::types::WorkItemRecord, u64)>,
-        resume: Option<&crate::domain::scheduler_protocol::WaitResumeClaim>,
+        admitted_wait_id: Option<&str>,
     ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
         use crate::domain::execution_protocol::{
             AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState,
@@ -1822,13 +1304,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 }
             }
             scheduler::CanonicalActivationScenario::ExactWaitResume { wait_id, .. } => {
-                let resume =
-                    resume.ok_or_else(|| anyhow!("wait resume requires admitted wait claim"))?;
+                if admitted_wait_id != Some(wait_id.as_str()) {
+                    return Err(anyhow!(
+                        "wait resume requires the exact admitted wait identity"
+                    ));
+                }
                 ExecutionSourceIdentity::TriggeredWait {
                     wait_id: wait_id.clone(),
-                    wait_generation: resume.wait_generation,
-                    trigger_id: resume.trigger_id.clone(),
-                    trigger_generation: resume.trigger_generation,
+                    trigger_message_id: message.id.clone(),
                 }
             }
             scheduler::CanonicalActivationScenario::InternalFollowup { .. } => {
@@ -1836,11 +1319,19 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     message_id: message.id.clone(),
                 }
             }
-            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
-                ExecutionSourceIdentity::QueueMessage {
-                    message_id: message.id.clone(),
-                }
-            }
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                wait_id: Some(wait_id),
+                ..
+            } => ExecutionSourceIdentity::TriggeredWait {
+                wait_id: wait_id.clone(),
+                trigger_message_id: message.id.clone(),
+            },
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                wait_id: None,
+                ..
+            } => ExecutionSourceIdentity::QueueMessage {
+                message_id: message.id.clone(),
+            },
             scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. }
                 if scheduler::runtime_owned_internal_followup(message) =>
             {
@@ -1869,12 +1360,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     .as_ref()
                     .and_then(|state| state.work_items.get(&work_item.id));
                 if existing_record.is_none() {
-                    let state = if let Some(resume) = resume {
+                    let state = if let Some(wait_id) = admitted_wait_id {
                         WorkItemExecutionState::Waiting {
                             generation: scheduling_generation,
                             wait: crate::domain::execution_protocol::WaitReference {
-                                wait_id: resume.wait_id.clone(),
-                                generation: resume.wait_generation,
+                                wait_id: wait_id.to_string(),
                             },
                         }
                     } else {
@@ -2001,6 +1491,71 @@ pub(super) fn canonical_activation_id(message_id: &str) -> String {
     format!("activation:message:{message_id}")
 }
 
+fn align_execution_claim_with_wait_transition(
+    execution_protocol: &mut crate::runtime_db::transitions::ExecutionProtocolTransition,
+    wait_transition: Option<&crate::runtime_db::transitions::QueueWaitTransition>,
+) -> Result<()> {
+    let Some(crate::runtime_db::transitions::WorkItemMutation::Update { record, .. }) =
+        wait_transition.and_then(|transition| transition.work_item.as_ref())
+    else {
+        return Ok(());
+    };
+    let Some(admit_index) = execution_protocol.commands.iter().position(|command| {
+        matches!(
+            command,
+            crate::domain::execution_protocol::ExecutionProtocolCommand::Admit(_)
+        )
+    }) else {
+        return Ok(());
+    };
+    let crate::domain::execution_protocol::ExecutionProtocolCommand::Admit(admit) =
+        &mut execution_protocol.commands[admit_index]
+    else {
+        unreachable!("admit index was selected by variant");
+    };
+    let crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } =
+        &admit.attempt.binding
+    else {
+        return Ok(());
+    };
+    if work_item_id != &record.id {
+        return Err(anyhow!(
+            "wait transition WorkItem does not match execution admission binding"
+        ));
+    }
+    let Some(expected_source_revision) = admit.attempt.admitted_fences.work_item_source_revision
+    else {
+        return Err(anyhow!(
+            "WorkItem wait admission is missing its source revision fence"
+        ));
+    };
+    if record.revision == expected_source_revision {
+        return Ok(());
+    }
+    if record.revision < expected_source_revision {
+        return Err(anyhow!(
+            "wait transition WorkItem revision precedes execution admission fence"
+        ));
+    }
+    admit.attempt.admitted_fences.work_item_source_revision = Some(record.revision);
+    let command_id = format!(
+        "advance:{}:work_item_source_revision",
+        admit.attempt.attempt_id
+    );
+    execution_protocol.commands.insert(
+        admit_index,
+        crate::domain::execution_protocol::ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(
+            crate::domain::execution_protocol::AdvanceWorkItemSourceRevision {
+                command_id,
+                work_item_id: record.id.clone(),
+                expected_source_revision,
+                source_revision: record.revision,
+            },
+        ),
+    );
+    Ok(())
+}
+
 pub(super) fn canonical_open_activation_id(
     snapshot: &crate::domain::scheduler_protocol::Snapshot,
     message_id: &str,
@@ -2024,26 +1579,140 @@ pub(super) fn canonical_open_activation_id(
         })
 }
 
-fn canonical_activation_id_for_attempt(
-    snapshot: Option<&crate::domain::scheduler_protocol::Snapshot>,
+fn canonical_execution_attempt_id_for_message(
+    state: Option<&crate::domain::execution_protocol::ExecutionProtocolState>,
     message_id: &str,
 ) -> String {
     let base = canonical_activation_id(message_id);
-    let Some(snapshot) = snapshot else {
-        return base;
-    };
-    // Admissions are an append-only identity ledger: settlement changes the
-    // activation state but never removes its admission. Counting matching
-    // admissions therefore remains monotonic across persistence reloads.
-    let matching_attempts = snapshot
-        .activation_admissions
-        .values()
-        .filter(|admission| admission.activation.provenance.source_id == message_id)
-        .count();
+    let matching_attempts = state.map_or(0, |state| {
+        state
+            .attempts
+            .values()
+            .filter(|attempt| attempt.source_message_id.as_deref() == Some(message_id))
+            .count()
+    });
     if matching_attempts == 0 {
         base
     } else {
         format!("{base}:attempt:{}", matching_attempts + 1)
+    }
+}
+
+fn execution_attempt_matches_scenario(
+    attempt: &crate::domain::execution_protocol::ExecutionAttempt,
+    message: &MessageEnvelope,
+    scenario: &scheduler::CanonicalActivationScenario,
+) -> bool {
+    use crate::domain::execution_protocol::{ExecutionBinding, ExecutionSourceIdentity};
+
+    if attempt.agent_id != message.agent_id
+        || attempt.source_message_id.as_deref() != Some(message.id.as_str())
+        || attempt.provenance.origin != canonical_execution_origin_for_scenario(message, scenario)
+        || attempt.provenance.trust != canonical_execution_trust_for_scenario(message, scenario)
+    {
+        return false;
+    }
+    match (&attempt.source.identity, &attempt.binding, scenario) {
+        (
+            ExecutionSourceIdentity::WorkItemContinuation {
+                work_item_id: source_work_item_id,
+            },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
+                work_item_id: expected,
+            },
+        ) => source_work_item_id == expected && work_item_id == expected,
+        (
+            ExecutionSourceIdentity::InternalFollowup { message_id },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::InternalFollowup {
+                work_item_id: expected,
+            },
+        ) => message_id == &message.id && work_item_id == expected,
+        (
+            ExecutionSourceIdentity::TaskResult {
+                task_id,
+                result_message_id,
+            },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin {
+                task_id: expected_task,
+                work_item_id: expected_work_item,
+                ..
+            },
+        ) => {
+            task_id == expected_task
+                && result_message_id == &message.id
+                && work_item_id == expected_work_item
+        }
+        (
+            ExecutionSourceIdentity::TriggeredWait {
+                wait_id,
+                trigger_message_id,
+            },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ExactWaitResume {
+                owner:
+                    crate::domain::scheduler_protocol::SchedulerOwner::WorkItem {
+                        work_item_id: expected_work_item,
+                    },
+                wait_id: expected_wait,
+            },
+        ) => {
+            wait_id == expected_wait
+                && trigger_message_id == &message.id
+                && work_item_id == expected_work_item
+        }
+        (
+            ExecutionSourceIdentity::TriggeredWait {
+                wait_id,
+                trigger_message_id,
+            },
+            ExecutionBinding::AgentLifecycle { agent_id },
+            scheduler::CanonicalActivationScenario::ExactWaitResume {
+                owner:
+                    crate::domain::scheduler_protocol::SchedulerOwner::AgentLifecycle {
+                        agent_id: expected_agent,
+                    },
+                wait_id: expected_wait,
+            },
+        ) => {
+            wait_id == expected_wait
+                && trigger_message_id == &message.id
+                && agent_id == expected_agent
+        }
+        (
+            ExecutionSourceIdentity::QueueMessage { message_id }
+            | ExecutionSourceIdentity::InternalFollowup { message_id },
+            ExecutionBinding::AgentLifecycle { agent_id },
+            scheduler::CanonicalActivationScenario::LifecycleExternalNudge {
+                agent_id: expected_agent,
+            },
+        ) => message_id == &message.id && agent_id == expected_agent,
+        (
+            ExecutionSourceIdentity::QueueMessage { message_id },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                work_item_id: expected,
+                wait_id: None,
+            },
+        ) => message_id == &message.id && work_item_id == expected,
+        (
+            ExecutionSourceIdentity::TriggeredWait {
+                wait_id,
+                trigger_message_id,
+            },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                work_item_id: expected,
+                wait_id: Some(expected_wait),
+            },
+        ) => {
+            wait_id == expected_wait
+                && trigger_message_id == &message.id
+                && work_item_id == expected
+        }
+        _ => false,
     }
 }
 
@@ -2194,143 +1863,6 @@ fn canonical_execution_trust_for_scenario(
         crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence => {
             ExecutionTrust::ExternalEvidence
         }
-    }
-}
-
-fn canonical_admission_matches_scenario(
-    admission: &crate::domain::scheduler_protocol::AdmitActivationCommand,
-    message: &MessageEnvelope,
-    scenario: &scheduler::CanonicalActivationScenario,
-) -> bool {
-    use crate::domain::scheduler_protocol::{ActivationBinding, ActivationCause};
-    let activation = &admission.activation;
-    if activation.agent_id != message.agent_id
-        || activation.provenance.source_id != message.id
-        || activation.provenance.origin
-            != canonical_activation_origin_for_scenario(message, scenario)
-        || activation.provenance.trust != canonical_activation_trust_for_scenario(message, scenario)
-    {
-        return false;
-    }
-    match (&activation.cause, &activation.binding, scenario) {
-        (
-            ActivationCause::WorkItemRunnable { work_item_id, .. },
-            ActivationBinding::WorkItem {
-                work_item_id: bound_work_item_id,
-            },
-            scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
-                work_item_id: expected,
-            },
-        ) => work_item_id == expected && bound_work_item_id == expected,
-        (
-            ActivationCause::InternalFollowup { message_id },
-            ActivationBinding::WorkItem { work_item_id },
-            scheduler::CanonicalActivationScenario::InternalFollowup {
-                work_item_id: expected,
-            },
-        ) => message_id == &message.id && work_item_id == expected,
-        (
-            ActivationCause::TaskRejoin {
-                task_id,
-                message_id,
-                resume,
-            },
-            ActivationBinding::WorkItem { work_item_id },
-            scheduler::CanonicalActivationScenario::ExactTaskRejoin {
-                task_id: expected_task,
-                work_item_id: expected_work_item,
-                wait_id,
-            },
-        ) => {
-            task_id == expected_task
-                && message_id == &message.id
-                && work_item_id == expected_work_item
-                && resume.as_ref().map(|claim| claim.wait_id.as_str()) == wait_id.as_deref()
-        }
-        (
-            ActivationCause::WaitResume { wait_id, .. },
-            ActivationBinding::WaitOwner {
-                wait_id: bound_wait_id,
-                owner:
-                    crate::domain::scheduler_protocol::SchedulerOwner::WorkItem {
-                        work_item_id: owner_work_item_id,
-                    },
-            },
-            scheduler::CanonicalActivationScenario::ExactWaitResume {
-                owner: crate::domain::scheduler_protocol::SchedulerOwner::WorkItem { work_item_id },
-                wait_id: expected_wait,
-            },
-        ) => {
-            wait_id == expected_wait
-                && bound_wait_id == expected_wait
-                && owner_work_item_id == work_item_id
-        }
-        (
-            ActivationCause::WaitResume { wait_id, .. },
-            ActivationBinding::Lifecycle { agent_id },
-            scheduler::CanonicalActivationScenario::ExactWaitResume {
-                owner:
-                    crate::domain::scheduler_protocol::SchedulerOwner::AgentLifecycle {
-                        agent_id: expected_agent_id,
-                    },
-                wait_id: expected_wait,
-            },
-        ) => {
-            wait_id == expected_wait
-                && agent_id == expected_agent_id
-                && agent_id == &message.agent_id
-        }
-        (
-            ActivationCause::LifecycleExternalNudge { message_id },
-            ActivationBinding::Lifecycle { agent_id },
-            scheduler::CanonicalActivationScenario::ExactWaitResume {
-                owner:
-                    crate::domain::scheduler_protocol::SchedulerOwner::AgentLifecycle {
-                        agent_id: expected_agent_id,
-                    },
-                ..
-            },
-        ) => {
-            message_id == &message.id
-                && agent_id == expected_agent_id
-                && agent_id == &message.agent_id
-        }
-        (
-            ActivationCause::LifecycleExternalNudge { message_id },
-            ActivationBinding::Lifecycle { agent_id },
-            scheduler::CanonicalActivationScenario::LifecycleExternalNudge {
-                agent_id: expected_agent_id,
-            },
-        ) => {
-            message_id == &message.id
-                && agent_id == expected_agent_id
-                && agent_id == &message.agent_id
-        }
-        (
-            ActivationCause::InternalFollowup { message_id },
-            ActivationBinding::Lifecycle { agent_id },
-            scheduler::CanonicalActivationScenario::LifecycleExternalNudge {
-                agent_id: expected_agent_id,
-            },
-        ) => {
-            scheduler::runtime_owned_internal_followup(message)
-                && message_id == &message.id
-                && agent_id == expected_agent_id
-                && agent_id == &message.agent_id
-        }
-        (
-            ActivationCause::OperatorInput { message_id, resume },
-            ActivationBinding::WorkItem { work_item_id },
-            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
-                work_item_id: expected_work_item,
-                wait_id,
-            },
-        ) => {
-            message_id == &message.id
-                && work_item_id == expected_work_item
-                && resume.as_ref().map(|claim| claim.wait_id.as_str()) == wait_id.as_deref()
-        }
-        _ => false,
     }
 }
 

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -62,11 +62,21 @@ fn task_status_phase(status: &TaskStatus) -> u8 {
 pub(super) struct TaskTransition<'a> {
     pub(super) task: &'a TaskRecord,
     pub(super) event_kind: &'static str,
+    pub(super) message_evidence: Option<&'a MessageEnvelope>,
 }
 
 impl<'a> TaskTransition<'a> {
     pub(super) fn new(task: &'a TaskRecord, event_kind: &'static str) -> Self {
-        Self { task, event_kind }
+        Self {
+            task,
+            event_kind,
+            message_evidence: None,
+        }
+    }
+
+    pub(super) fn with_message_evidence(mut self, message: &'a MessageEnvelope) -> Self {
+        self.message_evidence = Some(message);
+        self
     }
 }
 
@@ -276,6 +286,15 @@ impl RuntimeHandle {
                 expected: Some(Box::new(expected_state)),
                 record: Box::new(state),
             });
+        let message_evidence = transition
+            .message_evidence
+            .map(|message| {
+                let mut message = message.clone();
+                message.normalize_admission_fields();
+                message
+            })
+            .into_iter()
+            .collect();
         let commit = self.inner.runtime_db.transitions().commit_task(
             &crate::runtime_db::transitions::TaskTransitionCommand {
                 agent_id,
@@ -283,6 +302,7 @@ impl RuntimeHandle {
                 work_items,
                 wait_conditions,
                 agent_state,
+                message_evidence,
                 audit_events,
                 index_changes,
                 notify_scheduler: false,
@@ -339,6 +359,18 @@ impl RuntimeHandle {
     ) -> Result<()> {
         self.apply_task_transition(TaskTransition::new(task, event_kind))
             .await
+    }
+
+    pub(super) async fn persist_task_transition_with_message(
+        &self,
+        task: &TaskRecord,
+        event_kind: &'static str,
+        message: &MessageEnvelope,
+    ) -> Result<()> {
+        self.apply_task_transition(
+            TaskTransition::new(task, event_kind).with_message_evidence(message),
+        )
+        .await
     }
 
     pub(super) async fn reduce_task_status_message(&self, task: TaskRecord) -> Result<()> {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -450,7 +450,11 @@ impl RuntimeHandle {
             let terminal_task =
                 task_with_result_message(&task_record, status, Some(task_detail), &result_message);
             if let Err(error) = runtime
-                .persist_task_status_direct(&terminal_task, "task_status_updated")
+                .persist_task_transition_with_message(
+                    &terminal_task,
+                    "task_status_updated",
+                    &result_message,
+                )
                 .await
             {
                 tracing::warn!(
@@ -959,7 +963,11 @@ impl RuntimeHandle {
             let terminal_task =
                 task_with_result_message(&task_record, status, Some(task_detail), &result_message);
             if let Err(error) = runtime
-                .persist_task_status_direct(&terminal_task, "task_status_updated")
+                .persist_task_transition_with_message(
+                    &terminal_task,
+                    "task_status_updated",
+                    &result_message,
+                )
                 .await
             {
                 tracing::warn!(
@@ -1099,7 +1107,11 @@ impl RuntimeHandle {
                         &result_message,
                     );
                     if let Err(error) = runtime
-                        .persist_task_status_direct(&failed_task, "task_status_updated")
+                        .persist_task_transition_with_message(
+                            &failed_task,
+                            "task_status_updated",
+                            &result_message,
+                        )
                         .await
                     {
                         tracing::warn!(
@@ -1412,7 +1424,11 @@ impl RuntimeHandle {
         let terminal_task =
             task_with_result_message(&task_record, status, Some(task_detail), &result_message);
         if let Err(error) = self
-            .persist_task_status_direct(&terminal_task, "task_status_updated")
+            .persist_task_transition_with_message(
+                &terminal_task,
+                "task_status_updated",
+                &result_message,
+            )
             .await
         {
             tracing::warn!(

--- a/src/runtime/tests/contracts/wait.rs
+++ b/src/runtime/tests/contracts/wait.rs
@@ -1,6 +1,8 @@
 use super::super::support::*;
-use crate::runtime::WaitForWakeKind;
-use crate::types::{MessageEnvelope, WaitConditionStatus, WorkItemState};
+use crate::runtime::{WaitForRegistrationOutcome, WaitForWakeKind};
+use crate::types::{
+    AdmissionContext, MessageEnvelope, QueueEntryRecord, WaitConditionStatus, WorkItemState,
+};
 use chrono::DateTime;
 
 fn task_result_message(task_id: &str) -> MessageEnvelope {
@@ -16,6 +18,162 @@ fn task_result_message(task_id: &str) -> MessageEnvelope {
             text: "task completed".into(),
         },
     )
+}
+
+fn running_task(
+    task_id: &str,
+    work_item_id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> TaskRecord {
+    TaskRecord {
+        id: task_id.into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: now,
+        updated_at: now,
+        parent_message_id: None,
+        work_item_id: Some(work_item_id.into()),
+        summary: Some(task_id.into()),
+        detail: None,
+        recovery: None,
+    }
+}
+
+fn terminal_task_with_result(
+    task: &TaskRecord,
+    result_message: &MessageEnvelope,
+    now: chrono::DateTime<chrono::Utc>,
+) -> TaskRecord {
+    TaskRecord {
+        status: TaskStatus::Completed,
+        updated_at: now,
+        parent_message_id: Some(result_message.id.clone()),
+        detail: Some(serde_json::json!({
+            "rejoin_obligation_id": task.id,
+            "rejoin_generation": 1,
+            "parent_turn_id": "turn-late-task-parent",
+        })),
+        ..task.clone()
+    }
+}
+
+fn late_task_result_message(task_id: &str, work_item_id: &str) -> MessageEnvelope {
+    let mut message = task_result_message(task_id).with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.task_id = Some(task_id.into());
+    message.work_item_id = Some(work_item_id.into());
+    message.turn_id = Some("turn-late-task-result".into());
+    message
+}
+
+fn persist_open_work_execution(
+    harness: &LifecycleHarness,
+    work_item: &WorkItemRecord,
+    attempt_id: &str,
+) {
+    use crate::domain::execution_protocol::{
+        AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding, ExecutionOrigin,
+        ExecutionPriority, ExecutionProtocolState, ExecutionProvenance, ExecutionSource,
+        ExecutionSourceIdentity, ExecutionTrust, WorkItemExecutionRecord, WorkItemExecutionState,
+    };
+
+    let generation = work_item.revision.max(1);
+    let mut execution = ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        WorkItemExecutionRecord {
+            source_revision: generation,
+            state: WorkItemExecutionState::InFlight {
+                generation,
+                attempt_id: attempt_id.into(),
+            },
+        },
+    );
+    execution.attempts.insert(
+        attempt_id.into(),
+        ExecutionAttempt {
+            attempt_id: attempt_id.into(),
+            agent_id: "default".into(),
+            source_message_id: Some(format!("message:{attempt_id}")),
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::WorkItemContinuation {
+                    work_item_id: work_item.id.clone(),
+                },
+                generation,
+            },
+            binding: ExecutionBinding::WorkItem {
+                work_item_id: work_item.id.clone(),
+            },
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::System,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Normal,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: generation,
+                work_item_source_revision: Some(generation),
+                work_item_generation: Some(generation),
+                rejoin: None,
+                agent_control_revision: 1,
+                host_registry_revision: 1,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: Some("turn-late-wait".into()),
+            recovery_of_attempt_id: None,
+            terminal_outcome_id: None,
+            admitted_at: harness.now().to_rfc3339(),
+            terminal_at: None,
+        },
+    );
+    harness
+        .runtime()
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+}
+
+async fn persist_waiting_work_execution(
+    harness: &LifecycleHarness,
+    work_item_id: &str,
+    wait_id: &str,
+) {
+    use crate::domain::execution_protocol::{
+        ExecutionProtocolState, WaitReference, WorkItemExecutionRecord, WorkItemExecutionState,
+    };
+
+    let work_item = harness
+        .runtime()
+        .latest_work_item(work_item_id)
+        .await
+        .unwrap()
+        .expect("waiting execution requires a durable WorkItem");
+    let generation = work_item.revision.max(1);
+    let mut execution = ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id,
+        WorkItemExecutionRecord {
+            source_revision: generation,
+            state: WorkItemExecutionState::Waiting {
+                generation,
+                wait: WaitReference {
+                    wait_id: wait_id.into(),
+                },
+            },
+        },
+    );
+    harness
+        .runtime()
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
 }
 
 #[tokio::test]
@@ -135,12 +293,500 @@ async fn wait_post_commit_fault_recovers_active_wait_after_restart() {
 }
 
 #[tokio::test]
+async fn wait_trigger_and_message_enqueue_are_atomic_across_pre_commit_faults() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let work_item = harness
+            .runtime()
+            .create_work_item("atomic wait trigger".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        harness
+            .runtime()
+            .storage()
+            .append_task(&running_task(
+                "task-atomic-trigger",
+                &work_item.id,
+                harness.now(),
+            ))
+            .unwrap();
+        let registration = harness
+            .runtime()
+            .register_wait_for(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::TaskResult,
+                Some("task-atomic-trigger".into()),
+                "waiting for atomic task result".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        let before = harness.snapshot();
+        let message = task_result_message("task-atomic-trigger");
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .enqueue(message.clone())
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+
+        let queued = harness.runtime().enqueue(message).await.unwrap();
+        let after = harness.snapshot();
+        let triggered = after
+            .wait_conditions
+            .iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .unwrap();
+        assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+        assert_eq!(triggered.trigger_message_id(), Some(queued.id.as_str()));
+        assert_eq!(triggered.triggered_at(), Some(harness.now()));
+        assert!(after.queue_entries.iter().any(|entry| {
+            entry.message_id == queued.id && entry.status == QueueEntryStatus::Queued
+        }));
+        assert!(after.audit_events.iter().any(|event| {
+            event.kind == "wait_condition_triggered"
+                && event.data["wait_condition_id"].as_str()
+                    == Some(registration.condition.id.as_str())
+                && event.data["trigger_message_id"].as_str() == Some(queued.id.as_str())
+        }));
+    }
+}
+
+#[tokio::test]
+async fn late_task_result_queue_and_execution_settlement_are_atomic() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let work_item = harness
+            .runtime()
+            .create_work_item("late task result atomicity".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let running = running_task("task-late-atomic", &work_item.id, harness.now());
+        harness
+            .runtime()
+            .persist_task_transition(&running, "task_created")
+            .await
+            .unwrap();
+        let result_message = late_task_result_message("task-late-atomic", &work_item.id);
+        let terminal = terminal_task_with_result(&running, &result_message, harness.now());
+        harness
+            .runtime()
+            .persist_task_transition_with_message(&terminal, "task_status_updated", &result_message)
+            .await
+            .unwrap();
+        persist_open_work_execution(&harness, &work_item, "attempt-late-atomic");
+        let before = harness.snapshot();
+        let execution_before = harness
+            .runtime()
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .unwrap();
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .register_wait_for_outcome(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::TaskResult,
+                Some(terminal.id.clone()),
+                "late result should continue".into(),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+        assert_eq!(
+            harness
+                .runtime()
+                .inner
+                .runtime_db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("default")
+                .unwrap()
+                .unwrap(),
+            execution_before
+        );
+
+        let outcome = harness
+            .runtime()
+            .register_wait_for_outcome(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::TaskResult,
+                Some(terminal.id.clone()),
+                "late result should continue".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            WaitForRegistrationOutcome::TaskResultQueued {
+                task_id,
+                result_message_id,
+            } if task_id == terminal.id && result_message_id == result_message.id
+        ));
+        let after = harness.snapshot();
+        assert!(after.wait_conditions.is_empty());
+        assert!(after.queue_entries.iter().any(|entry| {
+            entry.message_id == result_message.id && entry.status == QueueEntryStatus::Queued
+        }));
+        assert_eq!(
+            after
+                .messages
+                .iter()
+                .filter(|message| message.id == result_message.id)
+                .count(),
+            1
+        );
+        let execution = harness
+            .runtime()
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .unwrap();
+        let attempt = &execution.attempts["attempt-late-atomic"];
+        assert_eq!(
+            attempt.state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Settled
+        );
+        assert!(matches!(
+            &execution.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+            crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+                crate::domain::execution_protocol::WorkItemOutcome::Continue
+            )
+        ));
+    }
+}
+
+#[tokio::test]
+async fn late_task_result_terminal_queue_states_are_already_consumed() {
+    for status in [
+        QueueEntryStatus::Dequeued,
+        QueueEntryStatus::Interjected,
+        QueueEntryStatus::Processed,
+        QueueEntryStatus::Aborted,
+        QueueEntryStatus::Dropped,
+    ] {
+        let harness = LifecycleHarness::new();
+        let work_item = harness
+            .runtime()
+            .create_work_item("late task consumed".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let running = running_task("task-late-consumed", &work_item.id, harness.now());
+        let result_message = late_task_result_message("task-late-consumed", &work_item.id);
+        let terminal = terminal_task_with_result(&running, &result_message, harness.now());
+        harness
+            .runtime()
+            .persist_task_transition_with_message(&terminal, "task_status_updated", &result_message)
+            .await
+            .unwrap();
+        harness
+            .runtime()
+            .storage()
+            .append_queue_entry(&QueueEntryRecord {
+                message_id: result_message.id.clone(),
+                agent_id: "default".into(),
+                priority: result_message.priority.clone(),
+                status: status.clone(),
+                created_at: result_message.created_at,
+                updated_at: harness.now(),
+            })
+            .unwrap();
+        let before = harness.snapshot();
+
+        let outcome = harness
+            .runtime()
+            .register_wait_for_outcome(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::TaskResult,
+                Some(terminal.id.clone()),
+                "already consumed".into(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            WaitForRegistrationOutcome::TaskResultAlreadyConsumed {
+                task_id,
+                result_message_id,
+            } if task_id == terminal.id && result_message_id == result_message.id
+        ));
+        harness.assert_unchanged(&before);
+    }
+}
+
+#[tokio::test]
+async fn late_task_result_missing_message_evidence_is_validation_only() {
+    let harness = LifecycleHarness::new();
+    let work_item = harness
+        .runtime()
+        .create_work_item("late task missing evidence".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut terminal = running_task("task-late-missing", &work_item.id, harness.now());
+    terminal.status = TaskStatus::Completed;
+    terminal.parent_message_id = Some("message-late-missing".into());
+    harness
+        .runtime()
+        .persist_task_transition(&terminal, "task_status_updated")
+        .await
+        .unwrap();
+    let before = harness.snapshot();
+
+    let error = harness
+        .runtime()
+        .register_wait_for_outcome(
+            "default",
+            Some(work_item.id),
+            WaitForWakeKind::TaskResult,
+            Some(terminal.id),
+            "missing evidence".into(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        crate::runtime_error::describe_runtime_error(&error).code,
+        "task_result_evidence_missing"
+    );
+    harness.assert_unchanged(&before);
+}
+
+#[tokio::test(start_paused = true)]
+async fn duplicate_historical_waits_do_not_reject_current_trigger_message() {
+    let harness = LifecycleHarness::new();
+    let historical_work = harness
+        .runtime()
+        .create_work_item("historical task wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let current_work = harness
+        .runtime()
+        .create_work_item("current task wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    harness
+        .runtime()
+        .storage()
+        .append_task(&running_task(
+            "task-duplicate-wait",
+            &current_work.id,
+            harness.now(),
+        ))
+        .unwrap();
+    let current = harness
+        .runtime()
+        .register_wait_for(
+            "default",
+            Some(current_work.id),
+            WaitForWakeKind::TaskResult,
+            Some("task-duplicate-wait".into()),
+            "current wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let mut historical = current.condition.clone();
+    historical.id = format!("{}-historical", current.condition.id);
+    historical.work_item_id = Some(historical_work.id);
+    historical.waiting_for = "historical wait".into();
+    historical.created_at -= chrono::Duration::milliseconds(1);
+    historical.updated_at = historical.created_at;
+    harness
+        .runtime()
+        .storage()
+        .append_wait_condition(&historical)
+        .unwrap();
+
+    let queued = harness
+        .runtime()
+        .enqueue(task_result_message("task-duplicate-wait"))
+        .await
+        .unwrap();
+
+    let waits = harness.snapshot().wait_conditions;
+    let historical = waits
+        .iter()
+        .find(|condition| condition.id == historical.id)
+        .unwrap();
+    let current = waits
+        .iter()
+        .find(|condition| condition.id == current.condition.id)
+        .unwrap();
+    assert_eq!(historical.status, WaitConditionStatus::Active);
+    assert_eq!(current.status, WaitConditionStatus::Triggered);
+    assert_eq!(current.trigger_message_id(), Some(queued.id.as_str()));
+}
+
+#[tokio::test]
+async fn wait_resolution_and_execution_admission_are_atomic_across_pre_commit_faults() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let work_item = harness
+            .runtime()
+            .create_work_item("atomic wait admission".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let registration = harness
+            .runtime()
+            .register_wait_for(
+                "default",
+                Some(work_item.id.clone()),
+                WaitForWakeKind::OperatorInput,
+                None,
+                "waiting for operator admission".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        persist_waiting_work_execution(&harness, &work_item.id, &registration.condition.id).await;
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("control".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "resume atomically".into(),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::HttpControlPrompt,
+            AdmissionContext::ControlAuthenticated,
+        );
+        message.work_item_id = Some(work_item.id.clone());
+        let queued = harness.runtime().enqueue(message).await.unwrap();
+        let triggered = harness
+            .snapshot()
+            .wait_conditions
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .unwrap();
+        assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+        let before_claim = harness.snapshot();
+        harness.arm_fault(fault);
+
+        let error = match super::super::super::scheduler_executor::SchedulerDecisionExecutor::new(
+            harness.runtime(),
+        )
+        .poll()
+        .await
+        {
+            Ok(_) => panic!("faulted claim should fail before commit"),
+            Err(error) => error,
+        };
+
+        assert_injected_transition_fault(&error);
+        let after_fault = harness.snapshot();
+        assert_eq!(after_fault.agent_state, before_claim.agent_state);
+        assert_eq!(after_fault.work_items, before_claim.work_items);
+        assert_eq!(
+            after_fault.work_item_continuations,
+            before_claim.work_item_continuations
+        );
+        assert_eq!(after_fault.wait_conditions, before_claim.wait_conditions);
+        assert_eq!(after_fault.queue_entries, before_claim.queue_entries);
+        assert_eq!(after_fault.tasks, before_claim.tasks);
+        assert_eq!(after_fault.messages, before_claim.messages);
+        assert_eq!(after_fault.briefs, before_claim.briefs);
+        assert_eq!(
+            after_fault.transcript_entries,
+            before_claim.transcript_entries
+        );
+        assert_eq!(
+            after_fault.index_outbox_high_watermark,
+            before_claim.index_outbox_high_watermark
+        );
+        assert!(after_fault
+            .audit_events
+            .iter()
+            .skip(before_claim.audit_events.len())
+            .all(|event| event.kind == "scheduling_advisory"));
+        let execution_after_fault = harness
+            .runtime()
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .expect("failed claim must preserve waiting execution authority");
+        assert!(execution_after_fault.attempts.is_empty());
+        assert!(matches!(
+            &execution_after_fault.work_items[&work_item.id].state,
+            crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+                if wait.wait_id == registration.condition.id
+        ));
+
+        let poll = super::super::super::scheduler_executor::SchedulerDecisionExecutor::new(
+            harness.runtime(),
+        )
+        .poll()
+        .await
+        .unwrap();
+        let super::super::super::scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+            panic!("retry should atomically admit the triggered wait");
+        };
+        assert_eq!(scheduled.message.id, queued.id);
+        let after_claim = harness.snapshot();
+        let resolved = after_claim
+            .wait_conditions
+            .iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .unwrap();
+        assert_eq!(resolved.status, WaitConditionStatus::Resolved);
+        assert_eq!(resolved.trigger_message_id(), Some(queued.id.as_str()));
+        assert_eq!(after_claim.work_items[0].blocked_by, None);
+        assert!(after_claim.queue_entries.iter().any(|entry| {
+            entry.message_id == queued.id && entry.status == QueueEntryStatus::Dequeued
+        }));
+        let execution = harness
+            .runtime()
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .expect("successful claim should initialize execution protocol");
+        assert!(execution
+            .attempts
+            .values()
+            .any(|attempt| attempt.source_message_id.as_deref() == Some(queued.id.as_str())));
+    }
+}
+
+#[tokio::test]
 async fn terminal_task_replay_repairs_wait_once_across_restart() {
     let mut harness = LifecycleHarness::new();
     let work = harness
         .runtime()
         .create_work_item("repair task wait".into(), None, None, Vec::new())
         .await
+        .unwrap();
+    harness
+        .runtime()
+        .storage()
+        .append_task(&running_task("task-replay", &work.id, harness.now()))
         .unwrap();
     let registration = harness
         .runtime()

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,8 +1,8 @@
 use super::super::*;
 use super::support::*;
 use crate::domain::scheduler_protocol::{
-    ActivationCause, ActivationSlot, AgentDispatchState, SchedulerOwner, Snapshot,
-    WaitGenerationRecord, WaitIdentity, WaitRecord, WaitState, WorkDemand, WorkStatus,
+    ActivationSlot, AgentDispatchState, SchedulerOwner, Snapshot, WaitGenerationRecord,
+    WaitIdentity, WaitRecord, WaitState, WorkDemand, WorkStatus,
 };
 use crate::types::{
     ActiveSkillRecord, AuthorityClass, BriefKind, BriefRecord, CompletionReportState,
@@ -123,8 +123,9 @@ fn task_wait_condition_for_work_item(task_id: &str, work_item_id: &str) -> WaitC
         expires_at: None,
         resolved_at: None,
         cancelled_at: None,
-
         turn_id: None,
+        trigger_message_id: None,
+        triggered_at: None,
     }
 }
 
@@ -168,6 +169,97 @@ fn append_completed_rejoin_task(
             })),
             recovery: None,
         })
+        .unwrap();
+}
+
+fn append_running_rejoin_task(runtime: &RuntimeHandle, task_id: &str, work_item_id: &str) {
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: task_id.into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: Some(work_item_id.into()),
+            summary: Some(format!("{task_id} running")),
+            detail: None,
+            recovery: None,
+        })
+        .unwrap();
+}
+
+fn persist_waiting_work_execution(
+    runtime: &RuntimeHandle,
+    work_item: &WorkItemRecord,
+    wait_id: &str,
+) {
+    let generation = work_item.revision.max(1);
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: generation,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: wait_id.into(),
+                },
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+}
+
+fn persist_execution_transition_only(
+    runtime: &RuntimeHandle,
+    transition: crate::runtime_db::transitions::ExecutionProtocolTransition,
+) {
+    use crate::domain::execution_protocol::ExecutionProtocolCommand;
+
+    let mut state = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("execution transition requires initialized authority");
+    for command in transition.commands {
+        state = match command {
+            ExecutionProtocolCommand::RegisterWorkItem(command) => {
+                crate::domain::execution_protocol::register_work_item_execution(&state, &command)
+            }
+            ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) => {
+                crate::domain::execution_protocol::advance_work_item_source_revision(
+                    &state, &command,
+                )
+            }
+            ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
+                crate::domain::execution_protocol::set_work_item_waiting(&state, &command)
+            }
+            ExecutionProtocolCommand::Admit(command) => {
+                crate::domain::execution_protocol::admit_execution(&state, &command)
+            }
+            ExecutionProtocolCommand::Settle(command) => {
+                crate::domain::execution_protocol::settle_execution(&state, &command)
+            }
+            ExecutionProtocolCommand::Interrupt(command) => {
+                crate::domain::execution_protocol::interrupt_execution(&state, &command)
+            }
+        }
+        .expect("test execution transition should be valid")
+        .state;
+    }
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &state))
         .unwrap();
 }
 
@@ -1174,7 +1266,7 @@ async fn legacy_recovery_commit_race_is_diagnostic_and_fresh_retry_converges() {
 }
 
 #[tokio::test]
-async fn canonical_claim_contention_retains_queue_head_without_failing_poll() {
+async fn legacy_scheduler_wait_does_not_block_unified_lifecycle_claim() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -1269,13 +1361,14 @@ async fn canonical_claim_contention_retains_queue_head_without_failing_poll() {
         .await
         .unwrap();
 
-    assert!(matches!(
-        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-            .poll()
-            .await
-            .unwrap(),
-        scheduler_executor::RunLoopPoll::AuthorityBlocked
-    ));
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("legacy scheduler wait must not block unified lifecycle claim");
+    };
+    assert_eq!(scheduled.message.id, message.id);
     assert_eq!(
         runtime
             .inner
@@ -1286,17 +1379,17 @@ async fn canonical_claim_contention_retains_queue_head_without_failing_poll() {
             .into_iter()
             .find(|entry| entry.message_id == message.id)
             .map(|entry| entry.status),
-        Some(QueueEntryStatus::Queued)
+        Some(QueueEntryStatus::Dequeued)
     );
     assert!(runtime
         .storage()
         .read_recent_events(usize::MAX)
         .unwrap()
         .iter()
-        .any(|event| {
-            event.kind == "scheduler_claim_contended"
+        .all(|event| {
+            !(event.kind == "scheduler_claim_contended"
                 && event.data["conflict_code"] == "agent_lane_reserved_by_other_owner"
-                && event.data["queue_disposition"] == "retained_queued"
+                && event.data["queue_disposition"] == "retained_queued")
         }));
 }
 
@@ -1362,14 +1455,23 @@ async fn canonical_work_item_wait_keeps_other_runnable_work_schedulable() {
         )
         .await
         .unwrap();
-    let mut snapshot = canonical_waiting_snapshot(&waiting_work, &wait.id, waiting_work.revision);
-    snapshot.dispatch = AgentDispatchState::Open;
-    snapshot.dispatch_revision = 0;
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        waiting_work.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: waiting_work.revision,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation: waiting_work.revision,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: wait.id.clone(),
+                },
+            },
+        },
+    );
     runtime
         .inner
         .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition("default", &snapshot)
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
         .unwrap();
 
     assert!(runtime.maybe_emit_pending_system_tick(None).await.unwrap());
@@ -1398,22 +1500,31 @@ async fn canonical_work_item_wait_keeps_other_runnable_work_schedulable() {
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
         .unwrap();
+    let claimed = claimed.expect("claim should initialize execution authority");
+    let activation_id = scheduler_executor::canonical_activation_id(&tick.id);
     assert!(matches!(
-        claimed.slot,
-        ActivationSlot::Running {
-            owner: SchedulerOwner::WorkItem { ref work_item_id },
-            ..
+        claimed.attempts[&activation_id].binding,
+        crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+            ref work_item_id
         } if work_item_id == &runnable_work.id
     ));
-    assert_eq!(
-        claimed.work[&waiting_work.id].status,
-        WorkStatus::Waiting {
-            wait_id: wait.id.clone(),
-        }
-    );
-    assert_eq!(claimed.dispatch, AgentDispatchState::Open);
+    let expected_wait_id = wait.id.clone();
+    assert!(matches!(
+        claimed.work_items[&waiting_work.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+            ref wait,
+            ..
+        } if wait.wait_id == expected_wait_id
+    ));
+    assert!(matches!(
+        claimed.work_items[&runnable_work.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            ref attempt_id,
+            ..
+        } if attempt_id == &activation_id
+    ));
     assert_eq!(
         tick.work_item_id.as_deref(),
         Some(runnable_work.id.as_str())
@@ -1510,94 +1621,6 @@ async fn late_terminal_task_result_for_completed_work_item_settles_without_model
 }
 
 #[tokio::test]
-async fn bootstrap_diagnostics_report_cross_model_scheduler_invariant_failures() {
-    let dir = tempdir().unwrap();
-    let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(CountingProvider {
-            calls: Mutex::new(0),
-            reply: "unused",
-        }),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-    let work_item = runtime
-        .create_work_item("diagnose stuck activation".into(), None, None, Vec::new())
-        .await
-        .unwrap();
-    let mut message = MessageEnvelope::new(
-        "default",
-        MessageKind::SystemTick,
-        MessageOrigin::System {
-            subsystem: "work_queue".into(),
-        },
-        AuthorityClass::RuntimeInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "claim and leave unsettled".into(),
-        },
-    );
-    message.work_item_id = Some(work_item.id.clone());
-    let message = runtime.enqueue(message).await.unwrap();
-    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-        .poll()
-        .await
-        .unwrap();
-    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
-    finish_claimed_test_run(&runtime).await;
-
-    let mut completed = runtime
-        .inner
-        .runtime_db
-        .work_items()
-        .latest(&work_item.id)
-        .unwrap()
-        .unwrap();
-    let expected_revision = completed.revision;
-    completed.revision += 1;
-    completed.state = WorkItemState::Completed;
-    completed.updated_at = Utc::now();
-    assert!(runtime
-        .inner
-        .runtime_db
-        .work_items()
-        .update_expected(&completed, expected_revision)
-        .unwrap());
-
-    let mut turn = crate::types::TurnRecord::new("default", "turn-stuck", 1);
-    turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
-    turn.terminal = Some(crate::types::TurnTerminalSummary {
-        kind: crate::types::TurnTerminalKind::Completed,
-        reason: None,
-        completed_at: Utc::now(),
-        duration_ms: 1,
-    });
-    runtime.storage().append_turn(&turn).unwrap();
-
-    runtime
-        .record_scheduler_bootstrap_diagnostics()
-        .await
-        .unwrap();
-
-    let reasons = runtime
-        .storage()
-        .read_recent_events(64)
-        .unwrap()
-        .into_iter()
-        .filter(|event| event.kind == "scheduler_diagnostic")
-        .filter_map(|event| event.data["reason"].as_str().map(ToString::to_string))
-        .collect::<std::collections::BTreeSet<_>>();
-    assert!(reasons.contains("running_activation_without_active_run"));
-    assert!(reasons.contains("completed_work_item_has_running_activation"));
-    assert!(reasons.contains("terminal_turn_has_dequeued_queue"));
-}
-
-#[tokio::test]
 async fn bootstrap_recovery_interrupts_open_attempt_and_releases_message_for_reentry() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -1648,30 +1671,17 @@ async fn bootstrap_recovery_interrupts_open_attempt_and_releases_message_for_ree
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    let report =
-        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-            .unwrap();
-    assert_eq!(report.candidates.len(), 1);
-    assert!(report.candidates[0].eligible);
-    assert_eq!(report.candidates[0].reason, "terminal_turn_missing");
-    assert!(matches!(
-        report.candidates[0].proposed_commands.as_slice(),
-        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command)]
-            if matches!(
-                command.settlement.disposition,
-                crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
-            )
-    ));
     assert_eq!(
         runtime
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
             .unwrap(),
-        claimed
+        Some(claimed.clone())
     );
     assert_eq!(
         runtime
@@ -1696,28 +1706,6 @@ async fn bootstrap_recovery_interrupts_open_attempt_and_releases_message_for_ree
     );
 
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let snapshot = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    assert_eq!(snapshot.slot, ActivationSlot::Idle);
-    assert_eq!(
-        snapshot
-            .activations
-            .get(&activation_id)
-            .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::Interrupted)
-    );
-    assert_eq!(
-        snapshot
-            .work
-            .get(&work_item.id)
-            .map(|demand| &demand.status),
-        Some(&WorkStatus::Runnable)
-    );
-    assert_eq!(snapshot.work[&work_item.id].scheduling_generation, 2);
     let execution = runtime
         .inner
         .runtime_db
@@ -1890,172 +1878,10 @@ async fn bootstrap_recovery_uses_execution_attempt_without_scheduler_compatibili
         .outcome,
         crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
             crate::domain::execution_protocol::WorkItemOutcome::Interrupted {
-                reason: "scheduler_compatibility_projection_missing".into(),
+                reason: "runtime_interrupted".into(),
             },
         )
     );
-}
-
-#[tokio::test]
-async fn settlement_recovery_repairs_processed_cross_work_item_pick_as_targeted_yield() {
-    let dir = tempdir().unwrap();
-    let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(CountingProvider {
-            calls: Mutex::new(0),
-            reply: "unused",
-        }),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-    let caller = runtime
-        .create_work_item("yield caller".into(), None, None, Vec::new())
-        .await
-        .unwrap();
-    let target = runtime
-        .create_work_item("yield target".into(), None, None, Vec::new())
-        .await
-        .unwrap();
-    runtime.pick_work_item(caller.id.clone()).await.unwrap();
-    let mut message = MessageEnvelope::new(
-        "default",
-        MessageKind::SystemTick,
-        MessageOrigin::System {
-            subsystem: "work_queue".into(),
-        },
-        AuthorityClass::RuntimeInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "yield caller activation".into(),
-        },
-    );
-    message.work_item_id = Some(caller.id.clone());
-    message.turn_id = Some("turn-targeted-yield-recovery".into());
-    let message = runtime.enqueue(message).await.unwrap();
-    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-        .poll()
-        .await
-        .unwrap();
-    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
-    runtime
-        .begin_interactive_turn(Some(&message), None, None)
-        .await
-        .unwrap();
-    let picked = runtime
-        .pick_work_item_with_reason(target.id.clone(), None)
-        .await
-        .unwrap();
-    assert!(picked.transition.terminal_transition);
-    let continuation_id = picked
-        .continuation_created
-        .expect("cross-work-item pick creates continuation")
-        .frame_id;
-    finish_claimed_test_run(&runtime).await;
-
-    let terminal = terminal_transition(&message, Some(&caller.id));
-    runtime
-        .storage()
-        .append_turn(&terminal.turn_record)
-        .unwrap();
-    let processed = QueueEntryRecord {
-        message_id: message.id.clone(),
-        agent_id: message.agent_id.clone(),
-        priority: message.priority.clone(),
-        status: QueueEntryStatus::Processed,
-        created_at: message.created_at,
-        updated_at: Utc::now(),
-    };
-    let scheduler_protocol_commands = runtime
-        .canonical_queue_settlement_commands(&processed, Some(&terminal.turn_record))
-        .await
-        .unwrap();
-    let settlement = scheduler_protocol_commands
-        .iter()
-        .find_map(|command| match command {
-            crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command) => {
-                Some(&command.settlement)
-            }
-            _ => None,
-        })
-        .expect("processed cross-work-item pick should produce a settlement");
-    assert!(matches!(
-        &settlement.disposition,
-        crate::domain::scheduler_protocol::ActivationDisposition::WorkYielded {
-            target_work_item_id: Some(target_work_item_id),
-            continuation_id: Some(settlement_continuation_id),
-            expected_target_generation: Some(_),
-        } if target_work_item_id == &target.id
-            && settlement_continuation_id == &continuation_id
-    ));
-    let execution_protocol = execution_protocol_settlement_transition(
-        &runtime.inner.runtime_db,
-        &message.agent_id,
-        &scheduler_protocol_commands,
-    )
-    .unwrap();
-    runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .commit_queue_with_execution_protocol(
-            &crate::runtime_db::transitions::QueueTransitionCommand {
-                agent_id: message.agent_id.clone(),
-                operation: crate::runtime_db::transitions::QueueOperation::Settle,
-                mutation: crate::runtime_db::transitions::QueueMutation::Upsert(processed),
-                scheduler_claim_work_item: None,
-                scheduler_protocol_bootstrap: None,
-                scheduler_protocol_commands,
-                agent_state: None,
-                message_evidence: Vec::new(),
-                transcript_entries: Vec::new(),
-                turn_record: None,
-                audit_events: Vec::new(),
-                notify_scheduler: false,
-                fault: None,
-                brief_evidence: Vec::new(),
-            },
-            &execution_protocol,
-        )
-        .unwrap();
-
-    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let settled = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let WorkStatus::Yielded { continuation } = &settled.work[&caller.id].status else {
-        panic!("caller should be atomically settled as canonically yielded");
-    };
-    assert_eq!(continuation.continuation_id, continuation_id);
-    assert_eq!(continuation.source_work_item_id, caller.id);
-    assert_eq!(continuation.target_work_item_id, target.id);
-    assert_eq!(settled.work[&target.id].status, WorkStatus::Runnable);
-    assert_eq!(
-        settled.activations[&activation_id].state,
-        crate::domain::scheduler_protocol::ActivationState::Settled
-    );
-    let report =
-        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-            .unwrap();
-    assert!(!report
-        .candidates
-        .iter()
-        .any(|candidate| candidate.kind == SchedulerRecoveryCandidateKind::NeedsSettlement));
-    let (applied, _) = apply_scheduler_recovery_plan(
-        &runtime.inner.storage,
-        &runtime.inner.runtime_db,
-        "default",
-        &report,
-    )
-    .unwrap();
-    assert_eq!(applied, 0, "unexpected recovery candidates: {report:#?}");
 }
 
 #[tokio::test]
@@ -2111,21 +1937,6 @@ async fn bootstrap_recovery_settles_dequeued_activation_from_terminal_turn() {
         .append_turn(&terminal.turn_record)
         .unwrap();
 
-    let report =
-        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-            .unwrap();
-    assert_eq!(report.candidates.len(), 1);
-    assert!(report.candidates[0].eligible);
-    assert_eq!(report.candidates[0].reason, "terminal_turn_settlement");
-    assert_eq!(
-        report.candidates[0].target_queue_status,
-        Some(QueueEntryStatus::Processed)
-    );
-    assert!(matches!(
-        report.candidates[0].proposed_commands.as_slice(),
-        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
-    ));
-
     assert_eq!(
         runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
         1
@@ -2136,25 +1947,24 @@ async fn bootstrap_recovery_settles_dequeued_activation_from_terminal_turn() {
     );
 
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    let attempt = &execution.attempts[&activation_id];
     assert_eq!(
-        snapshot
-            .activations
-            .get(&activation_id)
-            .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::Settled)
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
-    assert!(snapshot
-        .settlements
-        .contains_key(&canonical_settlement_id(&message.id)));
-    // Phase 4: missing-settlement recovery is replaced by Interrupted settlement.
-    assert!(snapshot.missing_settlements.is_empty());
+    assert!(matches!(
+        &execution.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Continue
+        )
+    ));
     assert_eq!(
         runtime
             .inner
@@ -2170,9 +1980,9 @@ async fn bootstrap_recovery_settles_dequeued_activation_from_terminal_turn() {
 }
 
 #[tokio::test]
-async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
+async fn bootstrap_restart_reconciles_dequeued_queue_after_unified_settlement() {
     let mut harness = LifecycleHarness::new();
-    let (message_id, activation_id, settled_snapshot) = {
+    let (message_id, activation_id, settled_execution) = {
         let runtime = harness.runtime();
         let work_item = runtime
             .create_work_item(
@@ -2211,26 +2021,37 @@ async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
             .storage()
             .append_turn(&terminal.turn_record)
             .unwrap();
-        let report =
-            scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-                .unwrap();
-        let command = report.candidates[0].proposed_commands[0].clone();
-        runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .commit_scheduler_protocol_command_unchecked_for_test("default", &command, None)
-            .unwrap();
         let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-        let snapshot = runtime
+        let mut processed = runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap();
+        let mut processed = processed
+            .drain(..)
+            .find(|entry| entry.message_id == message.id)
+            .expect("claimed queue entry");
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at = runtime.now();
+        let execution_transition = execution_protocol_settlement_transition_from_facts(
+            &runtime.inner.storage,
+            &runtime.inner.runtime_db,
+            &processed,
+            Some(&terminal.turn_record),
+        )
+        .unwrap();
+        persist_execution_transition_only(runtime, execution_transition);
+        let settled_execution = runtime
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
-            .unwrap();
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .expect("unified settlement should remain authoritative");
         assert_eq!(
-            snapshot.activations[&activation_id].state,
-            crate::domain::scheduler_protocol::ActivationState::Settled
+            settled_execution.attempts[&activation_id].state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Settled
         );
         assert_eq!(
             runtime
@@ -2244,7 +2065,7 @@ async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
                 .map(|entry| entry.status),
             Some(QueueEntryStatus::Dequeued)
         );
-        (message.id, activation_id, snapshot)
+        (message.id, activation_id, settled_execution)
     };
 
     harness.restart();
@@ -2262,9 +2083,9 @@ async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
             .unwrap(),
-        settled_snapshot
+        Some(settled_execution)
     );
     assert_eq!(
         runtime
@@ -2292,7 +2113,7 @@ async fn bootstrap_restart_repairs_legacy_queue_after_canonical_settlement() {
     assert_eq!(recovery_event.data["activation_id"], activation_id);
     assert_eq!(
         recovery_event.data["recovery_outcome"],
-        "settled_from_terminal_turn"
+        "legacy_queue_reconciled_from_execution_settlement"
     );
     assert_eq!(
         recovery_event.data["provenance"],
@@ -2397,17 +2218,6 @@ async fn bootstrap_recovery_settles_completed_work_item_from_bound_terminal_evid
         .append_turn(&terminal.turn_record)
         .unwrap();
 
-    let report =
-        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-            .unwrap();
-    assert_eq!(report.candidates.len(), 1);
-    assert!(report.candidates[0].eligible);
-    assert_eq!(report.candidates[0].reason, "terminal_turn_settlement");
-    assert!(matches!(
-        report.candidates[0].proposed_commands.as_slice(),
-        [crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(_)]
-    ));
-
     assert_eq!(
         runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
         1
@@ -2417,32 +2227,24 @@ async fn bootstrap_recovery_settles_completed_work_item_from_bound_terminal_evid
         0
     );
 
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    assert_eq!(snapshot.slot, ActivationSlot::Idle);
+    let attempt = &execution.attempts[&activation_id];
     assert_eq!(
-        snapshot
-            .activations
-            .get(&activation_id)
-            .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::Settled)
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
-    let settlement = snapshot
-        .settlements
-        .get(&canonical_settlement_id(&message.id))
-        .expect("completed activation settlement");
-    assert_eq!(
-        settlement.operator_delivery.as_deref(),
-        Some(result_brief_id.as_str())
-    );
-    assert!(settlement
-        .evidence
-        .iter()
-        .any(|evidence| evidence == &format!("turn:{}", terminal.terminal.turn_id)));
+    assert!(matches!(
+        &execution.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Complete { completion }
+        ) if completion == &result_brief_id
+    ));
     assert_eq!(
         runtime
             .inner
@@ -2455,188 +2257,6 @@ async fn bootstrap_recovery_settles_completed_work_item_from_bound_terminal_evid
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Processed)
     );
-}
-
-#[tokio::test]
-async fn stale_bootstrap_recovery_command_cannot_settle_successor_generation() {
-    let dir = tempdir().unwrap();
-    let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(CountingProvider {
-            calls: Mutex::new(0),
-            reply: "unused",
-        }),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-    let work_item = runtime
-        .create_work_item(
-            "fence stale bootstrap recovery".into(),
-            None,
-            None,
-            Vec::new(),
-        )
-        .await
-        .unwrap();
-    let mut first_message = MessageEnvelope::new(
-        "default",
-        MessageKind::SystemTick,
-        MessageOrigin::System {
-            subsystem: "work_queue".into(),
-        },
-        AuthorityClass::RuntimeInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "first claimed generation".into(),
-        },
-    );
-    first_message.work_item_id = Some(work_item.id.clone());
-    first_message.turn_id = Some("turn-bootstrap-stale-first".into());
-    let first_message = runtime.enqueue(first_message).await.unwrap();
-    assert!(matches!(
-        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-            .poll()
-            .await
-            .unwrap(),
-        scheduler_executor::RunLoopPoll::Message(_)
-    ));
-    finish_claimed_test_run(&runtime).await;
-    let terminal = terminal_transition(&first_message, Some(&work_item.id));
-    runtime
-        .storage()
-        .append_turn(&terminal.turn_record)
-        .unwrap();
-    let report =
-        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
-            .unwrap();
-    let mut stale_command = report.candidates[0].proposed_commands[0].clone();
-    let crate::domain::scheduler_protocol::ProtocolCommand::SettleActivation(command) =
-        &mut stale_command
-    else {
-        panic!("terminal recovery should propose settlement");
-    };
-    command.settlement.id = "settlement:stale-bootstrap-proposal".into();
-
-    let claimed = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    assert_eq!(
-        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
-        1
-    );
-    let mut successor_message = MessageEnvelope::new(
-        "default",
-        MessageKind::SystemTick,
-        MessageOrigin::System {
-            subsystem: "work_queue".into(),
-        },
-        AuthorityClass::RuntimeInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "successor claimed generation".into(),
-        },
-    );
-    successor_message.work_item_id = Some(work_item.id.clone());
-    let successor_message = runtime.enqueue(successor_message).await.unwrap();
-    assert!(matches!(
-        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-            .poll()
-            .await
-            .unwrap(),
-        scheduler_executor::RunLoopPoll::Message(_)
-    ));
-    finish_claimed_test_run(&runtime).await;
-    let before = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    assert_eq!(
-        before.work[&work_item.id].scheduling_generation,
-        claimed.work[&work_item.id].scheduling_generation + 1
-    );
-
-    let expected_entry = runtime
-        .inner
-        .runtime_db
-        .queue_entries()
-        .latest_all()
-        .unwrap()
-        .into_iter()
-        .find(|entry| entry.message_id == successor_message.id)
-        .unwrap();
-    let mut processed_entry = expected_entry.clone();
-    processed_entry.status = QueueEntryStatus::Processed;
-    processed_entry.updated_at = runtime.now();
-    let error = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .commit_queue(&crate::runtime_db::transitions::QueueTransitionCommand {
-            agent_id: "default".into(),
-            operation: crate::runtime_db::transitions::QueueOperation::Settle,
-            mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
-                expected: expected_entry,
-                record: processed_entry,
-            },
-            scheduler_claim_work_item: None,
-            scheduler_protocol_bootstrap: None,
-            scheduler_protocol_commands: vec![stale_command],
-            agent_state: None,
-            message_evidence: Vec::new(),
-            transcript_entries: Vec::new(),
-            turn_record: None,
-            audit_events: vec![AuditEvent::legacy(
-                "stale_bootstrap_recovery_attempt",
-                serde_json::json!({"message_id": first_message.id}),
-            )],
-            notify_scheduler: true,
-            fault: None,
-            brief_evidence: Vec::new(),
-        })
-        .unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("activation_terminal_settlement_already_recorded"),
-        "unexpected stale recovery error: {error:#}"
-    );
-    assert_eq!(
-        runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot("default")
-            .unwrap(),
-        before
-    );
-    assert_eq!(
-        runtime
-            .inner
-            .runtime_db
-            .queue_entries()
-            .latest_all()
-            .unwrap()
-            .into_iter()
-            .find(|entry| entry.message_id == successor_message.id)
-            .map(|entry| entry.status),
-        Some(QueueEntryStatus::Dequeued)
-    );
-    assert!(runtime
-        .storage()
-        .read_recent_events(64)
-        .unwrap()
-        .iter()
-        .all(|event| event.kind != "stale_bootstrap_recovery_attempt"));
 }
 
 #[tokio::test]
@@ -2700,8 +2320,9 @@ async fn bootstrap_recovery_fault_rolls_back_queue_canonical_and_audit() {
                 .inner
                 .runtime_db
                 .transitions()
-                .load_scheduler_protocol_snapshot("default")
-                .unwrap();
+                .load_execution_protocol_state_if_initialized("default")
+                .unwrap()
+                .expect("claim should initialize execution authority");
 
             runtime.inject_next_transition_fault(fault);
             let error = runtime
@@ -2714,9 +2335,9 @@ async fn bootstrap_recovery_fault_rolls_back_queue_canonical_and_audit() {
                     .inner
                     .runtime_db
                     .transitions()
-                    .load_scheduler_protocol_snapshot("default")
+                    .load_execution_protocol_state_if_initialized("default")
                     .unwrap(),
-                claimed
+                Some(claimed.clone())
             );
             assert_eq!(
                 runtime
@@ -2747,6 +2368,38 @@ async fn bootstrap_recovery_fault_rolls_back_queue_canonical_and_audit() {
             assert_eq!(
                 runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
                 0
+            );
+            let recovered = runtime
+                .inner
+                .runtime_db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("default")
+                .unwrap()
+                .expect("recovery should preserve execution authority");
+            let attempt_id = scheduler_executor::canonical_activation_id(&message.id);
+            assert_eq!(
+                recovered.attempts[&attempt_id].state,
+                if terminal_evidence {
+                    crate::domain::execution_protocol::ExecutionAttemptState::Settled
+                } else {
+                    crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+                }
+            );
+            assert_eq!(
+                runtime
+                    .inner
+                    .runtime_db
+                    .queue_entries()
+                    .latest_all()
+                    .unwrap()
+                    .into_iter()
+                    .find(|entry| entry.message_id == message.id)
+                    .map(|entry| entry.status),
+                Some(if terminal_evidence {
+                    QueueEntryStatus::Processed
+                } else {
+                    QueueEntryStatus::Interrupted
+                })
             );
         }
     }
@@ -2861,7 +2514,7 @@ async fn legacy_engine_claim_and_settlement_do_not_write_canonical_protocol() {
 }
 
 #[tokio::test]
-async fn legacy_engine_startup_rejects_running_canonical_activation() {
+async fn legacy_engine_startup_rejects_open_unified_execution_attempt() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let provider = Arc::new(CountingProvider {
@@ -2920,7 +2573,7 @@ async fn legacy_engine_startup_rejects_running_canonical_activation() {
     let error = legacy.run().await.unwrap_err();
     assert!(error
         .to_string()
-        .contains("non-terminal canonical activations remain"));
+        .contains("open unified execution attempts remain"));
 }
 
 #[tokio::test]
@@ -2975,20 +2628,20 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("claim should initialize execution authority");
     assert_eq!(
-        claimed.slot,
-        ActivationSlot::Running {
-            activation_id: activation_id.clone(),
-            owner: SchedulerOwner::WorkItem {
-                work_item_id: work_item.id.clone(),
-            },
-            admitted_generation: work_item.revision,
-            recovery_for: None,
-        }
+        claimed.attempts[&activation_id].state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Open
     );
-    assert!(claimed.activations.contains_key(&activation_id));
+    assert!(matches!(
+        claimed.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            ref attempt_id,
+            ..
+        } if attempt_id == &activation_id
+    ));
 
     finish_claimed_test_run(&runtime).await;
     let terminal = terminal_transition(&message, Some(&work_item.id));
@@ -3019,32 +2672,11 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    assert_eq!(settled.slot, ActivationSlot::Idle);
-    assert_eq!(
-        settled.work.get(&work_item.id).map(|demand| &demand.status),
-        Some(&WorkStatus::Runnable)
-    );
-    assert_eq!(
-        settled
-            .work
-            .get(&work_item.id)
-            .map(|demand| demand.scheduling_generation),
-        Some(work_item.revision + 1)
-    );
-    assert!(settled
-        .settlements
-        .contains_key(&canonical_settlement_id(&message.id)));
-    let execution = runtime
-        .inner
-        .runtime_db
-        .transitions()
         .load_execution_protocol_state_if_initialized("default")
         .unwrap()
-        .expect("canonical settlement should preserve the execution partition");
-    let outcome_id = format!("outcome:{}", canonical_settlement_id(&message.id));
-    let attempt = &execution.attempts[&activation_id];
+        .expect("settlement should preserve execution authority");
+    let outcome_id = format!("outcome:message:{}", message.id);
+    let attempt = &settled.attempts[&activation_id];
     assert_eq!(
         attempt.state,
         crate::domain::execution_protocol::ExecutionAttemptState::Settled
@@ -3054,17 +2686,17 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
         Some(outcome_id.as_str())
     );
     assert_eq!(
-        execution.outcomes[&outcome_id].outcome,
+        settled.outcomes[&outcome_id].outcome,
         crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
             crate::domain::execution_protocol::WorkItemOutcome::Continue,
         )
     );
     assert_eq!(
-        execution.work_items[&work_item.id].source_revision,
+        settled.work_items[&work_item.id].source_revision,
         work_item.revision
     );
     assert_eq!(
-        execution.work_items[&work_item.id].state,
+        settled.work_items[&work_item.id].state,
         crate::domain::execution_protocol::WorkItemExecutionState::Runnable {
             generation: work_item.revision + 1,
             recovery_ref: None,
@@ -3104,7 +2736,7 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
             .transitions()
             .load_execution_protocol_state_if_initialized("default")
             .unwrap(),
-        Some(execution)
+        Some(settled)
     );
 }
 
@@ -3156,6 +2788,7 @@ async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation(
         scheduler_executor::RunLoopPoll::Message(_)
     ));
 
+    append_running_rejoin_task(&runtime, "task-rejoin", &work_item.id);
     let registration = runtime
         .register_wait_for(
             "default",
@@ -3186,32 +2819,30 @@ async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation(
         .await
         .unwrap();
 
+    let first_attempt_id = scheduler_executor::canonical_activation_id(&message.id);
     let settled = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let wait_generation = work_item.revision + 1;
-    assert_eq!(settled.slot, ActivationSlot::Idle);
-    assert_eq!(settled.dispatch, AgentDispatchState::Open);
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("WaitFor should preserve execution authority");
+    let first_attempt = &settled.attempts[&first_attempt_id];
     assert_eq!(
-        settled.work.get(&work_item.id).map(|demand| &demand.status),
-        Some(&WorkStatus::Waiting {
-            wait_id: registration.condition.id.clone(),
-        })
+        first_attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
-    assert_eq!(
-        settled
-            .waits
-            .get(&registration.condition.id)
-            .map(|wait| wait.current_generation),
-        Some(wait_generation)
-    );
-    assert!(settled
-        .settlements
-        .contains_key(&canonical_settlement_id(&message.id)));
-    assert!(settled.missing_settlements.is_empty());
+    assert!(matches!(
+        &settled.outcomes[first_attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Wait { wait }
+        ) if wait.wait_id == registration.condition.id
+    ));
+    assert!(matches!(
+        &settled.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == registration.condition.id
+    ));
 
     append_completed_rejoin_task(
         &runtime,
@@ -3240,28 +2871,37 @@ async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation(
             .unwrap(),
         scheduler_executor::RunLoopPoll::Message(_)
     ));
+    let rejoin_attempt_id = scheduler_executor::canonical_activation_id(&rejoin.id);
     let rejoined = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("task rejoin should preserve execution authority");
     assert!(matches!(
-        rejoined.slot,
-        ActivationSlot::Running {
-            owner: SchedulerOwner::WorkItem { ref work_item_id },
-            admitted_generation,
+        &rejoined.attempts[&rejoin_attempt_id].source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TaskResult {
+            task_id,
+            result_message_id,
+        } if task_id == "task-rejoin" && result_message_id == &rejoin.id
+    ));
+    assert!(matches!(
+        &rejoined.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            attempt_id,
             ..
-        } if work_item_id == &work_item.id && admitted_generation == wait_generation
+        } if attempt_id == &rejoin_attempt_id
     ));
     assert_eq!(
-        rejoined.waits[&registration.condition.id].generations[&wait_generation].state,
-        WaitState::Consumed
-    );
-    assert_eq!(
-        rejoined.waits[&registration.condition.id].generations[&wait_generation]
-            .consuming_activation_id,
-        Some(scheduler_executor::canonical_activation_id(&rejoin.id))
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|wait| wait.id == registration.condition.id)
+            .map(|wait| wait.status),
+        Some(WaitConditionStatus::Resolved)
     );
 
     let external_wait = runtime
@@ -3298,38 +2938,39 @@ async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation(
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let external_wait_generation = wait_generation + 1;
-    assert_eq!(settled_rejoin.slot, ActivationSlot::Idle);
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("second WaitFor should preserve execution authority");
+    let rejoin_attempt = &settled_rejoin.attempts[&rejoin_attempt_id];
     assert_eq!(
-        settled_rejoin
-            .work
-            .get(&work_item.id)
-            .map(|demand| &demand.status),
-        Some(&WorkStatus::Waiting {
-            wait_id: external_wait.condition.id.clone(),
-        })
+        rejoin_attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
+    assert!(matches!(
+        &settled_rejoin.outcomes
+            [rejoin_attempt.terminal_outcome_id.as_deref().unwrap()]
+            .outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Wait { wait }
+        ) if wait.wait_id == external_wait.condition.id
+    ));
+    assert!(matches!(
+        &settled_rejoin.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == external_wait.condition.id
+    ));
     assert_eq!(
-        settled_rejoin
-            .waits
-            .get(&external_wait.condition.id)
-            .map(|wait| wait.current_generation),
-        Some(external_wait_generation)
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == rejoin.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
     );
-    assert_eq!(
-        settled_rejoin.waits[&registration.condition.id].generations[&wait_generation].state,
-        WaitState::Resolved
-    );
-    assert_eq!(
-        settled_rejoin.waits[&registration.condition.id].generations[&wait_generation]
-            .consuming_activation_id,
-        None
-    );
-    assert!(settled_rejoin
-        .settlements
-        .contains_key(&canonical_settlement_id(&rejoin.id)));
 }
 
 #[tokio::test]
@@ -3420,26 +3061,33 @@ async fn lifecycle_settlement_adopts_wait_without_work_item_turn_binding() {
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    assert_eq!(settled.slot, ActivationSlot::Idle);
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let attempt = &settled.attempts[&activation_id];
     assert_eq!(
-        settled.work.get(&work_item.id).map(|demand| &demand.status),
-        Some(&WorkStatus::Waiting {
-            wait_id: registration.condition.id.clone(),
-        })
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::Conversation(
+            crate::domain::execution_protocol::ConversationOutcome::HandoffToWorkItemWait {
+                work_item_id,
+                wait,
+            }
+        ) if work_item_id == &work_item.id && wait.wait_id == registration.condition.id
+    ));
+    assert!(matches!(
+        &settled.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == registration.condition.id
+    ));
     assert_eq!(
-        settled.waits[&registration.condition.id].generations[&updated_work_item.revision].owner,
-        SchedulerOwner::WorkItem {
-            work_item_id: work_item.id.clone(),
-        }
+        settled.work_items[&work_item.id].source_revision,
+        updated_work_item.revision
     );
-    assert_eq!(settled.dispatch, AgentDispatchState::Open);
-    assert!(settled
-        .settlements
-        .contains_key(&canonical_settlement_id(&message.id)));
-    assert!(settled.missing_settlements.is_empty());
     assert_eq!(
         runtime
             .inner
@@ -3511,14 +3159,26 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
     assert!(matches!(
-        &admitted.activation_admissions[&activation_id]
-            .activation
-            .cause,
-        ActivationCause::LifecycleExternalNudge { message_id }
-            if message_id == &message.id
+        &admitted.attempts[&activation_id],
+        crate::domain::execution_protocol::ExecutionAttempt {
+            binding: crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                agent_id
+            },
+            source:
+                crate::domain::execution_protocol::ExecutionSource {
+                    identity:
+                        crate::domain::execution_protocol::ExecutionSourceIdentity::QueueMessage {
+                            message_id
+                        },
+                    ..
+                },
+            state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
+            ..
+        } if agent_id == "default" && message_id == &message.id
     ));
 
     runtime
@@ -3535,6 +3195,7 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .await
         .unwrap();
     runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    append_running_rejoin_task(&runtime, "task-lifecycle-handoff", &work_item.id);
     let work_wait = runtime
         .register_wait_for(
             "default",
@@ -3571,45 +3232,42 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    let work_generation = updated_work_item.revision;
-    assert_eq!(settled.slot, ActivationSlot::Idle);
+    let work_generation = settled.work_items[&work_item.id].state.generation();
+    let attempt = &settled.attempts[&activation_id];
     assert_eq!(
-        settled.waits[&lifecycle_wait.condition.id].generations[&lifecycle_generation].state,
-        WaitState::Resolved
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::Conversation(
+            crate::domain::execution_protocol::ConversationOutcome::HandoffToWorkItemWait {
+                work_item_id,
+                wait,
+            }
+        ) if work_item_id == &work_item.id && wait.wait_id == work_wait.condition.id
+    ));
+    assert!(matches!(
+        &settled.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == work_wait.condition.id
+    ));
     assert_eq!(
-        settled.work[&work_item.id].status,
-        WorkStatus::Waiting {
-            wait_id: work_wait.condition.id.clone(),
-        }
+        settled.work_items[&work_item.id].source_revision,
+        updated_work_item.revision
     );
-    assert_eq!(
-        settled.waits[&work_wait.condition.id].generations[&work_generation].owner,
-        SchedulerOwner::WorkItem {
-            work_item_id: work_item.id.clone(),
-        }
-    );
-    assert_eq!(settled.dispatch, AgentDispatchState::Open);
-    assert_eq!(settled.focus.as_deref(), Some(work_item.id.as_str()));
-    assert!(settled.missing_settlements.is_empty());
-
-    let replay_commands = runtime
-        .canonical_queue_settlement_commands(&processed, Some(&terminal.turn_record))
-        .await
-        .unwrap();
-    assert!(replay_commands.is_empty());
     assert_eq!(
         runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .commit_scheduler_recovery_plan("default", &replay_commands)
-            .unwrap(),
-        crate::runtime_db::transitions::scheduler_protocol_repository::SchedulerRecoveryCommitOutcome::Applied(
-            false
-        )
+            .storage()
+            .raw_unresolved_wait_conditions_for_agent("default")
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == lifecycle_wait.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Active)
     );
 
     drop(runtime);
@@ -3683,26 +3341,47 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    let rejoin_generation = resolved_work_item.revision;
+    let rejoin_activation_id = scheduler_executor::canonical_activation_id(&rejoin.id);
     assert!(matches!(
-        rejoined.slot,
-        ActivationSlot::Running {
-            owner: SchedulerOwner::WorkItem { ref work_item_id },
-            admitted_generation,
+        &rejoined.attempts[&rejoin_activation_id],
+        crate::domain::execution_protocol::ExecutionAttempt {
+            binding: crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+                work_item_id
+            },
+            source:
+                crate::domain::execution_protocol::ExecutionSource {
+                    identity:
+                        crate::domain::execution_protocol::ExecutionSourceIdentity::TaskResult {
+                            task_id,
+                            result_message_id,
+                        },
+                    ..
+                },
+            state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
             ..
-        } if work_item_id == &work_item.id && admitted_generation == rejoin_generation
+        } if work_item_id == &work_item.id
+            && task_id == "task-lifecycle-handoff"
+            && result_message_id == &rejoin.id
+    ));
+    assert!(matches!(
+        &rejoined.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            generation,
+            attempt_id,
+        } if *generation == work_generation && attempt_id == &rejoin_activation_id
     ));
     assert_eq!(
-        rejoined.waits[&work_wait.condition.id].generations[&rejoin_generation].state,
-        WaitState::Consumed
-    );
-    assert_eq!(
-        rejoined.waits[&work_wait.condition.id].generations[&rejoin_generation]
-            .consuming_activation_id
-            .as_deref(),
-        Some(scheduler_executor::canonical_activation_id(&rejoin.id).as_str())
+        reopened
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == work_wait.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Resolved)
     );
 }
 
@@ -3733,6 +3412,7 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
         .await
         .unwrap();
     runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    append_running_rejoin_task(&runtime, "task-stale-legacy-rejoin", &work_item.id);
     let registration = runtime
         .register_wait_for(
             "default",
@@ -3768,7 +3448,6 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
                 generation: wait_generation,
                 wait: crate::domain::execution_protocol::WaitReference {
                     wait_id: registration.condition.id.clone(),
-                    generation: wait_generation,
                 },
             },
         },
@@ -3831,19 +3510,32 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("task rejoin should preserve execution authority");
+    let attempt_id = scheduler_executor::canonical_activation_id(&rejoin.id);
     assert!(matches!(
-        claimed.slot,
-        ActivationSlot::Running {
-            owner: SchedulerOwner::WorkItem { ref work_item_id },
-            admitted_generation,
-            ..
-        } if work_item_id == &work_item.id && admitted_generation == wait_generation
+        claimed.attempts[&attempt_id].binding,
+        crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+            ref work_item_id
+        } if work_item_id == &work_item.id
+    ));
+    assert!(matches!(
+        claimed.attempts[&attempt_id].source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TaskResult {
+            ref task_id,
+            ref result_message_id,
+        } if task_id == "task-stale-legacy-rejoin" && result_message_id == &rejoin.id
     ));
     assert_eq!(
-        claimed.waits[&registration.condition.id].generations[&wait_generation].state,
-        WaitState::Consumed
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|wait| wait.id == registration.condition.id)
+            .map(|wait| wait.status),
+        Some(WaitConditionStatus::Resolved)
     );
     assert_eq!(
         runtime
@@ -3857,6 +3549,159 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Dequeued)
     );
+}
+
+#[tokio::test]
+async fn stale_exact_task_rejoin_is_dropped_without_blocking_next_message() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "drop stale task rejoin queue head".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    append_running_rejoin_task(&runtime, "task-current-rejoin", &work_item.id);
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-current-rejoin".into()),
+            "waiting for current task".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem");
+    let wait_generation = waiting_work.revision;
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition(
+            "default",
+            &canonical_waiting_snapshot(&waiting_work, &registration.condition.id, wait_generation),
+        )
+        .unwrap();
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: work_item.revision.max(1),
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation: wait_generation,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: registration.condition.id.clone(),
+                },
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+    append_completed_rejoin_task(
+        &runtime,
+        "task-stale-rejoin",
+        &work_item.id,
+        "turn-stale-rejoin-parent",
+    );
+    append_completed_rejoin_task(
+        &runtime,
+        "task-current-rejoin",
+        &work_item.id,
+        "turn-current-rejoin-parent",
+    );
+
+    let mut stale = task_result_message("task-stale-rejoin").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    stale.work_item_id = Some(work_item.id.clone());
+    stale.metadata = Some(serde_json::json!({
+        "task_id": "task-stale-rejoin",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-stale-rejoin",
+        "work_item_id": work_item.id,
+    }));
+    stale.turn_id = Some("turn-stale-rejoin".into());
+    let stale = runtime.enqueue(stale).await.unwrap();
+    let mut valid = task_result_message("task-current-rejoin").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    valid.work_item_id = Some(work_item.id.clone());
+    valid.metadata = Some(serde_json::json!({
+        "task_id": "task-current-rejoin",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-current-rejoin",
+        "work_item_id": work_item.id,
+    }));
+    valid.turn_id = Some("turn-current-rejoin".into());
+    let valid = runtime.enqueue(valid).await.unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == stale.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dropped)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == stale.id
+                && event.data["reason"] == "canonical_task_rejoin_stale"
+                && event.data["queue_disposition"] == "dropped"
+        }));
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("valid message behind stale task result should be claimed");
+    };
+    assert_eq!(scheduled.message.id, valid.id);
 }
 
 #[tokio::test]
@@ -3881,6 +3726,7 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         .await
         .unwrap();
     runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    append_running_rejoin_task(&runtime, "task-rejoin", &work_item.id);
     let registration = runtime
         .register_wait_for(
             "default",
@@ -3897,40 +3743,8 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         .await
         .unwrap()
         .unwrap();
-    let wait_generation = work_item.revision;
-    let initial_seed =
-        canonical_waiting_snapshot(&work_item, &registration.condition.id, wait_generation);
-    runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition("default", &initial_seed)
-        .unwrap();
-    let initial = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    runtime
-        .persist_task_transition(
-            &TaskRecord {
-                id: "task-rejoin".into(),
-                agent_id: "default".into(),
-                kind: TaskKind::CommandTask,
-                status: TaskStatus::Running,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                parent_message_id: None,
-                work_item_id: Some(work_item.id.clone()),
-                summary: Some("task-rejoin".into()),
-                detail: None,
-                recovery: None,
-            },
-            "task_completed",
-        )
-        .await
-        .unwrap();
+    persist_waiting_work_execution(&runtime, &work_item, &registration.condition.id);
+    append_completed_rejoin_task(&runtime, "task-rejoin", &work_item.id, "turn-task-parent");
     assert_eq!(
         runtime
             .storage()
@@ -3953,79 +3767,18 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         "work_item_id": work_item.id,
     }));
     let message = runtime.enqueue(message).await.unwrap();
-
-    assert!(matches!(
-        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-            .poll()
-            .await
-            .unwrap(),
-        scheduler_executor::RunLoopPoll::AuthorityBlocked
-    ));
-    assert_eq!(
-        runtime
-            .inner
-            .runtime_db
-            .queue_entries()
-            .latest_all()
-            .unwrap()
-            .into_iter()
-            .find(|entry| entry.message_id == message.id)
-            .map(|entry| entry.status),
-        Some(QueueEntryStatus::Queued)
-    );
-    assert!(runtime
-        .storage()
-        .read_recent_events(32)
-        .unwrap()
-        .iter()
-        .any(|event| {
-            event.kind == "scheduler_authority_hard_blocker"
-                && event.data["blocker_code"] == "canonical_task_rejoin_contract_missing_or_invalid"
-        }));
-
-    let mut durable_task = runtime
-        .storage()
-        .latest_task_record("task-rejoin")
-        .unwrap()
-        .unwrap();
-    durable_task.updated_at = Utc::now();
-    durable_task.detail = Some(serde_json::json!({
-        "rejoin_obligation_id": "task-rejoin",
-        "rejoin_generation": 1,
-        "parent_turn_id": "turn-task-parent"
-    }));
-    durable_task.status = TaskStatus::Completed;
-    runtime
-        .persist_task_transition(&durable_task, "task_completed")
-        .await
-        .unwrap();
-    assert!(runtime
-        .storage()
-        .active_wait_conditions_for_work_item("default", &work_item.id)
-        .unwrap()
-        .is_empty());
-    assert_eq!(
-        runtime
-            .storage()
-            .latest_wait_conditions()
-            .unwrap()
-            .into_iter()
-            .find(|condition| condition.id == registration.condition.id)
-            .map(|condition| condition.status),
-        Some(WaitConditionStatus::Resolved)
-    );
-    let work_item = runtime
-        .latest_work_item(&work_item.id)
-        .await
-        .unwrap()
-        .unwrap();
-    let claim_wait_generation = work_item.revision;
     let state_before_claim = runtime.agent_state().await.unwrap();
+    let execution_before_claim = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("waiting execution authority");
 
     runtime.inject_next_transition_fault(
         crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
     );
-
     let error = match scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()
         .await
@@ -4040,9 +3793,9 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
             .unwrap(),
-        initial
+        Some(execution_before_claim)
     );
     assert_eq!(
         runtime
@@ -4056,13 +3809,16 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Queued)
     );
-    assert!(runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_execution_protocol_state_if_initialized("default")
-        .unwrap()
-        .is_none());
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Triggered)
+    );
 
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()
@@ -4073,52 +3829,13 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
     };
     assert_eq!(scheduled.message.id, message.id);
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let claimed = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    assert_eq!(
-        claimed.slot,
-        ActivationSlot::Running {
-            activation_id: activation_id.clone(),
-            owner: SchedulerOwner::WorkItem {
-                work_item_id: work_item.id.clone(),
-            },
-            admitted_generation: work_item.revision,
-            recovery_for: None,
-        }
-    );
-    assert_eq!(
-        claimed.waits[&registration.condition.id].generations[&claim_wait_generation].state,
-        WaitState::Consumed
-    );
-    assert_eq!(
-        claimed.waits[&registration.condition.id].generations[&claim_wait_generation]
-            .consuming_activation_id
-            .as_deref(),
-        Some(activation_id.as_str())
-    );
-    let admission = &claimed.activation_admissions[&activation_id].activation;
-    assert!(matches!(
-        &admission.cause,
-        ActivationCause::TaskRejoin {
-            task_id,
-            message_id,
-            resume: Some(resume),
-        } if task_id == "task-rejoin"
-            && message_id == &message.id
-            && resume.wait_id == registration.condition.id
-            && resume.wait_generation == claim_wait_generation
-    ));
     let execution = runtime
         .inner
         .runtime_db
         .transitions()
         .load_execution_protocol_state_if_initialized("default")
         .unwrap()
-        .expect("canonical claim should initialize execution protocol");
+        .expect("canonical claim should preserve execution protocol");
     let attempt = &execution.attempts[&activation_id];
     assert_eq!(
         attempt.source.identity,
@@ -4128,25 +3845,10 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         }
     );
     assert_eq!(
-        attempt.source.generation,
-        scheduled
-            .message
-            .message_seq
-            .expect("claimed message should carry its durable sequence")
-    );
-    assert_eq!(
         attempt.binding,
         crate::domain::execution_protocol::ExecutionBinding::WorkItem {
             work_item_id: work_item.id.clone(),
         }
-    );
-    assert_eq!(
-        attempt.admitted_fences.work_item_source_revision,
-        Some(work_item.revision)
-    );
-    assert_eq!(
-        attempt.admitted_fences.work_item_generation,
-        Some(work_item.revision)
     );
     assert_eq!(
         attempt.admitted_fences.rejoin,
@@ -4156,13 +3858,22 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
             parent_turn_id: "turn-task-parent".into(),
         })
     );
+    assert!(matches!(
+        execution.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            ref attempt_id,
+            ..
+        } if attempt_id == &activation_id
+    ));
     assert_eq!(
-        execution.work_items[&work_item.id].source_revision,
-        work_item.revision
-    );
-    assert_eq!(
-        execution.work_items[&work_item.id].generation(),
-        work_item.revision
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Resolved)
     );
     assert_eq!(
         runtime
@@ -4191,13 +3902,6 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
         context_config(),
     )
     .unwrap();
-    let restarted = reopened
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    assert_eq!(restarted, claimed);
     assert_eq!(
         reopened
             .inner
@@ -4315,21 +4019,6 @@ async fn restarted_interrupted_unbound_operator_prompt_does_not_block_resent_pro
     assert_eq!(scheduled.message.id, first.id);
     finish_claimed_test_run(runtime).await;
 
-    let work_item = runtime
-        .create_work_item("operator wait".into(), None, None, Vec::new())
-        .await
-        .unwrap();
-    runtime
-        .register_wait_for(
-            "default",
-            Some(work_item.id),
-            WaitForWakeKind::OperatorInput,
-            None,
-            "waiting on work item".into(),
-            None,
-        )
-        .await
-        .unwrap();
     runtime
         .register_wait_for(
             "default",
@@ -4378,7 +4067,7 @@ async fn restarted_interrupted_unbound_operator_prompt_does_not_block_resent_pro
         .into_iter()
         .find(|entry| entry.message_id == first.id)
         .map(|entry| entry.status);
-    assert_eq!(recovered_first_status, Some(QueueEntryStatus::Interrupted));
+    assert_eq!(recovered_first_status, Some(QueueEntryStatus::Aborted));
     let second = runtime
         .enqueue(trusted_operator_prompt(None, "resent operator prompt"))
         .await
@@ -4468,44 +4157,28 @@ async fn authoritative_explicit_operator_binding_ignores_unrelated_waits() {
         .await
         .unwrap()
         .unwrap();
-    let mut initial =
-        canonical_waiting_snapshot(&target, &target_wait.condition.id, target.revision);
-    initial.work.insert(
-        unrelated.id.clone(),
-        WorkDemand {
-            metadata_revision: unrelated.revision,
-            scheduling_generation: unrelated.revision,
-            status: WorkStatus::Waiting {
-                wait_id: unrelated_wait.condition.id.clone(),
-            },
-            capabilities: Default::default(),
-            locks: Default::default(),
-            locality: "runtime".into(),
-            cost_class: "default".into(),
-        },
-    );
-    initial.waits.insert(
-        unrelated_wait.condition.id.clone(),
-        WaitRecord {
-            current_generation: unrelated.revision,
-            generations: std::collections::BTreeMap::from([(
-                unrelated.revision,
-                WaitGenerationRecord {
-                    owner: SchedulerOwner::WorkItem {
-                        work_item_id: unrelated.id,
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    for (work_item, wait_id) in [
+        (&target, &target_wait.condition.id),
+        (&unrelated, &unrelated_wait.condition.id),
+    ] {
+        execution.work_items.insert(
+            work_item.id.clone(),
+            crate::domain::execution_protocol::WorkItemExecutionRecord {
+                source_revision: work_item.revision,
+                state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                    generation: work_item.revision,
+                    wait: crate::domain::execution_protocol::WaitReference {
+                        wait_id: wait_id.clone(),
                     },
-                    state: WaitState::Active,
-                    trigger: None,
-                    consuming_activation_id: None,
                 },
-            )]),
-        },
-    );
+            },
+        );
+    }
     runtime
         .inner
         .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition("default", &initial)
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
         .unwrap();
     let message = runtime
         .enqueue(trusted_operator_prompt(
@@ -4549,30 +4222,21 @@ async fn authoritative_explicit_operator_binding_ignores_unrelated_waits() {
         Some(target.id.as_str())
     );
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    let admission = &snapshot.activation_admissions[&activation_id].activation;
+    let attempt = &execution.attempts[&activation_id];
     assert!(matches!(
-        &admission.cause,
-        ActivationCause::OperatorInput {
-            message_id,
-            resume: Some(resume),
-        } if message_id == &message.id && resume.wait_id == target_wait.condition.id
+        &attempt.source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TriggeredWait {
+            wait_id,
+            trigger_message_id,
+        } if trigger_message_id == &message.id && wait_id == &target_wait.condition.id
     ));
-    let target_generation = snapshot.waits[&target_wait.condition.id].current_generation;
-    assert_eq!(
-        snapshot.waits[&target_wait.condition.id].generations[&target_generation].state,
-        WaitState::Consumed
-    );
-    let unrelated_generation = snapshot.waits[&unrelated_wait.condition.id].current_generation;
-    assert_eq!(
-        snapshot.waits[&unrelated_wait.condition.id].generations[&unrelated_generation].state,
-        WaitState::Active
-    );
     runtime
         .record_wait_reconciliation_signals(&message)
         .await
@@ -4682,157 +4346,13 @@ async fn canonical_processed_settlement_without_terminal_turn_fails_closed() {
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
             .unwrap()
-            .activations[&activation_id]
+            .unwrap()
+            .attempts[&activation_id]
             .state,
-        crate::domain::scheduler_protocol::ActivationState::Running
+        crate::domain::execution_protocol::ExecutionAttemptState::Open
     );
-}
-
-#[tokio::test]
-async fn authoritative_explicit_operator_wait_ambiguity_remains_queued() {
-    let dir = tempdir().unwrap();
-    let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(CountingProvider {
-            calls: Mutex::new(0),
-            reply: "unused",
-        }),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-    let work_item = runtime
-        .create_work_item("ambiguous operator wait".into(), None, None, Vec::new())
-        .await
-        .unwrap();
-    let registration = runtime
-        .register_wait_for(
-            "default",
-            Some(work_item.id.clone()),
-            WaitForWakeKind::OperatorInput,
-            None,
-            "waiting for operator".into(),
-            None,
-        )
-        .await
-        .unwrap();
-    let mut duplicate = registration.condition.clone();
-    duplicate.id = format!("{}-duplicate", registration.condition.id);
-    runtime.storage().append_wait_condition(&duplicate).unwrap();
-    let wait_generation = 1;
-    let wait_record = |owner| WaitRecord {
-        current_generation: wait_generation,
-        generations: std::collections::BTreeMap::from([(
-            wait_generation,
-            WaitGenerationRecord {
-                owner,
-                state: WaitState::Active,
-                trigger: None,
-                consuming_activation_id: None,
-            },
-        )]),
-    };
-    runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition(
-            "default",
-            &Snapshot {
-                slot: ActivationSlot::Idle,
-                dispatch: AgentDispatchState::Awaiting {
-                    wait: WaitIdentity {
-                        id: registration.condition.id.clone(),
-                        generation: wait_generation,
-                    },
-                },
-                dispatch_revision: 1,
-                focus: None,
-                work: Default::default(),
-                waits: std::collections::BTreeMap::from([
-                    (
-                        registration.condition.id.clone(),
-                        wait_record(SchedulerOwner::AgentLifecycle {
-                            agent_id: "default".into(),
-                        }),
-                    ),
-                    (
-                        duplicate.id.clone(),
-                        wait_record(SchedulerOwner::AgentLifecycle {
-                            agent_id: "default".into(),
-                        }),
-                    ),
-                ]),
-                activations: Default::default(),
-                activation_admissions: Default::default(),
-                settlements: Default::default(),
-                missing_settlements: Default::default(),
-                admitted_generations: Default::default(),
-                continuation_admissions: Default::default(),
-                activation_inputs: Default::default(),
-            },
-        )
-        .unwrap();
-    let message = runtime
-        .enqueue(trusted_operator_prompt(
-            Some(&work_item.id),
-            "ambiguous explicit operator input",
-        ))
-        .await
-        .unwrap();
-
-    for _ in 0..2 {
-        assert!(matches!(
-            scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-                .poll()
-                .await
-                .unwrap(),
-            scheduler_executor::RunLoopPoll::AuthorityBlocked
-        ));
-    }
-    assert_eq!(
-        runtime
-            .inner
-            .runtime_db
-            .queue_entries()
-            .latest_all()
-            .unwrap()
-            .into_iter()
-            .find(|entry| entry.message_id == message.id)
-            .map(|entry| entry.status),
-        Some(QueueEntryStatus::Queued)
-    );
-    let advisories = runtime
-        .storage()
-        .read_recent_events(usize::MAX)
-        .unwrap()
-        .into_iter()
-        .filter(|event| {
-            event.kind == "scheduling_advisory"
-                && event.data["kind"] == "ambiguous_canonical_wait_binding"
-                && event.data["evidence"].as_array().is_some_and(|evidence| {
-                    evidence
-                        .iter()
-                        .any(|item| item == &format!("message_id={}", message.id))
-                })
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(advisories.len(), 1);
-    assert!(advisories[0].data["evidence"]
-        .as_array()
-        .is_some_and(|evidence| {
-            evidence.iter().any(|item| {
-                item.as_str().is_some_and(|item| {
-                    item.contains(&registration.condition.id) && item.contains(&duplicate.id)
-                })
-            })
-        }));
 }
 
 #[tokio::test]
@@ -4953,16 +4473,20 @@ async fn authoritative_completion_terminalizes_canonical_work_and_binds_report()
     let runner = tokio::spawn(runtime.clone().run());
     tokio::time::timeout(std::time::Duration::from_secs(5), async {
         loop {
-            let snapshot = runtime
+            let execution = runtime
                 .inner
                 .runtime_db
                 .transitions()
-                .load_scheduler_protocol_snapshot_if_initialized("default")
+                .load_execution_protocol_state_if_initialized("default")
                 .unwrap();
-            if snapshot.as_ref().is_some_and(|snapshot| {
-                snapshot
-                    .settlements
-                    .contains_key(&canonical_settlement_id(&message.id))
+            if execution.as_ref().is_some_and(|execution| {
+                execution
+                    .attempts
+                    .get(&activation_id)
+                    .is_some_and(|attempt| {
+                        attempt.state
+                            == crate::domain::execution_protocol::ExecutionAttemptState::Settled
+                    })
             }) {
                 break;
             }
@@ -4983,25 +4507,36 @@ async fn authoritative_completion_terminalizes_canonical_work_and_binds_report()
         .result_brief_id
         .as_deref()
         .expect("completion report should bind");
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("completion should preserve execution authority");
     assert_eq!(
-        snapshot.activations[&activation_id].state,
-        crate::domain::scheduler_protocol::ActivationState::Settled
+        execution.attempts[&activation_id].state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
-    assert_eq!(snapshot.work[&work_item.id].status, WorkStatus::Terminal);
+    assert!(matches!(
+        execution.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Terminal {
+            ref completion,
+            ..
+        } if completion == result_brief_id
+    ));
+    let outcome_id = execution.attempts[&activation_id]
+        .terminal_outcome_id
+        .as_deref()
+        .expect("completion attempt should reference outcome");
     assert_eq!(
-        snapshot.settlements[&canonical_settlement_id(&message.id)]
-            .operator_delivery
-            .as_deref(),
-        Some(result_brief_id)
+        execution.outcomes[outcome_id].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Complete {
+                completion: result_brief_id.to_string(),
+            },
+        )
     );
-    // Phase 4: missing-settlement recovery is replaced by Interrupted settlement.
-    assert!(snapshot.missing_settlements.is_empty());
 }
 
 #[tokio::test]
@@ -5026,6 +4561,7 @@ async fn task_rejoin_ignores_legacy_wait_duplicate_missing_from_canonical_snapsh
         .await
         .unwrap();
     runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    append_running_rejoin_task(&runtime, "task-ambiguous", &work_item.id);
     let registration = runtime
         .register_wait_for(
             "default",
@@ -5037,8 +4573,34 @@ async fn task_rejoin_ignores_legacy_wait_duplicate_missing_from_canonical_snapsh
         )
         .await
         .unwrap();
+    let waiting_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem");
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: waiting_work.revision,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation: waiting_work.revision,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: registration.condition.id.clone(),
+                },
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
     let mut duplicate_wait = registration.condition.clone();
     duplicate_wait.id = "wait-task-ambiguous-duplicate".into();
+    duplicate_wait.status = WaitConditionStatus::Cancelled;
+    duplicate_wait.cancelled_at = Some(Utc::now());
+    duplicate_wait.updated_at = Utc::now();
     runtime
         .storage()
         .append_wait_condition(&duplicate_wait)
@@ -5150,7 +4712,8 @@ async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent(
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
             .unwrap();
         finish_claimed_test_run(&runtime).await;
 
@@ -5180,9 +4743,9 @@ async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent(
                 .inner
                 .runtime_db
                 .transitions()
-                .load_scheduler_protocol_snapshot("default")
+                .load_execution_protocol_state_if_initialized("default")
                 .unwrap(),
-            claimed
+            Some(claimed)
         );
         assert_eq!(
             runtime
@@ -5253,12 +4816,14 @@ async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent(
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
             .unwrap();
-        assert_eq!(settled.slot, ActivationSlot::Idle);
-        assert!(settled
-            .settlements
-            .contains_key(&canonical_settlement_id(&message.id)));
+        let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+        assert_eq!(
+            settled.attempts[&activation_id].state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Settled
+        );
         assert_eq!(
             runtime
                 .inner
@@ -5362,16 +4927,18 @@ async fn terminal_settlement_survives_post_commit_effect_faults() {
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].effect, expected_effect);
 
-        let snapshot = runtime
+        let execution = runtime
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
             .unwrap();
-        assert_eq!(snapshot.slot, ActivationSlot::Idle);
-        assert!(snapshot
-            .settlements
-            .contains_key(&canonical_settlement_id(&message.id)));
+        let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+        assert_eq!(
+            execution.attempts[&activation_id].state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Settled
+        );
         assert_eq!(
             runtime
                 .inner
@@ -5456,7 +5023,8 @@ async fn runtime_failure_terminal_fault_rolls_back_queue_canonical_and_failure_e
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
     runtime.inject_next_transition_fault(
         crate::runtime_db::transitions::TransitionFaultPoint::AfterAuditWrites,
@@ -5474,7 +5042,8 @@ async fn runtime_failure_terminal_fault_rolls_back_queue_canonical_and_failure_e
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
             .unwrap(),
         claimed
     );
@@ -5584,7 +5153,8 @@ async fn interrupted_terminal_fault_rolls_back_queue_canonical_and_turn_facts() 
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
     let run_id = runtime
         .agent_state()
@@ -5614,7 +5184,8 @@ async fn interrupted_terminal_fault_rolls_back_queue_canonical_and_turn_facts() 
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot("default")
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
             .unwrap(),
         claimed
     );
@@ -5696,41 +5267,6 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         )
         .await
         .unwrap();
-    let scheduling_generation = work_item.revision.saturating_sub(1);
-    runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition(
-            "default",
-            &Snapshot {
-                slot: ActivationSlot::Idle,
-                dispatch: AgentDispatchState::Open,
-                dispatch_revision: 0,
-                focus: None,
-                work: std::collections::BTreeMap::from([(
-                    work_item.id.clone(),
-                    WorkDemand {
-                        metadata_revision: work_item.revision,
-                        scheduling_generation,
-                        status: WorkStatus::Runnable,
-                        capabilities: Default::default(),
-                        locks: Default::default(),
-                        locality: "runtime".into(),
-                        cost_class: "default".into(),
-                    },
-                )]),
-                waits: Default::default(),
-                activations: Default::default(),
-                activation_admissions: Default::default(),
-                settlements: Default::default(),
-                missing_settlements: Default::default(),
-                admitted_generations: Default::default(),
-                continuation_admissions: Default::default(),
-                activation_inputs: Default::default(),
-            },
-        )
-        .unwrap();
     let mut message = MessageEnvelope::new(
         "default",
         MessageKind::SystemTick,
@@ -5757,13 +5293,6 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         .unwrap();
     assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let claimed = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let activation = &claimed.activations[&activation_id];
     let execution = runtime
         .inner
         .runtime_db
@@ -5771,16 +5300,14 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         .load_execution_protocol_state_if_initialized("default")
         .unwrap()
         .expect("production claim should initialize the execution partition");
+    let attempt = &execution.attempts[&activation_id];
     assert_eq!(
-        activation.admitted_generation,
-        execution.work_items[&work_item.id].generation()
-    );
-    assert_ne!(activation.admitted_generation, scheduling_generation);
-    assert_eq!(
-        claimed.activation_admissions[&activation_id]
-            .activation
-            .source_revision,
+        attempt.admitted_fences.work_item_source_revision,
         Some(work_item.revision)
+    );
+    assert_eq!(
+        attempt.admitted_fences.work_item_generation,
+        Some(execution.work_items[&work_item.id].generation())
     );
 
     runtime
@@ -5881,20 +5408,16 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    let settlement = settled
-        .settlements
-        .get(&canonical_settlement_id(&message.id))
-        .expect("completed activation should have an exact settlement");
-    assert_eq!(
-        settlement.operator_delivery.as_deref(),
-        Some(result_brief_id.as_str())
-    );
-    assert_ne!(
-        settlement.operator_delivery.as_deref(),
-        Some(decoy.id.as_str())
-    );
+    let attempt = &settled.attempts[&activation_id];
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Complete { completion }
+        ) if completion == &result_brief_id && completion != &decoy.id
+    ));
 }
 
 #[tokio::test]
@@ -5949,6 +5472,7 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
             .unwrap(),
         scheduler_executor::RunLoopPoll::Message(_)
     ));
+    append_running_rejoin_task(&runtime, "task-complete-after-wait", &work_item.id);
     let registration = runtime
         .register_wait_for(
             "default",
@@ -6012,18 +5536,30 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let source_revision = claimed.activation_admissions[&activation_id]
-        .activation
-        .source_revision
-        .expect("wait resume source revision");
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("wait resume should preserve execution authority");
+    let attempt = &claimed.attempts[&activation_id];
+    let source_revision = attempt
+        .admitted_fences
+        .work_item_source_revision
+        .expect("wait resume WorkItem source revision");
+    assert!(matches!(
+        &attempt.source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TaskResult {
+            task_id,
+            result_message_id,
+        } if task_id == "task-complete-after-wait" && result_message_id == &resume.id
+    ));
     assert_eq!(
-        claimed.waits[&registration.condition.id].generations
-            [&claimed.waits[&registration.condition.id].current_generation]
-            .consuming_activation_id
-            .as_deref(),
-        Some(activation_id.as_str())
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|wait| wait.id == registration.condition.id)
+            .map(|wait| wait.status),
+        Some(WaitConditionStatus::Resolved)
     );
 
     runtime
@@ -6052,7 +5588,7 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
             .as_ref()
             .expect("completion intent")
             .expected_work_revision,
-        source_revision + 1
+        source_revision
     );
     let completed = runtime
         .promote_work_item_completion_report(
@@ -6092,15 +5628,20 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("completion should preserve execution authority");
+    let attempt = &settled.attempts[&activation_id];
     assert_eq!(
-        settled.settlements[&canonical_settlement_id(&resume.id)]
-            .operator_delivery
-            .as_deref(),
-        Some(result_brief_id.as_str())
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
     );
-    assert!(settled.missing_settlements.is_empty());
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Complete { completion }
+        ) if completion == &result_brief_id
+    ));
 }
 
 #[tokio::test]
@@ -6226,30 +5767,25 @@ async fn completed_production_settlement_interrupts_mismatched_completion_execut
         .await
         .unwrap());
 
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    assert_eq!(snapshot.slot, ActivationSlot::Idle);
-    // Phase 4: missing-settlement replaced by Interrupted settlement.
-    assert!(snapshot
-        .settlements
-        .values()
-        .any(|s| s.activation_id == activation_id
-            && matches!(
-                s.disposition,
-                crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
-            )));
+    let attempt = &execution.attempts[&activation_id];
     assert_eq!(
-        snapshot
-            .activations
-            .get(&activation_id)
-            .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::Interrupted)
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
     );
+    assert!(matches!(
+        &execution.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { .. }
+        )
+    ));
     assert_eq!(
         runtime
             .inner
@@ -6344,39 +5880,23 @@ async fn completed_production_settlement_interrupts_without_result_report() {
         .unwrap());
 
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
-    assert_eq!(snapshot.slot, ActivationSlot::Idle);
-    // Phase 4: missing-settlement replaced by Interrupted settlement.
-    assert!(snapshot
-        .settlements
-        .values()
-        .any(|s| s.activation_id == activation_id
-            && matches!(
-                s.disposition,
-                crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
-            )));
+    let attempt = &execution.attempts[&activation_id];
     assert_eq!(
-        snapshot
-            .activations
-            .get(&activation_id)
-            .map(|activation| activation.state.clone()),
-        Some(crate::domain::scheduler_protocol::ActivationState::Interrupted)
-    );
-    assert_eq!(
-        snapshot
-            .work
-            .get(&work_item.id)
-            .map(|demand| &demand.status),
-        Some(&WorkStatus::Runnable)
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
     );
     assert!(matches!(
-        snapshot.settlements[&canonical_settlement_id(&message.id)].disposition,
-        crate::domain::scheduler_protocol::ActivationDisposition::Interrupted { .. }
+        &execution.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { .. }
+        )
     ));
 }
 
@@ -6427,12 +5947,7 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_protocol_fact
             .await
             .unwrap();
         assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
-        let claimed = runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot("default")
-            .unwrap();
+
         let claimed_execution = runtime
             .inner
             .runtime_db
@@ -6467,15 +5982,6 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_protocol_fact
             "unexpected error for {fault:?}: {error:#}"
         );
 
-        assert_eq!(
-            runtime
-                .inner
-                .runtime_db
-                .transitions()
-                .load_scheduler_protocol_snapshot("default")
-                .unwrap(),
-            claimed
-        );
         assert_eq!(
             runtime
                 .inner
@@ -7161,6 +6667,7 @@ async fn wait_for_task_result_marks_work_item_waiting_and_allows_sleep() {
         runtime.storage().write_agent(&guard.state).unwrap();
     }
 
+    append_running_rejoin_task(&runtime, "task-1", &work.id);
     runtime
         .register_wait_for(
             "default",
@@ -7343,6 +6850,7 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
         .create_work_item("wait for task".into(), None, None, Vec::new())
         .await
         .unwrap();
+    append_running_rejoin_task(&runtime, "task-1", &work.id);
     runtime
         .register_wait_for(
             "default",
@@ -8074,21 +7582,6 @@ async fn enqueue_inherits_current_work_item_and_preserves_canonical_provenance()
         scheduler_executor::RunLoopPoll::Message(_)
     ));
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let scheduler = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let activation = &scheduler.activation_admissions[&activation_id].activation;
-    assert_eq!(
-        activation.provenance.origin,
-        crate::domain::scheduler_protocol::ActivationOrigin::System
-    );
-    assert_eq!(
-        activation.provenance.trust,
-        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence
-    );
     let execution = runtime
         .inner
         .runtime_db
@@ -8099,6 +7592,10 @@ async fn enqueue_inherits_current_work_item_and_preserves_canonical_provenance()
     assert_eq!(
         execution.attempts[&activation_id].provenance.trust,
         crate::domain::execution_protocol::ExecutionTrust::ExternalEvidence
+    );
+    assert_eq!(
+        execution.attempts[&activation_id].provenance.origin,
+        crate::domain::execution_protocol::ExecutionOrigin::System
     );
     assert!(matches!(
         execution.attempts[&activation_id].source.identity,
@@ -8168,27 +7665,23 @@ async fn enqueue_does_not_bind_to_focus_without_current_turn_ownership() {
 
 #[tokio::test]
 async fn runtime_owned_followup_preserves_all_authority_classes() {
-    use crate::domain::{execution_protocol::ExecutionTrust, scheduler_protocol::ActivationTrust};
+    use crate::domain::execution_protocol::ExecutionTrust;
 
-    for (authority, activation_trust, execution_trust) in [
+    for (authority, execution_trust) in [
         (
             AuthorityClass::OperatorInstruction,
-            ActivationTrust::OperatorInstruction,
             ExecutionTrust::OperatorInstruction,
         ),
         (
             AuthorityClass::RuntimeInstruction,
-            ActivationTrust::RuntimeInstruction,
             ExecutionTrust::RuntimeInstruction,
         ),
         (
             AuthorityClass::IntegrationSignal,
-            ActivationTrust::IntegrationSignal,
             ExecutionTrust::IntegrationSignal,
         ),
         (
             AuthorityClass::ExternalEvidence,
-            ActivationTrust::ExternalEvidence,
             ExecutionTrust::ExternalEvidence,
         ),
     ] {
@@ -8237,19 +7730,6 @@ async fn runtime_owned_followup_preserves_all_authority_classes() {
             scheduler_executor::RunLoopPoll::Message(_)
         ));
         let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-        let scheduler = runtime
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot("default")
-            .unwrap();
-        assert_eq!(
-            scheduler.activation_admissions[&activation_id]
-                .activation
-                .provenance
-                .trust,
-            activation_trust
-        );
         let execution = runtime
             .inner
             .runtime_db
@@ -8312,21 +7792,6 @@ async fn runtime_owned_task_followup_preserves_task_origin_and_external_evidence
         scheduler_executor::RunLoopPoll::Message(_)
     ));
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
-    let scheduler = runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("child")
-        .unwrap();
-    let activation = &scheduler.activation_admissions[&activation_id].activation;
-    assert_eq!(
-        activation.provenance.origin,
-        crate::domain::scheduler_protocol::ActivationOrigin::Task
-    );
-    assert_eq!(
-        activation.provenance.trust,
-        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence
-    );
     let execution = runtime
         .inner
         .runtime_db
@@ -8407,27 +7872,6 @@ async fn runtime_owned_bound_task_followup_survives_scheduler_reload() {
         context_config(),
     )
     .unwrap();
-    let scheduler = reopened
-        .inner
-        .runtime_db
-        .transitions()
-        .load_scheduler_protocol_snapshot("child")
-        .unwrap();
-    let activation = &scheduler.activation_admissions[&activation_id].activation;
-    assert_eq!(
-        activation.provenance.origin,
-        crate::domain::scheduler_protocol::ActivationOrigin::Task
-    );
-    assert_eq!(
-        activation.provenance.trust,
-        crate::domain::scheduler_protocol::ActivationTrust::ExternalEvidence
-    );
-    assert!(matches!(
-        activation.binding,
-        crate::domain::scheduler_protocol::ActivationBinding::WorkItem {
-            ref work_item_id
-        } if work_item_id == &work_item.id
-    ));
     let execution = reopened
         .inner
         .runtime_db
@@ -8438,6 +7882,19 @@ async fn runtime_owned_bound_task_followup_survives_scheduler_reload() {
     assert!(matches!(
         execution.attempts[&activation_id].source.identity,
         crate::domain::execution_protocol::ExecutionSourceIdentity::InternalFollowup { .. }
+    ));
+    assert_eq!(
+        execution.attempts[&activation_id].provenance.origin,
+        crate::domain::execution_protocol::ExecutionOrigin::Task
+    );
+    assert_eq!(
+        execution.attempts[&activation_id].provenance.trust,
+        crate::domain::execution_protocol::ExecutionTrust::ExternalEvidence
+    );
+    assert!(matches!(
+        &execution.attempts[&activation_id].binding,
+        crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id }
+            if work_item_id == &work_item.id
     ));
 }
 
@@ -8579,32 +8036,26 @@ async fn canonical_stale_correlated_wait_is_dropped_without_blocking_next_messag
         .checked_sub(1)
         .filter(|generation| *generation > 0)
         .expect("wait fixture must have an older generation");
-    let mut canonical =
-        canonical_waiting_snapshot(&waiting, &registration.condition.id, current_generation);
-    canonical
-        .waits
-        .get_mut(&registration.condition.id)
-        .unwrap()
-        .generations
-        .insert(
-            old_generation,
-            WaitGenerationRecord {
-                owner: SchedulerOwner::WorkItem {
-                    work_item_id: work_item.id.clone(),
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        waiting.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: waiting.revision,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation: current_generation,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: registration.condition.id.clone(),
                 },
-                state: WaitState::Resolved,
-                trigger: None,
-                consuming_activation_id: None,
             },
-        );
+        },
+    );
     runtime
         .inner
         .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition("default", &canonical)
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
         .unwrap();
 
-    let correlated_message = |text: &str, generation: u64, priority: Priority| {
+    let correlated_message = |text: &str, wait_id: &str, generation: u64, priority: Priority| {
         let mut message = MessageEnvelope::new(
             "default",
             MessageKind::WebhookEvent,
@@ -8623,17 +8074,23 @@ async fn canonical_stale_correlated_wait_is_dropped_without_blocking_next_messag
         message.work_item_id = Some(work_item.id.clone());
         message
             .source_refs
-            .insert("wait_id".into(), registration.condition.id.clone());
+            .insert("wait_id".into(), wait_id.to_string());
         message
             .source_refs
             .insert("wait_generation".into(), generation.to_string());
         message
     };
-    let stale = correlated_message("stale webhook", old_generation, Priority::Next);
+    let stale = correlated_message(
+        "stale webhook",
+        "wait-stale-history",
+        old_generation,
+        Priority::Next,
+    );
     let stale = runtime.enqueue(stale).await.unwrap();
     let valid = runtime
         .enqueue(correlated_message(
             "current webhook",
+            &registration.condition.id,
             current_generation,
             Priority::Normal,
         ))
@@ -8709,6 +8166,8 @@ async fn scheduler_recovery_converges_completed_work_item_lane_reservation() {
         resolved_at: None,
         cancelled_at: Some(Utc::now()),
         turn_id: None,
+        trigger_message_id: None,
+        triggered_at: None,
     };
     runtime.storage().append_wait_condition(&wait).unwrap();
     runtime
@@ -8863,6 +8322,8 @@ async fn lifecycle_ingress_converges_completed_work_item_lane_before_claim() {
         resolved_at: None,
         cancelled_at: Some(Utc::now()),
         turn_id: None,
+        trigger_message_id: None,
+        triggered_at: None,
     };
     runtime.storage().append_wait_condition(&wait).unwrap();
     runtime
@@ -8890,25 +8351,42 @@ async fn lifecycle_ingress_converges_completed_work_item_lane_before_claim() {
         panic!("operator ingress should repair the stale lane before claim");
     };
     assert_eq!(scheduled.message.id, message.id);
-    let repaired = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
         .unwrap();
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
     assert!(matches!(
-        repaired.slot,
-        ActivationSlot::Running {
-            owner: SchedulerOwner::AgentLifecycle { ref agent_id },
+        &execution.attempts[&activation_id],
+        crate::domain::execution_protocol::ExecutionAttempt {
+            binding: crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                agent_id
+            },
+            state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
             ..
         } if agent_id == "default"
     ));
-    assert_eq!(repaired.dispatch, AgentDispatchState::Open);
-    assert_eq!(repaired.focus, None);
-    assert_eq!(repaired.work[&completed.id].status, WorkStatus::Terminal);
     assert_eq!(
-        repaired.waits[&wait.id].generations[&completed.revision].state,
-        WaitState::Resolved
+        runtime
+            .latest_work_item(&completed.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        WorkItemState::Completed
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == wait.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Cancelled)
     );
 }
 
@@ -9547,7 +9025,7 @@ async fn operator_interjection_prompt_is_interjected_before_next_provider_round(
 }
 
 #[tokio::test]
-async fn operator_interjection_attaches_to_lifecycle_activation() {
+async fn operator_interjection_preserves_unified_lifecycle_attempt() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -9576,6 +9054,18 @@ async fn operator_interjection_attaches_to_lifecycle_activation() {
         .begin_interactive_turn(Some(&scheduled.message), None, None)
         .await
         .unwrap();
+    let execution_before = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("lifecycle claim should initialize unified authority");
+    let attempt_id = scheduler_executor::canonical_activation_id(&message.id);
+    assert_eq!(
+        execution_before.attempts[&attempt_id].state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Open
+    );
 
     let mut interjection = trusted_operator_prompt(None, "use the smaller lifecycle fix");
     interjection.priority = Priority::Interject;
@@ -9590,27 +9080,14 @@ async fn operator_interjection_attaches_to_lifecycle_activation() {
         .unwrap();
     assert_eq!(follow_ups.len(), 1);
 
-    let snapshot = runtime
+    let execution_after = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let attachment = snapshot
-        .activation_inputs
-        .values()
-        .find(|attachment| attachment.message_id == interjection.id)
-        .expect("lifecycle activation input attachment");
-    assert_eq!(
-        attachment.activation_id,
-        scheduler_executor::canonical_activation_id(&message.id)
-    );
-    assert_eq!(
-        attachment.owner,
-        SchedulerOwner::AgentLifecycle {
-            agent_id: "default".into(),
-        }
-    );
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("interjection should preserve unified authority");
+    assert_eq!(execution_after, execution_before);
     assert_eq!(
         runtime
             .storage()
@@ -10030,6 +9507,8 @@ async fn task_result_records_wait_reconciliation_and_resolves_task_wait_conditio
             cancelled_at: None,
 
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -10134,6 +9613,8 @@ async fn legacy_task_result_resolves_unique_wait_without_canonical_partition() {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -10251,6 +9732,8 @@ async fn timer_and_system_ticks_record_wait_reconciliation_signals() {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
     }
@@ -10345,17 +9828,11 @@ async fn same_turn_message_does_not_reconcile_wait_condition() {
         resolved_at: None,
         cancelled_at: None,
         turn_id: Some("turn-seed".into()),
+        trigger_message_id: None,
+        triggered_at: None,
     };
     runtime.storage().append_wait_condition(&wait).unwrap();
-    runtime
-        .inner
-        .runtime_db
-        .transitions()
-        .initialize_scheduler_protocol_partition(
-            "default",
-            &canonical_waiting_snapshot(&work_item, &wait.id, work_item.revision),
-        )
-        .unwrap();
+    persist_waiting_work_execution(&runtime, &work_item, &wait.id);
 
     // Process an operator message that belongs to the SAME turn that created the
     // wait condition.  It must NOT reconcile the wait.
@@ -10456,6 +9933,24 @@ async fn work_item_wait_resume_repairs_missing_scheduler_wait_mirror() {
         .await
         .unwrap()
         .unwrap();
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: work_item.revision,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation: work_item.revision,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: wait.condition.id.clone(),
+                },
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
     let mut snapshot =
         canonical_waiting_snapshot(&work_item, &wait.condition.id, work_item.revision);
     snapshot.dispatch = AgentDispatchState::Open;
@@ -10485,25 +9980,26 @@ async fn work_item_wait_resume_repairs_missing_scheduler_wait_mirror() {
     };
     assert_eq!(scheduled.message.id, message.id);
 
-    let snapshot = runtime
+    let execution = runtime
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("claim should preserve unified execution authority");
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
     assert!(matches!(
-        &snapshot.activation_admissions[&activation_id].activation.cause,
-        ActivationCause::OperatorInput {
-            message_id,
-            resume: Some(resume),
-        } if message_id == &message.id
-            && resume.wait_id == wait.condition.id
-            && resume.wait_generation == work_item.revision
+        &execution.attempts[&activation_id].source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TriggeredWait {
+            wait_id,
+            trigger_message_id,
+        } if trigger_message_id == &message.id && wait_id == &wait.condition.id
     ));
     assert_eq!(
-        snapshot.waits[&wait.condition.id].generations[&work_item.revision].state,
-        WaitState::Consumed
+        execution.attempts[&activation_id].binding,
+        crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+            work_item_id: work_item.id.clone(),
+        }
     );
 
     runtime

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -131,6 +131,8 @@ fn append_active_external_wait_condition(
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 }
@@ -159,6 +161,8 @@ fn append_operator_wait_condition(
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 }
@@ -787,6 +791,8 @@ fn idle_boundary_decision_waits_for_non_current_work_item_wait() {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -1040,6 +1046,8 @@ fn scheduling_advisories_detect_weak_external_wait_and_unrecoverable_blocker() {
             cancelled_at: None,
 
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -1116,6 +1124,8 @@ fn scheduling_advisories_do_not_warn_for_common_legal_waits() {
             cancelled_at: None,
 
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -1162,6 +1172,8 @@ fn scheduling_advisory_append_dedupes_interleaved_recent_events() {
             cancelled_at: None,
 
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
     let appended = scheduler::append_scheduling_advisories(&storage, &agent, 0).unwrap();
@@ -1276,6 +1288,8 @@ fn append_task_wait_condition(
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 }
@@ -1570,15 +1584,15 @@ fn correlated_wait_resume_requires_the_exact_expected_owner() {
     for candidate in [
         scheduler::CanonicalActivationCandidate::ExactWaitResume {
             expected_work_item_id: Some("work-b".into()),
-            correlated_wait: Some(("wait-work".into(), 7)),
+            correlated_wait: Some("wait-work".into()),
         },
         scheduler::CanonicalActivationCandidate::ExactWaitResume {
             expected_work_item_id: None,
-            correlated_wait: Some(("wait-work".into(), 7)),
+            correlated_wait: Some("wait-work".into()),
         },
         scheduler::CanonicalActivationCandidate::ExactWaitResume {
             expected_work_item_id: Some("work-a".into()),
-            correlated_wait: Some(("wait-lifecycle".into(), 8)),
+            correlated_wait: Some("wait-lifecycle".into()),
         },
     ] {
         assert_eq!(
@@ -1594,7 +1608,7 @@ fn correlated_wait_resume_requires_the_exact_expected_owner() {
             &message,
             scheduler::CanonicalActivationCandidate::ExactWaitResume {
                 expected_work_item_id: Some("work-a".into()),
-                correlated_wait: Some(("wait-work".into(), 7)),
+                correlated_wait: Some("wait-work".into()),
             },
         )
         .unwrap(),
@@ -1611,7 +1625,7 @@ fn correlated_wait_resume_requires_the_exact_expected_owner() {
             &message,
             scheduler::CanonicalActivationCandidate::ExactWaitResume {
                 expected_work_item_id: None,
-                correlated_wait: Some(("wait-lifecycle".into(), 8)),
+                correlated_wait: Some("wait-lifecycle".into()),
             },
         )
         .unwrap(),
@@ -1628,11 +1642,16 @@ fn correlated_wait_resume_requires_the_exact_expected_owner() {
             &message,
             scheduler::CanonicalActivationCandidate::ExactWaitResume {
                 expected_work_item_id: Some("work-a".into()),
-                correlated_wait: Some(("wait-work".into(), 6)),
+                correlated_wait: Some("wait-work".into()),
             },
         )
         .unwrap(),
-        None
+        Some(scheduler::CanonicalActivationScenario::ExactWaitResume {
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: "work-a".into(),
+            },
+            wait_id: "wait-work".into(),
+        })
     );
 }
 
@@ -1772,6 +1791,8 @@ fn timer_tick_only_matches_the_wait_for_the_same_timer() {
         resolved_at: None,
         cancelled_at: None,
         turn_id: None,
+        trigger_message_id: None,
+        triggered_at: None,
     };
     let mut other = matching.clone();
     other.id = "wait-other".into();
@@ -1995,6 +2016,8 @@ fn setup_waiting_operator_work_item(
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 }

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1,6 +1,5 @@
 use super::super::*;
 use super::support::*;
-use crate::domain::scheduler_protocol::WaitState;
 use crate::types::{
     CompletionReportState, WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
     WorkItemContinuationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState,
@@ -448,6 +447,8 @@ async fn work_queue_projection_derives_scheduling_state_per_work_item() {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
     runtime
@@ -611,6 +612,8 @@ async fn work_item_query_tools_return_current_open_done_views() {
             cancelled_at: None,
 
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -976,6 +979,8 @@ async fn work_item_query_tools_return_readiness_views() {
             cancelled_at: None,
 
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
 
@@ -3697,6 +3702,8 @@ async fn agent_scoped_wake_hint_binds_unique_wildcard_external_wait() {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
     let capability = runtime
@@ -3779,6 +3786,8 @@ async fn agent_scoped_wake_hint_does_not_bind_ambiguous_wildcard_external_waits(
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
     }
@@ -4002,23 +4011,14 @@ async fn external_wake_records_wait_reconciliation_and_resolves_wait() {
         .inner
         .runtime_db
         .transitions()
-        .load_scheduler_protocol_snapshot("default")
-        .unwrap();
-    let canonical_wait = settled
-        .waits
-        .get(&wait_condition_id)
-        .expect("settlement should create the canonical external wait");
-    let canonical_generation = canonical_wait.current_generation;
-    assert_eq!(
-        canonical_wait.generations[&canonical_generation]
-            .owner
-            .work_item_id(),
-        Some(work.id.as_str())
-    );
-    assert_eq!(
-        canonical_wait.generations[&canonical_generation].state,
-        WaitState::Active
-    );
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("settlement should preserve unified execution authority");
+    assert!(matches!(
+        &settled.work_items[&work.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == wait_condition_id
+    ));
     let local_wait = runtime
         .storage()
         .latest_wait_conditions()
@@ -4046,7 +4046,7 @@ async fn external_wake_records_wait_reconciliation_and_resolves_wait() {
             .exact_external_wait_correlation(Some(&trigger_id))
             .await
             .unwrap(),
-        Some((wait_condition_id.clone(), canonical_generation)),
+        Some(wait_condition_id.clone()),
         "callback ingress should resolve one exact active canonical wait"
     );
 
@@ -4095,10 +4095,9 @@ async fn external_wake_records_wait_reconciliation_and_resolves_wait() {
     assert_eq!(scheduled.message.id, tick.id);
 
     let mut mismatched = scheduled.message.clone();
-    mismatched.source_refs.insert(
-        "wait_generation".into(),
-        canonical_generation.saturating_add(1).to_string(),
-    );
+    mismatched
+        .source_refs
+        .insert("wait_generation".into(), u64::MAX.to_string());
     runtime
         .record_wait_reconciliation_signals(&mismatched)
         .await
@@ -4108,9 +4107,8 @@ async fn external_wake_records_wait_reconciliation_and_resolves_wait() {
             .storage()
             .active_wait_conditions_for_work_item("default", &work.id)
             .unwrap()
-            .iter()
-            .any(|condition| condition.id == wait_condition_id),
-        "mismatched canonical generation must not resolve the external wait"
+            .is_empty(),
+        "legacy generation must not veto an exact unified wait identity"
     );
 
     runtime
@@ -4125,23 +4123,17 @@ async fn external_wake_records_wait_reconciliation_and_resolves_wait() {
         .unwrap();
 
     let events = runtime.storage().read_recent_events(100).unwrap();
-    let signal = events
-        .iter()
-        .find(|event| {
-            event.kind == "wait_reconciliation_requested"
-                && event.data["wait_condition_id"] == wait_condition_id
-        })
-        .expect("external wake should request wait reconciliation");
-    assert_eq!(
-        signal.data["wake_source"].as_str(),
-        Some("external_ingress")
+    assert!(
+        events.iter().any(|event| {
+            event.kind == "wait_conditions_resolved"
+                && event.data["message_id"] == tick.id
+                && event.data["reason"] == "execution_admission"
+                && event.data["wait_condition_ids"]
+                    .as_array()
+                    .is_some_and(|ids| ids.iter().any(|id| id == &wait_condition_id))
+        }),
+        "external wake admission should atomically resolve the exact wait"
     );
-    assert_eq!(signal.data["work_item_id"].as_str(), Some(work.id.as_str()));
-    assert_eq!(
-        signal.data["subject_ref"].as_str(),
-        Some(trigger_id.as_str())
-    );
-    assert_eq!(signal.data["waiting_for"].as_str(), Some("checks complete"));
 
     let active = runtime
         .storage()
@@ -4647,6 +4639,8 @@ async fn current_external_wait_does_not_suppress_queued_runnable_work_item() {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         })
         .unwrap();
     let mut agent = AgentState::new("default");

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -61,7 +61,7 @@ use crate::runtime::{
 };
 
 enum OperatorInterjectionPlan {
-    Attach(Vec<crate::domain::scheduler_protocol::ProtocolCommand>),
+    Admit,
     LegacyTurnDeferred {
         scenario_class: Option<crate::domain::scheduler_protocol::SchedulerScenarioClass>,
         effective_mode: crate::domain::scheduler_protocol::ScenarioMode,
@@ -432,14 +432,14 @@ impl RuntimeHandle {
                         break 'outer;
                     };
                     let expected_state = guard.state.clone();
-                    let protocol_commands = match self.operator_interjection_protocol_commands(
+                    match self.operator_interjection_plan(
                         agent_id,
                         &expected_state,
                         &message,
                         round,
                         boundary_str,
                     )? {
-                        OperatorInterjectionPlan::Attach(commands) => commands,
+                        OperatorInterjectionPlan::Admit => {}
                         OperatorInterjectionPlan::LegacyTurnDeferred {
                             scenario_class,
                             effective_mode,
@@ -456,7 +456,7 @@ impl RuntimeHandle {
                             )?;
                             break 'outer;
                         }
-                    };
+                    }
                     let mut committed_state = expected_state.clone();
                     committed_state.pending = guard.queue.len().saturating_sub(1);
                     let text = render_operator_interjection_text(&message);
@@ -512,7 +512,7 @@ impl RuntimeHandle {
                             ),
                             scheduler_claim_work_item: None,
                             scheduler_protocol_bootstrap: None,
-                            scheduler_protocol_commands: protocol_commands,
+                            scheduler_protocol_commands: Vec::new(),
                             agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
                                 expected: Some(Box::new(expected_state)),
                                 record: Box::new(committed_state.clone()),
@@ -531,9 +531,7 @@ impl RuntimeHandle {
                         Err(error) => {
                             let can_retry = attempt + 1
                                 < crate::runtime::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
-                                && crate::runtime::retryable_enqueue_agent_state_conflict(
-                                    &error, agent_id,
-                                );
+                                && crate::runtime::retryable_enqueue_conflict(&error, agent_id);
                             if !can_retry {
                                 return Err(error);
                             }
@@ -571,7 +569,7 @@ impl RuntimeHandle {
         Ok(follow_up_texts)
     }
 
-    fn operator_interjection_protocol_commands(
+    fn operator_interjection_plan(
         &self,
         agent_id: &str,
         expected_state: &crate::types::AgentState,
@@ -579,10 +577,7 @@ impl RuntimeHandle {
         round: usize,
         boundary: &str,
     ) -> Result<OperatorInterjectionPlan> {
-        use crate::domain::scheduler_protocol::{
-            ActivationInputAttachment, ActivationOrigin, ActivationProvenance, ActivationTrust,
-            AttachActivationInputCommand, ProtocolCommand, ScenarioMode,
-        };
+        use crate::domain::scheduler_protocol::ScenarioMode;
         use crate::types::ExecutionAdmissionProvenance;
 
         let execution_binding = expected_state
@@ -638,65 +633,42 @@ impl RuntimeHandle {
                 ));
             }
         };
-        let snapshot = self
+        let execution = self
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+            .load_execution_protocol_state_if_initialized(agent_id)?
             .ok_or_else(|| {
-                anyhow::anyhow!("operator interjection requires an initialized protocol partition")
+                anyhow::anyhow!("operator interjection requires unified execution authority")
             })?;
-        let activation = snapshot.activations.get(activation_id).ok_or_else(|| {
-            anyhow::anyhow!("operator interjection references an unknown canonical activation")
+        let attempt = execution.attempts.get(activation_id).ok_or_else(|| {
+            anyhow::anyhow!("operator interjection references an unknown execution attempt")
         })?;
-        if snapshot
-            .activation_admissions
-            .get(activation_id)
-            .is_none_or(|admission| {
-                admission.activation.provenance.source_id != execution_binding.source_message_id
-            })
+        if attempt.state != crate::domain::execution_protocol::ExecutionAttemptState::Open
+            || attempt.source_message_id.as_deref()
+                != Some(execution_binding.source_message_id.as_str())
         {
             return Err(anyhow::anyhow!(
-                "operator interjection activation disagrees with the source message"
+                "operator interjection attempt disagrees with the current source message"
             ));
         }
-        match &activation.owner {
-            crate::domain::scheduler_protocol::SchedulerOwner::WorkItem { work_item_id }
+        match &attempt.binding {
+            crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id }
                 if execution_binding.work_item_id.as_deref() == Some(work_item_id.as_str()) => {}
-            crate::domain::scheduler_protocol::SchedulerOwner::AgentLifecycle {
+            crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
                 agent_id: owner_agent_id,
             } if owner_agent_id == agent_id && execution_binding.work_item_id.is_none() => {}
+            crate::domain::execution_protocol::ExecutionBinding::Conversation { .. }
+                if execution_binding.work_item_id.is_none() => {}
             _ => {
                 return Err(anyhow::anyhow!(
-                    "operator interjection execution binding disagrees with activation owner"
+                    "operator interjection execution binding disagrees with attempt owner"
                 ));
             }
         }
 
-        Ok(OperatorInterjectionPlan::Attach(vec![
-            ProtocolCommand::AttachActivationInput(AttachActivationInputCommand {
-                attachment: ActivationInputAttachment {
-                    id: format!("activation-input:{}", message.id),
-                    activation_id: activation_id.to_string(),
-                    owner: activation.owner.clone(),
-                    expected_admitted_generation: activation.admitted_generation,
-                    expected_dispatch_revision: snapshot.dispatch_revision,
-                    message_id: message.id.clone(),
-                    turn_id: execution_binding.turn_id.clone(),
-                    boundary: boundary.to_string(),
-                    round: u64::try_from(round)
-                        .map_err(|_| anyhow::anyhow!("operator interjection round exceeds u64"))?,
-                    provenance: ActivationProvenance {
-                        origin: ActivationOrigin::Operator,
-                        trust: ActivationTrust::OperatorInstruction,
-                        source_id: message.id.clone(),
-                        correlation_id: message.correlation_id.clone(),
-                        causation_id: message.causation_id.clone(),
-                    },
-                    created_at: message.created_at.to_rfc3339(),
-                },
-            }),
-        ]))
+        let _ = (message, round, boundary);
+        Ok(OperatorInterjectionPlan::Admit)
     }
 
     fn record_deferred_operator_interjection(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -39,6 +39,22 @@ pub(crate) struct WaitForRegistration {
     pub(crate) cancelled_wait_condition_ids: Vec<String>,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "disposition", rename_all = "snake_case")]
+pub(crate) enum WaitForRegistrationOutcome {
+    Registered {
+        registration: WaitForRegistration,
+    },
+    TaskResultQueued {
+        task_id: String,
+        result_message_id: String,
+    },
+    TaskResultAlreadyConsumed {
+        task_id: String,
+        result_message_id: String,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct WorkItemBlockerClearance {
     pub(super) work_item: WorkItemRecord,
@@ -65,6 +81,118 @@ impl WorkItemBlockerClearance {
 }
 
 impl RuntimeHandle {
+    pub(super) fn wait_trigger_transition_for_message(
+        &self,
+        message: &MessageEnvelope,
+    ) -> Result<Option<crate::runtime_db::transitions::QueueWaitTransition>> {
+        let matching = self
+            .inner
+            .storage
+            .raw_active_wait_conditions_for_agent(&message.agent_id)?
+            .into_iter()
+            .filter(|condition| {
+                message
+                    .turn_id
+                    .as_deref()
+                    .zip(condition.turn_id.as_deref())
+                    .is_none_or(|(message_turn, wait_turn)| message_turn != wait_turn)
+            })
+            .filter(|condition| matching_wake_source(message, condition).is_some())
+            .collect::<Vec<_>>();
+        let correlated_wait_id = message.source_refs.get("wait_id");
+        let condition = if let Some(wait_id) = correlated_wait_id {
+            matching.iter().find(|condition| condition.id == *wait_id)
+        } else {
+            matching.iter().max_by_key(|condition| {
+                (
+                    condition.updated_at,
+                    condition.created_at,
+                    condition.id.as_str(),
+                )
+            })
+        };
+        let Some(condition) = condition else {
+            return Ok(None);
+        };
+        let mut triggered = condition.clone();
+        triggered.mark_triggered(&message.id, self.now());
+        Ok(Some(crate::runtime_db::transitions::QueueWaitTransition {
+            expected: crate::runtime_db::transitions::WaitConditionExpectation {
+                id: condition.id.clone(),
+                agent_id: condition.agent_id.clone(),
+                status: condition.status.clone(),
+                updated_at: condition.updated_at,
+            },
+            record: triggered,
+            work_item: None,
+            index_changes: Vec::new(),
+        }))
+    }
+
+    pub(super) fn wait_resolution_transition_for_message(
+        &self,
+        message: &MessageEnvelope,
+    ) -> Result<Option<crate::runtime_db::transitions::QueueWaitTransition>> {
+        let Some(condition) = self
+            .inner
+            .storage
+            .latest_wait_conditions()?
+            .into_iter()
+            .find(|condition| {
+                condition.agent_id == message.agent_id
+                    && condition.status == WaitConditionStatus::Triggered
+                    && condition.trigger_message_id() == Some(message.id.as_str())
+            })
+        else {
+            return Ok(None);
+        };
+        let now = self.now();
+        let mut resolved = condition.clone();
+        resolved.status = WaitConditionStatus::Resolved;
+        resolved.updated_at = now;
+        resolved.resolved_at = Some(now);
+
+        let mut work_item = None;
+        let mut index_changes = Vec::new();
+        if let Some(work_item_id) = resolved.work_item_id.as_deref() {
+            if let Some(existing) = self.inner.runtime_db.work_items().latest(work_item_id)? {
+                if existing.state == WorkItemState::Open
+                    && existing.blocked_by.as_deref() == Some(resolved.waiting_for.as_str())
+                {
+                    let mut record = WorkItemRecord {
+                        revision: existing.revision + 1,
+                        blocked_by: None,
+                        recheck_at: None,
+                        recheck_consumed_at: None,
+                        updated_at: now,
+                        ..existing.clone()
+                    };
+                    crate::work_item_plan::refresh_plan_artifact_metadata(
+                        self.agent_home().as_path(),
+                        &mut record,
+                    )?;
+                    index_changes.extend(self.inner.storage.index_changes_for_work_item(&record)?);
+                    work_item = Some(crate::runtime_db::transitions::WorkItemMutation::Update {
+                        record,
+                        expected_revision: existing.revision,
+                    });
+                }
+            }
+        }
+
+        Ok(Some(crate::runtime_db::transitions::QueueWaitTransition {
+            expected: crate::runtime_db::transitions::WaitConditionExpectation {
+                id: condition.id.clone(),
+                agent_id: condition.agent_id.clone(),
+                status: condition.status.clone(),
+                updated_at: condition.updated_at,
+            },
+            record: resolved,
+            work_item,
+            index_changes,
+        }))
+    }
+
     pub(crate) async fn register_wait_for(
         &self,
         agent_id: &str,
@@ -74,9 +202,75 @@ impl RuntimeHandle {
         reason: String,
         recheck_after_ms: Option<u64>,
     ) -> Result<WaitForRegistration> {
+        match self
+            .register_wait_for_outcome(
+                agent_id,
+                work_item_id,
+                wake,
+                resource,
+                reason,
+                recheck_after_ms,
+            )
+            .await?
+        {
+            WaitForRegistrationOutcome::Registered { registration } => Ok(registration),
+            WaitForRegistrationOutcome::TaskResultQueued {
+                task_id,
+                result_message_id,
+            } => Err(RuntimeError::validation(
+                "task_result_already_queued",
+                format!(
+                    "task {task_id} completed before wait registration; result {result_message_id} was queued"
+                ),
+            )
+            .into()),
+            WaitForRegistrationOutcome::TaskResultAlreadyConsumed {
+                task_id,
+                result_message_id,
+            } => Err(RuntimeError::validation(
+                "task_result_already_consumed",
+                format!(
+                    "task {task_id} result was already consumed: {result_message_id}"
+                ),
+            )
+            .into()),
+        }
+    }
+
+    pub(crate) async fn register_wait_for_outcome(
+        &self,
+        agent_id: &str,
+        work_item_id: Option<String>,
+        wake: WaitForWakeKind,
+        resource: Option<String>,
+        reason: String,
+        recheck_after_ms: Option<u64>,
+    ) -> Result<WaitForRegistrationOutcome> {
         let runtime_agent_id = self.agent_id().await?;
         if agent_id != runtime_agent_id {
             return Err(anyhow!("wait_for agent mismatch: {}", agent_id));
+        }
+
+        let mut expected_task = None;
+        if wake == WaitForWakeKind::TaskResult {
+            let task_id = wait_resource_required(wake, resource.clone())?;
+            let task = self
+                .inner
+                .runtime_db
+                .tasks()
+                .latest(&task_id)?
+                .ok_or_else(|| {
+                    RuntimeError::not_found(
+                        "task_not_found",
+                        format!("wait_for task does not exist: {task_id}"),
+                    )
+                    .with_safe_context("task_id", &task_id)
+                })?;
+            self.validate_wait_for_task_owner(agent_id, work_item_id.as_deref(), &task)?;
+            if task_state_reducer::is_terminal_task_status(&task.status) {
+                return self.settle_terminal_task_result(task).await;
+            }
+            expected_task = Some(task_expectation(&task));
         }
 
         let now = self.now();
@@ -120,14 +314,14 @@ impl RuntimeHandle {
         let active_waits = if let Some(work_item_id) = work_item_id.as_deref() {
             self.inner
                 .storage
-                .raw_active_wait_conditions_for_agent(agent_id)?
+                .raw_unresolved_wait_conditions_for_agent(agent_id)?
                 .into_iter()
                 .filter(|record| record.work_item_id.as_deref() == Some(work_item_id))
                 .collect::<Vec<_>>()
         } else {
             self.inner
                 .storage
-                .active_wait_conditions_for_agent(agent_id)?
+                .raw_unresolved_wait_conditions_for_agent(agent_id)?
                 .into_iter()
                 .filter(|record| record.work_item_id.is_none())
                 .collect()
@@ -167,39 +361,33 @@ impl RuntimeHandle {
                 .with_safe_context("work_item_id", work_item_id)
                 .into());
             }
-            let mut updated = existing.clone();
-            if existing.blocked_by.as_deref() != Some(reason.as_str())
-                || existing.recheck_at != recheck_at
-                || existing.recheck_consumed_at.is_some()
-            {
-                updated = WorkItemRecord {
-                    revision: existing.revision + 1,
-                    blocked_by: Some(reason.clone()),
-                    recheck_at,
-                    recheck_consumed_at: None,
-                    updated_at: now,
-                    ..existing.clone()
-                };
-                let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
-                    self.agent_home().as_path(),
-                    &mut updated,
-                )?;
-                if plan_artifact_changed {
-                    if let Some(event) = self.work_item_plan_artifact_refreshed_event(&updated) {
-                        audit_events.push(event);
-                    }
+            let mut updated = WorkItemRecord {
+                revision: existing.revision + 1,
+                blocked_by: Some(reason.clone()),
+                recheck_at,
+                recheck_consumed_at: None,
+                updated_at: now,
+                ..existing.clone()
+            };
+            let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+                self.agent_home().as_path(),
+                &mut updated,
+            )?;
+            if plan_artifact_changed {
+                if let Some(event) = self.work_item_plan_artifact_refreshed_event(&updated) {
+                    audit_events.push(event);
                 }
-                audit_events.push(self.work_item_written_event(
-                    "wait_for_blocked",
-                    &updated,
-                    Value::Null,
-                ));
-                index_changes.extend(self.inner.storage.index_changes_for_work_item(&updated)?);
-                work_items.push(crate::runtime_db::transitions::WorkItemMutation::Update {
-                    record: updated.clone(),
-                    expected_revision: existing.revision,
-                });
             }
+            audit_events.push(self.work_item_written_event(
+                "wait_for_blocked",
+                &updated,
+                Value::Null,
+            ));
+            index_changes.extend(self.inner.storage.index_changes_for_work_item(&updated)?);
+            work_items.push(crate::runtime_db::transitions::WorkItemMutation::Update {
+                record: updated.clone(),
+                expected_revision: existing.revision,
+            });
             if state.current_turn_work_item_id.as_deref() == Some(updated.id.as_str()) {
                 state.current_turn_work_item_id = None;
                 audit_events.push(AuditEvent::legacy(
@@ -261,6 +449,8 @@ impl RuntimeHandle {
             resolved_at: None,
             cancelled_at: None,
             turn_id: current_turn_id,
+            trigger_message_id: None,
+            triggered_at: None,
         };
         wait_conditions.push(condition.clone());
         audit_events.extend(
@@ -282,38 +472,398 @@ impl RuntimeHandle {
                 "cancelled_wait_condition_ids": &cancelled_wait_condition_ids,
             }),
         ));
-        let commit = self.inner.runtime_db.transitions().commit_wait(
-            &crate::runtime_db::transitions::WaitTransitionCommand {
-                agent_id: agent_id.to_string(),
-                work_items,
-                expected_wait_conditions: Vec::new(),
-                wait_conditions,
-                agent_state: committed_agent_state.map(|record| {
-                    crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(expected_state)),
-                        record: Box::new(record),
+        let execution_protocol =
+            self.execution_wait_settlement_transition(&condition, work_item.as_ref(), now)?;
+        let command = crate::runtime_db::transitions::WaitTransitionCommand {
+            agent_id: agent_id.to_string(),
+            work_items,
+            expected_wait_conditions: Vec::new(),
+            wait_conditions,
+            agent_state: committed_agent_state.map(|record| {
+                crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(expected_state)),
+                    record: Box::new(record),
+                }
+            }),
+            audit_events,
+            index_changes,
+            notify_scheduler: true,
+            fault: self.take_transition_fault(),
+        };
+        let commit = 'retry: {
+            for attempt in 0..3 {
+                match self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .commit_wait_with_execution_protocol_and_task_expectation(
+                        &command,
+                        &execution_protocol,
+                        expected_task.as_ref(),
+                    ) {
+                    Ok(commit) => break 'retry commit,
+                    Err(error)
+                        if expected_task.is_some()
+                            && error
+                                .downcast_ref::<crate::runtime_db::RuntimeStateTransitionConflict>()
+                                .is_some_and(|conflict| {
+                                    conflict.retryable() && conflict.domain() == "task_wait"
+                                }) =>
+                    {
+                        let task_id = expected_task
+                            .as_ref()
+                            .expect("task expectation exists")
+                            .id
+                            .clone();
+                        let Some(task) = self.inner.runtime_db.tasks().latest(&task_id)? else {
+                            return Err(error);
+                        };
+                        self.validate_wait_for_task_owner(
+                            agent_id,
+                            work_item_id.as_deref(),
+                            &task,
+                        )?;
+                        if task_state_reducer::is_terminal_task_status(&task.status) {
+                            return self.settle_terminal_task_result(task).await;
+                        }
+                        if attempt + 1 == 3 {
+                            return Err(error);
+                        }
+                        expected_task = Some(task_expectation(&task));
                     }
-                }),
-                audit_events,
-                index_changes,
-                notify_scheduler: true,
-                fault: self.take_transition_fault(),
-            },
-        )?;
+                    Err(error) => return Err(error),
+                }
+            }
+            unreachable!("wait registration retry budget is non-empty")
+        };
         self.apply_transition_commit(commit).await;
 
-        Ok(WaitForRegistration {
-            scope: if condition.work_item_id.is_some() {
-                WaitForScope::WorkItem
-            } else {
-                WaitForScope::Agent
+        Ok(WaitForRegistrationOutcome::Registered {
+            registration: WaitForRegistration {
+                scope: if condition.work_item_id.is_some() {
+                    WaitForScope::WorkItem
+                } else {
+                    WaitForScope::Agent
+                },
+                condition,
+                recheck_after_ms,
+                recheck_at,
+                work_item,
+                cancelled_wait_condition_ids,
             },
-            condition,
-            recheck_after_ms,
-            recheck_at,
-            work_item,
-            cancelled_wait_condition_ids,
         })
+    }
+
+    fn validate_wait_for_task_owner(
+        &self,
+        agent_id: &str,
+        work_item_id: Option<&str>,
+        task: &TaskRecord,
+    ) -> Result<()> {
+        if task.agent_id != agent_id {
+            return Err(RuntimeError::validation(
+                "task_agent_mismatch",
+                format!("wait_for task belongs to another agent: {}", task.id),
+            )
+            .with_safe_context("task_id", &task.id)
+            .into());
+        }
+        if task.work_item_id.as_deref() != work_item_id {
+            return Err(RuntimeError::validation(
+                "task_work_item_mismatch",
+                format!(
+                    "wait_for task owner does not match the current work item: {}",
+                    task.id
+                ),
+            )
+            .with_safe_context("task_id", &task.id)
+            .into());
+        }
+        Ok(())
+    }
+
+    async fn settle_terminal_task_result(
+        &self,
+        task: TaskRecord,
+    ) -> Result<WaitForRegistrationOutcome> {
+        let result_message_id = task.parent_message_id.clone().ok_or_else(|| {
+            RuntimeError::validation(
+                "task_result_evidence_missing",
+                format!(
+                    "terminal task has no exact result message identity: {}",
+                    task.id
+                ),
+            )
+            .with_safe_context("task_id", &task.id)
+        })?;
+        let result_message = self
+            .inner
+            .storage
+            .read_message_by_id(&result_message_id)?
+            .ok_or_else(|| {
+                RuntimeError::validation(
+                    "task_result_evidence_missing",
+                    format!(
+                        "terminal task result message evidence is missing: {}",
+                        task.id
+                    ),
+                )
+                .with_safe_context("task_id", &task.id)
+                .with_safe_context("result_message_id", &result_message_id)
+            })?;
+        let existing_entry = self
+            .inner
+            .storage
+            .latest_queue_entries()?
+            .into_iter()
+            .find(|entry| entry.message_id == result_message_id);
+        if existing_entry.as_ref().is_some_and(|entry| {
+            matches!(
+                entry.status,
+                QueueEntryStatus::Dequeued
+                    | QueueEntryStatus::Interjected
+                    | QueueEntryStatus::Processed
+                    | QueueEntryStatus::Aborted
+                    | QueueEntryStatus::Dropped
+            )
+        }) {
+            return Ok(WaitForRegistrationOutcome::TaskResultAlreadyConsumed {
+                task_id: task.id,
+                result_message_id,
+            });
+        }
+
+        let now = self.now();
+        let expected_task = task_expectation(&task);
+        let execution_protocol =
+            self.execution_continue_settlement_transition(&task, &result_message, now)?;
+        let commit = {
+            let mut guard = self.inner.agent.lock().await;
+            let already_in_memory = guard
+                .queue
+                .peek_next_matching(|message| message.id == result_message_id)
+                .is_some();
+            let expected_state = guard.last_persisted_state.clone();
+            let mut committed_state = guard.state.clone();
+            committed_state.pending = guard
+                .queue
+                .len()
+                .saturating_add(usize::from(!already_in_memory));
+            committed_state.last_wake_reason = Some("TaskResult".into());
+            committed_state.total_message_count = self.inner.storage.count_messages()?;
+            scheduler::apply_message_wake_projection(&mut committed_state);
+            let queue_entry = QueueEntryRecord {
+                message_id: result_message_id.clone(),
+                agent_id: task.agent_id.clone(),
+                priority: result_message.priority.clone(),
+                status: QueueEntryStatus::Queued,
+                created_at: existing_entry
+                    .as_ref()
+                    .map_or(result_message.created_at, |entry| entry.created_at),
+                updated_at: now,
+            };
+            let commit = self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_queue_with_execution_protocol_and_task_expectation(
+                    &crate::runtime_db::transitions::QueueTransitionCommand {
+                        agent_id: task.agent_id.clone(),
+                        operation: crate::runtime_db::transitions::QueueOperation::Admit,
+                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
+                            queue_entry,
+                        ),
+                        scheduler_claim_work_item: None,
+                        scheduler_protocol_bootstrap: None,
+                        scheduler_protocol_commands: Vec::new(),
+                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                            expected: Some(Box::new(expected_state)),
+                            record: Box::new(committed_state.clone()),
+                        }),
+                        message_evidence: vec![result_message.clone()],
+                        transcript_entries: Vec::new(),
+                        turn_record: None,
+                        audit_events: vec![AuditEvent::legacy(
+                            "late_task_result_queued",
+                            serde_json::json!({
+                                "agent_id": task.agent_id,
+                                "task_id": task.id,
+                                "result_message_id": result_message_id,
+                            }),
+                        )],
+                        notify_scheduler: true,
+                        fault: self.take_transition_fault(),
+                        brief_evidence: Vec::new(),
+                    },
+                    &execution_protocol,
+                    &expected_task,
+                )?;
+            if !already_in_memory {
+                guard.queue.push(result_message);
+            }
+            guard.state = committed_state.clone();
+            guard.last_persisted_state = committed_state;
+            commit
+        };
+        self.apply_transition_commit(commit).await;
+        Ok(WaitForRegistrationOutcome::TaskResultQueued {
+            task_id: task.id,
+            result_message_id,
+        })
+    }
+
+    fn execution_continue_settlement_transition(
+        &self,
+        task: &TaskRecord,
+        result_message: &MessageEnvelope,
+        settled_at: DateTime<Utc>,
+    ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+        use crate::domain::execution_protocol::{
+            ConversationOutcome, ExecutionBinding, ExecutionOutcome, ExecutionOutcomeRecord,
+            ExecutionProtocolCommand, SettleExecution, WorkItemOutcome,
+        };
+
+        let Some(state) = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&task.agent_id)?
+        else {
+            return Ok(Default::default());
+        };
+        let Some(attempt) = state.open_attempt() else {
+            return Ok(Default::default());
+        };
+        let outcome = match &attempt.binding {
+            ExecutionBinding::WorkItem { work_item_id }
+                if task.work_item_id.as_deref() == Some(work_item_id.as_str()) =>
+            {
+                ExecutionOutcome::WorkItem(WorkItemOutcome::Continue)
+            }
+            ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. }
+                if task.work_item_id.is_none() =>
+            {
+                ExecutionOutcome::Conversation(ConversationOutcome::Replied)
+            }
+            ExecutionBinding::Command => {
+                return Err(anyhow!("command execution cannot settle through WaitFor"));
+            }
+            _ => {
+                return Err(anyhow!(
+                    "task result owner does not match the current execution binding"
+                ));
+            }
+        };
+        Ok(
+            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: None,
+                commands: vec![ExecutionProtocolCommand::Settle(SettleExecution {
+                    outcome: ExecutionOutcomeRecord {
+                        outcome_id: format!(
+                            "outcome:late-task-result:{}:{}",
+                            attempt.attempt_id, result_message.id
+                        ),
+                        attempt_id: attempt.attempt_id.clone(),
+                        outcome,
+                        created_at: settled_at.to_rfc3339(),
+                    },
+                })],
+            },
+        )
+    }
+
+    fn execution_wait_settlement_transition(
+        &self,
+        condition: &WaitConditionRecord,
+        work_item: Option<&WorkItemRecord>,
+        settled_at: DateTime<Utc>,
+    ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+        use crate::domain::execution_protocol::{
+            ConversationOutcome, ExecutionBinding, ExecutionOutcome, ExecutionOutcomeRecord,
+            ExecutionProtocolCommand, SetWorkItemWaiting, SettleExecution, WaitReference,
+            WorkItemExecutionRecord, WorkItemExecutionState, WorkItemOutcome,
+        };
+
+        let Some(state) = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&condition.agent_id)?
+        else {
+            return Ok(Default::default());
+        };
+        let Some(attempt) = state.open_attempt() else {
+            return Ok(Default::default());
+        };
+        let wait = WaitReference {
+            wait_id: condition.id.clone(),
+        };
+        let mut commands = Vec::with_capacity(2);
+        let outcome = match &attempt.binding {
+            ExecutionBinding::WorkItem { work_item_id }
+                if condition.work_item_id.as_deref() == Some(work_item_id.as_str()) =>
+            {
+                ExecutionOutcome::WorkItem(WorkItemOutcome::Wait { wait })
+            }
+            ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. } => {
+                if let Some(work_item_id) = condition.work_item_id.as_deref() {
+                    let work_item = work_item
+                        .filter(|record| record.id == work_item_id)
+                        .ok_or_else(|| {
+                            anyhow!("WorkItem wait handoff is missing its updated WorkItem")
+                        })?;
+                    let expected = state.work_items.get(work_item_id).cloned();
+                    let generation = expected
+                        .as_ref()
+                        .map_or(work_item.revision.max(1), |record| record.generation() + 1);
+                    commands.push(ExecutionProtocolCommand::SetWorkItemWaiting(Box::new(
+                        SetWorkItemWaiting {
+                            command_id: format!(
+                                "handoff:{}:work_item_wait:{}",
+                                attempt.attempt_id, condition.id
+                            ),
+                            work_item_id: work_item_id.to_string(),
+                            expected,
+                            record: WorkItemExecutionRecord {
+                                source_revision: work_item.revision,
+                                state: WorkItemExecutionState::Waiting {
+                                    generation,
+                                    wait: wait.clone(),
+                                },
+                            },
+                        },
+                    )));
+                    ExecutionOutcome::Conversation(ConversationOutcome::HandoffToWorkItemWait {
+                        work_item_id: work_item_id.to_string(),
+                        wait,
+                    })
+                } else {
+                    ExecutionOutcome::Conversation(ConversationOutcome::Wait { wait })
+                }
+            }
+            ExecutionBinding::Command => {
+                return Err(anyhow!("command execution cannot settle through WaitFor"));
+            }
+            _ => {
+                return Err(anyhow!(
+                    "WaitFor owner does not match the current execution binding"
+                ));
+            }
+        };
+        commands.push(ExecutionProtocolCommand::Settle(SettleExecution {
+            outcome: ExecutionOutcomeRecord {
+                outcome_id: format!("outcome:wait-for:{}:{}", attempt.attempt_id, condition.id),
+                attempt_id: attempt.attempt_id.clone(),
+                outcome,
+                created_at: settled_at.to_rfc3339(),
+            },
+        }));
+        Ok(
+            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: None,
+                commands,
+            },
+        )
     }
 
     pub(super) async fn clear_work_item_blocker_for_pick(
@@ -326,7 +876,7 @@ impl RuntimeHandle {
         let active_waits = self
             .inner
             .storage
-            .raw_active_wait_conditions_for_agent(agent_id)?
+            .raw_unresolved_wait_conditions_for_agent(agent_id)?
             .into_iter()
             .filter(|condition| condition.work_item_id.as_deref() == Some(existing.id.as_str()))
             .collect::<Vec<_>>();
@@ -767,22 +1317,11 @@ impl RuntimeHandle {
     pub(super) async fn exact_external_wait_correlation(
         &self,
         external_trigger_id: Option<&str>,
-    ) -> Result<Option<(String, u64)>> {
-        if !self.inner.scheduler_engine.is_canonical() {
-            return Ok(None);
-        }
+    ) -> Result<Option<String>> {
         let Some(external_trigger_id) = external_trigger_id else {
             return Ok(None);
         };
         let agent_id = self.agent_id().await?;
-        let Some(snapshot) = self
-            .inner
-            .runtime_db
-            .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(&agent_id)?
-        else {
-            return Ok(None);
-        };
         let correlations = self
             .inner
             .storage
@@ -798,22 +1337,7 @@ impl RuntimeHandle {
                     )
                 })
             })
-            .filter_map(|condition| {
-                let canonical_wait = snapshot.waits.get(&condition.id)?;
-                let generation = canonical_wait
-                    .generations
-                    .get(&canonical_wait.current_generation)?;
-                let owner_matches = match condition.work_item_id.as_deref() {
-                    Some(work_item_id) => generation.owner.work_item_id() == Some(work_item_id),
-                    None => generation.owner.lifecycle_agent_id() == Some(agent_id.as_str()),
-                };
-                (owner_matches
-                    && matches!(
-                        generation.state,
-                        crate::domain::scheduler_protocol::WaitState::Active
-                    ))
-                .then(|| (condition.id, canonical_wait.current_generation))
-            })
+            .map(|condition| condition.id)
             .collect::<Vec<_>>();
         let [correlation] = correlations.as_slice() else {
             return Ok(None);
@@ -881,18 +1405,27 @@ impl RuntimeHandle {
         message: &MessageEnvelope,
     ) -> Result<()> {
         let agent_id = self.agent_id().await?;
-        let active_conditions = self
+        let unresolved_conditions = self
             .inner
             .storage
-            .active_wait_conditions_for_agent(&agent_id)?;
-        if active_conditions.is_empty() {
+            .latest_wait_conditions()?
+            .into_iter()
+            .filter(|condition| {
+                condition.agent_id == agent_id
+                    && matches!(
+                        condition.status,
+                        WaitConditionStatus::Active | WaitConditionStatus::Triggered
+                    )
+            })
+            .collect::<Vec<_>>();
+        if unresolved_conditions.is_empty() {
             return Ok(());
         }
-        let active_conditions = self
-            .reconciliation_conditions_for_message(&agent_id, message, active_conditions)
+        let unresolved_conditions = self
+            .reconciliation_conditions_for_message(&agent_id, message, unresolved_conditions)
             .await?;
 
-        let signals = reconciliation_signals_for_message(message, &active_conditions);
+        let signals = reconciliation_signals_for_message(message, &unresolved_conditions);
         for signal in &signals {
             let duplicate = self
                 .inner
@@ -915,8 +1448,13 @@ impl RuntimeHandle {
         // Resolve matching wait conditions and clear WorkItem blockers so the
         // scheduler can advance the WorkItem without requiring the model to
         // explicitly call PickWorkItem(clear_blocker) or CompleteWorkItem.
-        self.resolve_reconciled_wait_conditions(&agent_id, message, &active_conditions, &signals)
-            .await?;
+        self.resolve_reconciled_wait_conditions(
+            &agent_id,
+            message,
+            &unresolved_conditions,
+            &signals,
+        )
+        .await?;
 
         Ok(())
     }
@@ -989,46 +1527,33 @@ impl RuntimeHandle {
         message: &MessageEnvelope,
         active_conditions: &[WaitConditionRecord],
     ) -> Result<Option<WaitConditionRecord>> {
-        use crate::domain::scheduler_protocol::{ActivationCause, WaitState};
+        use crate::domain::execution_protocol::{
+            ExecutionAttemptState, ExecutionBinding, ExecutionSourceIdentity,
+        };
 
-        let Some(snapshot) = self
+        let Some(execution) = self
             .inner
             .runtime_db
             .transitions()
-            .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
+            .load_execution_protocol_state_if_initialized(agent_id)?
         else {
             return Ok(None);
         };
-        let Some(activation_id) =
-            scheduler_executor::canonical_open_activation_id(&snapshot, &message.id)
+        let Some(attempt) = execution.attempts.values().find(|attempt| {
+            attempt.state == ExecutionAttemptState::Open
+                && attempt.source_message_id.as_deref() == Some(message.id.as_str())
+        }) else {
+            return Ok(None);
+        };
+        let ExecutionSourceIdentity::TriggeredWait {
+            wait_id,
+            trigger_message_id,
+        } = &attempt.source.identity
         else {
             return Ok(None);
         };
-        let Some(admission) = snapshot.activation_admissions.get(&activation_id) else {
+        if trigger_message_id != &message.id {
             return Ok(None);
-        };
-        let (wait_id, wait_generation, external_resume) = match &admission.activation.cause {
-            ActivationCause::OperatorInput {
-                message_id,
-                resume: Some(resume),
-            } if message_id == &message.id => (&resume.wait_id, resume.wait_generation, false),
-            ActivationCause::WaitResume {
-                wait_id,
-                wait_generation,
-                ..
-            } => (wait_id, *wait_generation, true),
-            _ => return Ok(None),
-        };
-        if external_resume {
-            let correlated_wait_id = message.source_refs.get("wait_id");
-            let correlated_generation = message
-                .source_refs
-                .get("wait_generation")
-                .and_then(|generation| generation.parse::<u64>().ok());
-            if correlated_wait_id != Some(wait_id) || correlated_generation != Some(wait_generation)
-            {
-                return Ok(None);
-            }
         }
 
         let Some(condition) = active_conditions
@@ -1037,30 +1562,21 @@ impl RuntimeHandle {
         else {
             return Ok(None);
         };
-        let Some(wait) = snapshot
-            .waits
-            .get(wait_id)
-            .filter(|wait| wait.current_generation == wait_generation)
-        else {
-            return Ok(None);
-        };
-        let Some(generation) = wait.generations.get(&wait_generation) else {
-            return Ok(None);
-        };
-        let owner_matches = match condition.work_item_id.as_deref() {
-            Some(work_item_id) => {
-                generation.owner.work_item_id() == Some(work_item_id)
-                    && message.work_item_id.as_deref() == Some(work_item_id)
+        let owner_matches = match (&attempt.binding, condition.work_item_id.as_deref()) {
+            (ExecutionBinding::WorkItem { work_item_id }, Some(condition_work_item_id)) => {
+                work_item_id == condition_work_item_id
+                    && message.work_item_id.as_deref() == Some(condition_work_item_id)
             }
-            None => {
-                generation.owner.lifecycle_agent_id() == Some(agent_id)
-                    && message.work_item_id.is_none()
-            }
+            (
+                ExecutionBinding::AgentLifecycle {
+                    agent_id: owner_agent_id,
+                },
+                None,
+            ) => owner_agent_id == agent_id && message.work_item_id.is_none(),
+            (ExecutionBinding::Conversation { .. }, None) => message.work_item_id.is_none(),
+            _ => false,
         };
-        Ok((owner_matches
-            && generation.state == WaitState::Consumed
-            && generation.consuming_activation_id.as_deref() == Some(activation_id.as_str()))
-        .then(|| condition.clone()))
+        Ok(owner_matches.then(|| condition.clone()))
     }
 
     async fn resolve_reconciled_wait_conditions(
@@ -1086,7 +1602,10 @@ impl RuntimeHandle {
             let Some(condition) = active_conditions.iter().find(|c| c.id == condition_id) else {
                 continue;
             };
-            if condition.status != WaitConditionStatus::Active {
+            if !matches!(
+                condition.status,
+                WaitConditionStatus::Active | WaitConditionStatus::Triggered
+            ) {
                 continue;
             }
 
@@ -1323,6 +1842,11 @@ fn matching_wake_source(
     message: &MessageEnvelope,
     condition: &WaitConditionRecord,
 ) -> Option<(String, Option<String>)> {
+    if condition.status == WaitConditionStatus::Triggered
+        && condition.trigger_message_id() != Some(message.id.as_str())
+    {
+        return None;
+    }
     match (&message.kind, &message.origin) {
         (MessageKind::TaskResult, MessageOrigin::Task { task_id }) => condition
             .wake_sources
@@ -1332,7 +1856,6 @@ fn matching_wake_source(
         (MessageKind::CallbackEvent, _) => {
             let external_trigger_id = message.source_refs.get("external_trigger_id");
             let correlated_wait_id = message.source_refs.get("wait_id");
-            let has_correlated_generation = message.source_refs.contains_key("wait_generation");
             condition
                 .wake_sources
                 .iter()
@@ -1340,9 +1863,7 @@ fn matching_wake_source(
                     WakeSource::ExternalIngress {
                         external_trigger_id: Some(id),
                     } => {
-                        external_trigger_id == Some(id)
-                            && correlated_wait_id == Some(&condition.id)
-                            && has_correlated_generation
+                        external_trigger_id == Some(id) && correlated_wait_id == Some(&condition.id)
                     }
                     _ => false,
                 })
@@ -1392,15 +1913,10 @@ fn matching_wake_hint_external_source(
         .get("external_trigger_id")
         .and_then(serde_json::Value::as_str);
     let correlated_wait_id = message.source_refs.get("wait_id");
-    let has_correlated_generation = message.source_refs.contains_key("wait_generation");
     let matches_external = condition.wake_sources.iter().any(|source| match source {
         WakeSource::ExternalIngress {
             external_trigger_id: Some(id),
-        } => {
-            Some(id.as_str()) == external_trigger_id
-                && correlated_wait_id == Some(&condition.id)
-                && has_correlated_generation
-        }
+        } => Some(id.as_str()) == external_trigger_id && correlated_wait_id == Some(&condition.id),
         _ => false,
     });
     matches_external.then(|| {
@@ -1409,6 +1925,17 @@ fn matching_wake_hint_external_source(
             external_trigger_id.map(ToString::to_string),
         )
     })
+}
+
+fn task_expectation(task: &TaskRecord) -> crate::runtime_db::transitions::TaskExpectation {
+    crate::runtime_db::transitions::TaskExpectation {
+        id: task.id.clone(),
+        agent_id: task.agent_id.clone(),
+        work_item_id: task.work_item_id.clone(),
+        status: task.status.clone(),
+        updated_at: task.updated_at,
+        result_message_id: task.parent_message_id.clone(),
+    }
 }
 
 fn advance_time(base: chrono::DateTime<Utc>, delta_ms: u64) -> Result<chrono::DateTime<Utc>> {

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -136,11 +136,10 @@ impl RuntimeHandle {
         let Some(condition) = self
             .inner
             .storage
-            .latest_wait_conditions()?
+            .raw_unresolved_wait_conditions_for_agent(&message.agent_id)?
             .into_iter()
             .find(|condition| {
-                condition.agent_id == message.agent_id
-                    && condition.status == WaitConditionStatus::Triggered
+                condition.status == WaitConditionStatus::Triggered
                     && condition.trigger_message_id() == Some(message.id.as_str())
             })
         else {
@@ -1408,16 +1407,7 @@ impl RuntimeHandle {
         let unresolved_conditions = self
             .inner
             .storage
-            .latest_wait_conditions()?
-            .into_iter()
-            .filter(|condition| {
-                condition.agent_id == agent_id
-                    && matches!(
-                        condition.status,
-                        WaitConditionStatus::Active | WaitConditionStatus::Triggered
-                    )
-            })
-            .collect::<Vec<_>>();
+            .raw_unresolved_wait_conditions_for_agent(&agent_id)?;
         if unresolved_conditions.is_empty() {
             return Ok(());
         }

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -760,6 +760,320 @@ CREATE UNIQUE INDEX idx_scheduler_activations_recovery_admission_fence
     result
 }
 
+fn migrate_wait_trigger_identity(connection: &mut Connection, migration: &Migration) -> Result<()> {
+    let transaction = connection.transaction()?;
+    if table_exists_internal(&transaction, "wait_conditions")? {
+        let columns = transaction
+            .prepare("PRAGMA table_info(wait_conditions)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        if !columns.iter().any(|column| column == "trigger_message_id") {
+            transaction
+                .execute_batch("ALTER TABLE wait_conditions ADD COLUMN trigger_message_id TEXT;")?;
+        }
+        if !columns.iter().any(|column| column == "triggered_at") {
+            transaction
+                .execute_batch("ALTER TABLE wait_conditions ADD COLUMN triggered_at TEXT;")?;
+        }
+        transaction.execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS wait_conditions_trigger_message
+               ON wait_conditions(agent_id, trigger_message_id)
+               WHERE trigger_message_id IS NOT NULL;",
+        )?;
+    }
+    record_migration(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn migrate_wait_unresolved_owner_uniqueness(
+    connection: &mut Connection,
+    migration: &Migration,
+) -> Result<()> {
+    let transaction = connection.transaction()?;
+    if table_exists_internal(&transaction, "wait_conditions")? {
+        converge_unresolved_wait_owners(&transaction)?;
+        transaction.execute_batch(migration.sql)?;
+    }
+    record_migration(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn migrate_wait_protocol_cutover(connection: &mut Connection, migration: &Migration) -> Result<()> {
+    let transaction = connection.transaction()?;
+    let has_execution_attempts =
+        table_exists_internal(&transaction, "execution_protocol_attempts")?;
+    if has_execution_attempts {
+        let attempts = transaction
+            .prepare(
+                "SELECT attempt_id, payload_json
+                 FROM execution_protocol_attempts",
+            )?
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        for (attempt_id, payload_json) in attempts {
+            let mut payload: serde_json::Value =
+                serde_json::from_str(&payload_json).with_context(|| {
+                    format!("decoding execution attempt {attempt_id} during cutover")
+                })?;
+            let source_message_id = payload
+                .get("source_message_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned);
+            let Some(identity) = payload
+                .get_mut("source")
+                .and_then(|source| source.get_mut("identity"))
+                .and_then(serde_json::Value::as_object_mut)
+            else {
+                continue;
+            };
+            if identity.get("kind").and_then(serde_json::Value::as_str) != Some("triggered_wait")
+                || identity.contains_key("trigger_message_id")
+            {
+                continue;
+            }
+            let Some(trigger_message_id) = source_message_id else {
+                continue;
+            };
+            identity.insert(
+                "trigger_message_id".into(),
+                serde_json::Value::String(trigger_message_id),
+            );
+            identity.remove("wait_generation");
+            identity.remove("trigger_id");
+            identity.remove("trigger_generation");
+            let normalized_identity = serde_json::Value::Object(identity.clone());
+            transaction.execute(
+                "UPDATE execution_protocol_attempts
+                 SET source_identity_json = ?1,
+                     payload_json = ?2
+                 WHERE attempt_id = ?3",
+                params![
+                    serde_json::to_string(&normalized_identity)?,
+                    serde_json::to_string(&payload)?,
+                    attempt_id,
+                ],
+            )?;
+        }
+    }
+
+    let has_wait_conditions = table_exists_internal(&transaction, "wait_conditions")?;
+    if !has_wait_conditions {
+        record_migration(&transaction, migration)?;
+        transaction.commit()?;
+        return Ok(());
+    }
+    let has_work_items = table_exists_internal(&transaction, "work_items")?;
+    let has_execution_work_items =
+        table_exists_internal(&transaction, "execution_protocol_work_items")?;
+
+    let waits = transaction
+        .prepare(
+            "SELECT payload_json
+             FROM wait_conditions
+             WHERE status IN ('active', 'triggered')
+             ORDER BY created_at ASC, wait_condition_id ASC",
+        )?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let now = Utc::now();
+    for payload_json in waits {
+        let mut wait: WaitConditionRecord = serde_json::from_str(&payload_json)
+            .context("decoding unresolved wait during protocol cutover")?;
+        let original_updated_at = wait.updated_at;
+        wait.status = crate::types::WaitConditionStatus::Cancelled;
+        wait.updated_at = now;
+        wait.resolved_at = None;
+        wait.cancelled_at = Some(now);
+        let mut continuation = wait
+            .continuation
+            .take()
+            .unwrap_or_else(|| serde_json::json!({}));
+        if let Some(object) = continuation.as_object_mut() {
+            object.insert(
+                "cancel_reason".into(),
+                serde_json::Value::String("protocol_cutover".into()),
+            );
+        } else {
+            continuation = serde_json::json!({
+                "legacy_continuation": continuation,
+                "cancel_reason": "protocol_cutover",
+            });
+        }
+        wait.continuation = Some(continuation);
+        transaction.execute(
+            "UPDATE wait_conditions
+             SET status = 'cancelled',
+                 updated_at = ?1,
+                 resolved_at = NULL,
+                 cancelled_at = ?1,
+                 continuation_json = ?2,
+                 payload_json = ?3
+             WHERE wait_condition_id = ?4",
+            params![
+                timestamp(now),
+                wait.continuation
+                    .as_ref()
+                    .map(serde_json::to_string)
+                    .transpose()?,
+                serde_json::to_string(&wait)?,
+                wait.id,
+            ],
+        )?;
+
+        let Some(work_item_id) = wait.work_item_id.as_deref() else {
+            continue;
+        };
+        if !has_work_items {
+            continue;
+        }
+        let work_item_payload = transaction
+            .query_row(
+                "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+                [work_item_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let Some(work_item_payload) = work_item_payload else {
+            continue;
+        };
+        let mut work_item: WorkItemRecord = serde_json::from_str(&work_item_payload)
+            .with_context(|| format!("decoding WorkItem {work_item_id} during wait cutover"))?;
+        let owns_blocker = wait.source.as_deref() == Some("WaitFor")
+            && work_item.state == crate::domain::work_item::WorkItemState::Open
+            && work_item.blocked_by.as_deref() == Some(wait.waiting_for.as_str())
+            && work_item.updated_at == original_updated_at;
+        if owns_blocker {
+            work_item.revision = work_item
+                .revision
+                .checked_add(1)
+                .context("WorkItem revision overflow during wait cutover")?;
+            work_item.blocked_by = None;
+            work_item.recheck_at = None;
+            work_item.recheck_consumed_at = None;
+            work_item.updated_at = now;
+            transaction.execute(
+                "UPDATE work_items
+                 SET revision = ?1,
+                     updated_at = ?2,
+                     blocked_by = NULL,
+                     recheck_at = NULL,
+                     recheck_consumed_at = NULL,
+                     payload_json = ?3
+                 WHERE work_item_id = ?4",
+                params![
+                    i64::try_from(work_item.revision)
+                        .context("WorkItem revision exceeds SQLite range")?,
+                    timestamp(now),
+                    serde_json::to_string(&work_item)?,
+                    work_item_id,
+                ],
+            )?;
+        }
+    }
+
+    if has_execution_work_items {
+        let waiting = transaction
+            .prepare(
+                "SELECT agent_id, work_item_id, payload_json
+                 FROM execution_protocol_work_items
+                 WHERE lifecycle_state = 'waiting'",
+            )?
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        for (agent_id, work_item_id, execution_payload) in waiting {
+            let mut execution: WorkItemExecutionRecord = serde_json::from_str(&execution_payload)
+                .with_context(|| {
+                format!("decoding WorkItem execution {work_item_id} during wait cutover")
+            })?;
+            let WorkItemExecutionState::Waiting {
+                generation,
+                wait: reference,
+            } = &execution.state
+            else {
+                continue;
+            };
+            let unresolved = transaction
+                .query_row(
+                    "SELECT 1
+                     FROM wait_conditions
+                     WHERE wait_condition_id = ?1
+                       AND status IN ('active', 'triggered')",
+                    [&reference.wait_id],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some();
+            if unresolved {
+                continue;
+            }
+            if has_work_items {
+                if let Some(source_revision) = transaction
+                    .query_row(
+                        "SELECT revision FROM work_items WHERE work_item_id = ?1",
+                        [&work_item_id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .optional()?
+                {
+                    execution.source_revision = u64::try_from(source_revision)
+                        .context("WorkItem source revision is negative during wait cutover")?
+                        .max(1);
+                }
+            }
+            let generation = generation
+                .checked_add(1)
+                .context("WorkItem scheduling generation overflow during wait cutover")?;
+            execution.state = WorkItemExecutionState::Runnable {
+                generation,
+                recovery_ref: Some("protocol_cutover".into()),
+            };
+            transaction.execute(
+                "UPDATE execution_protocol_work_items
+                 SET source_revision = ?1,
+                     generation = ?2,
+                     lifecycle_state = 'runnable',
+                     payload_json = ?3
+                 WHERE agent_id = ?4 AND work_item_id = ?5",
+                params![
+                    i64::try_from(execution.source_revision)
+                        .context("WorkItem source revision exceeds SQLite range")?,
+                    i64::try_from(execution.generation())
+                        .context("WorkItem generation exceeds SQLite range")?,
+                    serde_json::to_string(&execution)?,
+                    agent_id,
+                    work_item_id,
+                ],
+            )?;
+        }
+    }
+
+    record_migration(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn record_migration(transaction: &Transaction<'_>, migration: &Migration) -> Result<()> {
+    transaction.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        (
+            migration.version,
+            migration.name,
+            Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        ),
+    )?;
+    Ok(())
+}
+
 pub(crate) const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -2584,6 +2898,36 @@ CREATE TABLE IF NOT EXISTS execution_protocol_command_results (
         name: "scheduler_internal_followup_admission",
         sql: "",
     },
+    Migration {
+        version: 43,
+        name: "wait_trigger_identity",
+        sql: r#"
+ALTER TABLE wait_conditions ADD COLUMN trigger_message_id TEXT;
+ALTER TABLE wait_conditions ADD COLUMN triggered_at TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS wait_conditions_trigger_message
+  ON wait_conditions(agent_id, trigger_message_id)
+  WHERE trigger_message_id IS NOT NULL;
+"#,
+    },
+    Migration {
+        version: 44,
+        name: "wait_unresolved_owner_uniqueness",
+        sql: r#"
+CREATE UNIQUE INDEX IF NOT EXISTS wait_conditions_unresolved_agent_owner
+  ON wait_conditions(agent_id)
+  WHERE work_item_id IS NULL AND status IN ('active', 'triggered');
+
+CREATE UNIQUE INDEX IF NOT EXISTS wait_conditions_unresolved_work_item_owner
+  ON wait_conditions(agent_id, work_item_id)
+  WHERE work_item_id IS NOT NULL AND status IN ('active', 'triggered');
+"#,
+    },
+    Migration {
+        version: 45,
+        name: "wait_protocol_cutover",
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -2624,6 +2968,15 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     if migration.name == "scheduler_internal_followup_admission" {
         return migrate_scheduler_internal_followup_admission(connection, migration);
     }
+    if migration.name == "wait_trigger_identity" {
+        return migrate_wait_trigger_identity(connection, migration);
+    }
+    if migration.name == "wait_unresolved_owner_uniqueness" {
+        return migrate_wait_unresolved_owner_uniqueness(connection, migration);
+    }
+    if migration.name == "wait_protocol_cutover" {
+        return migrate_wait_protocol_cutover(connection, migration);
+    }
 
     let transaction = connection.transaction()?;
     if migration.name == "strict_runtime_sequences" {
@@ -2658,6 +3011,54 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
         ),
     )?;
     transaction.commit()?;
+    Ok(())
+}
+
+fn converge_unresolved_wait_owners(transaction: &Transaction<'_>) -> Result<()> {
+    let rows = transaction
+        .prepare(
+            "SELECT wait_condition_id, agent_id, work_item_id, payload_json
+             FROM wait_conditions
+             WHERE status IN ('active', 'triggered')
+             ORDER BY agent_id ASC,
+                      work_item_id IS NOT NULL ASC,
+                      work_item_id ASC,
+                      updated_at DESC,
+                      created_at DESC,
+                      wait_condition_id DESC",
+        )?
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let now = Utc::now();
+    let mut owners = std::collections::BTreeSet::new();
+    for (wait_id, agent_id, work_item_id, payload_json) in rows {
+        if owners.insert((agent_id, work_item_id)) {
+            continue;
+        }
+        let mut record: WaitConditionRecord = serde_json::from_str(&payload_json)
+            .with_context(|| format!("decoding duplicate unresolved wait {wait_id}"))?;
+        record.status = crate::types::WaitConditionStatus::Cancelled;
+        record.updated_at = now;
+        record.cancelled_at = Some(now);
+        record.resolved_at = None;
+        transaction.execute(
+            "UPDATE wait_conditions
+             SET status = 'cancelled',
+                 updated_at = ?1,
+                 resolved_at = NULL,
+                 cancelled_at = ?1,
+                 payload_json = ?2
+             WHERE wait_condition_id = ?3",
+            params![timestamp(now), serde_json::to_string(&record)?, wait_id,],
+        )?;
+    }
     Ok(())
 }
 
@@ -3038,15 +3439,13 @@ fn migration_execution_source(
         }
         ActivationCause::WaitResume {
             wait_id,
-            wait_generation,
+            wait_generation: _,
             trigger_id,
-            trigger_generation,
+            trigger_generation: _,
         } => (
             ExecutionSourceIdentity::TriggeredWait {
                 wait_id: wait_id.clone(),
-                wait_generation: *wait_generation,
-                trigger_id: trigger_id.clone(),
-                trigger_generation: *trigger_generation,
+                trigger_message_id: trigger_id.clone(),
             },
             None,
             None,

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1347,7 +1347,7 @@ impl WaitConditionRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
                 subject_ref, waiting_for, created_at, updated_at, expires_at,
-                resolved_at, cancelled_at, last_turn_id,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
                 wake_sources_json, continuation_json
              FROM wait_conditions
              ORDER BY wait_condition_id ASC",
@@ -1368,7 +1368,7 @@ impl WaitConditionRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
                 subject_ref, waiting_for, created_at, updated_at, expires_at,
-                resolved_at, cancelled_at, last_turn_id,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
                 wake_sources_json, continuation_json
              FROM wait_conditions
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
@@ -1397,7 +1397,7 @@ impl WaitConditionRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
                 subject_ref, waiting_for, created_at, updated_at, expires_at,
-                resolved_at, cancelled_at, last_turn_id,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
                 wake_sources_json, continuation_json
              FROM wait_conditions
              WHERE agent_id = ?1
@@ -1419,7 +1419,7 @@ impl WaitConditionRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
                 subject_ref, waiting_for, created_at, updated_at, expires_at,
-                resolved_at, cancelled_at, last_turn_id,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
                 wake_sources_json, continuation_json
              FROM wait_conditions
              WHERE agent_id = ?1 AND status = 'active'
@@ -1432,12 +1432,30 @@ impl WaitConditionRepository<'_> {
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
     }
 
+    pub fn unresolved_for_agent(&self, agent_id: &str) -> Result<Vec<WaitConditionRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
+                wake_sources_json, continuation_json
+             FROM wait_conditions
+             WHERE agent_id = ?1 AND status IN ('active', 'triggered')
+             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| {
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading unresolved wait conditions: {e}"))
+    }
+
     pub fn active_all(&self) -> Result<Vec<WaitConditionRecord>> {
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
             "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
                 subject_ref, waiting_for, created_at, updated_at, expires_at,
-                resolved_at, cancelled_at, last_turn_id,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
                 wake_sources_json, continuation_json
              FROM wait_conditions
              WHERE status = 'active'
@@ -1475,6 +1493,19 @@ impl QueueEntryRepository<'_> {
     pub fn try_claim_queued_message(&self, record: &QueueEntryRecord) -> Result<bool> {
         self.db
             .transaction(|tx| try_claim_queued_message_tx(tx, record))
+    }
+
+    pub fn latest(&self, message_id: &str) -> Result<Option<QueueEntryRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM queue_entries WHERE message_id = ?1",
+                [message_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_queue_entry_payload(&payload))
+            .transpose()
     }
 
     pub fn latest_all(&self) -> Result<Vec<QueueEntryRecord>> {
@@ -3327,9 +3358,9 @@ pub(crate) fn upsert_wait_condition_tx(
         "INSERT INTO wait_conditions (
             wait_condition_id, agent_id, work_item_id, status, kind, source,
             subject_ref, waiting_for, created_at, updated_at, expires_at,
-            resolved_at, cancelled_at, last_turn_id,
+            resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
             wake_sources_json, continuation_json, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
          ON CONFLICT(wait_condition_id) DO UPDATE SET
             agent_id = excluded.agent_id,
             work_item_id = excluded.work_item_id,
@@ -3344,6 +3375,8 @@ pub(crate) fn upsert_wait_condition_tx(
             resolved_at = excluded.resolved_at,
             cancelled_at = excluded.cancelled_at,
             last_turn_id = excluded.last_turn_id,
+            trigger_message_id = excluded.trigger_message_id,
+            triggered_at = excluded.triggered_at,
             wake_sources_json = excluded.wake_sources_json,
             continuation_json = excluded.continuation_json,
             payload_json = excluded.payload_json
@@ -3363,6 +3396,8 @@ pub(crate) fn upsert_wait_condition_tx(
             record.resolved_at.map(timestamp),
             record.cancelled_at.map(timestamp),
             record.turn_id,
+            record.trigger_message_id(),
+            record.triggered_at().map(timestamp),
             wake_sources_json,
             continuation_json,
             payload_json,
@@ -3544,6 +3579,31 @@ pub(crate) fn wait_condition_transition(
     }
     if incoming.updated_at < existing.updated_at {
         return Ok(StateTransitionOutcome::Idempotent);
+    }
+    let valid = matches!(
+        (&existing.status, &incoming.status),
+        (WaitConditionStatus::Active, WaitConditionStatus::Triggered)
+            | (WaitConditionStatus::Active, WaitConditionStatus::Resolved)
+            | (WaitConditionStatus::Active, WaitConditionStatus::Cancelled)
+            | (WaitConditionStatus::Active, WaitConditionStatus::Expired)
+            | (
+                WaitConditionStatus::Triggered,
+                WaitConditionStatus::Resolved
+            )
+            | (
+                WaitConditionStatus::Triggered,
+                WaitConditionStatus::Cancelled
+            )
+            | (WaitConditionStatus::Triggered, WaitConditionStatus::Expired)
+    );
+    if !valid {
+        return Err(RuntimeStateTransitionConflict::new(
+            "wait condition",
+            &existing.id,
+            enum_string(&existing.status)?,
+            enum_string(&incoming.status)?,
+        )
+        .into());
     }
     Ok(StateTransitionOutcome::Applied)
 }
@@ -4354,8 +4414,10 @@ pub(crate) fn decode_wait_condition_row(row: &rusqlite::Row<'_>) -> Result<WaitC
     let resolved_at_str: Option<String> = row.get(11)?;
     let cancelled_at_str: Option<String> = row.get(12)?;
     let turn_id: Option<String> = row.get(13)?;
-    let wake_sources_json: String = row.get(14)?;
-    let continuation_json: Option<String> = row.get(15)?;
+    let trigger_message_id: Option<String> = row.get(14)?;
+    let triggered_at_str: Option<String> = row.get(15)?;
+    let wake_sources_json: String = row.get(16)?;
+    let continuation_json: Option<String> = row.get(17)?;
     let status: WaitConditionStatus = serde_json::from_value(serde_json::Value::String(status_str))
         .context("parsing wait condition status")?;
     let kind: WaitConditionKind = serde_json::from_value(serde_json::Value::String(kind_str))
@@ -4384,6 +4446,8 @@ pub(crate) fn decode_wait_condition_row(row: &rusqlite::Row<'_>) -> Result<WaitC
         resolved_at: parse_optional_timestamp(resolved_at_str.as_deref())?,
         cancelled_at: parse_optional_timestamp(cancelled_at_str.as_deref())?,
         turn_id,
+        trigger_message_id,
+        triggered_at: parse_optional_timestamp(triggered_at_str.as_deref())?,
     })
 }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -76,6 +76,10 @@ pub mod test_support {
 mod tests {
     use super::*;
     use crate::{
+        domain::execution_protocol::{
+            ExecutionAttempt, ExecutionSourceIdentity, WaitReference, WorkItemExecutionRecord,
+            WorkItemExecutionState,
+        },
         domain::scheduler_protocol::{
             self, ActivationBinding, ActivationCause, ActivationDisposition,
             ActivationInputAttachment, ActivationLifecycleState, ActivationOrigin,
@@ -3987,6 +3991,8 @@ CREATE TABLE working_memory_deltas (
             resolved_at: Some(now + chrono::Duration::seconds(1)),
             cancelled_at: None,
             turn_id: Some("turn-1".into()),
+            trigger_message_id: None,
+            triggered_at: None,
         };
         db.wait_conditions().upsert(&terminal)?;
         let persisted_terminal = db.wait_conditions().latest_all()?;
@@ -4025,6 +4031,341 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn wait_owner_uniqueness_migration_cancels_older_unresolved_rows() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        {
+            let connection = db.connection()?;
+            connection.execute_batch(
+                "DROP INDEX wait_conditions_unresolved_agent_owner;
+                 DROP INDEX wait_conditions_unresolved_work_item_owner;
+                 DELETE FROM schema_migrations WHERE version = 44;",
+            )?;
+        }
+        let now = Utc::now();
+        let older = WaitConditionRecord {
+            id: "wait-owner-older".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some("work-owner".into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Operator,
+            source: Some("test".into()),
+            subject_ref: None,
+            waiting_for: "older wait".into(),
+            wake_sources: Vec::new(),
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
+        };
+        let mut newer = older.clone();
+        newer.id = "wait-owner-newer".into();
+        newer.status = WaitConditionStatus::Triggered;
+        newer.waiting_for = "newer wait".into();
+        newer.created_at = now + chrono::Duration::seconds(1);
+        newer.updated_at = newer.created_at;
+        newer.trigger_message_id = Some("message-owner-newer".into());
+        newer.triggered_at = Some(newer.created_at);
+        db.wait_conditions().upsert(&older)?;
+        db.wait_conditions().upsert(&newer)?;
+
+        let migration = MIGRATIONS
+            .iter()
+            .find(|migration| migration.version == 44)
+            .expect("migration 44");
+        let mut connection = db.connection()?;
+        apply_migration(&mut connection, migration)?;
+
+        let waits = db.wait_conditions().latest_all()?;
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.id == older.id)
+                .map(|wait| &wait.status),
+            Some(&WaitConditionStatus::Cancelled)
+        );
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.id == newer.id)
+                .map(|wait| &wait.status),
+            Some(&WaitConditionStatus::Triggered)
+        );
+        let mut duplicate = older;
+        duplicate.id = "wait-owner-duplicate".into();
+        duplicate.created_at = now + chrono::Duration::seconds(2);
+        duplicate.updated_at = duplicate.created_at;
+        assert!(db.wait_conditions().upsert(&duplicate).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn wait_protocol_cutover_cancels_history_and_releases_exact_work_item_authority() -> Result<()>
+    {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        {
+            let connection = db.connection()?;
+            connection.execute("DELETE FROM schema_migrations WHERE version = 45", [])?;
+        }
+
+        let now = Utc::now();
+        let mut owned = WorkItemRecord::new("agent-a", "owned wait", WorkItemState::Open);
+        owned.id = "work-cutover-owned".into();
+        owned.blocked_by = Some("owned blocker".into());
+        owned.updated_at = now;
+        db.work_items().insert_new(&owned)?;
+
+        let mut original_changed =
+            WorkItemRecord::new("agent-a", "changed wait", WorkItemState::Open);
+        original_changed.id = "work-cutover-changed".into();
+        original_changed.blocked_by = Some("older blocker".into());
+        original_changed.updated_at = now;
+        db.work_items().insert_new(&original_changed)?;
+        let mut changed = original_changed.clone();
+        changed.id = "work-cutover-changed".into();
+        changed.revision = 2;
+        changed.blocked_by = Some("newer blocker".into());
+        changed.updated_at = now + chrono::Duration::seconds(1);
+        db.work_items()
+            .update_expected(&changed, original_changed.revision)?;
+
+        let owned_wait = WaitConditionRecord {
+            id: "wait-cutover-owned".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some(owned.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Operator,
+            source: Some("WaitFor".into()),
+            subject_ref: None,
+            waiting_for: "owned blocker".into(),
+            wake_sources: Vec::new(),
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: Some("turn-cutover-owned".into()),
+            trigger_message_id: None,
+            triggered_at: None,
+        };
+        let changed_wait = WaitConditionRecord {
+            id: "wait-cutover-changed".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some(changed.id.clone()),
+            waiting_for: "older blocker".into(),
+            turn_id: Some("turn-cutover-changed".into()),
+            ..owned_wait.clone()
+        };
+        let agent_wait = WaitConditionRecord {
+            id: "wait-cutover-agent".into(),
+            agent_id: "agent-b".into(),
+            work_item_id: None,
+            waiting_for: "lifecycle wait".into(),
+            turn_id: Some("turn-cutover-agent".into()),
+            ..owned_wait.clone()
+        };
+        db.wait_conditions().upsert(&owned_wait)?;
+        db.wait_conditions().upsert(&changed_wait)?;
+        db.wait_conditions().upsert(&agent_wait)?;
+
+        let owned_execution = WorkItemExecutionRecord {
+            source_revision: owned.revision,
+            state: WorkItemExecutionState::Waiting {
+                generation: 4,
+                wait: WaitReference {
+                    wait_id: owned_wait.id.clone(),
+                },
+            },
+        };
+        let changed_execution = WorkItemExecutionRecord {
+            source_revision: 2,
+            state: WorkItemExecutionState::Waiting {
+                generation: 7,
+                wait: WaitReference {
+                    wait_id: "wait-cutover-stale-history".into(),
+                },
+            },
+        };
+        {
+            let connection = db.connection()?;
+            let legacy_attempt = serde_json::json!({
+                "attempt_id": "activation:message:message-cutover-trigger",
+                "agent_id": "agent-a",
+                "source_message_id": "message-cutover-trigger",
+                "source": {
+                    "identity": {
+                        "kind": "triggered_wait",
+                        "wait_id": "wait-cutover-history",
+                        "wait_generation": 9,
+                        "trigger_id": "external-trigger-history",
+                        "trigger_generation": 12
+                    },
+                    "generation": 12
+                },
+                "binding": {
+                    "kind": "work_item",
+                    "work_item_id": owned.id
+                },
+                "provenance": {
+                    "origin": "system",
+                    "trust": "runtime_instruction",
+                    "priority": "next",
+                    "correlation_id": null,
+                    "causation_id": null
+                },
+                "admitted_fences": {
+                    "source_revision": 12,
+                    "work_item_source_revision": owned.revision,
+                    "work_item_generation": 4,
+                    "rejoin": null,
+                    "agent_control_revision": 1,
+                    "host_registry_revision": 1
+                },
+                "state": "settled",
+                "run_id": null,
+                "turn_id": "turn-cutover-history",
+                "recovery_of_attempt_id": null,
+                "terminal_outcome_id": null,
+                "admitted_at": "2026-08-01T00:00:00Z",
+                "terminal_at": "2026-08-01T00:01:00Z"
+            });
+            connection.execute(
+                "INSERT INTO execution_protocol_attempts (
+                   agent_id, attempt_id, lifecycle_state,
+                   source_identity_json, source_generation,
+                   recovery_of_attempt_id, terminal_outcome_id, payload_json
+                 ) VALUES (?1, ?2, 'settled', ?3, 12, NULL, NULL, ?4)",
+                params![
+                    "agent-a",
+                    "activation:message:message-cutover-trigger",
+                    serde_json::to_string(&legacy_attempt["source"]["identity"])?,
+                    serde_json::to_string(&legacy_attempt)?,
+                ],
+            )?;
+            connection.execute(
+                "INSERT INTO execution_protocol_work_items (
+                   agent_id, work_item_id, source_revision, generation,
+                   lifecycle_state, payload_json
+                 ) VALUES (?1, ?2, ?3, ?4, 'waiting', ?5)",
+                params![
+                    "agent-a",
+                    owned.id,
+                    owned_execution.source_revision as i64,
+                    owned_execution.generation() as i64,
+                    serde_json::to_string(&owned_execution)?,
+                ],
+            )?;
+            connection.execute(
+                "INSERT INTO execution_protocol_work_items (
+                   agent_id, work_item_id, source_revision, generation,
+                   lifecycle_state, payload_json
+                 ) VALUES (?1, ?2, ?3, ?4, 'waiting', ?5)",
+                params![
+                    "agent-a",
+                    changed.id,
+                    changed_execution.source_revision as i64,
+                    changed_execution.generation() as i64,
+                    serde_json::to_string(&changed_execution)?,
+                ],
+            )?;
+        }
+
+        let migration = MIGRATIONS
+            .iter()
+            .find(|migration| migration.version == 45)
+            .expect("migration 45");
+        let mut connection = db.connection()?;
+        apply_migration(&mut connection, migration)?;
+
+        let waits = db.wait_conditions().latest_all()?;
+        for wait_id in [&owned_wait.id, &changed_wait.id, &agent_wait.id] {
+            let wait = waits
+                .iter()
+                .find(|wait| wait.id == *wait_id)
+                .expect("cutover wait");
+            assert_eq!(wait.status, WaitConditionStatus::Cancelled);
+            assert_eq!(
+                wait.continuation
+                    .as_ref()
+                    .and_then(|value| value.get("cancel_reason"))
+                    .and_then(serde_json::Value::as_str),
+                Some("protocol_cutover")
+            );
+        }
+
+        let persisted_owned = db.work_items().latest(&owned.id)?.expect("owned WorkItem");
+        assert_eq!(persisted_owned.blocked_by, None);
+        assert_eq!(persisted_owned.revision, owned.revision + 1);
+        let persisted_changed = db
+            .work_items()
+            .latest(&changed.id)?
+            .expect("changed WorkItem");
+        assert_eq!(
+            persisted_changed.blocked_by.as_deref(),
+            Some("newer blocker")
+        );
+        assert_eq!(persisted_changed.revision, changed.revision);
+
+        let load_execution = |work_item_id: &str| -> Result<WorkItemExecutionRecord> {
+            let payload = connection.query_row(
+                "SELECT payload_json
+                 FROM execution_protocol_work_items
+                 WHERE agent_id = 'agent-a' AND work_item_id = ?1",
+                [work_item_id],
+                |row| row.get::<_, String>(0),
+            )?;
+            Ok(serde_json::from_str(&payload)?)
+        };
+        let owned_execution = load_execution(&owned.id)?;
+        assert_eq!(owned_execution.source_revision, persisted_owned.revision);
+        assert_eq!(
+            owned_execution.state,
+            WorkItemExecutionState::Runnable {
+                generation: 5,
+                recovery_ref: Some("protocol_cutover".into()),
+            }
+        );
+        let changed_execution = load_execution(&changed.id)?;
+        assert_eq!(
+            changed_execution.source_revision,
+            persisted_changed.revision
+        );
+        assert_eq!(
+            changed_execution.state,
+            WorkItemExecutionState::Runnable {
+                generation: 8,
+                recovery_ref: Some("protocol_cutover".into()),
+            }
+        );
+        let normalized_attempt_payload = connection.query_row(
+            "SELECT payload_json
+             FROM execution_protocol_attempts
+             WHERE agent_id = 'agent-a'
+               AND attempt_id = 'activation:message:message-cutover-trigger'",
+            [],
+            |row| row.get::<_, String>(0),
+        )?;
+        let normalized_attempt: ExecutionAttempt =
+            serde_json::from_str(&normalized_attempt_payload)?;
+        assert_eq!(
+            normalized_attempt.source.identity,
+            ExecutionSourceIdentity::TriggeredWait {
+                wait_id: "wait-cutover-history".into(),
+                trigger_message_id: "message-cutover-trigger".into(),
+            }
+        );
+        assert_eq!(current_schema_version(&connection)?, 45);
+        Ok(())
+    }
+
+    #[test]
     fn queue_and_wait_terminal_state_survive_restart_and_second_db_handle() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let first = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -4055,6 +4396,8 @@ CREATE TABLE working_memory_deltas (
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         };
         first.queue_entries().upsert(&queue_terminal)?;
         first.wait_conditions().upsert(&wait_terminal)?;
@@ -4131,6 +4474,8 @@ CREATE TABLE working_memory_deltas (
             resolved_at: None,
             cancelled_at: Some(now),
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         };
         let mut wait_late = wait_terminal.clone();
         wait_late.status = WaitConditionStatus::Active;

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -168,6 +168,24 @@ pub(crate) struct WaitConditionExpectation {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct TaskExpectation {
+    pub id: String,
+    pub agent_id: String,
+    pub work_item_id: Option<String>,
+    pub status: crate::types::TaskStatus,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub result_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueueWaitTransition {
+    pub expected: WaitConditionExpectation,
+    pub record: WaitConditionRecord,
+    pub work_item: Option<WorkItemMutation>,
+    pub index_changes: Vec<RuntimeIndexChange>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct WorkItemFocusTransitionCommand {
     pub agent_id: String,
     pub work_items: Vec<WorkItemMutation>,
@@ -218,6 +236,7 @@ pub(crate) struct TaskTransitionCommand {
     pub work_items: Vec<WorkItemMutation>,
     pub wait_conditions: Vec<WaitConditionRecord>,
     pub agent_state: Option<AgentStateMutation>,
+    pub message_evidence: Vec<MessageEnvelope>,
     pub audit_events: Vec<AuditEvent>,
     pub index_changes: Vec<RuntimeIndexChange>,
     pub notify_scheduler: bool,
@@ -245,9 +264,9 @@ impl RuntimeDb {
                  WHERE q.status = 'dequeued'
                    AND NOT EXISTS (
                      SELECT 1
-                     FROM scheduler_activations a
+                     FROM execution_protocol_attempts a
                      WHERE a.agent_id = q.agent_id
-                       AND a.activation_id = 'activation:message:' || q.message_id
+                       AND a.attempt_id = 'activation:message:' || q.message_id
                    )
                    AND NOT EXISTS (
                      SELECT 1
@@ -285,7 +304,7 @@ impl RuntimeDb {
                     data: serde_json::json!({
                         "message_id": expected.message_id,
                         "agent_id": expected.agent_id,
-                        "reason": "no_canonical_activation_or_terminal_turn",
+                        "reason": "no_execution_attempt_or_terminal_turn",
                         "previous_status": "dequeued",
                         "next_status": "interrupted",
                     }),
@@ -401,6 +420,27 @@ impl RuntimeTransitionRepository<'_> {
     }
 
     pub fn commit_wait(&self, command: &WaitTransitionCommand) -> Result<TransitionCommit> {
+        self.commit_wait_with_execution_protocol(command, &ExecutionProtocolTransition::default())
+    }
+
+    pub fn commit_wait_with_execution_protocol(
+        &self,
+        command: &WaitTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+    ) -> Result<TransitionCommit> {
+        self.commit_wait_with_execution_protocol_and_task_expectation(
+            command,
+            execution_protocol,
+            None,
+        )
+    }
+
+    pub fn commit_wait_with_execution_protocol_and_task_expectation(
+        &self,
+        command: &WaitTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        task_expectation: Option<&TaskExpectation>,
+    ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             for work_item in &command.work_items {
                 validate_work_item_mutation_tx(tx, work_item)?;
@@ -409,41 +449,20 @@ impl RuntimeTransitionRepository<'_> {
                 validate_wait_condition_tx(tx, condition)?;
             }
             for expected in &command.expected_wait_conditions {
-                let actual = tx
-                    .query_row(
-                        "SELECT agent_id, status, updated_at
-                         FROM wait_conditions
-                         WHERE wait_condition_id = ?1",
-                        [&expected.id],
-                        |row| {
-                            Ok((
-                                row.get::<_, String>(0)?,
-                                row.get::<_, String>(1)?,
-                                row.get::<_, String>(2)?,
-                            ))
-                        },
-                    )
-                    .optional()?;
-                let expected_status =
-                    crate::runtime_db::repositories::enum_string(&expected.status)?;
-                let expected_updated_at =
-                    crate::runtime_db::repositories::timestamp(expected.updated_at);
-                if actual
-                    .as_ref()
-                    .is_none_or(|(agent_id, status, updated_at)| {
-                        agent_id != &expected.agent_id
-                            || status != &expected_status
-                            || updated_at != &expected_updated_at
-                    })
-                {
-                    return Err(RuntimeStateTransitionConflict::concurrent_mutation(
-                        "wait_condition_repair",
-                        &expected.id,
-                    )
-                    .into());
-                }
+                validate_wait_condition_expectation_tx(tx, expected)?;
+            }
+            if let Some(task_expectation) = task_expectation {
+                validate_task_expectation_tx(tx, task_expectation)?;
             }
             validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
+                tx,
+                &command.agent_id,
+                execution_protocol.bootstrap.as_ref(),
+                &execution_protocol.commands,
+                &command.work_items,
+                &command.wait_conditions,
+            )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
             let mut applied = false;
@@ -461,9 +480,13 @@ impl RuntimeTransitionRepository<'_> {
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             applied |= agent_state_applied;
+            applied |= execution_protocol
+                .as_ref()
+                .is_some_and(|prepared| prepared.has_writes());
             if !applied {
                 return Ok(TransitionCommit::default());
             }
+            execution_protocol_repository::persist_execution_commands_tx(tx, execution_protocol)?;
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
 
             finish_transition_tx(
@@ -486,7 +509,12 @@ impl RuntimeTransitionRepository<'_> {
     }
 
     pub fn commit_queue(&self, command: &QueueTransitionCommand) -> Result<TransitionCommit> {
-        self.commit_queue_with_execution_protocol(command, &ExecutionProtocolTransition::default())
+        self.commit_queue_with_protocol_and_wait_trigger(
+            command,
+            &ExecutionProtocolTransition::default(),
+            None,
+            None,
+        )
     }
 
     pub fn commit_queue_with_execution_protocol(
@@ -494,9 +522,70 @@ impl RuntimeTransitionRepository<'_> {
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
     ) -> Result<TransitionCommit> {
+        self.commit_queue_with_protocol_and_wait_trigger(command, execution_protocol, None, None)
+    }
+
+    pub fn commit_queue_with_wait_trigger(
+        &self,
+        command: &QueueTransitionCommand,
+        wait_transition: Option<&QueueWaitTransition>,
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_with_protocol_and_wait_trigger(
+            command,
+            &ExecutionProtocolTransition::default(),
+            wait_transition,
+            None,
+        )
+    }
+
+    pub fn commit_queue_with_execution_protocol_and_wait_transition(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        wait_transition: Option<&QueueWaitTransition>,
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_with_protocol_and_wait_trigger(
+            command,
+            execution_protocol,
+            wait_transition,
+            None,
+        )
+    }
+
+    pub fn commit_queue_with_execution_protocol_and_task_expectation(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        task_expectation: &TaskExpectation,
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_with_protocol_and_wait_trigger(
+            command,
+            execution_protocol,
+            None,
+            Some(task_expectation),
+        )
+    }
+
+    fn commit_queue_with_protocol_and_wait_trigger(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        wait_transition: Option<&QueueWaitTransition>,
+        task_expectation: Option<&TaskExpectation>,
+    ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_queue_operation(command)?;
             validate_queue_mutation_tx(tx, &command.mutation)?;
+            if let Some(wait_transition) = wait_transition {
+                validate_wait_condition_expectation_tx(tx, &wait_transition.expected)?;
+                validate_wait_condition_tx(tx, &wait_transition.record)?;
+                if let Some(work_item) = wait_transition.work_item.as_ref() {
+                    validate_work_item_mutation_tx(tx, work_item)?;
+                }
+            }
+            if let Some(task_expectation) = task_expectation {
+                validate_task_expectation_tx(tx, task_expectation)?;
+            }
             if let QueueMutation::Consume(record) = &command.mutation {
                 let include_interrupted = match command.operation {
                     QueueOperation::Claim => true,
@@ -575,6 +664,12 @@ impl RuntimeTransitionRepository<'_> {
                 &command.agent_id,
                 execution_protocol.bootstrap.as_ref(),
                 &execution_protocol.commands,
+                wait_transition
+                    .and_then(|transition| transition.work_item.as_ref())
+                    .map_or(&[], std::slice::from_ref),
+                wait_transition
+                    .map(|transition| std::slice::from_ref(&transition.record))
+                    .unwrap_or_default(),
             )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
             let mutation_applied = match &command.mutation {
@@ -604,10 +699,28 @@ impl RuntimeTransitionRepository<'_> {
             let execution_protocol_applied = execution_protocol
                 .as_ref()
                 .is_some_and(|prepared| prepared.has_writes());
+            let wait_transition_applied = wait_transition
+                .map(|wait_transition| upsert_wait_condition_tx(tx, &wait_transition.record))
+                .transpose()?
+                .unwrap_or(false);
+            let mut wait_work_items = Vec::new();
+            let wait_work_item_applied = if let Some(work_item) =
+                wait_transition.and_then(|wait_transition| wait_transition.work_item.as_ref())
+            {
+                let applied = apply_work_item_mutation_tx(tx, work_item)?;
+                if applied {
+                    wait_work_items.push(work_item.record().clone());
+                }
+                applied
+            } else {
+                false
+            };
             let applied = mutation_applied
                 || agent_state_applied
                 || protocol_applied
-                || execution_protocol_applied;
+                || execution_protocol_applied
+                || wait_transition_applied
+                || wait_work_item_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
@@ -635,12 +748,13 @@ impl RuntimeTransitionRepository<'_> {
                 applied,
                 &command.agent_id,
                 &command.audit_events,
-                &[],
+                wait_transition.map_or(&[], |transition| transition.index_changes.as_slice()),
                 command.fault,
                 PostCommitEffects {
                     agent_state: agent_state_applied
                         .then(|| command.agent_state.clone())
                         .flatten(),
+                    work_items: wait_work_items,
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
                 },
@@ -676,6 +790,9 @@ impl RuntimeTransitionRepository<'_> {
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             applied |= agent_state_applied;
+            for message in &command.message_evidence {
+                append_message_tx(tx, message)?;
+            }
             applied |= command.commit_on_idempotent;
             if !applied {
                 return Ok(TransitionCommit::default());
@@ -704,6 +821,68 @@ impl RuntimeTransitionRepository<'_> {
             )
         })
     }
+}
+
+fn validate_wait_condition_expectation_tx(
+    tx: &Transaction<'_>,
+    expected: &WaitConditionExpectation,
+) -> Result<()> {
+    let actual = tx
+        .query_row(
+            "SELECT agent_id, status, updated_at
+             FROM wait_conditions
+             WHERE wait_condition_id = ?1",
+            [&expected.id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let expected_status = crate::runtime_db::repositories::enum_string(&expected.status)?;
+    let expected_updated_at = crate::runtime_db::repositories::timestamp(expected.updated_at);
+    if actual
+        .as_ref()
+        .is_none_or(|(agent_id, status, updated_at)| {
+            agent_id != &expected.agent_id
+                || status != &expected_status
+                || updated_at != &expected_updated_at
+        })
+    {
+        return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+            "wait_condition_trigger",
+            &expected.id,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_task_expectation_tx(tx: &Transaction<'_>, expected: &TaskExpectation) -> Result<()> {
+    let actual = tx
+        .query_row(
+            "SELECT payload_json FROM tasks WHERE task_id = ?1",
+            [&expected.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<TaskRecord>(&payload))
+        .transpose()?;
+    if actual.as_ref().is_none_or(|task| {
+        task.agent_id != expected.agent_id
+            || task.work_item_id != expected.work_item_id
+            || task.status != expected.status
+            || task.updated_at != expected.updated_at
+            || task.parent_message_id != expected.result_message_id
+    }) {
+        return Err(
+            RuntimeStateTransitionConflict::concurrent_mutation("task_wait", &expected.id).into(),
+        );
+    }
+    Ok(())
 }
 
 fn finish_transition_tx(
@@ -1250,9 +1429,11 @@ mod tests {
     use crate::{
         domain::execution_protocol::{
             AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState,
-            ExecutionBinding, ExecutionOrigin, ExecutionPriority, ExecutionProtocolCommand,
-            ExecutionProtocolState, ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity,
-            ExecutionTrust, WorkItemExecutionRecord, WorkItemExecutionState,
+            ExecutionBinding, ExecutionOrigin, ExecutionOutcome, ExecutionOutcomeRecord,
+            ExecutionPriority, ExecutionProtocolCommand, ExecutionProtocolState,
+            ExecutionProvenance, ExecutionSource, ExecutionSourceIdentity, ExecutionTrust,
+            SettleExecution, WaitReference, WorkItemExecutionRecord, WorkItemExecutionState,
+            WorkItemOutcome,
         },
         domain::scheduler_protocol::{
             ActivationSlot, AgentDispatchState, ProtocolCommand, Snapshot,
@@ -1316,6 +1497,8 @@ mod tests {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         }
     }
 
@@ -1829,6 +2012,123 @@ mod tests {
     }
 
     #[test]
+    fn wait_registration_and_execution_settlement_roll_back_together() -> Result<()> {
+        for fault in [
+            TransitionFaultPoint::AfterValidation,
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let now = Utc::now();
+            db.agent_states().upsert(&AgentState::new("agent-a"))?;
+            db.agent_identities().upsert(&AgentIdentityRecord::new(
+                "agent-a",
+                AgentKind::Named,
+                AgentVisibility::Public,
+                AgentOwnership::SelfOwned,
+                AgentProfilePreset::PublicNamed,
+                None,
+                None,
+            ))?;
+            let admission = execution_admission("message-wait", "attempt-wait", "work-wait");
+            db.transitions().commit_queue_with_execution_protocol(
+                &QueueTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    operation: QueueOperation::Admit,
+                    mutation: QueueMutation::Upsert(QueueEntryRecord {
+                        message_id: "message-wait".into(),
+                        agent_id: "agent-a".into(),
+                        priority: Priority::Normal,
+                        status: QueueEntryStatus::Queued,
+                        created_at: now,
+                        updated_at: now,
+                    }),
+                    scheduler_claim_work_item: None,
+                    scheduler_protocol_bootstrap: None,
+                    scheduler_protocol_commands: Vec::new(),
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    turn_record: None,
+                    audit_events: Vec::new(),
+                    notify_scheduler: false,
+                    fault: None,
+                    brief_evidence: Vec::new(),
+                },
+                &admission,
+            )?;
+            let wait = wait_condition("wait-execution", "work-wait", "task-wait");
+            let settlement = ExecutionProtocolTransition {
+                bootstrap: None,
+                commands: vec![ExecutionProtocolCommand::Settle(SettleExecution {
+                    outcome: ExecutionOutcomeRecord {
+                        outcome_id: "outcome-wait".into(),
+                        attempt_id: "attempt-wait".into(),
+                        outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
+                            wait: WaitReference {
+                                wait_id: wait.id.clone(),
+                            },
+                        }),
+                        created_at: now.to_rfc3339(),
+                    },
+                })],
+            };
+            db.transitions()
+                .commit_wait_with_execution_protocol(
+                    &WaitTransitionCommand {
+                        agent_id: "agent-a".into(),
+                        work_items: Vec::new(),
+                        expected_wait_conditions: Vec::new(),
+                        wait_conditions: vec![wait.clone()],
+                        agent_state: None,
+                        audit_events: Vec::new(),
+                        index_changes: Vec::new(),
+                        notify_scheduler: false,
+                        fault: Some(fault),
+                    },
+                    &settlement,
+                )
+                .unwrap_err();
+
+            assert!(db.wait_conditions().latest_all()?.is_empty());
+            let state = db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("agent-a")?
+                .expect("admission state");
+            assert_eq!(
+                state.attempts["attempt-wait"].state,
+                ExecutionAttemptState::Open
+            );
+
+            db.transitions().commit_wait_with_execution_protocol(
+                &WaitTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    work_items: Vec::new(),
+                    expected_wait_conditions: Vec::new(),
+                    wait_conditions: vec![wait],
+                    agent_state: None,
+                    audit_events: Vec::new(),
+                    index_changes: Vec::new(),
+                    notify_scheduler: false,
+                    fault: None,
+                },
+                &settlement,
+            )?;
+            let state = db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("agent-a")?
+                .expect("settled state");
+            assert_eq!(
+                state.attempts["attempt-wait"].state,
+                ExecutionAttemptState::Settled
+            );
+            assert_eq!(db.wait_conditions().latest_all()?.len(), 1);
+        }
+        Ok(())
+    }
+
+    #[test]
     fn execution_admission_command_is_idempotent_across_queue_commits() -> Result<()> {
         let (_dir, db) = runtime_db()?;
         db.agent_states().upsert(&AgentState::new("agent-a"))?;
@@ -2120,6 +2420,7 @@ mod tests {
             }],
             wait_conditions: vec![resolved],
             agent_state: None,
+            message_evidence: Vec::new(),
             audit_events: vec![
                 AuditEvent::legacy("task_terminal", serde_json::json!({})),
                 AuditEvent::legacy("wait_resolved", serde_json::json!({})),

--- a/src/runtime_db/transitions/execution_protocol_fixture_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_fixture_repository.rs
@@ -481,7 +481,6 @@ fn adopt_legacy_to_execution_state(
                 generation,
                 wait: WaitReference {
                     wait_id: wait_id.unwrap_or_default(),
-                    generation,
                 },
             },
             "needs_settlement" => WorkItemExecutionState::InFlight {
@@ -579,9 +578,7 @@ fn adopt_legacy_to_execution_state(
                     } else {
                         ExecutionSourceIdentity::TriggeredWait {
                             wait_id: format!("adopted:{activation_id}"),
-                            wait_generation: generation,
-                            trigger_id: format!("adopted:{activation_id}"),
-                            trigger_generation: generation,
+                            trigger_message_id: format!("adopted:{activation_id}"),
                         }
                     },
                     generation,

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -7,11 +7,13 @@ use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 
 use crate::domain::execution_protocol::{
-    self, ExecutionProtocolCommand, ExecutionProtocolState, ExecutionTransition,
-    WorkItemExecutionState,
+    self, ExecutionOutcomeRecord, ExecutionProtocolCommand, ExecutionProtocolState,
+    ExecutionTransition, WorkItemExecutionState,
 };
 use crate::{
-    runtime_db::transitions::{ExecutionAuthorityFences, RuntimeTransitionRepository},
+    runtime_db::transitions::{
+        ExecutionAuthorityFences, RuntimeTransitionRepository, WorkItemMutation,
+    },
     types::{AgentIdentityRecord, AgentRegistryStatus, AgentStatus},
 };
 
@@ -39,6 +41,8 @@ pub(super) fn validate_execution_commands_tx(
     agent_id: &str,
     bootstrap: Option<&ExecutionProtocolState>,
     commands: &[ExecutionProtocolCommand],
+    work_item_mutations: &[WorkItemMutation],
+    wait_conditions: &[crate::types::WaitConditionRecord],
 ) -> Result<Option<PreparedExecutionProtocolCommands>> {
     if commands.is_empty() {
         return Ok(None);
@@ -75,6 +79,12 @@ pub(super) fn validate_execution_commands_tx(
         }
         if let ExecutionProtocolCommand::Admit(command) = command {
             validate_admission_authority_tx(tx, agent_id, &command.attempt.admitted_fences)?;
+        }
+        if let ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) = command {
+            validate_work_item_source_revision_advance(command, work_item_mutations)?;
+        }
+        if let ExecutionProtocolCommand::SetWorkItemWaiting(command) = command {
+            validate_set_work_item_waiting(command, work_item_mutations, wait_conditions)?;
         }
         let transition = reduce(&state, command)
             .map_err(|error| anyhow!("execution protocol command rejected: {error}"))?;
@@ -129,6 +139,12 @@ fn reduce(
         ExecutionProtocolCommand::RegisterWorkItem(command) => {
             execution_protocol::register_work_item_execution(state, command)
         }
+        ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) => {
+            execution_protocol::advance_work_item_source_revision(state, command)
+        }
+        ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
+            execution_protocol::set_work_item_waiting(state, command)
+        }
         ExecutionProtocolCommand::Admit(command) => {
             execution_protocol::admit_execution(state, command)
         }
@@ -146,6 +162,12 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
         ExecutionProtocolCommand::RegisterWorkItem(command) => {
             ("register_work_item_execution", &command.work_item_id)
         }
+        ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) => {
+            ("advance_work_item_source_revision", &command.command_id)
+        }
+        ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
+            ("set_work_item_waiting", &command.command_id)
+        }
         ExecutionProtocolCommand::Admit(command) => {
             ("admit_execution", &command.attempt.attempt_id)
         }
@@ -156,6 +178,59 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
             ("interrupt_execution", &command.outcome_id)
         }
     }
+}
+
+fn validate_set_work_item_waiting(
+    command: &execution_protocol::SetWorkItemWaiting,
+    mutations: &[WorkItemMutation],
+    wait_conditions: &[crate::types::WaitConditionRecord],
+) -> Result<()> {
+    let Some(record) = mutations.iter().find_map(|mutation| match mutation {
+        WorkItemMutation::Update { record, .. }
+            if record.id == command.work_item_id
+                && record.revision == command.record.source_revision =>
+        {
+            Some(record)
+        }
+        _ => None,
+    }) else {
+        bail!("WorkItem waiting transition requires an atomic WorkItem update");
+    };
+    let execution_protocol::WorkItemExecutionState::Waiting { wait, .. } = &command.record.state
+    else {
+        bail!("WorkItem waiting transition record is not Waiting");
+    };
+    if record.agent_id.is_empty()
+        || !wait_conditions.iter().any(|condition| {
+            condition.id == wait.wait_id
+                && condition.agent_id == record.agent_id
+                && condition.work_item_id.as_deref() == Some(record.id.as_str())
+                && condition.status == crate::types::WaitConditionStatus::Active
+        })
+    {
+        bail!("WorkItem waiting transition does not match its atomic wait condition");
+    }
+    Ok(())
+}
+
+fn validate_work_item_source_revision_advance(
+    command: &execution_protocol::AdvanceWorkItemSourceRevision,
+    mutations: &[WorkItemMutation],
+) -> Result<()> {
+    let Some(record) = mutations.iter().find_map(|mutation| match mutation {
+        WorkItemMutation::Update { record, .. }
+            if record.id == command.work_item_id && record.revision == command.source_revision =>
+        {
+            Some(record)
+        }
+        _ => None,
+    }) else {
+        bail!("WorkItem source revision advance requires an atomic WorkItem update");
+    };
+    if record.agent_id.is_empty() {
+        bail!("WorkItem source revision advance does not match its atomic WorkItem update");
+    }
+    Ok(())
 }
 
 fn partition_exists_tx(tx: &Transaction<'_>, agent_id: &str) -> Result<bool> {
@@ -357,7 +432,7 @@ pub(crate) fn persist_state_tx(tx: &Transaction<'_>, state: &ExecutionProtocolSt
             )
             .optional()?;
         if let Some(existing) = existing {
-            if existing != payload {
+            if !stored_outcome_matches(&existing, outcome)? {
                 bail!(
                     "execution outcome identity conflict for {}",
                     outcome.outcome_id
@@ -378,6 +453,12 @@ pub(crate) fn persist_state_tx(tx: &Transaction<'_>, state: &ExecutionProtocolSt
         )?;
     }
     Ok(())
+}
+
+fn stored_outcome_matches(existing: &str, outcome: &ExecutionOutcomeRecord) -> Result<bool> {
+    let existing: ExecutionOutcomeRecord = serde_json::from_str(existing)
+        .with_context(|| format!("decoding stored execution outcome {}", outcome.outcome_id))?;
+    Ok(existing == *outcome)
 }
 
 pub(super) fn load_state_tx(
@@ -453,4 +534,44 @@ fn work_item_state_token(state: &WorkItemExecutionState) -> &'static str {
 
 fn to_i64(value: u64) -> Result<i64> {
     i64::try_from(value).context("execution protocol generation exceeds SQLite INTEGER")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::execution_protocol::{ExecutionOutcome, WaitReference, WorkItemOutcome};
+
+    fn wait_outcome(wait_id: &str) -> ExecutionOutcomeRecord {
+        ExecutionOutcomeRecord {
+            outcome_id: "outcome-1".into(),
+            attempt_id: "attempt-1".into(),
+            outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
+                wait: WaitReference {
+                    wait_id: wait_id.into(),
+                },
+            }),
+            created_at: "2026-08-05T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn stored_outcome_identity_ignores_removed_wait_generation_field() {
+        let existing = serde_json::json!({
+            "outcome_id": "outcome-1",
+            "attempt_id": "attempt-1",
+            "outcome": {
+                "owner": "work_item",
+                "outcome": {
+                    "kind": "wait",
+                    "wait": {
+                        "wait_id": "wait-1",
+                        "generation": 7
+                    }
+                }
+            },
+            "created_at": "2026-08-05T00:00:00Z"
+        });
+        assert!(stored_outcome_matches(&existing.to_string(), &wait_outcome("wait-1")).unwrap());
+        assert!(!stored_outcome_matches(&existing.to_string(), &wait_outcome("wait-2")).unwrap());
+    }
 }

--- a/src/runtime_db/transitions/scheduler_protocol_repository.rs
+++ b/src/runtime_db/transitions/scheduler_protocol_repository.rs
@@ -1264,7 +1264,6 @@ fn execution_authority_matches_adoption_tx(
             generation == &compatibility_wait.generation
                 && wait.wait_id == *wait_id
                 && wait.wait_id == compatibility_wait.wait_id
-                && wait.generation == compatibility_wait.generation
                 && compatibility_wait.owner_work_item_id == command.work_item_id
         }
         _ => false,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1086,6 +1086,16 @@ impl AppStorage {
         Ok(records)
     }
 
+    /// Returns unresolved wait conditions without the live-scope filter.
+    pub fn raw_unresolved_wait_conditions_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<WaitConditionRecord>> {
+        self.runtime_db
+            .wait_conditions()
+            .unresolved_for_agent(agent_id)
+    }
+
     pub fn latest_wait_conditions(&self) -> Result<Vec<WaitConditionRecord>> {
         let runtime_db = self.runtime_db.clone();
         return runtime_db.wait_conditions().latest_all();
@@ -1611,6 +1621,8 @@ mod tests {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         };
         let queue_entry = QueueEntryRecord {
             message_id: "msg-1".into(),
@@ -1640,9 +1652,11 @@ mod tests {
 
         let mut later_wait_condition = wait_condition.clone();
         later_wait_condition.id = "wait-2".into();
+        later_wait_condition.work_item_id = Some("work-2".into());
         later_wait_condition.updated_at = now + chrono::Duration::seconds(1);
         let mut latest_wait_condition = wait_condition.clone();
         latest_wait_condition.id = "wait-3".into();
+        latest_wait_condition.work_item_id = Some("work-3".into());
         latest_wait_condition.updated_at = now + chrono::Duration::seconds(2);
         storage
             .append_wait_condition(&later_wait_condition)
@@ -1787,6 +1801,8 @@ mod tests {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         };
         let queue_entry = QueueEntryRecord {
             message_id: "message-db-only".into(),
@@ -2041,6 +2057,8 @@ mod tests {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         };
         let episode_for = |agent_id: &str, id: &str| ContextEpisodeRecord {
             id: id.into(),
@@ -3219,6 +3237,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -3241,6 +3261,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
 
@@ -3308,6 +3330,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
 
@@ -3360,6 +3384,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             },
             WaitConditionRecord {
                 id: "recoverable".into(),
@@ -3386,6 +3412,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             },
             WaitConditionRecord {
                 id: "explicit".into(),
@@ -3409,6 +3437,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             },
         ] {
             storage.append_wait_condition(&record).unwrap();
@@ -3518,6 +3548,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -3541,6 +3573,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -3562,6 +3596,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -3585,6 +3621,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage
@@ -3606,6 +3644,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
 
@@ -3751,6 +3791,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         assert_eq!(
@@ -3792,6 +3834,8 @@ mod tests {
                 cancelled_at: None,
 
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         let task_projection = storage.agent_posture_projection(&agent).unwrap();
@@ -3874,6 +3918,8 @@ mod tests {
                         cancelled_at: None,
 
                         turn_id: None,
+                        trigger_message_id: None,
+                        triggered_at: None,
                     })
                     .unwrap();
             };
@@ -4524,6 +4570,8 @@ mod tests {
                 resolved_at: None,
                 cancelled_at: None,
                 turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
             })
             .unwrap();
         storage

--- a/src/tool/tools/wait_for.rs
+++ b/src/tool/tools/wait_for.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    runtime::{RuntimeHandle, WaitForScope, WaitForWakeKind},
+    runtime::{RuntimeHandle, WaitForRegistrationOutcome, WaitForScope, WaitForWakeKind},
     tool::{
         helpers::{invalid_tool_input, parse_tool_args, validate_non_empty},
         spec::typed_spec,
@@ -106,7 +106,7 @@ pub(crate) async fn execute(
             })
     });
     let registration = runtime
-        .register_wait_for(
+        .register_wait_for_outcome(
             agent_id,
             work_item_id.clone(),
             args.wake.into(),
@@ -115,6 +115,43 @@ pub(crate) async fn execute(
             args.recheck_after_ms,
         )
         .await?;
+    let registration = match registration {
+        WaitForRegistrationOutcome::TaskResultQueued {
+            task_id,
+            result_message_id,
+        } => {
+            let mut result = ToolResult::success(
+                NAME,
+                json!({
+                    "disposition": "task_result_queued",
+                    "task_id": task_id,
+                    "result_message_id": result_message_id,
+                }),
+                Some(format!(
+                    "task result already completed; queued exact result message {result_message_id}"
+                )),
+            );
+            result.terminal_transition = true;
+            return Ok(result);
+        }
+        WaitForRegistrationOutcome::TaskResultAlreadyConsumed {
+            task_id,
+            result_message_id,
+        } => {
+            return Ok(ToolResult::success(
+                NAME,
+                json!({
+                    "disposition": "task_result_already_consumed",
+                    "task_id": task_id,
+                    "result_message_id": result_message_id,
+                }),
+                Some(format!(
+                    "task result was already consumed: {result_message_id}"
+                )),
+            ));
+        }
+        WaitForRegistrationOutcome::Registered { registration } => registration,
+    };
     let updated_context = query_context(runtime).await?;
     let work_item = match registration.work_item {
         Some(record) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -2249,6 +2249,7 @@ fn default_external_trigger_scope() -> ExternalTriggerScope {
 #[serde(rename_all = "snake_case")]
 pub enum WaitConditionStatus {
     Active,
+    Triggered,
     Resolved,
     Cancelled,
     Expired,
@@ -2316,9 +2317,28 @@ pub struct WaitConditionRecord {
     pub cancelled_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triggered_at: Option<DateTime<Utc>>,
 }
 
 impl WaitConditionRecord {
+    pub fn trigger_message_id(&self) -> Option<&str> {
+        self.trigger_message_id.as_deref()
+    }
+
+    pub fn triggered_at(&self) -> Option<DateTime<Utc>> {
+        self.triggered_at
+    }
+
+    pub fn mark_triggered(&mut self, message_id: &str, triggered_at: DateTime<Utc>) {
+        self.trigger_message_id = Some(message_id.to_string());
+        self.triggered_at = Some(triggered_at);
+        self.status = WaitConditionStatus::Triggered;
+        self.updated_at = triggered_at;
+    }
+
     pub fn external_recoverability(&self) -> Option<ExternalWaitRecoverability> {
         if self.kind != WaitConditionKind::External || self.status != WaitConditionStatus::Active {
             return None;

--- a/src/work_item_scheduling.rs
+++ b/src/work_item_scheduling.rs
@@ -495,6 +495,8 @@ mod tests {
             resolved_at: None,
             cancelled_at: None,
             turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
         }
     }
 

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -1780,19 +1780,19 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 {"scheduler-tick"},
             )
 
-    def test_canonical_wait_resolution_rejects_consuming_activation(self) -> None:
+    def test_canonical_wait_resolution_requires_exact_resolved_owner(self) -> None:
         harness = type(
             "CanonicalHarness",
             (),
-            {"canonical_scheduler_enabled": True},
+            {"canonical_scheduler_enabled": True, "agent_id": "default"},
         )()
         canonical_wait = {
-            "wait_id": "wait-1",
-            "owner_work_item_id": "work-1",
-            "lifecycle_state": "resolved",
-            "consuming_activation_id": None,
+            "wait_condition_id": "wait-1",
+            "agent_id": "default",
+            "work_item_id": "work-1",
+            "status": "resolved",
         }
-        snapshot = {"scheduler_wait_generations": [canonical_wait]}
+        snapshot = {"wait_conditions": [canonical_wait]}
         runner.require_scheduler_engine_wait_resolution(
             harness,
             snapshot,
@@ -1800,7 +1800,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             wait_ids={"wait-1"},
         )
 
-        canonical_wait["consuming_activation_id"] = "activation-unexpected"
+        canonical_wait["work_item_id"] = "work-unexpected"
         with self.assertRaisesRegex(
             AssertionError, "canonical waits did not resolve exactly once"
         ):
@@ -1980,33 +1980,66 @@ class DockerE2ERunnerTests(unittest.TestCase):
             },
         )()
         snapshot = {
-            "scheduler_activations": [
+            "execution_protocol_attempts": [
                 {
                     "agent_id": "default",
-                    "activation_id": "activation:message:message-create",
-                    "work_item_id": None,
-                    "admission_kind": "lifecycle_external_nudge",
+                    "attempt_id": "attempt-lifecycle",
                     "lifecycle_state": "settled",
+                    "terminal_outcome_id": "outcome-lifecycle",
+                    "payload_json": json.dumps(
+                        {
+                            "attempt_id": "attempt-lifecycle",
+                            "source_message_id": "message-create",
+                            "source": {
+                                "identity": {
+                                    "kind": "queue_message",
+                                    "message_id": "message-create",
+                                }
+                            },
+                            "binding": {
+                                "kind": "agent_lifecycle",
+                                "agent_id": "default",
+                            },
+                        }
+                    ),
                 },
                 {
                     "agent_id": "default",
-                    "activation_id": "activation:message:message-resume",
-                    "work_item_id": "work-1",
-                    "admission_kind": "wait_resume",
+                    "attempt_id": "attempt-resume",
                     "lifecycle_state": "settled",
+                    "terminal_outcome_id": "outcome-resume",
+                    "payload_json": json.dumps(
+                        {
+                            "attempt_id": "attempt-resume",
+                            "source_message_id": "message-resume",
+                            "source": {
+                                "identity": {
+                                    "kind": "triggered_wait",
+                                    "wait_id": "wait-1",
+                                    "trigger_message_id": "message-resume",
+                                }
+                            },
+                            "binding": {
+                                "kind": "work_item",
+                                "work_item_id": "work-1",
+                            },
+                        }
+                    ),
                 },
             ],
-            "scheduler_activation_settlements": [
-                {"activation_id": "activation:message:message-create"},
-                {"activation_id": "activation:message:message-resume"},
-            ],
-            "scheduler_missing_settlements": [],
-            "scheduler_agent_slots": [
+            "execution_protocol_outcomes": [
                 {
                     "agent_id": "default",
-                    "slot_kind": "idle",
-                    "activation_id": None,
-                }
+                    "outcome_id": "outcome-lifecycle",
+                    "payload_json": json.dumps(
+                        {"attempt_id": "attempt-lifecycle"}
+                    ),
+                },
+                {
+                    "agent_id": "default",
+                    "outcome_id": "outcome-resume",
+                    "payload_json": json.dumps({"attempt_id": "attempt-resume"}),
+                },
             ],
         }
 
@@ -2014,20 +2047,26 @@ class DockerE2ERunnerTests(unittest.TestCase):
             harness,
             snapshot,
             work_item_id="work-1",
-            expected_admission_kinds=("wait_resume",),
+            expected_source_kinds=("triggered_wait",),
             lifecycle_message_ids={"message-create"},
         )
 
-        snapshot["scheduler_activations"][0]["work_item_id"] = "work-1"
+        lifecycle = json.loads(
+            snapshot["execution_protocol_attempts"][0]["payload_json"]
+        )
+        lifecycle["binding"] = {"kind": "work_item", "work_item_id": "work-1"}
+        snapshot["execution_protocol_attempts"][0]["payload_json"] = json.dumps(
+            lifecycle
+        )
         with self.assertRaisesRegex(
             AssertionError,
-            "lifecycle activations did not settle without claiming a WorkItem",
+            "lifecycle attempts did not settle without claiming a WorkItem",
         ):
             runner.require_scheduler_engine_activation_chain(
                 harness,
                 snapshot,
                 work_item_id="work-1",
-                expected_admission_kinds=("wait_resume",),
+                expected_source_kinds=("triggered_wait",),
                 lifecycle_message_ids={"message-create"},
             )
 
@@ -2074,40 +2113,72 @@ class DockerE2ERunnerTests(unittest.TestCase):
             )
 
     def test_checkpoint_restart_lineage_binds_wait_generation(self) -> None:
+        def attempt(
+            attempt_id: str,
+            message_id: str,
+            generation: int,
+            identity: dict[str, object],
+        ) -> dict[str, object]:
+            return {
+                "attempt_id": attempt_id,
+                "source_message_id": message_id,
+                "source": {"identity": identity},
+                "binding": {"kind": "work_item", "work_item_id": "work-1"},
+                "admitted_fences": {"work_item_generation": generation},
+            }
+
         before_restart_snapshot = {
-            "scheduler_activations": [
+            "execution_protocol_attempts": [
                 {
-                    "activation_id": "activation:schedule",
-                    "work_item_id": "work-1",
-                    "admitted_generation": 1,
-                    "admission_kind": "scheduling",
-                    "idempotency_key": "work-queue-attempt:activation:schedule",
+                    "payload_json": json.dumps(
+                        attempt(
+                            "attempt-schedule",
+                            "message-schedule",
+                            1,
+                            {
+                                "kind": "work_item_continuation",
+                                "work_item_id": "work-1",
+                            },
+                        )
+                    ),
                 }
             ]
         }
         snapshot = {
-            "scheduler_activations": [
+            "execution_protocol_attempts": [
                 {
-                    "activation_id": "activation:schedule",
-                    "work_item_id": "work-1",
-                    "admitted_generation": 1,
-                    "admission_kind": "scheduling",
-                    "idempotency_key": "work-queue-attempt:activation:schedule",
+                    "payload_json": json.dumps(
+                        attempt(
+                            "attempt-schedule",
+                            "message-schedule",
+                            1,
+                            {
+                                "kind": "work_item_continuation",
+                                "work_item_id": "work-1",
+                            },
+                        )
+                    ),
                 },
                 {
-                    "activation_id": "activation:resume",
-                    "work_item_id": "work-1",
-                    "admitted_generation": 2,
-                    "admission_kind": "wait_resume",
-                    "idempotency_key": "wait-resume:wait-1:2:activation:resume",
+                    "payload_json": json.dumps(
+                        attempt(
+                            "attempt-resume",
+                            "message-resume",
+                            2,
+                            {
+                                "kind": "triggered_wait",
+                                "wait_id": "wait-1",
+                                "trigger_message_id": "message-resume",
+                            },
+                        )
+                    ),
                 },
             ],
-            "scheduler_wait_generations": [
+            "wait_conditions": [
                 {
-                    "wait_id": "wait-1",
-                    "owner_work_item_id": "work-1",
-                    "generation": 2,
-                    "lifecycle_state": "resolved",
+                    "wait_condition_id": "wait-1",
+                    "work_item_id": "work-1",
+                    "status": "resolved",
                 }
             ],
         }
@@ -2119,12 +2190,16 @@ class DockerE2ERunnerTests(unittest.TestCase):
             wait_id="wait-1",
         )
 
-        snapshot["scheduler_activations"][1]["idempotency_key"] = (
-            "wait-resume:other-wait:2:activation:resume"
+        resume = json.loads(
+            snapshot["execution_protocol_attempts"][1]["payload_json"]
+        )
+        resume["source"]["identity"]["wait_id"] = "other-wait"
+        snapshot["execution_protocol_attempts"][1]["payload_json"] = json.dumps(
+            resume
         )
         with self.assertRaisesRegex(
             AssertionError,
-            "wait-resume activation mismatch",
+            "wait-resume attempt mismatch",
         ):
             runner.require_checkpoint_restart_activation_lineage(
                 before_restart_snapshot,


### PR DESCRIPTION
## Summary

- make `ExecutionAttempt` the canonical authority for admission, turn binding,
  settlement, interruption, and startup recovery
- make `WaitFor`, wait triggering, queue admission, WorkItem execution state,
  and late task results commit through atomic execution-protocol transitions
- replace wait-generation correlation with exact `wait_id` and
  `trigger_message_id` identity, including lifecycle-to-WorkItem wait handoff
- fail open for stale or mismatched wake/task input instead of blocking the
  global queue head
- add schema migration 45 to cancel pre-cutover unresolved waits, release only
  provably owned blockers, converge stale `Waiting` execution records, and
  structurally normalize historical terminal attempts without reviving waits
- remove legacy scheduler authority reads from canonical startup, admission,
  settlement, interjection, wait reconciliation, and orphan-claim recovery

## Runtime contract

The legacy scheduler remains available as the process-wide rollback engine and
its tables remain available for explicit diagnostics during the observation
period. Canonical execution no longer consults those tables for authority.
Deleting the selector and obsolete schema remains a separate follow-up after
the observation period and rollback drill.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- OpenAPI and runtime-status snapshot checks
- `python3 scripts/check-test-temp-resources.py`
- `cargo test --all-targets -- --test-threads=1`
- `make lint`
- `make test-concurrent`
- targeted wait, scheduler, crash-fault, restart, lifecycle-handoff, late-task,
  migration, and orphan-claim regressions

All checks passed.

## Copied production database rehearsal

An online SQLite backup of the running production database (about 13 GB,
schema 42) was upgraded with this branch:

- schema reached version 45 and `PRAGMA quick_check` returned `ok`
- 13 historical unresolved waits converged to zero
- stale `Waiting(wait_id)` execution references converged to zero
- a second migration run made no database changes
- isolated startup of the three active agents with pre-existing open attempts
  atomically interrupted each attempt and its matching dequeued queue entry
- the rehearsal used a loopback-only unavailable provider and made no external
  provider requests

The rehearsal exposed and this PR fixes two additional historical compatibility
shapes: legacy `TriggeredWait` attempt payloads and semantically identical
immutable outcomes containing removed wait-generation fields.

Closes #2499
