### PR TITLE
fix: drop stale WorkItem-bound internal followups

### DIFF
--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -334,6 +334,16 @@ even when historical wait correlation is absent or stale. Contentful external
 input keeps its original ingress trust but loses stale correlation; a
 wait-trigger-only envelope is dropped as a whole.
 
+A WorkItem-bound internal follow-up is eligible only while its exact WorkItem
+owner is runnable. If the WorkItem becomes waiting, paused, completing, or
+otherwise non-runnable before admission, the queued follow-up is stale and is
+terminally dropped with audit evidence. New operator input may independently
+resume a `needs_input` WorkItem, but it does not revive or replay an older
+follow-up. A WorkItem snapshot conflict at atomic queue claim discards the
+entire prepared claim and rebuilds the candidate from current durable facts;
+the runtime never retries the old execution plan against a refreshed partial
+baseline.
+
 ## Persistence And Compatibility
 
 The runtime database remains the transactional store. The target normalized

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -300,6 +300,9 @@ struct RuntimeInner {
     task_transition_conflicts_remaining: AtomicUsize,
     #[cfg(test)]
     fail_after_next_runtime_claim: AtomicBool,
+    #[cfg(test)]
+    claim_work_item_plan_status_before_commit:
+        StdMutex<Option<(String, crate::types::WorkItemPlanStatus)>>,
     transition_warnings: StdMutex<Vec<PostCommitWarning>>,
 }
 
@@ -2574,6 +2577,39 @@ impl RuntimeHandle {
             .fail_after_next_runtime_claim
             .store(true, Ordering::SeqCst);
         self.inner.notify.notify_one();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_claim_work_item_plan_status_before_commit(
+        &self,
+        work_item_id: String,
+        plan_status: crate::types::WorkItemPlanStatus,
+    ) {
+        let mut injected = self
+            .inner
+            .claim_work_item_plan_status_before_commit
+            .lock()
+            .expect("claim WorkItem mutation lock poisoned");
+        assert!(
+            injected.replace((work_item_id, plan_status)).is_none(),
+            "a claim WorkItem mutation is already armed"
+        );
+    }
+
+    #[cfg(test)]
+    async fn apply_claim_work_item_plan_status_before_commit(&self) -> Result<()> {
+        let injected = self
+            .inner
+            .claim_work_item_plan_status_before_commit
+            .lock()
+            .expect("claim WorkItem mutation lock poisoned")
+            .take();
+        let Some((work_item_id, plan_status)) = injected else {
+            return Ok(());
+        };
+        self.update_work_item_fields(work_item_id, None, Some(plan_status), None, None, None)
+            .await?;
+        Ok(())
     }
 
     pub(super) fn take_transition_warnings(&self) -> Vec<PostCommitWarning> {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -473,6 +473,8 @@ impl RuntimeHandle {
                 task_transition_conflicts_remaining: AtomicUsize::new(0),
                 #[cfg(test)]
                 fail_after_next_runtime_claim: AtomicBool::new(false),
+                #[cfg(test)]
+                claim_work_item_plan_status_before_commit: StdMutex::new(None),
                 transition_warnings: StdMutex::new(Vec::new()),
             }),
         };

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -114,6 +114,11 @@ struct QueueCandidate {
     queue_len: usize,
 }
 
+enum PrepareMessageOutcome {
+    Poll(RunLoopPoll),
+    Replan,
+}
+
 impl RuntimeHandle {
     pub(super) fn legacy_execution_admission_provenance(
         &self,
@@ -330,42 +335,64 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
     pub(super) async fn poll(&self) -> Result<RunLoopPoll> {
         let started_at = std::time::Instant::now();
-        let candidate = {
-            let guard = self.runtime.inner.agent.lock().await;
-            if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
-                let poll = self.shutdown(guard)?;
-                crate::diagnostics::record_scheduler_poll(
-                    poll.outcome_name(),
-                    started_at.elapsed(),
-                );
-                return Ok(poll);
-            }
-            if guard.state.status == AgentStatus::Stopped {
-                let poll = RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len());
-                crate::diagnostics::record_scheduler_poll(
-                    poll.outcome_name(),
-                    started_at.elapsed(),
-                );
-                return Ok(poll);
-            }
-            let Some(message) = guard.queue.peek().cloned() else {
-                let poll = RunLoopPoll::Idle;
-                crate::diagnostics::record_scheduler_poll(
-                    poll.outcome_name(),
-                    started_at.elapsed(),
-                );
-                return Ok(poll);
+        let mut replans = 0;
+        loop {
+            let candidate = {
+                let guard = self.runtime.inner.agent.lock().await;
+                if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
+                    let poll = self.shutdown(guard)?;
+                    crate::diagnostics::record_scheduler_poll(
+                        poll.outcome_name(),
+                        started_at.elapsed(),
+                    );
+                    return Ok(poll);
+                }
+                if guard.state.status == AgentStatus::Stopped {
+                    let poll = RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len());
+                    crate::diagnostics::record_scheduler_poll(
+                        poll.outcome_name(),
+                        started_at.elapsed(),
+                    );
+                    return Ok(poll);
+                }
+                let Some(message) = guard.queue.peek().cloned() else {
+                    let poll = RunLoopPoll::Idle;
+                    crate::diagnostics::record_scheduler_poll(
+                        poll.outcome_name(),
+                        started_at.elapsed(),
+                    );
+                    return Ok(poll);
+                };
+                QueueCandidate {
+                    message,
+                    prior_state: guard.state.clone(),
+                    queue_len: guard.queue.len(),
+                }
             };
-            QueueCandidate {
-                message,
-                prior_state: guard.state.clone(),
-                queue_len: guard.queue.len(),
-            }
-        };
 
-        let poll = self.prepare_message(candidate).await?;
-        crate::diagnostics::record_scheduler_poll(poll.outcome_name(), started_at.elapsed());
-        Ok(poll)
+            match self.prepare_message(candidate).await? {
+                PrepareMessageOutcome::Poll(poll) => {
+                    crate::diagnostics::record_scheduler_poll(
+                        poll.outcome_name(),
+                        started_at.elapsed(),
+                    );
+                    return Ok(poll);
+                }
+                PrepareMessageOutcome::Replan
+                    if replans + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS =>
+                {
+                    replans += 1;
+                }
+                PrepareMessageOutcome::Replan => {
+                    let poll = RunLoopPoll::AuthorityBlocked;
+                    crate::diagnostics::record_scheduler_poll(
+                        poll.outcome_name(),
+                        started_at.elapsed(),
+                    );
+                    return Ok(poll);
+                }
+            }
+        }
     }
 
     fn shutdown(
@@ -377,7 +404,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         Ok(RunLoopPoll::Shutdown)
     }
 
