### PR TITLE
fix: authorize autonomous work from execution state

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -249,6 +249,11 @@ impl RuntimeHandle {
             work_queue_projection,
             self.now(),
         )?;
+        let projection = if self.inner.scheduler_engine.is_canonical() {
+            projection
+        } else {
+            projection.without_canonical_authority()
+        };
         let runtime_error = runtime_error_override.unwrap_or(projection.runtime_error);
         Ok(derive_closure_decision(&ClosureFacts {
             runtime_error,
@@ -1801,6 +1806,11 @@ impl RuntimeHandle {
             .read_agent()?
             .ok_or_else(|| anyhow!("agent state is missing for lifecycle sleep"))?;
         let projection = scheduler::SchedulerProjection::from_state(&self.inner.storage, &state)?;
+        let projection = if self.inner.scheduler_engine.is_canonical() {
+            projection
+        } else {
+            projection.without_canonical_authority()
+        };
         Ok(projection
             .work_reactivation_work_item()
             .map(|(work_item, mode)| {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1795,15 +1795,23 @@ impl RuntimeHandle {
     fn indefinite_sleep_runnable_work(
         &self,
     ) -> Result<Option<(crate::types::WorkItemRecord, &'static str)>> {
-        let projection = self.inner.storage.work_queue_prompt_projection()?;
-        if let Some(current) = projection.current_runnable {
-            return Ok(Some((current.work_item, "continue_active")));
-        }
+        let state = self
+            .inner
+            .storage
+            .read_agent()?
+            .ok_or_else(|| anyhow!("agent state is missing for lifecycle sleep"))?;
+        let projection = scheduler::SchedulerProjection::from_state(&self.inner.storage, &state)?;
         Ok(projection
-            .queued_runnable
-            .into_iter()
-            .next()
-            .map(|queued| (queued.work_item, "queued_available")))
+            .work_reactivation_work_item()
+            .map(|(work_item, mode)| {
+                (
+                    work_item.clone(),
+                    match mode {
+                        crate::types::WorkReactivationMode::ContinueActive => "continue_active",
+                        crate::types::WorkReactivationMode::ActivateQueued => "queued_available",
+                    },
+                )
+            }))
     }
 
     fn spawn_session_sleep_wake(

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    storage::WorkQueueReadModel,
-    types::{BriefKind, TaskStatus, TodoItemState},
-};
+use crate::types::{BriefKind, TaskStatus, TodoItemState};
 
 const CONTINUE_ACTIVE_SIGNAL_SCAN_LIMIT: usize = 512;
 
@@ -16,20 +13,24 @@ enum IdleTickTrigger {
 
 fn idle_tick_trigger_from_state(
     pending_wake_hint: Option<PendingWakeHint>,
-    projection: WorkQueueReadModel,
+    work_reactivation: Option<(
+        crate::types::WorkItemRecord,
+        crate::types::WorkReactivationMode,
+    )>,
     due_rechecks: Vec<crate::types::WorkItemRecord>,
 ) -> Option<IdleTickTrigger> {
     if let Some(pending) = pending_wake_hint {
         Some(IdleTickTrigger::WakeHint(pending))
     } else {
-        if let Some(current) = projection.current_runnable {
-            return Some(IdleTickTrigger::WorkQueueActive(current.work_item));
-        }
-        projection
-            .queued_runnable
-            .into_iter()
-            .next()
-            .map(|item| IdleTickTrigger::WorkQueueQueued(item.work_item))
+        work_reactivation
+            .map(|(work_item, mode)| match mode {
+                crate::types::WorkReactivationMode::ContinueActive => {
+                    IdleTickTrigger::WorkQueueActive(work_item)
+                }
+                crate::types::WorkReactivationMode::ActivateQueued => {
+                    IdleTickTrigger::WorkQueueQueued(work_item)
+                }
+            })
             .or_else(|| {
                 if due_rechecks.is_empty() {
                     None
@@ -140,9 +141,12 @@ impl RuntimeHandle {
                 work_queue_projection.clone(),
                 self.now(),
             )?;
+        let work_reactivation = scheduler_projection
+            .work_reactivation_work_item()
+            .map(|(work_item, mode)| (work_item.clone(), mode));
         let trigger = idle_tick_trigger_from_state(
             pending_wake_hint,
-            work_queue_projection,
+            work_reactivation,
             due_rechecks.clone(),
         );
 
@@ -1098,6 +1102,49 @@ mod tests {
         } else {
             repository.insert_new(record).unwrap();
         }
+        persist_test_work_execution(test_runtime, record);
+    }
+
+    fn persist_test_work_execution(test_runtime: &TestRuntime, record: &WorkItemRecord) {
+        use crate::domain::execution_protocol::{
+            ExecutionProtocolState, WorkItemExecutionRecord, WorkItemExecutionState,
+        };
+
+        let mut execution = test_runtime
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&record.agent_id)
+            .unwrap()
+            .unwrap_or_else(|| ExecutionProtocolState::empty(&record.agent_id));
+        let generation = execution
+            .work_items
+            .get(&record.id)
+            .map_or(record.revision.max(1), WorkItemExecutionRecord::generation);
+        let state = record.blocked_by.as_ref().map_or_else(
+            || WorkItemExecutionState::Runnable {
+                generation,
+                recovery_ref: None,
+            },
+            |reason| WorkItemExecutionState::Paused {
+                generation,
+                reason: reason.clone(),
+            },
+        );
+        execution.work_items.insert(
+            record.id.clone(),
+            WorkItemExecutionRecord {
+                source_revision: record.revision,
+                state,
+            },
+        );
+        test_runtime
+            .runtime
+            .inner
+            .runtime_db
+            .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+            .unwrap();
     }
 
     fn add_current_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
@@ -1716,12 +1763,7 @@ mod tests {
         let mut updated = queued.clone();
         updated.revision += 1;
         updated.updated_at = chrono::Utc::now();
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .append_work_item(&updated)
-            .unwrap();
+        persist_test_work_item(&test_runtime, &updated);
 
         assert!(rt
             .block_on(test_runtime.runtime.maybe_emit_pending_system_tick(None))
@@ -2306,12 +2348,7 @@ mod tests {
             state: TodoItemState::InProgress,
         }];
         active.updated_at = chrono::Utc::now();
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .append_work_item(&active)
-            .unwrap();
+        persist_test_work_item(&test_runtime, &active);
         append_result_brief_for_work_item(&test_runtime, &active.id, "Progress report.");
 
         let rt = tokio::runtime::Runtime::new().unwrap();

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -141,6 +141,11 @@ impl RuntimeHandle {
                 work_queue_projection.clone(),
                 self.now(),
             )?;
+        let scheduler_projection = if self.inner.scheduler_engine.is_canonical() {
+            scheduler_projection
+        } else {
+            scheduler_projection.without_canonical_authority()
+        };
         let work_reactivation = scheduler_projection
             .work_reactivation_work_item()
             .map(|(work_item, mode)| (work_item.clone(), mode));

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -30,6 +30,7 @@ pub(crate) const EXPLICITLY_BOUND_OPERATOR_INPUT_SCENARIO: SchedulerScenarioClas
 pub(crate) enum CanonicalActivationScenario {
     WorkItemAutonomousContinuation {
         work_item_id: String,
+        expected_work_item_revision: u64,
     },
     ProviderRecovery {
         work_item_id: String,
@@ -60,6 +61,7 @@ pub(crate) enum CanonicalActivationCandidate {
     UnboundTaskResultWaitOrReduce,
     WorkItemAutonomousContinuation {
         work_item_id: String,
+        expected_work_item_revision: u64,
     },
     ProviderRecovery {
         work_item_id: String,
@@ -104,7 +106,7 @@ impl std::error::Error for AmbiguousCanonicalWaits {}
 impl CanonicalActivationScenario {
     pub(crate) fn work_item_id(&self) -> Option<&str> {
         match self {
-            Self::WorkItemAutonomousContinuation { work_item_id }
+            Self::WorkItemAutonomousContinuation { work_item_id, .. }
             | Self::ProviderRecovery { work_item_id }
             | Self::InternalFollowup { work_item_id }
             | Self::ExactTaskRejoin { work_item_id, .. }
@@ -133,7 +135,7 @@ impl CanonicalActivationCandidate {
     fn expected_work_item_id(&self) -> Option<&str> {
         match self {
             Self::UnboundTaskResultWaitOrReduce => None,
-            Self::WorkItemAutonomousContinuation { work_item_id }
+            Self::WorkItemAutonomousContinuation { work_item_id, .. }
             | Self::ProviderRecovery { work_item_id }
             | Self::InternalFollowup { work_item_id }
             | Self::ExactTaskRejoin { work_item_id, .. }
@@ -177,6 +179,7 @@ pub(crate) struct SchedulerProjection {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CanonicalWorkExecutionState {
+    Runnable { source_revision: u64 },
     Waiting { wait_id: String },
     Other,
 }
@@ -334,23 +337,33 @@ impl SchedulerProjection {
             })
             .transpose()?
             .flatten();
-        let canonical_work_states = execution_snapshot.as_ref().map(|snapshot| {
-            snapshot
-                .work_items
-                .iter()
-                .map(|(work_item_id, record)| {
-                    let state = match &record.state {
-                        WorkItemExecutionState::Waiting { wait, .. } => {
-                            CanonicalWorkExecutionState::Waiting {
-                                wait_id: wait.wait_id.clone(),
-                            }
-                        }
-                        _ => CanonicalWorkExecutionState::Other,
-                    };
-                    (work_item_id.clone(), state)
+        let canonical_work_states = Some(
+            execution_snapshot
+                .as_ref()
+                .map(|snapshot| {
+                    snapshot
+                        .work_items
+                        .iter()
+                        .map(|(work_item_id, record)| {
+                            let state = match &record.state {
+                                WorkItemExecutionState::Runnable { .. } => {
+                                    CanonicalWorkExecutionState::Runnable {
+                                        source_revision: record.source_revision,
+                                    }
+                                }
+                                WorkItemExecutionState::Waiting { wait, .. } => {
+                                    CanonicalWorkExecutionState::Waiting {
+                                        wait_id: wait.wait_id.clone(),
+                                    }
+                                }
+                                _ => CanonicalWorkExecutionState::Other,
+                            };
+                            (work_item_id.clone(), state)
+                        })
+                        .collect()
                 })
-                .collect()
-        });
+                .unwrap_or_default(),
+        );
         let active_work_item_waiting_intents = active_wait_conditions
             .iter()
             .filter(|condition| condition.work_item_id.is_some())
@@ -404,25 +417,40 @@ impl SchedulerProjection {
     }
 
     pub(crate) fn work_reactivation_signal(&self) -> Option<WorkReactivationSignal> {
+        self.work_reactivation_work_item()
+            .map(|(item, reactivation_mode)| WorkReactivationSignal {
+                work_item_id: item.id.clone(),
+                state: item.state.clone(),
+                reactivation_mode,
+            })
+    }
+
+    pub(crate) fn work_reactivation_work_item(
+        &self,
+    ) -> Option<(&WorkItemRecord, WorkReactivationMode)> {
         self.current_work_item
             .as_ref()
             .filter(|_| {
                 self.current_work_item_scheduling_state == Some(WorkItemSchedulingState::Runnable)
             })
-            .map(|item| WorkReactivationSignal {
-                work_item_id: item.id.clone(),
-                state: item.state.clone(),
-                reactivation_mode: WorkReactivationMode::ContinueActive,
-            })
+            .filter(|item| self.execution_authorizes_autonomous(item))
+            .map(|item| (item, WorkReactivationMode::ContinueActive))
             .or_else(|| {
                 self.queued_runnable_work_items
-                    .first()
-                    .map(|item| WorkReactivationSignal {
-                        work_item_id: item.id.clone(),
-                        state: item.state.clone(),
-                        reactivation_mode: WorkReactivationMode::ActivateQueued,
-                    })
+                    .iter()
+                    .find(|item| self.execution_authorizes_autonomous(item))
+                    .map(|item| (item, WorkReactivationMode::ActivateQueued))
             })
+    }
+
+    fn execution_authorizes_autonomous(&self, work_item: &WorkItemRecord) -> bool {
+        self.canonical_work_states.as_ref().is_none_or(|states| {
+            matches!(
+                states.get(&work_item.id),
+                Some(CanonicalWorkExecutionState::Runnable { source_revision })
+                    if *source_revision == work_item.revision
+            )
+        })
     }
 
     pub(crate) fn current_work_item_waits_for_operator(&self) -> bool {
@@ -1159,9 +1187,41 @@ pub(crate) fn canonical_activation_candidate(
         (MessageKind::SystemTick, MessageOrigin::System { subsystem })
             if subsystem == "work_queue"
     ) {
-        return Ok(message.work_item_id.clone().map(|work_item_id| {
-            CanonicalActivationCandidate::WorkItemAutonomousContinuation { work_item_id }
-        }));
+        let metadata = message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("work_queue"));
+        let metadata_work_item_id = metadata
+            .and_then(|metadata| metadata.get("work_item_id"))
+            .and_then(serde_json::Value::as_str);
+        let expected_work_item_revision = metadata
+            .and_then(|metadata| metadata.get("work_item_revision"))
+            .and_then(serde_json::Value::as_u64)
+            .filter(|revision| *revision > 0);
+        let reason = metadata
+            .and_then(|metadata| metadata.get("reason"))
+            .and_then(serde_json::Value::as_str);
+        return Ok(
+            match (
+                message.work_item_id.as_deref(),
+                metadata_work_item_id,
+                expected_work_item_revision,
+                reason,
+            ) {
+                (
+                    Some(bound_work_item_id),
+                    Some(metadata_work_item_id),
+                    Some(expected_work_item_revision),
+                    Some("continue_active" | "queued_available"),
+                ) if bound_work_item_id == metadata_work_item_id => Some(
+                    CanonicalActivationCandidate::WorkItemAutonomousContinuation {
+                        work_item_id: bound_work_item_id.to_string(),
+                        expected_work_item_revision,
+                    },
+                ),
+                _ => None,
+            },
+        );
     }
     if message.kind == MessageKind::InternalFollowup {
         if let Some(work_item_id) = message.work_item_id.clone() {
@@ -1287,10 +1347,16 @@ pub(crate) fn resolve_canonical_activation_scenario(
     message: &MessageEnvelope,
     candidate: CanonicalActivationCandidate,
 ) -> Result<Option<CanonicalActivationScenario>> {
-    if let CanonicalActivationCandidate::WorkItemAutonomousContinuation { work_item_id } = candidate
+    if let CanonicalActivationCandidate::WorkItemAutonomousContinuation {
+        work_item_id,
+        expected_work_item_revision,
+    } = candidate
     {
         return Ok(Some(
-            CanonicalActivationScenario::WorkItemAutonomousContinuation { work_item_id },
+            CanonicalActivationScenario::WorkItemAutonomousContinuation {
+                work_item_id,
+                expected_work_item_revision,
+            },
         ));
     }
     if let CanonicalActivationCandidate::ProviderRecovery { work_item_id } = candidate {
@@ -1371,7 +1437,10 @@ pub(crate) fn resolve_canonical_activation_scenario(
                 .as_ref()
                 .and_then(|states| states.get(&work_item_id))
             {
-                Some(CanonicalWorkExecutionState::Other) => {}
+                Some(
+                    CanonicalWorkExecutionState::Runnable { .. }
+                    | CanonicalWorkExecutionState::Other,
+                ) => {}
                 Some(CanonicalWorkExecutionState::Waiting { .. }) => {
                     return Ok(None);
                 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -444,6 +444,7 @@ impl SchedulerProjection {
     }
 
     fn execution_authorizes_autonomous(&self, work_item: &WorkItemRecord) -> bool {
+        // None means the legacy engine opted out of canonical execution authority.
         self.canonical_work_states.as_ref().is_none_or(|states| {
             matches!(
                 states.get(&work_item.id),

--- a/src/runtime/scheduler_acceptance.rs
+++ b/src/runtime/scheduler_acceptance.rs
@@ -865,6 +865,11 @@ async fn enqueue_scheduler_work_tick(
     work_item_id: &str,
     label: &str,
 ) -> Result<MessageEnvelope> {
+    let work_item = runtime
+        .inner
+        .storage
+        .latest_work_item(work_item_id)?
+        .ok_or_else(|| anyhow!("scheduler work item is missing before tick enqueue"))?;
     let mut message = MessageEnvelope::new(
         agent_id,
         MessageKind::SystemTick,
@@ -881,7 +886,14 @@ async fn enqueue_scheduler_work_tick(
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item_id.into());
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "work_queue": {
+            "reason": "queued_available",
+            "work_item_id": work_item.id,
+            "work_item_revision": work_item.revision
+        }
+    }));
     message.turn_id = Some(format!("turn-scheduler-restart-{label}"));
     let enqueued = runtime.enqueue(message).await?;
     runtime

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1140,6 +1140,18 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 reason: "canonical_work_item_not_open_same_agent",
             });
         }
+        if let scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
+            expected_work_item_revision,
+            ..
+        } = &scenario
+        {
+            if work_item.revision != *expected_work_item_revision {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_autonomous_work_item_revision_stale",
+                });
+            }
+        }
         let work_queue = self.runtime.inner.storage.work_queue_prompt_projection()?;
         let Some(work_projection) = work_queue
             .items
@@ -1198,6 +1210,24 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let authoritative_work = existing_execution
             .as_ref()
             .and_then(|state| state.work_items.get(work_item_id));
+        if let scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
+            expected_work_item_revision,
+            ..
+        } = &scenario
+        {
+            let Some(authoritative_work) = authoritative_work else {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_autonomous_execution_authority_missing",
+                });
+            };
+            if authoritative_work.source_revision != *expected_work_item_revision {
+                return Ok(CanonicalClaimOutcome::RejectQueued {
+                    scenario_class,
+                    reason: "canonical_autonomous_execution_revision_stale",
+                });
+            }
+        }
         let recovery_of_attempt_id = if matches!(
             scenario,
             scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
@@ -1575,6 +1605,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let source_identity = match scenario {
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
                 work_item_id,
+                ..
             } => ExecutionSourceIdentity::WorkItemContinuation {
                 work_item_id: work_item_id.clone(),
             },
@@ -2048,6 +2079,7 @@ fn execution_attempt_matches_scenario(
             ExecutionBinding::WorkItem { work_item_id },
             scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
                 work_item_id: expected,
+                ..
             },
         ) => source_work_item_id == expected && work_item_id == expected,
         (

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -7814,6 +7814,123 @@ async fn indefinite_sleep_with_queued_runnable_work_item_emits_selection_tick() 
 }
 
 #[tokio::test]
+async fn legacy_indefinite_sleep_uses_read_model_runnable_work_without_execution_partition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let queued = runtime
+        .create_work_item("legacy queued runnable work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .is_none());
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeRunning;
+        guard.state.current_run_id = Some("run-legacy".into());
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    runtime.transition_to_sleep(None).await.unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::AwakeRunning);
+    assert_eq!(state.pending, 1);
+    let tick = runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .into_iter()
+        .find(|message| {
+            matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                    if subsystem == "work_queue"
+            )
+        })
+        .expect("legacy runnable work should override indefinite sleep");
+    assert_eq!(tick.work_item_id.as_deref(), Some(queued.id.as_str()));
+}
+
+#[tokio::test]
+async fn legacy_idle_reactivation_uses_read_model_without_execution_partition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let queued = runtime
+        .create_work_item("legacy idle runnable work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .is_none());
+
+    let closure = runtime.current_closure_decision().await.unwrap();
+    assert_eq!(closure.outcome, ClosureOutcome::Continuable);
+    assert_eq!(
+        closure
+            .work_signal
+            .as_ref()
+            .map(|signal| signal.work_item_id.as_str()),
+        Some(queued.id.as_str())
+    );
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeIdle;
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    assert!(runtime.maybe_emit_pending_system_tick(None).await.unwrap());
+    assert!(runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .iter()
+        .any(|message| {
+            matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                    if subsystem == "work_queue"
+            ) && message.work_item_id.as_deref() == Some(queued.id.as_str())
+        }));
+}
+
+#[tokio::test]
 async fn idle_tick_ignores_read_model_runnable_when_execution_is_paused() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -326,6 +326,25 @@ fn persist_waiting_work_execution(
     wait_id: &str,
 ) {
     let generation = work_item.revision.max(1);
+    persist_work_execution(
+        runtime,
+        work_item,
+        work_item.revision,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+            generation,
+            wait: crate::domain::execution_protocol::WaitReference {
+                wait_id: wait_id.into(),
+            },
+        },
+    );
+}
+
+fn persist_work_execution(
+    runtime: &RuntimeHandle,
+    work_item: &WorkItemRecord,
+    source_revision: u64,
+    state: crate::domain::execution_protocol::WorkItemExecutionState,
+) {
     let mut execution = runtime
         .inner
         .runtime_db
@@ -338,13 +357,8 @@ fn persist_waiting_work_execution(
     execution.work_items.insert(
         work_item.id.clone(),
         crate::domain::execution_protocol::WorkItemExecutionRecord {
-            source_revision: generation,
-            state: crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
-                generation,
-                wait: crate::domain::execution_protocol::WaitReference {
-                    wait_id: wait_id.into(),
-                },
-            },
+            source_revision,
+            state,
         },
     );
     runtime
@@ -911,7 +925,7 @@ async fn runtime_failure_preserves_canonical_claim_for_bootstrap_reconciliation(
             text: "claim before runtime failure".into(),
         },
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-runtime-failure-canonical-claim".into());
     let message = runtime.enqueue(message).await.unwrap();
     assert!(matches!(
@@ -1924,7 +1938,7 @@ async fn bootstrap_recovery_interrupts_open_attempt_and_releases_message_for_ree
             text: "claim before restart".into(),
         },
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     let message = runtime.enqueue(message).await.unwrap();
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
         .poll()
@@ -2044,7 +2058,7 @@ async fn bootstrap_recovery_uses_execution_attempt_without_scheduler_compatibili
                 text: "claim before compatibility projection loss".into(),
             },
         );
-        message.work_item_id = Some(work_item.id);
+        bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
         let message = runtime.enqueue(message).await.unwrap();
         assert!(matches!(
             scheduler_executor::SchedulerDecisionExecutor::new(runtime)
@@ -2188,7 +2202,7 @@ async fn bootstrap_recovery_settles_dequeued_activation_from_terminal_turn() {
             text: "claim completed before restart".into(),
         },
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-bootstrap-terminal".into());
     let message = runtime.enqueue(message).await.unwrap();
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
@@ -2271,7 +2285,7 @@ async fn bootstrap_restart_reconciles_dequeued_queue_after_unified_settlement() 
                 text: "canonical settlement committed before restart".into(),
             },
         );
-        message.work_item_id = Some(work_item.id.clone());
+        bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
         message.turn_id = Some("turn-bootstrap-split-restart".into());
         let message = runtime.enqueue(message).await.unwrap();
         assert!(matches!(
@@ -2445,7 +2459,7 @@ async fn bootstrap_recovery_settles_completed_work_item_from_bound_terminal_evid
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-bootstrap-completed".into());
     let message = runtime.enqueue(message).await.unwrap();
     let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
@@ -2565,7 +2579,7 @@ async fn bootstrap_recovery_fault_rolls_back_queue_canonical_and_audit() {
                     text: "claim before recovery fault".into(),
                 },
             );
-            message.work_item_id = Some(work_item.id.clone());
+            bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
             message.turn_id = terminal_evidence
                 .then(|| format!("turn-bootstrap-fault-{terminal_evidence}-{fault:?}"));
             let message = runtime.enqueue(message).await.unwrap();
@@ -2813,7 +2827,7 @@ async fn legacy_engine_startup_rejects_open_unified_execution_attempt() {
             text: "leave canonical activation running".into(),
         },
     );
-    message.work_item_id = Some(work_item.id);
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-canonical-in-flight".into());
     runtime.enqueue(message).await.unwrap();
     assert!(matches!(
@@ -2879,7 +2893,7 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-canonical-production-loop".into());
     let message = runtime.enqueue(message).await.unwrap();
 
@@ -3043,7 +3057,7 @@ async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation(
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-canonical-wait-settlement".into());
     let message = runtime.enqueue(message).await.unwrap();
     assert!(matches!(
@@ -5120,7 +5134,7 @@ async fn canonical_processed_settlement_without_terminal_turn_fails_closed() {
             text: "must create a turn".into(),
         },
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-missing-terminal".into());
     let message = runtime.enqueue(message).await.unwrap();
     assert!(matches!(
@@ -5344,7 +5358,7 @@ async fn authoritative_completion_terminalizes_canonical_work_and_binds_report()
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     let message = runtime.enqueue(message).await.unwrap();
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
 
@@ -5578,7 +5592,7 @@ async fn terminal_settlement_fault_rolls_back_all_facts_and_retry_is_idempotent(
                 text: "commit terminal atomically".into(),
             },
         );
-        message.work_item_id = Some(work_item.id.clone());
+        bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
         message.turn_id = Some(format!("turn-terminal-fault-{fault:?}"));
         let message = runtime.enqueue(message).await.unwrap();
         let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
@@ -6034,7 +6048,7 @@ async fn terminal_settlement_survives_post_commit_effect_faults() {
                 text: "retain committed terminal".into(),
             },
         );
-        message.work_item_id = Some(work_item.id.clone());
+        bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
         message.turn_id = Some(format!("turn-terminal-post-commit-{fault:?}"));
         let message = runtime.enqueue(message).await.unwrap();
         let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
@@ -6150,7 +6164,7 @@ async fn runtime_failure_terminal_fault_rolls_back_queue_canonical_and_failure_e
             text: "fail after canonical claim".into(),
         },
     );
-    message.work_item_id = Some(work_item.id);
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     let message = runtime.enqueue(message).await.unwrap();
     let turn_id = message.turn_id.clone().expect("enqueued turn id");
 
@@ -6280,7 +6294,7 @@ async fn interrupted_terminal_fault_rolls_back_queue_canonical_and_turn_facts() 
             text: "abort after canonical claim".into(),
         },
     );
-    message.work_item_id = Some(work_item.id);
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     let message = runtime.enqueue(message).await.unwrap();
     let turn_id = message.turn_id.clone().expect("enqueued turn id");
 
@@ -6422,7 +6436,7 @@ async fn completed_production_settlement_uses_exact_bound_result_brief() {
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-exact-completion".into());
     let message = runtime.enqueue(message).await.unwrap();
 
@@ -6601,7 +6615,7 @@ async fn completed_wait_resume_settlement_accepts_exact_reconciliation_revision(
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    wait_message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut wait_message, &work_item, "queued_available");
     wait_message.turn_id = Some("turn-wait-before-completion".into());
     let wait_message = runtime.enqueue(wait_message).await.unwrap();
     assert!(matches!(
@@ -6825,7 +6839,7 @@ async fn completed_production_settlement_interrupts_mismatched_completion_execut
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-mismatched-completion".into());
     let message = runtime.enqueue(message).await.unwrap();
 
@@ -6981,7 +6995,7 @@ async fn completed_production_settlement_interrupts_without_result_report() {
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    message.work_item_id = Some(work_item.id.clone());
+    bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
     message.turn_id = Some("turn-missing-completion-report".into());
     let message = runtime.enqueue(message).await.unwrap();
 
@@ -7078,7 +7092,7 @@ async fn production_protocol_settlement_fault_rolls_back_queue_and_protocol_fact
                 text: "run canonical work".into(),
             },
         );
-        message.work_item_id = Some(work_item.id.clone());
+        bind_autonomous_work_queue_tick(&mut message, &work_item, "queued_available");
         message.turn_id = Some(format!("turn-canonical-settlement-fault-{fault:?}"));
         let message = runtime.enqueue(message).await.unwrap();
         let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
@@ -7324,6 +7338,95 @@ async fn run_loop_stale_head_noops_before_canonical_claim() {
     assert!(!events.iter().any(|event| {
         event.kind == "queue_entry_claimed" && event.data["message_id"] == message.id
     }));
+}
+
+#[tokio::test]
+async fn stale_work_queue_revision_is_dropped_before_canonical_claim() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("drop stale autonomous tick".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "stale autonomous continuation".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "work_queue": {
+            "reason": "queued_available",
+            "work_item_id": work_item.id,
+            "work_item_revision": work_item.revision
+        }
+    }));
+    let message = runtime.enqueue(message).await.unwrap();
+    let updated = runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            Some("newer objective revision".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(updated.revision > work_item.revision);
+
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Idle
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_queue_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == message.id)
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Dropped)
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "scheduler_authority_input_rejected"
+                && event.data["message_id"] == message.id
+                && event.data["reason"] == "canonical_autonomous_work_item_revision_stale"
+                && event.data["queue_disposition"] == "dropped"
+        }));
 }
 
 #[tokio::test]
@@ -7708,6 +7811,169 @@ async fn indefinite_sleep_with_queued_runnable_work_item_emits_selection_tick() 
             .and_then(|value| value.as_str()),
         Some("queued_available")
     );
+}
+
+#[tokio::test]
+async fn idle_tick_ignores_read_model_runnable_when_execution_is_paused() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "projection-only runnable work".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    persist_work_execution(
+        &runtime,
+        &work_item,
+        work_item.revision,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused {
+            generation: work_item.revision.max(1),
+            reason: "canonical pause".into(),
+        },
+    );
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeIdle;
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    assert!(!runtime.maybe_emit_pending_system_tick(None).await.unwrap());
+    assert!(runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .iter()
+        .all(|message| !matches!(
+            (&message.kind, &message.origin),
+            (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                if subsystem == "work_queue"
+        )));
+}
+
+#[tokio::test]
+async fn restart_sleep_ignores_read_model_runnable_when_execution_is_paused() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "restart projection divergence".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    persist_work_execution(
+        &runtime,
+        &work_item,
+        work_item.revision,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused {
+            generation: work_item.revision.max(1),
+            reason: "canonical pause survives restart".into(),
+        },
+    );
+    drop(runtime);
+
+    let reopened = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    {
+        let mut guard = reopened.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeRunning;
+        guard.state.current_run_id = Some("run-after-restart".into());
+        guard.persist_state(&reopened.inner.storage).unwrap();
+    }
+
+    reopened.transition_to_sleep(None).await.unwrap();
+
+    let state = reopened.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Asleep);
+    assert_eq!(state.pending, 0);
+    assert!(reopened
+        .storage()
+        .read_recent_events(usize::MAX)
+        .unwrap()
+        .iter()
+        .all(|event| event.data["reason"] != "sleep_overridden_runnable_work"));
+}
+
+#[tokio::test]
+async fn idle_tick_ignores_runnable_execution_with_stale_source_revision() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("stale execution revision".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    persist_work_execution(
+        &runtime,
+        &work_item,
+        work_item.revision + 1,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable {
+            generation: work_item.revision.max(1),
+            recovery_ref: None,
+        },
+    );
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeIdle;
+        guard.persist_state(&runtime.inner.storage).unwrap();
+    }
+
+    assert!(!runtime.maybe_emit_pending_system_tick(None).await.unwrap());
 }
 
 #[tokio::test]

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -834,6 +834,7 @@ fn idle_boundary_decision_reactivates_runnable_work_while_asleep() {
     work_item.id = "work-current".into();
     work_item.plan_status = WorkItemPlanStatus::Ready;
     storage.append_work_item(&work_item).unwrap();
+    seed_runnable_work_execution(&storage, &work_item);
     storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
@@ -857,6 +858,7 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
     work_item.id = "work-1".into();
     work_item.revision = 7;
     append_work_item_at_revision(&storage, &work_item);
+    seed_runnable_work_execution(&storage, &work_item);
 
     let pending = PendingWakeHint {
         reason: "external update".into(),
@@ -919,6 +921,7 @@ fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
     work_item.id = "work-queued".into();
     work_item.revision = 4;
     append_work_item_at_revision(&storage, &work_item);
+    seed_runnable_work_execution(&storage, &work_item);
     append_active_external_wait_condition(&storage, "agent-wait", "default", None);
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
@@ -991,6 +994,7 @@ fn scheduling_advisories_detect_idle_posture_with_runnable_work() {
     let work_item = WorkItemRecord::new("default", "runnable work", WorkItemState::Open);
     agent.current_work_item_id = Some(work_item.id.clone());
     storage.append_work_item(&work_item).unwrap();
+    seed_runnable_work_execution(&storage, &work_item);
     storage.write_agent(&agent).unwrap();
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
@@ -1293,10 +1297,11 @@ fn append_task_wait_condition(
         })
         .unwrap();
 }
-fn append_open_work_item(storage: &AppStorage, id: &str, agent_id: &str) {
+fn append_open_work_item(storage: &AppStorage, id: &str, agent_id: &str) -> WorkItemRecord {
     let mut record = WorkItemRecord::new(agent_id, "test objective", WorkItemState::Open);
     record.id = id.into();
     storage.append_work_item(&record).unwrap();
+    record
 }
 
 #[test]
@@ -1813,8 +1818,9 @@ fn wait_resume_claim_authority_scope_is_derived_without_shadow_evidence() {
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
-    append_open_work_item(&storage, "wi-1", "default");
+    let work_item = append_open_work_item(&storage, "wi-1", "default");
     append_task_wait_condition(&storage, "wait-1", "default", Some("wi-1"), "task-1");
+    seed_waiting_work_execution(&storage, &work_item, "wait-1");
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     let message = MessageEnvelope::new(
         "default",

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -259,6 +259,77 @@ pub(crate) async fn bind_turn_to_work_item(runtime: &RuntimeHandle, work_item_id
     guard.persist_state(&runtime.inner.storage).unwrap();
 }
 
+pub(crate) fn bind_autonomous_work_queue_tick(
+    message: &mut MessageEnvelope,
+    work_item: &WorkItemRecord,
+    reason: &str,
+) {
+    message.work_item_id = Some(work_item.id.clone());
+    message.metadata = Some(serde_json::json!({
+        "work_queue": {
+            "reason": reason,
+            "work_item_id": work_item.id,
+            "work_item_revision": work_item.revision
+        }
+    }));
+}
+
+pub(crate) fn seed_runnable_work_execution(storage: &AppStorage, work_item: &WorkItemRecord) {
+    seed_work_execution(
+        storage,
+        work_item,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable {
+            generation: work_item.revision.max(1),
+            recovery_ref: None,
+        },
+    );
+}
+
+pub(crate) fn seed_waiting_work_execution(
+    storage: &AppStorage,
+    work_item: &WorkItemRecord,
+    wait_id: &str,
+) {
+    seed_work_execution(
+        storage,
+        work_item,
+        crate::domain::execution_protocol::WorkItemExecutionState::Waiting {
+            generation: work_item.revision.max(1),
+            wait: crate::domain::execution_protocol::WaitReference {
+                wait_id: wait_id.into(),
+            },
+        },
+    );
+}
+
+fn seed_work_execution(
+    storage: &AppStorage,
+    work_item: &WorkItemRecord,
+    state: crate::domain::execution_protocol::WorkItemExecutionState,
+) {
+    let runtime_db = storage
+        .runtime_db()
+        .unwrap()
+        .expect("test storage should expose RuntimeDb");
+    let mut execution = runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized(&work_item.agent_id)
+        .unwrap()
+        .unwrap_or_else(|| {
+            crate::domain::execution_protocol::ExecutionProtocolState::empty(&work_item.agent_id)
+        });
+    execution.work_items.insert(
+        work_item.id.clone(),
+        crate::domain::execution_protocol::WorkItemExecutionRecord {
+            source_revision: work_item.revision,
+            state,
+        },
+    );
+    runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+}
+
 pub(crate) async fn seed_bound_work_item(
     runtime: &RuntimeHandle,
     state: WorkItemState,

--- a/src/runtime/tests/wake_hints.rs
+++ b/src/runtime/tests/wake_hints.rs
@@ -194,6 +194,7 @@ async fn runtime_emits_work_queue_system_tick_for_active_item_on_restart() {
         WorkItemState::Open,
     );
     storage.append_work_item(&active).unwrap();
+    seed_runnable_work_execution(&storage, &active);
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some(active.id.clone());
     storage.write_agent(&agent).unwrap();
@@ -238,6 +239,8 @@ async fn idle_tick_prefers_current_work_item_over_queued_work_item() {
     let queued = WorkItemRecord::new("default", "queued runtime cleanup", WorkItemState::Open);
     storage.append_work_item(&active).unwrap();
     storage.append_work_item(&queued).unwrap();
+    seed_runnable_work_execution(&storage, &active);
+    seed_runnable_work_execution(&storage, &queued);
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some(active.id.clone());
     storage.write_agent(&agent).unwrap();
@@ -410,6 +413,7 @@ async fn runtime_surfaces_queued_work_item_with_work_queue_system_tick_on_restar
     );
     let queued_id = queued.id.clone();
     storage.append_work_item(&queued).unwrap();
+    seed_runnable_work_execution(&storage, &queued);
 
     let runtime = RuntimeHandle::new(
         "default",

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -4625,7 +4625,7 @@ async fn external_wake_records_wait_reconciliation_and_resolves_wait() {
         MessageDeliverySurface::RuntimeSystem,
         AdmissionContext::RuntimeOwned,
     );
-    wait_message.work_item_id = Some(work.id.clone());
+    bind_autonomous_work_queue_tick(&mut wait_message, &work, "continue_active");
     wait_message.turn_id = Some("turn-wait-for-ci".into());
     let wait_message = runtime.enqueue(wait_message).await.unwrap();
     assert!(matches!(
@@ -5194,6 +5194,7 @@ async fn current_closure_reports_continuable_for_current_work_item() {
     );
     let active_id = active.id.clone();
     storage.append_work_item(&active).unwrap();
+    seed_runnable_work_execution(&storage, &active);
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some(active_id.clone());
     storage.write_agent(&agent).unwrap();
@@ -5283,6 +5284,8 @@ async fn current_external_wait_does_not_suppress_queued_runnable_work_item() {
     let queued = WorkItemRecord::new("default", "queued follow-up work", WorkItemState::Open);
     let queued_id = queued.id.clone();
     storage.append_work_item(&queued).unwrap();
+    seed_waiting_work_execution(&storage, &current, "wait-current");
+    seed_runnable_work_execution(&storage, &queued);
     let now = Utc::now();
     storage
         .append_wait_condition(&WaitConditionRecord {
@@ -5350,6 +5353,7 @@ async fn current_closure_reports_continuable_for_queued_work_item_without_active
     );
     let queued_id = queued.id.clone();
     storage.append_work_item(&queued).unwrap();
+    seed_runnable_work_execution(&storage, &queued);
 
     let runtime = RuntimeHandle::new(
         "default",


### PR DESCRIPTION
## 概要

- 将 autonomous candidate 与 work reactivation 统一改为由同一 agent partition 的 `WorkItemExecutionState::Runnable` 授权
- 要求 execution `source_revision` 与当前 `WorkItemRecord.revision` 精确匹配，避免 stale execution/read-model divergence 触发重复 system tick
- 让 idle tick 与 sleep override 复用同一 authoritative scheduler projection，并在 canonical admission 前丢弃 stale autonomous tick
- 补充 projection divergence、daemon restart、stale source/message revision 回归

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- Phase 2B 定向 runtime/scheduler/wake-hint/work-item 测试
- `cargo test --all-targets`

Closes #2532
