### PR TITLE
fix(web): persist session sync coverage

### DIFF
--- a/web-gui/app/src/runtime/idb-cache.ts
+++ b/web-gui/app/src/runtime/idb-cache.ts
@@ -8,9 +8,30 @@
 
 const DB_NAME = "holon-webgui-cache";
 const DB_VERSION = 1;
-export const CACHE_SCHEMA_VERSION = 4;
+export const CACHE_SCHEMA_VERSION = 5;
 const SESSIONS_STORE = "sessions";
 const META_STORE = "meta";
+
+export interface CachedSyncCoverage {
+  eventLogEpoch?: string;
+  contiguousSeq: number;
+  observedSeq: number;
+  retainedOldestSeq?: number;
+  retainedNewestSeq?: number;
+  gaps: Array<{ afterSeq: number; beforeSeq: number }>;
+}
+
+export interface CachedSemanticHistoryState {
+  eventLogEpoch?: string;
+  cursorSeq?: number;
+  hasOlder: boolean;
+}
+
+export interface CachedAgentReadState {
+  unreadCount?: number;
+  lastUnreadDeliverySeq?: number;
+  lastReadDeliverySeq?: number;
+}
 
 export interface CachedAgentSession {
   remoteKey: string;
@@ -26,6 +47,9 @@ export interface CachedAgentSession {
   briefRecordsById: Record<string, unknown>;
   newestSeq?: number;
   oldestSeq?: number;
+  syncCoverage?: CachedSyncCoverage;
+  semanticHistoryByDisplayLevel?: Record<string, CachedSemanticHistoryState>;
+  readState?: CachedAgentReadState;
   cachedAt: number;
 }
 

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -12,6 +12,7 @@ import {
   isLoopbackWebHostname,
   materializeProjectionDetail,
   mergeBootstrapAgentState,
+  mergeCachedReadState,
   mergeCachedSessionIntoCurrent,
   mergeTimelineEventPage,
   missingBriefIdsForHydration,
@@ -512,11 +513,24 @@ describe("session cache restoration", () => {
       eventSeqs: [1],
       newestSeq: 1,
       oldestSeq: 1,
+      semanticHistoryByDisplayLevel: {
+        info: {
+          eventLogEpoch: "epoch-cache",
+          cursorSeq: 1,
+          hasOlder: false,
+          loading: false,
+        },
+      },
     };
 
     const restored = mergeCachedSessionIntoCurrent(current, cached);
 
     expect(restored.eventSeqs).toEqual([1]);
+    expect(restored.semanticHistoryByDisplayLevel.info).toMatchObject({
+      cursorSeq: 1,
+      hasOlder: false,
+      loading: false,
+    });
     expect(restored.loading).toBe(true);
     expect(restored.liveStatus).toBe("connecting");
   });
@@ -627,6 +641,88 @@ describe("runtime connection storage", () => {
   });
 });
 
