### PR TITLE
fix: recover tasks and resume exact lifecycle waits

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -535,6 +535,17 @@ arms the new generation atomically.
 authority. Exact external resume requires a runtime-owned or
 capability-authenticated correlation carrying `wait_id + generation`.
 
+A terminal task result for an unbound task that does not request unconditional
+terminal re-entry is narrower. The terminal task transition resolves matching
+agent-lifecycle task waits and binds each resolved wait to the exact durable
+result message id in the same transaction as task and message evidence. The
+canonical scheduler may then lower the unique match to
+`ExactWaitResume(AgentLifecycle, wait_id)` and claim it with
+`TriggeredWait(wait_id, result_message_id)`. A result with no such exact wait is
+reducer-only; it must not create a lifecycle nudge or consume queue-head
+no-progress budget. A duplicate or historical result cannot resume the wait
+because its message identity does not match the resolved generation.
+
 Canonical scheduler tables persist `owner_kind + owner_id` and retain
 row-local primary-key, unique, `NOT NULL`, `CHECK`, generation, and idempotency
 constraints. Cross-table lifecycle consistency is enforced by typed commands,
@@ -835,8 +846,10 @@ callback capability does not make one semantic wait reusable.
 
 External and operator events trigger waits but do not resolve them. The
 consuming activation must resolve, cancel, or rearm. A matching runtime-owned
-terminal task result may perform trigger, consume, and resolve in one
-transaction while retaining all logical audit facts.
+terminal task result may persist the task/message evidence and exact resolved
+wait binding in one transaction, then atomically consume that same wait
+generation during canonical activation claim while retaining all logical audit
+facts.
 
 `recheck_after_ms` is a fallback wake source for the same wait generation, not
 a separate generic blocker timer.

--- a/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
+++ b/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
@@ -86,7 +86,7 @@ operator input, but does not project a transient agent-level
 broader live-runtime closure signal would require activation or a separate
 durable projection and is outside this read-only contract.
 
-## Startup recovery of orphaned claims
+## Startup recovery
 
 Startup recovery runs before listeners accept requests. It may change a queue
 entry from `dequeued` to `interrupted` only when one transaction proves:
@@ -101,9 +101,23 @@ The transition is compare-and-set and records an audit event. Any canonical
 activation or terminal turn excludes the entry from orphan recovery. No age,
 posture, or heuristic threshold is sufficient evidence.
 
-Recovered non-stopped agents are explicitly activated with the startup recovery
-reason before HTTP listeners open. Stopped agents retain the recoverable durable
-claim but are not started.
+The same pre-listener pass discovers distinct owner agents for durable active
+tasks (`queued`, `running`, or `cancelling`) directly from the shared runtime
+database. It does not enumerate agent directories or use read APIs to
+materialize runtimes.
+
+Every affected owner is explicitly activated with the startup recovery reason,
+and the host waits for a one-shot bootstrap result before continuing. Bootstrap
+completion includes task/timer recovery, scheduler bootstrap settlement, and
+canonical orphan-claim recovery; spawning a runtime task alone is not sufficient
+evidence that startup reconciliation completed.
+
+Non-stopped agents retain the normal task-kind recovery policy: supervised child
+tasks may reattach, while process-local command tasks become
+`interrupted(runtime_restarted)` and emit an idempotent terminal result. A
+stopped owner is materialized only to converge residual active tasks through the
+existing lifecycle-stop path; it must not reattach children or emit restart
+re-entry messages. Unrelated unloaded agents remain lazy.
 
 ## Verification
 
@@ -113,6 +127,9 @@ Tests cover:
 - activation and shutdown linearization in both orders;
 - execution ingress after admission closes;
 - orphan `dequeued` recovery and idempotence;
+- active-task owner discovery for unloaded named and default agents;
+- bootstrap completion before startup recovery returns;
+- stopped-owner task convergence without child reattach or model re-entry;
 - canonical or terminal ownership exclusions;
 - read-only HTTP routes without activation;
 - unloaded blocking task-output behavior.

