### PR TITLE
fix: replay interrupted turns after daemon restart

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -711,6 +711,12 @@ impl RuntimeHost {
         let recovered_queue_agent_ids = self
             .runtime_db()
             .recover_orphaned_dequeued_claims_at_startup()?;
+        let queue_recovery_candidate_ids = self
+            .runtime_db()
+            .queue_entries()
+            .recovery_candidate_agent_ids()?
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
         let active_task_owner_ids = self
             .runtime_db()
             .tasks()
@@ -721,13 +727,17 @@ impl RuntimeHost {
             .iter()
             .cloned()
             .collect::<std::collections::BTreeSet<_>>();
+        recovery_agent_ids.extend(queue_recovery_candidate_ids.iter().cloned());
         recovery_agent_ids.extend(active_task_owner_ids.iter().cloned());
         for agent_id in recovery_agent_ids {
             let state = self
                 .agent_storage_read_only(&agent_id)?
                 .read_agent()?
                 .unwrap_or_else(|| AgentState::new(&agent_id));
-            if state.status == AgentStatus::Stopped && !active_task_owner_ids.contains(&agent_id) {
+            if state.status == AgentStatus::Stopped
+                && !active_task_owner_ids.contains(&agent_id)
+                && !queue_recovery_candidate_ids.contains(&agent_id)
+            {
                 continue;
             }
             let runtime = self
@@ -3083,7 +3093,8 @@ mod tests {
             AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
             BriefRecord, ControlAction, DeliverySummaryRecord, MessageBody, MessageEnvelope,
             MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
-            TaskRecoverySpec, TaskStatus, TurnTerminalKind, WorkItemRecord, WorkItemState,
+            TaskRecoverySpec, TaskStatus, TurnTerminalKind, WaitConditionKind, WaitConditionRecord,
+            WaitConditionStatus, WakeSource, WorkItemRecord, WorkItemState,
         },
     };
 
@@ -5401,7 +5412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_loop_failure_preserves_canonical_claim_and_reconciles_on_next_host_access() {
+    async fn runtime_loop_failure_reconciles_and_replays_canonical_claim_on_next_host_access() {
         let (_home, host) = canonical_test_host();
         let agent_id = host.config().default_agent_id.clone();
         let runtime = host.default_runtime().await.unwrap();
@@ -5474,40 +5485,53 @@ mod tests {
         assert_eq!(rebuilt.agent_state().await.unwrap().id, agent_id);
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         loop {
-            let queue_reconciled = rebuilt
+            let queue_replayed = rebuilt
                 .storage()
                 .latest_queue_entries()
                 .unwrap()
                 .iter()
                 .any(|entry| {
-                    entry.message_id == message.id && entry.status == QueueEntryStatus::Interrupted
+                    entry.message_id == message.id && entry.status == QueueEntryStatus::Processed
                 });
-            let recovery_recorded = rebuilt
+            let events = rebuilt.storage().read_recent_events(64).unwrap();
+            let recovery_recorded = events.iter().any(|event| {
+                event.kind == "scheduler_bootstrap_claim_recovered"
+                    && event.data["message_id"].as_str() == Some(message.id.as_str())
+                    && event.data["recovery_outcome"].as_str()
+                        == Some("attempt_interrupted_for_reentry")
+            });
+            let replay_started = events.iter().any(|event| {
+                event.kind == "turn_replay_started"
+                    && event.data["message_id"].as_str() == Some(message.id.as_str())
+            });
+            let brief_delivered = rebuilt
                 .storage()
-                .read_recent_events(32)
+                .read_recent_briefs(10)
                 .unwrap()
                 .iter()
-                .any(|event| {
-                    event.kind == "scheduler_bootstrap_claim_recovered"
-                        && event.data["message_id"].as_str() == Some(message.id.as_str())
-                        && event.data["recovery_outcome"].as_str()
-                            == Some("attempt_interrupted_for_reentry")
-                });
-            if queue_reconciled && recovery_recorded {
+                .any(|brief| brief.related_message_id.as_deref() == Some(message.id.as_str()));
+            if queue_replayed && recovery_recorded && replay_started && brief_delivered {
                 break;
             }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "timed out waiting for canonical claim reconciliation"
-            );
+            if tokio::time::Instant::now() >= deadline {
+                let queue = rebuilt.storage().latest_queue_entries().unwrap();
+                let briefs = rebuilt.storage().read_recent_briefs(10).unwrap();
+                let task_finished = host
+                    .inner
+                    .runtimes
+                    .read()
+                    .await
+                    .agents
+                    .get(&agent_id)
+                    .is_none_or(|entry| entry.task.is_finished());
+                panic!(
+                    "timed out waiting for canonical claim reconciliation and replay: \
+                     queue={queue:?}, events={events:?}, briefs={briefs:?}, \
+                     task_finished={task_finished}"
+                );
+            }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        assert!(rebuilt
-            .storage()
-            .read_recent_briefs(10)
-            .unwrap()
-            .iter()
-            .all(|brief| brief.related_message_id.as_deref() != Some(message.id.as_str())));
         let registry = host.inner.runtimes.read().await;
         let entry = registry
             .agents
@@ -5946,6 +5970,109 @@ mod tests {
         let message_id = format!("message:task-restart:{}", task.id);
         assert!(storage.read_message_by_id(&message_id).unwrap().is_some());
         assert!(host.try_get_loaded_runtime(agent_id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_replays_interrupted_operator_prompt_while_work_item_waits_external() {
+        let (_home, host) = canonical_test_host();
+        let config = host.config().as_ref().clone();
+        let agent_id = "startup-interrupted-prompt";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        let mut work_item = WorkItemRecord::new(agent_id, "wait for review", WorkItemState::Open);
+        work_item.id = "work-startup-external".into();
+        storage.append_work_item(&work_item).unwrap();
+        let now = Utc::now();
+        storage
+            .append_wait_condition(&WaitConditionRecord {
+                id: "wait-startup-external".into(),
+                agent_id: agent_id.into(),
+                work_item_id: Some(work_item.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("github:holon-run/holon#2528".into()),
+                waiting_for: "review".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("trigger-startup-external".into()),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+                turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
+            })
+            .unwrap();
+        let mut state = storage.read_agent().unwrap().unwrap();
+        state.current_work_item_id = Some(work_item.id.clone());
+        storage.write_agent(&state).unwrap();
+        let mut message = MessageEnvelope::new(
+            agent_id,
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "resume after restart".into(),
+            },
+        );
+        message.id = "msg-startup-interrupted-prompt".into();
+        message.turn_id = Some("turn-startup-interrupted-prompt".into());
+        storage.append_message(&message).unwrap();
+        storage
+            .append_queue_entry(&QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: agent_id.into(),
+                priority: message.priority,
+                status: QueueEntryStatus::Interrupted,
+                created_at: message.created_at,
+                updated_at: now,
+            })
+            .unwrap();
+
+        assert!(storage.latest_active_task_records(10).unwrap().is_empty());
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        drop(storage);
+        drop(host);
+
+        let started = Arc::new(Notify::new());
+        let started_wait = started.notified();
+        tokio::pin!(started_wait);
+        started_wait.as_mut().enable();
+        let restarted = RuntimeHost::new_with_provider(
+            config,
+            Arc::new(BlockingProvider {
+                started: started.clone(),
+            }),
+        )
+        .unwrap();
+        assert!(restarted
+            .recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap()
+            .is_empty());
+        tokio::time::timeout(Duration::from_secs(5), &mut started_wait)
+            .await
+            .expect("startup recovery should replay the interrupted prompt");
+
+        let runtime = restarted
+            .try_get_loaded_runtime(agent_id)
+            .await
+            .expect("startup recovery should keep the interrupted prompt owner active");
+        assert!(runtime
+            .storage()
+            .read_recent_events(100)
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event.kind == "turn_replay_started"
+                    && event.data["source_turn_id"] == "turn-startup-interrupted-prompt"
+            }));
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4886,6 +4886,7 @@ impl RuntimeHandle {
                 if commit.applied {
                     recovered += 1;
                 }
+                drop(guard);
                 self.apply_transition_commit(commit).await;
                 continue;
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -426,16 +426,21 @@ fn canonical_matching_terminal_turn(
     terminal_turn: Option<&TurnRecord>,
 ) -> Result<Option<TurnRecord>> {
     let matches_activation = |turn: &TurnRecord| {
+        let matches_turn_identity = message
+            .turn_id
+            .as_deref()
+            .is_none_or(|turn_id| turn_id == turn.turn_id)
+            || turn.replay.as_ref().is_some_and(|replay| {
+                replay.source_message_id == record.message_id
+                    && message.turn_id.as_deref() == Some(replay.source_turn_id.as_str())
+            });
         turn.terminal.is_some()
             && turn
                 .trigger
                 .as_ref()
                 .and_then(|trigger| trigger.message_id.as_deref())
                 == Some(record.message_id.as_str())
-            && message
-                .turn_id
-                .as_deref()
-                .is_none_or(|turn_id| turn_id == turn.turn_id)
+            && matches_turn_identity
             && turn.current_work_item_id.as_deref() == owner_work_item_id
     };
     if let Some(turn) = terminal_turn.filter(|turn| matches_activation(turn)) {
@@ -2423,6 +2428,27 @@ impl RuntimeAgent {
         self.last_persisted_state = self.state.clone();
         crate::diagnostics::record_storage_persist_state(started.elapsed());
         Ok(())
+    }
+
+    fn restore_bootstrap_replay_message(
+        &mut self,
+        storage: &AppStorage,
+        message: &MessageEnvelope,
+    ) -> Result<()> {
+        if self
+            .queue
+            .peek_next_matching(|queued| queued.id == message.id)
+            .is_none()
+        {
+            self.queue.push(message.clone());
+        }
+        let queued_messages = self.queue.len();
+        self.state.pending = queued_messages;
+        scheduler_executor::apply_bootstrap_recovered_projection(
+            &mut self.state,
+            scheduler_executor::BootstrapRecoveryFacts { queued_messages },
+        );
+        self.persist_state(storage)
     }
 }
 
@@ -4760,7 +4786,7 @@ impl RuntimeHandle {
         let mut recovered = 0;
 
         for mut entry in claimed {
-            let _guard = self.inner.agent.lock().await;
+            let mut guard = self.inner.agent.lock().await;
             let expected_entry = entry.clone();
             let Some(message) = self.inner.storage.read_message_by_id(&entry.message_id)? else {
                 continue;
@@ -4907,7 +4933,9 @@ impl RuntimeHandle {
                 )?;
                 if commit.applied {
                     recovered += 1;
+                    guard.restore_bootstrap_replay_message(&self.inner.storage, &message)?;
                 }
+                drop(guard);
                 self.apply_transition_commit(commit).await;
                 continue;
             }
@@ -4971,7 +4999,11 @@ impl RuntimeHandle {
                 )?;
             if commit.applied {
                 recovered += 1;
+                if !terminal_is_completed {
+                    guard.restore_bootstrap_replay_message(&self.inner.storage, &message)?;
+                }
             }
+            drop(guard);
             self.apply_transition_commit(commit).await;
         }
         Ok(recovered)

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -145,6 +145,7 @@ pub(crate) struct SchedulerProjection {
     now: DateTime<Utc>,
     pub status: AgentStatus,
     pub queue_len: usize,
+    pub has_interrupted_replay: bool,
     pub active_run_id: Option<String>,
     pub active_tasks: Vec<TaskRecord>,
     pub has_blocking_active_tasks: bool,
@@ -270,6 +271,15 @@ impl SchedulerProjection {
     ) -> Result<Self> {
         let active_tasks =
             storage.latest_active_task_records_for_agent(&snapshot.id, usize::MAX)?;
+        let has_interrupted_replay = storage
+            .runtime_db()?
+            .map(|runtime_db| {
+                runtime_db
+                    .queue_entries()
+                    .has_interrupted_for_agent(&snapshot.id)
+            })
+            .transpose()?
+            .unwrap_or(false);
         let has_blocking_active_tasks = active_tasks.iter().any(TaskRecord::is_blocking);
         let queued_runnable_work_items = work_queue
             .queued_runnable
@@ -359,6 +369,7 @@ impl SchedulerProjection {
             now,
             status: snapshot.status.clone(),
             queue_len,
+            has_interrupted_replay,
             active_run_id: snapshot.active_run_id.clone(),
             active_tasks,
             has_blocking_active_tasks,
@@ -1615,6 +1626,9 @@ pub(crate) fn idle_noop_decision(projection: &SchedulerProjection) -> SchedulerD
 pub(crate) fn wait_decision_for_projection(
     projection: &SchedulerProjection,
 ) -> Option<SchedulerDecision> {
+    if projection.has_interrupted_replay {
+        return None;
+    }
     if projection.work_reactivation_signal().is_some() {
         return None;
     }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -915,11 +915,39 @@ async fn interrupted_message_replay_creates_new_turn_without_current_focus_drift
     assert_eq!(
         replay.replay,
         Some(crate::types::TurnReplayProvenance {
-            source_message_id: message.id,
+            source_message_id: message.id.clone(),
             source_turn_id,
             reason: "interrupted_queue_claim_reentry".into(),
             prior_terminal: None,
         })
+    );
+
+    finish_claimed_test_run(&runtime).await;
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&message.id)
+            .unwrap()
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
     );
 }
 

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -2112,3 +2112,60 @@ fn waiting_operator_with_future_recheck_still_waits() {
         scheduler::SchedulerDecisionKind::WaitForOperator
     );
 }
+
+#[test]
+fn waiting_external_with_interrupted_replay_does_not_return_liveness_only_wait() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = Some("work-external-replay".into());
+    append_active_external_wait_condition(
+        &storage,
+        "wait-external-replay",
+        "default",
+        Some("work-external-replay"),
+    );
+    storage.write_agent(&agent).unwrap();
+    storage
+        .append_queue_entry(&QueueEntryRecord {
+            message_id: "msg-interrupted-replay".into(),
+            agent_id: "default".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Interrupted,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+        .unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    assert_eq!(
+        projection.waiting_work_item_scheduling_state,
+        Some(WorkItemSchedulingState::WaitingExternal)
+    );
+    assert!(projection.has_interrupted_replay);
+    assert!(scheduler::wait_decision_for_projection(&projection).is_none());
+}
+
+#[test]
+fn waiting_external_without_interrupted_replay_remains_liveness_only() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = Some("work-external-idle".into());
+    append_active_external_wait_condition(
+        &storage,
+        "wait-external-idle",
+        "default",
+        Some("work-external-idle"),
+    );
+    storage.write_agent(&agent).unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let decision =
+        scheduler::wait_decision_for_projection(&projection).expect("external wait decision");
+    assert_eq!(
+        decision.kind,
+        scheduler::SchedulerDecisionKind::WaitForExternalChange
+    );
+    assert!(decision.liveness_only);
+}

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1587,6 +1587,36 @@ impl QueueEntryRepository<'_> {
         Ok(exists.is_some())
     }
 
+    pub fn recovery_candidate_agent_ids(&self) -> Result<Vec<String>> {
+        let connection = self.db.connection()?;
+        let dequeued_status = enum_string(&crate::types::QueueEntryStatus::Dequeued)?;
+        let interrupted_status = enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT agent_id
+             FROM queue_entries
+             WHERE status IN (?1, ?2)
+             ORDER BY agent_id ASC",
+        )?;
+        let rows = statement.query_map(params![dequeued_status, interrupted_status], |row| {
+            row.get::<_, String>(0)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub fn has_interrupted_for_agent(&self, agent_id: &str) -> Result<bool> {
+        let connection = self.db.connection()?;
+        let interrupted_status = enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
+        let exists: Option<i64> = connection
+            .query_row(
+                "SELECT 1 FROM queue_entries WHERE agent_id = ?1 AND status = ?2 LIMIT 1",
+                params![agent_id, interrupted_status],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?;
+        Ok(exists.is_some())
+    }
+
     /// Returns only entries currently queued for a specific agent.
     pub fn queued_for_agent(&self, agent_id: &str) -> Result<Vec<QueueEntryRecord>> {
         let connection = self.db.connection()?;

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -4900,6 +4900,48 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn recovery_candidate_agent_ids_include_dequeued_and_interrupted_entries() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        for (message_id, agent_id, status) in [
+            ("msg-queued", "agent-queued", QueueEntryStatus::Queued),
+            ("msg-dequeued", "agent-dequeued", QueueEntryStatus::Dequeued),
+            (
+                "msg-interrupted",
+                "agent-interrupted",
+                QueueEntryStatus::Interrupted,
+            ),
+            (
+                "msg-processed",
+                "agent-processed",
+                QueueEntryStatus::Processed,
+            ),
+        ] {
+            db.queue_entries().upsert(&QueueEntryRecord {
+                message_id: message_id.into(),
+                agent_id: agent_id.into(),
+                priority: crate::types::Priority::Normal,
+                status,
+                created_at: now,
+                updated_at: now,
+            })?;
+        }
+
+        assert_eq!(
+            db.queue_entries().recovery_candidate_agent_ids()?,
+            vec!["agent-dequeued", "agent-interrupted"]
+        );
+        assert!(db
+            .queue_entries()
+            .has_interrupted_for_agent("agent-interrupted")?);
+        assert!(!db
+            .queue_entries()
+            .has_interrupted_for_agent("agent-dequeued")?);
+        Ok(())
+    }
+
+    #[test]
     fn try_claim_succeeds_for_interrupted_entry() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;


### PR DESCRIPTION
## 概要

- startup recovery 将 `Dequeued` / `Interrupted` queue owner 纳入主动恢复候选，即使没有 active task 也会加载 runtime
- `WaitingExternal` WorkItem 存在 interrupted replay 时不再返回 liveness-only wait，允许 replay 继续调度
- canonical settlement 允许新 replay Turn 通过 replay provenance 匹配原始 message/turn，并在 bootstrap recovery 后恢复内存队列投影
- 增加 daemon restart、WaitingExternal、无 replay liveness-only 及 replay settlement 回归测试

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`

Closes #2528
