### PR TITLE
fix: skip deleted agents during startup recovery

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -6124,6 +6124,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn startup_recovery_ignores_interrupted_queue_for_deleted_private_child() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "tmp_child_deleted_recovery";
+        let now = Utc::now();
+        let mut identity = AgentIdentityRecord::new(
+            agent_id,
+            AgentKind::Child,
+            AgentVisibility::Private,
+            AgentOwnership::ParentSupervised,
+            AgentProfilePreset::PrivateChild,
+            Some(host.config().default_agent_id.clone()),
+            Some("task-deleted-child".into()),
+        );
+        identity.status = AgentRegistryStatus::Deleted;
+        identity.deleted_at = Some(now);
+        host.append_agent_identity(&identity).unwrap();
+        host.runtime_db()
+            .queue_entries()
+            .upsert(&QueueEntryRecord {
+                message_id: "msg-deleted-child".into(),
+                agent_id: agent_id.into(),
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Interrupted,
+                created_at: now,
+                updated_at: now,
+            })
+            .unwrap();
+
+        assert!(host
+            .recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        assert_eq!(
+            host.runtime_db()
+                .queue_entries()
+                .latest("msg-deleted-child")
+                .unwrap()
+                .unwrap()
+                .status,
+            QueueEntryStatus::Interrupted
+        );
+    }
+
+    #[tokio::test]
     async fn shutdown_rejects_new_runtime_activation() {
         let (_home, host) = test_host();
         let agent_id = host.config().default_agent_id.clone();

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1592,10 +1592,13 @@ impl QueueEntryRepository<'_> {
         let dequeued_status = enum_string(&crate::types::QueueEntryStatus::Dequeued)?;
         let interrupted_status = enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
         let mut statement = connection.prepare(
-            "SELECT DISTINCT agent_id
-             FROM queue_entries
-             WHERE status IN (?1, ?2)
-             ORDER BY agent_id ASC",
+            "SELECT DISTINCT q.agent_id
+             FROM queue_entries q
+             JOIN agent_identities i
+               ON i.agent_id = q.agent_id
+              AND i.status = 'active'
+             WHERE q.status IN (?1, ?2)
+             ORDER BY q.agent_id ASC",
         )?;
         let rows = statement.query_map(params![dequeued_status, interrupted_status], |row| {
             row.get::<_, String>(0)

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -4904,6 +4904,18 @@ CREATE TABLE working_memory_deltas (
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let now = Utc::now();
+        for agent_id in [
+            "agent-queued",
+            "agent-dequeued",
+            "agent-interrupted",
+            "agent-processed",
+        ] {
+            db.agent_identities().upsert(&agent_identity(agent_id, 0))?;
+        }
+        let mut deleted_identity = agent_identity("agent-deleted", 0);
+        deleted_identity.status = AgentRegistryStatus::Deleted;
+        deleted_identity.deleted_at = Some(now);
+        db.agent_identities().upsert(&deleted_identity)?;
         for (message_id, agent_id, status) in [
             ("msg-queued", "agent-queued", QueueEntryStatus::Queued),
             ("msg-dequeued", "agent-dequeued", QueueEntryStatus::Dequeued),
@@ -4916,6 +4928,11 @@ CREATE TABLE working_memory_deltas (
                 "msg-processed",
                 "agent-processed",
                 QueueEntryStatus::Processed,
+            ),
+            (
+                "msg-deleted",
+                "agent-deleted",
+                QueueEntryStatus::Interrupted,
             ),
         ] {
             db.queue_entries().upsert(&QueueEntryRecord {


### PR DESCRIPTION
## Summary

- restrict startup queue recovery candidates to active agent identities
- preserve stale queue evidence for deleted agents without attempting to reactivate them
- add repository- and host-level regressions for deleted private children with interrupted queue entries

## Runtime concept

Startup recovery now respects the agent identity lifecycle fence. A deleted private child may retain historical interrupted queue evidence, but that evidence must not make the runtime attempt to activate the deleted identity and fail daemon startup.

## Testing

- `cargo fmt --all -- --check`
- `cargo test recovery_candidate_agent_ids_include_dequeued_and_interrupted_entries`
- `cargo test startup_recovery_ignores_interrupted_queue_for_deleted_private_child`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