--- a/src/host.rs
+++ b/src/host.rs
@@ -708,21 +708,34 @@ impl RuntimeHost {
     }
 
     pub async fn recover_orphaned_queue_claims_at_startup(&self) -> Result<Vec<String>> {
-        let recovered_agent_ids = self
+        let recovered_queue_agent_ids = self
             .runtime_db()
             .recover_orphaned_dequeued_claims_at_startup()?;
-        for agent_id in &recovered_agent_ids {
+        let active_task_owner_ids = self
+            .runtime_db()
+            .tasks()
+            .active_owner_agent_ids()?
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+        let mut recovery_agent_ids = recovered_queue_agent_ids
+            .iter()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+        recovery_agent_ids.extend(active_task_owner_ids.iter().cloned());
+        for agent_id in recovery_agent_ids {
             let state = self
-                .agent_storage_read_only(agent_id)?
+                .agent_storage_read_only(&agent_id)?
                 .read_agent()?
-                .unwrap_or_else(|| AgentState::new(agent_id));
-            if state.status == AgentStatus::Stopped {
+                .unwrap_or_else(|| AgentState::new(&agent_id));
+            if state.status == AgentStatus::Stopped && !active_task_owner_ids.contains(&agent_id) {
                 continue;
             }
-            self.activate_agent(agent_id, RuntimeActivationReason::StartupRecovery)
+            let runtime = self
+                .activate_agent(&agent_id, RuntimeActivationReason::StartupRecovery)
                 .await?;
+            runtime.wait_for_bootstrap().await?;
         }
-        Ok(recovered_agent_ids)
+        Ok(recovered_queue_agent_ids)
     }
 
     fn active_agent_identity(
@@ -5895,6 +5908,92 @@ mod tests {
             .public_agent_scheduler_repair_inspection(&agent_id)
             .expect("scheduler repair inspection");
         assert!(host.inner.runtimes.read().await.agents.is_empty());
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_activates_active_task_owners_and_waits_for_bootstrap() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "startup-task-owner";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        storage
+            .append_task(&TaskRecord {
+                id: "task-startup-owner".into(),
+                agent_id: agent_id.into(),
+                kind: crate::types::TaskKind::CommandTask,
+                status: TaskStatus::Running,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                parent_message_id: None,
+                work_item_id: None,
+                summary: Some("startup owner task".into()),
+                detail: None,
+                recovery: None,
+            })
+            .unwrap();
+
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        let task = storage
+            .latest_task_record("task-startup-owner")
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Interrupted);
+        let message_id = format!("message:task-restart:{}", task.id);
+        assert!(storage.read_message_by_id(&message_id).unwrap().is_some());
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_converges_stopped_task_owner_without_reentry() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "stopped-task-owner";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        let mut state = storage.read_agent().unwrap().unwrap();
+        state.status = AgentStatus::Stopped;
+        storage.write_agent(&state).unwrap();
+        storage
+            .append_task(&TaskRecord {
+                id: "task-stopped-owner".into(),
+                agent_id: agent_id.into(),
+                kind: crate::types::TaskKind::CommandTask,
+                status: TaskStatus::Running,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                parent_message_id: None,
+                work_item_id: None,
+                summary: Some("stopped owner task".into()),
+                detail: None,
+                recovery: None,
+            })
+            .unwrap();
+
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        let task = storage
+            .latest_task_record("task-stopped-owner")
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Interrupted);
+        assert_eq!(
+            task.detail
+                .as_ref()
+                .and_then(|detail| detail["interrupted_reason"].as_str()),
+            Some("agent_stopped")
+        );
+        assert!(task.parent_message_id.is_none());
+        assert!(storage
+            .read_message_by_id("message:task-restart:task-stopped-owner")
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4967,12 +4967,14 @@ impl RuntimeHandle {
     fn complete_bootstrap(&self, result: &Result<()>) {
         *self.inner.bootstrap_result.lock().unwrap() =
             Some(result.as_ref().map(|_| ()).map_err(ToString::to_string));
-        self.inner.bootstrap_notify.notify_one();
+        self.inner.bootstrap_notify.notify_waiters();
     }
 
     pub(crate) async fn wait_for_bootstrap(&self) -> Result<()> {
         loop {
             let notified = self.inner.bootstrap_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             if let Some(result) = self.inner.bootstrap_result.lock().unwrap().clone() {
                 return result.map_err(|error| anyhow!("runtime bootstrap failed: {error}"));
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -291,6 +291,8 @@ struct RuntimeInner {
     task_handles: Mutex<HashMap<String, ManagedTaskHandle>>,
     recovered_tasks: Mutex<Option<Vec<TaskRecord>>>,
     recovered_timers: Mutex<Option<Vec<TimerRecord>>>,
+    bootstrap_result: StdMutex<Option<std::result::Result<(), String>>>,
+    bootstrap_notify: Notify,
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
     transition_faults: StdMutex<std::collections::VecDeque<TransitionFaultPoint>>,
@@ -4208,17 +4210,23 @@ impl RuntimeHandle {
 
     pub async fn run(self) -> Result<()> {
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        if !self.inner.scheduler_engine.is_canonical() {
-            // Fail fast on residual canonical state before general recovery mutates runtime state.
-            self.validate_legacy_engine_startup(&agent_id)?;
+        let bootstrap = async {
+            if !self.inner.scheduler_engine.is_canonical() {
+                // Fail fast on residual canonical state before general recovery mutates runtime state.
+                self.validate_legacy_engine_startup(&agent_id)?;
+            }
+            self.bootstrap_recovery().await?;
+            scheduler_executor::SchedulerDecisionExecutor::new(&self)
+                .bootstrap_recovered()
+                .await?;
+            if self.inner.scheduler_engine.is_canonical() {
+                self.recover_scheduler_bootstrap_claims().await?;
+            }
+            Ok(())
         }
-        self.bootstrap_recovery().await?;
-        scheduler_executor::SchedulerDecisionExecutor::new(&self)
-            .bootstrap_recovered()
-            .await?;
-        if self.inner.scheduler_engine.is_canonical() {
-            self.recover_scheduler_bootstrap_claims().await?;
-        }
+        .await;
+        self.complete_bootstrap(&bootstrap);
+        bootstrap?;
 
         loop {
             let poll = scheduler_executor::SchedulerDecisionExecutor::new(&self)
@@ -4924,19 +4932,24 @@ impl RuntimeHandle {
     async fn bootstrap_recovery(&self) -> Result<()> {
         let mut interrupted_for_delivery = self.missing_interrupted_task_results().await?;
         if let Some(tasks) = self.inner.recovered_tasks.lock().await.take() {
-            let (reattached, interrupted_tasks) =
-                self.recover_supervised_child_tasks(tasks).await?;
-            let interrupted = self.interrupt_active_tasks(interrupted_tasks).await?;
-            if !reattached.is_empty() {
-                self.inner.storage.append_event(&AuditEvent::legacy(
-                    "supervised_child_task_monitor_reattached",
-                    serde_json::json!({
-                        "agent_id": self.agent_id().await?,
-                        "task_ids": reattached.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
-                    }),
-                ))?;
+            if self.agent_state().await?.status == AgentStatus::Stopped {
+                self.interrupt_active_tasks_for_lifecycle_stop(tasks)
+                    .await?;
+            } else {
+                let (reattached, interrupted_tasks) =
+                    self.recover_supervised_child_tasks(tasks).await?;
+                let interrupted = self.interrupt_active_tasks(interrupted_tasks).await?;
+                if !reattached.is_empty() {
+                    self.inner.storage.append_event(&AuditEvent::legacy(
+                        "supervised_child_task_monitor_reattached",
+                        serde_json::json!({
+                            "agent_id": self.agent_id().await?,
+                            "task_ids": reattached.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
+                        }),
+                    ))?;
+                }
+                interrupted_for_delivery.extend(interrupted);
             }
-            interrupted_for_delivery.extend(interrupted);
         }
         interrupted_for_delivery.sort_by(|left, right| left.id.cmp(&right.id));
         interrupted_for_delivery.dedup_by(|left, right| left.id == right.id);
@@ -4949,6 +4962,22 @@ impl RuntimeHandle {
         }
         self.emit_recovered_pending_wake_hint().await?;
         Ok(())
+    }
+
+    fn complete_bootstrap(&self, result: &Result<()>) {
+        *self.inner.bootstrap_result.lock().unwrap() =
+            Some(result.as_ref().map(|_| ()).map_err(ToString::to_string));
+        self.inner.bootstrap_notify.notify_one();
+    }
+
+    pub(crate) async fn wait_for_bootstrap(&self) -> Result<()> {
+        loop {
+            let notified = self.inner.bootstrap_notify.notified();
+            if let Some(result) = self.inner.bootstrap_result.lock().unwrap().clone() {
+                return result.map_err(|error| anyhow!("runtime bootstrap failed: {error}"));
+            }
+            notified.await;
+        }
     }
 }
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -464,6 +464,8 @@ impl RuntimeHandle {
                 task_handles: Mutex::new(HashMap::new()),
                 recovered_tasks: Mutex::new(Some(active_tasks)),
                 recovered_timers: Mutex::new(Some(active_timers)),
+                bootstrap_result: StdMutex::new(None),
+                bootstrap_notify: Notify::new(),
                 suppress_next_continue_active_tick: Mutex::new(false),
                 shutdown_requested: AtomicBool::new(false),
                 transition_faults: StdMutex::new(std::collections::VecDeque::new()),

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -54,6 +54,7 @@ pub(crate) enum CanonicalActivationScenario {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CanonicalActivationCandidate {
+    UnboundTaskResultWaitOrReduce,
     WorkItemAutonomousContinuation {
         work_item_id: String,
     },
@@ -110,6 +111,7 @@ impl CanonicalActivationScenario {
 impl CanonicalActivationCandidate {
     pub(crate) fn scenario_class(&self) -> SchedulerScenarioClass {
         match self {
+            Self::UnboundTaskResultWaitOrReduce => EXACT_WAIT_RESUME_SCENARIO,
             Self::WorkItemAutonomousContinuation { .. } | Self::InternalFollowup { .. } => {
                 WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO
             }
@@ -123,6 +125,7 @@ impl CanonicalActivationCandidate {
 
     fn expected_work_item_id(&self) -> Option<&str> {
         match self {
+            Self::UnboundTaskResultWaitOrReduce => None,
             Self::WorkItemAutonomousContinuation { work_item_id }
             | Self::InternalFollowup { work_item_id }
             | Self::ExactTaskRejoin { work_item_id, .. }
@@ -1186,10 +1189,9 @@ pub(crate) fn canonical_activation_candidate(
                 agent_id: message.agent_id.clone(),
             }));
         }
-        return Ok(Some(CanonicalActivationCandidate::ExactWaitResume {
-            expected_work_item_id: None,
-            correlated_wait: None,
-        }));
+        return Ok(Some(
+            CanonicalActivationCandidate::UnboundTaskResultWaitOrReduce,
+        ));
     }
 
     if message.kind == MessageKind::OperatorPrompt {

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1186,7 +1186,10 @@ pub(crate) fn canonical_activation_candidate(
                 agent_id: message.agent_id.clone(),
             }));
         }
-        return Ok(None);
+        return Ok(Some(CanonicalActivationCandidate::ExactWaitResume {
+            expected_work_item_id: None,
+            correlated_wait: None,
+        }));
     }
 
     if message.kind == MessageKind::OperatorPrompt {
@@ -1430,6 +1433,7 @@ fn matching_wait_conditions_for_work_item<'a>(
                         && condition.status == WaitConditionStatus::Resolved
                         && condition.kind == WaitConditionKind::Task
                         && condition.work_item_id == message.work_item_id
+                        && condition.trigger_message_id() == Some(message.id.as_str())
                         && resolved_task_wait_is_current(projection, condition)))
                 && message_matches_wait_condition(message, condition)
                 && (!(message.kind == MessageKind::TaskResult
@@ -1447,7 +1451,7 @@ fn resolved_task_wait_is_current(
         return true;
     };
     let Some(work_item_id) = condition.work_item_id.as_deref() else {
-        return false;
+        return condition.trigger_message_id().is_some();
     };
     matches!(
         states.get(work_item_id),

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -998,14 +998,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
         }
         let Some(mut scenario) = scenario else {
-            if message.kind == MessageKind::TaskResult
-                && matches!(
-                    original_candidate,
-                    scheduler::CanonicalActivationCandidate::ExactWaitResume {
-                        expected_work_item_id: None,
-                        correlated_wait: None,
-                    }
-                )
+            if original_candidate
+                == scheduler::CanonicalActivationCandidate::UnboundTaskResultWaitOrReduce
             {
                 return Ok(CanonicalClaimOutcome::ReduceOnly);
             }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -998,6 +998,17 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
         }
         let Some(mut scenario) = scenario else {
+            if message.kind == MessageKind::TaskResult
+                && matches!(
+                    original_candidate,
+                    scheduler::CanonicalActivationCandidate::ExactWaitResume {
+                        expected_work_item_id: None,
+                        correlated_wait: None,
+                    }
+                )
+            {
+                return Ok(CanonicalClaimOutcome::ReduceOnly);
+            }
             if stale_task_rejoin {
                 return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
@@ -1262,7 +1273,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         condition.id == *wait_id
                             && condition.agent_id == message.agent_id
                             && condition.work_item_id.is_none()
-                            && condition.status == crate::types::WaitConditionStatus::Triggered
+                            && matches!(
+                                condition.status,
+                                crate::types::WaitConditionStatus::Triggered
+                                    | crate::types::WaitConditionStatus::Resolved
+                            )
                             && condition.trigger_message_id() == Some(message.id.as_str())
                             && scheduler::message_matches_wait_condition(message, condition)
                     });

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -206,6 +206,9 @@ impl RuntimeHandle {
                 })
                 .collect::<Vec<_>>();
             let now = Utc::now();
+            let trigger_message_id = transition
+                .message_evidence
+                .map(|message| message.id.as_str());
             let mut resolved_ids = Vec::with_capacity(matching.len());
             let mut updated_work_item_ids = std::collections::BTreeSet::new();
             for condition in matching {
@@ -213,6 +216,9 @@ impl RuntimeHandle {
                 resolved.status = WaitConditionStatus::Resolved;
                 resolved.updated_at = now;
                 resolved.resolved_at = Some(now);
+                if resolved.kind == WaitConditionKind::Task {
+                    resolved.trigger_message_id = trigger_message_id.map(ToString::to_string);
+                }
                 wait_conditions.push(resolved.clone());
                 resolved_ids.push(condition.id);
                 if resolved.kind == WaitConditionKind::Task {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3301,21 +3301,6 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         })),
         recovery: None,
     };
-    reopened
-        .persist_task_transition(&terminal_task, "task_completed")
-        .await
-        .unwrap();
-    assert!(reopened
-        .storage()
-        .active_wait_conditions_for_work_item("default", &work_item.id)
-        .unwrap()
-        .is_empty());
-    let resolved_work_item = reopened
-        .latest_work_item(&work_item.id)
-        .await
-        .unwrap()
-        .expect("task result should retain the WorkItem");
-    assert!(resolved_work_item.revision > work_generation);
     let mut rejoin = task_result_message("task-lifecycle-handoff").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -3329,6 +3314,21 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
         "work_item_id": work_item.id,
     }));
     rejoin.turn_id = Some("turn-lifecycle-handoff-rejoin".into());
+    reopened
+        .persist_task_transition_with_message(&terminal_task, "task_completed", &rejoin)
+        .await
+        .unwrap();
+    assert!(reopened
+        .storage()
+        .active_wait_conditions_for_work_item("default", &work_item.id)
+        .unwrap()
+        .is_empty());
+    let resolved_work_item = reopened
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("task result should retain the WorkItem");
+    assert!(resolved_work_item.revision > work_generation);
     let rejoin = reopened.enqueue(rejoin).await.unwrap();
     assert!(matches!(
         scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
@@ -3475,17 +3475,6 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
         })),
         recovery: None,
     };
-    runtime
-        .persist_task_transition(&terminal_task, "task_completed")
-        .await
-        .unwrap();
-    let resolved_work = runtime
-        .latest_work_item(&work_item.id)
-        .await
-        .unwrap()
-        .expect("resolved WorkItem");
-    assert!(resolved_work.revision > wait_generation);
-
     let mut rejoin = task_result_message("task-stale-legacy-rejoin").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
@@ -3499,6 +3488,17 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
         "work_item_id": work_item.id,
     }));
     rejoin.turn_id = Some("turn-stale-legacy-rejoin".into());
+    runtime
+        .persist_task_transition_with_message(&terminal_task, "task_completed", &rejoin)
+        .await
+        .unwrap();
+    let resolved_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("resolved WorkItem");
+    assert!(resolved_work.revision > wait_generation);
+
     let rejoin = runtime.enqueue(rejoin).await.unwrap();
 
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
@@ -4261,19 +4261,10 @@ async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
         .unwrap()
         .is_none());
 
-    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+    let _ = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()
         .await
         .unwrap();
-    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
-        panic!("task result without a WorkItem should use ordinary dispatch");
-    };
-    assert_eq!(scheduled.message.id, message.id);
-    assert!(!scheduled
-        .dispatch_plan
-        .continuation_resolution
-        .as_ref()
-        .is_some_and(|resolution| resolution.model_reentry));
     assert_eq!(
         runtime
             .inner
@@ -4293,6 +4284,209 @@ async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
         .load_scheduler_protocol_snapshot_if_initialized("default")
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn terminal_task_result_resumes_exact_agent_lifecycle_task_wait() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: "task-lifecycle-wait".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("task lifecycle wait".into()),
+            detail: None,
+            recovery: None,
+        })
+        .unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::TaskResult,
+            Some("task-lifecycle-wait".into()),
+            "waiting for lifecycle task".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let mut message = task_result_message("task-lifecycle-wait").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.task_id = Some("task-lifecycle-wait".into());
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-lifecycle-wait",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-lifecycle-wait",
+    }));
+    let terminal = TaskRecord {
+        status: TaskStatus::Completed,
+        updated_at: Utc::now(),
+        parent_message_id: Some(message.id.clone()),
+        ..runtime
+            .task_record("task-lifecycle-wait")
+            .await
+            .unwrap()
+            .unwrap()
+    };
+    runtime
+        .persist_task_transition_with_message(
+            &terminal,
+            "command_task_terminal_persisted",
+            &message,
+        )
+        .await
+        .unwrap();
+    let resolved = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == registration.condition.id)
+        .unwrap();
+    assert_eq!(resolved.status, WaitConditionStatus::Resolved);
+    assert_eq!(resolved.trigger_message_id(), Some(message.id.as_str()));
+
+    let queued = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("exact lifecycle task wait should resume into the model");
+    };
+    assert_eq!(scheduled.message.id, queued.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &execution.attempts[&scheduler_executor::canonical_activation_id(&queued.id)];
+    assert!(matches!(
+        &attempt.source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::TriggeredWait {
+            wait_id,
+            trigger_message_id,
+        } if wait_id == &registration.condition.id && trigger_message_id == &queued.id
+    ));
+}
+
+#[tokio::test]
+async fn exact_agent_lifecycle_task_wait_runs_one_model_continuation() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(CountingProvider {
+        calls: Mutex::new(0),
+        reply: "resumed",
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: "task-lifecycle-model-reentry".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("task lifecycle model reentry".into()),
+            detail: None,
+            recovery: None,
+        })
+        .unwrap();
+    runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::TaskResult,
+            Some("task-lifecycle-model-reentry".into()),
+            "waiting for lifecycle task model reentry".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let mut message = task_result_message("task-lifecycle-model-reentry").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.task_id = Some("task-lifecycle-model-reentry".into());
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-lifecycle-model-reentry",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-lifecycle-model-reentry",
+    }));
+    let terminal = TaskRecord {
+        status: TaskStatus::Completed,
+        updated_at: Utc::now(),
+        parent_message_id: Some(message.id.clone()),
+        ..runtime
+            .task_record("task-lifecycle-model-reentry")
+            .await
+            .unwrap()
+            .unwrap()
+    };
+    runtime
+        .persist_task_transition_with_message(
+            &terminal,
+            "command_task_terminal_persisted",
+            &message,
+        )
+        .await
+        .unwrap();
+    runtime.enqueue(message).await.unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    while provider.call_count().await == 0 {
+        assert!(
+            !runner.is_finished(),
+            "runtime exited before model continuation"
+        );
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "exact lifecycle task wait did not enter the model"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(provider.call_count().await, 1);
+    runner.abort();
 }
 
 #[tokio::test(start_paused = true)]
