### PR TITLE
fix: preserve provider fallback recovery

### DIFF
--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -112,6 +112,7 @@ Allowed transitions are:
 ```text
 Runnable(g) -> InFlight(g, attempt)
 Waiting(g, exact triggered wait) -> InFlight(g, attempt)
+Waiting(g, trusted provider lineage recovery) -> InFlight(g, attempt)
 
 InFlight(g, attempt) -> Runnable(g + 1)
 InFlight(g, attempt) -> Runnable(g + 1, recovery_ref)
@@ -128,6 +129,20 @@ Creating a new eligibility epoch increments the scheduling generation.
 Terminal transition resolves owned waits and continuation obligations and
 removes scheduler eligibility. Focus may be cleared or restored in the same
 transaction, but it does not grant eligibility.
+
+Provider lineage recovery is the only runtime-owned admission that may claim a
+`Waiting` WorkItem without consuming the wait that made it waiting. The source
+must carry runtime-owned `model_lineage_recovery` provenance plus a valid typed
+provider recovery directive. The directive must reference a durable same-agent
+source message, a matching provider-failure terminal Turn, and exactly one
+terminal execution attempt; the new attempt records that identity in
+`recovery_of_attempt_id`. Admission preserves the WorkItem source revision and
+generation fences, records `RuntimeRecovery(recovery_id)` as the execution
+source, and leaves the `WaitCondition` unresolved. Settlement projects the
+WorkItem back to `Waiting` when that wait remains Active or was Triggered while
+recovery owned the lane, so the exact queued wake can consume it next. Provider
+recovery does not admit `Paused`, `NeedsRepair`, `Terminal`, or already
+`InFlight` WorkItems, and it does not clear blockers or waits.
 
 ### WaitCondition
 
@@ -178,6 +193,7 @@ execution.
 | WorkItem continuation | exact runnable generation | WorkItem outcome | `Runnable -> InFlight` |
 | targeted yield/continuation | exact continuation frame | target-compatible outcome | consume exact continuation |
 | internal contentful follow-up | declared interaction or WorkItem binding | binding-compatible outcome | exact claim to terminal |
+| provider lineage recovery | exact Runnable or Waiting WorkItem generation, runtime-owned typed recovery provenance | WorkItem outcome | `Runnable/Waiting -> InFlight`; preserve an existing wait |
 | startup recovery, repair, stale reduction | command-owned, no model binding | typed `CommandResult` | deterministic state repair |
 | shutdown or closed host | none | reject or defer | no execution |
 

--- a/docs/rfcs/turn-model-lineage-and-recovery.md
+++ b/docs/rfcs/turn-model-lineage-and-recovery.md
@@ -359,6 +359,23 @@ the recovery turn must continue from current evidence:
 It should not repeat tool work just because the failed provider's hidden
 continuation state is unavailable.
 
+### 7.4 Recovery Admission Is Independent From Ordinary Work Scheduling
+
+A cross-lineage recovery message is a typed runtime recovery source, not an
+ordinary self-enqueued `InternalFollowup`. When it is bound to an open
+WorkItem, canonical admission may claim the WorkItem at its exact current
+execution generation while the WorkItem is `Runnable` or `Waiting`.
+
+If the WorkItem is waiting, recovery admission must not clear or resolve that
+wait. If the wait is triggered while recovery owns the lane, recovery
+settlement restores the exact `Waiting(wait_id)` execution state before the
+queued wake is admitted. The recovery directive must bind to a durable
+same-agent source message, matching provider-failure terminal Turn, and
+terminal execution attempt; the recovery attempt records that predecessor.
+`Paused`, `NeedsRepair`, `Terminal`, and already `InFlight` WorkItems remain
+ineligible. Missing, malformed, or unbound recovery directives fail closed
+rather than falling back to ordinary internal-follow-up scheduling.
+
 ## 8. Runtime State Model
 
 Suggested runtime additions:

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -551,6 +551,7 @@ fn validate_source_binding(
             QueueMessage { .. } | InternalFollowup { .. },
             Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. },
         ) => true,
+        (RuntimeRecovery { .. }, WorkItem { .. } | Command) => true,
         (TaskResult { .. }, Conversation { .. } | WorkItem { .. } | Command) => true,
         (ChildResult { .. }, Conversation { .. } | WorkItem { .. } | Command) => true,
         (TriggeredWait { .. }, Conversation { .. } | WorkItem { .. } | AgentLifecycle { .. }) => {
@@ -570,7 +571,6 @@ fn validate_source_binding(
             WorkItem { work_item_id },
         ) => target_work_item_id == work_item_id,
         (TargetedContinuation { .. }, Conversation { .. } | Command) => true,
-        (RuntimeRecovery { .. }, Command) => true,
         _ => false,
     };
     if !allowed {
@@ -1293,12 +1293,12 @@ mod tests {
         assert!(validate_source_binding(&queue, &agent_lifecycle, &fences).is_ok());
         assert!(validate_source_binding(&continuation, &work_item, &fences).is_ok());
         assert!(validate_source_binding(&recovery, &ExecutionBinding::Command, &fences).is_ok());
+        assert!(validate_source_binding(&recovery, &work_item, &fences).is_ok());
 
         // Rejected combinations
         assert!(validate_source_binding(&queue, &ExecutionBinding::Command, &fences).is_err());
         assert!(validate_source_binding(&continuation, &conversation, &fences).is_err());
         assert!(validate_source_binding(&recovery, &conversation, &fences).is_err());
-        assert!(validate_source_binding(&recovery, &work_item, &fences).is_err());
         assert!(validate_source_binding(&recovery, &agent_lifecycle, &fences).is_err());
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1031,6 +1031,49 @@ fn execution_protocol_settlement_transition_from_facts(
                     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
                         return Ok(interrupted("work_item_missing"));
                     };
+                    let recovery_wait_id = if matches!(
+                        attempt.source.identity,
+                        crate::domain::execution_protocol::ExecutionSourceIdentity::RuntimeRecovery {
+                            ..
+                        }
+                    ) {
+                        let unresolved_waits = storage
+                            .raw_unresolved_wait_conditions_for_agent(&record.agent_id)?
+                            .into_iter()
+                            .filter(|wait| {
+                                wait.work_item_id.as_deref() == Some(work_item_id.as_str())
+                            })
+                            .collect::<Vec<_>>();
+                        match unresolved_waits.as_slice() {
+                            [] => None,
+                            [wait] => Some(wait.id.clone()),
+                            _ => return Ok(interrupted("wait_outcome_ambiguous")),
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some(wait_id) = recovery_wait_id {
+                        return Ok(
+                            crate::runtime_db::transitions::ExecutionProtocolTransition {
+                                bootstrap: None,
+                                commands: vec![ExecutionProtocolCommand::Settle(SettleExecution {
+                                    outcome: ExecutionOutcomeRecord {
+                                        outcome_id: format!(
+                                            "outcome:message:{}",
+                                            record.message_id
+                                        ),
+                                        attempt_id: attempt.attempt_id.clone(),
+                                        outcome: ExecutionOutcome::WorkItem(
+                                            WorkItemOutcome::Wait {
+                                                wait: WaitReference { wait_id },
+                                            },
+                                        ),
+                                        created_at: record.updated_at.to_rfc3339(),
+                                    },
+                                })],
+                            },
+                        );
+                    }
                     let scheduling = storage
                         .work_queue_prompt_projection()?
                         .items

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -31,6 +31,9 @@ pub(crate) enum CanonicalActivationScenario {
     WorkItemAutonomousContinuation {
         work_item_id: String,
     },
+    ProviderRecovery {
+        work_item_id: String,
+    },
     InternalFollowup {
         work_item_id: String,
     },
@@ -56,6 +59,9 @@ pub(crate) enum CanonicalActivationScenario {
 pub(crate) enum CanonicalActivationCandidate {
     UnboundTaskResultWaitOrReduce,
     WorkItemAutonomousContinuation {
+        work_item_id: String,
+    },
+    ProviderRecovery {
         work_item_id: String,
     },
     InternalFollowup {
@@ -99,6 +105,7 @@ impl CanonicalActivationScenario {
     pub(crate) fn work_item_id(&self) -> Option<&str> {
         match self {
             Self::WorkItemAutonomousContinuation { work_item_id }
+            | Self::ProviderRecovery { work_item_id }
             | Self::InternalFollowup { work_item_id }
             | Self::ExactTaskRejoin { work_item_id, .. }
             | Self::ExplicitlyBoundOperatorInput { work_item_id, .. } => Some(work_item_id),
@@ -112,9 +119,9 @@ impl CanonicalActivationCandidate {
     pub(crate) fn scenario_class(&self) -> SchedulerScenarioClass {
         match self {
             Self::UnboundTaskResultWaitOrReduce => EXACT_WAIT_RESUME_SCENARIO,
-            Self::WorkItemAutonomousContinuation { .. } | Self::InternalFollowup { .. } => {
-                WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO
-            }
+            Self::WorkItemAutonomousContinuation { .. }
+            | Self::ProviderRecovery { .. }
+            | Self::InternalFollowup { .. } => WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
             Self::ExactTaskRejoin { .. } => EXACT_TASK_REJOIN_SCENARIO,
             Self::ExactWaitResume { .. } | Self::LifecycleExternalNudge { .. } => {
                 EXACT_WAIT_RESUME_SCENARIO
@@ -127,6 +134,7 @@ impl CanonicalActivationCandidate {
         match self {
             Self::UnboundTaskResultWaitOrReduce => None,
             Self::WorkItemAutonomousContinuation { work_item_id }
+            | Self::ProviderRecovery { work_item_id }
             | Self::InternalFollowup { work_item_id }
             | Self::ExactTaskRejoin { work_item_id, .. }
             | Self::ExplicitlyBoundOperatorInput { work_item_id } => Some(work_item_id),
@@ -1145,6 +1153,13 @@ pub(crate) fn canonical_activation_candidate(
         }));
     }
     if message.kind == MessageKind::InternalFollowup {
+        if let Some(work_item_id) = message.work_item_id.clone() {
+            if super::turn::TurnModelSelection::message_has_provider_recovery_provenance(message) {
+                return Ok(Some(CanonicalActivationCandidate::ProviderRecovery {
+                    work_item_id,
+                }));
+            }
+        }
         return Ok(if let Some(work_item_id) = message.work_item_id.clone() {
             Some(CanonicalActivationCandidate::InternalFollowup { work_item_id })
         } else if runtime_owned_internal_followup(message) {
@@ -1266,6 +1281,11 @@ pub(crate) fn resolve_canonical_activation_scenario(
         return Ok(Some(
             CanonicalActivationScenario::WorkItemAutonomousContinuation { work_item_id },
         ));
+    }
+    if let CanonicalActivationCandidate::ProviderRecovery { work_item_id } = candidate {
+        return Ok(Some(CanonicalActivationScenario::ProviderRecovery {
+            work_item_id,
+        }));
     }
     if let CanonicalActivationCandidate::InternalFollowup { work_item_id } = candidate {
         return Ok(Some(CanonicalActivationScenario::InternalFollowup {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1153,6 +1153,33 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         };
         if matches!(
             scenario,
+            scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
+        ) {
+            if !crate::runtime::turn::TurnModelSelection::message_has_valid_provider_recovery(
+                message,
+            ) {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_provider_recovery_directive_invalid",
+                });
+            }
+            if !matches!(
+                work_projection.scheduling_state,
+                crate::types::WorkItemSchedulingState::Runnable
+                    | crate::types::WorkItemSchedulingState::WaitingOperator
+                    | crate::types::WorkItemSchedulingState::WaitingTask
+                    | crate::types::WorkItemSchedulingState::WaitingExternal
+                    | crate::types::WorkItemSchedulingState::WaitingTimer
+                    | crate::types::WorkItemSchedulingState::WaitingSystem
+            ) {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_provider_recovery_work_item_not_recoverable",
+                });
+            }
+        }
+        if matches!(
+            scenario,
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
                 | scheduler::CanonicalActivationScenario::InternalFollowup { .. }
         ) && work_projection.scheduling_state != crate::types::WorkItemSchedulingState::Runnable
@@ -1171,6 +1198,43 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let authoritative_work = existing_execution
             .as_ref()
             .and_then(|state| state.work_items.get(work_item_id));
+        let recovery_of_attempt_id = if matches!(
+            scenario,
+            scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
+        ) {
+            let Some(attempt_id) =
+                self.provider_recovery_source_attempt_id(message, existing_execution.as_ref())?
+            else {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_provider_recovery_source_invalid",
+                });
+            };
+            Some(attempt_id)
+        } else {
+            None
+        };
+        if matches!(
+            scenario,
+            scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
+        ) {
+            let Some(authoritative_work) = authoritative_work else {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_provider_recovery_execution_authority_missing",
+                });
+            };
+            if !matches!(
+                authoritative_work.state,
+                crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+                    | crate::domain::execution_protocol::WorkItemExecutionState::Waiting { .. }
+            ) {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_provider_recovery_execution_not_recoverable",
+                });
+            }
+        }
         let wait_id = match &scenario {
             scheduler::CanonicalActivationScenario::ExactTaskRejoin { wait_id, .. }
             | scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
@@ -1181,6 +1245,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 Some(wait_id.as_str())
             }
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+            | scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
             | scheduler::CanonicalActivationScenario::InternalFollowup { .. } => None,
             scheduler::CanonicalActivationScenario::LifecycleExternalNudge { .. } => {
                 unreachable!("lifecycle scenario is planned before WorkItem lookup")
@@ -1203,7 +1268,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     reason: "canonical_wait_execution_authority_mismatch",
                 });
             }
-        } else if authoritative_work.is_some_and(|record| {
+        } else if !matches!(
+            scenario,
+            scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
+        ) && authoritative_work.is_some_and(|record| {
             !matches!(
                 record.state,
                 crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
@@ -1244,6 +1312,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &activation_id,
             Some((&work_item, scheduling_generation)),
             wait_id,
+            recovery_of_attempt_id,
         )?;
         let work_item_expectation = matches!(
             scenario,
@@ -1334,8 +1403,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 reason: "canonical_execution_attempt_replay_conflict",
             });
         }
-        let execution_protocol =
-            self.plan_execution_protocol_claim(message, &scenario, &activation_id, None, wait_id)?;
+        let execution_protocol = self.plan_execution_protocol_claim(
+            message,
+            &scenario,
+            &activation_id,
+            None,
+            wait_id,
+            None,
+        )?;
         Ok(CanonicalClaimOutcome::Plan(CanonicalClaimPlan {
             activation_id,
             scenario_class,
@@ -1454,6 +1529,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         attempt_id: &str,
         work_item: Option<(&crate::types::WorkItemRecord, u64)>,
         admitted_wait_id: Option<&str>,
+        recovery_of_attempt_id: Option<String>,
     ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
         use crate::domain::execution_protocol::{
             AdmitExecution, AdmittedFences, ExecutionAttempt, ExecutionAttemptState,
@@ -1502,6 +1578,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             } => ExecutionSourceIdentity::WorkItemContinuation {
                 work_item_id: work_item_id.clone(),
             },
+            scheduler::CanonicalActivationScenario::ProviderRecovery { .. } => {
+                ExecutionSourceIdentity::RuntimeRecovery {
+                    recovery_id: message.id.clone(),
+                }
+            }
             scheduler::CanonicalActivationScenario::ExactTaskRejoin { task_id, .. } => {
                 ExecutionSourceIdentity::TaskResult {
                     task_id: task_id.clone(),
@@ -1633,7 +1714,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 state: ExecutionAttemptState::Open,
                 run_id: None,
                 turn_id: message.turn_id.clone(),
-                recovery_of_attempt_id: None,
+                recovery_of_attempt_id,
                 terminal_outcome_id: None,
                 admitted_at: Utc::now().to_rfc3339(),
                 terminal_at: None,
@@ -1647,6 +1728,84 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 commands,
             },
         )
+    }
+
+    fn provider_recovery_source_attempt_id(
+        &self,
+        message: &MessageEnvelope,
+        execution: Option<&crate::domain::execution_protocol::ExecutionProtocolState>,
+    ) -> Result<Option<String>> {
+        use crate::domain::execution_protocol::ExecutionAttemptState;
+
+        let selection = crate::runtime::turn::TurnModelSelection::from_message(message)?;
+        let Some(recovery) = selection.recovery.as_ref() else {
+            return Ok(None);
+        };
+        if !matches!(
+            recovery.source_terminal_kind,
+            crate::types::TurnTerminalKind::DeferredToFallback
+                | crate::types::TurnTerminalKind::ProviderFailedNeedsRecovery
+        ) || message.source_refs.get("source_turn_id") != Some(&recovery.source_turn_id)
+            || message.source_refs.get("source_message_id") != Some(&recovery.source_message_id)
+            || message.causation_id.as_deref() != Some(recovery.source_message_id.as_str())
+        {
+            return Ok(None);
+        }
+        let Some(source_message) = self
+            .runtime
+            .inner
+            .storage
+            .read_message_by_id(&recovery.source_message_id)?
+        else {
+            return Ok(None);
+        };
+        if source_message.agent_id != message.agent_id
+            || source_message.turn_id.as_deref() != Some(recovery.source_turn_id.as_str())
+        {
+            return Ok(None);
+        }
+        let Some(source_turn) = self
+            .runtime
+            .inner
+            .storage
+            .read_turn_by_id(&recovery.source_turn_id)?
+        else {
+            return Ok(None);
+        };
+        if source_turn.agent_id != message.agent_id
+            || source_turn
+                .trigger
+                .as_ref()
+                .and_then(|trigger| trigger.message_id.as_deref())
+                != Some(recovery.source_message_id.as_str())
+            || source_turn.terminal.as_ref().map(|terminal| terminal.kind)
+                != Some(recovery.source_terminal_kind)
+        {
+            return Ok(None);
+        }
+        let Some(execution) = execution else {
+            return Ok(None);
+        };
+        let matching_attempts = execution
+            .attempts
+            .values()
+            .filter(|attempt| {
+                attempt.agent_id == message.agent_id
+                    && attempt.source_message_id.as_deref()
+                        == Some(recovery.source_message_id.as_str())
+                    && attempt.turn_id.as_deref() == Some(recovery.source_turn_id.as_str())
+                    && matches!(
+                        attempt.state,
+                        ExecutionAttemptState::Settled | ExecutionAttemptState::Interrupted
+                    )
+                    && attempt.terminal_outcome_id.is_some()
+            })
+            .map(|attempt| attempt.attempt_id.clone())
+            .collect::<Vec<_>>();
+        Ok(match matching_attempts.as_slice() {
+            [attempt_id] => Some(attempt_id.clone()),
+            _ => None,
+        })
     }
 
     async fn defer_or_quarantine_queue_head(
@@ -1892,6 +2051,13 @@ fn execution_attempt_matches_scenario(
             },
         ) => source_work_item_id == expected && work_item_id == expected,
         (
+            ExecutionSourceIdentity::RuntimeRecovery { recovery_id },
+            ExecutionBinding::WorkItem { work_item_id },
+            scheduler::CanonicalActivationScenario::ProviderRecovery {
+                work_item_id: expected,
+            },
+        ) => recovery_id == &message.id && work_item_id == expected,
+        (
             ExecutionSourceIdentity::InternalFollowup { message_id },
             ExecutionBinding::WorkItem { work_item_id },
             scheduler::CanonicalActivationScenario::InternalFollowup {
@@ -2052,6 +2218,9 @@ fn canonical_activation_origin_for_scenario(
         scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. } => {
             ActivationOrigin::System
         }
+        scheduler::CanonicalActivationScenario::ProviderRecovery { .. } => {
+            ActivationOrigin::RuntimeRecovery
+        }
         scheduler::CanonicalActivationScenario::InternalFollowup { .. }
             if !scheduler::runtime_owned_internal_followup(message) =>
         {
@@ -2076,6 +2245,7 @@ fn canonical_activation_trust_for_scenario(
     use crate::domain::scheduler_protocol::ActivationTrust;
     match scenario {
         scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation { .. }
+        | scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
         | scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. } => {
             ActivationTrust::RuntimeInstruction
         }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -81,6 +81,135 @@ fn trusted_operator_prompt(work_item_id: Option<&str>, text: &str) -> MessageEnv
     message
 }
 
+fn provider_recovery_message(runtime: &RuntimeHandle, work_item_id: &str) -> MessageEnvelope {
+    use crate::domain::execution_protocol::{
+        AdmitExecution, AdmittedFences, ConversationOutcome, ExecutionAttempt,
+        ExecutionAttemptState, ExecutionBinding, ExecutionOrigin, ExecutionOutcome,
+        ExecutionOutcomeRecord, ExecutionPriority, ExecutionProvenance, ExecutionSource,
+        ExecutionSourceIdentity, ExecutionTrust, SettleExecution,
+    };
+
+    let mut source = trusted_operator_prompt(None, "source provider failure");
+    source.turn_id = Some("turn-provider-failure".into());
+    source.message_seq = Some(1);
+    runtime.storage().append_message(&source).unwrap();
+    let mut source_turn = TurnRecord::new("default", "turn-provider-failure", 1);
+    source_turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&source));
+    source_turn.input_message_ids = vec![source.id.clone()];
+    source_turn.terminal = Some(crate::types::TurnTerminalSummary {
+        kind: TurnTerminalKind::DeferredToFallback,
+        reason: None,
+        completed_at: Utc::now(),
+        duration_ms: 1,
+    });
+    runtime.storage().append_turn(&source_turn).unwrap();
+
+    let state = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap_or_else(|| {
+            crate::domain::execution_protocol::ExecutionProtocolState::empty("default")
+        });
+    let source_attempt_id = format!("attempt-provider-failure:{}", source.id);
+    let admitted = crate::domain::execution_protocol::admit_execution(
+        &state,
+        &AdmitExecution {
+            attempt: ExecutionAttempt {
+                attempt_id: source_attempt_id.clone(),
+                agent_id: "default".into(),
+                source_message_id: Some(source.id.clone()),
+                source: ExecutionSource {
+                    identity: ExecutionSourceIdentity::QueueMessage {
+                        message_id: source.id.clone(),
+                    },
+                    generation: 1,
+                },
+                binding: ExecutionBinding::AgentLifecycle {
+                    agent_id: "default".into(),
+                },
+                provenance: ExecutionProvenance {
+                    origin: ExecutionOrigin::Operator,
+                    trust: ExecutionTrust::OperatorInstruction,
+                    priority: ExecutionPriority::Interject,
+                    correlation_id: None,
+                    causation_id: None,
+                },
+                admitted_fences: AdmittedFences {
+                    source_revision: 1,
+                    work_item_source_revision: None,
+                    work_item_generation: None,
+                    rejoin: None,
+                    agent_control_revision: 1,
+                    host_registry_revision: 1,
+                },
+                state: ExecutionAttemptState::Open,
+                run_id: None,
+                turn_id: source.turn_id.clone(),
+                recovery_of_attempt_id: None,
+                terminal_outcome_id: None,
+                admitted_at: Utc::now().to_rfc3339(),
+                terminal_at: None,
+            },
+        },
+    )
+    .unwrap();
+    let settled = crate::domain::execution_protocol::settle_execution(
+        &admitted.state,
+        &SettleExecution {
+            outcome: ExecutionOutcomeRecord {
+                outcome_id: format!("outcome-provider-failure:{}", source.id),
+                attempt_id: source_attempt_id,
+                outcome: ExecutionOutcome::Conversation(ConversationOutcome::Replied),
+                created_at: Utc::now().to_rfc3339(),
+            },
+        },
+    )
+    .unwrap();
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &settled.state))
+        .unwrap();
+
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "model_lineage_recovery".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "continue provider recovery".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item_id.into());
+    message.causation_id = Some(source.id.clone());
+    message
+        .source_refs
+        .insert("source_turn_id".into(), "turn-provider-failure".into());
+    message
+        .source_refs
+        .insert("source_message_id".into(), source.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "provider_recovery": {
+            "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+            "source_turn_id": "turn-provider-failure",
+            "source_message_id": source.id,
+            "source_terminal_kind": "deferred_to_fallback",
+            "source_round": 1
+        }
+    }));
+    message
+}
+
 fn append_default_host_identity(runtime: &RuntimeHandle) {
     runtime
         .runtime_db()
@@ -197,7 +326,15 @@ fn persist_waiting_work_execution(
     wait_id: &str,
 ) {
     let generation = work_item.revision.max(1);
-    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    let mut execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap_or_else(|| {
+            crate::domain::execution_protocol::ExecutionProtocolState::empty("default")
+        });
     execution.work_items.insert(
         work_item.id.clone(),
         crate::domain::execution_protocol::WorkItemExecutionRecord {
@@ -8819,6 +8956,668 @@ async fn stale_bound_internal_followup_is_dropped_before_operator_resume() {
         panic!("new operator input should advance after the stale follow-up");
     };
     assert_eq!(scheduled.message.id, operator.id);
+}
+
+#[tokio::test]
+async fn provider_recovery_claims_waiting_work_item_without_clearing_wait() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "provider recovery while waiting".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#provider-recovery".into()),
+            "waiting for external review".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        runtime
+            .storage()
+            .work_queue_prompt_projection()
+            .unwrap()
+            .items
+            .into_iter()
+            .find(|item| item.id == work_item.id)
+            .map(|item| item.scheduling_state),
+        Some(WorkItemSchedulingState::WaitingExternal)
+    );
+    persist_waiting_work_execution(&runtime, &waiting_work_item, &registration.condition.id);
+
+    let recovery = runtime
+        .enqueue(provider_recovery_message(&runtime, &work_item.id))
+        .await
+        .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("trusted provider recovery should claim the waiting WorkItem");
+    };
+    assert_eq!(scheduled.message.id, recovery.id);
+
+    let activation_id = scheduler_executor::canonical_activation_id(&recovery.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("provider recovery should preserve execution authority");
+    let attempt = &execution.attempts[&activation_id];
+    assert!(matches!(
+        attempt.source.identity,
+        crate::domain::execution_protocol::ExecutionSourceIdentity::RuntimeRecovery {
+            ref recovery_id
+        } if recovery_id == &recovery.id
+    ));
+    assert_eq!(
+        attempt.provenance.origin,
+        crate::domain::execution_protocol::ExecutionOrigin::RuntimeRecovery
+    );
+    assert_eq!(
+        attempt.provenance.trust,
+        crate::domain::execution_protocol::ExecutionTrust::RuntimeInstruction
+    );
+    let expected_source_attempt_id = format!(
+        "attempt-provider-failure:{}",
+        recovery.causation_id.as_deref().unwrap()
+    );
+    assert_eq!(
+        attempt.recovery_of_attempt_id.as_deref(),
+        Some(expected_source_attempt_id.as_str())
+    );
+    assert!(matches!(
+        &execution.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            attempt_id,
+            ..
+        } if attempt_id == &activation_id
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Active)
+    );
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&recovery, Some(&work_item.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: recovery.id.clone(),
+                agent_id: recovery.agent_id.clone(),
+                priority: recovery.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: recovery.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        &settled.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == registration.condition.id
+    ));
+    let outcome_id = settled.attempts[&activation_id]
+        .terminal_outcome_id
+        .as_deref()
+        .unwrap();
+    assert!(matches!(
+        &settled.outcomes[outcome_id].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Wait { wait }
+        ) if wait.wait_id == registration.condition.id
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Active)
+    );
+}
+
+#[tokio::test]
+async fn provider_recovery_claims_execution_waiting_projection_drift() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "recover execution waiting projection drift".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .storage()
+            .work_queue_prompt_projection()
+            .unwrap()
+            .items
+            .into_iter()
+            .find(|item| item.id == work_item.id)
+            .map(|item| item.scheduling_state),
+        Some(WorkItemSchedulingState::Runnable)
+    );
+    persist_waiting_work_execution(&runtime, &work_item, "wait-stale-projection");
+
+    let recovery = runtime
+        .enqueue(provider_recovery_message(&runtime, &work_item.id))
+        .await
+        .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("provider recovery should repair execution Waiting projection drift");
+    };
+    assert_eq!(scheduled.message.id, recovery.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        &execution.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight { .. }
+    ));
+}
+
+#[tokio::test]
+async fn malformed_provider_recovery_cannot_claim_waiting_work_item() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "reject malformed provider recovery".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#malformed-provider-recovery".into()),
+            "waiting for external review".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    persist_waiting_work_execution(&runtime, &waiting_work_item, &registration.condition.id);
+
+    let mut malformed = provider_recovery_message(&runtime, &work_item.id);
+    malformed.metadata = None;
+    let malformed = runtime.enqueue(malformed).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == malformed.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dropped)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == malformed.id
+                && event.data["reason"] == "canonical_provider_recovery_directive_invalid"
+        }));
+    assert!(matches!(
+        &runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .unwrap()
+            .work_items[&work_item.id]
+            .state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == registration.condition.id
+    ));
+}
+
+#[tokio::test]
+async fn provider_recovery_rejects_missing_durable_source() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "reject provider recovery with missing source".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::External,
+            Some("github:holon-run/holon#missing-recovery-source".into()),
+            "waiting for external review".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    persist_waiting_work_execution(&runtime, &waiting_work_item, &registration.condition.id);
+
+    let mut forged = provider_recovery_message(&runtime, &work_item.id);
+    forged.causation_id = Some("message-missing-provider-failure".into());
+    forged.source_refs.insert(
+        "source_message_id".into(),
+        "message-missing-provider-failure".into(),
+    );
+    forged.metadata.as_mut().unwrap()["provider_recovery"]["source_message_id"] =
+        serde_json::json!("message-missing-provider-failure");
+    let forged = runtime.enqueue(forged).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == forged.id
+                && event.data["reason"] == "canonical_provider_recovery_source_invalid"
+        }));
+}
+
+#[tokio::test]
+async fn triggered_wait_survives_provider_recovery_settlement_and_resumes() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "provider recovery wait trigger race".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting for operator".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work_item = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    persist_waiting_work_execution(&runtime, &waiting_work_item, &registration.condition.id);
+
+    let recovery = runtime
+        .enqueue(provider_recovery_message(&runtime, &work_item.id))
+        .await
+        .unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let wake = runtime
+        .enqueue(trusted_operator_prompt(
+            Some(&work_item.id),
+            "operator wakes recovery wait",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Triggered)
+    );
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&recovery, Some(&work_item.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: recovery.id.clone(),
+                agent_id: recovery.agent_id.clone(),
+                priority: recovery.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: recovery.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        &settled.work_items[&work_item.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
+            if wait.wait_id == registration.condition.id
+    ));
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("triggered wait should resume after provider recovery settlement");
+    };
+    assert_eq!(scheduled.message.id, wake.id);
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Resolved)
+    );
+}
+
+#[tokio::test]
+async fn provider_recovery_cannot_claim_blocked_work_item() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "provider recovery blocked boundary".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let blocked = runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("manual blocker".into())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .storage()
+            .work_queue_prompt_projection()
+            .unwrap()
+            .items
+            .into_iter()
+            .find(|item| item.id == work_item.id)
+            .map(|item| item.scheduling_state),
+        Some(WorkItemSchedulingState::Blocked)
+    );
+    persist_waiting_work_execution(&runtime, &blocked, "wait-blocked-boundary");
+
+    let recovery = runtime
+        .enqueue(provider_recovery_message(&runtime, &work_item.id))
+        .await
+        .unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == recovery.id
+                && event.data["reason"] == "canonical_provider_recovery_work_item_not_recoverable"
+        }));
+}
+
+#[tokio::test]
+async fn provider_recovery_cannot_claim_paused_execution() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "provider recovery paused execution boundary".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let generation = work_item.revision.max(1);
+    let mut execution = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: generation,
+            state: crate::domain::execution_protocol::WorkItemExecutionState::Paused {
+                generation,
+                reason: "manual pause".into(),
+            },
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+
+    let recovery = runtime
+        .enqueue(provider_recovery_message(&runtime, &work_item.id))
+        .await
+        .unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == recovery.id
+                && event.data["reason"] == "canonical_provider_recovery_execution_not_recoverable"
+        }));
 }
 
 #[tokio::test]

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1415,6 +1415,71 @@ fn runtime_owned_unbound_child_followup_is_lifecycle_nudge() {
 }
 
 #[test]
+fn trusted_bound_provider_recovery_has_a_dedicated_candidate() {
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "model_lineage_recovery".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "continue provider recovery".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some("work-provider-recovery".into());
+    message.metadata = Some(serde_json::json!({
+        "provider_recovery": {
+            "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+            "source_turn_id": "turn-provider-failure",
+            "source_message_id": "message-provider-failure",
+            "source_terminal_kind": "deferred_to_fallback",
+            "source_round": 1
+        }
+    }));
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        Some(scheduler::CanonicalActivationCandidate::ProviderRecovery {
+            work_item_id: "work-provider-recovery".into(),
+        })
+    );
+}
+
+#[test]
+fn malformed_bound_provider_recovery_keeps_its_dedicated_candidate() {
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "model_lineage_recovery".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "missing provider recovery directive".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some("work-malformed-recovery".into());
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        Some(scheduler::CanonicalActivationCandidate::ProviderRecovery {
+            work_item_id: "work-malformed-recovery".into(),
+        })
+    );
+}
+
+#[test]
 fn runtime_owned_unbound_system_followup_is_lifecycle_nudge() {
     let message = MessageEnvelope::new(
         "default",

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -69,15 +69,23 @@ enum OperatorInterjectionPlan {
 }
 
 impl TurnModelSelection {
-    pub(crate) fn from_message(message: &MessageEnvelope) -> Result<Self> {
-        let trusted_recovery = message.kind == MessageKind::InternalFollowup
+    pub(crate) fn message_has_provider_recovery_provenance(message: &MessageEnvelope) -> bool {
+        message.kind == MessageKind::InternalFollowup
             && message.authority_class == AuthorityClass::RuntimeInstruction
             && message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
             && message.admission_context == Some(AdmissionContext::RuntimeOwned)
             && matches!(
                 &message.origin,
                 MessageOrigin::System { subsystem } if subsystem == "model_lineage_recovery"
-            );
+            )
+    }
+
+    pub(crate) fn message_has_valid_provider_recovery(message: &MessageEnvelope) -> bool {
+        Self::from_message(message).is_ok_and(|selection| selection.recovery.is_some())
+    }
+
+    pub(crate) fn from_message(message: &MessageEnvelope) -> Result<Self> {
+        let trusted_recovery = Self::message_has_provider_recovery_provenance(message);
         if !trusted_recovery {
             return Ok(Self::default());
         }


### PR DESCRIPTION
## Summary

Fixes #2529.

- classify runtime-owned `model_lineage_recovery` as a dedicated canonical provider-recovery activation instead of a generic `InternalFollowup`
- admit recovery against exact `Runnable` or `Waiting` WorkItem execution generations while preserving blockers and unresolved waits
- bind recovery to a durable same-agent source message, provider-failure terminal Turn, and terminal execution attempt; record `recovery_of_attempt_id`
- preserve a wait that becomes Triggered during recovery settlement so the exact queued wake can resume next
- keep malformed/unbound recovery, blocked/paused WorkItems, and ordinary internal follow-ups fail closed
- update the model-lineage and unified execution RFCs

## Verification

- `cargo test provider_recovery --no-default-features`
- `cargo test runtime::tests::runtime_state::stale_bound_internal_followup_is_dropped_before_operator_resume --no-default-features`
- `cargo test domain::execution_protocol::tests::source_binding_matrix_rejects_unsupported_combinations --no-default-features`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- independent review: no remaining blocker/high findings
