### PR TITLE
fix: reconcile task rejoin with unified execution state

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::domain::scheduler_protocol::{SchedulerOwner, SchedulerScenarioClass, WorkStatus};
+use crate::domain::execution_protocol::WorkItemExecutionState;
+use crate::domain::scheduler_protocol::{SchedulerOwner, SchedulerScenarioClass};
 use crate::runtime::closure::runtime_error_active;
 use crate::storage::{AppStorage, WorkQueueReadModel};
 use crate::types::{
@@ -159,8 +160,13 @@ pub(crate) struct SchedulerProjection {
     pub turn_in_progress: bool,
     pub runtime_error: bool,
     activation_waits: Vec<WaitConditionRecord>,
-    canonical_work_statuses: Option<HashMap<String, WorkStatus>>,
-    canonical_wait_generations: HashMap<String, u64>,
+    canonical_work_states: Option<HashMap<String, CanonicalWorkExecutionState>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CanonicalWorkExecutionState {
+    Waiting { wait_id: String },
+    Other,
 }
 
 pub(crate) struct SchedulerAgentSnapshot {
@@ -193,21 +199,13 @@ impl SchedulerAgentSnapshot {
 impl SchedulerProjection {
     pub(crate) fn without_canonical_authority(mut self) -> Self {
         // activation_waits remains shared input for legacy wait-to-WorkItem correlation.
-        self.canonical_work_statuses = None;
-        self.canonical_wait_generations.clear();
+        self.canonical_work_states = None;
         self
     }
 
     #[cfg(test)]
-    pub(crate) fn set_canonical_wait_generation_for_test(
-        &mut self,
-        wait_id: impl Into<String>,
-        generation: u64,
-    ) {
-        self.canonical_work_statuses
-            .get_or_insert_with(HashMap::new);
-        self.canonical_wait_generations
-            .insert(wait_id.into(), generation);
+    pub(crate) fn enable_canonical_authority_for_test(&mut self) {
+        self.canonical_work_states.get_or_insert_with(HashMap::new);
     }
 
     pub(crate) fn from_state(storage: &AppStorage, state: &AgentState) -> Result<Self> {
@@ -306,31 +304,32 @@ impl SchedulerProjection {
                         && condition.kind == WaitConditionKind::Task)
             })
             .collect();
-        let canonical_snapshot = storage
+        let execution_snapshot = storage
             .runtime_db()?
             .map(|runtime_db| {
                 runtime_db
                     .transitions()
-                    .load_scheduler_protocol_snapshot_if_initialized(&snapshot.id)
+                    .load_execution_protocol_state_if_initialized(&snapshot.id)
             })
             .transpose()?
             .flatten();
-        let canonical_work_statuses = canonical_snapshot.as_ref().map(|snapshot| {
+        let canonical_work_states = execution_snapshot.as_ref().map(|snapshot| {
             snapshot
-                .work
+                .work_items
                 .iter()
-                .map(|(work_item_id, demand)| (work_item_id.clone(), demand.status.clone()))
+                .map(|(work_item_id, record)| {
+                    let state = match &record.state {
+                        WorkItemExecutionState::Waiting { wait, .. } => {
+                            CanonicalWorkExecutionState::Waiting {
+                                wait_id: wait.wait_id.clone(),
+                            }
+                        }
+                        _ => CanonicalWorkExecutionState::Other,
+                    };
+                    (work_item_id.clone(), state)
+                })
                 .collect()
         });
-        let canonical_wait_generations = canonical_snapshot
-            .map(|snapshot| {
-                snapshot
-                    .waits
-                    .into_iter()
-                    .map(|(wait_id, wait)| (wait_id, wait.current_generation))
-                    .collect()
-            })
-            .unwrap_or_default();
         let active_work_item_waiting_intents = active_wait_conditions
             .iter()
             .filter(|condition| condition.work_item_id.is_some())
@@ -378,8 +377,7 @@ impl SchedulerProjection {
                 &storage.read_recent_briefs(64)?,
             ),
             activation_waits,
-            canonical_work_statuses,
-            canonical_wait_generations,
+            canonical_work_states,
         })
     }
 
@@ -1312,7 +1310,7 @@ pub(crate) fn resolve_canonical_activation_scenario(
             candidate,
             CanonicalActivationCandidate::ExactTaskRejoin { .. }
         )
-        && projection.canonical_work_statuses.is_none()
+        && projection.canonical_work_states.is_none()
     {
         // The durable task rejoin fence is authoritative. Before the canonical
         // scheduler partition exists, duplicate legacy wait rows are mirrors
@@ -1331,14 +1329,19 @@ pub(crate) fn resolve_canonical_activation_scenario(
         work_item_id,
     } = candidate
     {
-        if matching_wait.is_none()
-            && projection
-                .canonical_work_statuses
+        if matching_wait.is_none() {
+            match projection
+                .canonical_work_states
                 .as_ref()
-                .and_then(|statuses| statuses.get(&work_item_id))
-                .is_some_and(|status| matches!(status, WorkStatus::Waiting { .. }))
-        {
-            return Ok(None);
+                .and_then(|states| states.get(&work_item_id))
+            {
+                Some(CanonicalWorkExecutionState::Other) => {}
+                Some(CanonicalWorkExecutionState::Waiting { .. }) => {
+                    return Ok(None);
+                }
+                None if projection.canonical_work_states.is_some() => return Ok(None),
+                None => {}
+            }
         }
         return Ok(Some(CanonicalActivationScenario::ExactTaskRejoin {
             task_id,
@@ -1440,15 +1443,15 @@ fn resolved_task_wait_is_current(
     projection: &SchedulerProjection,
     condition: &WaitConditionRecord,
 ) -> bool {
-    let Some(statuses) = &projection.canonical_work_statuses else {
+    let Some(states) = &projection.canonical_work_states else {
         return true;
     };
     let Some(work_item_id) = condition.work_item_id.as_deref() else {
         return false;
     };
     matches!(
-        statuses.get(work_item_id),
-        Some(WorkStatus::Waiting { wait_id }) if wait_id == &condition.id
+        states.get(work_item_id),
+        Some(CanonicalWorkExecutionState::Waiting { wait_id }) if wait_id == &condition.id
     )
 }
 

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -882,9 +882,23 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 });
             }
         }
-        let Some(mut scenario) =
-            scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?
-        else {
+        let unresolved_candidate = candidate.clone();
+        let mut scenario =
+            scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?;
+        if scenario.is_none() && task.is_some_and(TaskRecord::terminal_reentry) {
+            if let scheduler::CanonicalActivationCandidate::ExactTaskRejoin {
+                task_id,
+                work_item_id,
+            } = &unresolved_candidate
+            {
+                scenario = Some(scheduler::CanonicalActivationScenario::ExactTaskRejoin {
+                    task_id: task_id.clone(),
+                    work_item_id: work_item_id.clone(),
+                    wait_id: None,
+                });
+            }
+        }
+        let Some(mut scenario) = scenario else {
             if stale_task_rejoin {
                 return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
@@ -896,6 +910,24 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     scenario_class,
                     reason: "canonical_correlated_wait_stale",
                 });
+            }
+            if let scheduler::CanonicalActivationCandidate::ExactTaskRejoin {
+                work_item_id, ..
+            } = &unresolved_candidate
+            {
+                if self
+                    .runtime
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .load_execution_protocol_state_if_initialized(&message.agent_id)?
+                    .is_some_and(|execution| !execution.work_items.contains_key(work_item_id))
+                {
+                    return Ok(CanonicalClaimOutcome::RejectQueued {
+                        scenario_class,
+                        reason: "canonical_wait_execution_authority_missing",
+                    });
+                }
             }
             return Ok(canonical_claim_hard_blocker(
                 scenario_class,

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -882,14 +882,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 });
             }
         }
-        let unresolved_candidate = candidate.clone();
+        let original_candidate = candidate.clone();
         let mut scenario =
             scheduler::resolve_canonical_activation_scenario(projection, message, candidate)?;
         if scenario.is_none() && task.is_some_and(TaskRecord::terminal_reentry) {
             if let scheduler::CanonicalActivationCandidate::ExactTaskRejoin {
                 task_id,
                 work_item_id,
-            } = &unresolved_candidate
+            } = &original_candidate
             {
                 scenario = Some(scheduler::CanonicalActivationScenario::ExactTaskRejoin {
                     task_id: task_id.clone(),
@@ -913,7 +913,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
             if let scheduler::CanonicalActivationCandidate::ExactTaskRejoin {
                 work_item_id, ..
-            } = &unresolved_candidate
+            } = &original_candidate
             {
                 if self
                     .runtime

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3872,7 +3872,7 @@ async fn pre_cutover_task_rejoin_without_execution_owner_is_dropped() {
 }
 
 #[tokio::test]
-async fn task_rejoin_without_execution_owner_but_with_exact_wait_is_not_orphaned() {
+async fn task_rejoin_missing_from_initialized_execution_partition_is_rejected() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -7192,6 +7192,130 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
 }
 
 #[tokio::test]
+async fn resolved_task_result_uses_unified_wait_when_legacy_wait_is_stale() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item("resume resolved task wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    append_running_rejoin_task(&runtime, "task-unified-wait", &work.id);
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-unified-wait".into()),
+            "waiting for unified task result".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+
+    let now = Utc::now();
+    let mut resolved = registration.condition.clone();
+    resolved.status = WaitConditionStatus::Resolved;
+    resolved.updated_at = now;
+    resolved.resolved_at = Some(now);
+    runtime.storage().append_wait_condition(&resolved).unwrap();
+    let resumed = WorkItemRecord {
+        revision: waiting.revision + 1,
+        blocked_by: None,
+        updated_at: now,
+        ..waiting
+    };
+    runtime.storage().append_work_item(&resumed).unwrap();
+
+    let generation = resumed.revision - 1;
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        resumed.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: resumed.revision,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+                generation,
+                wait: crate::domain::execution_protocol::WaitReference {
+                    wait_id: resolved.id.clone(),
+                },
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+
+    runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .initialize_scheduler_protocol_partition(
+            "default",
+            &canonical_waiting_snapshot(&resumed, "wait-stale-legacy", resumed.revision),
+        )
+        .unwrap();
+    append_completed_rejoin_task(
+        &runtime,
+        "task-unified-wait",
+        &resumed.id,
+        "turn-unified-wait",
+    );
+    let mut result = task_result_message("task-unified-wait").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    result.work_item_id = Some(resumed.id.clone());
+    result.task_id = Some("task-unified-wait".into());
+    result.metadata = Some(serde_json::json!({
+        "task_id": "task-unified-wait",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-unified-wait",
+        "work_item_id": resumed.id,
+    }));
+    let result = runtime.enqueue(result).await.unwrap();
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("unified waiting authority should admit the resolved task result");
+    };
+    assert_eq!(scheduled.message.id, result.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &execution.attempts[&scheduler_executor::canonical_activation_id(&result.id)];
+    assert!(matches!(
+        &attempt.source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TaskResult {
+            task_id,
+            result_message_id,
+        } if task_id == "task-unified-wait" && result_message_id == &result.id
+    ));
+}
+
+#[tokio::test]
 async fn message_admission_wakes_asleep_and_booting_agents() {
     for status in [AgentStatus::Asleep, AgentStatus::Booting] {
         let dir = tempdir().unwrap();

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1565,8 +1565,7 @@ fn correlated_wait_resume_requires_the_exact_expected_owner() {
     append_active_external_wait_condition(&storage, "wait-work", "default", Some("work-a"));
     append_active_external_wait_condition(&storage, "wait-lifecycle", "default", None);
     let mut projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
-    projection.set_canonical_wait_generation_for_test("wait-work", 7);
-    projection.set_canonical_wait_generation_for_test("wait-lifecycle", 8);
+    projection.enable_canonical_authority_for_test();
     let message = MessageEnvelope::new(
         "default",
         MessageKind::CallbackEvent,
@@ -1685,7 +1684,7 @@ fn unbound_operator_input_exactly_resumes_agent_wait_or_becomes_nudge() {
 
     append_operator_wait_condition(&storage, "wait-operator", "default", None);
     let mut projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
-    projection.set_canonical_wait_generation_for_test("wait-operator", 1);
+    projection.enable_canonical_authority_for_test();
     let candidate = scheduler::canonical_activation_candidate(&message, Some(&continuation), None)
         .unwrap()
         .unwrap();


### PR DESCRIPTION
## Summary

Follow-up to #2499 after production acceptance exposed one remaining authority split in exact task-result rejoin.

When a background task completed, the task wait could be marked resolved while the unified `WorkItemExecutionState` still remained `waiting`. The queued task-result was then evaluated against stale legacy scheduler state and could remain unadmitted until unrelated operator input activated the agent.

This change:

- reads canonical WorkItem wait authority from the unified execution protocol instead of legacy scheduler `WorkDemand`/wait generations;
- permits terminal task reentry to reconcile the stale waiting projection while retaining the durable task rejoin fence;
- rejects task results when unified WorkItem authority is genuinely missing rather than hard-blocking the queue;
- adds a production-shaped regression with a resolved task wait, unified waiting state, and stale legacy wait mirror.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `python3 scripts/check-test-temp-resources.py`
- `cargo test --all-targets -- --test-threads=1`
- `make lint`
- `make test-concurrent`

All completed successfully on the latest `main` baseline (`010e5b70`).
