### PR TITLE
fix(runtime): preserve turn identity across restart replay

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -2123,6 +2123,18 @@ fn render_turn_record_projection(
         }
     )];
     lines.push(format!("  - turn_id: {}", sanitize_inline(&record.turn_id)));
+    if let Some(replay) = &record.replay {
+        lines.push(format!(
+            "  - replay: source_message_id={} source_turn_id={} reason={}",
+            sanitize_inline(&replay.source_message_id),
+            sanitize_inline(&replay.source_turn_id),
+            sanitize_inline(&replay.reason)
+        ));
+        lines.push(
+            "  - projection advisory: replay provenance is historical evidence, not continuation identity"
+                .to_string(),
+        );
+    }
     if let Some(trigger_message) = trigger_message {
         lines.push(format!(
             "  - trigger: {}",
@@ -3217,6 +3229,74 @@ mod tests {
         assert!(recent_turns.contains(&format!("message_ref=message:{}", operator.id)));
         assert!(recent_turns.contains("Rendered from DB turn record."));
         assert!(recent_turns.contains("brief_ref=brief:brief-db-context"));
+    }
+
+    #[test]
+    fn recent_turns_marks_replay_provenance_without_treating_source_as_continuation() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let mut source = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Historical input must not become current continuation.".into(),
+            },
+        );
+        source.turn_id = Some("turn-replay-source".into());
+        storage.append_message(&source).unwrap();
+
+        let mut replay = TurnRecord::new("default", "turn-replay-attempt", 8);
+        replay.input_message_ids = vec![source.id.clone()];
+        replay.trigger = Some(crate::types::TurnTriggerSummary::from_message(&source));
+        replay.replay = Some(crate::types::TurnReplayProvenance {
+            source_message_id: source.id.clone(),
+            source_turn_id: "turn-replay-source".into(),
+            reason: "interrupted_queue_claim_reentry".into(),
+            prior_terminal: None,
+        });
+        storage.append_turn(&replay).unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "New current instruction.".into(),
+            },
+        );
+        let context = build_context(
+            &storage,
+            &AgentState::new("default"),
+            &execution_snapshot_for(&AgentState::new("default")),
+            &SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig::default(),
+            dir.path(),
+        )
+        .unwrap();
+        let recent_turns = context
+            .sections
+            .iter()
+            .find(|section| section.name == "recent_turns")
+            .expect("recent_turns section")
+            .content
+            .clone();
+        assert!(recent_turns.contains("source_turn_id=turn-replay-source"));
+        assert!(recent_turns.contains(
+            "projection advisory: replay provenance is historical evidence, not continuation identity"
+        ));
+        assert!(!recent_turns.contains("Historical input must not become current continuation."));
     }
 
     #[test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -3080,10 +3080,10 @@ mod tests {
         system::WorkspaceProjectionKind,
         types::{
             AgentDeletionPhase, AgentDeletionStatus, AgentKind, AgentOwnership, AgentProfilePreset,
-            AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, ControlAction,
-            MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord,
-            QueueEntryStatus, TaskRecord, TaskRecoverySpec, TaskStatus, TurnTerminalKind,
-            WorkItemRecord, WorkItemState,
+            AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
+            BriefRecord, ControlAction, DeliverySummaryRecord, MessageBody, MessageEnvelope,
+            MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
+            TaskRecoverySpec, TaskStatus, TurnTerminalKind, WorkItemRecord, WorkItemState,
         },
     };
 
@@ -6140,7 +6140,7 @@ mod tests {
             })
             .expect("insert legacy activation");
 
-        // Has terminal turn: should NOT be recovered
+        // Has terminal turn: completion evidence settles the stale claim.
         let msg_c = make_message("msg-terminal");
         storage.append_message(&msg_c).unwrap();
         storage
@@ -6159,6 +6159,57 @@ mod tests {
             .upsert(&turn)
             .expect("upsert turn");
 
+        // Has a result brief without a terminal turn: should also settle, not replay.
+        let msg_result = make_message("msg-result-brief");
+        storage.append_message(&msg_result).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_result, QueueEntryStatus::Dequeued))
+            .unwrap();
+        let result_brief = BriefRecord::new(
+            &agent_id,
+            BriefKind::Result,
+            "completed before restart",
+            Some(msg_result.id.clone()),
+            None,
+        );
+        storage.append_brief(&result_brief).unwrap();
+
+        // Has failure evidence: should settle as aborted, not replay.
+        let msg_failure = make_message("msg-failure-brief");
+        storage.append_message(&msg_failure).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_failure, QueueEntryStatus::Dequeued))
+            .unwrap();
+        let failure_brief = BriefRecord::new(
+            &agent_id,
+            BriefKind::Failure,
+            "failed before restart",
+            Some(msg_failure.id.clone()),
+            None,
+        );
+        storage.append_brief(&failure_brief).unwrap();
+
+        // Has delivery evidence attached to its trigger turn: should settle, not replay.
+        let msg_delivery = make_message("msg-delivery");
+        storage.append_message(&msg_delivery).unwrap();
+        storage
+            .append_queue_entry(&make_queue_entry(&msg_delivery, QueueEntryStatus::Dequeued))
+            .unwrap();
+        let mut delivery_turn = crate::types::TurnRecord::new(&agent_id, "turn-delivery", 1);
+        delivery_turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(
+            &msg_delivery,
+        ));
+        storage.append_turn(&delivery_turn).unwrap();
+        let mut delivery = DeliverySummaryRecord::new(
+            &agent_id,
+            "work-delivery",
+            "delivered before restart",
+            Some(1),
+            None,
+        );
+        delivery.turn_id = Some(delivery_turn.turn_id);
+        storage.append_delivery_summary(&delivery).unwrap();
+
         let recovered = host
             .recover_orphaned_queue_claims_at_startup()
             .await
