### PR TITLE
feat: add release-aware runtime db baseline

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run release core E2E
         env:
-          HOLON_E2E_PREVIOUS_IMAGE: ${{ inputs.previous_image }}
+          HOLON_E2E_PREVIOUS_IMAGE: ${{ inputs.previous_image || 'ghcr.io/holon-run/holon:v0.30.0' }}
           HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
         run: |
           set -euo pipefail

--- a/docs/implementation-decisions/101-release-aware-runtime-db-baseline.md
+++ b/docs/implementation-decisions/101-release-aware-runtime-db-baseline.md
@@ -1,0 +1,31 @@
+# Release-aware runtime DB baseline
+
+## Decision
+
+The first release after `v0.30.0` treats schema `25` as the published migration
+floor. Databases at or below that floor run the released migrations through
+schema `25`, then apply one atomic release baseline that:
+
+- executes the real schema `26-30` data conversions;
+- creates the final schema `45` scheduler, execution, and wait objects directly;
+- records the covered schema `26-45` identities in `schema_migrations`; and
+- records explicit provenance and a final schema fingerprint in
+  `schema_migration_baselines`.
+
+Databases already at schema `26-45` continue through the original compatibility
+migrations.
+
+## Reason
+
+Release users never observed the intermediate scheduler rollout, shadow, owner,
+and internal-followup table shapes. Replaying those shapes creates and rebuilds
+empty tables without preserving additional release data. Development databases
+may contain real facts at those checkpoints, so their append-only migration
+history remains supported.
+
+## Preserved boundary
+
+The baseline is one transaction from schema `25`: any validation or DDL failure
+leaves the database at the published floor. CI compares the baseline schema with
+the compatibility-chain schema and runs a Docker upgrade case that creates data
+with the real `v0.30.0` runtime before opening the same volume with the candidate.

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -132,6 +132,7 @@ When a candidate image is already published, use an immutable reference:
 ```bash
 python3 scripts/docker-e2e.py \
   --image-digest ghcr.io/holon-run/holon@sha256:... \
+  --previous-image ghcr.io/holon-run/holon:v0.30.0 \
   --skip-build \
   --suite core
 ```
@@ -279,8 +280,11 @@ Exercise:
    WorkItems, tasks, waits, and workspace state.
 2. Interrupt tool execution, task completion, and worktree cleanup at
    controlled points; reconciliation must not duplicate side effects.
-3. Start from the current recommended release's runtime data and upgrade to
-   the candidate image.
+3. Start `v0.30.0` against an isolated shared volume, complete a real
+   deterministic agent turn, then start the candidate against that same
+   volume. The required release case verifies schema migration provenance,
+   preserved message/brief identities, and a successful post-upgrade agent
+   turn.
 4. Cover a locked database, missing workspace path, and orphaned worktree,
    verifying diagnostics and retention behavior.
 

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -228,6 +228,7 @@ class CaseHarness:
         tool_assertion_mode: str = "strict",
         resource_names: dict[str, str] | None = None,
         control_token: str | None = None,
+        previous_image: str | None = None,
     ) -> None:
         suffix = secrets.token_hex(4)
         self.case_id = case_id
@@ -255,6 +256,7 @@ class CaseHarness:
         self.model_runtime_override = dict(model_runtime_override or {})
         self._model_runtime_override_seeded = False
         self.tool_assertion_mode = tool_assertion_mode
+        self.previous_image = previous_image
         names = resource_names or {}
         self.volume = names.get("volume", f"holon-live-{case_id}-{suffix}")
         self.network = names.get("network", f"holon-live-{case_id}-{suffix}")
@@ -691,6 +693,11 @@ class CaseHarness:
 
     def restart(self, *, wait_idle: bool = True) -> None:
         self.stop()
+        self.start(wait_idle=wait_idle)
+
+    def restart_with_image(self, image: str, *, wait_idle: bool = True) -> None:
+        self.stop()
+        self.image = image
         self.start(wait_idle=wait_idle)
 
     def reset_callback(self, label: str) -> dict[str, Any]:
@@ -1534,14 +1541,81 @@ class CaseHarness:
         write_json(self.evidence / f"{label}-runtime-db.json", snapshot)
         return snapshot
 