@@ -7543,11 +7737,25 @@ async fn resolved_task_result_uses_unified_wait_when_legacy_wait_is_stale() {
         .unwrap();
     let waiting = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
 
+    let mut result = task_result_message("task-unified-wait").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    result.work_item_id = Some(waiting.id.clone());
+    result.task_id = Some("task-unified-wait".into());
+    result.metadata = Some(serde_json::json!({
+        "task_id": "task-unified-wait",
+        "task_kind": "command_task",
+        "task_status": "completed",
+        "task_result_id": "result-unified-wait",
+        "work_item_id": waiting.id,
+    }));
     let now = Utc::now();
     let mut resolved = registration.condition.clone();
     resolved.status = WaitConditionStatus::Resolved;
     resolved.updated_at = now;
     resolved.resolved_at = Some(now);
+    resolved.trigger_message_id = Some(result.id.clone());
     runtime.storage().append_wait_condition(&resolved).unwrap();
     let resumed = WorkItemRecord {
         revision: waiting.revision + 1,
@@ -7592,19 +7800,9 @@ async fn resolved_task_result_uses_unified_wait_when_legacy_wait_is_stale() {
         &resumed.id,
         "turn-unified-wait",
     );
-    let mut result = task_result_message("task-unified-wait").with_admission(
-        MessageDeliverySurface::TaskRejoin,
-        AdmissionContext::RuntimeOwned,
-    );
     result.work_item_id = Some(resumed.id.clone());
-    result.task_id = Some("task-unified-wait".into());
-    result.metadata = Some(serde_json::json!({
-        "task_id": "task-unified-wait",
-        "task_kind": "command_task",
-        "task_status": "completed",
-        "task_result_id": "result-unified-wait",
-        "work_item_id": resumed.id,
-    }));
+    result.metadata.as_mut().unwrap()["work_item_id"] =
+        serde_json::Value::String(resumed.id.clone());
     let result = runtime.enqueue(result).await.unwrap();
 
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -4278,12 +4278,20 @@ async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
         .poll()
         .await
         .unwrap();
-    assert!(matches!(
-        poll,
-        scheduler_executor::RunLoopPoll::Message(ref scheduled)
-            if scheduled.scheduler_decision.kind
-                == scheduler::SchedulerDecisionKind::ReduceMessageOnly
-    ));
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("unbound terminal TaskResult should be reduced as the queued message");
+    };
+    assert_eq!(scheduled.message.id, message.id);
+    assert_eq!(
+        scheduled.scheduler_decision.kind,
+        scheduler::SchedulerDecisionKind::ReduceMessageOnly
+    );
+    assert!(!scheduled.scheduler_decision.model_reentry);
+    assert!(scheduled
+        .dispatch_plan
+        .continuation_resolution
+        .as_ref()
+        .is_none_or(|resolution| !resolution.model_reentry));
     assert_eq!(
         runtime
             .inner
@@ -4303,6 +4311,43 @@ async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
         .load_scheduler_protocol_snapshot_if_initialized("default")
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn bootstrap_completion_releases_all_waiters() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let first = {
+        let runtime = runtime.clone();
+        tokio::spawn(async move { runtime.wait_for_bootstrap().await })
+    };
+    let second = {
+        let runtime = runtime.clone();
+        tokio::spawn(async move { runtime.wait_for_bootstrap().await })
+    };
+
+    tokio::task::yield_now().await;
+    runtime.complete_bootstrap(&Ok(()));
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+    })
+    .await
+    .expect("all bootstrap waiters should observe the durable result");
 }
 
 #[tokio::test]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -4260,11 +4260,30 @@ async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
         .load_scheduler_protocol_snapshot_if_initialized("default")
         .unwrap()
         .is_none());
