### PR TITLE
fix(web): make backfill recovery retryable

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -93,6 +93,7 @@ export function App() {
   const showTimelineEvents = useRuntimeStore((state) => state.showTimelineEvents);
   const refreshTimelineEvents = useRuntimeStore((state) => state.refreshTimelineEvents);
   const loadOlderTimelineEvents = useRuntimeStore((state) => state.loadOlderTimelineEvents);
+  const retryAgentSync = useRuntimeStore((state) => state.retryAgentSync);
   const showWorkItemDetail = useRuntimeStore((state) => state.showWorkItemDetail);
   const showTaskDetail = useRuntimeStore((state) => state.showTaskDetail);
   const showFileBrowser = useRuntimeStore((state) => state.showFileBrowser);
@@ -663,12 +664,15 @@ export function App() {
             hasOlderEvents={selectedSemanticHistory?.hasOlder ?? false}
             loadingOlderEvents={selectedSemanticHistory?.loading ?? false}
             historyError={selectedSemanticHistory?.error ?? selectedAgentSession?.targetEventError ?? selectedAgentSession?.error}
+            syncError={selectedAgentSession?.syncError}
+            syncRetryAttempt={selectedAgentSession?.syncRetryAttempt}
             targetEventSeq={selectedAgentSession?.targetEventSeq}
             resumeRevision={resumeRevision}
             onRefreshModels={refreshModelCatalog}
             onSetModel={(model, reasoningEffort) => setAgentModel(activeAgent.id, model, effectiveDisplayLevel, reasoningEffort)}
             onClearModel={() => clearAgentModel(activeAgent.id, effectiveDisplayLevel)}
             onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, effectiveDisplayLevel)}
