### PR TITLE
fix: bound queue head no-progress retries

### DIFF
--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -326,6 +326,20 @@ writes audit evidence in the same transaction.
 A normal typed conflict must not cause an unbounded queue-head retry, agent
 restart loop, or lane reservation leak.
 
+Every FIFO queue head has one explicit disposition:
+
+- `consume` when admission succeeds;
+- `drop` when current durable facts prove the input stale or inadmissible;
+- `bounded-defer` when authority may still converge;
+- `quarantine` when the durable no-progress budget is exhausted.
+
+Retained authority input, unresolved hard blockers, ambiguous waits, claim
+contention, and exhausted claim replanning all consume the same durable
+queue-head budget. The budget survives process restart. Its terminal
+transition atomically marks the queue entry `Quarantined`, updates the pending
+projection, and records diagnostic audit evidence, allowing the next queued
+input to advance.
+
 The run loop may terminalize a bounded number of provably stale or reduce-only
 queue heads in one poll and continue to the next candidate. Wake-only timer,
 callback, system, or legacy wait-trigger envelopes with no exact current

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5183,7 +5183,8 @@
                         "processed",
                         "interjected",
                         "aborted",
-                        "dropped"
+                        "dropped",
+                        "quarantined"
                       ],
                       "type": "string"
                     },
@@ -5272,7 +5273,8 @@
                           "processed",
                           "interjected",
                           "aborted",
-                          "dropped"
+                          "dropped",
+                          "quarantined"
                         ],
                         "type": "string"
                       },

--- a/docs/website/reference/runtime-status-enum-inventory.json
+++ b/docs/website/reference/runtime-status-enum-inventory.json
@@ -84,6 +84,7 @@
         "interjected",
         "aborted",
         "dropped",
+        "quarantined",
         "interrupted"
       ],
       "source": "src/types.rs"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3692,6 +3692,7 @@ impl RuntimeHandle {
                     | QueueEntryStatus::Processed
                     | QueueEntryStatus::Aborted
                     | QueueEntryStatus::Dropped
+                    | QueueEntryStatus::Quarantined
             )
         }) {
             return Ok(TransitionCommit::default());

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -240,5 +240,6 @@ fn operator_message_status(
         QueueEntryStatus::Processed => OperatorMessageStatus::Processed,
         QueueEntryStatus::Aborted => OperatorMessageStatus::Failed,
         QueueEntryStatus::Dropped => OperatorMessageStatus::Dropped,
+        QueueEntryStatus::Quarantined => OperatorMessageStatus::Quarantined,
     }
 }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -2,6 +2,8 @@ use super::message_dispatch::MessageDispatchPlan;
 use super::*;
 use crate::types::ExecutionAdmissionProvenance;
 
+const QUEUE_HEAD_NO_PROGRESS_MAX_ATTEMPTS: u32 = 3;
+
 pub(super) enum RunLoopPoll {
     Shutdown,
     Stopped(AgentState, usize),
@@ -104,10 +106,45 @@ struct CanonicalClaimHardBlocker {
     blocker_code: &'static str,
 }
 
+enum QueueHeadNoProgressCause {
+    RetainedAuthority {
+        scenario_class: crate::domain::scheduler_protocol::SchedulerScenarioClass,
+        reason: &'static str,
+    },
+    HardBlocker(CanonicalClaimHardBlocker),
+    AmbiguousWait,
+    ClaimContended {
+        scenario_class: Option<crate::domain::scheduler_protocol::SchedulerScenarioClass>,
+    },
+    ReplanExhausted,
+}
+
+impl QueueHeadNoProgressCause {
+    fn scenario_class(&self) -> Option<crate::domain::scheduler_protocol::SchedulerScenarioClass> {
+        match self {
+            Self::RetainedAuthority { scenario_class, .. } => Some(*scenario_class),
+            Self::HardBlocker(blocker) => Some(blocker.scenario_class),
+            Self::ClaimContended { scenario_class } => *scenario_class,
+            Self::AmbiguousWait | Self::ReplanExhausted => None,
+        }
+    }
+
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::RetainedAuthority { reason, .. } => reason,
+            Self::HardBlocker(blocker) => blocker.blocker_code,
+            Self::AmbiguousWait => "canonical_wait_ambiguous",
+            Self::ClaimContended { .. } => "canonical_claim_contended",
+            Self::ReplanExhausted => "canonical_claim_replan_exhausted",
+        }
+    }
+}
+
 pub(super) struct SchedulerDecisionExecutor<'a> {
     runtime: &'a RuntimeHandle,
 }
 
+#[derive(Clone)]
 struct QueueCandidate {
     message: MessageEnvelope,
     prior_state: AgentState,
@@ -370,7 +407,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 }
             };
 