+    assert_eq!(
+        scheduler::canonical_activation_candidate(
+            &message,
+            None,
+            runtime
+                .storage()
+                .latest_task_record("task-without-work-item")
+                .unwrap()
+                .as_ref(),
+        )
+        .unwrap(),
+        Some(scheduler::CanonicalActivationCandidate::UnboundTaskResultWaitOrReduce)
+    );
 
-    let _ = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()
         .await
         .unwrap();
+    assert!(matches!(
+        poll,
+        scheduler_executor::RunLoopPoll::Message(ref scheduled)
+            if scheduled.scheduler_decision.kind
+                == scheduler::SchedulerDecisionKind::ReduceMessageOnly
+    ));
     assert_eq!(
         runtime
             .inner

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1293,6 +1293,22 @@ impl TaskRepository<'_> {
         )
     }
 
+    pub fn active_owner_agent_ids(&self) -> Result<Vec<String>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT t.owner_agent_id
+             FROM tasks t
+             JOIN agent_identities i
+               ON i.agent_id = t.owner_agent_id
+              AND i.status = 'active'
+             WHERE t.status IN ('queued', 'running', 'cancelling')
+             ORDER BY t.owner_agent_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     fn query_for_agent(
         &self,
         _agent_id: &str,


### PR DESCRIPTION
## Summary

- discover durable active-task owners during daemon startup and wait for each runtime bootstrap reconciliation before listeners open
- converge stopped-agent residual tasks without child reattachment or restart re-entry
- bind resolved task waits to the exact durable `TaskResult` message and resume only that agent-lifecycle wait once
- keep unbound task results without an exact wait reducer-only, preserving the bounded queue-head disposition contract from #2519
- document both startup recovery and exact lifecycle task-wait authority contracts

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo test --all-targets -- --test-threads=1`

Closes #2518
Closes #2516