+            onRetrySync={() => retryAgentSync(activeAgent.id)}
             onSendPrompt={(text, attachments) => sendOperatorPrompt(activeAgent.id, text, effectiveDisplayLevel, attachments)}
             onConversationRead={markSelectedAgentConversationRead}
             onOpenInspector={() => {

--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import i18next from "i18next";
 
+import "../../i18n";
 import {
   attachmentKindForFile,
   captureScrollAnchor,
@@ -8,6 +12,7 @@ import {
   resizeComposerTextarea,
   restoredScrollTop,
   storedComposerDraftKey,
+  SyncRecoveryStatus,
   timelineForDisplayLevel,
   timelineLayoutRevision,
   writeStoredComposerDraft,
@@ -48,6 +53,23 @@ function installWindow(localStorage: Storage) {
     localStorage,
   });
 }
+
+describe("sync recovery status", () => {
+  it("renders the failure, retry attempt, and manual recovery action", async () => {
+    await i18next.changeLanguage("en");
+    const markup = renderToStaticMarkup(
+      createElement(SyncRecoveryStatus, {
+        error: "baseline unavailable",
+        retryAttempt: 3,
+        onRetry: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain("Conversation sync recovery failed (attempt 3)");
+    expect(markup).toContain("baseline unavailable");
+    expect(markup).toContain("Retry sync now");
+  });
+});
 
 describe("composer draft storage", () => {
   afterEach(() => {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -45,12 +45,15 @@ interface AgentPageProps {
   modelCatalogLoading: boolean;
   modelCatalogError?: string;
   historyError?: string;
+  syncError?: string;
+  syncRetryAttempt?: number;
   targetEventSeq?: number;
   resumeRevision?: number;
   onRefreshModels: () => Promise<void>;
   onSetModel: (model: string, reasoningEffort?: string) => Promise<void>;
   onClearModel: () => Promise<void>;
   onLoadOlderEvents: () => Promise<void>;
+  onRetrySync: () => void;
   onSendPrompt: (text: string, attachments?: OperatorPromptAttachment[]) => Promise<void>;
   onConversationRead: () => void;
   onOpenInspector: () => void;
@@ -309,12 +312,15 @@ export function AgentPage({
   modelCatalogLoading,
   modelCatalogError,
   historyError,
+  syncError,
+  syncRetryAttempt,
   targetEventSeq,
   resumeRevision = 0,
   onRefreshModels,
   onSetModel,
   onClearModel,
   onLoadOlderEvents,
+  onRetrySync,
   onSendPrompt,
   onConversationRead,
   onOpenInspector,
@@ -712,6 +718,13 @@ export function AgentPage({
                 {historyError}
               </div>
             ) : null}
+            {syncError ? (
+              <SyncRecoveryStatus
+                error={syncError}
+                retryAttempt={syncRetryAttempt}
+                onRetry={onRetrySync}
+              />
+            ) : null}
             {timelineTurns.length > 0 ? (
               <div
                 ref={virtualWrapperRef}
@@ -1063,5 +1076,27 @@ function isAgentWorking(agent: AgentSummary, sendingPrompt: boolean, t: TFunctio
 function cssEscape(value: string): string {
   if (typeof CSS !== "undefined" && CSS.escape) return CSS.escape(value);
   return value.replace(/["\\]/g, "\\$&");
+}
+
+export function SyncRecoveryStatus({
+  error,
+  retryAttempt,
+  onRetry,
+}: {
+  error: string;
+  retryAttempt?: number;
+  onRetry: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="history-status history-status--recovering sync-recovery-status" role="alert">
+      <span>
+        {t("agent.syncRecoveryFailed", { attempt: retryAttempt ?? 1 })}: {error}
+      </span>
+      <Button type="button" size="sm" variant="secondary" onClick={onRetry}>
+        {t("agent.retrySync")}
+      </Button>
+    </div>
+  );
 }
 

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -873,6 +873,8 @@ const en = {
     conversationAria: "Agent conversation",
     conversationEmpty: "Send the first operator message, or switch to Verbose/Debug to inspect low-level runtime events.",
     noEventsYet: "No runtime events are available for this agent yet. Try refreshing the session or sending an operator message.",
+    syncRecoveryFailed: "Conversation sync recovery failed (attempt {{attempt}})",
+    retrySync: "Retry sync now",
     // Composer
     sendInputAria: "Send operator input to {{id}}",
     sendInputPlaceholder: "Send operator input to {{id}}…",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -875,6 +875,8 @@ const zh: Record<string, any> = {
     conversationAria: "智能体对话",
     conversationEmpty: "发送第一条操作者消息，或切换到详细/调试模式查看底层运行时事件。",
     noEventsYet: "此智能体暂无运行时事件。尝试刷新会话或发送一条操作者消息。",
+    syncRecoveryFailed: "会话同步恢复失败（第 {{attempt}} 次）",
+    retrySync: "立即重试同步",
     // 输入框
     sendInputAria: "向 {{id}} 发送操作者消息",
     sendInputPlaceholder: "向 {{id}} 发送操作者消息…",

--- a/web-gui/app/src/runtime/runtime-store-helpers.ts
+++ b/web-gui/app/src/runtime/runtime-store-helpers.ts
@@ -61,6 +61,9 @@ export interface AgentSessionState extends SessionProjectionState {
   lastStreamActivityAt?: string;
   reconnectAttempt?: number;
   error?: string;
+  syncError?: string;
+  syncRetryAttempt?: number;
+  syncRetryAt?: number;
   targetEventError?: string;
   promptError?: string;
   modelError?: string;

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -4,6 +4,7 @@ import {
   agentBriefPatchFromEvents,
   agentDetailErrorKind,
   applyStreamEvents,
+  backfillRetryDelayMs,
   buildResumeRefreshes,
   canUseRemoteRuntimeConnections,
   hasEventIdentityConflict,
@@ -83,6 +84,19 @@ describe("skillDetailCacheKey", () => {
     expect(skillDetailCacheKey("workspace:root:demo", "agent-a")).toBe(
       "agent-a\u0000workspace:root:demo",
     );
+  });
+});
+
+describe("backfillRetryDelayMs", () => {
+  it("uses deterministic capped exponential backoff", () => {
+    expect([1, 2, 3, 4, 5, 6].map(backfillRetryDelayMs)).toEqual([
+      1_000,
+      2_000,
+      4_000,
+      8_000,
+      15_000,
+      15_000,
+    ]);
   });
 });
 
@@ -1186,6 +1200,97 @@ describe("global event stream recovery", () => {
     }));
     await vi.waitFor(() => {
       expect(useRuntimeStore.getState().globalStreamStatus).toBe("streaming");
+    });
+  });
+
+  it("retries baseline initialization before declaring recovery complete", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    const retryCallbacks: Array<() => void> = [];
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout: (callback: () => void, delay?: number) => {
+        if (delay === 1_000) retryCallbacks.push(callback);
+        return retryCallbacks.length;
+      },
+      clearTimeout: () => undefined,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    let baselineAttempts = 0;
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.pathname.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (url.pathname.endsWith("/events/stream")) {
+        return Promise.resolve(new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            init?.signal?.addEventListener("abort", () => controller.close());
+          },
+        }), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }));
+      }
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        if (url.searchParams.get("order") === "desc") {
+          baselineAttempts += 1;
+          if (baselineAttempts === 1) return Promise.reject(new Error("baseline unavailable"));
+          return Promise.resolve(jsonResponse({
+            events: [{
+              id: "event-1",
+              event_seq: 1,
+              event_log_epoch: "epoch-1",
+              ts: "2026-08-10T00:00:00Z",
+              agent_id: "agent-a",
+              type: "legacy_event",
+              payload: {},
+            }],
+            event_log_epoch: "epoch-1",
+            has_older: false,
+            has_newer: false,
+            order: "desc",
+            limit: 100,
+          }));
+        }
+        return Promise.resolve(jsonResponse({
+          events: [],
+          event_log_epoch: "epoch-1",
+          has_older: false,
+          has_newer: false,
+          order: "asc",
+          limit: 100,
+        }));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    fetchMock.mockClear();
+
+    useRuntimeStore.getState().registerAgentForEvents("agent-a");
+
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+        liveStatus: "recovering",
+        syncError: "baseline unavailable",
+        syncRetryAttempt: 1,
+      });
+    });
+    expect(useRuntimeStore.getState().globalStreamStatus).toBe("catching_up");
+    expect(retryCallbacks).toHaveLength(1);
+
+    retryCallbacks.shift()?.();
+
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().globalStreamStatus).toBe("streaming");
+    });
+    expect(baselineAttempts).toBe(2);
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      eventSeqs: [1],
+      liveStatus: "streaming",
+      syncError: undefined,
+      syncRetryAttempt: undefined,
     });
   });
 });

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -410,6 +410,7 @@ export interface RuntimeStoreState {
   stopGlobalEventStream: () => void;
   registerAgentForEvents: (agentId: string) => void;
   unregisterAgentForEvents: (agentId: string) => void;
+  retryAgentSync: (agentId: string) => void;
 }
 
 export function resetTransientRuntimeStateForResume(
@@ -3269,6 +3270,26 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   unregisterAgentForEvents: (agentId) => {
     unregisterAgentForEvents(agentId);
   },
+  retryAgentSync: (agentId) => {
+    if (!agentId) return;
+    if (!globalStreamSubscribedAgents.has(agentId)) {
+      registerAgentForEvents(get, set, agentId);
+      return;
+    }
+    clearGlobalBackfillRetry(agentId);
+    setStreamState(set, agentId, "recovering", {
+      syncError: undefined,
+      syncRetryAttempt: undefined,
+      syncRetryAt: undefined,
+    });
+    if (!globalEventStream) {
+      startGlobalEventStream(get, set);
+      return;
+    }
+    globalStreamCatchUpPendingAgents.add(agentId);
+    set({ globalStreamStatus: "catching_up" });
+    void recoverRegisteredGlobalAgent(get, set, agentId, captureClientRequest());
+  },
 }));
 
 // Initialize session cache on first load.
