### PR TITLE
fix(web): synchronize global events and unread state

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore, type CSSProperties } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore, type CSSProperties } from "react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
@@ -82,6 +82,7 @@ export function App() {
   const navCollapsed = useRuntimeStore((state) => state.navCollapsed);
   const setRoute = useRuntimeStore((state) => state.setRoute);
   const openAgent = useRuntimeStore((state) => state.openAgent);
+  const markAgentConversationRead = useRuntimeStore((state) => state.markAgentConversationRead);
   const openSkill = useRuntimeStore((state) => state.openSkill);
   const openTemplate = useRuntimeStore((state) => state.openTemplate);
   const setDisplayLevel = useRuntimeStore((state) => state.setDisplayLevel);
@@ -103,6 +104,9 @@ export function App() {
   const rosterActivityByAgentId = useRuntimeStore((state) => state.rosterActivityByAgentId);
   const activeAgentId = route === "agent" ? selectedAgent?.id ?? selectedAgentId : undefined;
   const sidePanelAgentId = selectedAgent?.id ?? selectedAgentId;
+  const markSelectedAgentConversationRead = useCallback(() => {
+    if (activeAgentId) markAgentConversationRead(activeAgentId);
+  }, [activeAgentId, markAgentConversationRead]);
   const selectedAgentSession = useRuntimeStore((state) =>
     sidePanelAgentId ? state.sessionsByAgentId[sidePanelAgentId] : undefined,
   );
@@ -664,6 +668,7 @@ export function App() {
             onClearModel={() => clearAgentModel(activeAgent.id, effectiveDisplayLevel)}
             onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, effectiveDisplayLevel)}
             onSendPrompt={(text, attachments) => sendOperatorPrompt(activeAgent.id, text, effectiveDisplayLevel, attachments)}
+            onConversationRead={markSelectedAgentConversationRead}
             onOpenInspector={() => {
               showAgentOverview(activeAgent.id);
             }}

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -52,6 +52,7 @@ interface AgentPageProps {
   onClearModel: () => Promise<void>;
   onLoadOlderEvents: () => Promise<void>;
   onSendPrompt: (text: string, attachments?: OperatorPromptAttachment[]) => Promise<void>;
+  onConversationRead: () => void;
   onOpenInspector: () => void;
   onInspectActivity: (activity: AgentTimelineActivity) => void;
   selectedActivityId?: string;
@@ -307,6 +308,7 @@ export function AgentPage({
   onClearModel,
   onLoadOlderEvents,
   onSendPrompt,
+  onConversationRead,
   onOpenInspector,
   onInspectActivity,
   selectedActivityId,
@@ -439,8 +441,25 @@ export function AgentPage({
 
     if (stickToBottomRef.current) {
       scrollToConversationBottom();
+      onConversationRead();
     }
-  }, [timelineVersion]);
+  }, [timelineVersion, syncStatus, onConversationRead]);
+
+  useEffect(() => {
+    const markReadIfVisible = () => {
+      const list = messageListRef.current;
+      if (
+        document.visibilityState === "visible" &&
+        list &&
+        isScrolledNearBottom(list)
+      ) {
+        onConversationRead();
+      }
+    };
+    markReadIfVisible();
+    document.addEventListener("visibilitychange", markReadIfVisible);
+    return () => document.removeEventListener("visibilitychange", markReadIfVisible);
+  }, [activeAgent.id, timelineVersion, syncStatus, onConversationRead]);
 
   useReconciledVirtualMeasurements({
     virtualizer: rowVirtualizer,
@@ -582,6 +601,7 @@ export function AgentPage({
       return;
     }
     stickToBottomRef.current = isScrolledNearBottom(list);
+    if (stickToBottomRef.current) onConversationRead();
   }
 
   async function handleLoadOlderEvents() {

--- a/web-gui/app/src/runtime/event-gap-recovery.test.ts
+++ b/web-gui/app/src/runtime/event-gap-recovery.test.ts
@@ -19,6 +19,28 @@ function eventPage(events: SequencedEvent[], eventLogEpoch?: string) {
 }
 
 describe("EventGapRecoveryTracker", () => {
+  it("starts cold agents at zero instead of treating the first live event as complete history", () => {
+    const tracker = new EventGapRecoveryTracker();
+
+    expect(tracker.observe("agent-a", 13)).toEqual({
+      contiguousSeq: 0,
+      highestObservedSeq: 13,
+      recovering: true,
+    });
+  });
+
+  it("rebases from hydrated cache while preserving newer live observations", () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a");
+    tracker.observe("agent-a", 13, "epoch-a");
+
+    expect(tracker.rebase("agent-a", 10, "epoch-a")).toEqual({
+      contiguousSeq: 10,
+      highestObservedSeq: 13,
+      recovering: true,
+    });
+  });
+
   it("keeps the contiguous cursor behind an observed high watermark", () => {
     const tracker = new EventGapRecoveryTracker();
     tracker.register("agent-a", 10);
@@ -94,10 +116,9 @@ describe("EventGapRecoveryTracker", () => {
     firstPage.resolve(eventPage([event(21), event(21), event(22)]));
     await firstRecovery;
 
-    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
     expect(fetchPage).toHaveBeenNthCalledWith(1, 20);
     expect(fetchPage).toHaveBeenNthCalledWith(2, 22);
-    expect(fetchPage).toHaveBeenNthCalledWith(3, 24);
     expect(tracker.snapshotFor("agent-a")?.contiguousSeq).toBe(24);
   });
 
@@ -126,6 +147,51 @@ describe("EventGapRecoveryTracker", () => {
 
     tracker.unregister("agent-a");
     expect(tracker.snapshotFor("agent-a")).toBeUndefined();
+  });
+
+  it("reports incomplete when an empty page does not reach the observed high watermark", async () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 30);
+    tracker.observe("agent-a", 32);
+
+    await expect(
+      recoverEventGap(tracker, "agent-a", {
+        limit: 100,
+        fetchPage: async () => eventPage([]),
+        applyEvents: () => undefined,
+      }),
+    ).resolves.toEqual({ complete: false });
+    expect(tracker.snapshotFor("agent-a")?.recovering).toBe(true);
+  });
+
+  it("bounds a recovery cycle and can continue from the advanced cursor", async () => {
+    const tracker = new EventGapRecoveryTracker();
+    tracker.register("agent-a", 10);
+    tracker.observe("agent-a", 14);
+    const fetchPage = vi
+      .fn<(afterSeq: number) => Promise<ReturnType<typeof eventPage>>>()
+      .mockResolvedValueOnce(eventPage([event(11), event(12)]))
+      .mockResolvedValueOnce(eventPage([event(13), event(14)]));
+
+    await expect(
+      recoverEventGap(tracker, "agent-a", {
+        limit: 2,
+        maxPages: 1,
+        fetchPage,
+        applyEvents: () => undefined,
+      }),
+    ).resolves.toEqual({ complete: false });
+
+    await expect(
+      recoverEventGap(tracker, "agent-a", {
+        limit: 2,
+        maxPages: 1,
+        fetchPage,
+        applyEvents: () => undefined,
+      }),
+    ).resolves.toEqual({ complete: true });
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 10);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 12);
   });
 
   it("does not let a stale backfill mutate a re-registered agent", async () => {

--- a/web-gui/app/src/runtime/event-gap-recovery.ts
+++ b/web-gui/app/src/runtime/event-gap-recovery.ts
@@ -23,6 +23,10 @@ export interface AgentRecoverySnapshot {
   recovering: boolean;
 }
 
+export interface EventGapRecoveryResult {
+  complete: boolean;
+}
+
 interface RecoveryCycle {
   generation: number;
   afterSeq: number;
@@ -37,16 +41,47 @@ export class EventGapRecoveryTracker {
     this.states.clear();
   }
 
-  register(agentId: string, baselineSeq?: number, eventLogEpoch?: string): void {
-    if (baselineSeq == null || this.states.has(agentId)) return;
+  register(
+    agentId: string,
+    baselineSeq = 0,
+    eventLogEpoch?: string,
+    highestObservedSeq = baselineSeq,
+  ): void {
+    if (this.states.has(agentId)) return;
     this.states.set(agentId, {
       generation: this.nextGeneration++,
       eventLogEpoch: normalizeEpoch(eventLogEpoch),
       contiguousSeq: baselineSeq,
-      highestObservedSeq: baselineSeq,
+      highestObservedSeq: Math.max(baselineSeq, highestObservedSeq),
       observationVersion: 0,
       backfillInFlight: false,
     });
+  }
+
+  rebase(
+    agentId: string,
+    baselineSeq = 0,
+    eventLogEpoch?: string,
+    observedSeq = baselineSeq,
+  ): AgentRecoverySnapshot {
+    const current = this.states.get(agentId);
+    const normalizedEpoch = normalizeEpoch(eventLogEpoch);
+    const preserveObserved =
+      current != null &&
+      (!normalizedEpoch || !current.eventLogEpoch || current.eventLogEpoch === normalizedEpoch);
+    const highestObservedSeq = preserveObserved
+      ? Math.max(current.highestObservedSeq, baselineSeq, observedSeq)
+      : Math.max(baselineSeq, observedSeq);
+    const state: AgentRecoveryState = {
+      generation: this.nextGeneration++,
+      eventLogEpoch: normalizedEpoch ?? (preserveObserved ? current?.eventLogEpoch : undefined),
+      contiguousSeq: baselineSeq,
+      highestObservedSeq,
+      observationVersion: current?.observationVersion ?? 0,
+      backfillInFlight: false,
+    };
+    this.states.set(agentId, state);
+    return this.snapshot(state);
   }
 
   unregister(agentId: string): void {
@@ -60,7 +95,7 @@ export class EventGapRecoveryTracker {
       state = {
         generation: this.nextGeneration++,
         eventLogEpoch: normalizeEpoch(eventLogEpoch),
-        contiguousSeq: seq,
+        contiguousSeq: 0,
         highestObservedSeq: seq,
         observationVersion: 0,
         backfillInFlight: false,
@@ -171,44 +206,62 @@ export async function recoverEventGap<T extends SequencedEvent>(
   options: {
     force?: boolean;
     limit: number;
+    maxPages?: number;
     fetchPage: (afterSeq: number) => Promise<SequencedEventPage<T>>;
     applyEvents: (events: T[]) => void;
   },
-): Promise<void> {
+): Promise<EventGapRecoveryResult> {
   let cycle = tracker.beginBackfill(agentId, options.force ?? false);
-  if (!cycle) return;
+  if (!cycle) {
+    return { complete: !tracker.snapshotFor(agentId)?.recovering };
+  }
   let cleanupCycle = cycle;
+  let pageCount = 0;
 
   try {
     while (cycle) {
       let cursor = cycle.afterSeq;
       let hasMore = true;
       while (hasMore) {
+        if (options.maxPages != null && pageCount >= options.maxPages) {
+          return { complete: false };
+        }
         const page = await options.fetchPage(cursor);
+        pageCount += 1;
         if (tracker.adoptEpoch(agentId, page.eventLogEpoch)) {
           const restartedCycle = tracker.beginBackfill(agentId, true);
-          if (!restartedCycle) return;
+          if (!restartedCycle) {
+            return { complete: !tracker.snapshotFor(agentId)?.recovering };
+          }
           cycle = restartedCycle;
           cleanupCycle = restartedCycle;
           cursor = restartedCycle.afterSeq;
           continue;
         }
         const events = page.events.filter((event) => event.event_seq != null);
-        if (!events.length) break;
+        if (!events.length) {
+          return { complete: !tracker.snapshotFor(agentId)?.recovering };
+        }
 
         const snapshot = tracker.acceptBackfill(
           agentId,
           cycle,
           events.map((event) => event.event_seq as number),
         );
-        if (!snapshot) return;
+        if (!snapshot) {
+          return { complete: !tracker.snapshotFor(agentId)?.recovering };
+        }
         options.applyEvents(events);
         const nextCursor = snapshot.contiguousSeq;
-        hasMore = events.length >= options.limit && nextCursor > cursor;
+        hasMore =
+          snapshot.recovering &&
+          events.length >= options.limit &&
+          nextCursor > cursor;
         cursor = nextCursor;
       }
       cycle = tracker.nextCycle(agentId, cycle);
     }
+    return { complete: !tracker.snapshotFor(agentId)?.recovering };
   } finally {
     tracker.endBackfill(agentId, cleanupCycle);
   }

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -627,10 +627,15 @@ describe("roster activity unread state", () => {
     const { readStoredRosterActivity } = await import("./runtime-store");
 
     expect(readStoredRosterActivity("local")).toEqual({
-      localAgent: { unreadCount: 2, lastUnreadSeq: 12, lastReadSeq: 7, briefAt: "2026-01-01T00:00:00.000Z" },
+      localAgent: {
+        unreadCount: 2,
+        lastUnreadDeliverySeq: 12,
+        lastReadDeliverySeq: 7,
+        briefAt: "2026-01-01T00:00:00.000Z",
+      },
     });
     expect(readStoredRosterActivity("http://remote.example:7878")).toEqual({
-      remoteAgent: { unreadCount: 4, lastUnreadSeq: 20 },
+      remoteAgent: { unreadCount: 4, lastUnreadDeliverySeq: 20 },
     });
   });
 
@@ -661,10 +666,13 @@ describe("roster activity unread state", () => {
       "agent-b",
     );
 
-    expect(afterAgentMessage["agent-a"]).toMatchObject({ unreadCount: 1, lastUnreadSeq: 10 });
+    expect(afterAgentMessage["agent-a"]).toMatchObject({
+      unreadCount: 1,
+      lastUnreadDeliverySeq: 10,
+    });
   });
 
-  it("does not count unread for the currently open agent or operator messages", async () => {
+  it("counts a selected brief until the conversation confirms it was viewed", async () => {
     const { touchRosterActivityFromEvent } = await import("./runtime-store");
     const afterSelectedBrief = touchRosterActivityFromEvent(
       {},
@@ -685,17 +693,15 @@ describe("roster activity unread state", () => {
       "agent-b",
     );
 
-    expect(afterOperatorMessage["agent-a"]?.unreadCount).toBeUndefined();
+    expect(afterOperatorMessage["agent-a"]?.unreadCount).toBe(1);
     expect(afterOperatorMessage["agent-a"]?.operatorAt).toBe("2026-01-01T00:00:01.000Z");
   });
 
-  it("advances lastReadSeq for the currently open agent to prevent re-counting on replay", async () => {
+  it("advances the delivery read marker only after the synchronized conversation is visible", async () => {
     const { touchRosterActivityFromEvent } = await import("./runtime-store");
-    // Simulate: user opens agent-a with lastReadSeq=7, then views events 8-10
-    // while the agent is selected.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let activity: Record<string, any> = {
-      "agent-a": { unreadCount: 0, lastUnreadSeq: 7, lastReadSeq: 7 },
+      "agent-a": { unreadCount: 0, lastUnreadDeliverySeq: 7, lastReadDeliverySeq: 7 },
     };
     for (const seq of [8, 9, 10]) {
       activity = touchRosterActivityFromEvent(
@@ -705,12 +711,44 @@ describe("roster activity unread state", () => {
         "agent-a",
       );
     }
-    // Unread should stay 0 and lastReadSeq should advance to 10.
-    expect(activity["agent-a"]?.unreadCount ?? 0).toBe(0);
-    expect(activity["agent-a"]?.lastReadSeq).toBe(10);
+    expect(activity["agent-a"]?.unreadCount).toBe(3);
 
-    // Now simulate a page reload: events 8-10 are re-delivered while agent-a
-    // is NOT selected. They must NOT be re-counted as unread.
+    vi.stubGlobal("document", { visibilityState: "visible" });
+    useRuntimeStore.setState({
+      route: "agent",
+      selectedAgentId: "agent-a",
+      rosterActivityByAgentId: activity,
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          cacheStatus: "hit",
+          contentStatus: "available",
+          syncStatus: "streaming",
+          liveStatus: "recovering",
+          eventsBySeq: {
+            8: { agent_id: "agent-a", event_seq: 8, type: "brief_created", payload: {} },
+            9: { agent_id: "agent-a", event_seq: 9, type: "brief_created", payload: {} },
+            10: { agent_id: "agent-a", event_seq: 10, type: "brief_created", payload: {} },
+          },
+          eventSeqs: [8, 9, 10],
+        }),
+      },
+    });
+    useRuntimeStore.getState().markAgentConversationRead("agent-a");
+    expect(useRuntimeStore.getState().rosterActivityByAgentId["agent-a"]?.unreadCount).toBe(3);
+    useRuntimeStore.setState((state) => ({
+      sessionsByAgentId: {
+        ...state.sessionsByAgentId,
+        "agent-a": {
+          ...state.sessionsByAgentId["agent-a"],
+          liveStatus: "streaming",
+        },
+      },
+    }));
+    useRuntimeStore.getState().markAgentConversationRead("agent-a");
+    activity = useRuntimeStore.getState().rosterActivityByAgentId;
+    expect(activity["agent-a"]?.unreadCount).toBe(0);
+    expect(activity["agent-a"]?.lastReadDeliverySeq).toBe(10);
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let replayed: Record<string, any> = activity;
     for (const seq of [8, 9, 10]) {
@@ -731,7 +769,7 @@ describe("roster activity unread state", () => {
       "agent-b",
     );
     expect(replayed["agent-a"]?.unreadCount).toBe(1);
-    expect(replayed["agent-a"]?.lastUnreadSeq).toBe(11);
+    expect(replayed["agent-a"]?.lastUnreadDeliverySeq).toBe(11);
   });
 });
 
@@ -1034,6 +1072,111 @@ describe("runtime client generation", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe("global event stream recovery", () => {
+  afterEach(() => {
+    useRuntimeStore.getState().stopGlobalEventStream();
+    useRuntimeStore.getState().unregisterAgentForEvents("agent-a");
+    useRuntimeStore.setState({
+      sessionsByAgentId: {},
+      globalStreamStatus: "idle",
+      selectedAgentId: "",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("does not report streaming until the subscribed agent backfill completes", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    let resolveBackfill!: (response: Response) => void;
+    const backfill = new Promise<Response>((resolve) => {
+      resolveBackfill = resolve;
+    });
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/events/stream")) {
+        return Promise.resolve(new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            init?.signal?.addEventListener("abort", () => controller.close());
+          },
+        }), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }));
+      }
+      if (url.pathname.endsWith("/agents/agent-a/events")) return backfill;
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+    useRuntimeStore.setState({
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          eventLogEpoch: "epoch-1",
+          eventsBySeq: {
+            1: {
+              agent_id: "agent-a",
+              event_seq: 1,
+              event_log_epoch: "epoch-1",
+              type: "legacy_event",
+              payload: {},
+            },
+            5: {
+              agent_id: "agent-a",
+              event_seq: 5,
+              event_log_epoch: "epoch-1",
+              type: "legacy_event",
+              payload: {},
+            },
+          },
+          eventSeqs: [1, 5],
+          newestSeq: 5,
+          gaps: [{ afterSeq: 1, beforeSeq: 5 }],
+        }),
+      },
+    });
+
+    useRuntimeStore.getState().registerAgentForEvents("agent-a");
+
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().globalStreamStatus).toBe("catching_up");
+    });
+    const eventRequest = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), "http://localhost"))
+      .find((url) => url.pathname.endsWith("/agents/agent-a/events"));
+    expect(eventRequest?.searchParams.get("after_seq")).toBe("1");
+
+    resolveBackfill(jsonResponse({
+      events: [2, 3, 4, 5].map((eventSeq) => ({
+        id: `event-${eventSeq}`,
+        event_seq: eventSeq,
+        event_log_epoch: "epoch-1",
+        ts: "2026-08-09T00:00:00Z",
+        agent_id: "agent-a",
+        type: "legacy_event",
+        payload: {},
+      })),
+      event_log_epoch: "epoch-1",
+      has_older: false,
+      has_newer: false,
+      order: "asc",
+      limit: 100,
+    }));
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().globalStreamStatus).toBe("streaming");
+    });
   });
 });
 
@@ -1452,6 +1595,79 @@ describe("brief hydration retry limits", () => {
       expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]?.briefRecordsById["brief-123"]?.text)
         .toBe("Hydrated after manual retry.");
     });