-            match self.prepare_message(candidate).await? {
+            match self.prepare_message(candidate.clone()).await? {
                 PrepareMessageOutcome::Poll(poll) => {
                     crate::diagnostics::record_scheduler_poll(
                         poll.outcome_name(),
@@ -384,7 +421,12 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     replans += 1;
                 }
                 PrepareMessageOutcome::Replan => {
-                    let poll = RunLoopPoll::AuthorityBlocked;
+                    let poll = self
+                        .defer_or_quarantine_queue_head(
+                            &candidate,
+                            QueueHeadNoProgressCause::ReplanExhausted,
+                        )
+                        .await?;
                     crate::diagnostics::record_scheduler_poll(
                         poll.outcome_name(),
                         started_at.elapsed(),
@@ -470,24 +512,25 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     scenario_class,
                     reason,
                 }) => {
-                    self.runtime
-                        .inner
-                        .storage
-                        .append_event(&AuditEvent::legacy(
-                            "scheduler_authority_input_rejected",
-                            serde_json::json!({
-                                "message_id": persisted_message.id,
-                                "agent_id": persisted_message.agent_id,
-                                "scenario_class": scenario_class.as_str(),
-                                "reason": reason,
-                                "queue_disposition": "retained_queued",
-                            }),
-                        ))?;
-                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
+                    return Ok(PrepareMessageOutcome::Poll(
+                        self.defer_or_quarantine_queue_head(
+                            &candidate,
+                            QueueHeadNoProgressCause::RetainedAuthority {
+                                scenario_class,
+                                reason,
+                            },
+                        )
+                        .await?,
+                    ));
                 }
                 Ok(CanonicalClaimOutcome::HardBlocker(blocker)) => {
-                    self.report_canonical_claim_hard_blocker(&persisted_message, blocker)?;
-                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
+                    return Ok(PrepareMessageOutcome::Poll(
+                        self.defer_or_quarantine_queue_head(
+                            &candidate,
+                            QueueHeadNoProgressCause::HardBlocker(blocker),
+                        )
+                        .await?,
+                    ));
                 }
                 Err(error) => {
                     if let Some(ambiguous) =
@@ -503,7 +546,13 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                             &candidate.prior_state,
                             candidate.queue_len,
                         )?;
-                        return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
+                        return Ok(PrepareMessageOutcome::Poll(
+                            self.defer_or_quarantine_queue_head(
+                                &candidate,
+                                QueueHeadNoProgressCause::AmbiguousWait,
+                            )
+                            .await?,
+                        ));
                     }
                     return Err(error);
                 }
@@ -683,7 +732,17 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     commit.effects.agent_state = None;
                     drop(guard);
                     self.runtime.apply_transition_commit(commit).await;
-                    return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::AuthorityBlocked));
+                    return Ok(PrepareMessageOutcome::Poll(
+                        self.defer_or_quarantine_queue_head(
+                            &candidate,
+                            QueueHeadNoProgressCause::ClaimContended {
+                                scenario_class: canonical_claim
+                                    .as_ref()
+                                    .map(|plan| plan.scenario_class),
+                            },
+                        )
+                        .await?,
+                    ));
                 }
                 if !commit.applied {
                     let _ = guard.queue.pop_if_next(&candidate.message.id);
@@ -1563,26 +1622,80 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         )
     }
 