@@ -3570,7 +3591,7 @@ function startGlobalEventStream(get: () => RuntimeStoreState, set: StoreSet): vo
     onEvent: (event) => {
       if (!isCurrentClientRequest(request)) return;
       scheduleGlobalStaleWatchdog(get, set);
-      dispatchGlobalStreamEvent(set, event);
+      dispatchGlobalStreamEvent(get, set, event);
     },
     onClose: () => {
       if (isCurrentClientRequest(request)) {
@@ -3692,13 +3713,10 @@ async function recoverRegisteredGlobalAgent(
   try {
     await ensureGlobalRecoveryBaseline(get, set, agentId);
     if (!isCurrentClientRequest(request) || !globalEventStream) return;
-    const recovered = await backfillAgentEvents(set, agentId, true);
+    const recovered = await backfillAgentEvents(get, set, agentId, true);
     if (recovered) completeGlobalStreamCatchUp(set, agentId);
   } catch (error) {
-    scheduleGlobalBackfillRetry(set, agentId);
-    setStreamState(set, agentId, "recovering", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    scheduleGlobalBackfillRetry(get, set, agentId, error);
   }
 }
 
@@ -3785,7 +3803,11 @@ function rebaseGlobalRecoveryFromSession(
   );
 }
 
-function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto): void {
+function dispatchGlobalStreamEvent(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  event: StreamEventEnvelopeDto,
+): void {
   const agentId = event.agent_id;
   if (!agentId || !globalStreamSubscribedAgents.has(agentId)) return;
 
@@ -3799,14 +3821,19 @@ function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto)
     const recovery = globalEventRecovery.observe(agentId, seq, incomingEpoch);
     if (recovery.recovering) {
       setAgentLiveStatus(set, agentId, "recovering");
-      void backfillAgentEvents(set, agentId);
+      void backfillAgentEvents(get, set, agentId);
     }
   }
 
   enqueueStreamEvent(set, agentId, event);
 }
 
