### PR TITLE
fix: make canonical settlement fact authoritative

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1008,6 +1008,26 @@ fn execution_protocol_settlement_transition_from_facts(
 
     let outcome = match &attempt.binding {
         ExecutionBinding::WorkItem { work_item_id } => {
+            let Some(authoritative_work) = state.work_items.get(work_item_id) else {
+                return Ok(interrupted("work_item_execution_missing"));
+            };
+            let crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+                generation,
+                attempt_id,
+            } = &authoritative_work.state
+            else {
+                return Ok(interrupted("work_item_execution_not_in_flight"));
+            };
+            if attempt_id != &attempt.attempt_id
+                || attempt.admitted_fences.work_item_generation != Some(*generation)
+            {
+                return Ok(interrupted("work_item_execution_attempt_mismatch"));
+            }
+            if attempt.admitted_fences.work_item_source_revision
+                != Some(authoritative_work.source_revision)
+            {
+                return Ok(interrupted("work_item_execution_revision_mismatch"));
+            }
             let matching_continuations = runtime_db
                 .work_item_continuations()
                 .active_for_agent(&record.agent_id)?
@@ -1022,9 +1042,16 @@ fn execution_protocol_settlement_transition_from_facts(
                     let Some(target) = storage.latest_work_item(&frame.active_work_item_id)? else {
                         return Ok(interrupted("yield_target_missing"));
                     };
+                    let Some(target_execution) = state.work_items.get(&target.id) else {
+                        return Ok(interrupted("yield_target_execution_missing"));
+                    };
                     if target.agent_id != record.agent_id
                         || target.state != crate::types::WorkItemState::Open
-                        || target.readiness() != crate::types::WorkItemReadiness::Runnable
+                        || target_execution.source_revision != target.revision
+                        || !matches!(
+                            target_execution.state,
+                            crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+                        )
                     {
                         return Ok(interrupted("yield_target_not_runnable"));
                     }
@@ -1036,128 +1063,107 @@ fn execution_protocol_settlement_transition_from_facts(
                     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
                         return Ok(interrupted("work_item_missing"));
                     };
-                    let recovery_wait_id = if matches!(
-                        attempt.source.identity,
-                        crate::domain::execution_protocol::ExecutionSourceIdentity::RuntimeRecovery {
-                            ..
+                    let completion_intent = work_item.completion_intent.as_ref();
+                    if let Some(intent) = completion_intent {
+                        if intent.work_item_id != *work_item_id
+                            || intent.source_activation_id.as_deref()
+                                != Some(attempt.attempt_id.as_str())
+                            || intent.source_message_id.as_deref()
+                                != Some(record.message_id.as_str())
+                            || intent.source_turn_id.as_deref()
+                                != Some(terminal_turn.turn_id.as_str())
+                            || Some(intent.expected_work_revision)
+                                != attempt.admitted_fences.work_item_source_revision
+                        {
+                            return Ok(interrupted("completion_intent_mismatch"));
                         }
-                    ) {
-                        let unresolved_waits = storage
-                            .raw_unresolved_wait_conditions_for_agent(&record.agent_id)?
-                            .into_iter()
-                            .filter(|wait| {
-                                wait.work_item_id.as_deref() == Some(work_item_id.as_str())
-                            })
-                            .collect::<Vec<_>>();
-                        match unresolved_waits.as_slice() {
-                            [] => None,
-                            [wait] => Some(wait.id.clone()),
-                            _ => return Ok(interrupted("wait_outcome_ambiguous")),
-                        }
+                        let Some(brief_id) = intent.result_brief_id.as_deref().filter(|brief_id| {
+                            work_item.result_brief_id.as_deref() == Some(*brief_id)
+                        }) else {
+                            return Ok(interrupted("completion_brief_binding_missing"));
+                        };
+                        let Some(brief) = storage.read_brief_by_id(brief_id)?.filter(|brief| {
+                            brief.kind.is_success()
+                                && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
+                                && brief.turn_id.as_deref() == Some(terminal_turn.turn_id.as_str())
+                                && brief.related_message_id.as_deref()
+                                    == Some(record.message_id.as_str())
+                                && !brief.text.trim().is_empty()
+                        }) else {
+                            return Ok(interrupted("completion_brief_evidence_missing"));
+                        };
+                        ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                            completion: brief.id,
+                        })
                     } else {
-                        None
-                    };
-                    if let Some(wait_id) = recovery_wait_id {
-                        return Ok(
-                            crate::runtime_db::transitions::ExecutionProtocolTransition {
-                                bootstrap: None,
-                                commands: vec![ExecutionProtocolCommand::Settle(SettleExecution {
-                                    outcome: ExecutionOutcomeRecord {
-                                        outcome_id: format!(
-                                            "outcome:message:{}",
-                                            record.message_id
-                                        ),
-                                        attempt_id: attempt.attempt_id.clone(),
-                                        outcome: ExecutionOutcome::WorkItem(
-                                            WorkItemOutcome::Wait {
-                                                wait: WaitReference { wait_id },
-                                            },
-                                        ),
-                                        created_at: record.updated_at.to_rfc3339(),
-                                    },
-                                })],
-                            },
-                        );
-                    }
-                    let scheduling = storage
-                        .work_queue_prompt_projection()?
-                        .items
-                        .into_iter()
-                        .find(|candidate| candidate.id == *work_item_id)
-                        .map(|candidate| candidate.scheduling_state);
-                    match scheduling {
-                        Some(crate::types::WorkItemSchedulingState::Runnable) => {
-                            ExecutionOutcome::WorkItem(WorkItemOutcome::Continue)
+                        if work_item.state != crate::types::WorkItemState::Open
+                            || work_item.result_brief_id.is_some()
+                        {
+                            return Ok(interrupted("completion_intent_missing"));
                         }
-                        Some(crate::types::WorkItemSchedulingState::Completed) => {
-                            let Some(intent) = work_item.completion_intent.as_ref() else {
-                                return Ok(interrupted("completion_intent_missing"));
-                            };
-                            if intent.work_item_id != *work_item_id
-                                || intent.source_activation_id.as_deref()
-                                    != Some(attempt.attempt_id.as_str())
-                                || intent.source_message_id.as_deref()
-                                    != Some(record.message_id.as_str())
-                                || intent.source_turn_id.as_deref()
-                                    != Some(terminal_turn.turn_id.as_str())
-                                || intent.expected_work_revision
-                                    != attempt
-                                        .admitted_fences
-                                        .work_item_source_revision
-                                        .unwrap_or_default()
-                            {
-                                return Ok(interrupted("completion_intent_mismatch"));
+                        let recovery_wait_id = if matches!(
+                            attempt.source.identity,
+                            crate::domain::execution_protocol::ExecutionSourceIdentity::RuntimeRecovery {
+                                ..
                             }
-                            let Some(brief_id) =
-                                intent.result_brief_id.as_deref().filter(|brief_id| {
-                                    work_item.result_brief_id.as_deref() == Some(*brief_id)
+                        ) {
+                            let unresolved_waits = storage
+                                .raw_unresolved_wait_conditions_for_agent(&record.agent_id)?
+                                .into_iter()
+                                .filter(|wait| {
+                                    wait.work_item_id.as_deref() == Some(work_item_id.as_str())
                                 })
-                            else {
-                                return Ok(interrupted("completion_brief_binding_missing"));
-                            };
-                            let Some(brief) = storage.read_brief_by_id(brief_id)?.filter(|brief| {
-                                brief.kind.is_success()
-                                    && brief.work_item_id.as_deref() == Some(work_item_id.as_str())
-                                    && brief.turn_id.as_deref()
-                                        == Some(terminal_turn.turn_id.as_str())
-                                    && brief.related_message_id.as_deref()
-                                        == Some(record.message_id.as_str())
-                                    && !brief.text.trim().is_empty()
-                            }) else {
-                                return Ok(interrupted("completion_brief_evidence_missing"));
-                            };
-                            ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
-                                completion: brief.id,
-                            })
-                        }
-                        Some(
-                            crate::types::WorkItemSchedulingState::WaitingOperator
-                            | crate::types::WorkItemSchedulingState::WaitingTask
-                            | crate::types::WorkItemSchedulingState::WaitingExternal
-                            | crate::types::WorkItemSchedulingState::WaitingTimer
-                            | crate::types::WorkItemSchedulingState::WaitingSystem,
-                        ) => {
-                            let active_waits = storage.active_wait_conditions_for_work_item(
-                                &record.agent_id,
-                                work_item_id,
-                            )?;
-                            let [wait] = active_waits.as_slice() else {
-                                return Ok(interrupted("wait_outcome_ambiguous"));
-                            };
+                                .collect::<Vec<_>>();
+                            match unresolved_waits.as_slice() {
+                                [] => None,
+                                [wait] => Some(wait.id.clone()),
+                                _ => return Ok(interrupted("wait_outcome_ambiguous")),
+                            }
+                        } else {
+                            None
+                        };
+                        if let Some(wait_id) = recovery_wait_id {
                             ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
-                                wait: WaitReference {
-                                    wait_id: wait.id.clone(),
-                                },
+                                wait: WaitReference { wait_id },
                             })
+                        } else {
+                            let unresolved_waits = storage
+                                .raw_unresolved_wait_conditions_for_agent(&record.agent_id)?
+                                .into_iter()
+                                .filter(|wait| {
+                                    wait.work_item_id.as_deref() == Some(work_item_id.as_str())
+                                })
+                                .collect::<Vec<_>>();
+                            let current_turn_waits = unresolved_waits
+                                .iter()
+                                .filter(|wait| {
+                                    wait.status == crate::types::WaitConditionStatus::Active
+                                        && wait.turn_id.as_deref()
+                                            == Some(terminal_turn.turn_id.as_str())
+                                })
+                                .collect::<Vec<_>>();
+                            match (unresolved_waits.as_slice(), current_turn_waits.as_slice()) {
+                                ([], []) => {
+                                    if authoritative_work.source_revision != work_item.revision {
+                                        return Ok(interrupted(
+                                            "work_item_execution_revision_mismatch",
+                                        ));
+                                    }
+                                    ExecutionOutcome::WorkItem(WorkItemOutcome::Continue)
+                                }
+                                ([_], [wait]) => {
+                                    ExecutionOutcome::WorkItem(WorkItemOutcome::Wait {
+                                        wait: WaitReference {
+                                            wait_id: wait.id.clone(),
+                                        },
+                                    })
+                                }
+                                ([_], []) => {
+                                    return Ok(interrupted("wait_outcome_turn_mismatch"));
+                                }
+                                _ => return Ok(interrupted("wait_outcome_ambiguous")),
+                            }
                         }
-                        Some(crate::types::WorkItemSchedulingState::YieldedToWorkItem) => {
-                            return Ok(interrupted("yield_continuation_missing"));
-                        }
-                        Some(
-                            crate::types::WorkItemSchedulingState::Blocked
-                            | crate::types::WorkItemSchedulingState::Completing,
-                        )
-                        | None => return Ok(interrupted("terminal_outcome_unresolved")),
                     }
                 }
                 _ => return Ok(interrupted("yield_continuation_ambiguous")),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1127,6 +1127,8 @@ fn execution_protocol_settlement_transition_from_facts(
                                 wait: WaitReference { wait_id },
                             })
                         } else {
+                            // Settlement inspects raw durable wait facts so read-model readiness
+                            // cannot become reverse authority over the canonical outcome.
                             let unresolved_waits = storage
                                 .raw_unresolved_wait_conditions_for_agent(&record.agent_id)?
                                 .into_iter()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1023,11 +1023,6 @@ fn execution_protocol_settlement_transition_from_facts(
             {
                 return Ok(interrupted("work_item_execution_attempt_mismatch"));
             }
-            if attempt.admitted_fences.work_item_source_revision
-                != Some(authoritative_work.source_revision)
-            {
-                return Ok(interrupted("work_item_execution_revision_mismatch"));
-            }
             let matching_continuations = runtime_db
                 .work_item_continuations()
                 .active_for_agent(&record.agent_id)?

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3346,6 +3346,129 @@ async fn production_settlement_interrupts_yield_to_stale_execution_revision() {
 }
 
 #[tokio::test]
+async fn production_settlement_accepts_authoritative_revision_advance_while_in_flight() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let owner = runtime
+        .create_work_item("advancing canonical owner".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "continue after an authoritative revision advance".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &owner, "queued_available");
+    message.turn_id = Some("turn-canonical-revision-advance".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    let updated = runtime
+        .update_work_item_fields(
+            owner.id.clone(),
+            Some("advanced while the canonical attempt remains in flight".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let in_flight = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &in_flight.attempts[&activation_id];
+    assert_eq!(
+        attempt.admitted_fences.work_item_source_revision,
+        Some(owner.revision)
+    );
+    assert_eq!(
+        in_flight.work_items[&owner.id].source_revision,
+        updated.revision
+    );
+    assert!(matches!(
+        &in_flight.work_items[&owner.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            attempt_id,
+            ..
+        } if attempt_id == &activation_id
+    ));
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&owner.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &settled.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Settled
+    );
+    assert_eq!(
+        settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Continue,
+        )
+    );
+}
+
+#[tokio::test]
 async fn production_settlement_interrupts_stale_owner_execution_revision() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -7467,8 +7467,8 @@ async fn completed_production_settlement_interrupts_without_result_report() {
     assert!(matches!(
         &execution.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
         crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
-            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { .. }
-        )
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { reason }
+        ) if reason == "completion_brief_binding_missing"
     ));
 }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3021,6 +3021,425 @@ async fn production_protocol_claim_and_settlement_release_the_canonical_slot() {
 }
 
 #[tokio::test]
+async fn production_settlement_ignores_foreign_turn_read_model_yield_divergence() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let owner = runtime
+        .create_work_item("canonical settlement owner".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let target = runtime
+        .create_work_item(
+            "foreign turn continuation target".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "settle from canonical facts".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &owner, "queued_available");
+    message.turn_id = Some("turn-canonical-read-model-divergence".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    runtime
+        .storage()
+        .append_work_item_continuation(&crate::types::WorkItemContinuationFrame::new_on_completed(
+            "default",
+            owner.id.clone(),
+            target.id,
+            Some("turn-foreign-continuation".into()),
+        ))
+        .unwrap();
+    let projection = runtime.storage().work_queue_prompt_projection().unwrap();
+    assert_eq!(
+        projection
+            .items
+            .iter()
+            .find(|item| item.work_item.id == owner.id)
+            .map(|item| item.scheduling_state),
+        Some(WorkItemSchedulingState::YieldedToWorkItem)
+    );
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&owner.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &settled.attempts[&activation_id];
+    assert_eq!(
+        settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Continue,
+        )
+    );
+}
+
+#[tokio::test]
+async fn production_settlement_yields_to_exact_matching_revision_continuation() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let owner = runtime
+        .create_work_item("yielding canonical owner".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let target = runtime
+        .create_work_item("canonical yield target".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "yield to exact target".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &owner, "queued_available");
+    message.turn_id = Some("turn-canonical-exact-yield".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    runtime
+        .storage()
+        .append_work_item_continuation(&crate::types::WorkItemContinuationFrame::new_on_completed(
+            "default",
+            owner.id.clone(),
+            target.id.clone(),
+            message.turn_id.clone(),
+        ))
+        .unwrap();
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&owner.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &settled.attempts[&activation_id];
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Yield {
+                target_work_item_id
+            }
+        ) if target_work_item_id == &target.id
+    ));
+    assert_eq!(
+        settled.work_items[&owner.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused {
+            generation: owner.revision + 1,
+            reason: format!("yielded_to:{}", target.id),
+        }
+    );
+}
+
+#[tokio::test]
+async fn production_settlement_interrupts_yield_to_stale_execution_revision() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let owner = runtime
+        .create_work_item("stale yield owner".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let target = runtime
+        .create_work_item("stale yield target".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "reject stale yield target".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &owner, "queued_available");
+    message.turn_id = Some("turn-canonical-stale-yield".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    let mut stale_target = target.clone();
+    stale_target.revision += 1;
+    stale_target.objective = "metadata advanced without canonical execution".into();
+    stale_target.updated_at = Utc::now();
+    runtime.storage().append_work_item(&stale_target).unwrap();
+    runtime
+        .storage()
+        .append_work_item_continuation(&crate::types::WorkItemContinuationFrame::new_on_completed(
+            "default",
+            owner.id.clone(),
+            target.id,
+            message.turn_id.clone(),
+        ))
+        .unwrap();
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&owner.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &settled.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+    );
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { reason }
+        ) if reason == "yield_target_not_runnable"
+    ));
+}
+
+#[tokio::test]
+async fn production_settlement_interrupts_stale_owner_execution_revision() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let owner = runtime
+        .create_work_item("stale canonical owner".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "reject stale owner revision".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &owner, "queued_available");
+    message.turn_id = Some("turn-canonical-stale-owner".into());
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    let mut stale_owner = owner.clone();
+    stale_owner.revision += 1;
+    stale_owner.objective = "metadata advanced beyond admitted execution".into();
+    stale_owner.updated_at = Utc::now();
+    runtime.storage().append_work_item(&stale_owner).unwrap();
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&message, Some(&owner.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let settled = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let attempt = &settled.attempts[&activation_id];
+    assert_eq!(
+        attempt.state,
+        crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+    );
+    assert!(matches!(
+        &settled.outcomes[attempt.terminal_outcome_id.as_deref().unwrap()].outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { reason }
+        ) if reason == "work_item_execution_revision_mismatch"
+    ));
+}
+
+#[tokio::test]
 async fn production_protocol_wait_settlement_creates_rejoinable_wait_generation() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();


### PR DESCRIPTION
## 变更摘要

- 让 canonical WorkItem settlement 仅依据 open `ExecutionAttempt`、matching-revision `WorkItemExecutionState` 以及精确绑定的 continuation/completion/wait durable facts 决定结果
- 按 `Yield`、`Complete`、`Wait`、`Continue` 的优先级结算，并让 stale、missing、conflicting 或 ambiguous facts fail closed 为 `Interrupted`
- 移除 canonical production settlement 对 `work_queue_prompt_projection` 与 `WorkItemSchedulingState` 的 authority 依赖，同时保留 provider-lineage wait recovery 和 legacy scheduler 行为
- 增加 read-model divergence、精确 identity/revision、restart/bootstrap、fault rollback 与 legacy 隔离回归

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- targeted canonical settlement、restart/bootstrap、rollback 与 legacy regression tests

Closes #2535
