### PR TITLE
fix: drop task results for completing work items

### DIFF
--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -761,10 +761,22 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         };
         let Some(work) = execution.work_items.get(work_item_id) else {
             // Once the unified partition exists, an exact task rejoin can only
-            // resume a WorkItem owned by that partition. Pre-cutover task
-            // results may still reference a legacy scheduler Waiting mirror,
-            // but they are only provably orphaned when no exact durable task
-            // wait remains for the same WorkItem.
+            // resume an open WorkItem owned by that partition. A completing or
+            // completed WorkItem cannot regain execution authority even when a
+            // pre-cutover resolved task wait still references it.
+            if self
+                .runtime
+                .inner
+                .runtime_db
+                .work_items()
+                .latest(work_item_id)?
+                .is_none_or(|work_item| work_item.state != WorkItemState::Open)
+            {
+                return Ok(true);
+            }
+            // Open pre-cutover WorkItems may still reference a legacy scheduler
+            // Waiting mirror, but they are only provably orphaned when no exact
+            // durable task wait remains for the same WorkItem.
             let exact_wait_exists = self
                 .runtime
                 .inner

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3756,33 +3756,11 @@ async fn pre_cutover_task_rejoin_without_execution_owner_is_dropped() {
             "default",
             &canonical_waiting_snapshot(
                 &waiting_work,
-                &registration.condition.id,
+                "legacy-current-wait-for-other-work",
                 waiting_work.revision,
             ),
         )
         .unwrap();
-    append_completed_rejoin_task(
-        &runtime,
-        "task-pre-cutover",
-        &work_item.id,
-        "turn-pre-cutover-parent",
-    );
-    let completing = runtime
-        .complete_work_item(work_item.id.clone(), Vec::new())
-        .await
-        .unwrap();
-    assert_eq!(completing.state, WorkItemState::Completing);
-    runtime
-        .inner
-        .runtime_db
-        .transaction(|tx| {
-            crate::runtime_db::transitions::persist_state_tx(
-                tx,
-                &crate::domain::execution_protocol::ExecutionProtocolState::empty("default"),
-            )
-        })
-        .unwrap();
-
     let mut stale = task_result_message("task-pre-cutover").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -3796,6 +3774,51 @@ async fn pre_cutover_task_rejoin_without_execution_owner_is_dropped() {
         "work_item_id": work_item.id,
     }));
     stale.turn_id = Some("turn-pre-cutover".into());
+    let running = runtime
+        .storage()
+        .latest_task_record("task-pre-cutover")
+        .unwrap()
+        .expect("running task");
+    let terminal = TaskRecord {
+        status: TaskStatus::Completed,
+        updated_at: Utc::now(),
+        parent_message_id: Some(stale.id.clone()),
+        detail: Some(serde_json::json!({
+            "rejoin_obligation_id": "task-pre-cutover",
+            "rejoin_generation": 1,
+            "parent_turn_id": "turn-pre-cutover-parent",
+        })),
+        ..running
+    };
+    runtime
+        .persist_task_transition_with_message(&terminal, "task_status_updated", &stale)
+        .await
+        .unwrap();
+    let completing = runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    assert_eq!(completing.state, WorkItemState::Completing);
+    assert!(runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .any(|condition| {
+            condition.id == registration.condition.id
+                && condition.status == WaitConditionStatus::Resolved
+        }));
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| {
+            crate::runtime_db::transitions::persist_state_tx(
+                tx,
+                &crate::domain::execution_protocol::ExecutionProtocolState::empty("default"),
+            )
+        })
+        .unwrap();
+
     let stale = runtime.enqueue(stale).await.unwrap();
     let valid = runtime
         .enqueue(trusted_operator_prompt(
@@ -3822,17 +3845,21 @@ async fn pre_cutover_task_rejoin_without_execution_owner_is_dropped() {
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Dropped)
     );
-    assert!(runtime
+    let stale_events = runtime
         .storage()
         .read_recent_events(usize::MAX)
         .unwrap()
-        .iter()
-        .any(|event| {
+        .into_iter()
+        .filter(|event| event.data["message_id"] == stale.id)
+        .collect::<Vec<_>>();
+    assert!(
+        stale_events.iter().any(|event| {
             event.kind == "scheduler_authority_input_rejected"
-                && event.data["message_id"] == stale.id
                 && event.data["reason"] == "canonical_task_rejoin_stale"
                 && event.data["queue_disposition"] == "dropped"
-        }));
+        }),
+        "unexpected stale task-result events: {stale_events:#?}"
+    );
 
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()


### PR DESCRIPTION
## 变更

- 修复 terminal task 已解析精确 wait 后，`completing/completed` WorkItem 的 task-result 仍被历史 wait 误认为可恢复、永久占据 FIFO 队首的问题。
- 当 exact task-rejoin 的 WorkItem 已不在 unified execution partition，且 durable WorkItem 已非 `open` 时，将该输入判定为 stale 并原子丢弃。
- 保留 open WorkItem + 精确 task wait 的既有保护，合法 task rejoin 不会被误丢。
- 回归测试复现真实顺序：terminal task transition 持久化消息并解析 wait，WorkItem 进入 `completing`，execution owner 被释放，随后 stale task-result 必须被丢弃且后续 operator 输入可立即调度。

## 验证

- `python3 scripts/check-test-temp-resources.py`
- `cargo test --all-targets -- --test-threads=1`
- `make lint`
- `make test-concurrent`

以上完整门禁全部通过。

Closes #2499