+  });
+
+  it("hydrates selected message references on the fresh streaming fast path", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/agents/agent-a/messages:batchGet")) {
+        return Promise.resolve(jsonResponse({
+          messages: [{
+            id: "message-123",
+            origin: { kind: "operator" },
+            body: { text: "Hydrated selected message." },
+          }],
+          missing_message_ids: [],
+        }));
+      }
+      if (url.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+
+    const now = Date.now();
+    useRuntimeStore.setState({
+      route: "agent",
+      selectedAgentId: "agent-a",
+      globalStreamStatus: "streaming",
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          cacheStatus: "hit",
+          contentStatus: "available",
+          syncStatus: "streaming",
+          detailValidatedAt: now,
+          eventsValidatedAt: now,
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          eventsBySeq: {
+            1: {
+              agent_id: "agent-a",
+              event_seq: 1,
+              type: "message_enqueued",
+              payload: {
+                message_id: "message-123",
+                origin: { kind: "operator" },
+              },
+            },
+          },
+          eventSeqs: [1],
+          referencedMessageIds: { "message-123": true },
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().ensureAgentSession("agent-a", "info");
+
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]?.messagesById["message-123"])
+        .toMatchObject({ id: "message-123" });
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -195,8 +195,8 @@ export interface AgentRosterActivity {
   operatorAt?: string;
   briefAt?: string;
   unreadCount?: number;
-  lastUnreadSeq?: number;
-  lastReadSeq?: number;
+  lastUnreadDeliverySeq?: number;
+  lastReadDeliverySeq?: number;
 }
 
 const OPTIMISTIC_OPERATOR_PROMPT_SOURCE = "pending-operator-prompt";
@@ -271,7 +271,7 @@ export interface RuntimeStoreState {
   bootstrap: RuntimeBootstrap;
   bootstrapLoading: boolean;
   bootstrapError?: string;
-  globalStreamStatus: "idle" | "connecting" | "streaming" | "reconnecting";
+  globalStreamStatus: "idle" | "connecting" | "catching_up" | "streaming" | "reconnecting";
   modelCatalog: RuntimeModelCatalog;
   modelCatalogLoading: boolean;
   modelCatalogError?: string;
@@ -314,6 +314,7 @@ export interface RuntimeStoreState {
 
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string, targetEventSeq?: number) => void;
+  markAgentConversationRead: (agentId: string) => void;
   openSkill: (skillId: string, agentId?: string) => void;
   openTemplate: (catalogId: string) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
@@ -505,7 +506,11 @@ let globalStreamReconnectTimer: number | undefined;
 let globalStreamStaleTimer: number | undefined;
 let globalStreamReconnectAttempt = 0;
 const globalStreamSubscribedAgents = new Set<string>();
+const globalStreamCatchUpPendingAgents = new Set<string>();
 const globalEventRecovery = new EventGapRecoveryTracker();
+const globalBackfillRetryTimers = new Map<string, number>();
+const globalBackfillRetryAttempts = new Map<string, number>();
+const globalRecoveryBaselineInFlight = new Map<string, Promise<void>>();
 const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
@@ -533,6 +538,8 @@ const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
 const GLOBAL_STREAM_STALE_TIMEOUT_MS = 45_000;
 const GLOBAL_BACKFILL_LIMIT = 100;
+const GLOBAL_BACKFILL_MAX_PAGES = 10;
+const GLOBAL_BACKFILL_CONCURRENCY = 4;
 const AGENT_VALIDATION_TTL_MS = 60_000;
 const RESUME_RECONCILIATION_THRESHOLD_MS = 60_000;
 const BRIEF_HYDRATION_RETRY_DELAYS_MS = [1_000, 2_000] as const;
@@ -589,6 +596,11 @@ function cancelClientGenerationWork(): void {
   for (const timer of agentDetailRetryTimers.values()) window.clearTimeout(timer);
   agentDetailRetryTimers.clear();
   agentDetailRetryAttempts.clear();
+  for (const timer of globalBackfillRetryTimers.values()) window.clearTimeout(timer);
+  globalBackfillRetryTimers.clear();
+  globalBackfillRetryAttempts.clear();
+  globalRecoveryBaselineInFlight.clear();
+  globalStreamCatchUpPendingAgents.clear();
   inspectorDetailInFlight.clear();
   workItemRefreshInFlight.clear();
   workItemDetailInFlight.clear();
@@ -931,18 +943,23 @@ function writeStoredRosterActivity(remoteKey: string, activityByAgentId: Record<
 }
 
 function coerceRosterActivity(value: unknown): AgentRosterActivity | undefined {
-  const parsed = value as Partial<AgentRosterActivity>;
+  const parsed = value as Partial<AgentRosterActivity> & {
+    lastUnreadSeq?: number;
+    lastReadSeq?: number;
+  };
   const activity: AgentRosterActivity = {};
   if (typeof parsed.operatorAt === "string") activity.operatorAt = parsed.operatorAt;
   if (typeof parsed.briefAt === "string") activity.briefAt = parsed.briefAt;
   if (typeof parsed.unreadCount === "number" && Number.isFinite(parsed.unreadCount) && parsed.unreadCount > 0) {
     activity.unreadCount = Math.floor(parsed.unreadCount);
   }
-  if (typeof parsed.lastUnreadSeq === "number" && Number.isFinite(parsed.lastUnreadSeq)) {
-    activity.lastUnreadSeq = Math.floor(parsed.lastUnreadSeq);
+  const lastUnreadDeliverySeq = parsed.lastUnreadDeliverySeq ?? parsed.lastUnreadSeq;
+  if (typeof lastUnreadDeliverySeq === "number" && Number.isFinite(lastUnreadDeliverySeq)) {
+    activity.lastUnreadDeliverySeq = Math.floor(lastUnreadDeliverySeq);
   }
-  if (typeof parsed.lastReadSeq === "number" && Number.isFinite(parsed.lastReadSeq)) {
-    activity.lastReadSeq = Math.floor(parsed.lastReadSeq);
+  const lastReadDeliverySeq = parsed.lastReadDeliverySeq ?? parsed.lastReadSeq;
+  if (typeof lastReadDeliverySeq === "number" && Number.isFinite(lastReadDeliverySeq)) {
+    activity.lastReadDeliverySeq = Math.floor(lastReadDeliverySeq);
   }
   return Object.keys(activity).length ? activity : undefined;
 }
@@ -1072,10 +1089,11 @@ function initSessionCacheForRemote(set: StoreSet, get?: () => RuntimeStoreState)
       if (get && sessionCacheContextIsCurrent(context)) {
         const displayLevel = get().displayLevel;
         const selectedAgentId = get().selectedAgentId;
+        for (const agentId of restoredAgentIds) {
+          rebaseGlobalRecoveryFromSession(agentId, get().sessionsByAgentId[agentId]);
+        }
         if (selectedAgentId && restoredAgentIds.includes(selectedAgentId)) {
-          scheduleMessageHydration(get, set, selectedAgentId, displayLevel);
-          scheduleTranscriptHydration(get, set, selectedAgentId, displayLevel);
-          scheduleBriefHydration(get, set, selectedAgentId, displayLevel);
+          reconcileSelectedSessionHydration(get, set, selectedAgentId, displayLevel);
         }
       }
     } catch {
@@ -1180,19 +1198,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   openAgent: (agentId, targetEventSeq) =>
     set((state) => {
       const currentSession = state.sessionsByAgentId[agentId];
-      const rosterActivityByAgentId = markAgentRead(
-        state.rosterActivityByAgentId,
-        agentId,
-        currentSession?.newestSeq,
-      );
-      if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
-        writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
-      }
       return {
         selectedAgentId: agentId,
         route: "agent",
         displayLevel: state.displayLevelsByAgentId[agentId] ?? "info",
-        rosterActivityByAgentId,
         sessionsByAgentId:
           targetEventSeq == null
             ? state.sessionsByAgentId
@@ -1207,6 +1216,43 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
               },
       };
     }),
+  markAgentConversationRead: (agentId) => {
+    const state = get();
+    const session = state.sessionsByAgentId[agentId];
+    if (
+      state.route !== "agent" ||
+      state.selectedAgentId !== agentId ||
+      typeof document === "undefined" ||
+      document.visibilityState !== "visible" ||
+      !session ||
+      session.loading ||
+      session.gaps.length > 0 ||
+      session.syncStatus === "refreshing" ||
+      session.syncStatus === "recovering" ||
+      session.syncStatus === "stale" ||
+      session.syncStatus === "error" ||
+      session.liveStatus === "connecting" ||
+      session.liveStatus === "reconnecting" ||
+      session.liveStatus === "recovering" ||
+      session.liveStatus === "stale" ||
+      session.liveStatus === "error" ||
+      missingBriefIdsForHydration(session).length > 0
+    ) {
+      return;
+    }
+    const deliverySeq = latestBriefDeliverySeq(session);
+    if (deliverySeq == null) return;
+    set((current) => {
+      const rosterActivityByAgentId = markAgentDeliveriesRead(
+        current.rosterActivityByAgentId,
+        agentId,
+        deliverySeq,
+      );
+      if (rosterActivityByAgentId === current.rosterActivityByAgentId) return current;
+      writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
+      return { rosterActivityByAgentId };
+    });
+  },
   setDisplayLevel: (displayLevel, agentId) =>
     set((state) => {
       const targetAgentId = agentId ?? state.selectedAgentId;
@@ -2490,6 +2536,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
               },
             };
           });
+          rebaseGlobalRecoveryFromSession(agentId, get().sessionsByAgentId[agentId]);
           startRuntimeSpan(trace, "ui.session_state_transition", {
             state: cached ? "cache_hit/stale" : "cache_miss/refreshing",
           }).end("ok");
@@ -2558,6 +2605,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         }
         await get().refreshAgentDetail(agentId, displayLevel, { trace, trigger: "agent.open" });
       } finally {
+        reconcileSelectedSessionHydration(get, set, agentId, displayLevel);
         if (ensureAgentSessionInFlight.get(agentId) === promise) {
           ensureAgentSessionInFlight.delete(agentId);
         }
@@ -3164,7 +3212,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     stopGlobalEventStream(set);
   },
   registerAgentForEvents: (agentId) => {
-    registerAgentForEvents(get, set, agentId, false);
+    registerAgentForEvents(get, set, agentId);
   },
   unregisterAgentForEvents: (agentId) => {
     unregisterAgentForEvents(agentId);
@@ -3455,9 +3503,9 @@ function startGlobalEventStream(get: () => RuntimeStoreState, set: StoreSet): vo
     onOpen: () => {
       if (!isCurrentClientRequest(request)) return;
       globalStreamReconnectAttempt = 0;
-      set({ globalStreamStatus: "streaming" });
       connectSpan.end("ok");
       scheduleGlobalStaleWatchdog(get, set);
+      void Promise.resolve().then(() => catchUpGlobalEventStream(get, set, request));
     },
     onActivity: () => {
       if (!isCurrentClientRequest(request)) return;
@@ -3495,6 +3543,10 @@ function stopGlobalEventStream(set: StoreSet): void {
     globalStreamStaleTimer = undefined;
   }
   globalStreamReconnectAttempt = 0;
+  globalStreamCatchUpPendingAgents.clear();
+  for (const agentId of Array.from(globalBackfillRetryTimers.keys())) {
+    clearGlobalBackfillRetry(agentId);
+  }
   set({ globalStreamStatus: "idle" });
   // Flush any pending events for all agents.
   for (const agentId of globalStreamSubscribedAgents) {
@@ -3506,25 +3558,142 @@ function registerAgentForEvents(
   get: () => RuntimeStoreState,
   set: StoreSet,
   agentId: string,
-  backfill = true,
 ): void {
   const wasSubscribed = globalStreamSubscribedAgents.has(agentId);
   globalStreamSubscribedAgents.add(agentId);
-  // Initialize seq tracking from existing session state.
-  const session = wasSubscribed ? undefined : get().sessionsByAgentId[agentId];
-  if (session && !globalEventRecovery.snapshotFor(agentId)) {
-    const lastSeq = highestSeq(session.eventSeqs) ?? session.newestSeq;
-    globalEventRecovery.register(agentId, lastSeq, session.eventLogEpoch);
+  if (!wasSubscribed && !globalEventRecovery.snapshotFor(agentId)) {
+    const session = get().sessionsByAgentId[agentId];
+    globalEventRecovery.register(
+      agentId,
+      contiguousEventSeq(session),
+      session?.eventLogEpoch,
+      observedEventSeq(session),
+    );
   }
   // Start global stream if not running.
   startGlobalEventStream(get, set);
-  // Initial backfill from the last known seq.
-  if (!wasSubscribed && backfill) void backfillAgentEvents(set, agentId);
+  const globalStreamStatus = get().globalStreamStatus;
+  if (
+    !wasSubscribed &&
+    (
+      globalStreamStatus === "streaming" ||
+      globalStreamStatus === "catching_up"
+    )
+  ) {
+    void catchUpRegisteredAgent(get, set, agentId);
+  }
 }
 
 function unregisterAgentForEvents(agentId: string): void {
   globalStreamSubscribedAgents.delete(agentId);
+  globalStreamCatchUpPendingAgents.delete(agentId);
+  globalRecoveryBaselineInFlight.delete(agentId);
+  clearGlobalBackfillRetry(agentId);
   globalEventRecovery.unregister(agentId);
+}
+
+async function catchUpGlobalEventStream(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  request: ClientRequest,
+): Promise<void> {
+  const agentIds = Array.from(globalStreamSubscribedAgents);
+  globalStreamCatchUpPendingAgents.clear();
+  agentIds.forEach((agentId) => globalStreamCatchUpPendingAgents.add(agentId));
+  set({ globalStreamStatus: "catching_up" });
+  await runWithConcurrencyLimit(
+    agentIds,
+    GLOBAL_BACKFILL_CONCURRENCY,
+    async (agentId) => {
+      if (!isCurrentClientRequest(request) || !globalEventStream) return;
+      await recoverRegisteredGlobalAgent(get, set, agentId, request);
+    },
+    () => isCurrentClientRequest(request) && Boolean(globalEventStream),
+  );
+  if (isCurrentClientRequest(request) && globalEventStream && globalStreamCatchUpPendingAgents.size === 0) {
+    set({ globalStreamStatus: "streaming" });
+  }
+}
+
+function catchUpRegisteredAgent(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+): Promise<void> {
+  if (globalStreamCatchUpPendingAgents.has(agentId)) return Promise.resolve();
+  const request = captureClientRequest();
+  globalStreamCatchUpPendingAgents.add(agentId);
+  set({ globalStreamStatus: "catching_up" });
+  return recoverRegisteredGlobalAgent(get, set, agentId, request);
+}
+
+async function recoverRegisteredGlobalAgent(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  request: ClientRequest,
+): Promise<void> {
+  try {
+    await ensureGlobalRecoveryBaseline(get, set, agentId);
+    if (!isCurrentClientRequest(request) || !globalEventStream) return;
+    const recovered = await backfillAgentEvents(set, agentId, true);
+    if (recovered) completeGlobalStreamCatchUp(set, agentId);
+  } catch (error) {
+    scheduleGlobalBackfillRetry(set, agentId);
+    setStreamState(set, agentId, "recovering", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function completeGlobalStreamCatchUp(set: StoreSet, agentId: string): void {
+  globalStreamCatchUpPendingAgents.delete(agentId);
+  if (globalEventStream && globalStreamCatchUpPendingAgents.size === 0) {
+    set({ globalStreamStatus: "streaming" });
+  }
+}
+
+async function ensureGlobalRecoveryBaseline(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+): Promise<void> {
+  const session = get().sessionsByAgentId[agentId];
+  if (session?.eventSeqs.length) {
+    rebaseGlobalRecoveryFromSession(agentId, session);
+    return;
+  }
+  const existing = globalRecoveryBaselineInFlight.get(agentId);
+  if (existing) return existing;
+  const generation = clientGeneration;
+  let initialization!: Promise<void>;
+  initialization = (async () => {
+    const page = await runtimeClient.getAgentEvents(agentId, {
+      order: "desc",
+      limit: GLOBAL_BACKFILL_LIMIT,
+    });
+    if (
+      !isCurrentClientGeneration(generation) ||
+      globalRecoveryBaselineInFlight.get(agentId) !== initialization ||
+      !globalStreamSubscribedAgents.has(agentId)
+    ) return;
+    const events = (page.events ?? [])
+      .filter((event) => event.event_seq != null)
+      .map((event) => streamEventFromBackfill(event, agentId, page.event_log_epoch));
+    const seqs = eventSeqs(events);
+    const baselineSeq = seqs.length ? Math.max(0, seqs[0] - 1) : 0;
+    globalEventRecovery.rebase(agentId, baselineSeq, page.event_log_epoch);
+    for (const seq of seqs) {
+      globalEventRecovery.observe(agentId, seq, page.event_log_epoch);
+    }
+    if (events.length) applyStreamEvents(set, agentId, events);
+  })().finally(() => {
+    if (globalRecoveryBaselineInFlight.get(agentId) === initialization) {
+      globalRecoveryBaselineInFlight.delete(agentId);
+    }
+  });
+  globalRecoveryBaselineInFlight.set(agentId, initialization);
+  return initialization;
 }
 
 function syncGlobalEventRoster(get: () => RuntimeStoreState, set: StoreSet): void {
@@ -3533,8 +3702,31 @@ function syncGlobalEventRoster(get: () => RuntimeStoreState, set: StoreSet): voi
     if (!agentIds.has(agentId)) unregisterAgentForEvents(agentId);
   }
   for (const agentId of agentIds) {
-    registerAgentForEvents(get, set, agentId, false);
+    registerAgentForEvents(get, set, agentId);
   }
+}
+
+function contiguousEventSeq(session: AgentSessionState | undefined): number {
+  if (!session) return 0;
+  return session.gaps[0]?.afterSeq ?? highestSeq(session.eventSeqs) ?? session.newestSeq ?? 0;
+}
+
+function observedEventSeq(session: AgentSessionState | undefined): number {
+  return session ? highestSeq(session.eventSeqs) ?? session.newestSeq ?? 0 : 0;
+}
+
+function rebaseGlobalRecoveryFromSession(
+  agentId: string,
+  session: AgentSessionState | undefined,
+): void {
+  if (!globalStreamSubscribedAgents.has(agentId)) return;
+  globalRecoveryBaselineInFlight.delete(agentId);
+  globalEventRecovery.rebase(
+    agentId,
+    contiguousEventSeq(session),
+    session?.eventLogEpoch,
+    observedEventSeq(session),
+  );
 }
 
 function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto): void {
@@ -3558,7 +3750,7 @@ function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto)
   enqueueStreamEvent(set, agentId, event);
 }
 
-async function backfillAgentEvents(set: StoreSet, agentId: string, force = false): Promise<void> {
+async function backfillAgentEvents(set: StoreSet, agentId: string, force = false): Promise<boolean> {
   const generation = clientGeneration;
   const span = startRuntimeSpan(
     createRuntimeTrace("stream.reconnect", { agentId, trigger: "events.backfill" }),
@@ -3567,9 +3759,10 @@ async function backfillAgentEvents(set: StoreSet, agentId: string, force = false
   );
   let eventCount = 0;
   try {
-    await recoverEventGap(globalEventRecovery, agentId, {
+    const result = await recoverEventGap(globalEventRecovery, agentId, {
       force,
       limit: GLOBAL_BACKFILL_LIMIT,
+      maxPages: GLOBAL_BACKFILL_MAX_PAGES,
       fetchPage: async (afterSeq) => {
         const page = await runtimeClient.getAgentEvents(agentId, {
           afterSeq,
@@ -3591,11 +3784,43 @@ async function backfillAgentEvents(set: StoreSet, agentId: string, force = false
         }
       },
     });
+    if (!result.complete) {
+      scheduleGlobalBackfillRetry(set, agentId);
+      setAgentLiveStatus(set, agentId, "recovering");
+      span.end("ok", { eventCount, incomplete: true });
+      return false;
+    }
+    clearGlobalBackfillRetry(agentId);
     span.end("ok", { eventCount });
-  } catch {
+    return true;
+  } catch (error) {
     span.end("error");
-    // Silently ignore backfill errors; the stream will retry.
+    scheduleGlobalBackfillRetry(set, agentId);
+    setStreamState(set, agentId, "recovering", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
   }
+}
+
+function scheduleGlobalBackfillRetry(set: StoreSet, agentId: string): void {
+  if (!globalStreamSubscribedAgents.has(agentId) || globalBackfillRetryTimers.has(agentId)) return;
+  const attempt = (globalBackfillRetryAttempts.get(agentId) ?? 0) + 1;
+  globalBackfillRetryAttempts.set(agentId, attempt);
+  const timer = window.setTimeout(() => {
+    globalBackfillRetryTimers.delete(agentId);
+    void backfillAgentEvents(set, agentId, true).then((recovered) => {
+      if (recovered) completeGlobalStreamCatchUp(set, agentId);
+    });
+  }, reconnectDelayMs(attempt));
+  globalBackfillRetryTimers.set(agentId, timer);
+}
+
+function clearGlobalBackfillRetry(agentId: string): void {
+  const timer = globalBackfillRetryTimers.get(agentId);
+  if (timer != null) window.clearTimeout(timer);
+  globalBackfillRetryTimers.delete(agentId);
+  globalBackfillRetryAttempts.delete(agentId);
 }
 
 export function streamEventFromBackfill(
@@ -3628,6 +3853,10 @@ function scheduleGlobalStreamReconnect(
 ): void {
   globalEventStream?.close();
   globalEventStream = undefined;
+  globalStreamCatchUpPendingAgents.clear();
+  for (const agentId of Array.from(globalBackfillRetryTimers.keys())) {
+    clearGlobalBackfillRetry(agentId);
+  }
   if (globalStreamStaleTimer != null) {
     window.clearTimeout(globalStreamStaleTimer);
     globalStreamStaleTimer = undefined;
@@ -4250,19 +4479,23 @@ function touchRosterActivity(
   };
 }
 
-function markAgentRead(
+function markAgentDeliveriesRead(
   current: Record<string, AgentRosterActivity>,
   agentId: string,
-  newestSeq: number | undefined,
+  deliverySeq: number,
 ): Record<string, AgentRosterActivity> {
   const existing = current[agentId];
-  if (!existing?.unreadCount && (newestSeq == null || existing?.lastReadSeq === newestSeq)) return current;
+  if (!existing?.unreadCount && existing?.lastReadDeliverySeq === deliverySeq) return current;
   return {
     ...current,
     [agentId]: {
       ...existing,
       unreadCount: 0,
-      lastReadSeq: Math.max(newestSeq ?? 0, existing?.lastUnreadSeq ?? 0, existing?.lastReadSeq ?? 0),
+      lastReadDeliverySeq: Math.max(
+        deliverySeq,
+        existing?.lastUnreadDeliverySeq ?? 0,
+        existing?.lastReadDeliverySeq ?? 0,
+      ),
     },
   };
 }
@@ -4271,7 +4504,7 @@ export function touchRosterActivityFromEvent(
   current: Record<string, AgentRosterActivity>,
   agentId: string,
   event: StreamEventEnvelopeDto,
-  selectedAgentId: string,
+  _selectedAgentId: string,
 ): Record<string, AgentRosterActivity> {
   if (!canApplySessionEvent(event)) return current;
   let next = current;
@@ -4282,14 +4515,7 @@ export function touchRosterActivityFromEvent(
     next = touchRosterActivity(next, agentId, "operator", eventTimestamp(event));
   }
   if (isUnreadEvent(event)) {
-    if (agentId !== selectedAgentId) {
-      next = incrementUnreadFromEvent(next, agentId, event);
-    } else {
-      // Advance the read watermark for the currently-viewed agent so that
-      // events seen in real time are not re-counted as unread after a page
-      // reload or session reset (when eventsBySeq is empty and dedup fails).
-      next = advanceReadSeqFromEvent(next, agentId, event);
-    }
+    next = incrementUnreadFromEvent(next, agentId, event);
   }
   return next;
 }
@@ -4305,34 +4531,32 @@ function incrementUnreadFromEvent(
 ): Record<string, AgentRosterActivity> {
   const existing = current[agentId];
   const seq = event.event_seq;
-  if (seq != null && existing?.lastReadSeq != null && seq <= existing.lastReadSeq) return current;
-  if (seq != null && existing?.lastUnreadSeq != null && seq <= existing.lastUnreadSeq) return current;
+  if (
+    seq != null &&
+    existing?.lastReadDeliverySeq != null &&
+    seq <= existing.lastReadDeliverySeq
+  ) return current;
+  if (
+    seq != null &&
+    existing?.lastUnreadDeliverySeq != null &&
+    seq <= existing.lastUnreadDeliverySeq
+  ) return current;
   return {
     ...current,
     [agentId]: {
       ...existing,
       unreadCount: (existing?.unreadCount ?? 0) + 1,
-      lastUnreadSeq: seq ?? existing?.lastUnreadSeq,
+      lastUnreadDeliverySeq: seq ?? existing?.lastUnreadDeliverySeq,
     },
   };
 }
 
-function advanceReadSeqFromEvent(
-  current: Record<string, AgentRosterActivity>,
-  agentId: string,
-  event: StreamEventEnvelopeDto,
-): Record<string, AgentRosterActivity> {
-  const existing = current[agentId];
-  const seq = event.event_seq;
-  if (seq == null) return current;
-  if (existing?.lastReadSeq != null && seq <= existing.lastReadSeq) return current;
-  return {
-    ...current,
-    [agentId]: {
-      ...existing,
-      lastReadSeq: Math.max(seq, existing?.lastReadSeq ?? 0),
-    },
-  };
+function latestBriefDeliverySeq(session: AgentSessionState): number | undefined {
+  for (let index = session.eventSeqs.length - 1; index >= 0; index -= 1) {
+    const seq = session.eventSeqs[index];
+    if (session.eventsBySeq[seq]?.type === "brief_created") return seq;
+  }
+  return undefined;
 }
 
 function eventTimestamp(event: StreamEventEnvelopeDto): string | undefined {
@@ -4779,6 +5003,18 @@ function isAgentStateCacheInvalidationEvent(event: StreamEventEnvelopeDto): bool
     event.type === "worktree_entered" ||
     event.type === "worktree_exited"
   );
+}
+
+function reconcileSelectedSessionHydration(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  displayLevel: DisplayLevel,
+): void {
+  if (get().route !== "agent" || get().selectedAgentId !== agentId) return;
+  scheduleMessageHydration(get, set, agentId, displayLevel);
+  scheduleTranscriptHydration(get, set, agentId, displayLevel);
+  scheduleBriefHydration(get, set, agentId, displayLevel);
 }
 
 function scheduleMessageHydration(


### PR DESCRIPTION
## Summary

- hydrate the selected agent's message, transcript, and brief event streams instead of relying on explicit navigation fetches
- keep the global SSE connection in catch-up mode until bounded per-agent backfill completes, with retry/backoff on recovery failures
- recover event gaps with separate contiguous and observed sequence watermarks
- update unread state from global brief delivery events and only mark a conversation read after sync when it is visible and scrolled to the bottom
- add regression coverage for global recovery, gap handling, hydration, and unread/read transitions

P0-5 is intentionally out of scope for this PR.

## Testing

- `cd web-gui/app && npm test` (305 tests passed)
- `cd web-gui/app && npm run build`
- `git diff --check`