-    async fn prepare_message(&self, candidate: QueueCandidate) -> Result<RunLoopPoll> {
+    async fn prepare_message(&self, candidate: QueueCandidate) -> Result<PrepareMessageOutcome> {
         let prior_closure = self
             .runtime
             .closure_decision_for_state(&candidate.prior_state, None)
@@ -437,7 +464,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     .await?;
                     // Terminalization notifies the scheduler, so the next poll can
                     // advance past the rejected queue head in the same session.
-                    return Ok(RunLoopPoll::Idle);
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::Idle));
                 }
                 Ok(CanonicalClaimOutcome::RetainQueued {
                     scenario_class,
@@ -456,11 +483,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                                 "queue_disposition": "retained_queued",
                             }),
                         ))?;
-                    return Ok(RunLoopPoll::AuthorityBlocked);
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
                 }
                 Ok(CanonicalClaimOutcome::HardBlocker(blocker)) => {
                     self.report_canonical_claim_hard_blocker(&persisted_message, blocker)?;
-                    return Ok(RunLoopPoll::AuthorityBlocked);
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
                 }
                 Err(error) => {
                     if let Some(ambiguous) =
@@ -476,7 +503,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             &candidate.prior_state,
                             candidate.queue_len,
                         )?;
-                        return Ok(RunLoopPoll::AuthorityBlocked);
+                        return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
                     }
                     return Err(error);
                 }
@@ -512,6 +539,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &candidate.prior_state,
             candidate.queue_len,
         )?;
+        #[cfg(test)]
+        self.runtime
+            .apply_claim_work_item_plan_status_before_commit()
+            .await?;
 
         let (message, running_state, transition_commit) = {
             let queue_record = QueueEntryRecord {
@@ -545,17 +576,20 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 }
                 let mut guard = self.runtime.inner.agent.lock().await;
                 if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
-                    return self.shutdown(guard);
+                    return Ok(PrepareMessageOutcome::Poll(self.shutdown(guard)?));
                 }
                 if matches!(guard.state.status, AgentStatus::Stopped) {
-                    return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::Stopped(
+                        guard.state.clone(),
+                        guard.queue.len(),
+                    )));
                 }
                 if !guard
                     .queue
                     .peek()
                     .is_some_and(|message| message.id == candidate.message.id)
                 {
-                    return Ok(RunLoopPoll::Idle);
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::Idle));
                 }
                 let mut running_state = guard.state.clone();
                 running_state.pending = guard.queue.len().saturating_sub(1);
@@ -624,6 +658,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 let mut commit = match commit_result {
                     Ok(commit) => commit,
                     Err(error) => {
+                        if scheduler_work_item_claim_conflict(&error) {
+                            drop(guard);
+                            return Ok(PrepareMessageOutcome::Replan);
+                        }
                         let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
                             && super::retryable_enqueue_conflict(&error, &agent_id);
                         if !can_retry {
@@ -645,13 +683,13 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     commit.effects.agent_state = None;
                     drop(guard);
                     self.runtime.apply_transition_commit(commit).await;
-                    return Ok(RunLoopPoll::AuthorityBlocked);
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
                 }
                 if !commit.applied {
                     let _ = guard.queue.pop_if_next(&candidate.message.id);
                     guard.state.pending = guard.queue.len();
                     guard.persist_state(&self.runtime.inner.storage)?;
-                    return Ok(RunLoopPoll::Idle);
+                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::Idle));
                 }
                 let queued_message = guard
                     .queue