@@ -6173,18 +6224,37 @@ mod tests {
                     QueueEntryStatus::Interrupted,
                     "orphaned should be recovered"
                 ),
-                "msg-activated" | "msg-terminal" => assert_eq!(
+                "msg-activated" => assert_eq!(
                     entry.status,
                     QueueEntryStatus::Dequeued,
-                    "non-orphaned should not be recovered"
+                    "active execution should retain its claim"
+                ),
+                "msg-terminal" | "msg-result-brief" | "msg-delivery" => assert_eq!(
+                    entry.status,
+                    QueueEntryStatus::Processed,
+                    "successful completion evidence should prevent replay"
+                ),
+                "msg-failure-brief" => assert_eq!(
+                    entry.status,
+                    QueueEntryStatus::Aborted,
+                    "failure completion evidence should prevent replay"
                 ),
                 _ => {}
             }
         }
 
         let events = storage.read_recent_events(32).unwrap();
-        assert!(events
-            .iter()
-            .any(|e| e.kind == "orphaned_queue_claim_recovered"));
+        assert!(events.iter().any(|event| {
+            event.kind == "orphaned_queue_claim_recovered"
+                && event.data["message_id"] == "msg-result-brief"
+                && event.data["next_status"] == "processed"
+                && event.data["reason"] == "terminal_or_result_completion_evidence"
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == "orphaned_queue_claim_recovered"
+                && event.data["message_id"] == "msg-failure-brief"
+                && event.data["next_status"] == "aborted"
+                && event.data["reason"] == "terminal_failure_completion_evidence"
+        }));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3257,6 +3257,21 @@ impl RuntimeHandle {
         operator_reply_route_id: Option<&str>,
         execution_admission_provenance: ExecutionAdmissionProvenance,
     ) -> Result<()> {
+        let replay_source = if let Some(message) = message {
+            if let Some(source_turn_id) = message.source_refs.get("replay_source_turn_id") {
+                Some((
+                    source_turn_id.clone(),
+                    self.inner
+                        .runtime_db
+                        .turn_records()
+                        .by_id(Some(&message.agent_id), source_turn_id)?,
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let canonical_execution_binding = match &execution_admission_provenance {
             ExecutionAdmissionProvenance::Canonical { activation_id, .. } => {
                 let message = message.ok_or_else(|| {
@@ -3332,13 +3347,21 @@ impl RuntimeHandle {
         let state = {
             let mut guard = self.inner.agent.lock().await;
             guard.state.turn_index += 1;
-            let turn_id = message
-                .and_then(|message| normalized_turn_id(message.turn_id.as_deref()))
-                .unwrap_or_else(crate::ids::turn_id);
+            let turn_id = if replay_source.is_some() {
+                crate::ids::turn_id()
+            } else {
+                message
+                    .and_then(|message| normalized_turn_id(message.turn_id.as_deref()))
+                    .unwrap_or_else(crate::ids::turn_id)
+            };
             guard.state.current_turn_id = Some(turn_id.clone());
             guard.state.last_turn_terminal = None;
             if let Some((_, work_item_id)) = canonical_execution_binding.as_ref() {
                 guard.state.current_turn_work_item_id = work_item_id.clone();
+            } else if let Some((_, source_turn)) = replay_source.as_ref() {
+                guard.state.current_turn_work_item_id = source_turn
+                    .as_ref()
+                    .and_then(|turn| turn.current_work_item_id.clone());
             } else if guard.state.current_turn_work_item_id.is_none() {
                 guard.state.current_turn_work_item_id = guard.state.current_work_item_id.clone();
             }
@@ -3412,6 +3435,22 @@ impl RuntimeHandle {
                     "turn_index": state.turn_index,
                 }),
             ))?;
+            if let Some((source_turn_id, source_turn)) = replay_source {
+                self.inner.storage.append_event(&AuditEvent::legacy(
+                    "turn_replay_started",
+                    serde_json::json!({
+                        "agent_id": message.agent_id,
+                        "message_id": message.id,
+                        "source_turn_id": source_turn_id,
+                        "replay_turn_id": state.current_turn_id,
+                        "reason": "interrupted_queue_claim_reentry",
+                        "source_work_item_id": source_turn
+                            .as_ref()
+                            .and_then(|turn| turn.current_work_item_id.clone()),
+                        "prior_terminal": source_turn.and_then(|turn| turn.terminal),
+                    }),
+                ))?;
+            }
         }
         Ok(())
     }
@@ -4594,57 +4633,10 @@ impl RuntimeHandle {
             return Ok(0);
         }
         let agent_id = self.inner.agent.lock().await.state.id.clone();
-        let claimed = self
-            .inner
+        self.inner
             .runtime_db
-            .queue_entries()
-            .recent(Some(&agent_id), usize::MAX)?
-            .into_iter()
-            .filter(|entry| entry.status == QueueEntryStatus::Dequeued)
-            .collect::<Vec<_>>();
-        let mut released = 0;
-        for mut entry in claimed {
-            entry.status = QueueEntryStatus::Interrupted;
-            entry.updated_at = Utc::now();
-            let message_id = entry.message_id.clone();
-            let execution_protocol =
-                crate::runtime_db::transitions::ExecutionProtocolTransition::default();
-            let commit = self
-                .inner
-                .runtime_db
-                .transitions()
-                .commit_queue_with_execution_protocol(
-                    &crate::runtime_db::transitions::QueueTransitionCommand {
-                        agent_id: agent_id.clone(),
-                        operation: crate::runtime_db::transitions::QueueOperation::Release,
-                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(entry),
-                        scheduler_claim_work_item: None,
-                        scheduler_protocol_bootstrap: None,
-                        scheduler_protocol_commands: Vec::new(),
-                        agent_state: None,
-                        message_evidence: Vec::new(),
-                        transcript_entries: Vec::new(),
-                        turn_record: None,
-                        audit_events: vec![AuditEvent::legacy(
-                            "queue_claim_released_for_runtime_restart",
-                            serde_json::json!({
-                                "agent_id": agent_id,
-                                "message_id": message_id,
-                                "status": QueueEntryStatus::Interrupted,
-                            }),
-                        )],
-                        notify_scheduler: true,
-                        fault: None,
-                        brief_evidence: Vec::new(),
-                    },
-                    &execution_protocol,
-                )?;
-            if commit.applied {
-                released += 1;
-            }
-            self.apply_transition_commit(commit).await;
-        }
-        Ok(released)
+            .reconcile_orphaned_dequeued_claims(Some(&agent_id))
+            .map(|(_, changed)| changed)
     }
 
     fn validate_legacy_engine_startup(&self, agent_id: &str) -> Result<()> {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -484,6 +484,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .storage
             .read_message_by_id(&candidate.message.id)?
             .ok_or_else(|| anyhow!("claimed message is missing persisted ingress evidence"))?;
+        let replay_source_turn_id = self
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&candidate.message.id)?
+            .filter(|entry| entry.status == QueueEntryStatus::Interrupted)
+            .and_then(|_| persisted_message.turn_id.clone());
         let canonical_claim = if self.runtime.inner.scheduler_engine.is_canonical() {
             match self.canonical_activation_plan(
                 &projection,
@@ -763,7 +771,17 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     reason: Arc::new(StdMutex::new("operator_aborted".into())),
                 });
                 commit.effects.agent_state = None;
-                break (persisted_message.clone(), running_state, commit);
+                let mut claimed_message = persisted_message.clone();
+                if let Some(source_turn_id) = replay_source_turn_id.as_ref() {
+                    claimed_message
+                        .source_refs
+                        .insert("replay_source_turn_id".into(), source_turn_id.clone());
+                    claimed_message.source_refs.insert(
+                        "replay_reason".into(),
+                        "interrupted_queue_claim_reentry".into(),
+                    );
+                }
+                break (claimed_message, running_state, commit);
             }
         };
         self.runtime

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -825,6 +825,102 @@ async fn runtime_failure_preserves_canonical_claim_for_bootstrap_reconciliation(
 }
 
 #[tokio::test]
+async fn interrupted_message_replay_creates_new_turn_without_current_focus_drift() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = runtime
+        .enqueue(trusted_operator_prompt(None, "replay interrupted message"))
+        .await
+        .unwrap();
+    let source_turn_id = message.turn_id.clone().expect("source turn id");
+    let mut interrupted = runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest(&message.id)
+        .unwrap()
+        .expect("queued message");
+    interrupted.status = QueueEntryStatus::Interrupted;
+    interrupted.updated_at = Utc::now();
+    runtime.storage().append_queue_entry(&interrupted).unwrap();
+    let current_work_item = runtime
+        .create_work_item("unrelated current focus".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_work_item_id = Some(current_work_item.id.clone());
+        guard.state.current_turn_work_item_id = Some(current_work_item.id);
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("interrupted message should be claimed for replay");
+    };
+    assert_eq!(
+        scheduled.message.source_refs.get("replay_source_turn_id"),
+        Some(&source_turn_id)
+    );
+    runtime
+        .begin_interactive_turn(Some(&scheduled.message), None, None)
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+    let replay_turn_id = state.current_turn_id.expect("replay turn id");
+    assert_ne!(replay_turn_id, source_turn_id);
+    assert_eq!(state.current_turn_work_item_id, None);
+
+    runtime
+        .persist_turn_record(&TurnTerminalRecord {
+            turn_id: replay_turn_id.clone(),
+            turn_index: state.turn_index,
+            kind: TurnTerminalKind::Completed,
+            reason: None,
+            last_assistant_message: None,
+            checkpoint: None,
+            completed_at: Utc::now(),
+            duration_ms: 1,
+        })
+        .await
+        .unwrap();
+
+    assert!(runtime
+        .storage()
+        .read_turn_by_id(&source_turn_id)
+        .unwrap()
+        .is_none());
+    let replay = runtime
+        .storage()
+        .read_turn_by_id(&replay_turn_id)
+        .unwrap()
+        .expect("replay turn");
+    assert_eq!(replay.current_work_item_id, None);
+    assert_eq!(
+        replay.replay,
+        Some(crate::types::TurnReplayProvenance {
+            source_message_id: message.id,
+            source_turn_id,
+            reason: "interrupted_queue_claim_reentry".into(),
+            prior_terminal: None,
+        })
+    );
+}
+
+#[tokio::test]
 async fn legacy_recovery_plan_reconciles_an_existing_dispatch_reservation() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -218,12 +218,26 @@ impl RuntimeHandle {
             .storage
             .read_recent_wait_conditions(TURN_RECORD_SCAN_LIMIT)?;
 
+        let source_message_id = {
+            let guard = self.inner.agent.lock().await;
+            guard
+                .state
+                .current_execution_binding
+                .as_ref()
+                .map(|binding| binding.source_message_id.clone())
+        };
         let input_messages = messages
             .iter()
-            .filter(|message| turn_optional_id_matches(message.turn_id.as_deref(), turn_id))
+            .filter(|message| {
+                turn_optional_id_matches(message.turn_id.as_deref(), turn_id)
+                    || source_message_id.as_deref() == Some(message.id.as_str())
+            })
             .collect::<Vec<_>>();
 
         let mut record = TurnRecord::new(agent_id, turn_id, terminal.turn_index);
+        if let Some(existing) = self.inner.storage.read_turn_by_id(turn_id)? {
+            record.created_at = existing.created_at;
+        }
         record.run_id = run_id;
         record.current_work_item_id = current_work_item_id;
         record.trigger = input_messages
@@ -259,6 +273,31 @@ impl RuntimeHandle {
             .map(|condition| condition.id.clone())
             .collect();
         record.terminal = Some(TurnTerminalSummary::from_terminal(terminal));
+        record.replay = source_message_id
+            .as_deref()
+            .and_then(|source_message_id| {
+                input_messages
+                    .iter()
+                    .find(|message| message.id == source_message_id)
+            })
+            .and_then(|message| {
+                let source_turn_id = message.turn_id.as_deref()?.trim();
+                (!source_turn_id.is_empty() && source_turn_id != turn_id).then(|| {
+                    let prior_terminal = self
+                        .inner
+                        .storage
+                        .read_turn_by_id(source_turn_id)
+                        .ok()
+                        .flatten()
+                        .and_then(|turn| turn.terminal);
+                    crate::types::TurnReplayProvenance {
+                        source_message_id: message.id.clone(),
+                        source_turn_id: source_turn_id.to_string(),
+                        reason: "interrupted_queue_claim_reentry".into(),
+                        prior_terminal,
+                    }
+                })
+            });
 
         Ok(record)
     }
@@ -301,6 +340,7 @@ impl RuntimeHandle {
                 "completed_work_item_ids": record.completed_work_item_ids,
                 "waiting_condition_ids": record.waiting_condition_ids,
                 "terminal": record.terminal,
+                "replay": record.replay,
                 "created_at": record.created_at,
             }),
         )

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -185,19 +185,35 @@ fn turn_record_identity_is_immutable_after_first_persist() {
     let mut initial = crate::types::TurnRecord::new("default", "turn-immutable", 7);
     initial.run_id = Some("run-original".into());
     initial.current_work_item_id = Some("work-original".into());
+    initial.replay = Some(crate::types::TurnReplayProvenance {
+        source_message_id: "message-original".into(),
+        source_turn_id: "turn-original".into(),
+        reason: "interrupted_queue_claim_reentry".into(),
+        prior_terminal: None,
+    });
     runtime.storage().append_turn(&initial).unwrap();
 
     let mut terminal_update = initial.clone();
-    terminal_update.terminal = Some(crate::types::TurnTerminalSummary {
+    let terminal = crate::types::TurnTerminalSummary {
         kind: TurnTerminalKind::Completed,
         reason: None,
         completed_at: Utc::now(),
         duration_ms: 5,
-    });
+    };
+    terminal_update.terminal = Some(terminal.clone());
+    terminal_update
+        .replay
+        .as_mut()
+        .expect("replay provenance")
+        .prior_terminal = Some(terminal);
     runtime.storage().append_turn(&terminal_update).unwrap();
 
     let mut conflicting = terminal_update.clone();
-    conflicting.current_work_item_id = Some("work-conflicting".into());
+    conflicting
+        .replay
+        .as_mut()
+        .expect("replay provenance")
+        .reason = "conflicting-replay-reason".into();
     let error = runtime.storage().append_turn(&conflicting).unwrap_err();
     let conflict = error
         .downcast_ref::<crate::runtime_db::RuntimeStateTransitionConflict>()

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -7,7 +7,8 @@ use crate::tool::{
     ToolError, ToolSpec,
 };
 use crate::types::{
-    TodoItemState, TurnTerminalCheckpointRecord, WorkItemPlanStatus, WorkItemRecord,
+    AuthorityClass, MessageBody, MessageKind, MessageOrigin, Priority, TodoItemState,
+    TurnTerminalCheckpointRecord, WorkItemPlanStatus, WorkItemRecord,
 };
 use chrono::Utc;
 
@@ -165,6 +166,151 @@ async fn persist_turn_record_uses_turn_id_not_numeric_sequence_collisions() {
     assert_eq!(record.tool_execution_ids, vec![owned_tool.id]);
     assert_eq!(record.produced_brief_ids, vec![owned_brief.id]);
     assert_eq!(record.completed_work_item_ids, vec!["work-owned"]);
+}
+
+#[test]
+fn turn_record_identity_is_immutable_after_first_persist() {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        std::sync::Arc::new(crate::provider::StubProvider::new("unused")),
+        "default".into(),
+        crate::runtime::tests::support::context_config(),
+    )
+    .unwrap();
+    let mut initial = crate::types::TurnRecord::new("default", "turn-immutable", 7);
+    initial.run_id = Some("run-original".into());
+    initial.current_work_item_id = Some("work-original".into());
+    runtime.storage().append_turn(&initial).unwrap();
+
+    let mut terminal_update = initial.clone();
+    terminal_update.terminal = Some(crate::types::TurnTerminalSummary {
+        kind: TurnTerminalKind::Completed,
+        reason: None,
+        completed_at: Utc::now(),
+        duration_ms: 5,
+    });
+    runtime.storage().append_turn(&terminal_update).unwrap();
+
+    let mut conflicting = terminal_update.clone();
+    conflicting.current_work_item_id = Some("work-conflicting".into());
+    let error = runtime.storage().append_turn(&conflicting).unwrap_err();
+    let conflict = error
+        .downcast_ref::<crate::runtime_db::RuntimeStateTransitionConflict>()
+        .expect("turn identity conflict should be typed");
+    assert_eq!(conflict.domain(), "turn identity");
+    assert_eq!(conflict.record_id(), "turn-immutable");
+
+    assert_eq!(
+        runtime.storage().read_turn_by_id("turn-immutable").unwrap(),
+        Some(terminal_update)
+    );
+}
+
+#[tokio::test]
+async fn replay_persists_a_new_turn_with_source_provenance() {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        std::sync::Arc::new(crate::provider::StubProvider::new("unused")),
+        "default".into(),
+        crate::runtime::tests::support::context_config(),
+    )
+    .unwrap();
+    let mut source_message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "resume after interrupted claim".into(),
+        },
+    );
+    source_message.id = "message-replay-source".into();
+    source_message.turn_id = Some("turn-replay-source".into());
+    runtime.storage().append_message(&source_message).unwrap();
+
+    let mut source_turn = crate::types::TurnRecord::new("default", "turn-replay-source", 4);
+    source_turn.current_work_item_id = Some("work-source".into());
+    source_turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(
+        &source_message,
+    ));
+    source_turn.terminal = Some(crate::types::TurnTerminalSummary {
+        kind: TurnTerminalKind::Aborted,
+        reason: Some("runtime_restart".into()),
+        completed_at: Utc::now(),
+        duration_ms: 10,
+    });
+    runtime.storage().append_turn(&source_turn).unwrap();
+
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.current_turn_id = Some("turn-replay-attempt".into());
+        guard.state.current_turn_work_item_id = Some("work-source".into());
+        guard.state.current_execution_binding = Some(crate::types::WorkItemExecutionBinding {
+            activation_id: Some("activation-replay".into()),
+            admission_provenance: None,
+            source_message_id: source_message.id.clone(),
+            turn_id: "turn-replay-attempt".into(),
+            work_item_id: Some("work-source".into()),
+            claimed_work_revision: Some(1),
+        });
+    }
+
+    runtime
+        .persist_turn_record(&TurnTerminalRecord {
+            turn_id: "turn-replay-attempt".into(),
+            turn_index: 5,
+            kind: TurnTerminalKind::Completed,
+            reason: None,
+            last_assistant_message: None,
+            checkpoint: None,
+            completed_at: Utc::now(),
+            duration_ms: 20,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runtime
+            .storage()
+            .read_turn_by_id("turn-replay-source")
+            .unwrap(),
+        Some(source_turn.clone()),
+        "replay must not overwrite the historical source turn"
+    );
+    let replay = runtime
+        .storage()
+        .read_turn_by_id("turn-replay-attempt")
+        .unwrap()
+        .expect("replay attempt turn");
+    assert_eq!(replay.turn_id, "turn-replay-attempt");
+    assert_eq!(replay.current_work_item_id.as_deref(), Some("work-source"));
+    assert_eq!(
+        replay
+            .trigger
+            .as_ref()
+            .and_then(|trigger| trigger.message_id.as_deref()),
+        Some(source_message.id.as_str())
+    );
+    assert_eq!(
+        replay.replay,
+        Some(crate::types::TurnReplayProvenance {
+            source_message_id: source_message.id,
+            source_turn_id: source_turn.turn_id,
+            reason: "interrupted_queue_claim_reentry".into(),
+            prior_terminal: source_turn.terminal,
+        })
+    );
 }
 
 #[test]

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -3920,6 +3920,15 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
         .map(|payload| decode_turn_record_payload(&payload))
         .transpose()?;
     if let Some(existing) = existing.as_ref() {
+        let replay_identity_matches = match (&existing.replay, &record.replay) {
+            (Some(existing), Some(record)) => {
+                existing.source_message_id == record.source_message_id
+                    && existing.source_turn_id == record.source_turn_id
+                    && existing.reason == record.reason
+            }
+            (None, None) => true,
+            _ => false,
+        };
         let identity_matches = existing.agent_id == record.agent_id
             && existing.turn_index == record.turn_index
             && existing.run_id == record.run_id
@@ -3933,7 +3942,7 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
                     .as_ref()
                     .and_then(|trigger| trigger.message_id.as_deref())
             && existing.created_at == record.created_at
-            && existing.replay == record.replay;
+            && replay_identity_matches;
         if !identity_matches {
             return Err(RuntimeStateTransitionConflict::new(
                 "turn identity",

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1728,7 +1728,8 @@ impl TurnRecordRepository<'_> {
                     wait_conditions,
                 )?;
                 for record in &records {
-                    upsert_turn_record_tx(tx, record)?;
+                    let record = merge_legacy_turn_evidence_tx(tx, record)?;
+                    upsert_turn_record_tx(tx, &record)?;
                 }
                 Ok(serde_json::json!({
                     "imported_records": records.len(),
@@ -3853,7 +3854,96 @@ fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
     Ok(())
 }
 
+fn merge_legacy_turn_evidence_tx(tx: &Transaction<'_>, derived: &TurnRecord) -> Result<TurnRecord> {
+    let Some(mut existing) = tx
+        .query_row(
+            "SELECT payload_json FROM turn_records WHERE turn_id = ?1",
+            [&derived.turn_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| decode_turn_record_payload(&payload))
+        .transpose()?
+    else {
+        return Ok(derived.clone());
+    };
+    if existing.agent_id != derived.agent_id {
+        return Err(RuntimeStateTransitionConflict::new(
+            "turn identity",
+            &derived.turn_id,
+            &existing.agent_id,
+            &derived.agent_id,
+        )
+        .into());
+    }
+    existing
+        .input_message_ids
+        .extend(derived.input_message_ids.iter().cloned());
+    existing
+        .tool_execution_ids
+        .extend(derived.tool_execution_ids.iter().cloned());
+    existing
+        .produced_brief_ids
+        .extend(derived.produced_brief_ids.iter().cloned());
+    existing
+        .delivery_summary_ids
+        .extend(derived.delivery_summary_ids.iter().cloned());
+    existing
+        .completed_work_item_ids
+        .extend(derived.completed_work_item_ids.iter().cloned());
+    existing
+        .waiting_condition_ids
+        .extend(derived.waiting_condition_ids.iter().cloned());
+    existing.input_message_ids.sort();
+    existing.input_message_ids.dedup();
+    existing.tool_execution_ids.sort();
+    existing.tool_execution_ids.dedup();
+    existing.produced_brief_ids.sort();
+    existing.produced_brief_ids.dedup();
+    existing.delivery_summary_ids.sort();
+    existing.delivery_summary_ids.dedup();
+    existing.completed_work_item_ids.sort();
+    existing.completed_work_item_ids.dedup();
+    existing.waiting_condition_ids.sort();
+    existing.waiting_condition_ids.dedup();
+    Ok(existing)
+}
+
 pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -> Result<()> {
+    let existing = tx
+        .query_row(
+            "SELECT payload_json FROM turn_records WHERE turn_id = ?1",
+            [&record.turn_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| decode_turn_record_payload(&payload))
+        .transpose()?;
+    if let Some(existing) = existing.as_ref() {
+        let identity_matches = existing.agent_id == record.agent_id
+            && existing.turn_index == record.turn_index
+            && existing.run_id == record.run_id
+            && existing.current_work_item_id == record.current_work_item_id
+            && existing
+                .trigger
+                .as_ref()
+                .and_then(|trigger| trigger.message_id.as_deref())
+                == record
+                    .trigger
+                    .as_ref()
+                    .and_then(|trigger| trigger.message_id.as_deref())
+            && existing.created_at == record.created_at
+            && existing.replay == record.replay;
+        if !identity_matches {
+            return Err(RuntimeStateTransitionConflict::new(
+                "turn identity",
+                &record.turn_id,
+                "immutable",
+                "conflicting",
+            )
+            .into());
+        }
+    }
     let payload_json = serde_json::to_string(record)?;
     let terminal_kind = record
         .terminal
@@ -3870,13 +3960,7 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
             trigger_message_id, terminal_kind, created_at, completed_at, payload_json
          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
          ON CONFLICT(turn_id) DO UPDATE SET
-            turn_index = excluded.turn_index,
-            agent_id = excluded.agent_id,
-            run_id = excluded.run_id,
-            current_work_item_id = excluded.current_work_item_id,
-            trigger_message_id = excluded.trigger_message_id,
             terminal_kind = excluded.terminal_kind,
-            created_at = excluded.created_at,
             completed_at = excluded.completed_at,
             payload_json = excluded.payload_json
          WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -5348,6 +5348,48 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn turn_record_legacy_import_preserves_existing_identity() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut canonical = crate::types::TurnRecord::new("agent-a", "turn-a", 11);
+        canonical.current_work_item_id = Some("work-current".into());
+        canonical.created_at = Utc::now() - chrono::Duration::seconds(5);
+        db.turn_records().upsert(&canonical)?;
+
+        let mut delivery = crate::types::DeliverySummaryRecord::new(
+            "agent-a",
+            "work-legacy",
+            "legacy delivery",
+            Some(7),
+            None,
+        );
+        delivery.id = "delivery-legacy".into();
+        delivery.turn_id = Some("turn-a".into());
+
+        db.turn_records().import_legacy(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![delivery],
+            Vec::new(),
+        )?;
+
+        let imported = db
+            .turn_records()
+            .by_id(Some("agent-a"), "turn-a")?
+            .expect("existing turn should remain");
+        assert_eq!(imported.turn_index, 11);
+        assert_eq!(
+            imported.current_work_item_id.as_deref(),
+            Some("work-current")
+        );
+        assert_eq!(imported.created_at, canonical.created_at);
+        assert_eq!(imported.delivery_summary_ids, vec!["delivery-legacy"]);
+        assert_eq!(imported.completed_work_item_ids, vec!["work-legacy"]);
+        Ok(())
+    }
+
+    #[test]
     fn runtime_db_temp_helper_uses_isolated_state_dir() -> Result<()> {
         let temp_db = test_support::TempRuntimeDb::new()?;
         assert!(temp_db.db.path().ends_with("state/runtime.sqlite"));

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -101,7 +101,6 @@ pub(crate) enum QueueOperation {
     Admit,
     Claim,
     Interject,
-    Release,
     Settle,
     RepairDrop,
 }
@@ -289,8 +288,31 @@ impl RuntimeDb {
     }
 
     pub(crate) fn recover_orphaned_dequeued_claims_at_startup(&self) -> Result<Vec<String>> {
+        self.reconcile_orphaned_dequeued_claims(None)
+            .map(|(agents, _)| agents)
+    }
+
+    pub(crate) fn reconcile_orphaned_dequeued_claims(
+        &self,
+        agent_id: Option<&str>,
+    ) -> Result<(Vec<String>, usize)> {
         self.transaction(|tx| {
-            let mut statement = tx.prepare(
+            let sql = if agent_id.is_some() {
+                "SELECT q.payload_json
+                 FROM queue_entries q
+                 JOIN agent_identities i
+                   ON i.agent_id = q.agent_id
+                  AND i.status = 'active'
+                 WHERE q.status = 'dequeued'
+                   AND q.agent_id = ?1
+                   AND NOT EXISTS (
+                     SELECT 1
+                     FROM execution_protocol_attempts a
+                     WHERE a.agent_id = q.agent_id
+                       AND a.attempt_id = 'activation:message:' || q.message_id
+                   )
+                 ORDER BY q.agent_id, q.updated_at, q.message_id"
+            } else {
                 "SELECT q.payload_json
                  FROM queue_entries q
                  JOIN agent_identities i
@@ -303,30 +325,93 @@ impl RuntimeDb {
                      WHERE a.agent_id = q.agent_id
                        AND a.attempt_id = 'activation:message:' || q.message_id
                    )
-                   AND NOT EXISTS (
-                     SELECT 1
-                     FROM turn_records t
-                     WHERE t.agent_id = q.agent_id
-                       AND t.trigger_message_id = q.message_id
-                       AND t.terminal_kind IS NOT NULL
-                   )
-                 ORDER BY q.agent_id, q.updated_at, q.message_id",
-            )?;
-            let candidates = statement
-                .query_map([], |row| row.get::<_, String>(0))?
-                .map(|row| Ok(serde_json::from_str::<QueueEntryRecord>(&row?)?))
-                .collect::<Result<Vec<_>>>()?;
+                 ORDER BY q.agent_id, q.updated_at, q.message_id"
+            };
+            let mut statement = tx.prepare(sql)?;
+            let candidates = if let Some(agent_id) = agent_id {
+                statement
+                    .query_map([agent_id], |row| row.get::<_, String>(0))?
+                    .map(|row| Ok(serde_json::from_str::<QueueEntryRecord>(&row?)?))
+                    .collect::<Result<Vec<_>>>()?
+            } else {
+                statement
+                    .query_map([], |row| row.get::<_, String>(0))?
+                    .map(|row| Ok(serde_json::from_str::<QueueEntryRecord>(&row?)?))
+                    .collect::<Result<Vec<_>>>()?
+            };
             drop(statement);
 
             let recovered_at = Utc::now();
             let mut recovered_agents = Vec::new();
+            let mut changed = 0;
             for expected in candidates {
                 let mut recovered = expected.clone();
-                recovered.status = QueueEntryStatus::Interrupted;
+                let terminal_kind = tx
+                    .query_row(
+                        "SELECT terminal_kind
+                         FROM turn_records
+                         WHERE agent_id = ?1
+                           AND trigger_message_id = ?2
+                           AND terminal_kind IS NOT NULL
+                         ORDER BY completed_at DESC
+                         LIMIT 1",
+                        rusqlite::params![expected.agent_id, expected.message_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?;
+                let terminal_brief_kind = tx
+                    .query_row(
+                        "SELECT kind
+                         FROM briefs
+                         WHERE agent_id = ?1
+                           AND message_id = ?2
+                           AND kind IN ('result', 'failure')
+                         ORDER BY created_at DESC
+                         LIMIT 1",
+                        rusqlite::params![expected.agent_id, expected.message_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?;
+                let delivered = tx.query_row(
+                    "SELECT EXISTS(
+                         SELECT 1
+                         FROM delivery_summaries d
+                         JOIN turn_records t
+                           ON t.agent_id = d.agent_id
+                          AND t.turn_id = d.turn_id
+                         WHERE d.agent_id = ?1
+                           AND t.trigger_message_id = ?2
+                     )",
+                    rusqlite::params![expected.agent_id, expected.message_id],
+                    |row| row.get::<_, bool>(0),
+                )?;
+                let (next_status, reason) = if terminal_kind.as_deref() == Some("completed")
+                    || terminal_brief_kind.as_deref() == Some("result")
+                    || delivered
+                {
+                    (
+                        QueueEntryStatus::Processed,
+                        "terminal_or_result_completion_evidence",
+                    )
+                } else if terminal_kind.is_some()
+                    || terminal_brief_kind.as_deref() == Some("failure")
+                {
+                    (
+                        QueueEntryStatus::Aborted,
+                        "terminal_failure_completion_evidence",
+                    )
+                } else {
+                    (
+                        QueueEntryStatus::Interrupted,
+                        "no_execution_attempt_or_completion_evidence",
+                    )
+                };
+                recovered.status = next_status.clone();
                 recovered.updated_at = recovered_at;
                 if !compare_and_set_queue_entry_tx(tx, &expected, &recovered)? {
                     continue;
                 }
+                changed += 1;
                 let event = AuditEvent {
                     id: format!("audit:orphaned-queue-claim:{}", expected.message_id),
                     event_seq: 0,
@@ -339,17 +424,22 @@ impl RuntimeDb {
                     data: serde_json::json!({
                         "message_id": expected.message_id,
                         "agent_id": expected.agent_id,
-                        "reason": "no_execution_attempt_or_terminal_turn",
+                        "reason": reason,
                         "previous_status": "dequeued",
-                        "next_status": "interrupted",
+                        "next_status": next_status,
+                        "terminal_kind": terminal_kind,
+                        "terminal_brief_kind": terminal_brief_kind,
+                        "delivery_evidence": delivered,
                     }),
                 };
                 append_audit_event_tx(tx, Some(&recovered.agent_id), &event)?;
-                recovered_agents.push(recovered.agent_id);
+                if recovered.status == QueueEntryStatus::Interrupted {
+                    recovered_agents.push(recovered.agent_id);
+                }
             }
             recovered_agents.sort();
             recovered_agents.dedup();
-            Ok(recovered_agents)
+            Ok((recovered_agents, changed))
         })
     }
 }
@@ -837,10 +927,7 @@ impl RuntimeTransitionRepository<'_> {
                 let include_interrupted = match command.operation {
                     QueueOperation::Claim => true,
                     QueueOperation::Interject => false,
-                    QueueOperation::Admit
-                    | QueueOperation::Release
-                    | QueueOperation::Settle
-                    | QueueOperation::RepairDrop => {
+                    QueueOperation::Admit | QueueOperation::Settle | QueueOperation::RepairDrop => {
                         unreachable!("queue operation validation rejects this combination")
                     }
                 };
@@ -923,10 +1010,7 @@ impl RuntimeTransitionRepository<'_> {
                 QueueMutation::Consume(record) => match command.operation {
                     QueueOperation::Claim => try_claim_queued_message_tx(tx, record)?,
                     QueueOperation::Interject => try_interject_queued_message_tx(tx, record)?,
-                    QueueOperation::Admit
-                    | QueueOperation::Release
-                    | QueueOperation::Settle
-                    | QueueOperation::RepairDrop => {
+                    QueueOperation::Admit | QueueOperation::Settle | QueueOperation::RepairDrop => {
                         unreachable!("queue operation validation rejects this combination")
                     }
                 },
@@ -1593,12 +1677,6 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
             QueueOperation::Interject,
             QueueMutation::Consume(QueueEntryRecord {
                 status: QueueEntryStatus::Interjected,
-                ..
-            })
-        ) | (
-            QueueOperation::Release,
-            QueueMutation::Upsert(QueueEntryRecord {
-                status: QueueEntryStatus::Interrupted,
                 ..
             })
         ) | (

--- a/src/types.rs
+++ b/src/types.rs
@@ -1718,6 +1718,15 @@ impl TurnTerminalSummary {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TurnReplayProvenance {
+    pub source_message_id: String,
+    pub source_turn_id: String,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prior_terminal: Option<TurnTerminalSummary>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TurnRecord {
     pub turn_id: String,
@@ -1743,6 +1752,8 @@ pub struct TurnRecord {
     pub waiting_condition_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal: Option<TurnTerminalSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay: Option<TurnReplayProvenance>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -1762,6 +1773,7 @@ impl TurnRecord {
             completed_work_item_ids: Vec::new(),
             waiting_condition_ids: Vec::new(),
             terminal: None,
+            replay: None,
             created_at: Utc::now(),
         }
     }


### PR DESCRIPTION
## 概要

修复 runtime restart/replay 过程中历史消息被错误重放并覆盖既有 turn identity 的问题。

- restart recovery 通过正式 transition 评估 replay eligibility；已有 completion evidence 的 `Dequeued` claim 收敛为 terminal，而不是重新进入 `Interrupted`
- 将 turn identity 设为首次持久化后不可变，拒绝 `turn_index`、message、WorkItem 或 provenance 冲突的覆盖写入
- 合法 replay 创建新的 turn attempt，并保留 `source_turn_id`、replay reason 与前序终态 provenance
- replay 不再从当前 focus 隐式继承 WorkItem；context/recent-turn projection 过滤跨 WorkItem、时间倒退和 source replay 污染
- 增加 recovery、repair、identity conflict、replay provenance 与 projection 回归测试

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`

以上全部通过。

Closes #2450
