### PR TITLE
fix: roster unread count only tracks brief_created events

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -634,7 +634,7 @@ describe("roster activity unread state", () => {
     });
   });
 
-  it("counts unread brief and non-operator message events once by seq", async () => {
+  it("counts unread brief events once by seq, ignores non-operator messages", async () => {
     const { touchRosterActivityFromEvent } = await import("./runtime-store");
     const afterBrief = touchRosterActivityFromEvent(
       {},
@@ -661,7 +661,7 @@ describe("roster activity unread state", () => {
       "agent-b",
     );
 
-    expect(afterAgentMessage["agent-a"]).toMatchObject({ unreadCount: 2, lastUnreadSeq: 11 });
+    expect(afterAgentMessage["agent-a"]).toMatchObject({ unreadCount: 1, lastUnreadSeq: 10 });
   });
 
   it("does not count unread for the currently open agent or operator messages", async () => {
@@ -687,6 +687,51 @@ describe("roster activity unread state", () => {
 
     expect(afterOperatorMessage["agent-a"]?.unreadCount).toBeUndefined();
     expect(afterOperatorMessage["agent-a"]?.operatorAt).toBe("2026-01-01T00:00:01.000Z");
+  });
+
+  it("advances lastReadSeq for the currently open agent to prevent re-counting on replay", async () => {
+    const { touchRosterActivityFromEvent } = await import("./runtime-store");
+    // Simulate: user opens agent-a with lastReadSeq=7, then views events 8-10
+    // while the agent is selected.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let activity: Record<string, any> = {
+      "agent-a": { unreadCount: 0, lastUnreadSeq: 7, lastReadSeq: 7 },
+    };
+    for (const seq of [8, 9, 10]) {
+      activity = touchRosterActivityFromEvent(
+        activity,
+        "agent-a",
+        { agent_id: "agent-a", event_seq: seq, ts: `2026-01-01T00:00:0${seq}.000Z`, type: "brief_created", payload: {} },
+        "agent-a",
+      );
+    }
+    // Unread should stay 0 and lastReadSeq should advance to 10.
+    expect(activity["agent-a"]?.unreadCount ?? 0).toBe(0);
+    expect(activity["agent-a"]?.lastReadSeq).toBe(10);
+
+    // Now simulate a page reload: events 8-10 are re-delivered while agent-a
+    // is NOT selected. They must NOT be re-counted as unread.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let replayed: Record<string, any> = activity;
+    for (const seq of [8, 9, 10]) {
+      replayed = touchRosterActivityFromEvent(
+        replayed,
+        "agent-a",
+        { agent_id: "agent-a", event_seq: seq, ts: `2026-01-01T00:00:0${seq}.000Z`, type: "brief_created", payload: {} },
+        "agent-b",
+      );
+    }
+    expect(replayed["agent-a"]?.unreadCount ?? 0).toBe(0);
+
+    // A genuinely new event (seq 11) should still be counted.
+    replayed = touchRosterActivityFromEvent(
+      replayed,
+      "agent-a",
+      { agent_id: "agent-a", event_seq: 11, ts: "2026-01-01T00:00:11.000Z", type: "brief_created", payload: {} },
+      "agent-b",
+    );
+    expect(replayed["agent-a"]?.unreadCount).toBe(1);
+    expect(replayed["agent-a"]?.lastUnreadSeq).toBe(11);
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4281,15 +4281,21 @@ export function touchRosterActivityFromEvent(
   if (event.type === "message_enqueued" && messageOrigin(event.payload) === "operator") {
     next = touchRosterActivity(next, agentId, "operator", eventTimestamp(event));
   }
-  if (isUnreadEvent(event) && agentId !== selectedAgentId) {
-    next = incrementUnreadFromEvent(next, agentId, event);
+  if (isUnreadEvent(event)) {
+    if (agentId !== selectedAgentId) {
+      next = incrementUnreadFromEvent(next, agentId, event);
+    } else {
+      // Advance the read watermark for the currently-viewed agent so that
+      // events seen in real time are not re-counted as unread after a page
+      // reload or session reset (when eventsBySeq is empty and dedup fails).
+      next = advanceReadSeqFromEvent(next, agentId, event);
+    }
   }
   return next;
 }
 
 function isUnreadEvent(event: StreamEventEnvelopeDto): boolean {
-  if (event.type === "brief_created") return true;
-  return event.type === "message_enqueued" && messageOrigin(event.payload) !== "operator";
+  return event.type === "brief_created";
 }
 
 function incrementUnreadFromEvent(
@@ -4307,6 +4313,24 @@ function incrementUnreadFromEvent(
       ...existing,
       unreadCount: (existing?.unreadCount ?? 0) + 1,
       lastUnreadSeq: seq ?? existing?.lastUnreadSeq,
+    },
+  };
+}
+
+function advanceReadSeqFromEvent(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  event: StreamEventEnvelopeDto,
+): Record<string, AgentRosterActivity> {
+  const existing = current[agentId];
+  const seq = event.event_seq;
+  if (seq == null) return current;
+  if (existing?.lastReadSeq != null && seq <= existing.lastReadSeq) return current;
+  return {
+    ...current,
+    [agentId]: {
+      ...existing,
+      lastReadSeq: Math.max(seq, existing?.lastReadSeq ?? 0),
     },
   };
 }


### PR DESCRIPTION
## Problem

The web GUI roster unread badge was inaccurate: dismissed unread items could reappear, and the count was inflated by counting non-operator `message_enqueued` events alongside `brief_created` events.

## Root Cause

1. `isUnreadEvent` counted both `brief_created` and non-operator `message_enqueued`, so the badge reflected more than just "unseen briefs."
2. When the currently open agent received events in real time, the read watermark (`lastReadSeq`) was not advanced. After a page reload or session reset, `eventsBySeq` starts empty and dedup fails, so previously-seen events were re-counted as unread.

## Fix

- **`isUnreadEvent` now only returns `true` for `brief_created`** — the unread badge represents unseen briefs only.
- **Added `advanceReadSeqFromEvent`**: when the open agent receives an unread event in real time, `lastReadSeq` advances so replayed events on reload are not re-counted.

## Test plan

- [x] Updated existing test to reflect brief-only counting (`unreadCount: 1` instead of `2`)
- [x] Added test verifying read-watermark advancement prevents re-counting on replay
- [x] All 44 tests in `runtime-store.test.ts` pass
- [x] `tsc --noEmit` clean