-    fn report_canonical_claim_hard_blocker(
+    async fn defer_or_quarantine_queue_head(
         &self,
-        message: &MessageEnvelope,
-        blocker: CanonicalClaimHardBlocker,
-    ) -> Result<()> {
-        let scenario_class = blocker.scenario_class.as_str();
-        self.runtime
+        candidate: &QueueCandidate,
+        cause: QueueHeadNoProgressCause,
+    ) -> Result<RunLoopPoll> {
+        let scenario_class = cause.scenario_class();
+        let reason = cause.reason();
+        let expected = self
+            .runtime
             .inner
-            .storage
-            .append_event(&AuditEvent::legacy(
-                "scheduler_authority_hard_blocker",
-                serde_json::json!({
-                    "message_id": message.id,
-                    "agent_id": message.agent_id,
-                    "scenario_class": scenario_class,
-                    "blocker_code": blocker.blocker_code,
-                    "queue_disposition": "retained_queued",
-                }),
-            ))?;
-        Ok(())
+            .runtime_db
+            .queue_entries()
+            .latest(&candidate.message.id)?
+            .ok_or_else(|| anyhow!("deferred queue head is missing durable state"))?;
+        if !matches!(
+            expected.status,
+            QueueEntryStatus::Queued | QueueEntryStatus::Interrupted
+        ) {
+            return Ok(RunLoopPoll::Idle);
+        }
+        let mut quarantined = expected.clone();
+        quarantined.status = QueueEntryStatus::Quarantined;
+        quarantined.updated_at = self.runtime.now();
+
+        let mut guard = self.runtime.inner.agent.lock().await;
+        if !guard
+            .queue
+            .peek()
+            .is_some_and(|queued| queued.id == candidate.message.id)
+        {
+            return Ok(RunLoopPoll::Idle);
+        }
+        let mut next_state = guard.state.clone();
+        next_state.pending = guard.queue.len().saturating_sub(1);
+        let Some(mut result) = self
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .commit_queue_head_no_progress(
+                &crate::runtime_db::transitions::QueueHeadNoProgressCommand {
+                    agent_id: candidate.message.agent_id.clone(),
+                    expected,
+                    quarantined,
+                    agent_state: crate::runtime_db::transitions::AgentStateMutation {
+                        expected: Some(Box::new(guard.state.clone())),
+                        record: Box::new(next_state.clone()),
+                    },
+                    reason: reason.into(),
+                    scenario_class: scenario_class.map(|scenario| scenario.as_str().to_string()),
+                    max_attempts: QUEUE_HEAD_NO_PROGRESS_MAX_ATTEMPTS,
+                    fault: self.runtime.take_transition_fault(),
+                },
+            )?
+        else {
+            return Ok(RunLoopPoll::Idle);
+        };
+        let quarantined = matches!(
+            result.outcome,
+            crate::runtime_db::transitions::QueueHeadNoProgressOutcome::Quarantined { .. }
+        );
+        if quarantined {
+            let _ = guard.queue.pop_if_next(&candidate.message.id);
+            guard.state = next_state.clone();
+            guard.last_persisted_state = next_state;
+            result.commit.effects.agent_state = None;
+        }
+        drop(guard);
+        self.runtime.apply_transition_commit(result.commit).await;
+        Ok(if quarantined {
+            RunLoopPoll::Idle
+        } else {
+            RunLoopPoll::AuthorityBlocked
+        })
     }
 
     fn append_posture_decision(
@@ -2022,6 +2135,209 @@ pub(super) fn apply_bootstrap_recovered_projection(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn no_progress_cause(reason: &'static str) -> QueueHeadNoProgressCause {
+        use crate::domain::scheduler_protocol::SchedulerScenarioClass;
+
+        match reason {
+            "explicit_binding_work_item_missing" => QueueHeadNoProgressCause::RetainedAuthority {
+                scenario_class: SchedulerScenarioClass::ExplicitlyBoundOperatorInput,
+                reason,
+            },
+            "canonical_activation_scenario_unresolved" => {
+                QueueHeadNoProgressCause::HardBlocker(CanonicalClaimHardBlocker {
+                    scenario_class: SchedulerScenarioClass::ExactWaitResume,
+                    blocker_code: reason,
+                })
+            }
+            "canonical_wait_ambiguous" => QueueHeadNoProgressCause::AmbiguousWait,
+            "canonical_claim_contended" => QueueHeadNoProgressCause::ClaimContended {
+                scenario_class: Some(SchedulerScenarioClass::WorkItemAutonomousContinuation),
+            },
+            "canonical_claim_replan_exhausted" => QueueHeadNoProgressCause::ReplanExhausted,
+            other => panic!("unknown queue-head no-progress test cause: {other}"),
+        }
+    }
+
+    fn operator_prompt(text: impl Into<String>) -> MessageEnvelope {
+        MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("control".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text { text: text.into() },
+        )
+        .with_admission(
+            MessageDeliverySurface::HttpControlPrompt,
+            AdmissionContext::ControlAuthenticated,
+        )
+    }
+
+    async fn queue_candidate(runtime: &RuntimeHandle) -> QueueCandidate {
+        let guard = runtime.inner.agent.lock().await;
+        QueueCandidate {
+            message: guard.queue.peek().cloned().expect("queued test message"),
+            prior_state: guard.state.clone(),
+            queue_len: guard.queue.len(),
+        }
+    }
+
+    #[test]
+    fn queue_head_no_progress_causes_have_total_diagnostic_mapping() {
+        use crate::domain::scheduler_protocol::SchedulerScenarioClass;
+
+        let cases = [
+            (
+                QueueHeadNoProgressCause::RetainedAuthority {
+                    scenario_class: SchedulerScenarioClass::ExplicitlyBoundOperatorInput,
+                    reason: "explicit_binding_work_item_missing",
+                },
+                Some(SchedulerScenarioClass::ExplicitlyBoundOperatorInput),
+                "explicit_binding_work_item_missing",
+            ),
+            (
+                QueueHeadNoProgressCause::HardBlocker(CanonicalClaimHardBlocker {
+                    scenario_class: SchedulerScenarioClass::ExactWaitResume,
+                    blocker_code: "canonical_activation_scenario_unresolved",
+                }),
+                Some(SchedulerScenarioClass::ExactWaitResume),
+                "canonical_activation_scenario_unresolved",
+            ),
+            (
+                QueueHeadNoProgressCause::AmbiguousWait,
+                None,
+                "canonical_wait_ambiguous",
+            ),
+            (
+                QueueHeadNoProgressCause::ClaimContended {
+                    scenario_class: Some(SchedulerScenarioClass::WorkItemAutonomousContinuation),
+                },
+                Some(SchedulerScenarioClass::WorkItemAutonomousContinuation),
+                "canonical_claim_contended",
+            ),
+            (
+                QueueHeadNoProgressCause::ReplanExhausted,
+                None,
+                "canonical_claim_replan_exhausted",
+            ),
+        ];
+
+        for (cause, scenario_class, reason) in cases {
+            assert_eq!(cause.scenario_class(), scenario_class);
+            assert_eq!(cause.reason(), reason);
+        }
+    }
+
+    #[tokio::test]
+    async fn queue_head_no_progress_matrix_quarantines_across_restart_and_advances_valid_next() {
+        use crate::runtime::tests::support::{context_config, CountingProvider};
+        use tempfile::tempdir;
+
+        for reason in [
+            "explicit_binding_work_item_missing",
+            "canonical_activation_scenario_unresolved",
+            "canonical_wait_ambiguous",
+            "canonical_claim_contended",
+            "canonical_claim_replan_exhausted",
+        ] {
+            let dir = tempdir().unwrap();
+            let workspace = tempdir().unwrap();
+            let runtime = RuntimeHandle::new(
+                "default",
+                dir.path().to_path_buf(),
+                workspace.path().to_path_buf(),
+                "http://127.0.0.1:7878".into(),
+                Arc::new(CountingProvider {
+                    calls: Mutex::new(0),
+                    reply: "unused",
+                }),
+                "default".into(),
+                context_config(),
+            )
+            .unwrap();
+            let blocked = runtime
+                .enqueue(operator_prompt(format!("blocked by {reason}")))
+                .await
+                .unwrap();
+            let valid = runtime
+                .enqueue(operator_prompt(format!("valid after {reason}")))
+                .await
+                .unwrap();
+            let candidate = queue_candidate(&runtime).await;
+            assert_eq!(candidate.message.id, blocked.id);
+            assert!(matches!(
+                SchedulerDecisionExecutor::new(&runtime)
+                    .defer_or_quarantine_queue_head(&candidate, no_progress_cause(reason))
+                    .await
+                    .unwrap(),
+                RunLoopPoll::AuthorityBlocked
+            ));
+            drop(runtime);
+
+            let reopened = RuntimeHandle::new(
+                "default",
+                dir.path().to_path_buf(),
+                workspace.path().to_path_buf(),
+                "http://127.0.0.1:7878".into(),
+                Arc::new(CountingProvider {
+                    calls: Mutex::new(0),
+                    reply: "unused",
+                }),
+                "default".into(),
+                context_config(),
+            )
+            .unwrap();
+            let candidate = queue_candidate(&reopened).await;
+            assert!(matches!(
+                SchedulerDecisionExecutor::new(&reopened)
+                    .defer_or_quarantine_queue_head(&candidate, no_progress_cause(reason))
+                    .await
+                    .unwrap(),
+                RunLoopPoll::AuthorityBlocked
+            ));
+            assert!(matches!(
+                SchedulerDecisionExecutor::new(&reopened)
+                    .defer_or_quarantine_queue_head(&candidate, no_progress_cause(reason))
+                    .await
+                    .unwrap(),
+                RunLoopPoll::Idle
+            ));
+            assert_eq!(
+                reopened
+                    .inner
+                    .runtime_db
+                    .queue_entries()
+                    .latest(&blocked.id)
+                    .unwrap()
+                    .map(|entry| entry.status),
+                Some(QueueEntryStatus::Quarantined),
+                "cause {reason}"
+            );
+
+            let poll = SchedulerDecisionExecutor::new(&reopened)
+                .poll()
+                .await
+                .unwrap();
+            let RunLoopPoll::Message(scheduled) = poll else {
+                panic!("valid input should advance after quarantining {reason}");
+            };
+            assert_eq!(scheduled.message.id, valid.id, "cause {reason}");
+            assert!(reopened
+                .storage()
+                .read_recent_events(usize::MAX)
+                .unwrap()
+                .iter()
+                .any(|event| {
+                    event.kind == "scheduler_queue_head_quarantined"
+                        && event.data["message_id"] == blocked.id
+                        && event.data["reason"] == reason
+                        && event.data["attempt"] == QUEUE_HEAD_NO_PROGRESS_MAX_ATTEMPTS
+                }));
+        }
+    }
 
     fn bootstrap_state(status: AgentStatus) -> AgentState {
         let mut state = AgentState::new("default");

--- a/src/runtime/tests/contracts/wait.rs
+++ b/src/runtime/tests/contracts/wait.rs
@@ -480,6 +480,7 @@ async fn late_task_result_terminal_queue_states_are_already_consumed() {
         QueueEntryStatus::Processed,
         QueueEntryStatus::Aborted,
         QueueEntryStatus::Dropped,
+        QueueEntryStatus::Quarantined,
     ] {
         let harness = LifecycleHarness::new();
         let work_item = harness

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -4650,7 +4650,7 @@ async fn canonical_processed_settlement_without_terminal_turn_fails_closed() {
 }
 
 #[tokio::test]
-async fn authoritative_explicit_operator_missing_target_remains_queued_without_rollback() {
+async fn authoritative_explicit_operator_missing_target_is_bounded_across_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -4670,6 +4670,13 @@ async fn authoritative_explicit_operator_missing_target_remains_queued_without_r
         .enqueue(trusted_operator_prompt(
             Some("work-missing"),
             "wrong-fence explicit operator input",
+        ))
+        .await
+        .unwrap();
+    let valid = runtime
+        .enqueue(trusted_operator_prompt(
+            None,
+            "continue after quarantined missing target",
         ))
         .await
         .unwrap();
@@ -4693,15 +4700,64 @@ async fn authoritative_explicit_operator_missing_target_remains_queued_without_r
             .map(|entry| entry.status),
         Some(QueueEntryStatus::Queued)
     );
-    assert!(runtime
+    drop(runtime);
+
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::AuthorityBlocked
+    ));
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        reopened
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&message.id)
+            .unwrap()
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Quarantined)
+    );
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("valid input should advance after the retained head is quarantined");
+    };
+    assert_eq!(scheduled.message.id, valid.id);
+    assert!(reopened
         .storage()
         .read_recent_events(usize::MAX)
         .unwrap()
         .iter()
         .any(|event| {
-            event.kind == "scheduler_authority_input_rejected"
+            event.kind == "scheduler_queue_head_quarantined"
                 && event.data["message_id"] == message.id
                 && event.data["reason"] == "explicit_binding_work_item_missing"
+                && event.data["attempt"] == 3
+                && event.data["queue_disposition"] == "quarantined"
         }));
 }
 

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -624,6 +624,7 @@ impl RuntimeHandle {
                     | QueueEntryStatus::Processed
                     | QueueEntryStatus::Aborted
                     | QueueEntryStatus::Dropped
+                    | QueueEntryStatus::Quarantined
             )
         }) {
             return Ok(WaitForRegistrationOutcome::TaskResultAlreadyConsumed {

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -2957,6 +2957,26 @@ CREATE UNIQUE INDEX IF NOT EXISTS wait_conditions_unresolved_work_item_owner
         name: "wait_protocol_cutover",
         sql: "",
     },
+    Migration {
+        version: 46,
+        name: "queue_head_no_progress",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS queue_head_no_progress (
+  message_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  attempts INTEGER NOT NULL CHECK (attempts > 0),
+  max_attempts INTEGER NOT NULL CHECK (max_attempts > 0),
+  status TEXT NOT NULL CHECK (status IN ('bounded_defer', 'quarantined')),
+  first_reason TEXT NOT NULL,
+  last_reason TEXT NOT NULL,
+  first_deferred_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_queue_head_no_progress_agent_status
+  ON queue_head_no_progress(agent_id, status, updated_at);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3611,7 +3611,10 @@ pub(crate) fn wait_condition_transition(
 fn is_terminal_queue_entry_status(status: &QueueEntryStatus) -> bool {
     matches!(
         status,
-        QueueEntryStatus::Processed | QueueEntryStatus::Aborted | QueueEntryStatus::Dropped
+        QueueEntryStatus::Processed
+            | QueueEntryStatus::Aborted
+            | QueueEntryStatus::Dropped
+            | QueueEntryStatus::Quarantined
     )
 }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -7,10 +7,10 @@ use crate::runtime_db::evidence::content_hash;
 use crate::runtime_db::evidence::insert_audit_event_tx;
 #[cfg(test)]
 use crate::runtime_db::migrations::{
-    apply_migration, backfill_wait_condition_payload_columns, backfill_work_item_recheck_columns,
-    current_schema_version, ensure_migration_table, max_known_migration_version,
-    schema_fingerprint, table_exists, MIGRATIONS, PUBLISHED_MIGRATION_FLOOR,
-    RELEASE_BASELINE_TARGET,
+    apply_migration, apply_release_baseline, backfill_wait_condition_payload_columns,
+    backfill_work_item_recheck_columns, current_schema_version, ensure_migration_table,
+    max_known_migration_version, schema_fingerprint, table_exists, MIGRATIONS,
+    PUBLISHED_MIGRATION_FLOOR, RELEASE_BASELINE_TARGET,
 };
 #[cfg(test)]
 use crate::runtime_db::storage_domain::upsert_storage_domain;
@@ -94,8 +94,9 @@ mod tests {
         },
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
-            scheduler_protocol_repository::SchedulerProtocolCommandIdentityConflict, QueueMutation,
-            QueueOperation, QueueTransitionCommand, TransitionFaultPoint,
+            scheduler_protocol_repository::SchedulerProtocolCommandIdentityConflict,
+            AgentStateMutation, QueueHeadNoProgressCommand, QueueHeadNoProgressOutcome,
+            QueueMutation, QueueOperation, QueueTransitionCommand, TransitionFaultPoint,
         },
         system::WorkspaceAccessMode,
         types::{
@@ -581,6 +582,7 @@ mod tests {
             "artifact_metadata",
             "wait_conditions",
             "queue_entries",
+            "queue_head_no_progress",
             "timers",
             "turn_records",
             "agent_states",
@@ -662,7 +664,16 @@ mod tests {
             serde_json::from_str::<Vec<i64>>(&baseline.2)?,
             (PUBLISHED_MIGRATION_FLOOR + 1..=RELEASE_BASELINE_TARGET).collect::<Vec<_>>()
         );
-        assert_eq!(baseline.3, schema_fingerprint(&connection)?);
+        let mut baseline_connection = rusqlite::Connection::open_in_memory()?;
+        ensure_migration_table(&baseline_connection)?;
+        for migration in MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version <= PUBLISHED_MIGRATION_FLOOR)
+        {
+            apply_migration(&mut baseline_connection, migration)?;
+        }
+        apply_release_baseline(&mut baseline_connection)?;
+        assert_eq!(baseline.3, schema_fingerprint(&baseline_connection)?);
 
         Ok(())
     }
@@ -4097,6 +4108,121 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn queue_head_no_progress_budget_is_atomic_and_survives_restart() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-no-progress".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut quarantined = queued.clone();
+        quarantined.status = QueueEntryStatus::Quarantined;
+        quarantined.updated_at = now + chrono::Duration::seconds(1);
+        let mut current_state = AgentState::new("agent-a");
+        current_state.pending = 1;
+        let mut terminal_state = current_state.clone();
+        terminal_state.pending = 0;
+        db.queue_entries().upsert(&queued)?;
+        db.agent_states().upsert(&current_state)?;
+
+        let command = |fault| QueueHeadNoProgressCommand {
+            agent_id: "agent-a".into(),
+            expected: queued.clone(),
+            quarantined: quarantined.clone(),
+            agent_state: AgentStateMutation {
+                expected: Some(Box::new(current_state.clone())),
+                record: Box::new(terminal_state.clone()),
+            },
+            reason: "canonical_claim_contended".into(),
+            scenario_class: Some("lifecycle_external_nudge".into()),
+            max_attempts: 3,
+            fault,
+        };
+
+        for fault in [
+            TransitionFaultPoint::AfterValidation,
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let error = db
+                .transitions()
+                .commit_queue_head_no_progress(&command(Some(fault)))
+                .unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("injected runtime transition fault"));
+            assert_eq!(
+                db.queue_entries().latest(&queued.message_id)?,
+                Some(queued.clone())
+            );
+            let no_progress_rows: i64 = db.connection()?.query_row(
+                "SELECT COUNT(*) FROM queue_head_no_progress WHERE message_id = ?1",
+                [&queued.message_id],
+                |row| row.get(0),
+            )?;
+            assert_eq!(no_progress_rows, 0);
+        }
+
+        assert_eq!(
+            db.transitions()
+                .commit_queue_head_no_progress(&command(None))?
+                .unwrap()
+                .outcome,
+            QueueHeadNoProgressOutcome::BoundedDefer {
+                attempt: 1,
+                max_attempts: 3,
+            }
+        );
+        drop(db);
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(
+            reopened
+                .transitions()
+                .commit_queue_head_no_progress(&command(None))?
+                .unwrap()
+                .outcome,
+            QueueHeadNoProgressOutcome::BoundedDefer {
+                attempt: 2,
+                max_attempts: 3,
+            }
+        );
+        assert_eq!(
+            reopened
+                .transitions()
+                .commit_queue_head_no_progress(&command(None))?
+                .unwrap()
+                .outcome,
+            QueueHeadNoProgressOutcome::Quarantined {
+                attempt: 3,
+                max_attempts: 3,
+            }
+        );
+        assert_eq!(
+            reopened.queue_entries().latest(&queued.message_id)?,
+            Some(quarantined)
+        );
+        assert_eq!(
+            reopened.agent_states().latest("agent-a")?,
+            Some(terminal_state)
+        );
+        let persisted: (u32, u32, String) = reopened.connection()?.query_row(
+            "SELECT attempts, max_attempts, status
+             FROM queue_head_no_progress WHERE message_id = ?1",
+            [&queued.message_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(persisted, (3, 3, "quarantined".into()));
+        Ok(())
+    }
+
+    #[test]
     fn queue_terminal_state_rejects_late_updates_and_allows_identical_retries() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -4533,7 +4659,10 @@ CREATE TABLE working_memory_deltas (
                 trigger_message_id: "message-cutover-trigger".into(),
             }
         );
-        assert_eq!(current_schema_version(&connection)?, 45);
+        assert_eq!(
+            current_schema_version(&connection)?,
+            max_known_migration_version()
+        );
         Ok(())
     }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -220,6 +220,30 @@ pub(crate) struct QueueTransitionCommand {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct QueueHeadNoProgressCommand {
+    pub agent_id: String,
+    pub expected: QueueEntryRecord,
+    pub quarantined: QueueEntryRecord,
+    pub agent_state: AgentStateMutation,
+    pub reason: String,
+    pub scenario_class: Option<String>,
+    pub max_attempts: u32,
+    pub fault: Option<TransitionFaultPoint>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QueueHeadNoProgressOutcome {
+    BoundedDefer { attempt: u32, max_attempts: u32 },
+    Quarantined { attempt: u32, max_attempts: u32 },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueueHeadNoProgressCommit {
+    pub outcome: QueueHeadNoProgressOutcome,
+    pub commit: TransitionCommit,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct TurnTerminalTransitionCommand {
     pub agent_id: String,
     pub agent_state: AgentStateMutation,
@@ -331,6 +355,167 @@ impl RuntimeDb {
 }
 
 impl RuntimeTransitionRepository<'_> {
+    pub fn commit_queue_head_no_progress(
+        &self,
+        command: &QueueHeadNoProgressCommand,
+    ) -> Result<Option<QueueHeadNoProgressCommit>> {
+        if command.max_attempts == 0 {
+            bail!("queue-head no-progress budget must be non-zero");
+        }
+        if command.expected.message_id != command.quarantined.message_id
+            || command.expected.agent_id != command.quarantined.agent_id
+            || command.expected.agent_id != command.agent_id
+        {
+            bail!("queue-head no-progress identity must remain unchanged");
+        }
+        if !matches!(
+            command.expected.status,
+            QueueEntryStatus::Queued | QueueEntryStatus::Interrupted
+        ) || command.quarantined.status != QueueEntryStatus::Quarantined
+        {
+            bail!("queue-head no-progress requires an active head and quarantined terminal record");
+        }
+
+        self.db.transaction(|tx| {
+            let current = tx
+                .query_row(
+                    "SELECT payload_json FROM queue_entries WHERE message_id = ?1",
+                    [&command.expected.message_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .map(|payload| serde_json::from_str::<QueueEntryRecord>(&payload))
+                .transpose()?;
+            if current.as_ref() != Some(&command.expected) {
+                return Ok(None);
+            }
+
+            let previous = tx
+                .query_row(
+                    "SELECT attempts, max_attempts, status, first_reason, first_deferred_at
+                     FROM queue_head_no_progress
+                     WHERE message_id = ?1",
+                    [&command.expected.message_id],
+                    |row| {
+                        Ok((
+                            row.get::<_, u32>(0)?,
+                            row.get::<_, u32>(1)?,
+                            row.get::<_, String>(2)?,
+                            row.get::<_, String>(3)?,
+                            row.get::<_, String>(4)?,
+                        ))
+                    },
+                )
+                .optional()?;
+            if previous
+                .as_ref()
+                .is_some_and(|(_, _, status, _, _)| status == "quarantined")
+            {
+                return Ok(None);
+            }
+            inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
+            let attempt = previous
+                .as_ref()
+                .map_or(1, |(attempts, _, _, _, _)| attempts.saturating_add(1));
+            let max_attempts = previous
+                .as_ref()
+                .map_or(command.max_attempts, |(_, max, _, _, _)| *max);
+            let now = Utc::now();
+            let first_reason = previous
+                .as_ref()
+                .map_or(command.reason.as_str(), |(_, _, _, reason, _)| {
+                    reason.as_str()
+                });
+            let first_deferred_at = previous
+                .as_ref()
+                .map_or_else(|| now.to_rfc3339(), |(_, _, _, _, value)| value.clone());
+            let quarantined = attempt >= max_attempts;
+            let status = if quarantined {
+                "quarantined"
+            } else {
+                "bounded_defer"
+            };
+
+            validate_agent_state_mutation_tx(tx, quarantined.then_some(&command.agent_state))?;
+            if quarantined
+                && !compare_and_set_queue_entry_tx(tx, &command.expected, &command.quarantined)?
+            {
+                return Ok(None);
+            }
+            tx.execute(
+                "INSERT INTO queue_head_no_progress (
+                    message_id, agent_id, attempts, max_attempts, status,
+                    first_reason, last_reason, first_deferred_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(message_id) DO UPDATE SET
+                    attempts = excluded.attempts,
+                    max_attempts = excluded.max_attempts,
+                    status = excluded.status,
+                    last_reason = excluded.last_reason,
+                    updated_at = excluded.updated_at",
+                rusqlite::params![
+                    command.expected.message_id,
+                    command.agent_id,
+                    attempt,
+                    max_attempts,
+                    status,
+                    first_reason,
+                    command.reason,
+                    first_deferred_at,
+                    now.to_rfc3339(),
+                ],
+            )?;
+            let agent_state_applied = if quarantined {
+                apply_agent_state_mutation_tx(tx, Some(&command.agent_state))?
+            } else {
+                false
+            };
+            inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
+            let event_kind = if quarantined {
+                "scheduler_queue_head_quarantined"
+            } else {
+                "scheduler_queue_head_deferred"
+            };
+            let event = AuditEvent::legacy(
+                event_kind,
+                serde_json::json!({
+                    "message_id": command.expected.message_id,
+                    "agent_id": command.agent_id,
+                    "reason": command.reason,
+                    "scenario_class": command.scenario_class,
+                    "attempt": attempt,
+                    "max_attempts": max_attempts,
+                    "queue_disposition": status,
+                }),
+            );
+            let commit = finish_transition_tx(
+                tx,
+                true,
+                &command.agent_id,
+                &[event],
+                &[],
+                command.fault,
+                PostCommitEffects {
+                    agent_state: agent_state_applied.then(|| command.agent_state.clone()),
+                    notify_scheduler: quarantined,
+                    ..PostCommitEffects::default()
+                },
+            )?;
+            let outcome = if quarantined {
+                QueueHeadNoProgressOutcome::Quarantined {
+                    attempt,
+                    max_attempts,
+                }
+            } else {
+                QueueHeadNoProgressOutcome::BoundedDefer {
+                    attempt,
+                    max_attempts,
+                }
+            };
+            Ok(Some(QueueHeadNoProgressCommit { outcome, commit }))
+        })
+    }
+
     pub fn commit_turn_terminal(
         &self,
         command: &TurnTerminalTransitionCommand,
@@ -1422,7 +1607,8 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
                 status: QueueEntryStatus::Processed
                     | QueueEntryStatus::Interrupted
                     | QueueEntryStatus::Aborted
-                    | QueueEntryStatus::Dropped,
+                    | QueueEntryStatus::Dropped
+                    | QueueEntryStatus::Quarantined,
                 ..
             })
         ) | (
@@ -1436,7 +1622,8 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
                     status: QueueEntryStatus::Processed
                         | QueueEntryStatus::Interrupted
                         | QueueEntryStatus::Aborted
-                        | QueueEntryStatus::Dropped,
+                        | QueueEntryStatus::Dropped
+                        | QueueEntryStatus::Quarantined,
                     ..
                 },
             }
@@ -1448,7 +1635,7 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
                     ..
                 },
                 record: QueueEntryRecord {
-                    status: QueueEntryStatus::Dropped,
+                    status: QueueEntryStatus::Dropped | QueueEntryStatus::Quarantined,
                     ..
                 },
             }

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -659,6 +659,7 @@ fn operator_message_status_label(status: OperatorMessageStatus) -> Option<&'stat
         OperatorMessageStatus::Processing | OperatorMessageStatus::Processed => None,
         OperatorMessageStatus::Failed => Some("failed"),
         OperatorMessageStatus::Dropped => Some("dropped"),
+        OperatorMessageStatus::Quarantined => Some("quarantined"),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3980,6 +3980,7 @@ pub enum QueueEntryStatus {
     Interrupted,
     Aborted,
     Dropped,
+    Quarantined,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3992,6 +3993,7 @@ pub enum OperatorMessageStatus {
     Processed,
     Failed,
     Dropped,
+    Quarantined,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -3374,8 +3374,11 @@ export interface components {
                 resolved_at?: string | null;
                 source?: string | null;
                 /** @enum {string} */
-                status: "active" | "resolved" | "cancelled" | "expired";
+                status: "active" | "triggered" | "resolved" | "cancelled" | "expired";
                 subject_ref?: string | null;
+                trigger_message_id?: string | null;
+                /** Format: date-time */
+                triggered_at?: string | null;
                 turn_id?: string | null;
                 /** Format: date-time */
                 updated_at: string;
@@ -3410,7 +3413,7 @@ export interface components {
                 message_id: string;
                 /** @enum {string} */
                 priority: "interject" | "next" | "normal" | "background";
-                status: ("queued" | "dequeued" | "processed" | "interjected" | "aborted" | "dropped") | "interrupted";
+                status: ("queued" | "dequeued" | "processed" | "interjected" | "aborted" | "dropped" | "quarantined") | "interrupted";
                 /** Format: date-time */
                 updated_at: string;
             }[];
@@ -3421,14 +3424,14 @@ export interface components {
             dry_run: boolean;
             operation: {
                 /** @enum {string} */
-                expected_status: "active" | "resolved" | "cancelled" | "expired";
+                expected_status: "active" | "triggered" | "resolved" | "cancelled" | "expired";
                 /** Format: date-time */
                 expected_updated_at: string;
                 /** @constant */
                 kind: "cancel_wait";
                 wait_id: string;
             } | {
-                expected_status: ("queued" | "dequeued" | "processed" | "interjected" | "aborted" | "dropped") | "interrupted";
+                expected_status: ("queued" | "dequeued" | "processed" | "interjected" | "aborted" | "dropped" | "quarantined") | "interrupted";
                 /** Format: date-time */
                 expected_updated_at: string;
                 /** @constant */


### PR DESCRIPTION
## Summary

- totalize FIFO queue-head outcomes as consume, drop, quarantine, or bounded defer
- persist atomic no-progress retry state so restart cannot reset the budget
- quarantine exhausted or non-actionable heads and allow the next valid trusted message to advance
- expose diagnostic state through runtime status/OpenAPI and document the scheduler contract

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- focused queue-head disposition, restart, migration, and wait-protocol tests
- `cargo test --test http_control -- --test-threads=1 --nocapture`
- `make transport-types`
- `make transport-types-check`
- `make snapshots-check`

## Notes

A full parallel `cargo test --all-targets` run stalled in the existing `http_control` integration suite; the suite passes when run serially, and all affected focused tests pass.
