### PR TITLE
fix: make terminal turn settlement atomic

### DIFF
--- a/docs/implementation-decisions/102-standalone-turn-terminal-transition-is-atomic.md
+++ b/docs/implementation-decisions/102-standalone-turn-terminal-transition-is-atomic.md
@@ -1,0 +1,17 @@
+# Standalone Turn Terminal Transition Is Atomic
+
+Decision:
+
+- persist `AgentState.last_turn_terminal`, the terminal `TurnRecord`, and their
+  audit events with one restricted runtime database transition
+- use the same optimistic-concurrency retry boundary as queue terminal
+  settlement
+- keep cache updates and event publication as post-commit effects
+
+Reason:
+
+- standalone interactive, task-rejoin, and compatibility entrypoints must not
+  leave a durable half-terminal turn when the process stops between writes
+- restart replay must be idempotent and must not duplicate terminal audits
+- fault injection after the AgentState write, TurnRecord write, audit writes,
+  and before commit verifies that every durable write point rolls back together

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3871,6 +3871,73 @@ impl RuntimeHandle {
         .await
     }
 
+    async fn commit_terminal_transition(
+        &self,
+        terminal_transition: &turn::TurnTerminalTransition,
+        audit_events: Vec<AuditEvent>,
+    ) -> Result<bool> {
+        let original_audit_len = audit_events.len();
+        let mut command = crate::runtime_db::transitions::TurnTerminalTransitionCommand {
+            agent_id: terminal_transition.turn_record.agent_id.clone(),
+            agent_state: crate::runtime_db::transitions::AgentStateMutation {
+                expected: None,
+                record: Box::new(self.inner.agent.lock().await.state.clone()),
+            },
+            turn_record: terminal_transition.turn_record.clone(),
+            audit_events: audit_events.clone(),
+            fault: None,
+        };
+        for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+            {
+                let guard = self.inner.agent.lock().await;
+                let mut state = guard.state.clone();
+                state.current_turn_id = Some(terminal_transition.terminal.turn_id.clone());
+                state.last_turn_terminal = Some(terminal_transition.terminal.clone());
+                command.agent_state = crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(guard.last_persisted_state.clone())),
+                    record: Box::new(state),
+                };
+            }
+            command.audit_events = audit_events.clone();
+            command.audit_events.truncate(original_audit_len);
+            command.audit_events.push(AuditEvent::legacy(
+                "turn_terminal",
+                serde_json::to_value(&terminal_transition.terminal)?,
+            ));
+            command.audit_events.push(Self::turn_record_audit_event(
+                &terminal_transition.turn_record,
+            ));
+            command.fault = self.take_transition_fault();
+            match self
+                .inner
+                .runtime_db
+                .transitions()
+                .commit_turn_terminal(&command)
+            {
+                Ok(commit) => {
+                    return Ok(self.apply_transition_commit(commit).await.applied);
+                }
+                Err(error) => {
+                    let can_retry = attempt + 1 < ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                        && retryable_enqueue_conflict(
+                            &error,
+                            &terminal_transition.turn_record.agent_id,
+                        );
+                    if !can_retry
+                        || !self
+                            .refresh_enqueue_agent_state_baseline(
+                                &terminal_transition.turn_record.agent_id,
+                            )
+                            .await?
+                    {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+        unreachable!("terminal transition OCC retry loop always returns or errors")
+    }
+
     async fn commit_queue_terminal_settlement_with_evidence(
         &self,
         record: QueueEntryRecord,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3876,38 +3876,32 @@ impl RuntimeHandle {
         terminal_transition: &turn::TurnTerminalTransition,
         audit_events: Vec<AuditEvent>,
     ) -> Result<bool> {
-        let original_audit_len = audit_events.len();
-        let mut command = crate::runtime_db::transitions::TurnTerminalTransitionCommand {
-            agent_id: terminal_transition.turn_record.agent_id.clone(),
-            agent_state: crate::runtime_db::transitions::AgentStateMutation {
-                expected: None,
-                record: Box::new(self.inner.agent.lock().await.state.clone()),
-            },
-            turn_record: terminal_transition.turn_record.clone(),
-            audit_events: audit_events.clone(),
-            fault: None,
-        };
         for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
-            {
+            let agent_state = {
                 let guard = self.inner.agent.lock().await;
                 let mut state = guard.state.clone();
                 state.current_turn_id = Some(terminal_transition.terminal.turn_id.clone());
                 state.last_turn_terminal = Some(terminal_transition.terminal.clone());
-                command.agent_state = crate::runtime_db::transitions::AgentStateMutation {
+                crate::runtime_db::transitions::AgentStateMutation {
                     expected: Some(Box::new(guard.last_persisted_state.clone())),
                     record: Box::new(state),
-                };
-            }
-            command.audit_events = audit_events.clone();
-            command.audit_events.truncate(original_audit_len);
-            command.audit_events.push(AuditEvent::legacy(
+                }
+            };
+            let mut transition_audit_events = audit_events.clone();
+            transition_audit_events.push(AuditEvent::legacy(
                 "turn_terminal",
                 serde_json::to_value(&terminal_transition.terminal)?,
             ));
-            command.audit_events.push(Self::turn_record_audit_event(
+            transition_audit_events.push(Self::turn_record_audit_event(
                 &terminal_transition.turn_record,
             ));
-            command.fault = self.take_transition_fault();
+            let command = crate::runtime_db::transitions::TurnTerminalTransitionCommand {
+                agent_id: terminal_transition.turn_record.agent_id.clone(),
+                agent_state,
+                turn_record: terminal_transition.turn_record.clone(),
+                audit_events: transition_audit_events,
+                fault: self.take_transition_fault(),
+            };
             match self
                 .inner
                 .runtime_db

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -5151,6 +5151,267 @@ async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent(
 }
 
 #[tokio::test]
+async fn standalone_terminal_transition_fault_rolls_back_and_restart_replays_exactly_once() {
+    for fault in TERMINAL_PRE_COMMIT_FAULTS {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let provider = Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        });
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            provider.clone(),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "persist terminal atomically".into(),
+            },
+        );
+        message.turn_id = Some(format!("turn-standalone-terminal-{fault:?}"));
+        let transition = terminal_transition(&message, None);
+        runtime.inject_next_transition_fault(fault);
+
+        let error = runtime
+            .persist_terminal_transition(&transition)
+            .await
+            .unwrap_err();
+        assert_injected_transition_fault(&error);
+        assert!(runtime
+            .inner
+            .runtime_db
+            .agent_states()
+            .latest("default")
+            .unwrap()
+            .unwrap()
+            .last_turn_terminal
+            .is_none());
+        assert!(runtime
+            .storage()
+            .read_recent_turns(16)
+            .unwrap()
+            .iter()
+            .all(|turn| turn.turn_id != transition.terminal.turn_id));
+        assert!(runtime
+            .storage()
+            .read_recent_events(64)
+            .unwrap()
+            .iter()
+            .all(|event| {
+                !(matches!(event.kind.as_str(), "turn_terminal" | "turn_record")
+                    && event.data["turn_id"] == transition.terminal.turn_id)
+            }));
+        drop(runtime);
+
+        let restarted = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            provider.clone(),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        restarted
+            .persist_terminal_transition(&transition)
+            .await
+            .unwrap();
+        restarted
+            .persist_terminal_transition(&transition)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            restarted
+                .storage()
+                .read_recent_turns(16)
+                .unwrap()
+                .iter()
+                .filter(|turn| turn.turn_id == transition.terminal.turn_id)
+                .count(),
+            1
+        );
+        for kind in ["turn_terminal", "turn_record"] {
+            assert_eq!(
+                restarted
+                    .storage()
+                    .read_recent_events(64)
+                    .unwrap()
+                    .iter()
+                    .filter(|event| {
+                        event.kind == kind && event.data["turn_id"] == transition.terminal.turn_id
+                    })
+                    .count(),
+                1
+            );
+        }
+        assert_eq!(
+            restarted
+                .inner
+                .runtime_db
+                .agent_states()
+                .latest("default")
+                .unwrap()
+                .unwrap()
+                .last_turn_terminal,
+            Some(transition.terminal.clone())
+        );
+    }
+}
+
+#[tokio::test]
+async fn standalone_terminal_transition_survives_post_commit_effect_faults() {
+    for (fault, expected_effect) in POST_COMMIT_FAULTS
+        .into_iter()
+        .filter(|(fault, _)| *fault != TransitionFaultPoint::BeforeSchedulerNotification)
+    {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "retain committed terminal".into(),
+            },
+        );
+        message.turn_id = Some(format!("turn-standalone-post-commit-{fault:?}"));
+        let transition = terminal_transition(&message, None);
+        runtime.inject_next_transition_fault(fault);
+
+        runtime
+            .persist_terminal_transition(&transition)
+            .await
+            .unwrap();
+        let warnings = runtime.take_transition_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].effect, expected_effect);
+        assert_eq!(
+            runtime
+                .inner
+                .runtime_db
+                .agent_states()
+                .latest("default")
+                .unwrap()
+                .unwrap()
+                .last_turn_terminal,
+            Some(transition.terminal.clone())
+        );
+        assert_eq!(
+            runtime
+                .storage()
+                .read_recent_turns(16)
+                .unwrap()
+                .iter()
+                .filter(|turn| turn.turn_id == transition.terminal.turn_id)
+                .count(),
+            1
+        );
+        for kind in ["turn_terminal", "turn_record"] {
+            assert_eq!(
+                runtime
+                    .storage()
+                    .read_recent_events(64)
+                    .unwrap()
+                    .iter()
+                    .filter(|event| {
+                        event.kind == kind && event.data["turn_id"] == transition.terminal.turn_id
+                    })
+                    .count(),
+                1
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn standalone_aborted_terminal_commits_terminal_and_abort_audits_atomically() {
+    for fault in TERMINAL_PRE_COMMIT_FAULTS {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        let turn_id = {
+            let mut guard = runtime.inner.agent.lock().await;
+            guard.state.current_turn_id = Some(format!("turn-aborted-terminal-{fault:?}"));
+            guard.persist_state(&runtime.inner.storage).unwrap();
+            guard.state.current_turn_id.clone().unwrap()
+        };
+        runtime.inject_next_transition_fault(fault);
+
+        let error = runtime
+            .persist_turn_aborted_record("run-aborted", "operator_aborted", None, 1, true)
+            .await
+            .unwrap_err();
+        assert_injected_transition_fault(&error);
+        assert!(runtime
+            .inner
+            .runtime_db
+            .agent_states()
+            .latest("default")
+            .unwrap()
+            .unwrap()
+            .last_turn_terminal
+            .is_none());
+        assert!(runtime
+            .storage()
+            .read_recent_turns(16)
+            .unwrap()
+            .iter()
+            .all(|turn| turn.turn_id != turn_id));
+        assert!(runtime
+            .storage()
+            .read_recent_events(64)
+            .unwrap()
+            .iter()
+            .all(|event| {
+                !(matches!(
+                    event.kind.as_str(),
+                    "turn_terminal" | "turn_record" | "turn_terminal_aborted"
+                ) && event.data["turn_id"] == turn_id)
+            }));
+    }
+}
+
+#[tokio::test]
 async fn terminal_settlement_survives_post_commit_effect_faults() {
     for (fault, expected_effect) in POST_COMMIT_FAULTS {
         let dir = tempdir().unwrap();

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -41,6 +41,7 @@ mod lifecycle;
 pub(crate) use lifecycle::{
     advance_lifecycle_time, assert_injected_transition_fault, controlled_clock,
     DurableLifecycleSnapshot, LifecycleHarness, POST_COMMIT_FAULTS, PRE_COMMIT_FAULTS,
+    TERMINAL_PRE_COMMIT_FAULTS,
 };
 
 pub(crate) fn context_config() -> ContextConfig {

--- a/src/runtime/tests/support/lifecycle.rs
+++ b/src/runtime/tests/support/lifecycle.rs
@@ -7,6 +7,16 @@ pub(crate) const PRE_COMMIT_FAULTS: [crate::runtime_db::transitions::TransitionF
     crate::runtime_db::transitions::TransitionFaultPoint::BeforeCommit,
 ];
 
+pub(crate) const TERMINAL_PRE_COMMIT_FAULTS:
+    [crate::runtime_db::transitions::TransitionFaultPoint; 6] = [
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterValidation,
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterTerminalAgentStateWrite,
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterTerminalTurnRecordWrite,
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
+    crate::runtime_db::transitions::TransitionFaultPoint::AfterAuditWrites,
+    crate::runtime_db::transitions::TransitionFaultPoint::BeforeCommit,
+];
+
 pub(crate) const POST_COMMIT_FAULTS: [(
     crate::runtime_db::transitions::TransitionFaultPoint,
     &str,

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -2140,6 +2140,7 @@ async fn runtime_failure_artifacts_create_terminal_turn_record_when_missing() {
         let mut guard = runtime.inner.agent.lock().await;
         guard.state.last_turn_terminal = None;
         runtime.storage().write_agent(&guard.state).unwrap();
+        guard.last_persisted_state = guard.state.clone();
     }
 
     runtime

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -153,7 +153,7 @@ impl RuntimeHandle {
         persist: bool,
     ) -> Result<TurnTerminalRecord> {
         let record = {
-            let mut guard = self.inner.agent.lock().await;
+            let guard = self.inner.agent.lock().await;
             let checkpoint = if kind == TurnTerminalKind::Completed {
                 checkpoint_state
                     .and_then(|state| terminal_checkpoint_from_state(state, guard.state.turn_index))
@@ -166,8 +166,7 @@ impl RuntimeHandle {
                 .clone()
                 .filter(|turn_id| !turn_id.trim().is_empty())
                 .unwrap_or_else(crate::ids::turn_id);
-            guard.state.current_turn_id = Some(turn_id.clone());
-            let record = TurnTerminalRecord {
+            TurnTerminalRecord {
                 turn_id,
                 turn_index: guard.state.turn_index,
                 kind,
@@ -176,18 +175,14 @@ impl RuntimeHandle {
                 checkpoint,
                 completed_at: chrono::Utc::now(),
                 duration_ms,
-            };
-            if persist {
-                guard.state.last_turn_terminal = Some(record.clone());
-                guard.persist_state(&self.inner.storage)?;
             }
-            record
         };
         if persist {
-            self.inner.storage.append_event(&AuditEvent::legacy(
-                "turn_terminal",
-                serde_json::to_value(&record)?,
-            ))?;
+            let transition = super::TurnTerminalTransition {
+                turn_record: self.build_turn_record(&record).await?,
+                terminal: record.clone(),
+            };
+            self.persist_terminal_transition(&transition).await?;
         }
         Ok(record)
     }

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -1,8 +1,7 @@
 //! Turn execution module: drives the provider conversation loop, context
 //! projection, checkpointing, tool execution, and completion handling.
 //!
-//! Public entrypoints are [`RuntimeHandle::run_agent_loop`],
-//! [`RuntimeHandle::persist_turn_record`], and
+//! Public entrypoints are [`RuntimeHandle::run_agent_loop`] and
 //! [`RuntimeHandle::persist_turn_aborted_record`].
 
 mod checkpoint;
@@ -263,6 +262,7 @@ impl RuntimeHandle {
         Ok(record)
     }
 
+    #[cfg(test)]
     pub(super) async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
         let record = self.build_turn_record(terminal).await?;
         self.persist_built_turn_record(&record)
@@ -272,19 +272,12 @@ impl RuntimeHandle {
         &self,
         transition: &TurnTerminalTransition,
     ) -> Result<()> {
-        {
-            let mut guard = self.inner.agent.lock().await;
-            guard.state.current_turn_id = Some(transition.terminal.turn_id.clone());
-            guard.state.last_turn_terminal = Some(transition.terminal.clone());
-            guard.persist_state(&self.inner.storage)?;
-        }
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "turn_terminal",
-            serde_json::to_value(&transition.terminal)?,
-        ))?;
-        self.persist_built_turn_record(&transition.turn_record)
+        self.commit_terminal_transition(transition, Vec::new())
+            .await
+            .map(|_| ())
     }
 
+    #[cfg(test)]
     pub(super) fn persist_built_turn_record(&self, record: &TurnRecord) -> Result<()> {
         self.inner.storage.append_turn(&record)?;
         self.inner
@@ -324,29 +317,26 @@ impl RuntimeHandle {
             .build_turn_aborted_record(reason, last_assistant_message, duration_ms)
             .await;
         if persist {
-            {
-                let mut guard = self.inner.agent.lock().await;
-                guard.state.current_turn_id = Some(record.turn_id.clone());
-                guard.state.last_turn_terminal = Some(record.clone());
-                guard.persist_state(&self.inner.storage)?;
-            }
-            self.persist_turn_record(&record).await?;
-            self.inner.storage.append_event(&AuditEvent::legacy(
-                "turn_terminal",
-                serde_json::to_value(&record)?,
-            ))?;
-            self.inner.storage.append_event(&AuditEvent::legacy(
-                "turn_terminal_aborted",
-                serde_json::json!({
-                    "run_id": run_id,
-                    "reason": reason,
-                    "turn_id": record.turn_id.clone(),
-                    "turn_index": record.turn_index,
-                    "kind": record.kind,
-                    "completed_at": record.completed_at,
-                    "duration_ms": record.duration_ms,
-                }),
-            ))?;
+            let transition = TurnTerminalTransition {
+                turn_record: self.build_turn_record(&record).await?,
+                terminal: record.clone(),
+            };
+            self.commit_terminal_transition(
+                &transition,
+                vec![AuditEvent::legacy(
+                    "turn_terminal_aborted",
+                    serde_json::json!({
+                        "run_id": run_id,
+                        "reason": reason,
+                        "turn_id": record.turn_id.clone(),
+                        "turn_index": record.turn_index,
+                        "kind": record.kind,
+                        "completed_at": record.completed_at,
+                        "duration_ms": record.duration_ms,
+                    }),
+                )],
+            )
+            .await?;
         }
         Ok(record)
     }

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -40,6 +40,8 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransitionFaultPoint {
     AfterValidation,
+    AfterTerminalAgentStateWrite,
+    AfterTerminalTurnRecordWrite,
     AfterCanonicalWrites,
     AfterAuditWrites,
     BeforeCommit,
@@ -217,6 +219,15 @@ pub(crate) struct QueueTransitionCommand {
     pub brief_evidence: Vec<BriefRecord>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct TurnTerminalTransitionCommand {
+    pub agent_id: String,
+    pub agent_state: AgentStateMutation,
+    pub turn_record: TurnRecord,
+    pub audit_events: Vec<AuditEvent>,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ExecutionProtocolTransition {
     pub bootstrap: Option<crate::domain::execution_protocol::ExecutionProtocolState>,
@@ -320,6 +331,57 @@ impl RuntimeDb {
 }
 
 impl RuntimeTransitionRepository<'_> {
+    pub fn commit_turn_terminal(
+        &self,
+        command: &TurnTerminalTransitionCommand,
+    ) -> Result<TransitionCommit> {
+        self.db.transaction(|tx| {
+            validate_agent_state_mutation_tx(tx, Some(&command.agent_state))?;
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+
+            let agent_state_applied =
+                apply_agent_state_mutation_tx(tx, Some(&command.agent_state))?;
+            inject_fault(
+                command.fault,
+                TransitionFaultPoint::AfterTerminalAgentStateWrite,
+            )?;
+            let turn_record_applied = tx
+                .query_row(
+                    "SELECT payload_json FROM turn_records WHERE turn_id = ?1",
+                    [&command.turn_record.turn_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .map(|payload| serde_json::from_str::<TurnRecord>(&payload))
+                .transpose()?
+                .as_ref()
+                != Some(&command.turn_record);
+            upsert_turn_record_tx(tx, &command.turn_record)?;
+            inject_fault(
+                command.fault,
+                TransitionFaultPoint::AfterTerminalTurnRecordWrite,
+            )?;
+            let applied = agent_state_applied || turn_record_applied;
+            if !applied {
+                return Ok(TransitionCommit::default());
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+
+            finish_transition_tx(
+                tx,
+                applied,
+                &command.agent_id,
+                &command.audit_events,
+                &[],
+                command.fault,
+                PostCommitEffects {
+                    agent_state: agent_state_applied.then(|| command.agent_state.clone()),
+                    ..PostCommitEffects::default()
+                },
+            )
+        })
+    }
+
     pub fn commit_work_item_focus(
         &self,
         command: &WorkItemFocusTransitionCommand,


### PR DESCRIPTION
## 概要

- 将 standalone turn 的 `AgentState` terminal、`TurnRecord` finalization 与 terminal audit 收敛到单一可重试数据库事务
- 让事务重试复用稳定的 terminal facts，避免回滚后产生重复 delivery 或不一致终态
- 增加逐写入点 fault injection、retry 幂等与 restart replay 回归
- 记录 standalone terminal transition 的原子性边界与保留的调度约束

## 验证

- `cargo test terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent --lib`
- `cargo test standalone_terminal_transition --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