+describe("agent deletion cache cleanup", () => {
+  afterEach(() => {
+    useRuntimeStore.setState({
+      selectedAgentId: "",
+      route: "dashboard",
+      sessionsByAgentId: {},
+      rosterActivityByAgentId: {},
+    });
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("removes persisted session and read state after server deletion succeeds", async () => {
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/handshake")) return Promise.resolve(jsonResponse({}));
+      if (url.endsWith("/agents/list")) return Promise.resolve(jsonResponse([]));
+      if (
+        url.endsWith("/control/agents/agent-a") &&
+        init?.method === "DELETE"
+      ) {
+        return Promise.resolve(jsonResponse({
+          created: true,
+          ok: true,
+          identity: { agent_id: "agent-a", status: "deleting" },
+          job: {
+            deletion_id: "delete-1",
+            status: "completed",
+            phase: "completed",
+            attempts: 1,
+            created_at: "2026-08-10T00:00:00Z",
+            updated_at: "2026-08-10T00:00:01Z",
+            completed_at: "2026-08-10T00:00:01Z",
+          },
+        }));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const idbModule = await import("./idb-cache");
+    const deleteSpy = vi.spyOn(idbModule, "cacheDeleteSession").mockResolvedValue(undefined);
+
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+    useRuntimeStore.setState({
+      selectedAgentId: "agent-a",
+      route: "agent",
+      sessionsByAgentId: {
+        "agent-a": sessionState({
+          eventSeqs: [1],
+          eventsBySeq: { 1: { id: "event-1", event_seq: 1 } },
+        }),
+      },
+      rosterActivityByAgentId: {
+        "agent-a": {
+          unreadCount: 2,
+          lastUnreadDeliverySeq: 3,
+          lastReadDeliverySeq: 1,
+        },
+      },
+    });
+
+    await useRuntimeStore.getState().deleteAgent("agent-a");
+
+    expect(deleteSpy).toHaveBeenCalledWith("local", "agent-a");
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toBeUndefined();
+    expect(useRuntimeStore.getState().rosterActivityByAgentId["agent-a"]).toBeUndefined();
+    expect(useRuntimeStore.getState()).toMatchObject({
+      selectedAgentId: "",
+      route: "dashboard",
+    });
+  });
+});
+
 describe("roster activity unread state", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -660,6 +756,30 @@ describe("roster activity unread state", () => {
     expect(readStoredRosterActivity("http://remote.example:7878")).toEqual({
       remoteAgent: { unreadCount: 4, lastUnreadDeliverySeq: 20 },
     });
+  });
+
+  it("uses IndexedDB read state only when localStorage has no read marker", () => {
+    const cached = {
+      unreadCount: 3,
+      lastUnreadDeliverySeq: 12,
+      lastReadDeliverySeq: 7,
+    };
+
+    expect(
+      mergeCachedReadState(
+        { operatorAt: "2026-01-01T00:00:00.000Z" },
+        cached,
+      ),
+    ).toEqual({
+      operatorAt: "2026-01-01T00:00:00.000Z",
+      ...cached,
+    });
+    const localStorageState = {
+      unreadCount: 1,
+      lastUnreadDeliverySeq: 20,
+      lastReadDeliverySeq: 19,
+    };
+    expect(mergeCachedReadState(localStorageState, cached)).toBe(localStorageState);
   });
 
   it("counts unread brief events once by seq, ignores non-operator messages", async () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -8,7 +8,10 @@ import {
   type StreamEventEnvelopeDto,
 } from "./client";
 import { EventGapRecoveryTracker, recoverEventGap } from "./event-gap-recovery";
-import { cacheClearRemote } from "./idb-cache";
+import {
+  cacheDeleteSession,
+  type CachedAgentReadState,
+} from "./idb-cache";
 import { ResumeReconciliationCoordinator } from "./resume-reconciliation";
 import {
   currentRemoteKey,
@@ -1092,23 +1095,34 @@ function initSessionCacheForRemote(set: StoreSet, get?: () => RuntimeStoreState)
       // Hydrate cached sessions into store.
       const cached = await hydrateAllSessions(context.remoteKey);
       if (!sessionCacheContextIsCurrent(context) || sessionCacheWriter !== writer) return;
-      if (Object.keys(cached).length === 0) return;
+      if (Object.keys(cached.sessionsByAgentId).length === 0) return;
 
       const restoredAgentIds: string[] = [];
       set((state) => {
         const sessionsByAgentId = { ...state.sessionsByAgentId };
-        for (const [agentId, partial] of Object.entries(cached)) {
+        for (const [agentId, partial] of Object.entries(cached.sessionsByAgentId)) {
           const current = sessionsByAgentId[agentId] ?? emptyAgentSession();
           const restored = mergeCachedSessionIntoCurrent(current, partial);
           if (restored === current) continue;
           sessionsByAgentId[agentId] = restored;
           restoredAgentIds.push(agentId);
         }
+        const rosterActivityByAgentId = mergeCachedReadStates(
+          state.rosterActivityByAgentId,
+          cached.readStateByAgentId,
+        );
+        if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
+          writeStoredRosterActivity(context.remoteKey, rosterActivityByAgentId);
+        }
         const withProvisional = rebuildProvisionalDetailsWithAgents(
           state.bootstrap.agents,
           sessionsByAgentId,
         );
-        return { sessionsByAgentId: withProvisional ?? sessionsByAgentId };
+        return {
+          bootstrap: sortBootstrapAgents(state.bootstrap, rosterActivityByAgentId),
+          rosterActivityByAgentId,
+          sessionsByAgentId: withProvisional ?? sessionsByAgentId,
+        };
       });
 
       if (get && sessionCacheContextIsCurrent(context)) {
@@ -1153,11 +1167,44 @@ export function mergeCachedSessionIntoCurrent(
     ...current,
     ...cached,
     loading: current.loading,
-    semanticHistoryByDisplayLevel: current.semanticHistoryByDisplayLevel,
+    semanticHistoryByDisplayLevel:
+      Object.keys(current.semanticHistoryByDisplayLevel).length > 0
+        ? current.semanticHistoryByDisplayLevel
+        : (cached.semanticHistoryByDisplayLevel ?? {}),
     targetEventLoading: current.targetEventLoading,
     liveStatus: current.liveStatus,
     sendingPrompt: current.sendingPrompt,
   };
+}
+
+export function mergeCachedReadState(
+  current: AgentRosterActivity | undefined,
+  cached: CachedAgentReadState | undefined,
+): AgentRosterActivity | undefined {
+  if (!cached) return current;
+  const currentHasReadState =
+    current?.unreadCount != null ||
+    current?.lastUnreadDeliverySeq != null ||
+    current?.lastReadDeliverySeq != null;
+  if (currentHasReadState) return current;
+  return {
+    ...current,
+    ...cached,
+  };
+}
+
+function mergeCachedReadStates(
+  current: Record<string, AgentRosterActivity>,
+  cached: Record<string, CachedAgentReadState>,
+): Record<string, AgentRosterActivity> {
+  let merged = current;
+  for (const [agentId, readState] of Object.entries(cached)) {
+    const activity = mergeCachedReadState(merged[agentId], readState);
+    if (!activity || activity === merged[agentId]) continue;
+    if (merged === current) merged = { ...current };
+    merged[agentId] = activity;
+  }
+  return merged;
 }
 
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
@@ -1278,6 +1325,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
       return { rosterActivityByAgentId };
     });
+    scheduleCacheWrite(get, agentId);
   },
   setDisplayLevel: (displayLevel, agentId) =>
     set((state) => {
@@ -2547,9 +2595,30 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
           );
           set((state) => {
             const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
-            const restored = cached ? mergeCachedSessionIntoCurrent(current, cached) : current;
+            const restored = cached
+              ? mergeCachedSessionIntoCurrent(current, cached.session)
+              : current;
             const available = Boolean(restored.detail?.timeline.length || restored.eventSeqs.length);
+            const cachedActivity = mergeCachedReadState(
+              state.rosterActivityByAgentId[agentId],
+              cached?.readState,
+            );
+            const rosterActivityByAgentId =
+              cachedActivity && cachedActivity !== state.rosterActivityByAgentId[agentId]
+                ? {
+                    ...state.rosterActivityByAgentId,
+                    [agentId]: cachedActivity,
+                  }
+                : state.rosterActivityByAgentId;
+            if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
+              writeStoredRosterActivity(
+                currentRemoteKey(runtimeConnectionConfig),
+                rosterActivityByAgentId,
+              );
+            }
             return {
+              bootstrap: sortBootstrapAgents(state.bootstrap, rosterActivityByAgentId),
+              rosterActivityByAgentId,
               sessionsByAgentId: {
                 ...state.sessionsByAgentId,
                 [agentId]: {
@@ -3011,6 +3080,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
+      scheduleCacheWrite(get, agentId);
     } catch (error) {
       if (!isCurrentClientRequest(request)) return;
       set((state) => ({
@@ -3181,11 +3251,28 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     try {
       await request.client.deleteAgent(agentId, cascadePrivateChildren);
       if (!isCurrentClientRequest(request)) return;
+      sessionCacheWriter?.discard(agentId);
+      await cacheDeleteSession(currentRemoteKey(runtimeConnectionConfig), agentId);
+      unregisterAgentForEvents(agentId);
+      stopAgentEventStream(agentId, set);
+      set((state) => {
+        const sessionsByAgentId = { ...state.sessionsByAgentId };
+        const rosterActivityByAgentId = { ...state.rosterActivityByAgentId };
+        delete sessionsByAgentId[agentId];
+        delete rosterActivityByAgentId[agentId];
+        writeStoredRosterActivity(
+          currentRemoteKey(runtimeConnectionConfig),
+          rosterActivityByAgentId,
+        );
+        return {
+          sessionsByAgentId,
+          rosterActivityByAgentId,
+        };
+      });
       await get().refreshBootstrap({ background: true });
       // If we deleted the currently selected agent, clean up and reset to dashboard
       // so the UI doesn't stay on a stale agent page that errors on refresh.
       if (get().selectedAgentId === agentId) {
-        stopAgentEventStream(agentId, set);
         set({
           selectedAgentId: "",
           route: "dashboard",
@@ -3538,9 +3625,29 @@ type StoreSet = (
  */
 function scheduleCacheWrite(get: () => RuntimeStoreState, agentId: string): void {
   if (!sessionCacheWriter) return;
-  const session = get().sessionsByAgentId[agentId];
+  const state = get();
+  const session = state.sessionsByAgentId[agentId];
   if (!session) return;
-  sessionCacheWriter.scheduleWrite(agentId, session);
+  sessionCacheWriter.scheduleWrite(
+    agentId,
+    session,
+    cachedReadState(state.rosterActivityByAgentId[agentId]),
+  );
+}
+
+function cachedReadState(
+  activity: AgentRosterActivity | undefined,
+): CachedAgentReadState | undefined {
+  if (!activity) return undefined;
+  const readState: CachedAgentReadState = {};
+  if (activity.unreadCount != null) readState.unreadCount = activity.unreadCount;
+  if (activity.lastUnreadDeliverySeq != null) {
+    readState.lastUnreadDeliverySeq = activity.lastUnreadDeliverySeq;
+  }
+  if (activity.lastReadDeliverySeq != null) {
+    readState.lastReadDeliverySeq = activity.lastReadDeliverySeq;
+  }
+  return Object.keys(readState).length ? readState : undefined;
 }
 
 function scheduleAgentDetailRetry(

--- a/web-gui/app/src/runtime/session-cache.test.ts
+++ b/web-gui/app/src/runtime/session-cache.test.ts
@@ -3,12 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   currentRemoteKey,
   extractCacheableSession,
+  hydrateAllSessions,
   hydrateSessionFromCache,
   SessionCacheWriter,
   enforceCacheLimits,
 } from "./session-cache";
 import type { AgentSessionState } from "./runtime-store-helpers";
-import { CACHE_SCHEMA_VERSION } from "./idb-cache";
+import { CACHE_SCHEMA_VERSION, type CachedAgentSession } from "./idb-cache";
 import {
   SESSION_PROJECTION_GENERATION,
   createSessionProjectionState,
@@ -30,6 +31,38 @@ function makeSession(overrides: Partial<AgentSessionState> = {}): AgentSessionSt
     workItemDetailsById: {},
     taskDetailsById: {},
     toolExecutionDetailsById: {},
+    ...overrides,
+  };
+}
+
+function makeCachedSession(
+  overrides: Partial<CachedAgentSession> = {},
+): CachedAgentSession {
+  const eventSeqs = overrides.eventSeqs ?? [];
+  const eventLogEpoch = overrides.eventLogEpoch;
+  const newestSeq = overrides.newestSeq ?? eventSeqs.at(-1);
+  return {
+    remoteKey: "local",
+    agentId: "agent-1",
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    projectionGeneration: SESSION_PROJECTION_GENERATION,
+    eventLogEpoch,
+    eventsBySeq: {},
+    eventSeqs,
+    messagesById: {},
+    transcriptEntriesById: {},
+    briefRecordsById: {},
+    newestSeq,
+    oldestSeq: overrides.oldestSeq ?? eventSeqs[0],
+    syncCoverage: {
+      eventLogEpoch,
+      contiguousSeq: newestSeq ?? 0,
+      observedSeq: newestSeq ?? 0,
+      retainedOldestSeq: eventSeqs[0],
+      retainedNewestSeq: eventSeqs.at(-1),
+      gaps: [],
+    },
+    cachedAt: Date.now(),
     ...overrides,
   };
 }
@@ -73,7 +106,51 @@ describe("extractCacheableSession", () => {
     expect(result.agentSummary).toBeUndefined();
     expect(result.newestSeq).toBe(2);
     expect(result.oldestSeq).toBe(1);
+    expect(result.syncCoverage).toEqual({
+      eventLogEpoch: "epoch-1",
+      contiguousSeq: 2,
+      observedSeq: 2,
+      retainedOldestSeq: 1,
+      retainedNewestSeq: 2,
+      gaps: [],
+    });
     expect(result.cachedAt).toBeGreaterThan(0);
+  });
+
+  it("persists sync gaps, semantic history coverage, and read state atomically", () => {
+    const session = makeSession({
+      eventLogEpoch: "epoch-1",
+      eventsBySeq: { 1: { id: "e1" }, 5: { id: "e5" } },
+      eventSeqs: [1, 5],
+      gaps: [{ afterSeq: 1, beforeSeq: 5 }],
+      newestSeq: 5,
+      oldestSeq: 1,
+      semanticHistoryByDisplayLevel: {
+        info: { eventLogEpoch: "epoch-1", cursorSeq: 1, hasOlder: false, loading: false },
+        verbose: { eventLogEpoch: "epoch-1", cursorSeq: 1, hasOlder: true, loading: true },
+        debug: { eventLogEpoch: "epoch-old", cursorSeq: 1, hasOlder: true, loading: false },
+      },
+    });
+
+    const result = extractCacheableSession("local", "agent-1", session, {
+      unreadCount: 2,
+      lastUnreadDeliverySeq: 5,
+      lastReadDeliverySeq: 3,
+    });
+
+    expect(result.syncCoverage).toMatchObject({
+      contiguousSeq: 1,
+      observedSeq: 5,
+      gaps: [{ afterSeq: 1, beforeSeq: 5 }],
+    });
+    expect(result.semanticHistoryByDisplayLevel).toEqual({
+      info: { eventLogEpoch: "epoch-1", cursorSeq: 1, hasOlder: false },
+    });
+    expect(result.readState).toEqual({
+      unreadCount: 2,
+      lastUnreadDeliverySeq: 5,
+      lastReadDeliverySeq: 3,
+    });
   });
 
   it("persists the agent summary needed to render cached history", () => {
@@ -141,26 +218,33 @@ describe("extractCacheableSession", () => {
     expect(result.eventSeqs[MAX - 1]).toBe(MAX + 100);
     expect(result.oldestSeq).toBe(101);
     expect(result.newestSeq).toBe(MAX + 100);
+    expect(result.syncCoverage).toMatchObject({
+      contiguousSeq: MAX + 100,
+      observedSeq: MAX + 100,
+      retainedOldestSeq: 101,
+      retainedNewestSeq: MAX + 100,
+    });
   });
 });
 
 describe("hydrateSessionFromCache", () => {
   it("returns partial session with cached data", () => {
-    const cached = {
-      remoteKey: "local",
-      agentId: "agent-1",
-      schemaVersion: CACHE_SCHEMA_VERSION,
-      projectionGeneration: SESSION_PROJECTION_GENERATION,
+    const cached = makeCachedSession({
       eventLogEpoch: "epoch-1",
       eventsBySeq: { 1: { id: "e1" } },
       eventSeqs: [1],
       messagesById: { m1: { id: "m1" } },
-      transcriptEntriesById: {},
-      briefRecordsById: {},
       newestSeq: 1,
       oldestSeq: 1,
-      cachedAt: Date.now(),
-    };
+      syncCoverage: {
+        eventLogEpoch: "epoch-1",
+        contiguousSeq: 1,
+        observedSeq: 1,
+        retainedOldestSeq: 1,
+        retainedNewestSeq: 1,
+        gaps: [],
+      },
+    });
 
     const result = hydrateSessionFromCache(cached);
 
@@ -172,11 +256,7 @@ describe("hydrateSessionFromCache", () => {
   });
 
   it("restores a renderable detail when the cache includes an agent summary", () => {
-    const cached = {
-      remoteKey: "local",
-      agentId: "agent-1",
-      schemaVersion: CACHE_SCHEMA_VERSION,
-      projectionGeneration: SESSION_PROJECTION_GENERATION,
+    const cached = makeCachedSession({
       agentSummary: {
         id: "agent-1",
         badge: "A",
@@ -198,11 +278,14 @@ describe("hydrateSessionFromCache", () => {
       },
       eventsBySeq: { 1: { id: "e1", event_seq: 1 } },
       eventSeqs: [1],
-      messagesById: {},
-      transcriptEntriesById: {},
-      briefRecordsById: {},
-      cachedAt: Date.now(),
-    };
+      syncCoverage: {
+        contiguousSeq: 1,
+        observedSeq: 1,
+        retainedOldestSeq: 1,
+        retainedNewestSeq: 1,
+        gaps: [],
+      },
+    });
 
     const result = hydrateSessionFromCache(cached);
 
@@ -213,19 +296,18 @@ describe("hydrateSessionFromCache", () => {
   });
 
   it("ignores a malformed or mismatched cached agent summary", () => {
-    const cached = {
-      remoteKey: "local",
-      agentId: "agent-1",
-      schemaVersion: CACHE_SCHEMA_VERSION,
-      projectionGeneration: SESSION_PROJECTION_GENERATION,
+    const cached = makeCachedSession({
       agentSummary: { id: "agent-2" },
       eventsBySeq: { 1: { id: "e1", event_seq: 1 } },
       eventSeqs: [1],
-      messagesById: {},
-      transcriptEntriesById: {},
-      briefRecordsById: {},
-      cachedAt: Date.now(),
-    };
+      syncCoverage: {
+        contiguousSeq: 1,
+        observedSeq: 1,
+        retainedOldestSeq: 1,
+        retainedNewestSeq: 1,
+        gaps: [],
+      },
+    });
 
     const result = hydrateSessionFromCache(cached);
 
@@ -235,23 +317,109 @@ describe("hydrateSessionFromCache", () => {
   });
 
   it("does not include UI state fields", () => {
-    const cached = {
-      remoteKey: "local",
-      agentId: "agent-1",
-      schemaVersion: CACHE_SCHEMA_VERSION,
-      eventsBySeq: {},
-      eventSeqs: [],
-      messagesById: {},
-      transcriptEntriesById: {},
-      briefRecordsById: {},
-      cachedAt: Date.now(),
-    };
+    const cached = makeCachedSession();
 
     const result = hydrateSessionFromCache(cached);
 
     expect(result).not.toHaveProperty("loading");
     expect(result).not.toHaveProperty("liveStatus");
     expect(result).not.toHaveProperty("detail");
+  });
+
+  it("restores persisted gaps and independent display-level history coverage", () => {
+    const cached = makeCachedSession({
+      eventLogEpoch: "epoch-1",
+      eventsBySeq: {
+        1: { id: "e1", event_seq: 1 },
+        5: { id: "e5", event_seq: 5 },
+      },
+      eventSeqs: [1, 5],
+      newestSeq: 5,
+      oldestSeq: 1,
+      syncCoverage: {
+        eventLogEpoch: "epoch-1",
+        contiguousSeq: 1,
+        observedSeq: 5,
+        retainedOldestSeq: 1,
+        retainedNewestSeq: 5,
+        gaps: [{ afterSeq: 1, beforeSeq: 5 }],
+      },
+      semanticHistoryByDisplayLevel: {
+        info: { eventLogEpoch: "epoch-1", cursorSeq: 1, hasOlder: false },
+        verbose: { eventLogEpoch: "epoch-1", cursorSeq: 3, hasOlder: true },
+        debug: { eventLogEpoch: "epoch-old", cursorSeq: 1, hasOlder: true },
+      },
+    });
+
+    const result = hydrateSessionFromCache(cached);
+
+    expect(result.gaps).toEqual([{ afterSeq: 1, beforeSeq: 5 }]);
+    expect(result.semanticHistoryByDisplayLevel).toEqual({
+      info: { eventLogEpoch: "epoch-1", cursorSeq: 1, hasOlder: false, loading: false },
+      verbose: { eventLogEpoch: "epoch-1", cursorSeq: 3, hasOlder: true, loading: false },
+    });
+  });
+
+  it("invalidates incomplete or internally inconsistent cache metadata", () => {
+    const missingCoverage = makeCachedSession({
+      eventsBySeq: { 1: { id: "e1", event_seq: 1 } },
+      eventSeqs: [1],
+      syncCoverage: undefined,
+    });
+    const mismatchedRetainedWindow = makeCachedSession({
+      eventsBySeq: { 1: { id: "e1", event_seq: 1 } },
+      eventSeqs: [1],
+      syncCoverage: {
+        contiguousSeq: 1,
+        observedSeq: 1,
+        retainedOldestSeq: 2,
+        retainedNewestSeq: 1,
+        gaps: [],
+      },
+    });
+
+    expect(hydrateSessionFromCache(missingCoverage)).toMatchObject({
+      eventSeqs: [],
+      invalidatedReason: "cache_integrity_mismatch",
+      syncStatus: "stale",
+    });
+    expect(hydrateSessionFromCache(mismatchedRetainedWindow)).toMatchObject({
+      eventSeqs: [],
+      invalidatedReason: "cache_integrity_mismatch",
+      syncStatus: "stale",
+    });
+  });
+});
+
+describe("hydrateAllSessions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("restores session and read state from the same cached record", async () => {
+    const cached = makeCachedSession({
+      eventsBySeq: { 1: { id: "e1", event_seq: 1 } },
+      eventSeqs: [1],
+      syncCoverage: {
+        contiguousSeq: 1,
+        observedSeq: 1,
+        retainedOldestSeq: 1,
+        retainedNewestSeq: 1,
+        gaps: [],
+      },
+      readState: {
+        unreadCount: 2,
+        lastUnreadDeliverySeq: 8,
+        lastReadDeliverySeq: 5,
+      },
+    });
+    const idbModule = await import("./idb-cache");
+    vi.spyOn(idbModule, "cacheGetAllSessions").mockResolvedValue([cached]);
+
+    const result = await hydrateAllSessions("local");
+
+    expect(result.sessionsByAgentId["agent-1"]?.eventSeqs).toEqual([1]);
+    expect(result.readStateByAgentId["agent-1"]).toEqual(cached.readState);
   });
 });
 
@@ -316,6 +484,20 @@ describe("SessionCacheWriter", () => {
 
     expect(putSpy).not.toHaveBeenCalled();
 
+    putSpy.mockRestore();
+  });
+
+  it("discard cancels a deleted agent without affecting other pending writes", async () => {
+    const writer = new SessionCacheWriter("local");
+    const putSpy = vi.spyOn(await import("./idb-cache"), "cachePutSession").mockResolvedValue(undefined);
+
+    writer.scheduleWrite("agent-1", makeSession({ eventSeqs: [1] }));
+    writer.scheduleWrite("agent-2", makeSession({ eventSeqs: [2] }));
+    writer.discard("agent-1");
+    await writer.flush();
+
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    expect(putSpy.mock.calls[0]?.[0].agentId).toBe("agent-2");
     putSpy.mockRestore();
   });
 });

--- a/web-gui/app/src/runtime/session-cache.ts
+++ b/web-gui/app/src/runtime/session-cache.ts
@@ -12,7 +12,10 @@ import {
   cacheGetSession,
   cachePutSession,
   ensureCacheSchemaVersion,
+  type CachedAgentReadState,
   type CachedAgentSession,
+  type CachedSemanticHistoryState,
+  type CachedSyncCoverage,
 } from "./idb-cache";
 import type { AgentSessionState } from "./runtime-store-helpers";
 import {
@@ -24,6 +27,7 @@ import {
 } from "./session-projection";
 import type {
   AgentSummary,
+  DisplayLevel,
   RuntimeBriefRecord,
   RuntimeMessageEnvelope,
   RuntimeTranscriptEntry,
@@ -35,6 +39,17 @@ export type { CachedAgentSession };
 const MAX_CACHED_AGENTS_PER_REMOTE = 50;
 const MAX_EVENTS_PER_AGENT = 5000;
 const WRITE_DEBOUNCE_MS = 2000;
+const DISPLAY_LEVELS: DisplayLevel[] = ["info", "verbose", "debug"];
+
+export interface HydratedAgentCache {
+  session: Partial<AgentSessionState>;
+  readState?: CachedAgentReadState;
+}
+
+export interface HydratedRemoteCache {
+  sessionsByAgentId: Record<string, Partial<AgentSessionState>>;
+  readStateByAgentId: Record<string, CachedAgentReadState>;
+}
 
 function cachedAgentSummary(
   value: unknown,
@@ -63,7 +78,10 @@ export function extractCacheableSession(
   remoteKey: string,
   agentId: string,
   session: AgentSessionState,
+  readState?: CachedAgentReadState,
 ): CachedAgentSession {
+  const syncCoverage = extractSyncCoverage(session);
+
   // Trim events if exceeding the per-agent limit (keep the newest).
   let eventsBySeq = session.eventsBySeq;
   let eventSeqs = session.eventSeqs;
@@ -93,8 +111,56 @@ export function extractCacheableSession(
     briefRecordsById: session.briefRecordsById as Record<string, unknown>,
     newestSeq: eventSeqs.at(-1) ?? session.newestSeq,
     oldestSeq: eventSeqs[0] ?? session.oldestSeq,
+    syncCoverage: {
+      ...syncCoverage,
+      retainedOldestSeq: eventSeqs[0],
+      retainedNewestSeq: eventSeqs.at(-1),
+    },
+    semanticHistoryByDisplayLevel: extractSemanticHistory(
+      session.semanticHistoryByDisplayLevel,
+      session.eventLogEpoch,
+      eventSeqs[0],
+    ),
+    readState: coerceReadState(readState),
     cachedAt: Date.now(),
   };
+}
+
+function extractSyncCoverage(session: AgentSessionState): CachedSyncCoverage {
+  const observedSeq = Math.max(session.newestSeq ?? 0, session.eventSeqs.at(-1) ?? 0);
+  return {
+    eventLogEpoch: session.eventLogEpoch,
+    contiguousSeq: session.gaps[0]?.afterSeq ?? observedSeq,
+    observedSeq,
+    retainedOldestSeq: session.eventSeqs[0],
+    retainedNewestSeq: session.eventSeqs.at(-1),
+    gaps: session.gaps.map((gap) => ({ ...gap })),
+  };
+}
+
+function extractSemanticHistory(
+  histories: AgentSessionState["semanticHistoryByDisplayLevel"],
+  eventLogEpoch: string | undefined,
+  retainedOldestSeq: number | undefined,
+): Record<string, CachedSemanticHistoryState> {
+  const cached: Record<string, CachedSemanticHistoryState> = {};
+  for (const displayLevel of DISPLAY_LEVELS) {
+    const history = histories[displayLevel];
+    if (!history || history.loading || history.error) continue;
+    if (history.eventLogEpoch && eventLogEpoch && history.eventLogEpoch !== eventLogEpoch) continue;
+    let cursorSeq = finiteSequence(history.cursorSeq);
+    let hasOlder = history.hasOlder;
+    if (cursorSeq != null && retainedOldestSeq != null && cursorSeq < retainedOldestSeq) {
+      cursorSeq = retainedOldestSeq;
+      hasOlder = true;
+    }
+    cached[displayLevel] = {
+      eventLogEpoch: history.eventLogEpoch ?? eventLogEpoch,
+      cursorSeq,
+      hasOlder,
+    };
+  }
+  return cached;
 }
 
 /**
@@ -102,6 +168,17 @@ export function extractCacheableSession(
  * The caller merges this into an emptyAgentSession() base.
  */
 export function hydrateSessionFromCache(cached: CachedAgentSession): Partial<AgentSessionState> {
+  const coverage = coerceSyncCoverage(cached);
+  if (!coverage) {
+    return {
+      ...createSessionProjectionState(cached.eventLogEpoch),
+      invalidatedReason: "cache_integrity_mismatch",
+      cacheStatus: "hit",
+      contentStatus: "unknown",
+      syncStatus: "stale",
+      semanticHistoryByDisplayLevel: {},
+    };
+  }
   const projection = reduceSessionProjection(createSessionProjectionState(), {
     type: "cache_restored",
     generation: cached.projectionGeneration ?? SESSION_PROJECTION_GENERATION - 1,
@@ -114,24 +191,45 @@ export function hydrateSessionFromCache(cached: CachedAgentSession): Partial<Age
     newestSeq: cached.newestSeq,
     oldestSeq: cached.oldestSeq,
   });
+  if (projection.invalidatedReason) {
+    return {
+      ...projection,
+      cacheStatus: "hit",
+      contentStatus: "unknown",
+      syncStatus: "stale",
+      semanticHistoryByDisplayLevel: {},
+    };
+  }
+  const restoredProjection = {
+    ...projection,
+    eventLogEpoch: coverage.eventLogEpoch,
+    gaps: coverage.gaps,
+    newestSeq: coverage.observedSeq || undefined,
+    oldestSeq: coverage.retainedOldestSeq,
+  };
+  const semanticHistoryByDisplayLevel = hydrateSemanticHistory(
+    cached.semanticHistoryByDisplayLevel,
+    coverage,
+  );
   const agent = cachedAgentSummary(cached.agentSummary, cached.agentId);
-  const events = projection.eventSeqs
-    .map((seq) => projection.eventsBySeq[seq])
+  const events = restoredProjection.eventSeqs
+    .map((seq) => restoredProjection.eventsBySeq[seq])
     .filter((event): event is ProjectionEvent => Boolean(event));
   return {
-    ...projection,
+    ...restoredProjection,
+    semanticHistoryByDisplayLevel,
     cacheStatus: "hit",
-    contentStatus: projection.eventSeqs.length ? "available" : "unknown",
+    contentStatus: restoredProjection.eventSeqs.length ? "available" : "unknown",
     syncStatus: "stale",
     ...(agent
       ? { detail: {
           agent,
-          timeline: deriveSessionTimeline(projection, "debug"),
+          timeline: deriveSessionTimeline(restoredProjection, "debug"),
           source: "http",
           events,
-          eventLogEpoch: cached.eventLogEpoch,
-          newestEventSeq: cached.newestSeq,
-          oldestEventSeq: cached.oldestSeq,
+          eventLogEpoch: restoredProjection.eventLogEpoch,
+          newestEventSeq: restoredProjection.newestSeq,
+          oldestEventSeq: restoredProjection.oldestSeq,
         } }
       : {}),
   };
@@ -140,9 +238,112 @@ export function hydrateSessionFromCache(cached: CachedAgentSession): Partial<Age
 export async function hydrateAgentSession(
   remoteKey: string,
   agentId: string,
-): Promise<Partial<AgentSessionState> | undefined> {
+): Promise<HydratedAgentCache | undefined> {
   const cached = await cacheGetSession(remoteKey, agentId);
-  return cached ? hydrateSessionFromCache(cached) : undefined;
+  return cached
+    ? {
+        session: hydrateSessionFromCache(cached),
+        readState: coerceReadState(cached.readState),
+      }
+    : undefined;
+}
+
+function coerceSyncCoverage(cached: CachedAgentSession): CachedSyncCoverage | undefined {
+  const coverage = cached.syncCoverage;
+  if (!coverage || typeof coverage !== "object") return undefined;
+  const observedSeq = finiteSequence(coverage.observedSeq);
+  const contiguousSeq = finiteSequence(coverage.contiguousSeq);
+  const retainedOldestSeq = finiteSequence(coverage.retainedOldestSeq);
+  const retainedNewestSeq = finiteSequence(coverage.retainedNewestSeq);
+  const actualOldestSeq = finiteSequence(cached.eventSeqs[0]);
+  const actualNewestSeq = finiteSequence(cached.eventSeqs.at(-1));
+  if (
+    observedSeq == null ||
+    contiguousSeq == null ||
+    contiguousSeq > observedSeq ||
+    retainedOldestSeq !== actualOldestSeq ||
+    retainedNewestSeq !== actualNewestSeq ||
+    (actualNewestSeq != null && actualNewestSeq > observedSeq) ||
+    coverage.eventLogEpoch !== cached.eventLogEpoch
+  ) {
+    return undefined;
+  }
+  if (!Array.isArray(coverage.gaps)) return undefined;
+  const gaps = coverage.gaps.flatMap((gap) => {
+    const afterSeq = finiteSequence(gap?.afterSeq);
+    const beforeSeq = finiteSequence(gap?.beforeSeq);
+    return afterSeq != null && beforeSeq != null && afterSeq < beforeSeq && beforeSeq <= observedSeq
+      ? [{ afterSeq, beforeSeq }]
+      : [];
+  });
+  if (gaps.length !== coverage.gaps.length) return undefined;
+  for (let index = 1; index < gaps.length; index += 1) {
+    if (gaps[index - 1].beforeSeq > gaps[index].afterSeq) return undefined;
+  }
+  if ((gaps[0]?.afterSeq ?? observedSeq) !== contiguousSeq) return undefined;
+  return {
+    eventLogEpoch: coverage.eventLogEpoch,
+    contiguousSeq,
+    observedSeq,
+    retainedOldestSeq,
+    retainedNewestSeq,
+    gaps,
+  };
+}
+
+function hydrateSemanticHistory(
+  cached: CachedAgentSession["semanticHistoryByDisplayLevel"],
+  coverage: CachedSyncCoverage,
+): AgentSessionState["semanticHistoryByDisplayLevel"] {
+  if (!cached || typeof cached !== "object") return {};
+  const histories: AgentSessionState["semanticHistoryByDisplayLevel"] = {};
+  for (const displayLevel of DISPLAY_LEVELS) {
+    const value = cached[displayLevel];
+    if (!value || typeof value !== "object" || typeof value.hasOlder !== "boolean") continue;
+    if (value.eventLogEpoch !== coverage.eventLogEpoch) continue;
+    let cursorSeq = finiteSequence(value.cursorSeq);
+    let hasOlder = value.hasOlder;
+    if (cursorSeq != null && cursorSeq > coverage.observedSeq) continue;
+    if (
+      cursorSeq != null &&
+      coverage.retainedOldestSeq != null &&
+      cursorSeq < coverage.retainedOldestSeq
+    ) {
+      cursorSeq = coverage.retainedOldestSeq;
+      hasOlder = true;
+    }
+    histories[displayLevel] = {
+      eventLogEpoch: coverage.eventLogEpoch,
+      cursorSeq,
+      hasOlder,
+      loading: false,
+    };
+  }
+  return histories;
+}
+
+function coerceReadState(value: CachedAgentReadState | undefined): CachedAgentReadState | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const readState: CachedAgentReadState = {};
+  const unreadCount = finiteNonNegative(value.unreadCount);
+  const lastUnreadDeliverySeq = finiteSequence(value.lastUnreadDeliverySeq);
+  const lastReadDeliverySeq = finiteSequence(value.lastReadDeliverySeq);
+  if (unreadCount != null) readState.unreadCount = unreadCount;
+  if (lastUnreadDeliverySeq != null) readState.lastUnreadDeliverySeq = lastUnreadDeliverySeq;
+  if (lastReadDeliverySeq != null) readState.lastReadDeliverySeq = lastReadDeliverySeq;
+  return Object.keys(readState).length ? readState : undefined;
+}
+
+function finiteSequence(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : undefined;
 }
 
 /**
@@ -163,15 +364,23 @@ export async function enforceCacheLimits(remoteKey: string): Promise<void> {
  */
 export class SessionCacheWriter {
   private timers = new Map<string, number>();
-  private pending = new Map<string, { remoteKey: string; session: AgentSessionState }>();
+  private pending = new Map<string, {
+    remoteKey: string;
+    session: AgentSessionState;
+    readState?: CachedAgentReadState;
+  }>();
   private readonly remoteKey: string;
 
   constructor(remoteKey: string) {
     this.remoteKey = remoteKey;
   }
 
-  scheduleWrite(agentId: string, session: AgentSessionState): void {
-    this.pending.set(agentId, { remoteKey: this.remoteKey, session });
+  scheduleWrite(
+    agentId: string,
+    session: AgentSessionState,
+    readState?: CachedAgentReadState,
+  ): void {
+    this.pending.set(agentId, { remoteKey: this.remoteKey, session, readState });
 
     const existing = this.timers.get(agentId);
     if (existing != null) {
@@ -190,7 +399,12 @@ export class SessionCacheWriter {
     if (!entry) return;
     this.pending.delete(agentId);
     try {
-      const cached = extractCacheableSession(entry.remoteKey, agentId, entry.session);
+      const cached = extractCacheableSession(
+        entry.remoteKey,
+        agentId,
+        entry.session,
+        entry.readState,
+      );
       await cachePutSession(cached);
     } catch {
       // Silent fallback.
@@ -216,6 +430,13 @@ export class SessionCacheWriter {
     this.timers.clear();
     this.pending.clear();
   }
+
+  discard(agentId: string): void {
+    const timer = this.timers.get(agentId);
+    if (timer != null) globalThis.clearTimeout(timer);
+    this.timers.delete(agentId);
+    this.pending.delete(agentId);
+  }
 }
 
 /**
@@ -233,11 +454,14 @@ export async function initSessionCache(): Promise<boolean> {
  */
 export async function hydrateAllSessions(
   remoteKey: string,
-): Promise<Record<string, Partial<AgentSessionState>>> {
+): Promise<HydratedRemoteCache> {
   const cached = await cacheGetAllSessions(remoteKey);
-  const result: Record<string, Partial<AgentSessionState>> = {};
+  const sessionsByAgentId: Record<string, Partial<AgentSessionState>> = {};
+  const readStateByAgentId: Record<string, CachedAgentReadState> = {};
   for (const entry of cached) {
-    result[entry.agentId] = hydrateSessionFromCache(entry);
+    sessionsByAgentId[entry.agentId] = hydrateSessionFromCache(entry);
+    const readState = coerceReadState(entry.readState);
+    if (readState) readStateByAgentId[entry.agentId] = readState;
   }
-  return result;
+  return { sessionsByAgentId, readStateByAgentId };
 }

--- a/web-gui/app/src/runtime/session-projection.ts
+++ b/web-gui/app/src/runtime/session-projection.ts
@@ -46,7 +46,10 @@ export interface SessionProjectionState {
   referencedBriefIds: Record<string, true>;
   newestSeq?: number;
   oldestSeq?: number;
-  invalidatedReason?: "event_identity_conflict" | "cache_generation_mismatch";
+  invalidatedReason?:
+    | "event_identity_conflict"
+    | "cache_generation_mismatch"
+    | "cache_integrity_mismatch";
 }
 
 export type SessionProjectionAction =


### PR DESCRIPTION
## Summary

- bump the Web GUI IndexedDB cache schema and persist per-agent sync coverage alongside cached events
- persist independent semantic history cursors/coverage for each `DisplayLevel`
- persist browser-local unread/read markers in the same per-agent record, while preserving newer `localStorage` state during migration
- invalidate incomplete or inconsistent cache metadata instead of treating it as synchronized
- delete pending and persisted session/read cache state when an agent is deleted

## Correctness boundaries

- cached sessions always hydrate as `stale` and still require normal server recovery/validation
- transient loading, error, and retry state is not persisted
- cache retention rebases history cursors to the retained event window and keeps `hasOlder=true`
- this does not claim to solve exact unread/latest-preview recovery for events created while the browser was offline; that remains dependent on the planned sync/summary/read-marker API

## Verification

- `npm test` — 29 files / 320 tests passed
- `npm run build`
- `git diff --check`