-async function backfillAgentEvents(set: StoreSet, agentId: string, force = false): Promise<boolean> {
+async function backfillAgentEvents(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  force = false,
+): Promise<boolean> {
   const generation = clientGeneration;
   const span = startRuntimeSpan(
     createRuntimeTrace("stream.reconnect", { agentId, trigger: "events.backfill" }),
@@ -3841,34 +3868,44 @@ async function backfillAgentEvents(set: StoreSet, agentId: string, force = false
       },
     });
     if (!result.complete) {
-      scheduleGlobalBackfillRetry(set, agentId);
-      setAgentLiveStatus(set, agentId, "recovering");
+      scheduleGlobalBackfillRetry(get, set, agentId);
       span.end("ok", { eventCount, incomplete: true });
       return false;
     }
     clearGlobalBackfillRetry(agentId);
+    setStreamState(set, agentId, "streaming", {
+      syncError: undefined,
+      syncRetryAttempt: undefined,
+      syncRetryAt: undefined,
+    });
     span.end("ok", { eventCount });
     return true;
   } catch (error) {
     span.end("error");
-    scheduleGlobalBackfillRetry(set, agentId);
-    setStreamState(set, agentId, "recovering", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    scheduleGlobalBackfillRetry(get, set, agentId, error);
     return false;
   }
 }
 
-function scheduleGlobalBackfillRetry(set: StoreSet, agentId: string): void {
+function scheduleGlobalBackfillRetry(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  error?: unknown,
+): void {
   if (!globalStreamSubscribedAgents.has(agentId) || globalBackfillRetryTimers.has(agentId)) return;
   const attempt = (globalBackfillRetryAttempts.get(agentId) ?? 0) + 1;
   globalBackfillRetryAttempts.set(agentId, attempt);
+  const delay = backfillRetryDelayMs(attempt);
+  setStreamState(set, agentId, "recovering", {
+    syncError: error == null ? undefined : error instanceof Error ? error.message : String(error),
+    syncRetryAttempt: attempt,
+    syncRetryAt: Date.now() + delay,
+  });
   const timer = window.setTimeout(() => {
     globalBackfillRetryTimers.delete(agentId);
-    void backfillAgentEvents(set, agentId, true).then((recovered) => {
-      if (recovered) completeGlobalStreamCatchUp(set, agentId);
-    });
-  }, reconnectDelayMs(attempt));
+    void recoverRegisteredGlobalAgent(get, set, agentId, captureClientRequest());
+  }, delay);
   globalBackfillRetryTimers.set(agentId, timer);
 }
 
@@ -4250,6 +4287,13 @@ function reconnectDelayMs(attempt: number): number {
   const exponential = Math.min(STREAM_RECONNECT_MAX_MS, STREAM_RECONNECT_BASE_MS * 2 ** Math.max(0, attempt - 1));
   const jitter = Math.floor(Math.random() * 500);
   return exponential + jitter;
+}
+
+export function backfillRetryDelayMs(attempt: number): number {
+  return Math.min(
+    STREAM_RECONNECT_MAX_MS,
+    STREAM_RECONNECT_BASE_MS * 2 ** Math.max(0, attempt - 1),
+  );
 }
 
 function setSessionModelError(set: StoreSet, agentId: string, error: string | undefined): void {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1858,6 +1858,13 @@ code {
   color: var(--danger);
 }
 
+.sync-recovery-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 12px;
+}
+
 .timeline-turn {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr);


### PR DESCRIPTION
## Summary

- retry the complete global recovery flow after baseline or gap-backfill failures
- use deterministic capped exponential backoff and expose per-agent retry state
- show sync recovery errors separately from history errors with a manual retry action

## Correctness boundary

The global SSE stream remains live-only. A subscribed agent is not removed from `catching_up` until baseline initialization and gap recovery both succeed. Scheduled retries now re-run baseline initialization instead of calling gap recovery against an uninitialized tracker.

## Verification

- `npm run typecheck`
- `npm test` — 313 tests passed
- `npm run build`