+    def upgrade_db_snapshot(self, label: str, marker: str) -> dict[str, Any]:
+        snapshot_dir = self.evidence / f"{label}-runtime-state"
+        if snapshot_dir.exists():
+            shutil.rmtree(snapshot_dir)
+        snapshot_dir.mkdir(parents=True)
+        for name in ("runtime.sqlite", "runtime.sqlite-wal", "runtime.sqlite-shm"):
+            self.docker(
+                "cp",
+                f"{self.container}:/var/lib/holon/state/{name}",
+                str(snapshot_dir / name),
+                check=name == "runtime.sqlite",
+                timeout=RUNTIME_DB_COPY_TIMEOUT_SECONDS,
+            )
+        connection = sqlite3.connect(
+            f"file:{snapshot_dir / 'runtime.sqlite'}?mode=ro", uri=True
+        )
+        connection.row_factory = sqlite3.Row
+        try:
+            has_baseline = connection.execute(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'schema_migration_baselines')"
+            ).fetchone()[0]
+            snapshot = {
+                "integrity_check": connection.execute(
+                    "PRAGMA integrity_check"
+                ).fetchone()[0],
+                "schema_revision": connection.execute(
+                    "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+                ).fetchone()[0],
+                "agent_ids": [
+                    row[0]
+                    for row in connection.execute(
+                        "SELECT agent_id FROM agent_states ORDER BY agent_id"
+                    )
+                ],
+                "messages": sqlite_rows(
+                    connection,
+                    "SELECT evidence_id, message_id, turn_id, payload_json "
+                    "FROM messages WHERE payload_json LIKE ? ORDER BY created_at",
+                    (f"%{marker}%",),
+                ),
+                "briefs": sqlite_rows(
+                    connection,
+                    "SELECT evidence_id, message_id, turn_id, payload_json "
+                    "FROM briefs WHERE payload_json LIKE ? ORDER BY created_at",
+                    (f"%{marker}%",),
+                ),
+                "baseline": (
+                    sqlite_rows(
+                        connection,
+                        "SELECT baseline_id, source_version, target_version, "
+                        "covered_versions_json, schema_fingerprint "
+                        "FROM schema_migration_baselines",
+                    )
+                    if has_baseline
+                    else []
+                ),
+            }
+        finally:
+            connection.close()
+        write_json(self.evidence / f"{label}-upgrade-db.json", snapshot)
+        return snapshot
+
 
 def result_value(detail: dict[str, Any]) -> dict[str, Any]:
     output = detail.get("output", {})
     return output.get("envelope", {}).get("result", output.get("result", output))
 
 
-def sqlite_rows(connection: sqlite3.Connection, query: str) -> list[dict[str, Any]]:
-    return [dict(row) for row in connection.execute(query).fetchall()]
+def sqlite_rows(
+    connection: sqlite3.Connection,
+    query: str,
+    parameters: tuple[Any, ...] = (),
+) -> list[dict[str, Any]]:
+    return [dict(row) for row in connection.execute(query, parameters).fetchall()]
 
 
 def require_processed_queue_entries(
@@ -2061,6 +2135,84 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
         and marker in json.dumps(entry, ensure_ascii=False)
     ]
     require(assistant_rounds, "marker assistant round is missing from transcript")
+
+
+def run_runtime_upgrade_v030_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    require(
+        bool(harness.previous_image),
+        f"{case['id']} requires --previous-image",
+    )
+    candidate_image = harness.image
+    old_marker = f"UPGRADE-V030-OLD-{secrets.token_hex(6)}"
+    new_marker = f"UPGRADE-V030-NEW-{secrets.token_hex(6)}"
+
+    harness.image = str(harness.previous_image)
+    harness.initialize_workspace()
+    harness.start()
+    harness.prompt(
+        "upgrade-v030-old",
+        case["phases"][0]["prompt"].format(marker=old_marker),
+    )
+    old_snapshot = harness.upgrade_db_snapshot("upgrade-v030-old", old_marker)
+    require(
+        old_snapshot["integrity_check"] == "ok",
+        f"old database is invalid: {old_snapshot}",
+    )
+    require(
+        old_snapshot["schema_revision"] == 25,
+        f"previous release did not produce schema 25: {old_snapshot}",
+    )
+    require(
+        old_snapshot["messages"] and old_snapshot["briefs"],
+        f"previous release did not persist the marker: {old_snapshot}",
+    )
+    old_agent_ids = set(old_snapshot["agent_ids"])
+    old_message_ids = {row["message_id"] for row in old_snapshot["messages"]}
+    old_brief_ids = {row["evidence_id"] for row in old_snapshot["briefs"]}
+
+    harness.restart_with_image(candidate_image)
+    migrated = harness.upgrade_db_snapshot("upgrade-v030-migrated", old_marker)
+    require(
+        migrated["integrity_check"] == "ok",
+        f"migrated database is invalid: {migrated}",
+    )
+    require(
+        migrated["schema_revision"] > old_snapshot["schema_revision"],
+        f"candidate did not advance the schema: {migrated}",
+    )
+    require(
+        len(migrated["baseline"]) == 1,
+        f"baseline provenance is missing: {migrated}",
+    )
+    require(
+        old_agent_ids.issubset(set(migrated["agent_ids"]))
+        and old_message_ids.issubset(
+            {row["message_id"] for row in migrated["messages"]}
+        )
+        and old_brief_ids.issubset(
+            {row["evidence_id"] for row in migrated["briefs"]}
+        ),
+        f"release data was not preserved: old={old_snapshot}, migrated={migrated}",
+    )
+
+    before_turn = int(
+        harness.state("upgrade-v030-before-new")["agent"]["agent"]["turn_index"]
+    )
+    harness.prompt(
+        "upgrade-v030-new",
+        case["phases"][1]["prompt"].format(marker=new_marker),
+    )
+    after_turn = int(
+        harness.state("upgrade-v030-after-new")["agent"]["agent"]["turn_index"]
+    )
+    require(after_turn > before_turn, "upgraded agent did not complete a new turn")
+    final_snapshot = harness.upgrade_db_snapshot("upgrade-v030-final", new_marker)
+    require(
+        final_snapshot["messages"] and final_snapshot["briefs"],
+        f"upgraded agent did not persist the new marker: {final_snapshot}",
+    )
 
 
 def run_memory_case(harness: CaseHarness, case: dict[str, Any]) -> None:
@@ -4008,6 +4160,7 @@ def run_scheduler_checkpoint_replay_case(
 
 CASE_RUNNERS = {
     "runtime-auth-model-delivery": run_runtime_case,
+    "runtime-upgrade-v030": run_runtime_upgrade_v030_case,
     "memory-agent-home-persistence": run_memory_case,
     "workspace-restart-lifecycle": run_workspace_case,
     "workitem-wait-restart-complete": run_workitem_case,
@@ -4103,6 +4256,11 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             require(
                 isinstance(case["requires_model"], bool),
                 f"{case_id} requires_model must be boolean",
+            )
+        if "requires_previous_image" in case:
+            require(
+                isinstance(case["requires_previous_image"], bool),
+                f"{case_id} requires_previous_image must be boolean",
             )
         coverage_ids = case.get("coverage_ids", [])
         require(
@@ -4742,6 +4900,11 @@ def main(argv: list[str] | None = None) -> int:
         suite=args.suite,
         tags=args.tag,
     )
+    if any(case.get("requires_previous_image") for case in selected):
+        require(
+            bool(args.previous_image),
+            "selected upgrade case requires --previous-image",
+        )
     if args.scheduler_matrix:
         require(
             any("scheduler" in case.get("tags", []) for case in selected),
@@ -4891,6 +5054,7 @@ def main(argv: list[str] | None = None) -> int:
             stub_scenario=case.get("stub_scenario", profile.get("stub_scenario")),
             model_runtime_override=case.get("model_runtime_override"),
             tool_assertion_mode=profile.get("tool_assertion_mode", "strict"),
+            previous_image=args.previous_image,
         )
         control_tokens.append(harness.token)
         error_text = ""

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use std::collections::BTreeSet;
 
 use crate::domain::{
     execution_protocol::{
@@ -24,6 +25,11 @@ pub struct Migration {
     pub(crate) name: &'static str,
     pub(crate) sql: &'static str,
 }
+
+pub(crate) const PUBLISHED_MIGRATION_FLOOR: i64 = 25;
+pub(crate) const RELEASE_BASELINE_TARGET: i64 = 45;
+const RELEASE_BASELINE_SCHEMA_TARGET: i64 = 42;
+const RELEASE_BASELINE_ID: &str = "v0.30.0-schema-25-to-schema-45";
 
 fn migrate_scheduler_lifecycle_owners(
     connection: &mut Connection,
@@ -762,6 +768,15 @@ CREATE UNIQUE INDEX idx_scheduler_activations_recovery_admission_fence
 
 fn migrate_wait_trigger_identity(connection: &mut Connection, migration: &Migration) -> Result<()> {
     let transaction = connection.transaction()?;
+    apply_wait_trigger_identity_transaction(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn apply_wait_trigger_identity_transaction(
+    transaction: &Transaction<'_>,
+    migration: &Migration,
+) -> Result<()> {
     if table_exists_internal(&transaction, "wait_conditions")? {
         let columns = transaction
             .prepare("PRAGMA table_info(wait_conditions)")?
@@ -782,7 +797,6 @@ fn migrate_wait_trigger_identity(connection: &mut Connection, migration: &Migrat
         )?;
     }
     record_migration(&transaction, migration)?;
-    transaction.commit()?;
     Ok(())
 }
 
@@ -791,17 +805,34 @@ fn migrate_wait_unresolved_owner_uniqueness(
     migration: &Migration,
 ) -> Result<()> {
     let transaction = connection.transaction()?;
+    apply_wait_unresolved_owner_uniqueness_transaction(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn apply_wait_unresolved_owner_uniqueness_transaction(
+    transaction: &Transaction<'_>,
+    migration: &Migration,
+) -> Result<()> {
     if table_exists_internal(&transaction, "wait_conditions")? {
         converge_unresolved_wait_owners(&transaction)?;
         transaction.execute_batch(migration.sql)?;
     }
     record_migration(&transaction, migration)?;
-    transaction.commit()?;
     Ok(())
 }
 
 fn migrate_wait_protocol_cutover(connection: &mut Connection, migration: &Migration) -> Result<()> {
     let transaction = connection.transaction()?;
+    apply_wait_protocol_cutover_transaction(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn apply_wait_protocol_cutover_transaction(
+    transaction: &Transaction<'_>,
+    migration: &Migration,
+) -> Result<()> {
     let has_execution_attempts =
         table_exists_internal(&transaction, "execution_protocol_attempts")?;
     if has_execution_attempts {
@@ -863,7 +894,6 @@ fn migrate_wait_protocol_cutover(connection: &mut Connection, migration: &Migrat
     let has_wait_conditions = table_exists_internal(&transaction, "wait_conditions")?;
     if !has_wait_conditions {
         record_migration(&transaction, migration)?;
-        transaction.commit()?;
         return Ok(());
     }
     let has_work_items = table_exists_internal(&transaction, "work_items")?;
@@ -1058,7 +1088,6 @@ fn migrate_wait_protocol_cutover(connection: &mut Connection, migration: &Migrat
     }
 
     record_migration(&transaction, migration)?;
-    transaction.commit()?;
     Ok(())
 }
 
@@ -2938,9 +2967,181 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
   name TEXT NOT NULL,
   applied_at TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS schema_migration_baselines (
+  baseline_id TEXT PRIMARY KEY,
+  source_version INTEGER NOT NULL,
+  target_version INTEGER NOT NULL,
+  covered_versions_json TEXT NOT NULL,
+  schema_fingerprint TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
 "#,
     )?;
     Ok(())
+}
+
+pub(crate) fn apply_release_baseline(connection: &mut Connection) -> Result<()> {
+    let current_version = current_schema_version(connection)?;
+    if current_version != PUBLISHED_MIGRATION_FLOOR {
+        bail!(
+            "release baseline {} requires schema version {}, found {}",
+            RELEASE_BASELINE_ID,
+            PUBLISHED_MIGRATION_FLOOR,
+            current_version
+        );
+    }
+
+    let final_schema = release_baseline_final_schema()?;
+    let transaction = connection.transaction()?;
+    for migration in MIGRATIONS.iter().filter(|migration| {
+        migration.version > PUBLISHED_MIGRATION_FLOOR && migration.version <= 30
+    }) {
+        apply_migration_transaction(&transaction, migration)?;
+    }
+    for sql in final_schema {
+        transaction.execute_batch(&sql)?;
+    }
+    ensure_execution_protocol_authority_columns(&transaction)?;
+    transaction.execute_batch(
+        r#"
+INSERT INTO scheduler_protocol_config (
+  config_id, protocol_mode, config_revision, latest_preflight_revision, updated_at
+) VALUES (1, 'authoritative', 1, 0, CURRENT_TIMESTAMP);
+
+INSERT INTO scheduler_rollout_retirement (
+  retirement_id, retired_schema_revision, reason, retired_at
+) VALUES (
+  1, 40,
+  'production scheduler authority no longer reads rollout metadata',
+  CURRENT_TIMESTAMP
+);
+"#,
+    )?;
+    let wait_trigger_identity = MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == 43)
+        .context("missing wait trigger identity migration")?;
+    apply_wait_trigger_identity_transaction(&transaction, wait_trigger_identity)?;
+    backfill_wait_condition_payload_columns(&transaction)?;
+    backfill_work_item_recheck_columns(&transaction)?;
+    let wait_owner_uniqueness = MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == 44)
+        .context("missing wait owner uniqueness migration")?;
+    apply_wait_unresolved_owner_uniqueness_transaction(&transaction, wait_owner_uniqueness)?;
+    let wait_protocol_cutover = MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == 45)
+        .context("missing wait protocol cutover migration")?;
+    apply_wait_protocol_cutover_transaction(&transaction, wait_protocol_cutover)?;
+
+    let applied_at = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    for migration in MIGRATIONS.iter().filter(|migration| {
+        migration.version > 30 && migration.version <= RELEASE_BASELINE_SCHEMA_TARGET
+    }) {
+        transaction.execute(
+            "INSERT INTO schema_migrations (version, name, applied_at)
+             VALUES (?1, ?2, ?3)",
+            (migration.version, migration.name, &applied_at),
+        )?;
+    }
+    let fingerprint = schema_fingerprint(&transaction)?;
+    let covered_versions =
+        (PUBLISHED_MIGRATION_FLOOR + 1..=RELEASE_BASELINE_TARGET).collect::<Vec<_>>();
+    transaction.execute(
+        "INSERT INTO schema_migration_baselines (
+           baseline_id, source_version, target_version, covered_versions_json,
+           schema_fingerprint, applied_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        (
+            RELEASE_BASELINE_ID,
+            PUBLISHED_MIGRATION_FLOOR,
+            RELEASE_BASELINE_TARGET,
+            serde_json::to_string(&covered_versions)?,
+            fingerprint,
+            applied_at,
+        ),
+    )?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn release_baseline_final_schema() -> Result<Vec<String>> {
+    let mut scratch = Connection::open_in_memory()?;
+    ensure_migration_table(&scratch)?;
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 30)
+    {
+        apply_migration(&mut scratch, migration)?;
+    }
+    let before = schema_object_keys(&scratch)?;
+    for migration in MIGRATIONS.iter().filter(|migration| {
+        migration.version > 30 && migration.version <= RELEASE_BASELINE_SCHEMA_TARGET
+    }) {
+        apply_migration(&mut scratch, migration)?;
+    }
+
+    let mut statement = scratch.prepare(
+        "SELECT type, name, sql
+         FROM sqlite_master
+         WHERE sql IS NOT NULL
+           AND name NOT LIKE 'sqlite_%'
+         ORDER BY
+           CASE type WHEN 'table' THEN 0 WHEN 'index' THEN 1 WHEN 'trigger' THEN 2 ELSE 3 END,
+           name",
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|(object_type, name, sql)| {
+            (!before.contains(&(object_type, name))).then_some(sql)
+        })
+        .collect())
+}
+
+fn schema_object_keys(connection: &Connection) -> Result<BTreeSet<(String, String)>> {
+    let mut statement = connection.prepare(
+        "SELECT type, name
+         FROM sqlite_master
+         WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'",
+    )?;
+    let keys = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<std::result::Result<_, _>>()?;
+    Ok(keys)
+}
+
+pub(crate) fn schema_fingerprint(connection: &Connection) -> Result<String> {
+    let mut statement = connection.prepare(
+        "SELECT type, name, sql
+         FROM sqlite_master
+         WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'
+         ORDER BY type, name",
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(format!(
+                "{}\n{}\n{}",
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(content_hash(&rows.join("\n")))
 }
 
 pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration) -> Result<()> {
@@ -2979,28 +3180,34 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
     }
 
     let transaction = connection.transaction()?;
+    apply_migration_transaction(&transaction, migration)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migration) -> Result<()> {
     if migration.name == "strict_runtime_sequences" {
-        repair_runtime_sequence_duplicates(&transaction)?;
+        repair_runtime_sequence_duplicates(transaction)?;
     }
     if migration.name == "canonical_work_item_focus" {
-        preflight_work_item_focus(&transaction)?;
-        migrate_work_item_focus(&transaction)?;
+        preflight_work_item_focus(transaction)?;
+        migrate_work_item_focus(transaction)?;
     }
     if migration.name == "execution_protocol_authority" {
-        ensure_execution_protocol_authority_columns(&transaction)?;
+        ensure_execution_protocol_authority_columns(transaction)?;
     }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "execution_protocol_authority" {
-        backfill_execution_protocol_authority(&transaction)?;
+        backfill_execution_protocol_authority(transaction)?;
     }
     if migration.name == "drop_work_item_readiness" {
-        drop_work_item_readiness(&transaction)?;
+        drop_work_item_readiness(transaction)?;
     }
     if migration.name == "strict_runtime_sequences" {
-        migrate_runtime_sequences(&transaction)?;
+        migrate_runtime_sequences(transaction)?;
     }
     if migration.name == "runtime_retention_created_at_indexes" {
-        migrate_runtime_retention_created_at_indexes(&transaction)?;
+        migrate_runtime_retention_created_at_indexes(transaction)?;
     }
     transaction.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
@@ -3010,7 +3217,6 @@ pub(crate) fn apply_migration(connection: &mut Connection, migration: &Migration
             Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         ),
     )?;
-    transaction.commit()?;
     Ok(())
 }
 

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -63,8 +63,9 @@ use crate::runtime_db::connection::{
     unlock, LockMode,
 };
 use crate::runtime_db::migrations::{
-    apply_migration, backfill_wait_condition_payload_columns, backfill_work_item_recheck_columns,
-    current_schema_version, ensure_migration_table, max_known_migration_version, MIGRATIONS,
+    apply_migration, apply_release_baseline, backfill_wait_condition_payload_columns,
+    backfill_work_item_recheck_columns, current_schema_version, ensure_migration_table,
+    max_known_migration_version, MIGRATIONS, PUBLISHED_MIGRATION_FLOOR, RELEASE_BASELINE_TARGET,
 };
 use crate::runtime_db::storage_domain::{
     read_storage_domain_connection, upsert_storage_domain, upsert_storage_domain_checkpoint_json,
@@ -698,8 +699,26 @@ impl RuntimeDb {
                 max_known_version
             );
         }
-        for migration in MIGRATIONS {
-            apply_migration(&mut connection, migration)?;
+        if current_version <= PUBLISHED_MIGRATION_FLOOR
+            && max_known_version >= RELEASE_BASELINE_TARGET
+        {
+            for migration in MIGRATIONS
+                .iter()
+                .filter(|migration| migration.version <= PUBLISHED_MIGRATION_FLOOR)
+            {
+                apply_migration(&mut connection, migration)?;
+            }
+            apply_release_baseline(&mut connection)?;
+            for migration in MIGRATIONS
+                .iter()
+                .filter(|migration| migration.version > RELEASE_BASELINE_TARGET)
+            {
+                apply_migration(&mut connection, migration)?;
+            }
+        } else {
+            for migration in MIGRATIONS {
+                apply_migration(&mut connection, migration)?;
+            }
         }
         ensure_event_log_epoch(&connection)?;
         backfill_wait_condition_payload_columns(&connection)?;

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -8,8 +8,9 @@ use crate::runtime_db::evidence::insert_audit_event_tx;
 #[cfg(test)]
 use crate::runtime_db::migrations::{
     apply_migration, backfill_wait_condition_payload_columns, backfill_work_item_recheck_columns,
-    current_schema_version, ensure_migration_table, max_known_migration_version, table_exists,
-    MIGRATIONS,
+    current_schema_version, ensure_migration_table, max_known_migration_version,
+    schema_fingerprint, table_exists, MIGRATIONS, PUBLISHED_MIGRATION_FLOOR,
+    RELEASE_BASELINE_TARGET,
 };
 #[cfg(test)]
 use crate::runtime_db::storage_domain::upsert_storage_domain;
@@ -561,6 +562,7 @@ mod tests {
         assert_eq!(version, max_known_migration_version());
         for table in [
             "schema_migrations",
+            "schema_migration_baselines",
             "storage_domains",
             "runtime_metadata",
             "agents",
@@ -647,6 +649,176 @@ mod tests {
         assert!(!activation_input_columns.contains("work_item_id"));
         assert!(!activation_input_columns.contains("expected_scheduling_generation"));
 
+        let baseline: (i64, i64, String, String) = connection.query_row(
+            "SELECT source_version, target_version, covered_versions_json,
+                    schema_fingerprint
+             FROM schema_migration_baselines",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+        assert_eq!(baseline.0, PUBLISHED_MIGRATION_FLOOR);
+        assert_eq!(baseline.1, RELEASE_BASELINE_TARGET);
+        assert_eq!(
+            serde_json::from_str::<Vec<i64>>(&baseline.2)?,
+            (PUBLISHED_MIGRATION_FLOOR + 1..=RELEASE_BASELINE_TARGET).collect::<Vec<_>>()
+        );
+        assert_eq!(baseline.3, schema_fingerprint(&connection)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn release_baseline_matches_compatibility_migration_schema() -> Result<()> {
+        let (_baseline_temp, baseline_path, baseline_lock) = temp_paths()?;
+        let baseline = RuntimeDb::open_and_migrate(&baseline_path, &baseline_lock)?;
+        let baseline_connection = baseline.connection()?;
+        let schema_objects = |connection: &rusqlite::Connection| -> Result<Vec<String>> {
+            let mut statement = connection.prepare(
+                "SELECT type, name, sql
+                 FROM sqlite_master
+                 WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'
+                 ORDER BY type, name",
+            )?;
+            let objects = statement
+                .query_map([], |row| {
+                    Ok(format!(
+                        "{}\n{}\n{}",
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?
+                            .split_whitespace()
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    ))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(objects)
+        };
+        let baseline_schema = schema_objects(&baseline_connection)?;
+        let baseline_fingerprint = schema_fingerprint(&baseline_connection)?;
+        drop(baseline_connection);
+        drop(baseline);
+
+        let (_compat_temp, compat_path, compat_lock) = temp_paths()?;
+        {
+            let mut connection = open_connection(&compat_path)?;
+            ensure_migration_table(&connection)?;
+            for migration in MIGRATIONS {
+                apply_migration(&mut connection, migration)?;
+            }
+            backfill_wait_condition_payload_columns(&connection)?;
+            backfill_work_item_recheck_columns(&connection)?;
+        }
+        let compat = RuntimeDb::open_and_migrate(&compat_path, &compat_lock)?;
+        let compat_connection = compat.connection()?;
+        let compat_schema = schema_objects(&compat_connection)?;
+        let baseline_only = baseline_schema
+            .iter()
+            .filter(|object| !compat_schema.contains(object))
+            .collect::<Vec<_>>();
+        let compatibility_only = compat_schema
+            .iter()
+            .filter(|object| !baseline_schema.contains(object))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            baseline_schema,
+            compat_schema,
+            "release baseline and checkpoint compatibility chain must have identical schema objects\nbaseline only: {baseline_only:#?}\ncompatibility only: {compatibility_only:#?}"
+        );
+        assert_eq!(
+            baseline_fingerprint,
+            schema_fingerprint(&compat_connection)?,
+            "release baseline and checkpoint compatibility chain must converge"
+        );
+        let baseline_count: i64 = compat_connection.query_row(
+            "SELECT COUNT(*) FROM schema_migration_baselines",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(baseline_count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn unreleased_checkpoints_use_compatibility_chain_without_baseline() -> Result<()> {
+        for checkpoint in PUBLISHED_MIGRATION_FLOOR + 1..=RELEASE_BASELINE_TARGET {
+            let (_temp_dir, db_path, lock_path) = temp_paths()?;
+            {
+                let mut connection = open_connection(&db_path)?;
+                ensure_migration_table(&connection)?;
+                for migration in MIGRATIONS
+                    .iter()
+                    .filter(|migration| migration.version <= checkpoint)
+                {
+                    apply_migration(&mut connection, migration)?;
+                }
+                backfill_wait_condition_payload_columns(&connection)?;
+                backfill_work_item_recheck_columns(&connection)?;
+            }
+
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)
+                .with_context(|| format!("migrating unreleased checkpoint {checkpoint}"))?;
+            let connection = db.connection()?;
+            assert_eq!(
+                current_schema_version(&connection)?,
+                MIGRATIONS.last().map_or(0, |migration| migration.version),
+                "checkpoint {checkpoint} did not reach the current schema"
+            );
+            let baseline_count: i64 = connection.query_row(
+                "SELECT COUNT(*) FROM schema_migration_baselines",
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(
+                baseline_count, 0,
+                "checkpoint {checkpoint} must use the compatibility chain"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn release_baseline_failure_rolls_back_to_published_floor() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            ensure_migration_table(&connection)?;
+            for migration in MIGRATIONS
+                .iter()
+                .filter(|migration| migration.version <= PUBLISHED_MIGRATION_FLOOR)
+            {
+                apply_migration(&mut connection, migration)?;
+            }
+            connection.execute(
+                "INSERT INTO work_items (
+                   work_item_id, agent_id, state, objective, plan_status, readiness,
+                   revision, current_focus, created_at, updated_at, payload_json
+                 ) VALUES (
+                   'work-invalid', 'agent-a', 'completed', 'invalid focus', NULL, NULL,
+                   1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'
+                 )",
+                [],
+            )?;
+        }
+
+        let error = RuntimeDb::open_and_migrate(&db_path, &lock_path)
+            .expect_err("invalid release data must fail the baseline");
+        assert!(
+            error.to_string().contains("invalid legacy focus"),
+            "{error:#}"
+        );
+        let connection = open_connection(&db_path)?;
+        assert_eq!(
+            current_schema_version(&connection)?,
+            PUBLISHED_MIGRATION_FLOOR
+        );
+        assert!(!table_exists(&connection, "runtime_sequences")?);
+        let baseline_count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM schema_migration_baselines",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(baseline_count, 0);
         Ok(())
     }
 

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -70,6 +70,31 @@
       ]
     },
     {
+      "id": "runtime-upgrade-v030",
+      "tier": "core",
+      "tags": ["runtime", "upgrade", "migration", "persistence"],
+      "timeout_seconds": 300,
+      "requires_model": false,
+      "requires_previous_image": true,
+      "provider_mode": "stub",
+      "stub_scenario": "runtime-upgrade-v030",
+      "description": "Run v0.30.0 against a shared volume, persist one agent turn, upgrade the same database to the candidate, verify baseline provenance and preserved data, then complete a new agent turn.",
+      "phases": [
+        {
+          "id": "old-release",
+          "prompt": "Reply with the exact marker {marker}.",
+          "required_tools": [],
+          "forbidden_tools": []
+        },
+        {
+          "id": "candidate",
+          "prompt": "Reply with the exact marker {marker}.",
+          "required_tools": [],
+          "forbidden_tools": []
+        }
+      ]
+    },
+    {
       "id": "memory-agent-home-persistence",
       "tier": "core",
       "tags": ["memory", "agent-home", "restart", "persistence"],

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -10,6 +10,7 @@ CALLBACK_CAPABILITY_PATTERN = re.compile(
     r"(/api/callbacks/(?:wake|enqueue)/)[A-Za-z0-9_-]+"
 )
 SCENARIOS = (
+    "runtime-upgrade-v030",
     "scheduler-task-wait",
     "scheduler-provider-retry",
     "scheduler-multi",
@@ -138,6 +139,14 @@ class Scenario:
                 and "This is the first run of Holon" in current_input
             ):
                 return 200, response([text_item("Deterministic Holon test runtime ready.")], "resp_intro")
+            if self.name == "runtime-upgrade-v030":
+                match = re.search(r"UPGRADE-V030-(?:OLD|NEW)-[0-9a-f]+", raw)
+                if match and self.phase < self.expected_phase():
+                    self.phase += 1
+                    return 200, response(
+                        [text_item(match.group(0))],
+                        f"resp_runtime_upgrade_v030_{self.phase}",
+                    )
             if self.phase == self.expected_phase() - 1:
                 self.phase += 1
                 return 200, response(
@@ -822,6 +831,7 @@ class Scenario:
 
     def expected_phase(self) -> int:
         return {
+            "runtime-upgrade-v030": 2,
             "scheduler-task-wait": 10,
             "scheduler-provider-retry": 3,
             "scheduler-multi": 12,

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -40,6 +40,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             [case["id"] for case in selected],
             [
                 "runtime-auth-model-delivery",
+                "runtime-upgrade-v030",
                 "memory-agent-home-persistence",
                 "workspace-restart-lifecycle",
                 "workitem-wait-restart-complete",
@@ -657,13 +658,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(scenario.phase, 8)
 
     def test_openai_stub_registers_every_required_scenario(self) -> None:
-        profile = runner.resolve_profile(self.manifest, "scheduler-required")
-        selected = runner.select_cases(
-            self.manifest,
-            requested=profile["case_ids"],
-            suite="core",
-            tags=[],
-        )
+        selected = [
+            case for case in self.manifest["cases"] if case.get("stub_scenario")
+        ]
         self.assertEqual(
             {case["stub_scenario"] for case in selected},
             set(stub.SCENARIOS),
@@ -1561,6 +1558,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             [(case["id"], engine) for case, engine in expanded],
             [
                 ("runtime-auth-model-delivery", None),
+                ("runtime-upgrade-v030", None),
                 ("memory-agent-home-persistence", None),
                 ("workspace-restart-lifecycle", None),
                 ("workitem-wait-restart-complete", None),


### PR DESCRIPTION
## 摘要

- 将 `v0.30.0` 的 schema 25 定义为已发布 migration floor
- 对 schema <= 25 的数据库执行原子的 release-aware baseline，直达 schema 45，并记录独立 provenance/fingerprint
- 对 schema 26-45 的开发 checkpoint 保留原 compatibility migration 链
- 增加真实 `v0.30.0` image 造数、候选 image 升级、数据保留与升级后 agent 正常运行的 release core Docker E2E

## 运行时边界

baseline 保留 schema 26-30 的真实通用数据转换，直接构造 scheduler/execution 的 schema 42 最终结构，再在同一事务中复用 schema 43-45 的 wait protocol 数据转换。任何失败都会回滚到 schema 25；已应用 schema 26-45 的开发数据库不会走 baseline。

## 验证

通过：

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime_db::tests::tests --lib`（107/107）
- release baseline schema/fingerprint 等价、原子回滚、schema 26-45 checkpoint compatibility 测试
- `python -m unittest tests.test_docker_e2e_runner`（66/66）
- `python3 scripts/docker-e2e.py --validate-manifest`
- `git diff --check`

限制：

- 本机 Docker daemon 不可用，因此真实 v0.30.0 → candidate Docker E2E 由本 PR 的 release/CI workflow 执行。
- `cargo test --all-targets` 已通过 2624 个 lib tests 及后续多组 integration tests，但最终停在与本改动无关的 `wt203_task_stop_cleans_clean_task_owned_worktree` 超过数分钟，已终止该总套件；上述相关测试和 warning-free build 均完整通过。
