### PR TITLE
fix: synchronize WorkItem execution readiness

### DIFF
--- a/docs/rfcs/work-item-scheduling-read-model.md
+++ b/docs/rfcs/work-item-scheduling-read-model.md
@@ -107,6 +107,21 @@ The matrix fixes previously divergent cases:
 - metadata edits do not create a new runnable generation; and
 - a running or settlement-missing activation outranks queued demand.
 
+## Canonical Mutation Synchronization
+
+WorkItem creation and revision changes commit their canonical
+`WorkItemExecutionRecord` in the same `runtime_db::transitions` transaction.
+Creation registers the initial Runnable generation before first admission.
+Display-only metadata edits advance `source_revision` without changing the
+execution lifecycle or generation, including while an activation is InFlight.
+
+During compatibility migration, an explicit blocker mutation is an adapter
+input to a fenced Runnable-to-Paused execution transition; blocker text is not
+independently read as canonical authority. Explicit blocker or wait clearance
+commits the matching Paused/Waiting-to-Runnable transition with the WorkItem,
+wait cancellation, and focus facts. Readiness changes advance scheduling
+generation, while same-readiness metadata changes do not.
+
 Consumed and terminal waits do not occupy the blocking-wait column. They
 remain projection facets and diagnostics. An orphan consumed wait emits a
 diagnostic and must be repaired through activation/settlement recovery; the

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -330,6 +330,14 @@ pub struct AdvanceWorkItemSourceRevision {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetWorkItemReadiness {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub expected: WorkItemExecutionRecord,
+    pub record: WorkItemExecutionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InterruptExecution {
     pub attempt_id: String,
     pub outcome_id: String,
@@ -342,6 +350,7 @@ pub struct InterruptExecution {
 pub enum ExecutionProtocolCommand {
     RegisterWorkItem(Box<RegisterWorkItemExecution>),
     AdvanceWorkItemSourceRevision(AdvanceWorkItemSourceRevision),
+    SetWorkItemReadiness(Box<SetWorkItemReadiness>),
     SetWorkItemWaiting(Box<SetWorkItemWaiting>),
     Admit(Box<AdmitExecution>),
     Settle(SettleExecution),
@@ -410,10 +419,81 @@ pub fn advance_work_item_source_revision(
     if record.source_revision != command.expected_source_revision {
         return Err("WorkItem source revision advance fence is stale".into());
     }
-    if matches!(record.state, WorkItemExecutionState::InFlight { .. }) {
-        return Err("WorkItem source revision cannot advance while InFlight".into());
+    if matches!(record.state, WorkItemExecutionState::Terminal { .. }) {
+        return Err("terminal WorkItem source revision cannot advance".into());
     }
     record.source_revision = command.source_revision;
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![format!("work_item:{}", command.work_item_id)],
+    })
+}
+
+pub fn set_work_item_readiness(
+    state: &ExecutionProtocolState,
+    command: &SetWorkItemReadiness,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.expected.source_revision == 0
+        || command.record.source_revision < command.expected.source_revision
+    {
+        return Err(
+            "WorkItem readiness transition requires identity and monotonic revision".into(),
+        );
+    }
+    if state.work_items.get(&command.work_item_id) != Some(&command.expected) {
+        return Err("WorkItem readiness transition fence is stale".into());
+    }
+    let generation = command.expected.generation();
+    let valid = match (&command.expected.state, &command.record.state) {
+        (
+            WorkItemExecutionState::Runnable { .. },
+            WorkItemExecutionState::Runnable {
+                generation: next, ..
+            },
+        )
+        | (
+            WorkItemExecutionState::Paused { .. },
+            WorkItemExecutionState::Paused {
+                generation: next, ..
+            },
+        ) => {
+            *next == generation && command.record.source_revision > command.expected.source_revision
+        }
+        (
+            WorkItemExecutionState::Runnable { .. },
+            WorkItemExecutionState::Paused {
+                generation: next, ..
+            },
+        )
+        | (
+            WorkItemExecutionState::Paused { .. },
+            WorkItemExecutionState::Runnable {
+                generation: next, ..
+            },
+        )
+        | (
+            WorkItemExecutionState::Waiting { .. },
+            WorkItemExecutionState::Runnable {
+                generation: next, ..
+            },
+        ) => {
+            *next
+                == generation
+                    .checked_add(1)
+                    .ok_or_else(|| "WorkItem scheduling generation overflow".to_string())?
+        }
+        _ => false,
+    };
+    if !valid {
+        return Err("WorkItem readiness transition is not allowed".into());
+    }
+    let mut next = state.clone();
+    next.work_items
+        .insert(command.work_item_id.clone(), command.record.clone());
     assert_invariants(&next)?;
     Ok(ExecutionTransition {
         state: next,
@@ -957,6 +1037,118 @@ mod tests {
         assert!(register_work_item_execution(&registered.state, &conflict)
             .unwrap_err()
             .contains("different state"));
+    }
+
+    #[test]
+    fn readiness_transition_is_fenced_and_advances_generation() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        let runnable = work_item_record(WorkItemExecutionState::Runnable {
+            generation: 1,
+            recovery_ref: None,
+        });
+        state.work_items.insert("work-a".into(), runnable.clone());
+        let paused = WorkItemExecutionRecord {
+            source_revision: 2,
+            state: WorkItemExecutionState::Paused {
+                generation: 2,
+                reason: "manual hold".into(),
+            },
+        };
+        let paused = set_work_item_readiness(
+            &state,
+            &SetWorkItemReadiness {
+                command_id: "pause-work-a".into(),
+                work_item_id: "work-a".into(),
+                expected: runnable,
+                record: paused,
+            },
+        )
+        .unwrap()
+        .state;
+        let paused_record = paused.work_items.get("work-a").unwrap().clone();
+        assert!(matches!(
+            paused_record.state,
+            WorkItemExecutionState::Paused { generation: 2, .. }
+        ));
+
+        let resumed = set_work_item_readiness(
+            &paused,
+            &SetWorkItemReadiness {
+                command_id: "resume-work-a".into(),
+                work_item_id: "work-a".into(),
+                expected: paused_record,
+                record: WorkItemExecutionRecord {
+                    source_revision: 3,
+                    state: WorkItemExecutionState::Runnable {
+                        generation: 3,
+                        recovery_ref: None,
+                    },
+                },
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            resumed.state.work_items["work-a"].state,
+            WorkItemExecutionState::Runnable { generation: 3, .. }
+        ));
+
+        let stale = SetWorkItemReadiness {
+            command_id: "stale-pause".into(),
+            work_item_id: "work-a".into(),
+            expected: work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+            record: WorkItemExecutionRecord {
+                source_revision: 4,
+                state: WorkItemExecutionState::Paused {
+                    generation: 2,
+                    reason: "stale".into(),
+                },
+            },
+        };
+        assert!(set_work_item_readiness(&resumed.state, &stale)
+            .unwrap_err()
+            .contains("fence is stale"));
+    }
+
+    #[test]
+    fn source_revision_can_advance_without_stealing_in_flight_ownership() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        state.work_items.insert(
+            "work-a".into(),
+            work_item_record(WorkItemExecutionState::Runnable {
+                generation: 1,
+                recovery_ref: None,
+            }),
+        );
+        let admitted = admit_execution(
+            &state,
+            &AdmitExecution {
+                attempt: attempt("attempt-a", None),
+            },
+        )
+        .unwrap()
+        .state;
+        let advanced = advance_work_item_source_revision(
+            &admitted,
+            &AdvanceWorkItemSourceRevision {
+                command_id: "advance-work-a".into(),
+                work_item_id: "work-a".into(),
+                expected_source_revision: 1,
+                source_revision: 2,
+            },
+        )
+        .unwrap();
+        let record = &advanced.state.work_items["work-a"];
+        assert_eq!(record.source_revision, 2);
+        assert!(matches!(
+            record.state,
+            WorkItemExecutionState::InFlight {
+                ref attempt_id,
+                generation: 1
+            } if attempt_id == "attempt-a"
+        ));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2512,6 +2512,62 @@ impl RuntimeHandle {
             .pop_front()
     }
 
+    pub(super) fn commit_work_item_transition(
+        &self,
+        command: &crate::runtime_db::transitions::WorkItemTransitionCommand,
+    ) -> Result<crate::runtime_db::transitions::TransitionCommit> {
+        self.commit_work_item_transition_with_execution(
+            command,
+            &crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+        )
+    }
+
+    pub(super) fn commit_work_item_transition_with_execution(
+        &self,
+        command: &crate::runtime_db::transitions::WorkItemTransitionCommand,
+        execution_protocol: &crate::runtime_db::transitions::ExecutionProtocolTransition,
+    ) -> Result<crate::runtime_db::transitions::TransitionCommit> {
+        if self.inner.scheduler_engine.is_canonical() {
+            self.inner
+                .runtime_db
+                .transitions()
+                .commit_work_item_with_execution_protocol(command, execution_protocol)
+        } else {
+            self.inner
+                .runtime_db
+                .transitions()
+                .commit_work_item(command)
+        }
+    }
+
+    pub(super) fn commit_work_item_focus_transition(
+        &self,
+        command: &crate::runtime_db::transitions::WorkItemFocusTransitionCommand,
+    ) -> Result<crate::runtime_db::transitions::TransitionCommit> {
+        self.commit_work_item_focus_transition_with_execution(
+            command,
+            &crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+        )
+    }
+
+    pub(super) fn commit_work_item_focus_transition_with_execution(
+        &self,
+        command: &crate::runtime_db::transitions::WorkItemFocusTransitionCommand,
+        execution_protocol: &crate::runtime_db::transitions::ExecutionProtocolTransition,
+    ) -> Result<crate::runtime_db::transitions::TransitionCommit> {
+        if self.inner.scheduler_engine.is_canonical() {
+            self.inner
+                .runtime_db
+                .transitions()
+                .commit_work_item_focus_with_execution_protocol(command, execution_protocol)
+        } else {
+            self.inner
+                .runtime_db
+                .transitions()
+                .commit_work_item_focus(command)
+        }
+    }
+
     pub(super) fn inject_next_acceptance_transition_fault(
         &self,
         fault: TransitionFaultPoint,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -131,7 +131,7 @@ impl RuntimeHandle {
                 Value::Null,
             ));
             let agent_id = self.agent_id().await?;
-            let commit = self.inner.runtime_db.transitions().commit_work_item(
+            let commit = self.commit_work_item_transition(
                 &crate::runtime_db::transitions::WorkItemTransitionCommand {
                     agent_id,
                     mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
@@ -196,7 +196,7 @@ impl RuntimeHandle {
                 updated_at: Utc::now(),
                 ..existing
             };
-            let commit = self.inner.runtime_db.transitions().commit_work_item(
+            let commit = self.commit_work_item_transition(
                 &crate::runtime_db::transitions::WorkItemTransitionCommand {
                     agent_id: record.agent_id.clone(),
                     mutation: crate::runtime_db::transitions::WorkItemMutation::Update {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -325,7 +325,7 @@ impl RuntimeHandle {
         record.work_refs = merged;
         record.revision = record.revision.saturating_add(1);
         record.updated_at = Utc::now();
-        let commit = self.inner.runtime_db.transitions().commit_work_item(
+        let commit = self.commit_work_item_transition(
             &crate::runtime_db::transitions::WorkItemTransitionCommand {
                 agent_id: agent.id.clone(),
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Update {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -28,6 +28,12 @@ const TASK_OUTPUT_PREVIEW_CHAR_BUDGET: usize = 8_000;
 const SPAWN_AGENT_TASK_LABEL_CHAR_BUDGET: usize = 120;
 
 #[derive(Debug, Clone)]
+enum WorkItemReadinessMutation {
+    Pause(String),
+    Resume,
+}
+
+#[derive(Debug, Clone)]
 struct TaskMessageSnapshot {
     state: TaskStatus,
     text: String,
@@ -2400,7 +2406,8 @@ impl RuntimeHandle {
             .active_workspace_entry
             .map(|entry| entry.workspace_id)
             .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
-        let commit = self.inner.runtime_db.transitions().commit_work_item(
+        let execution_protocol = self.plan_work_item_execution_create(&record)?;
+        let commit = self.commit_work_item_transition_with_execution(
             &crate::runtime_db::transitions::WorkItemTransitionCommand {
                 agent_id,
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Insert {
@@ -2413,9 +2420,301 @@ impl RuntimeHandle {
                 notify_scheduler: true,
                 fault: self.take_transition_fault(),
             },
+            &execution_protocol,
         )?;
         self.apply_transition_commit(commit).await;
         Ok(record)
+    }
+
+    fn plan_work_item_execution_create(
+        &self,
+        record: &WorkItemRecord,
+    ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+        use crate::domain::execution_protocol::{
+            ExecutionProtocolCommand, ExecutionProtocolState, RegisterWorkItemExecution,
+            WorkItemExecutionRecord, WorkItemExecutionState,
+        };
+
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(Default::default());
+        }
+        let existing = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&record.agent_id)?;
+        Ok(
+            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: existing
+                    .is_none()
+                    .then(|| ExecutionProtocolState::empty(&record.agent_id)),
+                commands: vec![ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                    RegisterWorkItemExecution {
+                        work_item_id: record.id.clone(),
+                        record: WorkItemExecutionRecord {
+                            source_revision: record.revision,
+                            state: WorkItemExecutionState::Runnable {
+                                generation: record.revision,
+                                recovery_ref: None,
+                            },
+                        },
+                    },
+                ))],
+            },
+        )
+    }
+
+    fn plan_work_item_execution_update(
+        &self,
+        record: &WorkItemRecord,
+        readiness_mutation: Option<WorkItemReadinessMutation>,
+    ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+        use crate::domain::execution_protocol::{
+            AdvanceWorkItemSourceRevision, ExecutionProtocolCommand, ExecutionProtocolState,
+            RegisterWorkItemExecution, SetWorkItemReadiness, WorkItemExecutionRecord,
+            WorkItemExecutionState,
+        };
+
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(Default::default());
+        }
+        let existing = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&record.agent_id)?;
+        let authoritative = existing
+            .as_ref()
+            .and_then(|state| state.work_items.get(&record.id));
+        let Some(authoritative) = authoritative else {
+            let state = match readiness_mutation {
+                Some(WorkItemReadinessMutation::Pause(reason)) => WorkItemExecutionState::Paused {
+                    generation: record.revision,
+                    reason,
+                },
+                _ => WorkItemExecutionState::Runnable {
+                    generation: record.revision,
+                    recovery_ref: None,
+                },
+            };
+            return Ok(
+                crate::runtime_db::transitions::ExecutionProtocolTransition {
+                    bootstrap: existing
+                        .is_none()
+                        .then(|| ExecutionProtocolState::empty(&record.agent_id)),
+                    commands: vec![ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                        RegisterWorkItemExecution {
+                            work_item_id: record.id.clone(),
+                            record: WorkItemExecutionRecord {
+                                source_revision: record.revision,
+                                state,
+                            },
+                        },
+                    ))],
+                },
+            );
+        };
+        if readiness_mutation.is_some()
+            && matches!(
+                authoritative.state,
+                WorkItemExecutionState::InFlight { .. }
+                    | WorkItemExecutionState::Waiting { .. }
+                    | WorkItemExecutionState::NeedsRepair { .. }
+            )
+        {
+            return Err(anyhow!(
+                "cannot change WorkItem readiness while canonical execution state is active or requires repair"
+            ));
+        }
+        let next_state = match (&authoritative.state, readiness_mutation) {
+            (WorkItemExecutionState::InFlight { .. }, _)
+            | (WorkItemExecutionState::NeedsRepair { .. }, _)
+            | (WorkItemExecutionState::Waiting { .. }, None)
+            | (WorkItemExecutionState::Waiting { .. }, Some(WorkItemReadinessMutation::Pause(_)))
+            | (WorkItemExecutionState::Waiting { .. }, Some(WorkItemReadinessMutation::Resume))
+            | (_, None) => None,
+            (
+                WorkItemExecutionState::Runnable { generation, .. },
+                Some(WorkItemReadinessMutation::Pause(reason)),
+            )
+            | (
+                WorkItemExecutionState::Paused { generation, .. },
+                Some(WorkItemReadinessMutation::Pause(reason)),
+            ) => Some(WorkItemExecutionState::Paused {
+                generation: if matches!(
+                    authoritative.state,
+                    WorkItemExecutionState::Runnable { .. }
+                ) {
+                    generation
+                        .checked_add(1)
+                        .ok_or_else(|| anyhow!("WorkItem scheduling generation overflow"))?
+                } else {
+                    *generation
+                },
+                reason,
+            }),
+            (
+                WorkItemExecutionState::Runnable { generation, .. },
+                Some(WorkItemReadinessMutation::Resume),
+            )
+            | (
+                WorkItemExecutionState::Paused { generation, .. },
+                Some(WorkItemReadinessMutation::Resume),
+            ) => Some(WorkItemExecutionState::Runnable {
+                generation: if matches!(authoritative.state, WorkItemExecutionState::Paused { .. })
+                {
+                    generation
+                        .checked_add(1)
+                        .ok_or_else(|| anyhow!("WorkItem scheduling generation overflow"))?
+                } else {
+                    *generation
+                },
+                recovery_ref: None,
+            }),
+            (WorkItemExecutionState::Terminal { .. }, _) => {
+                return Err(anyhow!("cannot update terminal WorkItem execution state"));
+            }
+        };
+        let command = if let Some(state) = next_state {
+            ExecutionProtocolCommand::SetWorkItemReadiness(Box::new(SetWorkItemReadiness {
+                command_id: format!("work_item:update:{}:{}", record.id, record.revision),
+                work_item_id: record.id.clone(),
+                expected: authoritative.clone(),
+                record: WorkItemExecutionRecord {
+                    source_revision: record.revision,
+                    state,
+                },
+            }))
+        } else {
+            ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(AdvanceWorkItemSourceRevision {
+                command_id: format!("work_item:update:{}:{}", record.id, record.revision),
+                work_item_id: record.id.clone(),
+                expected_source_revision: authoritative.source_revision,
+                source_revision: record.revision,
+            })
+        };
+        Ok(
+            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: None,
+                commands: vec![command],
+            },
+        )
+    }
+
+    fn plan_work_item_execution_clear_blocker(
+        &self,
+        record: &WorkItemRecord,
+        wait_conditions: &[crate::types::WaitConditionRecord],
+    ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+        use crate::domain::execution_protocol::{
+            AdvanceWorkItemSourceRevision, ExecutionProtocolCommand, ExecutionProtocolState,
+            RegisterWorkItemExecution, SetWorkItemReadiness, WorkItemExecutionRecord,
+            WorkItemExecutionState,
+        };
+
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(Default::default());
+        }
+        let existing = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&record.agent_id)?;
+        let Some(authoritative) = existing
+            .as_ref()
+            .and_then(|state| state.work_items.get(&record.id))
+        else {
+            return Ok(
+                crate::runtime_db::transitions::ExecutionProtocolTransition {
+                    bootstrap: existing
+                        .is_none()
+                        .then(|| ExecutionProtocolState::empty(&record.agent_id)),
+                    commands: vec![ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                        RegisterWorkItemExecution {
+                            work_item_id: record.id.clone(),
+                            record: WorkItemExecutionRecord {
+                                source_revision: record.revision,
+                                state: WorkItemExecutionState::Runnable {
+                                    generation: record.revision,
+                                    recovery_ref: None,
+                                },
+                            },
+                        },
+                    ))],
+                },
+            );
+        };
+        let revision_changed = authoritative.source_revision != record.revision;
+        let command = match &authoritative.state {
+            WorkItemExecutionState::Waiting { generation, .. }
+            | WorkItemExecutionState::Paused { generation, .. } => Some(
+                ExecutionProtocolCommand::SetWorkItemReadiness(Box::new(SetWorkItemReadiness {
+                    command_id: format!(
+                        "work_item:clear_blocker:{}:{}",
+                        record.id, record.revision
+                    ),
+                    work_item_id: record.id.clone(),
+                    expected: authoritative.clone(),
+                    record: WorkItemExecutionRecord {
+                        source_revision: record.revision,
+                        state: WorkItemExecutionState::Runnable {
+                            generation: generation.checked_add(1).ok_or_else(|| {
+                                anyhow!("WorkItem scheduling generation overflow")
+                            })?,
+                            recovery_ref: None,
+                        },
+                    },
+                })),
+            ),
+            WorkItemExecutionState::Runnable { generation, .. } if revision_changed => Some(
+                ExecutionProtocolCommand::SetWorkItemReadiness(Box::new(SetWorkItemReadiness {
+                    command_id: format!(
+                        "work_item:clear_blocker:{}:{}",
+                        record.id, record.revision
+                    ),
+                    work_item_id: record.id.clone(),
+                    expected: authoritative.clone(),
+                    record: WorkItemExecutionRecord {
+                        source_revision: record.revision,
+                        state: WorkItemExecutionState::Runnable {
+                            generation: *generation,
+                            recovery_ref: None,
+                        },
+                    },
+                })),
+            ),
+            WorkItemExecutionState::InFlight { .. }
+            | WorkItemExecutionState::NeedsRepair { .. }
+                if revision_changed =>
+            {
+                Some(ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(
+                    AdvanceWorkItemSourceRevision {
+                        command_id: format!(
+                            "work_item:clear_blocker:{}:{}",
+                            record.id, record.revision
+                        ),
+                        work_item_id: record.id.clone(),
+                        expected_source_revision: authoritative.source_revision,
+                        source_revision: record.revision,
+                    },
+                ))
+            }
+            WorkItemExecutionState::Terminal { .. } => {
+                return Err(anyhow!("cannot clear terminal WorkItem execution state"));
+            }
+            _ => None,
+        };
+        if command.is_none() && !wait_conditions.is_empty() {
+            return Err(anyhow!(
+                "cancelled WorkItem waits require a canonical readiness transition"
+            ));
+        }
+        Ok(
+            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: None,
+                commands: command.into_iter().collect(),
+            },
+        )
     }
 
     pub async fn pick_work_item(
@@ -2663,7 +2962,12 @@ impl RuntimeHandle {
                 }]
             })
             .unwrap_or_default();
-        let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
+        let execution_protocol = if blocker_cleared {
+            self.plan_work_item_execution_clear_blocker(&record, &wait_conditions)?
+        } else {
+            Default::default()
+        };
+        let commit = self.commit_work_item_focus_transition_with_execution(
             &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
                 agent_id: agent_id.clone(),
                 work_items,
@@ -2679,6 +2983,7 @@ impl RuntimeHandle {
                 notify_scheduler: true,
                 fault: self.take_transition_fault(),
             },
+            &execution_protocol,
         )?;
         self.apply_transition_commit(commit).await;
         Ok(PickedWorkItem {
@@ -2753,6 +3058,10 @@ impl RuntimeHandle {
             record.updated_at = Utc::now();
             wrote_item = true;
         }
+        let readiness_mutation = blocked_by.as_ref().map(|blocked_by| match blocked_by {
+            Some(reason) => WorkItemReadinessMutation::Pause(reason.clone()),
+            None => WorkItemReadinessMutation::Resume,
+        });
         if let Some(blocked_by) = blocked_by {
             let now = self.now();
             record.blocked_by = blocked_by;
@@ -2827,7 +3136,9 @@ impl RuntimeHandle {
                     });
                 }
             }
-            let commit = self.inner.runtime_db.transitions().commit_work_item(
+            let execution_protocol =
+                self.plan_work_item_execution_update(&record, readiness_mutation)?;
+            let commit = self.commit_work_item_transition_with_execution(
                 &crate::runtime_db::transitions::WorkItemTransitionCommand {
                     agent_id,
                     mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
@@ -2841,6 +3152,7 @@ impl RuntimeHandle {
                     notify_scheduler: true,
                     fault: self.take_transition_fault(),
                 },
+                &execution_protocol,
             )?;
             self.apply_transition_commit(commit).await;
         }
@@ -2895,7 +3207,7 @@ impl RuntimeHandle {
                 "recheck_consumed_at": record.recheck_consumed_at,
             }),
         ));
-        let commit = self.inner.runtime_db.transitions().commit_work_item(
+        let commit = self.commit_work_item_transition(
             &crate::runtime_db::transitions::WorkItemTransitionCommand {
                 agent_id,
                 mutation: crate::runtime_db::transitions::WorkItemMutation::Update {
@@ -3045,7 +3357,7 @@ impl RuntimeHandle {
                 "completion_intent": record.completion_intent,
             }),
         ));
-        let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
+        let commit = self.commit_work_item_focus_transition(
             &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
                 agent_id,
                 work_items: vec![crate::runtime_db::transitions::WorkItemMutation::Update {
@@ -3577,7 +3889,7 @@ impl RuntimeHandle {
             #[cfg(test)]
             self.apply_completion_binding_replacement_before_commit()
                 .await?;
-            let commit = self.inner.runtime_db.transitions().commit_work_item_focus(
+            let commit = self.commit_work_item_focus_transition(
                 &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
                     agent_id: agent_id.clone(),
                     work_items: vec![crate::runtime_db::transitions::WorkItemMutation::Update {

--- a/src/runtime/tests/contracts/work_item.rs
+++ b/src/runtime/tests/contracts/work_item.rs
@@ -23,6 +23,19 @@ async fn work_item_runtime_path_rolls_back_each_pre_commit_fault() {
             .unwrap();
         let after = harness.snapshot();
         assert_eq!(after.work_items, vec![created]);
+        let execution = after
+            .execution_protocol
+            .as_ref()
+            .expect("create initializes execution protocol");
+        let execution_work = execution
+            .work_items
+            .get(&after.work_items[0].id)
+            .expect("create registers WorkItem execution state");
+        assert_eq!(execution_work.source_revision, after.work_items[0].revision);
+        assert!(matches!(
+            execution_work.state,
+            crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+        ));
         assert_eq!(
             after.index_outbox_high_watermark,
             before.index_outbox_high_watermark + 1
@@ -63,6 +76,14 @@ async fn work_item_post_commit_fault_recovers_projection_after_restart() {
             fault != crate::runtime_db::transitions::TransitionFaultPoint::BeforeCacheUpdate
         );
         let committed = harness.snapshot();
+        assert_eq!(
+            committed
+                .execution_protocol
+                .as_ref()
+                .and_then(|state| state.work_items.get(&created.id))
+                .map(|record| record.source_revision),
+            Some(created.revision)
+        );
 
         harness.restart();
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -240,6 +240,9 @@ fn persist_execution_transition_only(
                     &state, &command,
                 )
             }
+            ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
+                crate::domain::execution_protocol::set_work_item_readiness(&state, &command)
+            }
             ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
                 crate::domain::execution_protocol::set_work_item_waiting(&state, &command)
             }
@@ -924,7 +927,7 @@ async fn interrupted_message_replay_creates_new_turn_without_current_focus_drift
 async fn legacy_recovery_plan_reconciles_an_existing_dispatch_reservation() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -935,6 +938,7 @@ async fn legacy_recovery_plan_reconciles_an_existing_dispatch_reservation() {
         }),
         "default".into(),
         context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
     )
     .unwrap();
     let work_item = runtime
@@ -1276,7 +1280,7 @@ async fn legacy_recovery_commit_returns_typed_rejection_when_source_changes_afte
 async fn legacy_recovery_commit_race_is_diagnostic_and_fresh_retry_converges() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
@@ -1287,6 +1291,7 @@ async fn legacy_recovery_commit_race_is_diagnostic_and_fresh_retry_converges() {
         }),
         "default".into(),
         context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
     )
     .unwrap();
     let work_item = runtime
@@ -3908,10 +3913,12 @@ async fn pre_cutover_task_rejoin_without_execution_owner_is_dropped() {
         .inner
         .runtime_db
         .transaction(|tx| {
-            crate::runtime_db::transitions::persist_state_tx(
-                tx,
-                &crate::domain::execution_protocol::ExecutionProtocolState::empty("default"),
-            )
+            tx.execute(
+                "DELETE FROM execution_protocol_work_items
+                 WHERE agent_id = ?1 AND work_item_id = ?2",
+                ["default", work_item.id.as_str()],
+            )?;
+            Ok(())
         })
         .unwrap();
 
@@ -4028,10 +4035,12 @@ async fn task_rejoin_missing_from_initialized_execution_partition_is_rejected() 
         .inner
         .runtime_db
         .transaction(|tx| {
-            crate::runtime_db::transitions::persist_state_tx(
-                tx,
-                &crate::domain::execution_protocol::ExecutionProtocolState::empty("default"),
-            )
+            tx.execute(
+                "DELETE FROM execution_protocol_work_items
+                 WHERE agent_id = ?1 AND work_item_id = ?2",
+                ["default", work_item.id.as_str()],
+            )?;
+            Ok(())
         })
         .unwrap();
     append_completed_rejoin_task(

--- a/src/runtime/tests/support/lifecycle.rs
+++ b/src/runtime/tests/support/lifecycle.rs
@@ -38,6 +38,8 @@ pub(crate) const POST_COMMIT_FAULTS: [(
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DurableLifecycleSnapshot {
     pub(crate) agent_state: Option<AgentState>,
+    pub(crate) execution_protocol:
+        Option<crate::domain::execution_protocol::ExecutionProtocolState>,
     pub(crate) work_items: Vec<WorkItemRecord>,
     pub(crate) work_item_continuations: Vec<crate::types::WorkItemContinuationFrame>,
     pub(crate) wait_conditions: Vec<crate::types::WaitConditionRecord>,
@@ -173,6 +175,10 @@ impl LifecycleHarness {
                 .agent_states()
                 .latest("default")
                 .expect("read agent state"),
+            execution_protocol: runtime_db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("default")
+                .expect("read execution protocol"),
             work_items: runtime_db
                 .work_items()
                 .latest_all()

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -333,6 +333,169 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
     assert!(cleared.recheck_consumed_at.is_none());
 }
 
+#[tokio::test]
+async fn work_item_mutations_atomically_track_execution_readiness() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("track execution readiness".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("create initializes execution protocol");
+    let registered = execution
+        .work_items
+        .get(&work.id)
+        .expect("create registers WorkItem");
+    assert_eq!(registered.source_revision, work.revision);
+    assert!(matches!(
+        registered.state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+
+    let updated = runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            Some("track updated execution readiness".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let registered = execution.work_items.get(&work.id).unwrap();
+    assert_eq!(registered.source_revision, updated.revision);
+    assert!(matches!(
+        registered.state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+
+    let blocked = runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("manual hold".into())),
+        )
+        .await
+        .unwrap();
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let registered = execution.work_items.get(&work.id).unwrap();
+    assert_eq!(registered.source_revision, blocked.revision);
+    assert!(matches!(
+        &registered.state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused { reason, .. }
+            if reason == "manual hold"
+    ));
+
+    let consumed_recheck = runtime
+        .consume_work_item_recheck(&work.id)
+        .await
+        .unwrap()
+        .expect("blocked recheck is consumed");
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let registered = execution.work_items.get(&work.id).unwrap();
+    assert_eq!(registered.source_revision, consumed_recheck.revision);
+    assert!(matches!(
+        registered.state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused { .. }
+    ));
+
+    let cleared = runtime
+        .pick_work_item_with_reason_and_clear_blocker(
+            work.id.clone(),
+            Some("manual hold resolved".into()),
+            true,
+        )
+        .await
+        .unwrap()
+        .current_work_item;
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let registered = execution.work_items.get(&work.id).unwrap();
+    assert_eq!(registered.source_revision, cleared.revision);
+    assert!(matches!(
+        registered.state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+
+    let before_rejected_block = cleared.clone();
+    let mut waiting_execution = execution;
+    let waiting_record = waiting_execution.work_items.get_mut(&work.id).unwrap();
+    waiting_record.state = crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+        generation: waiting_record.generation() + 1,
+        wait: crate::domain::execution_protocol::WaitReference {
+            wait_id: "wait-active".into(),
+        },
+    };
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &waiting_execution))
+        .unwrap();
+    let error = runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("different manual blocker".into())),
+        )
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("cannot change WorkItem readiness"));
+    assert_eq!(
+        runtime.latest_work_item(&work.id).await.unwrap().unwrap(),
+        before_rejected_block
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn runtime_wakes_itself_for_blocked_work_item_recheck_deadline() {
     let dir = tempdir().unwrap();
@@ -5849,6 +6012,25 @@ async fn pick_blocked_work_item_with_clear_blocker_resumes_runnable_focus() {
         .active_wait_conditions_for_work_item("default", &work.id)
         .unwrap()
         .is_empty());
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("execution protocol remains initialized");
+    let execution_work = execution
+        .work_items
+        .get(&work.id)
+        .expect("clear blocker retains WorkItem execution state");
+    assert_eq!(
+        execution_work.source_revision,
+        picked.current_work_item.revision
+    );
+    assert!(matches!(
+        execution_work.state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
 }
 
 #[tokio::test]

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -661,6 +661,27 @@ impl RuntimeTransitionRepository<'_> {
         &self,
         command: &WorkItemFocusTransitionCommand,
     ) -> Result<TransitionCommit> {
+        self.commit_work_item_focus_internal(
+            command,
+            &ExecutionProtocolTransition::default(),
+            false,
+        )
+    }
+
+    pub fn commit_work_item_focus_with_execution_protocol(
+        &self,
+        command: &WorkItemFocusTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+    ) -> Result<TransitionCommit> {
+        self.commit_work_item_focus_internal(command, execution_protocol, true)
+    }
+
+    fn commit_work_item_focus_internal(
+        &self,
+        command: &WorkItemFocusTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        synchronize_execution_protocol: bool,
+    ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             for work_item in &command.work_items {
                 validate_work_item_mutation_tx(tx, work_item)?;
@@ -673,6 +694,24 @@ impl RuntimeTransitionRepository<'_> {
             }
             validate_agent_state_mutation_tx(tx, Some(&command.agent_state))?;
             validate_focus_target_tx(tx, &command.agent_state.record)?;
+            let execution_protocol = if synchronize_execution_protocol {
+                execution_protocol_repository::synchronize_work_item_revisions_tx(
+                    tx,
+                    &command.agent_id,
+                    execution_protocol,
+                    &command.work_items,
+                )?
+            } else {
+                execution_protocol.clone()
+            };
+            let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
+                tx,
+                &command.agent_id,
+                execution_protocol.bootstrap.as_ref(),
+                &execution_protocol.commands,
+                &command.work_items,
+                &command.wait_conditions,
+            )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
             let agent_state_applied =
@@ -692,9 +731,13 @@ impl RuntimeTransitionRepository<'_> {
             for continuation in &command.continuations {
                 applied |= upsert_work_item_continuation_tx(tx, continuation)?;
             }
+            applied |= execution_protocol
+                .as_ref()
+                .is_some_and(|prepared| prepared.has_writes());
             if !applied {
                 return Ok(TransitionCommit::default());
             }
+            execution_protocol_repository::persist_execution_commands_tx(tx, execution_protocol)?;
             for brief in &command.brief_evidence {
                 insert_brief_evidence_tx(tx, brief)?;
             }
@@ -721,18 +764,58 @@ impl RuntimeTransitionRepository<'_> {
         &self,
         command: &WorkItemTransitionCommand,
     ) -> Result<TransitionCommit> {
+        self.commit_work_item_internal(command, &ExecutionProtocolTransition::default(), false)
+    }
+
+    pub fn commit_work_item_with_execution_protocol(
+        &self,
+        command: &WorkItemTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+    ) -> Result<TransitionCommit> {
+        self.commit_work_item_internal(command, execution_protocol, true)
+    }
+
+    fn commit_work_item_internal(
+        &self,
+        command: &WorkItemTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        synchronize_execution_protocol: bool,
+    ) -> Result<TransitionCommit> {
         let record = command.mutation.record().clone();
         self.db.transaction(|tx| {
             validate_work_item_mutation_tx(tx, &command.mutation)?;
             validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            let work_items = std::slice::from_ref(&command.mutation);
+            let execution_protocol = if synchronize_execution_protocol {
+                execution_protocol_repository::synchronize_work_item_revisions_tx(
+                    tx,
+                    &command.agent_id,
+                    execution_protocol,
+                    work_items,
+                )?
+            } else {
+                execution_protocol.clone()
+            };
+            let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
+                tx,
+                &command.agent_id,
+                execution_protocol.bootstrap.as_ref(),
+                &execution_protocol.commands,
+                work_items,
+                &[],
+            )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
             let mut applied = apply_work_item_mutation_tx(tx, &command.mutation)?;
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             applied |= agent_state_applied;
+            applied |= execution_protocol
+                .as_ref()
+                .is_some_and(|prepared| prepared.has_writes());
             if !applied {
                 return Ok(TransitionCommit::default());
             }
+            execution_protocol_repository::persist_execution_commands_tx(tx, execution_protocol)?;
             for brief in &command.brief_evidence {
                 insert_brief_evidence_tx(tx, brief)?;
             }

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -80,8 +80,14 @@ pub(super) fn validate_execution_commands_tx(
         if let ExecutionProtocolCommand::Admit(command) = command {
             validate_admission_authority_tx(tx, agent_id, &command.attempt.admitted_fences)?;
         }
+        if let ExecutionProtocolCommand::RegisterWorkItem(command) = command {
+            validate_register_work_item(tx, agent_id, command, work_item_mutations)?;
+        }
         if let ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) = command {
             validate_work_item_source_revision_advance(command, work_item_mutations)?;
+        }
+        if let ExecutionProtocolCommand::SetWorkItemReadiness(command) = command {
+            validate_set_work_item_readiness(command, work_item_mutations, wait_conditions)?;
         }
         if let ExecutionProtocolCommand::SetWorkItemWaiting(command) = command {
             validate_set_work_item_waiting(command, work_item_mutations, wait_conditions)?;
@@ -102,6 +108,122 @@ pub(super) fn validate_execution_commands_tx(
         initialized_partition,
         results,
     }))
+}
+
+pub(super) fn synchronize_work_item_revisions_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    transition: &crate::runtime_db::transitions::ExecutionProtocolTransition,
+    work_item_mutations: &[WorkItemMutation],
+) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+    if !partition_exists_tx(tx, agent_id)? {
+        return Ok(transition.clone());
+    }
+    let state = load_state_tx(tx, agent_id)?;
+    let mut synchronized = transition.clone();
+    for mutation in work_item_mutations {
+        let WorkItemMutation::Update { record, .. } = mutation else {
+            continue;
+        };
+        if record.state != crate::types::WorkItemState::Open {
+            continue;
+        }
+        let command_targets_work_item = synchronized.commands.iter().any(|command| match command {
+            ExecutionProtocolCommand::RegisterWorkItem(command) => {
+                command.work_item_id == record.id
+            }
+            ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) => {
+                command.work_item_id == record.id
+            }
+            ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
+                command.work_item_id == record.id
+            }
+            ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
+                command.work_item_id == record.id
+            }
+            _ => false,
+        });
+        let Some(authoritative) = state.work_items.get(&record.id) else {
+            if !command_targets_work_item {
+                let mut statement = tx.prepare(
+                    "SELECT wait_condition_id
+                     FROM wait_conditions
+                     WHERE agent_id = ?1
+                       AND work_item_id = ?2
+                       AND status IN ('active', 'triggered')
+                     ORDER BY created_at ASC, wait_condition_id ASC",
+                )?;
+                let wait_ids = statement
+                    .query_map([agent_id, record.id.as_str()], |row| {
+                        row.get::<_, String>(0)
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                let execution_state = match wait_ids.as_slice() {
+                    [wait_id] => WorkItemExecutionState::Waiting {
+                        generation: record.revision.max(1),
+                        wait: execution_protocol::WaitReference {
+                            wait_id: wait_id.clone(),
+                        },
+                    },
+                    [] if record.blocked_by.is_some() => WorkItemExecutionState::Paused {
+                        generation: record.revision.max(1),
+                        reason: record
+                            .blocked_by
+                            .clone()
+                            .expect("manual blocker checked above"),
+                    },
+                    [] => WorkItemExecutionState::Runnable {
+                        generation: record.revision.max(1),
+                        recovery_ref: None,
+                    },
+                    _ => WorkItemExecutionState::NeedsRepair {
+                        generation: record.revision.max(1),
+                        repair_id: format!("work_item_waits_ambiguous:{}", record.id),
+                    },
+                };
+                synchronized.commands.insert(
+                    0,
+                    ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                        execution_protocol::RegisterWorkItemExecution {
+                            work_item_id: record.id.clone(),
+                            record: execution_protocol::WorkItemExecutionRecord {
+                                source_revision: record.revision,
+                                state: execution_state,
+                            },
+                        },
+                    )),
+                );
+            }
+            continue;
+        };
+        if authoritative.source_revision == record.revision {
+            continue;
+        }
+        if authoritative.source_revision > record.revision {
+            bail!(
+                "WorkItem execution source revision {} exceeds durable revision {}",
+                authoritative.source_revision,
+                record.revision
+            );
+        }
+        if !command_targets_work_item {
+            synchronized.commands.insert(
+                0,
+                ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(
+                    execution_protocol::AdvanceWorkItemSourceRevision {
+                        command_id: format!(
+                            "work_item:auto_revision:{}:{}",
+                            record.id, record.revision
+                        ),
+                        work_item_id: record.id.clone(),
+                        expected_source_revision: authoritative.source_revision,
+                        source_revision: record.revision,
+                    },
+                ),
+            );
+        }
+    }
+    Ok(synchronized)
 }
 
 pub(super) fn persist_execution_commands_tx(
@@ -142,6 +264,9 @@ fn reduce(
         ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) => {
             execution_protocol::advance_work_item_source_revision(state, command)
         }
+        ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
+            execution_protocol::set_work_item_readiness(state, command)
+        }
         ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
             execution_protocol::set_work_item_waiting(state, command)
         }
@@ -164,6 +289,9 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
         }
         ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) => {
             ("advance_work_item_source_revision", &command.command_id)
+        }
+        ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
+            ("set_work_item_readiness", &command.command_id)
         }
         ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
             ("set_work_item_waiting", &command.command_id)
@@ -213,6 +341,42 @@ fn validate_set_work_item_waiting(
     Ok(())
 }
 
+fn validate_register_work_item(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &execution_protocol::RegisterWorkItemExecution,
+    mutations: &[WorkItemMutation],
+) -> Result<()> {
+    let atomic_record = mutations.iter().find_map(|mutation| {
+        let record = mutation.record();
+        (record.id == command.work_item_id
+            && record.revision == command.record.source_revision
+            && !record.agent_id.is_empty())
+        .then_some(record)
+    });
+    if atomic_record.is_some_and(|record| record.state == crate::types::WorkItemState::Open) {
+        return Ok(());
+    }
+    let compatible_record = tx
+        .query_row(
+            "SELECT payload_json
+             FROM work_items
+             WHERE work_item_id = ?1 AND agent_id = ?2",
+            [&command.work_item_id, agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<crate::types::WorkItemRecord>(&payload))
+        .transpose()?;
+    if !compatible_record.is_some_and(|record| {
+        record.state == crate::types::WorkItemState::Open
+            && record.revision == command.record.source_revision
+    }) {
+        bail!("WorkItem registration requires an open WorkItem");
+    }
+    Ok(())
+}
+
 fn validate_work_item_source_revision_advance(
     command: &execution_protocol::AdvanceWorkItemSourceRevision,
     mutations: &[WorkItemMutation],
@@ -229,6 +393,45 @@ fn validate_work_item_source_revision_advance(
     };
     if record.agent_id.is_empty() {
         bail!("WorkItem source revision advance does not match its atomic WorkItem update");
+    }
+    Ok(())
+}
+
+fn validate_set_work_item_readiness(
+    command: &execution_protocol::SetWorkItemReadiness,
+    mutations: &[WorkItemMutation],
+    wait_conditions: &[crate::types::WaitConditionRecord],
+) -> Result<()> {
+    let mutation = mutations.iter().find_map(|mutation| match mutation {
+        WorkItemMutation::Update { record, .. } if record.id == command.work_item_id => {
+            Some(record)
+        }
+        _ => None,
+    });
+    if let Some(record) = mutation {
+        if record.revision != command.record.source_revision || record.agent_id.is_empty() {
+            bail!("WorkItem readiness transition does not match its atomic WorkItem update");
+        }
+    } else if command.record.source_revision != command.expected.source_revision {
+        bail!("WorkItem readiness revision advance requires an atomic WorkItem update");
+    }
+    match &command.record.state {
+        WorkItemExecutionState::Paused { .. } => {
+            if mutation.is_none_or(|record| record.blocked_by.is_none()) {
+                bail!("WorkItem pause transition requires an atomic blocker update");
+            }
+        }
+        WorkItemExecutionState::Runnable { .. } => {
+            let clears_blocker = mutation.is_some_and(|record| record.blocked_by.is_none());
+            let cancels_wait = wait_conditions.iter().any(|condition| {
+                condition.work_item_id.as_deref() == Some(command.work_item_id.as_str())
+                    && condition.status == crate::types::WaitConditionStatus::Cancelled
+            });
+            if !clears_blocker && !cancels_wait {
+                bail!("WorkItem runnable transition requires blocker or wait clearance");
+            }
+        }
+        _ => bail!("WorkItem readiness transition must target Runnable or Paused"),
     }
     Ok(())
 }

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -204,7 +204,7 @@ pub async fn task_result_rejoin_after_compaction_preserves_current_work_truth() 
         "Close the compaction regression gap",
         WorkItemState::Open,
         true,
-        Some("waiting for command task evidence"),
+        None,
     )
     .await?;
     runtime


### PR DESCRIPTION
## Summary

- register canonical WorkItem execution readiness atomically on `CreateWorkItem`
- synchronize every canonical open WorkItem revision mutation with `ExecutionProtocolState` in the same `runtime_db::transitions` transaction
- add fenced `SetWorkItemReadiness` transitions for manual pause and explicit blocker/wait clearance while preserving InFlight ownership
- keep legacy scheduler mutations isolated from the canonical execution aggregate and retain validated lazy registration for historical WorkItems
- extend fault/restart snapshots and regressions for create, update, block, clear-block, wait/rejoin, legacy recovery, and compaction

## Runtime boundary

This is Phase 2A only. It closes the WorkItem mutation → canonical execution-state gap without changing autonomous candidate selection or settlement outcome authority. Those remain the next Phase 2 slice.

Metadata-only revisions update `source_revision` without creating a new scheduling generation. Readiness changes advance generation. Manual blocker changes fail closed while execution is InFlight, Waiting, or NeedsRepair instead of allowing metadata and execution authority to diverge.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- targeted domain, transition, WorkItem, wait, scheduler, legacy-engine, recovery, and compaction regressions

Closes #2526
