### PR TITLE
fix: fence work item completion authority

### DIFF
--- a/src/http/tasks.rs
+++ b/src/http/tasks.rs
@@ -531,6 +531,7 @@ pub async fn complete_work_item(
         crate::types::WorkItemState::Open | crate::types::WorkItemState::Completed => runtime
             .complete_work_item_with_report(
                 work_item_id,
+                crate::runtime::WorkItemCompletionAuthority::Control,
                 report_text.to_string(),
                 None,
                 None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -158,6 +158,12 @@ pub(super) enum WorkItemCompletionReportPromotionOutcome {
     Promoted(WorkItemCompletionReportPromotion),
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum WorkItemCompletionAuthority {
+    AgentExecution(WorkItemExecutionBinding),
+    Control,
+}
+
 impl WorkItemCompletionReportPromotionOutcome {
     pub(super) fn into_record(self) -> crate::types::WorkItemRecord {
         match self {
@@ -288,6 +294,8 @@ struct RuntimeInner {
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
     transition_faults: StdMutex<std::collections::VecDeque<TransitionFaultPoint>>,
+    #[cfg(test)]
+    completion_binding_replacement: StdMutex<Option<WorkItemExecutionBinding>>,
     #[cfg(test)]
     task_transition_conflicts_remaining: AtomicUsize,
     #[cfg(test)]
@@ -2511,6 +2519,38 @@ impl RuntimeHandle {
     pub(crate) fn inject_next_transition_fault(&self, fault: TransitionFaultPoint) {
         self.inject_next_transition_fault_unchecked(fault)
             .expect("a transition fault is already armed for this runtime fixture");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_completion_binding_replacement_before_commit(
+        &self,
+        binding: WorkItemExecutionBinding,
+    ) {
+        let mut replacement = self
+            .inner
+            .completion_binding_replacement
+            .lock()
+            .expect("completion binding replacement lock poisoned");
+        assert!(
+            replacement.replace(binding).is_none(),
+            "a completion binding replacement is already armed"
+        );
+    }
+
+    #[cfg(test)]
+    async fn apply_completion_binding_replacement_before_commit(&self) -> Result<()> {
+        let replacement = self
+            .inner
+            .completion_binding_replacement
+            .lock()
+            .expect("completion binding replacement lock poisoned")
+            .take();
+        let Some(binding) = replacement else {
+            return Ok(());
+        };
+        let mut guard = self.inner.agent.lock().await;
+        guard.state.current_execution_binding = Some(binding);
+        guard.persist_state(&self.inner.storage)
     }
 
     fn inject_next_transition_fault_unchecked(&self, fault: TransitionFaultPoint) -> Result<()> {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -468,6 +468,8 @@ impl RuntimeHandle {
                 shutdown_requested: AtomicBool::new(false),
                 transition_faults: StdMutex::new(std::collections::VecDeque::new()),
                 #[cfg(test)]
+                completion_binding_replacement: StdMutex::new(None),
+                #[cfg(test)]
                 task_transition_conflicts_remaining: AtomicUsize::new(0),
                 #[cfg(test)]
                 fail_after_next_runtime_claim: AtomicBool::new(false),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3095,6 +3095,7 @@ impl RuntimeHandle {
     pub(crate) async fn complete_work_item_with_report(
         &self,
         work_item_id: String,
+        authority: WorkItemCompletionAuthority,
         report_text: String,
         source_turn_index: Option<u64>,
         source_round: Option<usize>,
@@ -3138,25 +3139,6 @@ impl RuntimeHandle {
             .into());
         }
 
-        let execution_binding = self.agent_state().await?.current_execution_binding;
-        if let Some(bound_work_item_id) = execution_binding
-            .as_ref()
-            .and_then(|binding| binding.work_item_id.as_deref())
-            .filter(|bound_work_item_id| *bound_work_item_id != existing.id)
-        {
-            return Err(RuntimeError::policy(
-                "work_item_execution_binding_mismatch",
-                format!(
-                    "current execution is bound to work item {bound_work_item_id}, not {work_item_id}"
-                ),
-            )
-            .with_safe_context("work_item_id", work_item_id)
-            .with_recovery_hint(
-                "complete the WorkItem from its own execution or from an agent-lifecycle execution without another WorkItem binding",
-            )
-            .into());
-        }
-
         let mut brief =
             BriefRecord::new(agent_id.clone(), BriefKind::Result, report_text, None, None);
         brief.work_item_id = Some(existing.id.clone());
@@ -3169,6 +3151,7 @@ impl RuntimeHandle {
         let Some(completed) = self
             .finalize_open_work_item_completion_with_brief(
                 &work_item_id,
+                &authority,
                 &brief,
                 AuditEvent::legacy(
                     "work_item_completion_report_promoted",
@@ -3286,6 +3269,7 @@ impl RuntimeHandle {
     ) -> Result<Option<CompletedWorkItem>> {
         self.finalize_work_item_completion_with_brief_mode(
             work_item_id,
+            None,
             brief,
             binding_event,
             false,
@@ -3296,16 +3280,24 @@ impl RuntimeHandle {
     async fn finalize_open_work_item_completion_with_brief(
         &self,
         work_item_id: &str,
+        authority: &WorkItemCompletionAuthority,
         brief: &BriefRecord,
         binding_event: AuditEvent,
     ) -> Result<Option<CompletedWorkItem>> {
-        self.finalize_work_item_completion_with_brief_mode(work_item_id, brief, binding_event, true)
-            .await
+        self.finalize_work_item_completion_with_brief_mode(
+            work_item_id,
+            Some(authority),
+            brief,
+            binding_event,
+            true,
+        )
+        .await
     }
 
     async fn finalize_work_item_completion_with_brief_mode(
         &self,
         work_item_id: &str,
+        authority: Option<&WorkItemCompletionAuthority>,
         brief: &BriefRecord,
         binding_event: AuditEvent,
         require_open: bool,
@@ -3334,13 +3326,58 @@ impl RuntimeHandle {
             let now = Utc::now();
             let mut state = self.agent_state().await?;
             let expected_agent_state = state.clone();
-            let matching_execution_binding =
-                state.current_execution_binding.as_ref().filter(|binding| {
-                    binding.work_item_id.as_deref() == Some(existing.id.as_str())
-                        && Some(binding.turn_id.as_str()) == brief.turn_id.as_deref()
-                        && Some(binding.source_message_id.as_str())
-                            == brief.related_message_id.as_deref()
-                });
+            let matching_execution_binding = match authority {
+                Some(WorkItemCompletionAuthority::AgentExecution(expected_binding)) => {
+                    if let Some(bound_work_item_id) = expected_binding.work_item_id.as_deref() {
+                        if bound_work_item_id != existing.id {
+                            return Err(RuntimeError::policy(
+                                "work_item_execution_binding_mismatch",
+                                format!(
+                                    "current execution is bound to work item {bound_work_item_id}, not {work_item_id}"
+                                ),
+                            )
+                            .with_safe_context("work_item_id", work_item_id)
+                            .with_recovery_hint(
+                                "complete the WorkItem from its own execution or from an agent-lifecycle execution without another WorkItem binding",
+                            )
+                            .into());
+                        }
+                    }
+                    let Some(current_binding) = state.current_execution_binding.as_ref() else {
+                        return Err(RuntimeError::policy(
+                            "work_item_execution_binding_missing",
+                            "the execution binding that authorized this completion is no longer active",
+                        )
+                        .with_safe_context("work_item_id", work_item_id)
+                        .into());
+                    };
+                    if current_binding != expected_binding {
+                        return Err(RuntimeError::policy(
+                            "work_item_execution_binding_stale",
+                            "the execution binding that authorized this completion changed before commit",
+                        )
+                        .with_safe_context("work_item_id", work_item_id)
+                        .with_recovery_hint(
+                            "retry completion from the WorkItem's current execution",
+                        )
+                        .into());
+                    }
+                    if Some(expected_binding.turn_id.as_str()) != brief.turn_id.as_deref()
+                        || Some(expected_binding.source_message_id.as_str())
+                            != brief.related_message_id.as_deref()
+                    {
+                        return Err(RuntimeError::policy(
+                            "work_item_completion_report_binding_mismatch",
+                            "the completion report does not belong to the authorizing execution",
+                        )
+                        .with_safe_context("work_item_id", work_item_id)
+                        .into());
+                    }
+                    (expected_binding.work_item_id.as_deref() == Some(existing.id.as_str()))
+                        .then_some(expected_binding)
+                }
+                Some(WorkItemCompletionAuthority::Control) | None => None,
+            };
             let mut completion_intent = if require_open {
                 WorkItemCompletionIntent {
                     work_item_id: existing.id.clone(),
@@ -3528,6 +3565,9 @@ impl RuntimeHandle {
                 }),
             ));
 
+            #[cfg(test)]
+            self.apply_completion_binding_replacement_before_commit()
+                .await?;
             let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
                 &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
                     agent_id: agent_id.clone(),

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2098,6 +2098,112 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
 }
 
 #[tokio::test]
+async fn complete_work_item_resuming_direct_caller_ends_current_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let caller = seed_runtime
+        .create_work_item(
+            "resume caller after completion".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(caller.id.clone())
+        .await
+        .unwrap();
+    let callee = seed_runtime
+        .create_work_item("complete callee".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(callee.id.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        seed_runtime
+            .storage()
+            .latest_work_item_continuations()
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let provider = Arc::new(CompleteWorkItemReportProvider {
+        work_item_id: callee.id.clone(),
+        report_text: Some("Callee work is complete.".into()),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "finish the callee".into(),
+        },
+    );
+
+    runtime
+        .process_interactive_message(
+            &message,
+            None,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        *provider.calls.lock().await,
+        1,
+        "resuming a direct caller must terminate the callee provider loop"
+    );
+    assert_eq!(
+        runtime
+            .latest_work_item(&callee.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        WorkItemState::Completed
+    );
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(caller.id.as_str())
+    );
+    assert_eq!(
+        state.current_turn_work_item_id.as_deref(),
+        Some(caller.id.as_str())
+    );
+}
+
+#[tokio::test]
 async fn atomic_completion_rolls_back_all_effects_on_transition_failure() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -2140,6 +2246,7 @@ async fn atomic_completion_rolls_back_all_effects_on_transition_failure() {
     let error = runtime
         .complete_work_item_with_report(
             work_item.id.clone(),
+            WorkItemCompletionAuthority::Control,
             "Atomic completion report".into(),
             Some(1),
             Some(1),
@@ -2197,22 +2304,24 @@ async fn lifecycle_execution_can_complete_without_borrowing_work_item_authority(
         )
         .await
         .unwrap();
+    let execution_binding = WorkItemExecutionBinding {
+        activation_id: Some("activation-lifecycle".into()),
+        admission_provenance: None,
+        source_message_id: "message-lifecycle".into(),
+        turn_id: "turn-lifecycle".into(),
+        work_item_id: None,
+        claimed_work_revision: None,
+    };
     {
         let mut guard = runtime.inner.agent.lock().await;
-        guard.state.current_execution_binding = Some(WorkItemExecutionBinding {
-            activation_id: Some("activation-lifecycle".into()),
-            admission_provenance: None,
-            source_message_id: "message-lifecycle".into(),
-            turn_id: "turn-lifecycle".into(),
-            work_item_id: None,
-            claimed_work_revision: None,
-        });
+        guard.state.current_execution_binding = Some(execution_binding.clone());
         guard.persist_state(&runtime.inner.storage).unwrap();
     }
 
     let completed = runtime
         .complete_work_item_with_report(
             work_item.id.clone(),
+            WorkItemCompletionAuthority::AgentExecution(execution_binding),
             "Lifecycle completion report".into(),
             Some(4),
             Some(2),
@@ -2237,6 +2346,65 @@ async fn lifecycle_execution_can_complete_without_borrowing_work_item_authority(
 }
 
 #[tokio::test]
+async fn control_completion_ignores_unrelated_execution_binding() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let target = runtime
+        .create_work_item("control completion target".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let active = runtime
+        .create_work_item("active agent execution".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_execution_binding = Some(WorkItemExecutionBinding {
+            activation_id: Some("activation-active".into()),
+            admission_provenance: None,
+            source_message_id: "message-active".into(),
+            turn_id: "turn-active".into(),
+            work_item_id: Some(active.id.clone()),
+            claimed_work_revision: Some(active.revision),
+        });
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    let completed = runtime
+        .complete_work_item_with_report(
+            target.id.clone(),
+            WorkItemCompletionAuthority::Control,
+            "Completed through authenticated control.".into(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .expect("control authority should not borrow the active execution binding")
+        .into_record();
+
+    assert_eq!(completed.state, WorkItemState::Completed);
+    let intent = completed.completion_intent.expect("completion intent");
+    assert_eq!(intent.source_activation_id, None);
+    assert_eq!(intent.source_message_id, None);
+    assert_eq!(intent.source_turn_id, None);
+}
+
+#[tokio::test]
 async fn work_item_execution_cannot_complete_an_unrelated_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -2258,22 +2426,24 @@ async fn work_item_execution_cannot_complete_an_unrelated_work_item() {
         .create_work_item("unrelated completion target".into(), None, None, Vec::new())
         .await
         .unwrap();
+    let execution_binding = WorkItemExecutionBinding {
+        activation_id: Some("activation-active".into()),
+        admission_provenance: None,
+        source_message_id: "message-active".into(),
+        turn_id: "turn-active".into(),
+        work_item_id: Some(active.id.clone()),
+        claimed_work_revision: Some(active.revision),
+    };
     {
         let mut guard = runtime.inner.agent.lock().await;
-        guard.state.current_execution_binding = Some(WorkItemExecutionBinding {
-            activation_id: Some("activation-active".into()),
-            admission_provenance: None,
-            source_message_id: "message-active".into(),
-            turn_id: "turn-active".into(),
-            work_item_id: Some(active.id.clone()),
-            claimed_work_revision: Some(active.revision),
-        });
+        guard.state.current_execution_binding = Some(execution_binding.clone());
         guard.persist_state(&runtime.inner.storage).unwrap();
     }
 
     let error = runtime
         .complete_work_item_with_report(
             unrelated.id.clone(),
+            WorkItemCompletionAuthority::AgentExecution(execution_binding),
             "Must be rejected".into(),
             Some(1),
             Some(1),
@@ -2299,6 +2469,82 @@ async fn work_item_execution_cannot_complete_an_unrelated_work_item() {
     assert_eq!(unchanged.state, WorkItemState::Open);
     assert!(unchanged.completion_intent.is_none());
     assert!(unchanged.result_brief_id.is_none());
+}
+
+#[tokio::test]
+async fn completion_retry_rejects_replaced_execution_binding() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let target = runtime
+        .create_work_item("completion retry target".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let execution_binding = WorkItemExecutionBinding {
+        activation_id: Some("activation-original".into()),
+        admission_provenance: None,
+        source_message_id: "message-original".into(),
+        turn_id: "turn-original".into(),
+        work_item_id: Some(target.id.clone()),
+        claimed_work_revision: Some(target.revision),
+    };
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_execution_binding = Some(execution_binding.clone());
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+    runtime.inject_completion_binding_replacement_before_commit(WorkItemExecutionBinding {
+        activation_id: Some("activation-replacement".into()),
+        admission_provenance: None,
+        source_message_id: "message-replacement".into(),
+        turn_id: "turn-replacement".into(),
+        work_item_id: Some(target.id.clone()),
+        claimed_work_revision: Some(target.revision),
+    });
+
+    let error = runtime
+        .complete_work_item_with_report(
+            target.id.clone(),
+            WorkItemCompletionAuthority::AgentExecution(execution_binding),
+            "Must not commit after authority changes.".into(),
+            Some(1),
+            Some(1),
+            Some("turn-original".into()),
+            Some("message-original".into()),
+            Some("assistant-round-original".into()),
+            Some("tool-call-original".into()),
+            Vec::new(),
+        )
+        .await
+        .expect_err("retry must revalidate the execution binding");
+    assert_eq!(
+        error
+            .downcast_ref::<crate::runtime_error::RuntimeError>()
+            .map(|error| error.descriptor().code.as_str()),
+        Some("work_item_execution_binding_stale")
+    );
+    let unchanged = runtime.latest_work_item(&target.id).await.unwrap().unwrap();
+    assert_eq!(unchanged.state, WorkItemState::Open);
+    assert!(unchanged.completion_intent.is_none());
+    assert!(unchanged.result_brief_id.is_none());
+    assert!(runtime
+        .recent_briefs(10)
+        .await
+        .unwrap()
+        .iter()
+        .all(|brief| {
+            brief.kind != BriefKind::Result
+                || brief.work_item_id.as_deref() != Some(target.id.as_str())
+        }));
 }
 
 #[tokio::test]
@@ -3325,6 +3571,23 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
         )
         .await
         .unwrap();
+    let work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_execution_binding = Some(WorkItemExecutionBinding {
+            activation_id: Some("activation-complete-with-warning".into()),
+            admission_provenance: None,
+            source_message_id: "message-complete-with-warning".into(),
+            turn_id: "turn-complete-with-warning".into(),
+            work_item_id: Some(work_item.id.clone()),
+            claimed_work_revision: Some(work_item.revision),
+        });
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
 
     let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
     let (result, _) = registry
@@ -3342,8 +3605,8 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
                     text: "Completed with unfinished todos.".into(),
                     source_turn_index: 1,
                     source_round: 1,
-                    source_turn_id: None,
-                    source_message_id: None,
+                    source_turn_id: Some("turn-complete-with-warning".into()),
+                    source_message_id: Some("message-complete-with-warning".into()),
                     source_assistant_round_id: "assistant-round-complete".into(),
                     source_tool_call_id: "complete".into(),
                 }),

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    runtime::{RuntimeHandle, WorkItemCompletionReportPromotionOutcome},
+    runtime::{
+        RuntimeHandle, WorkItemCompletionAuthority, WorkItemCompletionReportPromotionOutcome,
+    },
+    runtime_error::RuntimeError,
     tool::helpers::{parse_tool_args, validate_non_empty},
     tool::spec::{typed_spec, ToolExecutionContext},
     types::{AuthorityClass, TodoItem, TodoItemState, ToolCapabilityFamily, WorkItemRecord},
@@ -59,9 +62,20 @@ pub(crate) async fn execute(
     let before = runtime.latest_work_item(&work_item_id).await?;
     let warnings = before.as_ref().map(completion_warnings).unwrap_or_default();
     let candidate = context.completion_report_candidate.as_ref();
+    let execution_binding = runtime
+        .agent_state()
+        .await?
+        .current_execution_binding
+        .ok_or_else(|| {
+            RuntimeError::policy(
+                "work_item_execution_binding_missing",
+                "CompleteWorkItem requires an active agent execution binding",
+            )
+        })?;
     let outcome = runtime
         .complete_work_item_with_report(
             work_item_id,
+            WorkItemCompletionAuthority::AgentExecution(execution_binding),
             candidate
                 .map(|candidate| candidate.text.clone())
                 .unwrap_or_default(),
@@ -85,6 +99,7 @@ pub(crate) async fn execute(
         };
     let context = query_context(runtime).await?;
     let work_item = view_for_record(runtime, &context, completed, true, None, None).await?;
+    let terminal_transition = continuation_resumed.is_some();
     let mut result = serde_json::to_value(
         WorkItemMutationResult::with_completion_transition(
             work_item,
@@ -105,7 +120,12 @@ pub(crate) async fn execute(
             );
         }
     }
-    serialize_success(NAME, &result)
+    let mut result = serialize_success(NAME, &result)?;
+    if terminal_transition {
+        result.should_sleep = true;
+        result.terminal_transition = true;
+    }
+    Ok(result)
 }
 
 pub(crate) fn completion_warnings(record: &WorkItemRecord) -> Vec<WorkItemCompletionWarning> {


### PR DESCRIPTION
## 背景

这是 PR #2505 的两个聚焦 follow-up：

1. `CompleteWorkItem` 恢复 direct caller continuation 后，callee 的当前 provider loop 仍会继续下一轮；
2. agent tool completion 与 authenticated control completion 共用隐式 `current_execution_binding`，导致 control 入口错误借用 agent execution authority，且 agent completion 的 execution fence 未覆盖 OCC retry。

## 修改

- direct caller continuation 恢复时，将 `CompleteWorkItem` tool result 标记为 terminal/sleep，立即结束 callee 当前 turn；
- 引入显式 `WorkItemCompletionAuthority::{AgentExecution, Control}`：
  - agent tool 必须携带当前 execution binding，并校验 WorkItem、turn、message；
  - HTTP control completion 不借用当前 agent execution binding；
- 每次 completion OCC retry 都重新校验 authorizing execution binding，authority 已替换时 fail closed；
- 增加 direct caller terminalization、control authority 隔离、stale execution retry fence 回归测试。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test runtime::tests::work_items --lib`（84 passed）
- `cargo test --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

基线已 rebase 到 `origin/main@949669fc`（PR #2506）。
