### PR TITLE
fix(web): prefer local timeline expansion

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   attachmentKindForFile,
   captureScrollAnchor,
+  historyLoadDecision,
   readStoredComposerDraft,
   resizeComposerTextarea,
   restoredScrollTop,
@@ -167,6 +168,21 @@ describe("timeline display levels", () => {
 
     expect(timelineForDisplayLevel([semanticItem, debugItem], "debug", 20).map((item) => item.id))
       .toEqual(["assistant-message", "runtime:debug"]);
+  });
+});
+
+describe("history loading", () => {
+  it("expands already loaded timeline items before requesting network history", () => {
+    expect(historyLoadDecision(true, true)).toBe("expand-local");
+    expect(historyLoadDecision(true, false)).toBe("expand-local");
+  });
+
+  it("requests network history only after the local timeline reaches its boundary", () => {
+    expect(historyLoadDecision(false, true)).toBe("load-network");
+  });
+
+  it("does nothing when neither local nor server history remains", () => {
+    expect(historyLoadDecision(false, false)).toBe("none");
   });
 });
 

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -68,6 +68,14 @@ const COMPOSER_DRAFT_STORAGE_PREFIX = "holon.webGui.composerDraft.v1";
 const COMPOSER_TEXTAREA_MAX_HEIGHT = 320;
 const MESSAGE_LIST_BOTTOM_SAFE_SPACE = 96;
 
+export type HistoryLoadDecision = "expand-local" | "load-network" | "none";
+
+export function historyLoadDecision(hasHiddenTimelineItems: boolean, hasOlderEvents: boolean): HistoryLoadDecision {
+  if (hasHiddenTimelineItems) return "expand-local";
+  if (hasOlderEvents) return "load-network";
+  return "none";
+}
+
 export function storedComposerDraftKey(agentId: string): string {
   return `${COMPOSER_DRAFT_STORAGE_PREFIX}:${encodeURIComponent(agentId)}`;
 }
@@ -360,6 +368,8 @@ export function AgentPage({
     getItemKey: (index) => timelineTurns[index]?.id ?? `empty:${index}`,
   });
   const hasHiddenTimelineItems = timeline.length >= visibleTimelineItemLimit && sourceTimeline.length > visibleTimelineItemLimit;
+  const historyLoadAction = historyLoadDecision(hasHiddenTimelineItems, hasOlderEvents);
+  const loadingNetworkHistory = historyLoadAction === "load-network" && loadingOlderEvents;
   const groupedModelOptions = useMemo(() => groupModelOptionsByProvider(modelCatalog.options), [modelCatalog.options]);
   const activeModelOption = useMemo(() => modelCatalog.options.find((option) => option.routeRef === activeAgent.model), [activeAgent.model, modelCatalog.options]);
   const activeModelSupportsReasoning = activeModelOption?.supportsReasoningEffort ?? Boolean(activeAgent.modelReasoningEffort);
@@ -605,6 +615,7 @@ export function AgentPage({
   }
 
   async function handleLoadOlderEvents() {
+    if (historyLoadAction === "none") return;
     const list = messageListRef.current;
     if (list) {
       const contentOffset = virtualWrapperRef.current?.offsetTop ?? 0;
@@ -615,6 +626,10 @@ export function AgentPage({
           ? captureScrollAnchor([anchorItem], virtualScrollTop)
           : null;
       stickToBottomRef.current = false;
+    }
+    if (historyLoadAction === "expand-local") {
+      setVisibleTimelineItemLimit((limit) => limit + HISTORY_PAGE_VISIBLE_INCREMENT);
+      return;
     }
     try {
       await onLoadOlderEvents();
@@ -685,10 +700,10 @@ export function AgentPage({
       <div className="agent-workbench">
         <section className="conversation-pane">
           <div className="message-list" ref={messageListRef} onScroll={handleMessageListScroll}>
-            {hasOlderEvents || hasHiddenTimelineItems ? (
+            {historyLoadAction !== "none" ? (
               <div className="history-loader">
-                <Button type="button" size="sm" variant="secondary" disabled={loadingOlderEvents} onClick={handleLoadOlderEvents}>
-                  {loadingOlderEvents ? t("agent.loadingEarlier") : t("agent.loadEarlier")}
+                <Button type="button" size="sm" variant="secondary" disabled={loadingNetworkHistory} onClick={handleLoadOlderEvents}>
+                  {loadingNetworkHistory ? t("agent.loadingEarlier") : t("agent.loadEarlier")}
                 </Button>
               </div>
             ) : null}


### PR DESCRIPTION
## Summary

- separate local timeline expansion from network history loading
- expand already-loaded hidden items before requesting another event page
- keep local expansion available while a network history request is in flight

## Verification

- `npm test` (308 tests)
- `npm run build`