@@ -673,12 +711,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .apply_transition_commit(transition_commit)
             .await;
 
-        Ok(RunLoopPoll::Message(ScheduledMessage {
-            message,
-            running_state,
-            dispatch_plan,
-            scheduler_decision: effective_decision,
-        }))
+        Ok(PrepareMessageOutcome::Poll(RunLoopPoll::Message(
+            ScheduledMessage {
+                message,
+                running_state,
+                dispatch_plan,
+                scheduler_decision: effective_decision,
+            },
+        )))
     }
 
     fn provably_stale_correlated_wait(
@@ -1032,11 +1072,17 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         if matches!(
             scenario,
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+                | scheduler::CanonicalActivationScenario::InternalFollowup { .. }
         ) && work_projection.scheduling_state != crate::types::WorkItemSchedulingState::Runnable
         {
             return Ok(CanonicalClaimOutcome::RejectQueued {
                 scenario_class,
-                reason: "canonical_autonomous_work_item_not_runnable",
+                reason: match scenario {
+                    scheduler::CanonicalActivationScenario::InternalFollowup { .. } => {
+                        "canonical_internal_followup_work_item_not_runnable"
+                    }
+                    _ => "canonical_autonomous_work_item_not_runnable",
+                },
             });
         }
 
@@ -1562,6 +1608,16 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
 pub(super) fn canonical_activation_id(message_id: &str) -> String {
     format!("activation:message:{message_id}")
+}
+
+fn scheduler_work_item_claim_conflict(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<RuntimeStateTransitionConflict>()
+            .is_some_and(|conflict| {
+                conflict.retryable() && conflict.domain() == "scheduler_claim_work_item"
+            })
+    })
 }
 
 fn align_execution_claim_with_wait_transition(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -8022,6 +8022,215 @@ async fn enqueue_inherits_current_work_item_and_preserves_canonical_provenance()
 }
 
 #[tokio::test]
+async fn stale_bound_internal_followup_is_dropped_before_operator_resume() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "stale bound follow-up".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut followup = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "tool_enqueue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "continue stale work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    followup.work_item_id = Some(work_item.id.clone());
+    let followup = runtime.enqueue(followup).await.unwrap();
+    runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            None,
+            Some(WorkItemPlanStatus::NeedsInput),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let operator = runtime
+        .enqueue(trusted_operator_prompt(
+            Some(&work_item.id),
+            "resume with new operator input",
+        ))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == followup.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dropped)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == followup.id
+                && event.data["reason"] == "canonical_internal_followup_work_item_not_runnable"
+                && event.data["queue_disposition"] == "dropped"
+        }));
+
+    drop(runtime);
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("new operator input should advance after the stale follow-up");
+    };
+    assert_eq!(scheduled.message.id, operator.id);
+}
+
+#[tokio::test]
+async fn claim_time_work_item_change_replans_and_drops_stale_internal_followup() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "claim race follow-up".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut followup = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "tool_enqueue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "race with needs input".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    followup.work_item_id = Some(work_item.id.clone());
+    let followup = runtime.enqueue(followup).await.unwrap();
+    let operator = runtime
+        .enqueue(trusted_operator_prompt(
+            Some(&work_item.id),
+            "continue after claim race",
+        ))
+        .await
+        .unwrap();
+    runtime.inject_claim_work_item_plan_status_before_commit(
+        work_item.id.clone(),
+        WorkItemPlanStatus::NeedsInput,
+    );
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .latest_work_item(&work_item.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .plan_status,
+        WorkItemPlanStatus::NeedsInput
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == followup.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dropped)
+    );
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("operator input behind claim-race follow-up should remain runnable");
+    };
+    assert_eq!(scheduled.message.id, operator.id);
+}
+
+#[tokio::test]
 async fn enqueue_does_not_bind_to_focus_without_current_turn_ownership() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- reject WorkItem-bound `InternalFollowup` messages when their owner is no
  longer runnable, terminalizing the stale queue head as `Dropped`
- rebuild the full canonical claim plan after an atomic
  `scheduler_claim_work_item` conflict instead of retrying an obsolete
  WorkItem snapshot
- add deterministic TOCTOU, restart, operator-resume, and queue-progress
  regression coverage
- document stale internal follow-up lifecycle in the unified execution
  protocol

## Runtime concept

`needs_input` and other non-runnable WorkItem states are authoritative. An
older internal self-follow-up cannot resume that WorkItem. The transactional
claim guard remains the final race fence; if it detects that the WorkItem
changed after planning, the executor abandons the whole prepared claim and
replans from current durable facts.

## Verification

- `cargo fmt --all -- --check`
- `cargo test internal_followup -- --nocapture`
- `cargo test runtime::tests::runtime_state --lib`
- `cargo test --test scheduler_workitem_mvp`
- `cargo test --test runtime_waiting_and_reactivation`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2510.
