### PR TITLE
fix(web): separate semantic history pagination

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -213,6 +213,8 @@ export function App() {
     refresh: refreshAgentDetail,
   } = useAgentDetail(activeAgentId, effectiveDisplayLevel);
   const activeAgent = selectedAgent ?? selectedAgentDetail?.agent;
+  const selectedSemanticHistory =
+    selectedAgentSession?.semanticHistoryByDisplayLevel[effectiveDisplayLevel];
   const selectedAgentLiveStatus = selectedAgentSession?.liveStatus ?? "idle";
   const selectedAgentLiveTitle = liveStatusTitle(selectedAgentLiveStatus, t, selectedAgentSession?.lastStreamActivityAt, selectedAgentSession?.error);
   const selectedAgentStatus = route === "agent" && activeAgent ? deriveAgentDisplayStatus(activeAgent, t) : undefined;
@@ -658,9 +660,9 @@ export function App() {
             modelCatalog={modelCatalog}
             modelCatalogLoading={modelCatalogLoading}
             modelCatalogError={selectedAgentSession?.modelError ?? modelCatalogError}
-            hasOlderEvents={selectedAgentSession?.hasOlder ?? selectedAgentDetail?.hasOlderEvents ?? false}
-            loadingOlderEvents={selectedAgentSession?.loadingOlder ?? false}
-            historyError={selectedAgentSession?.historyError ?? selectedAgentSession?.error}
+            hasOlderEvents={selectedSemanticHistory?.hasOlder ?? false}
+            loadingOlderEvents={selectedSemanticHistory?.loading ?? false}
+            historyError={selectedSemanticHistory?.error ?? selectedAgentSession?.targetEventError ?? selectedAgentSession?.error}
             targetEventSeq={selectedAgentSession?.targetEventSeq}
             resumeRevision={resumeRevision}
             onRefreshModels={refreshModelCatalog}

--- a/web-gui/app/src/runtime/runtime-store-helpers.ts
+++ b/web-gui/app/src/runtime/runtime-store-helpers.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeBriefRecord,
   RuntimeMessageEnvelope,
   RuntimeTranscriptEntry,
+  DisplayLevel,
   WorkItemDetailState,
   TaskDetailState,
   ToolExecutionDetailState,
@@ -22,6 +23,14 @@ export type AgentLiveStatus = "idle" | "connecting" | "streaming" | "reconnectin
 export type AgentCacheStatus = "unchecked" | "loading" | "hit" | "miss" | "unavailable";
 export type AgentContentStatus = "unknown" | "available" | "confirmed-empty";
 export type AgentSyncStatus = "idle" | "refreshing" | "streaming" | "recovering" | "stale" | "error";
+
+export interface SemanticHistoryState {
+  eventLogEpoch?: string;
+  cursorSeq?: number;
+  hasOlder: boolean;
+  loading: boolean;
+  error?: string;
+}
 
 export interface TimelineEventsState {
   eventLogEpoch?: string;
@@ -37,7 +46,8 @@ export interface TimelineEventsState {
 
 export interface AgentSessionState extends SessionProjectionState {
   loading: boolean;
-  loadingOlder: boolean;
+  semanticHistoryByDisplayLevel: Partial<Record<DisplayLevel, SemanticHistoryState>>;
+  targetEventLoading: boolean;
   liveStatus: AgentLiveStatus;
   cacheStatus: AgentCacheStatus;
   contentStatus: AgentContentStatus;
@@ -47,12 +57,11 @@ export interface AgentSessionState extends SessionProjectionState {
   eventsValidatedAt?: number;
   sendingPrompt: boolean;
   detail: AgentDetail | null;
-  hasOlder?: boolean;
   targetEventSeq?: number;
   lastStreamActivityAt?: string;
   reconnectAttempt?: number;
   error?: string;
-  historyError?: string;
+  targetEventError?: string;
   promptError?: string;
   modelError?: string;
   workItemDetailsById: Record<string, WorkItemDetailState>;

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -62,7 +62,8 @@ function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionS
   return {
     ...createSessionProjectionState(),
     loading: false,
-    loadingOlder: false,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
     liveStatus: "idle",
     cacheStatus: "unchecked",
     contentStatus: "unknown",
@@ -159,7 +160,10 @@ describe("resume session reset", () => {
     const reset = resetSessionsForResume({
       "agent-a": sessionState({
         loading: true,
-        loadingOlder: true,
+        semanticHistoryByDisplayLevel: {
+          info: { cursorSeq: 10, hasOlder: true, loading: true },
+        },
+        targetEventLoading: true,
         sendingPrompt: true,
         liveStatus: "recovering",
         reconnectAttempt: 4,
@@ -175,7 +179,10 @@ describe("resume session reset", () => {
 
     expect(reset["agent-a"]).toMatchObject({
       loading: false,
-      loadingOlder: false,
+      semanticHistoryByDisplayLevel: {
+        info: { cursorSeq: 10, hasOlder: true, loading: false },
+      },
+      targetEventLoading: false,
       sendingPrompt: false,
       liveStatus: "stale",
       reconnectAttempt: 0,
@@ -366,7 +373,9 @@ describe("runtime event epoch", () => {
       messagesById: { msg: { id: "msg" } },
       newestSeq: 7,
       oldestSeq: 7,
-      hasOlder: true,
+      semanticHistoryByDisplayLevel: {
+        info: { cursorSeq: 7, hasOlder: true, loading: false },
+      },
       detail: {
         agent: { id: "agent-1" } as NonNullable<AgentSessionState["detail"]>["agent"],
         source: "http",
@@ -385,7 +394,7 @@ describe("runtime event epoch", () => {
     expect(reset.messagesById).toEqual({});
     expect(reset.newestSeq).toBeUndefined();
     expect(reset.oldestSeq).toBeUndefined();
-    expect(reset.hasOlder).toBeUndefined();
+    expect(reset.semanticHistoryByDisplayLevel).toEqual({});
     expect(reset.detail?.eventCursorSeq).toBeUndefined();
     expect(reset.detail?.hasOlderEvents).toBeUndefined();
   });
@@ -877,7 +886,8 @@ describe("brief projection and hydration", () => {
     const session: AgentSessionState = {
       ...createSessionProjectionState(),
       loading: false,
-      loadingOlder: false,
+      semanticHistoryByDisplayLevel: {},
+      targetEventLoading: false,
       liveStatus: "idle",
       cacheStatus: "unchecked",
       contentStatus: "unknown",
@@ -1668,6 +1678,182 @@ describe("brief hydration retry limits", () => {
         .toMatchObject({ id: "message-123" });
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("semantic history pagination", () => {
+  afterEach(() => {
+    useRuntimeStore.setState({
+      sessionsByAgentId: {},
+      selectedAgentId: "",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("continues across raw pages until the selected display level gains a timeline item", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const event = (
+      eventSeq: number,
+      type: string,
+      payload: Record<string, unknown> = {},
+    ): StreamEventEnvelopeDto => ({
+      id: `event-${eventSeq}`,
+      event_seq: eventSeq,
+      event_log_epoch: "epoch-1",
+      ts: `2026-08-09T00:00:${String(eventSeq % 60).padStart(2, "0")}Z`,
+      agent_id: "agent-a",
+      type,
+      payload,
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/agents/agent-a/messages:batchGet")) {
+        return Promise.resolve(jsonResponse({ messages: [], missing_message_ids: ["message-80"] }));
+      }
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        const beforeSeq = Number(url.searchParams.get("before_seq"));
+        if (beforeSeq === 90) {
+          return Promise.resolve(jsonResponse({
+            events: [event(89, "legacy_event"), event(88, "legacy_event")],
+            event_log_epoch: "epoch-1",
+            oldest_seq: 88,
+            newest_seq: 89,
+            has_older: true,
+            has_newer: false,
+            order: "desc",
+            limit: 80,
+          }));
+        }
+        if (beforeSeq === 88) {
+          return Promise.resolve(jsonResponse({
+            events: [event(80, "message_enqueued", {
+              message_id: "message-80",
+              origin: { kind: "operator" },
+              body: "Older operator message",
+            })],
+            event_log_epoch: "epoch-1",
+            oldest_seq: 80,
+            newest_seq: 80,
+            has_older: false,
+            has_newer: false,
+            order: "desc",
+            limit: 80,
+          }));
+        }
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+
+    useRuntimeStore.setState({
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          eventLogEpoch: "epoch-1",
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          semanticHistoryByDisplayLevel: {
+            info: { eventLogEpoch: "epoch-1", cursorSeq: 90, hasOlder: true, loading: false },
+            verbose: { eventLogEpoch: "epoch-1", cursorSeq: 70, hasOlder: true, loading: false },
+          },
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().loadOlderAgentEvents("agent-a", "info");
+
+    const eventRequests = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), "http://localhost"))
+      .filter((url) => url.pathname.endsWith("/agents/agent-a/events"));
+    expect(eventRequests.map((url) => url.searchParams.get("before_seq"))).toEqual(["90", "88"]);
+    expect(eventRequests.every((url) => !url.searchParams.has("max_level"))).toBe(true);
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      oldestSeq: 80,
+      semanticHistoryByDisplayLevel: {
+        info: { cursorSeq: 80, hasOlder: false, loading: false },
+        verbose: { cursorSeq: 70, hasOlder: true, loading: false },
+      },
+    });
+  });
+
+  it("bounds a load when raw pages keep producing no semantic timeline items", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        const beforeSeq = Number(url.searchParams.get("before_seq"));
+        const nextSeq = beforeSeq - 1;
+        return Promise.resolve(jsonResponse({
+          events: [{
+            id: `event-${nextSeq}`,
+            event_seq: nextSeq,
+            event_log_epoch: "epoch-1",
+            agent_id: "agent-a",
+            type: "legacy_event",
+            payload: {},
+          }],
+          event_log_epoch: "epoch-1",
+          oldest_seq: nextSeq,
+          newest_seq: nextSeq,
+          has_older: true,
+          has_newer: false,
+          order: "desc",
+          limit: 80,
+        }));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+    useRuntimeStore.setState({
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          eventLogEpoch: "epoch-1",
+          detail: {
+            agent: agentSummary({ id: "agent-a" }),
+            source: "http",
+            timeline: [],
+          },
+          semanticHistoryByDisplayLevel: {
+            info: { eventLogEpoch: "epoch-1", cursorSeq: 90, hasOlder: true, loading: false },
+          },
+        }),
+      },
+    });
+
+    await useRuntimeStore.getState().loadOlderAgentEvents("agent-a", "info");
+
+    const eventRequests = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), "http://localhost"))
+      .filter((url) => url.pathname.endsWith("/agents/agent-a/events"));
+    expect(eventRequests).toHaveLength(5);
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]?.semanticHistoryByDisplayLevel.info)
+      .toMatchObject({ cursorSeq: 85, hasOlder: true, loading: false });
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -27,6 +27,7 @@ import type { AgentSessionState as AgentSessionStateBase } from "./runtime-store
 import {
   compactAgentTimelineItems,
   briefIdForPayload,
+  filterTimelineByDisplayLevel,
 } from "./session-reducer";
 import {
   briefIdsForProjectionHydration,
@@ -81,8 +82,16 @@ import type {
   ToolExecutionArtifactContent,
 } from "./types";
 
-import type { AgentLiveStatus, AgentSessionState, TimelineEventsState, WorkItemDetailState, TaskDetailState, ToolExecutionDetailState } from "./runtime-store-helpers";
-export type { AgentLiveStatus, AgentSessionState, TimelineEventsState };
+import type {
+  AgentLiveStatus,
+  AgentSessionState,
+  SemanticHistoryState,
+  TimelineEventsState,
+  WorkItemDetailState,
+  TaskDetailState,
+  ToolExecutionDetailState,
+} from "./runtime-store-helpers";
+export type { AgentLiveStatus, AgentSessionState, SemanticHistoryState, TimelineEventsState };
 
 export interface BootstrapRefreshOptions {
   background?: boolean;
@@ -202,6 +211,7 @@ export interface AgentRosterActivity {
 const OPTIMISTIC_OPERATOR_PROMPT_SOURCE = "pending-operator-prompt";
 const OPTIMISTIC_OPERATOR_CLIENT_PREFIX = "operator-prompt-client:";
 const OPTIMISTIC_OPERATOR_MESSAGE_PREFIX = "operator-prompt-message:";
+const MAX_SEMANTIC_HISTORY_PAGES_PER_LOAD = 5;
 
 function appendOptimisticOperatorPrompt(
   detail: AgentDetail | null,
@@ -662,7 +672,10 @@ export function resetSessionsForResume(
       {
         ...session,
         loading: false,
-        loadingOlder: false,
+        semanticHistoryByDisplayLevel: resetSemanticHistoryLoading(
+          session.semanticHistoryByDisplayLevel,
+        ),
+        targetEventLoading: false,
         sendingPrompt: false,
         liveStatus: "stale" as const,
         reconnectAttempt: 0,
@@ -676,6 +689,17 @@ export function resetSessionsForResume(
         taskDetailsById: resetDetailLoading(session.taskDetailsById),
         toolExecutionDetailsById: resetDetailLoading(session.toolExecutionDetailsById),
       },
+    ]),
+  );
+}
+
+function resetSemanticHistoryLoading(
+  histories: AgentSessionState["semanticHistoryByDisplayLevel"],
+): AgentSessionState["semanticHistoryByDisplayLevel"] {
+  return Object.fromEntries(
+    Object.entries(histories).map(([displayLevel, history]) => [
+      displayLevel,
+      history?.loading ? { ...history, loading: false } : history,
     ]),
   );
 }
@@ -1128,7 +1152,8 @@ export function mergeCachedSessionIntoCurrent(
     ...current,
     ...cached,
     loading: current.loading,
-    loadingOlder: current.loadingOlder,
+    semanticHistoryByDisplayLevel: current.semanticHistoryByDisplayLevel,
+    targetEventLoading: current.targetEventLoading,
     liveStatus: current.liveStatus,
     sendingPrompt: current.sendingPrompt,
   };
@@ -1211,7 +1236,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
                   ...emptyAgentSession(),
                   ...currentSession,
                   targetEventSeq,
-                  historyError: undefined,
+                  targetEventError: undefined,
                 },
               },
       };
@@ -2657,7 +2682,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           !isCurrentClientRequest(request) ||
           agentDetailRequestSequence.get(agentId) !== sequence
         ) return;
-        set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
+        set((state) => mergeAgentDetailIntoSession(state, agentId, detail, displayLevel));
         startRuntimeSpan(trace, "ui.session_state_transition", {
           state: `${get().sessionsByAgentId[agentId]?.contentStatus ?? "unknown"}/${
             get().sessionsByAgentId[agentId]?.syncStatus ?? "idle"
@@ -2761,7 +2786,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           [agentId]: {
             ...emptyAgentSession(),
             ...state.sessionsByAgentId[agentId],
-            historyError: error instanceof Error ? error.message : String(error),
+            error: error instanceof Error ? error.message : String(error),
           },
         },
       }));
@@ -2926,41 +2951,62 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   loadOlderAgentEvents: async (agentId, displayLevel) => {
     if (!agentId) return;
     const session = get().sessionsByAgentId[agentId] ?? emptyAgentSession();
-    if (session.loadingOlder || !session.hasOlder || session.oldestSeq == null) return;
+    const history = semanticHistoryState(session, displayLevel);
+    if (history.loading || !history.hasOlder || history.cursorSeq == null) return;
 
     const request = captureClientRequest();
-    set((state) => ({
-      sessionsByAgentId: {
-        ...state.sessionsByAgentId,
-        [agentId]: {
-          ...emptyAgentSession(),
-          ...state.sessionsByAgentId[agentId],
-          loadingOlder: true,
-          historyError: undefined,
-        },
-      },
+    set((state) => updateSemanticHistoryState(state, agentId, displayLevel, {
+      ...semanticHistoryState(state.sessionsByAgentId[agentId], displayLevel),
+      loading: true,
+      error: undefined,
     }));
 
     try {
-      const page = await request.client.getAgentEvents(agentId, {
-        beforeSeq: session.oldestSeq,
-        limit: 80,
-        order: "desc",
-        displayLevel,
-      });
-      if (!isCurrentClientRequest(request)) return;
+      const initialTimelineItemIds = semanticTimelineItemIds(session, displayLevel);
+      let cursorSeq = history.cursorSeq;
+      for (let pageCount = 0; pageCount < MAX_SEMANTIC_HISTORY_PAGES_PER_LOAD; pageCount += 1) {
+        const page = await request.client.getAgentEvents(agentId, {
+          beforeSeq: cursorSeq,
+          limit: 80,
+          order: "desc",
+        });
+        if (!isCurrentClientRequest(request)) return;
 
-      set((state) =>
-        mergeEventPageIntoSession(
-          state,
-          agentId,
-          page.events ?? [],
-          page.oldest_seq ?? undefined,
-          page.has_older,
-          displayLevel,
-          { eventLogEpoch: page.event_log_epoch },
-        ),
-      );
+        const nextCursorSeq = page.oldest_seq ?? undefined;
+        if (page.has_older && (nextCursorSeq == null || nextCursorSeq >= cursorSeq)) {
+          throw new Error("Agent semantic history page did not advance its cursor.");
+        }
+        set((state) =>
+          mergeEventPageIntoSession(
+            state,
+            agentId,
+            page.events ?? [],
+            page.oldest_seq ?? undefined,
+            page.has_older,
+            displayLevel,
+            {
+              eventLogEpoch: page.event_log_epoch,
+              historyDisplayLevel: displayLevel,
+              historyLoading: true,
+            },
+          ),
+        );
+        const current = get().sessionsByAgentId[agentId];
+        if (
+          semanticTimelineHasNewItem(current, displayLevel, initialTimelineItemIds) ||
+          !page.has_older ||
+          nextCursorSeq == null
+        ) {
+          break;
+        }
+        cursorSeq = nextCursorSeq;
+      }
+      if (!isCurrentClientRequest(request)) return;
+      set((state) => updateSemanticHistoryState(state, agentId, displayLevel, {
+        ...semanticHistoryState(state.sessionsByAgentId[agentId], displayLevel),
+        loading: false,
+        error: undefined,
+      }));
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
@@ -2972,8 +3018,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           [agentId]: {
             ...emptyAgentSession(),
             ...state.sessionsByAgentId[agentId],
-            loadingOlder: false,
-            historyError: error instanceof Error ? error.message : String(error),
+            semanticHistoryByDisplayLevel: {
+              ...state.sessionsByAgentId[agentId]?.semanticHistoryByDisplayLevel,
+              [displayLevel]: {
+                ...semanticHistoryState(state.sessionsByAgentId[agentId], displayLevel),
+                loading: false,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            },
           },
         },
       }));
@@ -3267,7 +3319,8 @@ function emptyAgentSession(): AgentSessionState {
   return {
     ...createSessionProjectionState(),
     loading: false,
-    loadingOlder: false,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
     liveStatus: "idle",
     cacheStatus: "unchecked",
     contentStatus: "unknown",
@@ -3413,7 +3466,9 @@ export function sessionForEventLogEpoch(
   const reset = applyProjectionAction(current, { type: "reset", eventLogEpoch: incomingEpoch });
   return {
     ...reset,
-    hasOlder: undefined,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
+    targetEventError: undefined,
     detail: reset.detail
       ? {
           ...reset.detail,
@@ -3442,7 +3497,8 @@ function resetSessionForEventConflict(
       reason: "event_identity_conflict",
     }),
     liveStatus: "stale",
-    hasOlder: undefined,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
     error: "runtime event identity conflict; refreshing projection",
   };
 }
@@ -4627,7 +4683,12 @@ function updateAgentModelInState(
   };
 }
 
-function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, detail: AgentDetail): Partial<RuntimeStoreState> {
+function mergeAgentDetailIntoSession(
+  state: RuntimeStoreState,
+  agentId: string,
+  detail: AgentDetail,
+  displayLevel: DisplayLevel,
+): Partial<RuntimeStoreState> {
   const epochSession = sessionForEventLogEpoch(
     state.sessionsByAgentId[agentId] ?? emptyAgentSession(),
     detail.eventLogEpoch,
@@ -4642,7 +4703,7 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
     ...detail,
     agent,
     timeline: current.detail?.timeline ?? detail.timeline,
-    hasOlderEvents: detail.hasOlderEvents,
+    hasOlderEvents: undefined,
   };
   let projected = applyProjectionAction(current, {
     type: "events_received",
@@ -4689,7 +4750,15 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
         detailValidatedAt: detail.error ? current.detailValidatedAt : Date.now(),
         newestSeq: newestSeq || undefined,
         oldestSeq: detail.oldestEventSeq ?? projected.oldestSeq,
-        hasOlder: detail.hasOlderEvents,
+        semanticHistoryByDisplayLevel: {
+          ...projected.semanticHistoryByDisplayLevel,
+          [displayLevel]: {
+            eventLogEpoch: detail.eventLogEpoch,
+            cursorSeq: detail.oldestEventSeq,
+            hasOlder: detail.hasOlderEvents ?? false,
+            loading: false,
+          },
+        },
         error: detail.error,
       },
     },
@@ -4790,6 +4859,7 @@ async function catchUpAgentEvents(
             newestSeq: displayTailConsumedSeq,
             append: true,
             eventLogEpoch: displayTailPage.event_log_epoch,
+            historyDisplayLevel: displayLevel,
           },
         ),
       );
@@ -5056,7 +5126,7 @@ function scheduleMessageHydration(
           ...state.sessionsByAgentId,
           [agentId]: {
             ...(state.sessionsByAgentId[agentId] ?? emptyAgentSession()),
-            historyError: error instanceof Error ? error.message : String(error),
+            error: error instanceof Error ? error.message : String(error),
           },
         },
       }));
@@ -5117,7 +5187,7 @@ function scheduleTranscriptHydration(
           ...state.sessionsByAgentId,
           [agentId]: {
             ...(state.sessionsByAgentId[agentId] ?? emptyAgentSession()),
-            historyError: error instanceof Error ? error.message : String(error),
+            error: error instanceof Error ? error.message : String(error),
           },
         },
       }));
@@ -5433,6 +5503,67 @@ function patchAgentDetail(
   };
 }
 
+function semanticHistoryState(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+): SemanticHistoryState {
+  return session?.semanticHistoryByDisplayLevel[displayLevel] ?? {
+    eventLogEpoch: session?.eventLogEpoch,
+    cursorSeq: undefined,
+    hasOlder: false,
+    loading: false,
+  };
+}
+
+function semanticTimelineItemIds(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+): Set<string> {
+  return new Set(semanticTimeline(session, displayLevel).map((item) => item.id));
+}
+
+function semanticTimelineHasNewItem(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+  initialItemIds: Set<string>,
+): boolean {
+  return semanticTimeline(session, displayLevel).some((item) => !initialItemIds.has(item.id));
+}
+
+function semanticTimeline(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+): AgentTimelineItem[] {
+  return session
+    ? filterTimelineByDisplayLevel(
+        deriveSessionTimeline(session, displayLevel),
+        displayLevel,
+        { itemLimit: Number.MAX_SAFE_INTEGER },
+      )
+    : [];
+}
+
+function updateSemanticHistoryState(
+  state: RuntimeStoreState,
+  agentId: string,
+  displayLevel: DisplayLevel,
+  history: SemanticHistoryState,
+): Partial<RuntimeStoreState> {
+  const session = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+  return {
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: {
+        ...session,
+        semanticHistoryByDisplayLevel: {
+          ...session.semanticHistoryByDisplayLevel,
+          [displayLevel]: history,
+        },
+      },
+    },
+  };
+}
+
 function mergeEventPageIntoSession(
   state: RuntimeStoreState,
   agentId: string,
@@ -5440,7 +5571,13 @@ function mergeEventPageIntoSession(
   pageOldestSeq: number | undefined,
   pageHasOlder: boolean | undefined,
   displayLevel: DisplayLevel,
-  options: { newestSeq?: number; append?: boolean; eventLogEpoch?: string } = {},
+  options: {
+    newestSeq?: number;
+    append?: boolean;
+    eventLogEpoch?: string;
+    historyDisplayLevel?: DisplayLevel;
+    historyLoading?: boolean;
+  } = {},
 ): Partial<RuntimeStoreState> {
   const epochSession = sessionForEventLogEpoch(
     state.sessionsByAgentId[agentId] ?? emptyAgentSession(),
@@ -5449,17 +5586,23 @@ function mergeEventPageIntoSession(
   const current = hasEventIdentityConflict(epochSession, pageEvents)
     ? resetSessionForEventConflict(epochSession, options.eventLogEpoch)
     : epochSession;
-  const detailBase = current.detail
-    ? {
-        ...current.detail,
-        hasOlderEvents: pageHasOlder,
-      }
-    : current.detail;
   const projected = applyProjectionAction(current, {
     type: "events_received",
     events: pageEvents,
     eventLogEpoch: options.eventLogEpoch,
-  }, displayLevel, detailBase);
+  }, displayLevel, current.detail);
+  const historyDisplayLevel = options.historyDisplayLevel;
+  const semanticHistoryByDisplayLevel = historyDisplayLevel
+    ? {
+        ...projected.semanticHistoryByDisplayLevel,
+        [historyDisplayLevel]: {
+          eventLogEpoch: options.eventLogEpoch ?? projected.eventLogEpoch,
+          cursorSeq: pageOldestSeq,
+          hasOlder: pageHasOlder ?? false,
+          loading: options.historyLoading ?? false,
+        },
+      }
+    : projected.semanticHistoryByDisplayLevel;
 
   return {
     sessionsByAgentId: {
@@ -5473,9 +5616,7 @@ function mergeEventPageIntoSession(
           pageOldestSeq != null && projected.oldestSeq != null
             ? Math.min(pageOldestSeq, projected.oldestSeq)
             : (pageOldestSeq ?? projected.oldestSeq),
-        hasOlder: pageHasOlder,
-        loadingOlder: false,
-        historyError: undefined,
+        semanticHistoryByDisplayLevel,
       },
     },
   };
@@ -5498,8 +5639,8 @@ async function loadTargetAgentEventWindow(
       [agentId]: {
         ...emptyAgentSession(),
         ...state.sessionsByAgentId[agentId],
-        loadingOlder: true,
-        historyError: undefined,
+        targetEventLoading: true,
+        targetEventError: undefined,
       },
     },
   }));
@@ -5527,6 +5668,17 @@ async function loadTargetAgentEventWindow(
         },
       ),
     );
+    set((state) => ({
+      sessionsByAgentId: {
+        ...state.sessionsByAgentId,
+        [agentId]: {
+          ...emptyAgentSession(),
+          ...state.sessionsByAgentId[agentId],
+          targetEventLoading: false,
+          targetEventError: undefined,
+        },
+      },
+    }));
   } catch (error) {
     if (!isCurrentClientGeneration(generation)) return;
     set((state) => ({
@@ -5535,8 +5687,8 @@ async function loadTargetAgentEventWindow(
         [agentId]: {
           ...emptyAgentSession(),
           ...state.sessionsByAgentId[agentId],
-          loadingOlder: false,
-          historyError: error instanceof Error ? error.message : String(error),
+          targetEventLoading: false,
+          targetEventError: error instanceof Error ? error.message : String(error),
         },
       },
     }));

--- a/web-gui/app/src/runtime/session-cache.test.ts
+++ b/web-gui/app/src/runtime/session-cache.test.ts
@@ -19,7 +19,8 @@ function makeSession(overrides: Partial<AgentSessionState> = {}): AgentSessionSt
   return {
     ...createSessionProjectionState(),
     loading: false,
-    loadingOlder: false,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
     liveStatus: "idle",
     cacheStatus: "unchecked",
     contentStatus: "unknown",

--- a/web-gui/app/src/runtime/useAgentDetail.ts
+++ b/web-gui/app/src/runtime/useAgentDetail.ts
@@ -20,6 +20,9 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
   const syncStatus = useRuntimeStore((state) =>
     agentId ? state.sessionsByAgentId[agentId]?.syncStatus ?? "idle" : "idle",
   );
+  const hasDisplayHistory = useRuntimeStore((state) =>
+    agentId ? state.sessionsByAgentId[agentId]?.semanticHistoryByDisplayLevel[displayLevel] != null : false,
+  );
   const ensureAgentSession = useRuntimeStore((state) => state.ensureAgentSession);
   const refreshAgentDetail = useRuntimeStore((state) => state.refreshAgentDetail);
   const registerAgentForEvents = useRuntimeStore((state) => state.registerAgentForEvents);
@@ -39,11 +42,11 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
     const levelRank: Record<DisplayLevel, number> = { info: 0, verbose: 1, debug: 2 };
     const levelIncreased = prevLevel != null && levelRank[displayLevel] > levelRank[prevLevel];
     void ensureAgentSession(agentId, displayLevel);
-    if (detail && !detail.error && levelIncreased) {
+    if (detail && !detail.error && (levelIncreased || !hasDisplayHistory)) {
       void refreshAgentDetail(agentId, displayLevel, { trigger: "display_level.increased" });
     }
     prevDisplayLevelRef.current = displayLevel;
-  }, [agentId, displayLevel, ensureAgentSession, refreshAgentDetail]);
+  }, [agentId, displayLevel, ensureAgentSession, refreshAgentDetail, hasDisplayHistory]);
 
   return { detail, loading, contentStatus, syncStatus, refresh };
 }


### PR DESCRIPTION
## 概要

- 将 raw event projection coverage 与按 `DisplayLevel` 管理的 semantic history pagination 状态分离
- 历史加载使用对应 display level 的 cursor/hasOlder/loading/error，不再复用 raw sync 水位
- 当 raw page 没有产生新的可见 semantic timeline item 时，有界继续翻页（单次最多 5 页）
- display level 切换时独立初始化对应历史状态，并在 epoch reset/resume 时正确清理 loading/cursor 状态

## 验证

- `npm test`：310 tests 通过
- `npm run build`：通过（含 TypeScript typecheck）
- `git diff --check`：通过
