### PR TITLE
feat: canonical CompletionCommit for CompleteWorkItem (#2540)

### DIFF
--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -257,6 +257,15 @@ queue terminal state, Turn terminal record, attempt outcome, owner state, and
 wait/continuation mutations commits. A terminal tool returns success only
 after that commit and then ends the provider/tool loop.
 
+For `CompleteWorkItem`, this transaction is the `CompletionCommit`. It also
+binds the result brief, completes the legacy WorkItem, records the successful
+tool execution, cancels child waits, resumes or cancels the matching
+continuation frame, and applies the parent canonical transition through the
+same WorkItem outcome planner used by ordinary settlement. The committed
+terminal receipt is the only authority for success. A standalone Turn writer
+must reject a prepared completion, and replay of the same command must not
+duplicate Turn, queue, audit, brief, tool, or index-outbox facts.
+
 `WaitFor(task_result)` reads the task and rejoin authority inside the same
 transaction:
 

--- a/docs/rfcs/turn-based-context-projection.md
+++ b/docs/rfcs/turn-based-context-projection.md
@@ -53,8 +53,7 @@ from unrelated message and brief windows.
   input, assistant result briefs, tool references, WorkItem changes, and wait
   or completion transitions.
 - Support multiple user-facing briefs from one turn when one activation
-  completes multiple WorkItems or produces both lifecycle reports and a final
-  continuation result.
+  produces both a lifecycle report and other turn-linked delivery evidence.
 - Keep trusted operator intent and WorkItem state from being displaced by
   provider fallback, retry, timer, duplicate wake, or bookkeeping turns.
 - Make prompt retention priority rule-based and provenance-aware before using
@@ -146,35 +145,31 @@ assistant result is one kind of brief. A `CompleteWorkItem` transition may also
 produce a completion-report brief, and that brief is simultaneously the
 canonical report stored on the completed WorkItem.
 
-`CompleteWorkItem` is a WorkItem lifecycle boundary, not a hard turn boundary:
+`CompleteWorkItem` is both a WorkItem lifecycle boundary and a hard provider
+turn boundary:
 
-- completing a WorkItem records the WorkItem state transition
-- the runtime captures the completion report associated with that transition
-- waits attached to the completed WorkItem are resolved or cancelled
-- the current turn may continue if the model has further assistant output,
-  tool calls, queue updates, or other explicit continuation work
+- the provider/tool loop stops at the first successful `CompleteWorkItem`;
+- tool calls after it in the same assistant response are not executed;
+- the completion report, WorkItem transition, waits, continuation, Turn
+  terminal record, queue settlement, and canonical execution outcome commit in
+  one terminal transaction;
+- any resumed caller runs only in a later scheduler activation.
 
-If no continuation follows a successful `CompleteWorkItem`, the runtime may
-soft-stop without asking the model to restate the same report as another final
-brief. That duplicate-suppression behavior must not prevent same-turn
-continuation or same-turn completion of additional WorkItems.
+The completion-report brief may also be the turn's operator-facing result. The
+runtime must not ask the model to restate it after commit.
 
 Completion report capture should be deterministic and local to the tool call.
-For a sequence such as:
+For a response such as:
 
 ```text
 assistant text: report for WorkItem A
 tool call: CompleteWorkItem(A)
-assistant text: report for WorkItem B
-tool call: CompleteWorkItem(B)
+tool call: some_other_tool()
 ```
 
-the turn should produce two completion-report briefs, each linked to its own
-WorkItem completion. The runtime should not rely on the whole turn's final text
-to infer every completed WorkItem report, and it should not reject report
-promotion merely because multiple `CompleteWorkItem` calls appear in one turn.
-If a completion lacks nearby non-empty assistant report text, the runtime may
-record a missing-report warning for that specific completion.
+the report is bound to `A`, `some_other_tool` is not executed, and the Turn
+closes at the completion settlement. Completing another WorkItem requires a
+later activation with its own execution binding.
 
 ### 5.3 Link Operator Inputs And Briefs Through Turns
 

--- a/docs/rfcs/work-item-continuation-stack.md
+++ b/docs/rfcs/work-item-continuation-stack.md
@@ -193,26 +193,30 @@ fact is still an explicit continuation frame rather than a synthetic blocker.
 When `CompleteWorkItem(B)` succeeds, the following steps are one durable
 transition transaction:
 
-1. Complete `B` using the existing completion rules.
-2. Cancel or resolve active wait conditions owned by `B` as today.
+1. Terminalize the source queue claim, Turn, and current canonical execution
+   attempt with `WorkItemOutcome::Complete`.
+2. Complete legacy WorkItem `B`, bind its result brief, and cancel its active
+   waits.
 3. Find the active direct-caller continuation frame with
    `active_work_item_id = B`.
 4. If its return policy is satisfied:
    - mark the frame `resumed`;
+   - transition canonical `B` to `Terminal`;
+   - derive canonical `A` through the shared WorkItem outcome planner from its
+     exact `Paused(yielded_to:B)` state;
    - set `current_work_item_id` to `suspended_work_item_id`;
-   - set the current turn binding to `suspended_work_item_id` when continuing
-     inside the same runtime turn would otherwise require another model pick;
    - emit visible audit/scheduler evidence with reason
      `continuation_resumed`.
 
 This is an explicit stack return, not a queued WorkItem silently replacing
-current focus. The continuation frame is the evidence that authorizes the focus
-restore.
+current focus. The continuation frame is the typed cause that authorizes both
+the canonical parent transition and the legacy focus projection.
 
-After completing `B` and restoring `A`, the current model turn should close as
-continuable. The scheduler should then start the next pass anchored on the
-resumed WorkItem. The agent should not need to call `PickWorkItem(A)` merely to
-restore the stack.
+After completing `B` and restoring `A`, the current model turn closes
+immediately. The scheduler may then admit a new activation for `A` only when
+the committed canonical target is `Runnable`; an existing wait or blocker may
+instead leave it `Waiting`, `Paused`, or `NeedsRepair`. The agent should not
+need to call `PickWorkItem(A)` merely to restore the stack.
 
 ### Explicit Switching
 
@@ -448,9 +452,6 @@ A = Fix issue 1617
 
 ## Open Questions
 
-- When `CompleteWorkItem(B)` restores `A`, should the runtime always close the
-  current turn immediately, or only when the completion consumed the active
-  stack frame?
 - Should nested stack depth be capped in phase one to prevent accidental long
   chains?
 - Should clients receive `continuation_resumed` in tool results even though
@@ -467,7 +468,8 @@ Phase one should use stack semantics:
   `B` by default.
 - No public `PickWorkItem` mode is added in phase one.
 - `CompleteWorkItem(B)` resumes the direct caller `A`, restores current focus to
-  `A`, and lets the scheduler continue from that restored frame.
+  `A`, closes the current Turn, and lets the scheduler continue from the
+  canonical state committed with that restored frame.
 - Active frames form an acyclic single-caller/single-callee chain, not a general
   dependency graph.
 

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -16,12 +16,147 @@ pub struct ExecutionProtocolState {
     pub outcomes: BTreeMap<String, ExecutionOutcomeRecord>,
 }
 
+pub fn resume_work_item_continuation(
+    state: &ExecutionProtocolState,
+    command: &ResumeWorkItemContinuation,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.active_work_item_id.is_empty()
+        || command.continuation_id.is_empty()
+    {
+        return Err("continuation resume requires complete identity".into());
+    }
+    if state.work_items.get(&command.work_item_id) != Some(&command.expected) {
+        return Err("continuation resume WorkItem fence is stale".into());
+    }
+    if !matches!(
+        &command.expected.state,
+        WorkItemExecutionState::Paused { reason, .. }
+            if reason == &format!("yielded_to:{}", command.active_work_item_id)
+    ) {
+        return Err("continuation resume requires the exact yielded WorkItem state".into());
+    }
+    if matches!(
+        &command.outcome,
+        WorkItemOutcome::Complete { .. } | WorkItemOutcome::Yield { .. }
+    ) {
+        return Err("continuation resume cannot complete or yield the resumed WorkItem".into());
+    }
+    let mut next = state.clone();
+    let record = next
+        .work_items
+        .get_mut(&command.work_item_id)
+        .expect("continuation resume preserved WorkItem");
+    record.state = plan_work_item_outcome(record.generation(), &command.outcome)?;
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![
+            format!("work_item:{}", command.work_item_id),
+            format!("work_item:{}", command.active_work_item_id),
+            format!("continuation:{}", command.continuation_id),
+        ],
+    })
+}
+
+pub fn suspend_work_item_continuation(
+    state: &ExecutionProtocolState,
+    command: &SuspendWorkItemContinuation,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.active_work_item_id.is_empty()
+        || command.continuation_id.is_empty()
+    {
+        return Err("continuation suspension requires complete identity".into());
+    }
+    if state.work_items.get(&command.work_item_id) != Some(&command.expected) {
+        return Err("continuation suspension WorkItem fence is stale".into());
+    }
+    let WorkItemExecutionState::Runnable { generation, .. } = command.expected.state else {
+        return Err("continuation suspension requires a Runnable WorkItem".into());
+    };
+    let next_generation = generation
+        .checked_add(1)
+        .ok_or_else(|| "WorkItem scheduling generation overflow".to_string())?;
+    let mut next = state.clone();
+    let record = next
+        .work_items
+        .get_mut(&command.work_item_id)
+        .expect("continuation suspension preserved WorkItem");
+    record.state = WorkItemExecutionState::Paused {
+        generation: next_generation,
+        reason: format!("yielded_to:{}", command.active_work_item_id),
+    };
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![
+            format!("work_item:{}", command.work_item_id),
+            format!("work_item:{}", command.active_work_item_id),
+            format!("continuation:{}", command.continuation_id),
+        ],
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SetWorkItemWaiting {
     pub command_id: String,
     pub work_item_id: String,
     pub expected: Option<WorkItemExecutionRecord>,
     pub record: WorkItemExecutionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompleteWorkItemExecution {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub expected: WorkItemExecutionRecord,
+    pub completion: String,
+}
+
+pub fn complete_work_item_execution(
+    state: &ExecutionProtocolState,
+    command: &CompleteWorkItemExecution,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.completion.is_empty()
+    {
+        return Err("WorkItem completion requires complete identity".into());
+    }
+    if state.work_items.get(&command.work_item_id) != Some(&command.expected) {
+        return Err("WorkItem completion fence is stale".into());
+    }
+    if matches!(
+        command.expected.state,
+        WorkItemExecutionState::InFlight { .. } | WorkItemExecutionState::Terminal { .. }
+    ) {
+        return Err("WorkItem is not eligible for lifecycle completion".into());
+    }
+    let mut next = state.clone();
+    let record = next
+        .work_items
+        .get_mut(&command.work_item_id)
+        .expect("WorkItem completion preserved WorkItem");
+    record.state = plan_work_item_outcome(
+        record.generation(),
+        &WorkItemOutcome::Complete {
+            completion: command.completion.clone(),
+        },
+    )?;
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![
+            format!("work_item:{}", command.work_item_id),
+            format!("completion:{}", command.completion),
+        ],
+    })
 }
 
 impl ExecutionProtocolState {
@@ -338,6 +473,25 @@ pub struct SetWorkItemReadiness {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResumeWorkItemContinuation {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub active_work_item_id: String,
+    pub continuation_id: String,
+    pub expected: WorkItemExecutionRecord,
+    pub outcome: WorkItemOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SuspendWorkItemContinuation {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub active_work_item_id: String,
+    pub continuation_id: String,
+    pub expected: WorkItemExecutionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InterruptExecution {
     pub attempt_id: String,
     pub outcome_id: String,
@@ -351,7 +505,10 @@ pub enum ExecutionProtocolCommand {
     RegisterWorkItem(Box<RegisterWorkItemExecution>),
     AdvanceWorkItemSourceRevision(AdvanceWorkItemSourceRevision),
     SetWorkItemReadiness(Box<SetWorkItemReadiness>),
+    SuspendWorkItemContinuation(Box<SuspendWorkItemContinuation>),
+    ResumeWorkItemContinuation(Box<ResumeWorkItemContinuation>),
     SetWorkItemWaiting(Box<SetWorkItemWaiting>),
+    CompleteWorkItem(Box<CompleteWorkItemExecution>),
     Admit(Box<AdmitExecution>),
     Settle(SettleExecution),
     Interrupt(InterruptExecution),
@@ -753,7 +910,10 @@ pub fn settle_execution(
             } if attempt_id == &attempt.attempt_id => *generation,
             _ => return Err("WorkItem does not reference the settling attempt".into()),
         };
-        work_record.state = settle_work_item(generation, &outcome.outcome)?;
+        let ExecutionOutcome::WorkItem(work_item_outcome) = &outcome.outcome else {
+            unreachable!("WorkItem binding validated above");
+        };
+        work_record.state = plan_work_item_outcome(generation, work_item_outcome)?;
     }
 
     attempt.state = ExecutionAttemptState::Settled;
@@ -827,58 +987,46 @@ fn validate_outcome_binding(
     }
 }
 
-fn settle_work_item(
+fn plan_work_item_outcome(
     generation: u64,
-    outcome: &ExecutionOutcome,
+    outcome: &WorkItemOutcome,
 ) -> Result<WorkItemExecutionState, String> {
     let next_generation = generation
         .checked_add(1)
         .ok_or_else(|| "WorkItem scheduling generation overflow".to_string())?;
     match outcome {
-        ExecutionOutcome::WorkItem(WorkItemOutcome::Continue) => {
-            Ok(WorkItemExecutionState::Runnable {
-                generation: next_generation,
-                recovery_ref: None,
-            })
-        }
-        ExecutionOutcome::WorkItem(WorkItemOutcome::Interrupted { .. }) => {
-            Ok(WorkItemExecutionState::Runnable {
-                generation: next_generation,
-                recovery_ref: Some("interrupted".into()),
-            })
-        }
-        ExecutionOutcome::WorkItem(WorkItemOutcome::Wait { wait }) => {
-            Ok(WorkItemExecutionState::Waiting {
-                generation: next_generation,
-                wait: wait.clone(),
-            })
-        }
-        ExecutionOutcome::WorkItem(WorkItemOutcome::Pause { reason })
-        | ExecutionOutcome::WorkItem(WorkItemOutcome::Failed { policy: reason }) => {
+        WorkItemOutcome::Continue => Ok(WorkItemExecutionState::Runnable {
+            generation: next_generation,
+            recovery_ref: None,
+        }),
+        WorkItemOutcome::Interrupted { .. } => Ok(WorkItemExecutionState::Runnable {
+            generation: next_generation,
+            recovery_ref: Some("interrupted".into()),
+        }),
+        WorkItemOutcome::Wait { wait } => Ok(WorkItemExecutionState::Waiting {
+            generation: next_generation,
+            wait: wait.clone(),
+        }),
+        WorkItemOutcome::Pause { reason } | WorkItemOutcome::Failed { policy: reason } => {
             Ok(WorkItemExecutionState::Paused {
                 generation: next_generation,
                 reason: reason.clone(),
             })
         }
-        ExecutionOutcome::WorkItem(WorkItemOutcome::NeedsRepair { repair_id }) => {
-            Ok(WorkItemExecutionState::NeedsRepair {
-                generation: next_generation,
-                repair_id: repair_id.clone(),
-            })
-        }
-        ExecutionOutcome::WorkItem(WorkItemOutcome::Complete { completion }) => {
-            Ok(WorkItemExecutionState::Terminal {
-                generation: next_generation,
-                completion: completion.clone(),
-            })
-        }
-        ExecutionOutcome::WorkItem(WorkItemOutcome::Yield {
+        WorkItemOutcome::NeedsRepair { repair_id } => Ok(WorkItemExecutionState::NeedsRepair {
+            generation: next_generation,
+            repair_id: repair_id.clone(),
+        }),
+        WorkItemOutcome::Complete { completion } => Ok(WorkItemExecutionState::Terminal {
+            generation: next_generation,
+            completion: completion.clone(),
+        }),
+        WorkItemOutcome::Yield {
             target_work_item_id,
-        }) => Ok(WorkItemExecutionState::Paused {
+        } => Ok(WorkItemExecutionState::Paused {
             generation: next_generation,
             reason: format!("yielded_to:{target_work_item_id}"),
         }),
-        _ => Err("WorkItem settlement requires a WorkItem outcome".into()),
     }
 }
 
@@ -1110,6 +1258,88 @@ mod tests {
         assert!(set_work_item_readiness(&resumed.state, &stale)
             .unwrap_err()
             .contains("fence is stale"));
+    }
+
+    #[test]
+    fn continuation_resume_reuses_work_item_outcome_planner() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        let paused = work_item_record(WorkItemExecutionState::Paused {
+            generation: 2,
+            reason: "yielded_to:work-b".into(),
+        });
+        state.work_items.insert("work-a".into(), paused.clone());
+
+        let resumed = resume_work_item_continuation(
+            &state,
+            &ResumeWorkItemContinuation {
+                command_id: "resume:continuation-a".into(),
+                work_item_id: "work-a".into(),
+                active_work_item_id: "work-b".into(),
+                continuation_id: "continuation-a".into(),
+                expected: paused.clone(),
+                outcome: WorkItemOutcome::Continue,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            resumed.state.work_items["work-a"].state,
+            WorkItemExecutionState::Runnable {
+                generation: 3,
+                recovery_ref: None,
+            }
+        );
+
+        let stale = ResumeWorkItemContinuation {
+            command_id: "resume:continuation-a:stale".into(),
+            work_item_id: "work-a".into(),
+            active_work_item_id: "work-b".into(),
+            continuation_id: "continuation-a".into(),
+            expected: paused,
+            outcome: WorkItemOutcome::Continue,
+        };
+        assert!(resume_work_item_continuation(&resumed.state, &stale)
+            .unwrap_err()
+            .contains("stale"));
+    }
+
+    #[test]
+    fn continuation_suspension_requires_runnable_parent_and_exact_fence() {
+        let mut state = ExecutionProtocolState::empty("agent-a");
+        let runnable = work_item_record(WorkItemExecutionState::Runnable {
+            generation: 2,
+            recovery_ref: None,
+        });
+        state.work_items.insert("work-a".into(), runnable.clone());
+
+        let suspended = suspend_work_item_continuation(
+            &state,
+            &SuspendWorkItemContinuation {
+                command_id: "suspend:continuation-a".into(),
+                work_item_id: "work-a".into(),
+                active_work_item_id: "work-b".into(),
+                continuation_id: "continuation-a".into(),
+                expected: runnable.clone(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            suspended.state.work_items["work-a"].state,
+            WorkItemExecutionState::Paused {
+                generation: 3,
+                reason: "yielded_to:work-b".into(),
+            }
+        );
+
+        let stale = SuspendWorkItemContinuation {
+            command_id: "suspend:continuation-a:stale".into(),
+            work_item_id: "work-a".into(),
+            active_work_item_id: "work-b".into(),
+            continuation_id: "continuation-a".into(),
+            expected: runnable,
+        };
+        assert!(suspend_work_item_continuation(&suspended.state, &stale)
+            .unwrap_err()
+            .contains("stale"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -60,7 +60,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use arc_swap::ArcSwap;
 use bootstrap::ConfigSnapshot;
 use chrono::Utc;
@@ -146,6 +146,23 @@ pub(super) struct WorkItemCompletionReportPromotion {
     pub(super) record: crate::types::WorkItemRecord,
     pub(super) brief_id: String,
     pub(super) continuation_resumed: Option<WorkItemContinuationSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedWorkItemCompletion {
+    pub(crate) record: crate::types::WorkItemRecord,
+    pub(crate) brief: crate::types::BriefRecord,
+    pub(crate) expected_execution_protocol_state:
+        Option<crate::domain::execution_protocol::ExecutionProtocolState>,
+    pub(crate) expected_agent_state: crate::types::AgentState,
+    pub(crate) committed_agent_state: crate::types::AgentState,
+    pub(crate) wait_conditions: Vec<crate::types::WaitConditionRecord>,
+    pub(crate) continuations: Vec<crate::types::WorkItemContinuationFrame>,
+    pub(crate) continuation_resumed: Option<WorkItemContinuationSummary>,
+    pub(crate) audit_events: Vec<crate::types::AuditEvent>,
+    pub(crate) index_changes: Vec<crate::runtime_db::RuntimeIndexChange>,
+    pub(crate) tool_execution: Option<crate::types::ToolExecutionRecord>,
+    pub(crate) transcript_entries: Vec<crate::types::TranscriptEntry>,
 }
 
 #[derive(Debug, Clone)]
@@ -416,6 +433,134 @@ fn canonical_command_batch_rejection(
         proposed = outcome.outcome.snapshot;
     }
     None
+}
+
+fn execution_protocol_completion_transition_from_prepared(
+    record: &QueueEntryRecord,
+    terminal_turn: &TurnRecord,
+    prepared: &PreparedWorkItemCompletion,
+) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
+    use crate::domain::execution_protocol::{
+        CompleteWorkItemExecution, ConversationOutcome, ExecutionAttemptState, ExecutionBinding,
+        ExecutionOutcome, ExecutionOutcomeRecord, ExecutionProtocolCommand, SettleExecution,
+        WorkItemExecutionState, WorkItemOutcome,
+    };
+
+    anyhow::ensure!(
+        record.status == QueueEntryStatus::Processed,
+        "completion commit requires a processed source queue claim"
+    );
+    let state = prepared
+        .expected_execution_protocol_state
+        .as_ref()
+        .ok_or_else(|| anyhow!("completion commit requires canonical execution state"))?;
+    let intent = prepared
+        .record
+        .completion_intent
+        .as_ref()
+        .ok_or_else(|| anyhow!("completion commit intent is missing"))?;
+    let activation_id = intent
+        .source_activation_id
+        .as_deref()
+        .ok_or_else(|| anyhow!("completion commit activation identity is missing"))?;
+    let attempt = state
+        .attempts
+        .get(activation_id)
+        .ok_or_else(|| anyhow!("completion commit execution attempt is missing"))?;
+    anyhow::ensure!(
+        attempt.state == ExecutionAttemptState::Open,
+        "completion commit requires an open execution attempt"
+    );
+    let authoritative = state
+        .work_items
+        .get(&prepared.record.id)
+        .ok_or_else(|| anyhow!("completion commit WorkItem execution state is missing"))?;
+    anyhow::ensure!(
+        intent.work_item_id == prepared.record.id
+            && intent.source_activation_id.as_deref() == Some(attempt.attempt_id.as_str())
+            && intent.source_message_id.as_deref() == Some(record.message_id.as_str())
+            && intent.source_turn_id.as_deref() == Some(terminal_turn.turn_id.as_str())
+            && intent.result_brief_id.as_deref() == Some(prepared.brief.id.as_str())
+            && prepared.record.result_brief_id.as_deref() == Some(prepared.brief.id.as_str()),
+        "completion commit intent does not match the admitted execution"
+    );
+    anyhow::ensure!(
+        prepared.brief.kind.is_success()
+            && prepared.brief.work_item_id.as_deref() == Some(prepared.record.id.as_str())
+            && prepared.brief.turn_id.as_deref() == Some(terminal_turn.turn_id.as_str())
+            && prepared.brief.related_message_id.as_deref() == Some(record.message_id.as_str())
+            && !prepared.brief.text.trim().is_empty(),
+        "completion commit brief evidence is invalid"
+    );
+
+    let commands = match &attempt.binding {
+        ExecutionBinding::WorkItem { work_item_id } => {
+            anyhow::ensure!(
+                work_item_id == &prepared.record.id,
+                "completion commit WorkItem binding mismatch"
+            );
+            anyhow::ensure!(
+                matches!(
+                    &authoritative.state,
+                    WorkItemExecutionState::InFlight {
+                        attempt_id,
+                        generation,
+                    } if attempt_id == &attempt.attempt_id
+                        && Some(*generation) == attempt.admitted_fences.work_item_generation
+                ) && Some(intent.expected_work_revision)
+                    == attempt.admitted_fences.work_item_source_revision,
+                "completion commit execution attempt fence is stale"
+            );
+            vec![ExecutionProtocolCommand::Settle(SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: format!("outcome:complete:{}", attempt.attempt_id),
+                    attempt_id: attempt.attempt_id.clone(),
+                    outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                        completion: prepared.brief.id.clone(),
+                    }),
+                    created_at: record.updated_at.to_rfc3339(),
+                },
+            })]
+        }
+        ExecutionBinding::AgentLifecycle { agent_id } => {
+            anyhow::ensure!(
+                agent_id == &record.agent_id
+                    && authoritative.source_revision == intent.expected_work_revision
+                    && !matches!(
+                        authoritative.state,
+                        WorkItemExecutionState::InFlight { .. }
+                            | WorkItemExecutionState::Terminal { .. }
+                    ),
+                "completion commit lifecycle WorkItem fence is stale"
+            );
+            vec![
+                ExecutionProtocolCommand::Settle(SettleExecution {
+                    outcome: ExecutionOutcomeRecord {
+                        outcome_id: format!("outcome:complete:{}", attempt.attempt_id),
+                        attempt_id: attempt.attempt_id.clone(),
+                        outcome: ExecutionOutcome::Conversation(ConversationOutcome::Replied),
+                        created_at: record.updated_at.to_rfc3339(),
+                    },
+                }),
+                ExecutionProtocolCommand::CompleteWorkItem(Box::new(CompleteWorkItemExecution {
+                    command_id: format!("completion:work_item:{}", attempt.attempt_id),
+                    work_item_id: prepared.record.id.clone(),
+                    expected: authoritative.clone(),
+                    completion: prepared.brief.id.clone(),
+                })),
+            ]
+        }
+        ExecutionBinding::Conversation { .. } | ExecutionBinding::Command => {
+            bail!("completion commit requires a WorkItem or agent-lifecycle execution")
+        }
+    };
+
+    Ok(
+        crate::runtime_db::transitions::ExecutionProtocolTransition {
+            bootstrap: None,
+            commands,
+        },
+    )
 }
 
 fn canonical_matching_terminal_turn(
@@ -4133,16 +4278,99 @@ impl RuntimeHandle {
         transcript_entries: Vec<TranscriptEntry>,
         brief_evidence: Vec<BriefRecord>,
     ) -> Result<bool> {
-        let execution_protocol = if self.inner.scheduler_engine.is_canonical() {
-            execution_protocol_settlement_transition_from_facts(
-                &self.inner.storage,
-                &self.inner.runtime_db,
-                &record,
-                terminal_transition.map(|transition| &transition.turn_record),
-            )?
+        let prepared_completion = terminal_transition
+            .and_then(|transition| transition.prepared_work_item_completion.as_ref());
+        let mut execution_protocol = if self.inner.scheduler_engine.is_canonical() {
+            if let Some(prepared) = prepared_completion {
+                execution_protocol_completion_transition_from_prepared(
+                    &record,
+                    terminal_transition
+                        .map(|transition| &transition.turn_record)
+                        .expect("prepared completion requires a terminal Turn"),
+                    prepared,
+                )?
+            } else {
+                execution_protocol_settlement_transition_from_facts(
+                    &self.inner.storage,
+                    &self.inner.runtime_db,
+                    &record,
+                    terminal_transition.map(|transition| &transition.turn_record),
+                )?
+            }
         } else {
             Default::default()
         };
+        if self.inner.scheduler_engine.is_canonical() {
+            if let Some(prepared) = prepared_completion {
+                let state = prepared
+                    .expected_execution_protocol_state
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow!("completion commit requires canonical execution state")
+                    })?;
+                for continuation in &prepared.continuations {
+                    if continuation.state != crate::types::WorkItemContinuationState::Resumed {
+                        continue;
+                    }
+                    let parent = state
+                        .work_items
+                        .get(&continuation.suspended_work_item_id)
+                        .ok_or_else(|| anyhow!("completion parent execution state is missing"))?;
+                    let parent_record = self
+                        .inner
+                        .runtime_db
+                        .work_items()
+                        .latest(&continuation.suspended_work_item_id)?
+                        .ok_or_else(|| anyhow!("completion parent WorkItem is missing"))?;
+                    let parent_waits = self
+                        .inner
+                        .storage
+                        .raw_active_wait_conditions_for_agent(&record.agent_id)?
+                        .into_iter()
+                        .filter(|wait| {
+                            wait.work_item_id.as_deref()
+                                == Some(continuation.suspended_work_item_id.as_str())
+                        })
+                        .collect::<Vec<_>>();
+                    let outcome = match parent_waits.as_slice() {
+                        [wait] => crate::domain::execution_protocol::WorkItemOutcome::Wait {
+                            wait: crate::domain::execution_protocol::WaitReference {
+                                wait_id: wait.id.clone(),
+                            },
+                        },
+                        [] if parent_record.blocked_by.is_some() => {
+                            crate::domain::execution_protocol::WorkItemOutcome::Pause {
+                                reason: parent_record
+                                    .blocked_by
+                                    .clone()
+                                    .expect("parent blocker checked above"),
+                            }
+                        }
+                        [] => crate::domain::execution_protocol::WorkItemOutcome::Continue,
+                        _ => crate::domain::execution_protocol::WorkItemOutcome::NeedsRepair {
+                            repair_id: format!(
+                                "work_item_waits_ambiguous:{}",
+                                continuation.suspended_work_item_id
+                            ),
+                        },
+                    };
+                    execution_protocol.commands.push(
+                        crate::domain::execution_protocol::ExecutionProtocolCommand::ResumeWorkItemContinuation(
+                            Box::new(
+                                crate::domain::execution_protocol::ResumeWorkItemContinuation {
+                                    command_id: format!("completion:resume:{}", continuation.id),
+                                    work_item_id: continuation.suspended_work_item_id.clone(),
+                                    active_work_item_id: continuation.active_work_item_id.clone(),
+                                    continuation_id: continuation.id.clone(),
+                                    expected: parent.clone(),
+                                    outcome,
+                                },
+                            ),
+                        ),
+                    );
+                }
+            }
+        }
         let original_audit_len = audit_events.len();
         let mut command = crate::runtime_db::transitions::QueueTransitionCommand {
             agent_id: record.agent_id.clone(),
@@ -4151,25 +4379,44 @@ impl RuntimeHandle {
             scheduler_claim_work_item: None,
             agent_state: None,
             message_evidence: Vec::new(),
-            transcript_entries: transcript_entries.clone(),
+            transcript_entries: transcript_entries
+                .into_iter()
+                .chain(
+                    prepared_completion
+                        .into_iter()
+                        .flat_map(|prepared| prepared.transcript_entries.clone()),
+                )
+                .collect(),
             turn_record: terminal_transition.map(|transition| transition.turn_record.clone()),
             audit_events: audit_events.clone(),
             notify_scheduler,
             fault: None,
-            brief_evidence: brief_evidence.clone(),
+            brief_evidence: brief_evidence
+                .into_iter()
+                .chain(
+                    prepared_completion
+                        .into_iter()
+                        .map(|prepared| prepared.brief.clone()),
+                )
+                .collect(),
         };
         for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
             // Rebuild guard-dependent fields from the current baseline.
             let agent_state = {
                 let guard = self.inner.agent.lock().await;
-                let mut state = committed_agent_state
-                    .clone()
+                let mut state = prepared_completion
+                    .map(|prepared| prepared.committed_agent_state.clone())
+                    .or_else(|| committed_agent_state.clone())
                     .unwrap_or_else(|| guard.state.clone());
                 let agent_state = if let Some(transition) = terminal_transition {
                     state.current_turn_id = Some(transition.terminal.turn_id.clone());
                     state.last_turn_terminal = Some(transition.terminal.clone());
                     Some(crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(guard.last_persisted_state.clone())),
+                        expected: Some(Box::new(
+                            prepared_completion
+                                .map(|prepared| prepared.expected_agent_state.clone())
+                                .unwrap_or_else(|| guard.last_persisted_state.clone()),
+                        )),
                         record: Box::new(state.clone()),
                     })
                 } else {
@@ -4189,13 +4436,44 @@ impl RuntimeHandle {
                     .audit_events
                     .push(Self::turn_record_audit_event(&transition.turn_record));
             }
+            if let Some(prepared) = prepared_completion {
+                command.audit_events.extend(prepared.audit_events.clone());
+            }
             command.fault = self.take_transition_fault();
-            match self
-                .inner
-                .runtime_db
-                .transitions()
-                .commit_queue_with_execution_protocol(&command, &execution_protocol)
-            {
+            let commit = if let Some(prepared) = prepared_completion {
+                let tool_execution = prepared.tool_execution.clone().ok_or_else(|| {
+                    anyhow!("completion commit is missing tool execution evidence")
+                })?;
+                self.inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_completion(
+                        &command,
+                        &execution_protocol,
+                        &crate::runtime_db::transitions::CompletionTransition {
+                            requires_execution_continuation: self
+                                .inner
+                                .scheduler_engine
+                                .is_canonical(),
+                            work_items: vec![
+                                crate::runtime_db::transitions::WorkItemMutation::Update {
+                                    record: prepared.record.clone(),
+                                    expected_revision: prepared.record.revision - 1,
+                                },
+                            ],
+                            wait_conditions: prepared.wait_conditions.clone(),
+                            continuations: prepared.continuations.clone(),
+                            tool_execution,
+                            index_changes: prepared.index_changes.clone(),
+                        },
+                    )
+            } else {
+                self.inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_execution_protocol(&command, &execution_protocol)
+            };
+            match commit {
                 Ok(commit) => {
                     return Ok(self.apply_transition_commit(commit).await.applied);
                 }
@@ -4624,6 +4902,7 @@ impl RuntimeHandle {
                     let terminal_transition = turn::TurnTerminalTransition {
                         terminal,
                         turn_record,
+                        prepared_work_item_completion: None,
                     };
                     let committed_state = {
                         let guard = self.inner.agent.lock().await;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -165,6 +165,30 @@ pub(crate) struct PreparedWorkItemCompletion {
     pub(crate) transcript_entries: Vec<crate::types::TranscriptEntry>,
 }
 
+fn rebase_prepared_completion_agent_state(
+    prepared: &PreparedWorkItemCompletion,
+    baseline: &AgentState,
+) -> Result<AgentState> {
+    let expected = &prepared.expected_agent_state;
+    anyhow::ensure!(
+        baseline.id == expected.id
+            && baseline.current_run_id == expected.current_run_id
+            && baseline.current_work_item_id == expected.current_work_item_id
+            && baseline.current_turn_work_item_id == expected.current_turn_work_item_id
+            && baseline.current_execution_binding == expected.current_execution_binding,
+        "completion commit execution or focus binding changed before settlement"
+    );
+    let committed = &prepared.committed_agent_state;
+    let mut state = baseline.clone();
+    state.status = committed.status.clone();
+    state.current_run_id = committed.current_run_id.clone();
+    state.last_brief_at = committed.last_brief_at;
+    state.current_work_item_id = committed.current_work_item_id.clone();
+    state.current_turn_work_item_id = committed.current_turn_work_item_id.clone();
+    state.current_execution_binding = committed.current_execution_binding.clone();
+    Ok(state)
+}
+
 #[derive(Debug, Clone)]
 pub(super) enum WorkItemCompletionReportPromotionOutcome {
     /// Completion changed the WorkItem state, but did not create a new
@@ -4404,19 +4428,18 @@ impl RuntimeHandle {
             // Rebuild guard-dependent fields from the current baseline.
             let agent_state = {
                 let guard = self.inner.agent.lock().await;
-                let mut state = prepared_completion
-                    .map(|prepared| prepared.committed_agent_state.clone())
-                    .or_else(|| committed_agent_state.clone())
-                    .unwrap_or_else(|| guard.state.clone());
+                let mut state = if let Some(prepared) = prepared_completion {
+                    rebase_prepared_completion_agent_state(prepared, &guard.last_persisted_state)?
+                } else {
+                    committed_agent_state
+                        .clone()
+                        .unwrap_or_else(|| guard.state.clone())
+                };
                 let agent_state = if let Some(transition) = terminal_transition {
                     state.current_turn_id = Some(transition.terminal.turn_id.clone());
                     state.last_turn_terminal = Some(transition.terminal.clone());
                     Some(crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(
-                            prepared_completion
-                                .map(|prepared| prepared.expected_agent_state.clone())
-                                .unwrap_or_else(|| guard.last_persisted_state.clone()),
-                        )),
+                        expected: Some(Box::new(guard.last_persisted_state.clone())),
                         record: Box::new(state.clone()),
                     })
                 } else {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -223,6 +223,13 @@ impl RuntimeHandle {
             MessageKind::BriefAck | MessageKind::BriefResult => {}
         }
 
+        if terminal_transition
+            .as_ref()
+            .is_some_and(|transition| transition.prepared_work_item_completion.is_some())
+        {
+            return Ok(terminal_transition);
+        }
+
         if let Some(resolution) = continuation_resolution.as_ref() {
             self.persist_last_continuation(resolution).await?;
             self.record_continuation_resolution_event(&message, resolution)

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -180,7 +180,11 @@ impl RuntimeHandle {
         crate::diagnostics::record_turn_total(context_build_started.elapsed());
         let cleanup_started = std::time::Instant::now();
 
-        if outcome.terminal_kind.is_failure() {
+        if outcome.prepared_work_item_completion.is_some() {
+            // The completion report brief, WorkItem transition, tool execution,
+            // Turn terminal, queue claim, and execution outcome are committed
+            // together by the outer canonical terminal settlement.
+        } else if outcome.terminal_kind.is_failure() {
             let mut brief =
                 brief::make_failure(&message.agent_id, message, outcome.final_text.clone());
             if !outcome.final_citations.is_empty() {
@@ -211,10 +215,32 @@ impl RuntimeHandle {
             );
             self.persist_brief(&brief).await?;
         }
-        let turn_record = self.build_turn_record(&outcome.terminal).await?;
+        let mut turn_record = self.build_turn_record(&outcome.terminal).await?;
+        if let Some(prepared) = outcome.prepared_work_item_completion.as_ref() {
+            if !turn_record.produced_brief_ids.contains(&prepared.brief.id) {
+                turn_record
+                    .produced_brief_ids
+                    .push(prepared.brief.id.clone());
+            }
+            if !turn_record
+                .completed_work_item_ids
+                .contains(&prepared.record.id)
+            {
+                turn_record
+                    .completed_work_item_ids
+                    .push(prepared.record.id.clone());
+            }
+            if let Some(tool_execution) = prepared.tool_execution.as_ref() {
+                if !turn_record.tool_execution_ids.contains(&tool_execution.id) {
+                    turn_record
+                        .tool_execution_ids
+                        .push(tool_execution.id.clone());
+                }
+            }
+        }
         self.promote_turn_active_skills().await?;
 
-        if outcome.should_sleep {
+        if outcome.should_sleep && outcome.prepared_work_item_completion.is_none() {
             if outcome.allow_sleep_runnable_work_override {
                 self.transition_to_sleep(outcome.sleep_duration_ms).await?;
             } else {
@@ -227,6 +253,7 @@ impl RuntimeHandle {
         Ok(TurnTerminalTransition {
             terminal: outcome.terminal,
             turn_record,
+            prepared_work_item_completion: outcome.prepared_work_item_completion,
         })
     }
 

--- a/src/runtime/scheduler_acceptance.rs
+++ b/src/runtime/scheduler_acceptance.rs
@@ -636,6 +636,7 @@ async fn seed_scheduler_waiting_work(
     let terminal_transition = super::turn::TurnTerminalTransition {
         terminal,
         turn_record,
+        prepared_work_item_completion: None,
     };
     let task_id = format!("scheduler-restart-task-{agent_id}");
     let registration = runtime
@@ -825,6 +826,7 @@ async fn scheduler_acceptance_terminal_transition(
     Ok(super::turn::TurnTerminalTransition {
         terminal,
         turn_record,
+        prepared_work_item_completion: None,
     })
 }
 

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -15,8 +15,9 @@ use crate::types::{
     SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult,
     TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef,
     WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
-    WorkItemContinuationReturnPolicy, WorkItemDelegationRecord, WorkItemDelegationState,
-    WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
+    WorkItemContinuationReturnPolicy, WorkItemContinuationState, WorkItemDelegationRecord,
+    WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
+    CHILD_AGENT_TASK_KIND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -2717,6 +2718,43 @@ impl RuntimeHandle {
         )
     }
 
+    fn plan_work_item_execution_continuation_suspend(
+        &self,
+        parent: &WorkItemRecord,
+        continuation: &WorkItemContinuationFrame,
+    ) -> Result<Option<crate::domain::execution_protocol::ExecutionProtocolCommand>> {
+        use crate::domain::execution_protocol::{
+            ExecutionProtocolCommand, SuspendWorkItemContinuation,
+        };
+
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(None);
+        }
+        let state = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(&parent.agent_id)?
+            .ok_or_else(|| anyhow!("continuation suspension requires canonical execution state"))?;
+        let authoritative = state
+            .work_items
+            .get(&parent.id)
+            .ok_or_else(|| anyhow!("continuation suspension parent execution state is missing"))?;
+        anyhow::ensure!(
+            authoritative.source_revision == parent.revision,
+            "continuation suspension parent WorkItem fence is stale"
+        );
+        Ok(Some(ExecutionProtocolCommand::SuspendWorkItemContinuation(
+            Box::new(SuspendWorkItemContinuation {
+                command_id: format!("continuation:suspend:{}", continuation.id),
+                work_item_id: parent.id.clone(),
+                active_work_item_id: continuation.active_work_item_id.clone(),
+                continuation_id: continuation.id.clone(),
+                expected: authoritative.clone(),
+            }),
+        )))
+    }
+
     pub async fn pick_work_item(
         &self,
         work_item_id: String,
@@ -2962,11 +3000,29 @@ impl RuntimeHandle {
                 }]
             })
             .unwrap_or_default();
-        let execution_protocol = if blocker_cleared {
+        let mut execution_protocol = if blocker_cleared {
             self.plan_work_item_execution_clear_blocker(&record, &wait_conditions)?
         } else {
             Default::default()
         };
+        if yield_current && !terminal_transition {
+            let previous = previous
+                .as_ref()
+                .expect("yielding current focus requires the previous WorkItem");
+            let continuation = continuation_records
+                .iter()
+                .find(|frame| {
+                    frame.state == WorkItemContinuationState::Active
+                        && frame.suspended_work_item_id == previous.id
+                        && frame.active_work_item_id == record.id
+                })
+                .expect("yielding current focus creates an active continuation");
+            if let Some(command) =
+                self.plan_work_item_execution_continuation_suspend(previous, continuation)?
+            {
+                execution_protocol.commands.push(command);
+            }
+        }
         let commit = self.commit_work_item_focus_transition_with_execution(
             &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
                 agent_id: agent_id.clone(),
@@ -3501,6 +3557,90 @@ impl RuntimeHandle {
         ))
     }
 
+    pub(crate) async fn prepare_work_item_completion_with_report(
+        &self,
+        work_item_id: String,
+        authority: WorkItemCompletionAuthority,
+        report_text: String,
+        citations: Vec<crate::types::Citation>,
+        source_turn_index: Option<u64>,
+        source_round: Option<usize>,
+        source_turn_id: Option<String>,
+        source_message_id: Option<String>,
+        source_assistant_round_id: Option<String>,
+        source_tool_call_id: Option<String>,
+        warnings: Vec<serde_json::Value>,
+    ) -> Result<Option<PreparedWorkItemCompletion>> {
+        let agent_id = self.agent_id().await?;
+        let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
+        if existing.state == WorkItemState::Completed {
+            return Ok(None);
+        }
+        if existing.state != WorkItemState::Open {
+            return Err(RuntimeError::new(
+                RuntimeErrorDomain::Conflict,
+                "work_item_completion_in_progress",
+                format!(
+                    "work item {work_item_id} already has a legacy completion intent in progress"
+                ),
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .with_recovery_hint(
+                "complete the existing legacy completion intent through the control completion API",
+            )
+            .into());
+        }
+        let report_text = report_text.trim();
+        if report_text.is_empty() {
+            return Err(RuntimeError::validation(
+                "missing_completion_report",
+                "CompleteWorkItem requires nearby preceding same-round operator-facing report text",
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .with_recovery_hint(
+                "write the concise operator-facing completion report immediately before CompleteWorkItem in the same assistant response",
+            )
+            .into());
+        }
+
+        let mut brief =
+            BriefRecord::new(agent_id.clone(), BriefKind::Result, report_text, None, None);
+        if !citations.is_empty() {
+            brief.citations = Some(citations);
+        }
+        brief.work_item_id = Some(existing.id.clone());
+        brief.workspace_id = existing.workspace_id.clone();
+        brief.turn_index = source_turn_index;
+        brief.turn_id = source_turn_id;
+        brief.related_message_id = source_message_id;
+        brief.finalizes_assistant_round_id = source_assistant_round_id.clone();
+
+        self.plan_work_item_completion_with_brief_mode(
+            &work_item_id,
+            Some(&authority),
+            &brief,
+            AuditEvent::legacy(
+                "work_item_completion_report_promoted",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": work_item_id,
+                    "source_turn_index": source_turn_index,
+                    "source_round": source_round,
+                    "source_assistant_round_id": source_assistant_round_id,
+                    "source_tool_call_id": source_tool_call_id,
+                    "source": "same_assistant_round_preceding_text",
+                    "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
+                    "warnings": warnings.clone(),
+                    "warning_count": warnings.len(),
+                    "brief_id": brief.id.clone(),
+                }),
+            ),
+            true,
+            true,
+        )
+        .await
+    }
+
     pub(super) async fn promote_work_item_completion_report_with_metadata(
         &self,
         work_item_id: String,
@@ -3626,285 +3766,40 @@ impl RuntimeHandle {
         const MAX_ATTEMPTS: usize = 8;
 
         for attempt in 0..MAX_ATTEMPTS {
-            let agent_id = self.agent_id().await?;
-            let existing = self.validate_owned_work_item(&agent_id, work_item_id)?;
-            if existing.state == WorkItemState::Completed {
-                return Ok(None);
-            }
-            let expected_state = if require_open {
-                WorkItemState::Open
-            } else {
-                WorkItemState::Completing
-            };
-            if existing.state != expected_state {
-                return Err(anyhow!(
-                    "cannot finalize completion report for work item {} in state {:?}; expected {:?}",
+            let Some(prepared) = self
+                .plan_work_item_completion_with_brief_mode(
                     work_item_id,
-                    existing.state,
-                    expected_state,
-                ));
-            }
-            let now = Utc::now();
-            let mut state = self.agent_state().await?;
-            let expected_agent_state = state.clone();
-            let matching_execution_binding = match authority {
-                Some(WorkItemCompletionAuthority::AgentExecution(expected_binding)) => {
-                    if let Some(bound_work_item_id) = expected_binding.work_item_id.as_deref() {
-                        if bound_work_item_id != existing.id {
-                            return Err(RuntimeError::policy(
-                                "work_item_execution_binding_mismatch",
-                                format!(
-                                    "current execution is bound to work item {bound_work_item_id}, not {work_item_id}"
-                                ),
-                            )
-                            .with_safe_context("work_item_id", work_item_id)
-                            .with_recovery_hint(
-                                "complete the WorkItem from its own execution or from an agent-lifecycle execution without another WorkItem binding",
-                            )
-                            .into());
-                        }
-                    }
-                    let Some(current_binding) = state.current_execution_binding.as_ref() else {
-                        return Err(RuntimeError::policy(
-                            "work_item_execution_binding_missing",
-                            "the execution binding that authorized this completion is no longer active",
-                        )
-                        .with_safe_context("work_item_id", work_item_id)
-                        .into());
-                    };
-                    if current_binding != expected_binding {
-                        return Err(RuntimeError::policy(
-                            "work_item_execution_binding_stale",
-                            "the execution binding that authorized this completion changed before commit",
-                        )
-                        .with_safe_context("work_item_id", work_item_id)
-                        .with_recovery_hint(
-                            "retry completion from the WorkItem's current execution",
-                        )
-                        .into());
-                    }
-                    if Some(expected_binding.turn_id.as_str()) != brief.turn_id.as_deref()
-                        || Some(expected_binding.source_message_id.as_str())
-                            != brief.related_message_id.as_deref()
-                    {
-                        return Err(RuntimeError::policy(
-                            "work_item_completion_report_binding_mismatch",
-                            "the completion report does not belong to the authorizing execution",
-                        )
-                        .with_safe_context("work_item_id", work_item_id)
-                        .into());
-                    }
-                    (expected_binding.work_item_id.as_deref() == Some(existing.id.as_str()))
-                        .then_some(expected_binding)
-                }
-                Some(WorkItemCompletionAuthority::Control) | None => None,
+                    authority,
+                    brief,
+                    binding_event.clone(),
+                    require_open,
+                    false,
+                )
+                .await?
+            else {
+                return Ok(None);
             };
-            let mut completion_intent = if require_open {
-                WorkItemCompletionIntent {
-                    work_item_id: existing.id.clone(),
-                    source_activation_id: matching_execution_binding
-                        .and_then(|binding| binding.activation_id.clone()),
-                    source_message_id: brief.related_message_id.clone(),
-                    source_turn_id: brief.turn_id.clone(),
-                    expected_work_revision: matching_execution_binding
-                        .and_then(|binding| binding.claimed_work_revision)
-                        .unwrap_or(existing.revision),
-                    report_requirement: CompletionReportRequirement::Required,
-                    report_state: CompletionReportState::Pending,
-                    result_brief_id: None,
-                    created_at: now,
-                    updated_at: now,
-                }
-            } else {
-                let intent = existing.completion_intent.clone().ok_or_else(|| {
-                    anyhow!("completion brief binding requires a completion intent")
-                })?;
-                if intent.work_item_id != existing.id
-                    || intent.source_turn_id != brief.turn_id
-                    || intent.source_message_id != brief.related_message_id
-                {
-                    return Err(anyhow!(
-                        "completion brief identity does not match work item {} intent",
-                        work_item_id
-                    ));
-                }
-                intent
-            };
-            completion_intent.report_state = CompletionReportState::Bound;
-            completion_intent.result_brief_id = Some(brief.id.clone());
-            completion_intent.updated_at = now;
-            let mut record = WorkItemRecord {
-                revision: existing.revision + 1,
-                state: WorkItemState::Completed,
-                blocked_by: None,
-                recheck_at: None,
-                recheck_consumed_at: None,
-                result_brief_id: Some(brief.id.clone()),
-                completion_intent: Some(completion_intent),
-                updated_at: now,
-                ..existing
-            };
-            let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
-                self.agent_home().as_path(),
-                &mut record,
-            )?;
-
-            let active_waits = self
-                .inner
-                .storage
-                .raw_active_wait_conditions_for_agent(&agent_id)?
-                .into_iter()
-                .filter(|condition| condition.work_item_id.as_deref() == Some(record.id.as_str()))
-                .collect::<Vec<_>>();
-            let mut wait_conditions = Vec::with_capacity(active_waits.len());
-            let mut cancelled_wait_condition_ids = Vec::with_capacity(active_waits.len());
-            for condition in active_waits {
-                let mut cancelled = condition.clone();
-                cancelled.status = WaitConditionStatus::Cancelled;
-                cancelled.updated_at = now;
-                cancelled.cancelled_at = Some(now);
-                cancelled_wait_condition_ids.push(condition.id);
-                wait_conditions.push(cancelled);
-            }
-
-            state.last_brief_at = Some(brief.created_at);
-            let release_current = state.current_work_item_id.as_deref() == Some(record.id.as_str());
-            let release_turn =
-                state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
-            if release_current {
-                state.current_work_item_id = None;
-            }
-            if release_turn {
-                state.current_turn_work_item_id = None;
-            }
-
-            let mut audit_events = vec![
-                AuditEvent::typed(
-                    RuntimeEventKind::BriefCreated,
-                    &BriefCreatedAuditEvent::from_brief(brief),
-                )?,
-                binding_event.clone(),
-            ];
-            if plan_artifact_changed {
-                if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
-                    audit_events.push(event);
-                }
-            }
-            if release_current || release_turn {
-                audit_events.push(AuditEvent::legacy(
-                    "work_item_focus_released",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "work_item_id": record.id,
-                        "reason": "work_item_completed",
-                        "readiness": record.readiness(),
-                        "revision": record.revision,
-                    }),
-                ));
-            }
-
-            let mut continuation_records = Vec::new();
-            let mut continuation_resumed = None;
-            if let Some(frame) = self
-                .inner
-                .storage
-                .latest_active_work_item_continuation_for_active(&agent_id, &record.id)?
-            {
-                let suspended = self
-                    .inner
-                    .runtime_db
-                    .work_items()
-                    .latest(&frame.suspended_work_item_id)?;
-                match suspended {
-                    Some(suspended)
-                        if suspended.agent_id == agent_id
-                            && suspended.state == WorkItemState::Open =>
-                    {
-                        let resumed = frame.resume("active_work_item_completed");
-                        let summary = continuation_summary(&resumed, "active_work_item_completed");
-                        state.current_work_item_id = Some(suspended.id.clone());
-                        state.current_turn_work_item_id = Some(suspended.id.clone());
-                        audit_events.push(AuditEvent::legacy(
-                            "work_item_continuation_resumed",
-                            serde_json::json!({
-                                "agent_id": agent_id,
-                                "continuation": summary,
-                                "completed_work_item_id": record.id,
-                                "resumed_work_item_id": suspended.id,
-                            }),
-                        ));
-                        audit_events.push(AuditEvent::legacy(
-                            "work_item_continuation_scheduler_evidence",
-                            serde_json::json!({
-                                "agent_id": agent_id,
-                                "reason": "continuation_resumed",
-                                "work_item_id": suspended.id,
-                                "completed_work_item_id": record.id,
-                                "continuation_frame_id": summary.frame_id,
-                            }),
-                        ));
-                        continuation_resumed = Some(summary);
-                        continuation_records.push(resumed);
-                    }
-                    suspended => {
-                        let reason = if suspended.is_some() {
-                            "suspended_work_item_not_open"
-                        } else {
-                            "suspended_work_item_missing"
-                        };
-                        let cancelled = frame.cancel(reason);
-                        audit_events.push(AuditEvent::legacy(
-                            "work_item_continuation_cancelled",
-                            serde_json::json!({
-                                "agent_id": agent_id,
-                                "continuation": continuation_summary(&cancelled, reason),
-                                "suspended_work_item_state": suspended.map(|record| record.state),
-                            }),
-                        ));
-                        continuation_records.push(cancelled);
-                    }
-                }
-            }
-            if !cancelled_wait_condition_ids.is_empty() {
-                audit_events.push(AuditEvent::legacy(
-                    "wait_conditions_cancelled",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "work_item_id": record.id,
-                        "reason": "work_item_completed",
-                        "wait_condition_ids": cancelled_wait_condition_ids,
-                    }),
-                ));
-            }
-            audit_events.push(self.work_item_written_event(
-                "completed",
-                &record,
-                serde_json::json!({
-                    "continuation_resumed": continuation_resumed,
-                    "completion_intent": record.completion_intent,
-                    "brief_id": brief.id,
-                }),
-            ));
-
+            let record = prepared.record.clone();
+            let continuation_resumed = prepared.continuation_resumed.clone();
             #[cfg(test)]
             self.apply_completion_binding_replacement_before_commit()
                 .await?;
             let commit = self.commit_work_item_focus_transition(
                 &crate::runtime_db::transitions::WorkItemFocusTransitionCommand {
-                    agent_id: agent_id.clone(),
+                    agent_id: record.agent_id.clone(),
                     work_items: vec![crate::runtime_db::transitions::WorkItemMutation::Update {
                         record: record.clone(),
                         expected_revision: record.revision - 1,
                     }],
-                    wait_conditions,
-                    continuations: continuation_records,
+                    wait_conditions: prepared.wait_conditions,
+                    continuations: prepared.continuations,
                     agent_state: crate::runtime_db::transitions::AgentStateMutation {
-                        expected: Some(Box::new(expected_agent_state)),
-                        record: Box::new(state),
+                        expected: Some(Box::new(prepared.expected_agent_state)),
+                        record: Box::new(prepared.committed_agent_state),
                     },
-                    brief_evidence: vec![brief.clone()],
-                    audit_events,
-                    index_changes: self.inner.storage.index_changes_for_work_item(&record)?,
+                    brief_evidence: vec![prepared.brief],
+                    audit_events: prepared.audit_events,
+                    index_changes: prepared.index_changes,
                     notify_scheduler: true,
                     fault: self.take_transition_fault(),
                 },
@@ -3931,6 +3826,381 @@ impl RuntimeHandle {
             }
         }
         unreachable!("completion finalization attempts return or continue")
+    }
+
+    async fn plan_work_item_completion_with_brief_mode(
+        &self,
+        work_item_id: &str,
+        authority: Option<&WorkItemCompletionAuthority>,
+        brief: &BriefRecord,
+        binding_event: AuditEvent,
+        require_open: bool,
+        require_completion_commit_attempt: bool,
+    ) -> Result<Option<PreparedWorkItemCompletion>> {
+        let agent_id = self.agent_id().await?;
+        let existing = self.validate_owned_work_item(&agent_id, work_item_id)?;
+        if existing.state == WorkItemState::Completed {
+            return Ok(None);
+        }
+        let expected_state = if require_open {
+            WorkItemState::Open
+        } else {
+            WorkItemState::Completing
+        };
+        if existing.state != expected_state {
+            return Err(anyhow!(
+                "cannot finalize completion report for work item {} in state {:?}; expected {:?}",
+                work_item_id,
+                existing.state,
+                expected_state,
+            ));
+        }
+        let now = Utc::now();
+        let mut state = self.agent_state().await?;
+        let expected_execution_protocol_state = if self.inner.scheduler_engine.is_canonical()
+            && require_completion_commit_attempt
+            && matches!(
+                authority,
+                Some(WorkItemCompletionAuthority::AgentExecution(_))
+            ) {
+            self.inner
+                .runtime_db
+                .transitions()
+                .load_execution_protocol_state_if_initialized(&agent_id)?
+        } else {
+            None
+        };
+        let expected_agent_state = state.clone();
+        let agent_execution_authority = matches!(
+            authority,
+            Some(WorkItemCompletionAuthority::AgentExecution(_))
+        );
+        let matching_execution_binding = match authority {
+            Some(WorkItemCompletionAuthority::AgentExecution(expected_binding)) => {
+                if let Some(bound_work_item_id) = expected_binding.work_item_id.as_deref() {
+                    if bound_work_item_id != existing.id {
+                        return Err(RuntimeError::policy(
+                                "work_item_execution_binding_mismatch",
+                                format!(
+                                    "current execution is bound to work item {bound_work_item_id}, not {work_item_id}"
+                                ),
+                            )
+                            .with_safe_context("work_item_id", work_item_id)
+                            .with_recovery_hint(
+                                "complete the WorkItem from its own execution or from an agent-lifecycle execution without another WorkItem binding",
+                            )
+                            .into());
+                    }
+                }
+                let Some(current_binding) = state.current_execution_binding.as_ref() else {
+                    return Err(RuntimeError::policy(
+                        "work_item_execution_binding_missing",
+                        "the execution binding that authorized this completion is no longer active",
+                    )
+                    .with_safe_context("work_item_id", work_item_id)
+                    .into());
+                };
+                if current_binding != expected_binding {
+                    return Err(RuntimeError::policy(
+                            "work_item_execution_binding_stale",
+                            "the execution binding that authorized this completion changed before commit",
+                        )
+                        .with_safe_context("work_item_id", work_item_id)
+                        .with_recovery_hint(
+                            "retry completion from the WorkItem's current execution",
+                        )
+                        .into());
+                }
+                if Some(expected_binding.turn_id.as_str()) != brief.turn_id.as_deref()
+                    || Some(expected_binding.source_message_id.as_str())
+                        != brief.related_message_id.as_deref()
+                {
+                    return Err(RuntimeError::policy(
+                        "work_item_completion_report_binding_mismatch",
+                        "the completion report does not belong to the authorizing execution",
+                    )
+                    .with_safe_context("work_item_id", work_item_id)
+                    .into());
+                }
+                (expected_binding.work_item_id.as_deref() == Some(existing.id.as_str()))
+                    .then_some(expected_binding)
+            }
+            Some(WorkItemCompletionAuthority::Control) | None => None,
+        };
+        let mut source_activation_id =
+            matching_execution_binding.and_then(|binding| binding.activation_id.clone());
+        if source_activation_id.is_none()
+            && agent_execution_authority
+            && require_completion_commit_attempt
+        {
+            if let Some(protocol_state) = expected_execution_protocol_state.as_ref() {
+                let mut matching_attempts = protocol_state.attempts.values().filter(|attempt| {
+                    attempt.state
+                        == crate::domain::execution_protocol::ExecutionAttemptState::Open
+                        && attempt.source_message_id.as_deref()
+                            == brief.related_message_id.as_deref()
+                        && match &attempt.binding {
+                            crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+                                work_item_id,
+                            } => {
+                                work_item_id == &existing.id
+                                    && attempt.admitted_fences.work_item_source_revision
+                                        == matching_execution_binding
+                                            .and_then(|binding| binding.claimed_work_revision)
+                                            .or(Some(existing.revision))
+                                    && protocol_state
+                                        .work_items
+                                        .get(&existing.id)
+                                        .is_some_and(|work_item| {
+                                            matches!(
+                                                &work_item.state,
+                                                crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+                                                    attempt_id,
+                                                    generation,
+                                                } if attempt_id == &attempt.attempt_id
+                                                    && Some(*generation)
+                                                        == attempt
+                                                            .admitted_fences
+                                                            .work_item_generation
+                                            )
+                                        })
+                            }
+                            crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                                agent_id: binding_agent_id,
+                            } => {
+                                binding_agent_id == &agent_id
+                                    && protocol_state
+                                        .work_items
+                                        .get(&existing.id)
+                                        .is_some_and(|work_item| {
+                                            work_item.source_revision == existing.revision
+                                                && !matches!(
+                                                    work_item.state,
+                                                    crate::domain::execution_protocol::WorkItemExecutionState::InFlight { .. }
+                                                        | crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
+                                                )
+                                        })
+                            }
+                            crate::domain::execution_protocol::ExecutionBinding::Conversation {
+                                ..
+                            }
+                            | crate::domain::execution_protocol::ExecutionBinding::Command => false,
+                        }
+                });
+                let matching_attempt = matching_attempts
+                    .next()
+                    .ok_or_else(|| anyhow!("completion commit execution attempt is missing"))?;
+                if matching_attempts.next().is_some() {
+                    return Err(anyhow!("completion commit execution attempt is ambiguous"));
+                }
+                source_activation_id = Some(matching_attempt.attempt_id.clone());
+            }
+        }
+        let mut completion_intent = if require_open {
+            WorkItemCompletionIntent {
+                work_item_id: existing.id.clone(),
+                source_activation_id,
+                source_message_id: brief.related_message_id.clone(),
+                source_turn_id: brief.turn_id.clone(),
+                expected_work_revision: matching_execution_binding
+                    .and_then(|binding| binding.claimed_work_revision)
+                    .unwrap_or(existing.revision),
+                report_requirement: CompletionReportRequirement::Required,
+                report_state: CompletionReportState::Pending,
+                result_brief_id: None,
+                created_at: now,
+                updated_at: now,
+            }
+        } else {
+            let intent = existing
+                .completion_intent
+                .clone()
+                .ok_or_else(|| anyhow!("completion brief binding requires a completion intent"))?;
+            if intent.work_item_id != existing.id
+                || intent.source_turn_id != brief.turn_id
+                || intent.source_message_id != brief.related_message_id
+            {
+                return Err(anyhow!(
+                    "completion brief identity does not match work item {} intent",
+                    work_item_id
+                ));
+            }
+            intent
+        };
+        completion_intent.report_state = CompletionReportState::Bound;
+        completion_intent.result_brief_id = Some(brief.id.clone());
+        completion_intent.updated_at = now;
+        let mut record = WorkItemRecord {
+            revision: existing.revision + 1,
+            state: WorkItemState::Completed,
+            blocked_by: None,
+            recheck_at: None,
+            recheck_consumed_at: None,
+            result_brief_id: Some(brief.id.clone()),
+            completion_intent: Some(completion_intent),
+            updated_at: now,
+            ..existing
+        };
+        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+            self.agent_home().as_path(),
+            &mut record,
+        )?;
+
+        let active_waits = self
+            .inner
+            .storage
+            .raw_active_wait_conditions_for_agent(&agent_id)?
+            .into_iter()
+            .filter(|condition| condition.work_item_id.as_deref() == Some(record.id.as_str()))
+            .collect::<Vec<_>>();
+        let mut wait_conditions = Vec::with_capacity(active_waits.len());
+        let mut cancelled_wait_condition_ids = Vec::with_capacity(active_waits.len());
+        for condition in active_waits {
+            let mut cancelled = condition.clone();
+            cancelled.status = WaitConditionStatus::Cancelled;
+            cancelled.updated_at = now;
+            cancelled.cancelled_at = Some(now);
+            cancelled_wait_condition_ids.push(condition.id);
+            wait_conditions.push(cancelled);
+        }
+
+        state.last_brief_at = Some(brief.created_at);
+        let release_current = state.current_work_item_id.as_deref() == Some(record.id.as_str());
+        let release_turn = state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
+        if release_current {
+            state.current_work_item_id = None;
+        }
+        if release_turn {
+            state.current_turn_work_item_id = None;
+        }
+        state.current_execution_binding = None;
+        state.current_run_id = None;
+        if !matches!(state.status, AgentStatus::Asleep | AgentStatus::Stopped) {
+            state.status = AgentStatus::AwakeIdle;
+        }
+
+        let mut audit_events = vec![
+            AuditEvent::typed(
+                RuntimeEventKind::BriefCreated,
+                &BriefCreatedAuditEvent::from_brief(brief),
+            )?,
+            binding_event.clone(),
+        ];
+        if plan_artifact_changed {
+            if let Some(event) = self.work_item_plan_artifact_refreshed_event(&record) {
+                audit_events.push(event);
+            }
+        }
+        if release_current || release_turn {
+            audit_events.push(AuditEvent::legacy(
+                "work_item_focus_released",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": record.id,
+                    "reason": "work_item_completed",
+                    "readiness": record.readiness(),
+                    "revision": record.revision,
+                }),
+            ));
+        }
+
+        let mut continuation_records = Vec::new();
+        let mut continuation_resumed = None;
+        if let Some(frame) = self
+            .inner
+            .storage
+            .latest_active_work_item_continuation_for_active(&agent_id, &record.id)?
+        {
+            let suspended = self
+                .inner
+                .runtime_db
+                .work_items()
+                .latest(&frame.suspended_work_item_id)?;
+            match suspended {
+                Some(suspended)
+                    if suspended.agent_id == agent_id && suspended.state == WorkItemState::Open =>
+                {
+                    let resumed = frame.resume("active_work_item_completed");
+                    let summary = continuation_summary(&resumed, "active_work_item_completed");
+                    state.current_work_item_id = Some(suspended.id.clone());
+                    state.current_turn_work_item_id = Some(suspended.id.clone());
+                    audit_events.push(AuditEvent::legacy(
+                        "work_item_continuation_resumed",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "continuation": summary,
+                            "completed_work_item_id": record.id,
+                            "resumed_work_item_id": suspended.id,
+                        }),
+                    ));
+                    audit_events.push(AuditEvent::legacy(
+                        "work_item_continuation_scheduler_evidence",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "reason": "continuation_resumed",
+                            "work_item_id": suspended.id,
+                            "completed_work_item_id": record.id,
+                            "continuation_frame_id": summary.frame_id,
+                        }),
+                    ));
+                    continuation_resumed = Some(summary);
+                    continuation_records.push(resumed);
+                }
+                suspended => {
+                    let reason = if suspended.is_some() {
+                        "suspended_work_item_not_open"
+                    } else {
+                        "suspended_work_item_missing"
+                    };
+                    let cancelled = frame.cancel(reason);
+                    audit_events.push(AuditEvent::legacy(
+                        "work_item_continuation_cancelled",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "continuation": continuation_summary(&cancelled, reason),
+                            "suspended_work_item_state": suspended.map(|record| record.state),
+                        }),
+                    ));
+                    continuation_records.push(cancelled);
+                }
+            }
+        }
+        if !cancelled_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::legacy(
+                "wait_conditions_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": record.id,
+                    "reason": "work_item_completed",
+                    "wait_condition_ids": cancelled_wait_condition_ids,
+                }),
+            ));
+        }
+        audit_events.push(self.work_item_written_event(
+            "completed",
+            &record,
+            serde_json::json!({
+                "continuation_resumed": continuation_resumed,
+                "completion_intent": record.completion_intent,
+                "brief_id": brief.id,
+            }),
+        ));
+
+        let index_changes = self.inner.storage.index_changes_for_work_item(&record)?;
+        Ok(Some(PreparedWorkItemCompletion {
+            record,
+            brief: brief.clone(),
+            expected_execution_protocol_state,
+            expected_agent_state,
+            committed_agent_state: state,
+            wait_conditions,
+            continuations: continuation_records,
+            continuation_resumed,
+            audit_events,
+            index_changes,
+            tool_execution: None,
+            transcript_entries: Vec::new(),
+        }))
     }
 
     pub async fn record_work_item_completion_warning(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -395,8 +395,17 @@ fn persist_execution_transition_only(
             ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
                 crate::domain::execution_protocol::set_work_item_readiness(&state, &command)
             }
+            ExecutionProtocolCommand::SuspendWorkItemContinuation(command) => {
+                crate::domain::execution_protocol::suspend_work_item_continuation(&state, &command)
+            }
+            ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
+                crate::domain::execution_protocol::resume_work_item_continuation(&state, &command)
+            }
             ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
                 crate::domain::execution_protocol::set_work_item_waiting(&state, &command)
+            }
+            ExecutionProtocolCommand::CompleteWorkItem(command) => {
+                crate::domain::execution_protocol::complete_work_item_execution(&state, &command)
             }
             ExecutionProtocolCommand::Admit(command) => {
                 crate::domain::execution_protocol::admit_execution(&state, &command)
@@ -5971,6 +5980,367 @@ async fn authoritative_completion_terminalizes_canonical_work_and_binds_report()
                 completion: result_brief_id.to_string(),
             },
         )
+    );
+}
+
+#[tokio::test]
+async fn authoritative_completion_resumes_parent_canonically_and_writes_terminal_once() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let parent = seed_runtime
+        .create_work_item(
+            "resume canonical parent after child completion".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(parent.id.clone())
+        .await
+        .unwrap();
+    let child = seed_runtime
+        .create_work_item("complete canonical child".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    seed_runtime.pick_work_item(child.id.clone()).await.unwrap();
+    let frame = seed_runtime
+        .storage()
+        .latest_work_item_continuations()
+        .unwrap()
+        .into_iter()
+        .find(|frame| {
+            frame.suspended_work_item_id == parent.id && frame.active_work_item_id == child.id
+        })
+        .expect("child pick should create a continuation frame");
+    let provider = Arc::new(CanonicalCompletionProvider {
+        work_item_id: child.id.clone(),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let outbox_before = runtime
+        .inner
+        .runtime_db
+        .runtime_index_outbox()
+        .high_watermark_for_agent("default")
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete canonical child".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &child, "queued_available");
+    let message = runtime.enqueue(message).await.unwrap();
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+
+    let mut runner = tokio::spawn(runtime.clone().run());
+    tokio::select! {
+        result = &mut runner => {
+            panic!("runtime exited before canonical child completion settled: {result:?}");
+        }
+        result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let execution = runtime
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .load_execution_protocol_state_if_initialized("default")
+                    .unwrap();
+                if execution.as_ref().is_some_and(|execution| {
+                    execution
+                        .attempts
+                        .get(&activation_id)
+                        .is_some_and(|attempt| {
+                            attempt.state
+                                == crate::domain::execution_protocol::ExecutionAttemptState::Settled
+                        })
+                }) {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        }) => {
+            result.expect("canonical child completion should settle");
+        }
+    }
+    runner.abort();
+
+    let child_record = runtime
+        .latest_work_item(&child.id)
+        .await
+        .unwrap()
+        .expect("completed child");
+    assert_eq!(child_record.state, WorkItemState::Completed);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("canonical execution state");
+    assert!(matches!(
+        execution.work_items[&child.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
+    ));
+    assert!(matches!(
+        execution.work_items[&parent.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_work_item_continuations()
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.id == frame.id)
+            .map(|candidate| candidate.state),
+        Some(crate::types::WorkItemContinuationState::Resumed)
+    );
+    let agent = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        agent.current_work_item_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(
+        agent.current_turn_work_item_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&message.id)
+            .unwrap()
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
+    );
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    let turn_id = execution.attempts[&activation_id]
+        .turn_id
+        .as_deref()
+        .expect("settled attempt should retain Turn identity");
+    for kind in ["turn_terminal", "turn_record"] {
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == kind && event.data["turn_id"] == turn_id)
+                .count(),
+            1,
+            "{kind} must be written exactly once"
+        );
+    }
+    assert_eq!(
+        runtime
+            .storage()
+            .read_recent_tool_executions(32)
+            .unwrap()
+            .into_iter()
+            .filter(|record| {
+                record.tool_name == "CompleteWorkItem"
+                    && record.work_item_id.as_deref() == Some(child.id.as_str())
+            })
+            .count(),
+        1
+    );
+    let outbox_changes = runtime
+        .inner
+        .runtime_db
+        .runtime_index_outbox()
+        .read_after("default", outbox_before, 16)
+        .unwrap()
+        .into_iter()
+        .filter(|change| change.source_kind == "work_item" && change.source_id == child.id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outbox_changes.len(),
+        1,
+        "CompletionCommit should emit one WorkItem index change"
+    );
+}
+
+#[tokio::test]
+async fn legacy_completion_resumes_parent_without_canonical_execution_state() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let parent = seed_runtime
+        .create_work_item(
+            "resume legacy parent after completion".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(parent.id.clone())
+        .await
+        .unwrap();
+    let child = seed_runtime
+        .create_work_item("complete legacy child".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    seed_runtime.pick_work_item(child.id.clone()).await.unwrap();
+    let frame = seed_runtime
+        .storage()
+        .latest_work_item_continuations()
+        .unwrap()
+        .into_iter()
+        .find(|frame| {
+            frame.suspended_work_item_id == parent.id && frame.active_work_item_id == child.id
+        })
+        .expect("child pick should create a continuation frame");
+    drop(seed_runtime);
+
+    let provider = Arc::new(CanonicalCompletionProvider {
+        work_item_id: child.id.clone(),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new_with_scheduler_engine(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+        crate::config::SchedulerEngineMode::Legacy,
+    )
+    .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete legacy child".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &child, "queued_available");
+    let message = runtime.enqueue(message).await.unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if runtime
+                .latest_work_item(&child.id)
+                .await
+                .unwrap()
+                .is_some_and(|record| record.state == WorkItemState::Completed)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("legacy child completion should settle");
+    runner.abort();
+
+    assert!(
+        *provider.calls.lock().await >= 1,
+        "completion turn must reach the provider"
+    );
+    assert_eq!(
+        runtime
+            .storage()
+            .read_recent_tool_executions(32)
+            .unwrap()
+            .into_iter()
+            .filter(|record| {
+                record.tool_name == "CompleteWorkItem"
+                    && record.work_item_id.as_deref() == Some(child.id.as_str())
+            })
+            .count(),
+        1,
+        "parent resumption may start another provider turn, but completion must remain terminal-once"
+    );
+    assert!(runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_work_item_continuations()
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.id == frame.id)
+            .map(|candidate| candidate.state),
+        Some(crate::types::WorkItemContinuationState::Resumed)
+    );
+    let agent = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        agent.current_work_item_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&message.id)
+            .unwrap()
+            .map(|entry| entry.status),
+        Some(QueueEntryStatus::Processed)
     );
 }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -5891,7 +5891,7 @@ async fn authoritative_completion_terminalizes_canonical_work_and_binds_report()
             calls: Mutex::new(0),
         }),
         "default".into(),
-        context_config(),
+        continuation_ready_context_config(&workspace, 16_000),
     )
     .unwrap();
     let mut message = MessageEnvelope::new(

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -127,6 +127,7 @@ pub(crate) fn terminal_transition(
     super::super::turn::TurnTerminalTransition {
         terminal,
         turn_record,
+        prepared_work_item_completion: None,
     }
 }
 

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2184,9 +2184,13 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
     .expect("timed out waiting for canonical completion commit");
     assert_eq!(
         *provider.calls.lock().await,
-        1,
-        "CompleteWorkItem must hard-stop the provider loop"
+        2,
+        "standalone completion must allow the provider to consume its tool result"
     );
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.total_model_rounds, 2);
+    assert_eq!(state.total_input_tokens, 20);
+    assert_eq!(state.total_output_tokens, 20);
 
     let completed = runtime
         .latest_work_item(&work_item.id)
@@ -3946,7 +3950,7 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
         )
         .await
         .unwrap();
-    assert!(result.terminal_transition);
+    assert!(!result.terminal_transition);
     let prepared = result
         .prepared_work_item_completion
         .as_ref()

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -3340,7 +3340,7 @@ async fn promoted_completion_report_resumes_next_queued_work_item_via_system_tic
         "http://127.0.0.1:7878".into(),
         provider,
         "default".into(),
-        context_config(),
+        continuation_ready_context_config(&workspace, 16_000),
     )
     .unwrap();
     let mut message = MessageEnvelope::new(

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2133,31 +2133,59 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "finish the tracked work".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(work_item.id.clone());
 
-    runtime
-        .process_interactive_message(
-            &message,
-            None,
-            LoopControlOptions {
-                max_tool_rounds: None,
-            },
-        )
-        .await
-        .unwrap();
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message.clone()).await.unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if runtime
+                .storage()
+                .read_recent_events(200)
+                .unwrap()
+                .iter()
+                .any(|event| {
+                    event.kind == "work_item_written"
+                        && event.data["action"].as_str() == Some("completed")
+                        && event.data["work_item_id"].as_str() == Some(work_item.id.as_str())
+                })
+            {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before completion commit: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for canonical completion commit");
     assert_eq!(
         *provider.calls.lock().await,
-        2,
-        "promoted completion report should not hard-stop the provider loop"
+        1,
+        "CompleteWorkItem must hard-stop the provider loop"
     );
 
     let completed = runtime
@@ -2259,10 +2287,11 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         tool_result["result"]["completion_report_promoted"].as_bool(),
         Some(true)
     );
+    runtime_task.abort();
 }
 
 #[tokio::test]
-async fn complete_work_item_resuming_direct_caller_ends_current_turn() {
+async fn standalone_turn_writer_rejects_prepared_completion() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let seed_runtime = RuntimeHandle::new(
@@ -2320,33 +2349,60 @@ async fn complete_work_item_resuming_direct_caller_ends_current_turn() {
         continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
-        AuthorityClass::OperatorInstruction,
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "finish the callee".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
     );
+    bind_autonomous_work_queue_tick(&mut message, &callee, "continue_active");
+    let message = runtime.enqueue(message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
 
-    runtime
-        .process_interactive_message(
+    let transition = runtime
+        .process_interactive_message_deferred_with_cleanup(
             &message,
             None,
+            ExecutionAdmissionProvenance::Canonical {
+                scenario_class: scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
+                activation_id,
+            },
             LoopControlOptions {
                 max_tool_rounds: None,
             },
         )
         .await
         .unwrap();
+    let error = runtime
+        .persist_terminal_transition(&transition)
+        .await
+        .expect_err("standalone Turn persistence must not bypass CompletionCommit");
 
     assert_eq!(
         *provider.calls.lock().await,
         1,
-        "resuming a direct caller must terminate the callee provider loop"
+        "CompleteWorkItem must still terminate the provider loop"
     );
+    assert!(error
+        .to_string()
+        .contains("canonical queue terminal settlement"));
     assert_eq!(
         runtime
             .latest_work_item(&callee.id)
@@ -2354,16 +2410,22 @@ async fn complete_work_item_resuming_direct_caller_ends_current_turn() {
             .unwrap()
             .unwrap()
             .state,
-        WorkItemState::Completed
+        WorkItemState::Open
     );
     let state = runtime.agent_state().await.unwrap();
     assert_eq!(
         state.current_work_item_id.as_deref(),
-        Some(caller.id.as_str())
+        Some(callee.id.as_str())
     );
     assert_eq!(
-        state.current_turn_work_item_id.as_deref(),
-        Some(caller.id.as_str())
+        runtime
+            .storage()
+            .latest_work_item_continuations()
+            .unwrap()
+            .into_iter()
+            .find(|frame| frame.active_work_item_id == callee.id)
+            .map(|frame| frame.state),
+        Some(WorkItemContinuationState::Active)
     );
 }
 
@@ -3047,36 +3109,84 @@ async fn complete_work_item_followed_by_same_round_tool_keeps_terminal_brief() {
         continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "complete and verify".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(work_item.id.clone());
 
-    runtime
-        .process_interactive_message(
-            &message,
-            None,
-            LoopControlOptions {
-                max_tool_rounds: None,
-            },
-        )
-        .await
-        .unwrap();
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if runtime
+                .storage()
+                .read_recent_events(200)
+                .unwrap()
+                .iter()
+                .any(|event| {
+                    event.kind == "work_item_written"
+                        && event.data["action"].as_str() == Some("completed")
+                        && event.data["work_item_id"].as_str() == Some(work_item.id.as_str())
+                })
+            {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before completion commit: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for canonical completion commit");
 
-    assert_eq!(*provider.calls.lock().await, 2);
+    assert_eq!(
+        *provider.calls.lock().await,
+        1,
+        "CompleteWorkItem must terminate the provider loop"
+    );
+    assert_eq!(
+        runtime
+            .latest_work_item(&work_item.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        WorkItemState::Completed
+    );
     let briefs = runtime.recent_briefs(10).await.unwrap();
     assert!(briefs.iter().any(|brief| {
         brief.kind == BriefKind::Result && brief.text == "Finished the tracked work."
     }));
-    assert!(briefs.iter().any(|brief| {
-        brief.kind == BriefKind::Result && brief.text == "Verified after completion."
-    }));
+    assert!(briefs
+        .iter()
+        .all(|brief| brief.text != "Verified after completion."));
+    assert!(runtime
+        .storage()
+        .read_recent_tool_executions(10)
+        .unwrap()
+        .iter()
+        .all(|tool| tool.tool_name != "ExecCommand"));
+    runtime_task.abort();
 }
 
 #[tokio::test]
@@ -3229,21 +3339,63 @@ async fn promoted_completion_report_resumes_next_queued_work_item_via_system_tic
         context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "finish active work".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(active.id.clone());
 
-    runtime
-        .process_message(message, closure_decision(ClosureOutcome::Completed, None))
-        .await
-        .unwrap();
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            let active_completed = runtime
+                .latest_work_item(&active.id)
+                .await
+                .unwrap()
+                .is_some_and(|record| record.state == WorkItemState::Completed);
+            let tick_emitted = runtime
+                .storage()
+                .read_recent_messages(10)
+                .unwrap()
+                .iter()
+                .any(|message| {
+                    matches!(
+                        (&message.kind, &message.origin),
+                        (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                            if subsystem == "work_queue"
+                    )
+                });
+            if active_completed && tick_emitted {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before completion and queued-work tick: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("completion should emit the next queued WorkItem tick");
+    runtime_task.abort();
 
     let messages = runtime.storage().read_recent_messages(10).unwrap();
     let tick = messages
@@ -3380,7 +3532,7 @@ async fn complete_work_item_without_same_round_report_fails_without_mutation() {
 }
 
 #[tokio::test]
-async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circuit() {
+async fn complete_work_item_is_a_hard_turn_boundary() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let seed_runtime = RuntimeHandle::new(
@@ -3401,6 +3553,7 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
         .create_work_item("second completion".into(), None, None, Vec::new())
         .await
         .unwrap();
+    seed_runtime.pick_work_item(first.id.clone()).await.unwrap();
 
     let provider = Arc::new(MultiCompleteWorkItemReportProvider {
         work_item_ids: vec![first.id.clone(), second.id.clone()],
@@ -3420,92 +3573,98 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
         continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "finish both tracked items".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(first.id.clone());
 
-    runtime
-        .process_interactive_message(
-            &message,
-            None,
-            LoopControlOptions {
-                max_tool_rounds: None,
-            },
-        )
-        .await
-        .unwrap();
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if runtime
+                .storage()
+                .read_recent_events(200)
+                .unwrap()
+                .iter()
+                .any(|event| {
+                    event.kind == "work_item_written"
+                        && event.data["action"].as_str() == Some("completed")
+                        && event.data["work_item_id"].as_str() == Some(first.id.as_str())
+                })
+            {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before completion commit: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for canonical completion commit");
 
-    for (work_item_id, report_text) in [
-        (&first.id, "Finished the first work item."),
-        (&second.id, "Finished the second work item."),
-    ] {
-        let completed = runtime
-            .latest_work_item(work_item_id)
+    let completion_turn = runtime
+        .storage()
+        .read_recent_turns(10)
+        .unwrap()
+        .into_iter()
+        .find(|turn| turn.completed_work_item_ids.contains(&first.id))
+        .expect("completion commit must write the terminal Turn");
+    assert_eq!(
+        completion_turn.tool_execution_ids.len(),
+        1,
+        "CompleteWorkItem must stop later tools in the same provider round"
+    );
+    assert_eq!(
+        completion_turn.completed_work_item_ids,
+        vec![first.id.clone()],
+        "the terminal Turn must settle only the first completion"
+    );
+    assert!(
+        completion_turn.terminal.is_some(),
+        "the completion commit must own the terminal Turn write"
+    );
+    assert_eq!(
+        runtime
+            .latest_work_item(&first.id)
             .await
             .unwrap()
-            .unwrap();
-        assert_eq!(completed.state, WorkItemState::Completed);
-        assert_eq!(completed.result_summary, None);
-        let result_brief_id = completed
-            .result_brief_id
-            .as_deref()
-            .expect("completion report should store result brief id");
-        assert_eq!(
-            runtime
-                .storage()
-                .read_brief_by_id(result_brief_id)
-                .unwrap()
-                .expect("completion result brief should exist")
-                .text,
-            report_text
-        );
-        assert!(runtime
-            .storage()
-            .latest_delivery_summary(work_item_id)
             .unwrap()
-            .is_none());
-    }
-    assert_eq!(
-        *provider.calls.lock().await,
-        2,
-        "multiple completion reports should not hard-stop the provider loop"
-    );
-    let briefs = runtime.recent_briefs(10).await.unwrap();
-    assert_eq!(
-        briefs
-            .iter()
-            .filter(|brief| brief.kind == BriefKind::Result
-                && brief.work_item_id.as_deref() == Some(first.id.as_str()))
-            .count(),
-        1
+            .state,
+        WorkItemState::Completed,
+        "the first completion must commit through the queue terminal transaction"
     );
     assert_eq!(
-        briefs
-            .iter()
-            .filter(|brief| brief.kind == BriefKind::Result
-                && brief.work_item_id.as_deref() == Some(second.id.as_str()))
-            .count(),
-        1
+        runtime
+            .latest_work_item(&second.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        WorkItemState::Open,
+        "tools after CompleteWorkItem must not execute"
     );
-    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
-    assert_eq!(
-        events
-            .iter()
-            .filter(|event| {
-                event.kind == "work_item_completion_warning"
-                    && event.data["kind"].as_str()
-                        == Some("completion_report_not_promoted_multiple_completions")
-            })
-            .count(),
-        0
-    );
+    runtime_task.abort();
 }
 
 #[tokio::test]
@@ -3787,6 +3946,11 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
         )
         .await
         .unwrap();
+    assert!(result.terminal_transition);
+    let prepared = result
+        .prepared_work_item_completion
+        .as_ref()
+        .expect("completion tool should prepare a terminal commit");
     let payload = result.envelope.result.unwrap();
     assert_eq!(
         payload["warnings"][0]["kind"].as_str(),
@@ -3797,33 +3961,30 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
         payload["warnings"][0]["in_progress_count"].as_u64(),
         Some(1)
     );
-    let events = runtime.storage().read_recent_events(20).unwrap();
-    let completed_event = events
+    let completed_event = prepared
+        .audit_events
         .iter()
         .find(|event| {
             event.kind == "work_item_written" && event.data["action"].as_str() == Some("completed")
         })
-        .expect("completed event should be recorded");
+        .expect("prepared completion should include the completed event");
     assert_eq!(
         completed_event.data["work_item_id"].as_str(),
         Some(work_item.id.as_str())
     );
     assert!(completed_event.data.get("record").is_none());
-    let completed = runtime
+    let durable = runtime
         .latest_work_item(&work_item.id)
         .await
         .unwrap()
-        .expect("completed work item");
-    let brief = runtime
+        .expect("durable work item");
+    assert_eq!(durable.state, WorkItemState::Open);
+    assert!(runtime
         .storage()
-        .read_brief_by_id(
-            completed
-                .result_brief_id
-                .as_deref()
-                .expect("completion result brief"),
-        )
+        .read_brief_by_id(&prepared.brief.id)
         .unwrap()
-        .expect("completion brief");
+        .is_none());
+    let brief = &prepared.brief;
     assert_eq!(
         brief.citations,
         Some(vec![crate::types::Citation {

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -150,6 +150,7 @@ impl RuntimeHandle {
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
             terminal_kind: TurnTerminalKind::Aborted,
+            prepared_work_item_completion: None,
         }))
     }
 
@@ -190,6 +191,7 @@ impl RuntimeHandle {
             let transition = super::TurnTerminalTransition {
                 turn_record: self.build_turn_record(&record).await?,
                 terminal: record.clone(),
+                prepared_work_item_completion: None,
             };
             self.persist_terminal_transition(&transition).await?;
         }
@@ -344,6 +346,7 @@ impl RuntimeHandle {
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
             terminal_kind,
+            prepared_work_item_completion: None,
         }))
     }
     pub(super) async fn complete_turn_with_abort(
@@ -903,6 +906,7 @@ impl TurnExecution<'_> {
         let turn_started_at = Instant::now();
         let mut sleep_duration_ms = None;
         let mut completed_work_item_this_turn = false;
+        let mut prepared_work_item_completion = None;
         let mut round = 0usize;
         let mut truncated_text_history = Vec::new();
         let mut truncated_citation_history = Vec::<Citation>::new();
@@ -997,6 +1001,7 @@ impl TurnExecution<'_> {
                         sleep_duration_ms: None,
                         allow_sleep_runnable_work_override: false,
                         terminal_kind: TurnTerminalKind::Aborted,
+                        prepared_work_item_completion: None,
                     });
                 }
             }
@@ -1316,6 +1321,7 @@ impl TurnExecution<'_> {
                                 sleep_duration_ms: None,
                                 allow_sleep_runnable_work_override: false,
                                 terminal_kind: TurnTerminalKind::BaselineOverBudget,
+                                prepared_work_item_completion: None,
                             });
                         }
                     }
@@ -1953,6 +1959,7 @@ impl TurnExecution<'_> {
                     sleep_duration_ms,
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
+                    prepared_work_item_completion: None,
                 });
             }
 
@@ -2182,7 +2189,7 @@ impl TurnExecution<'_> {
                 };
                 crate::diagnostics::record_turn_tool_execution(tool_exec_started.elapsed());
                 match tool_execution {
-                    Ok((result, mut record)) => {
+                    Ok((mut result, mut record)) => {
                         let result_content =
                             crate::tool::tools::render_tool_result_for_model(&result)?;
                         let duration_ms = record.duration_ms;
@@ -2214,18 +2221,7 @@ impl TurnExecution<'_> {
                             all_tool_results_should_sleep = false;
                         }
                         tool_execution_refs.push((tool_call_id.clone(), record.id.clone()));
-                        runtime.persist_tool_execution_evidence(&record)?;
-                        if matches!(record.status, crate::types::ToolExecutionStatus::Success) {
-                            runtime
-                                .record_skill_tool_activation(
-                                    &record.tool_name,
-                                    &record.input,
-                                    &result,
-                                )
-                                .await?;
-                        }
-
-                        runtime.inner.storage.append_event(&AuditEvent::legacy(
+                        let tool_executed_event = AuditEvent::legacy(
                             "tool_executed",
                             to_json_value(&ToolExecutionAuditEvent {
                                 tool_call_id: tool_call_id.clone(),
@@ -2269,7 +2265,26 @@ impl TurnExecution<'_> {
                                 tool_error: result.tool_error().cloned(),
                                 reason: None,
                             }),
-                        ))?;
+                        );
+                        if let Some(mut prepared) = result.prepared_work_item_completion.take() {
+                            prepared.tool_execution = Some(record.clone());
+                            prepared.audit_events.push(tool_executed_event);
+                            prepared_work_item_completion = Some(prepared);
+                        } else {
+                            runtime.persist_tool_execution_evidence(&record)?;
+                            runtime.inner.storage.append_event(&tool_executed_event)?;
+                        }
+                        if prepared_work_item_completion.is_none()
+                            && matches!(record.status, crate::types::ToolExecutionStatus::Success)
+                        {
+                            runtime
+                                .record_skill_tool_activation(
+                                    &record.tool_name,
+                                    &record.input,
+                                    &result,
+                                )
+                                .await?;
+                        }
                         tool_result_envelopes.push(result.envelope.clone());
                         tool_results.push(ToolResultBlock {
                             tool_use_id: tool_call_id,
@@ -2423,13 +2438,18 @@ impl TurnExecution<'_> {
                     }
                 })
                 .collect();
-            runtime.persist_transcript_evidence(&TranscriptEntry::new(
+            let tool_results_transcript = TranscriptEntry::new(
                 agent_id.to_string(),
                 TranscriptEntryKind::ToolResults,
                 Some(round),
                 None,
                 to_json_value(&ToolResultData::RefsWithWrapper { refs }),
-            ))?;
+            );
+            if let Some(prepared) = prepared_work_item_completion.as_mut() {
+                prepared.transcript_entries.push(tool_results_transcript);
+            } else {
+                runtime.persist_transcript_evidence(&tool_results_transcript)?;
+            }
             let after_tool_results_interjections = runtime
                 .drain_operator_interjections(
                     agent_id,
@@ -2505,6 +2525,7 @@ impl TurnExecution<'_> {
                     sleep_duration_ms: sleep_duration_ms.or(legacy_sleep_duration_ms),
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
+                    prepared_work_item_completion: prepared_work_item_completion.take(),
                 });
             }
         }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1959,7 +1959,7 @@ impl TurnExecution<'_> {
                     sleep_duration_ms,
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
-                    prepared_work_item_completion: None,
+                    prepared_work_item_completion: prepared_work_item_completion.take(),
                 });
             }
 
@@ -1971,7 +1971,7 @@ impl TurnExecution<'_> {
             let mut tool_execution_refs: Vec<(String, String)> = Vec::new();
             let mut all_tool_results_should_sleep = !round_tool_calls.is_empty();
             let mut terminal_tool_transition = false;
-            for call in tool_calls {
+            for (tool_call_index, call) in tool_calls.into_iter().enumerate() {
                 if let Err(err) = runtime.ensure_not_aborted().await {
                     if let Some(aborted) = err.downcast_ref::<CurrentRunAborted>() {
                         runtime
@@ -2266,6 +2266,7 @@ impl TurnExecution<'_> {
                                 reason: None,
                             }),
                         );
+                        let stops_tool_batch = result.prepared_work_item_completion.is_some();
                         if let Some(mut prepared) = result.prepared_work_item_completion.take() {
                             prepared.tool_execution = Some(record.clone());
                             prepared.audit_events.push(tool_executed_event);
@@ -2292,8 +2293,9 @@ impl TurnExecution<'_> {
                             is_error: result.is_error(),
                             error: result.tool_error().cloned(),
                         });
-                        if result.terminal_transition {
-                            terminal_tool_transition = true;
+                        if result.terminal_transition || stops_tool_batch {
+                            terminal_tool_transition = result.terminal_transition
+                                || tool_call_index + 1 < round_tool_calls.len();
                             break;
                         }
                     }

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -44,12 +44,16 @@ pub(crate) struct AgentLoopOutcome {
     pub(super) sleep_duration_ms: Option<u64>,
     pub(super) allow_sleep_runnable_work_override: bool,
     pub(super) terminal_kind: TurnTerminalKind,
+    pub(super) prepared_work_item_completion:
+        Option<Box<crate::runtime::PreparedWorkItemCompletion>>,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct TurnTerminalTransition {
     pub(super) terminal: TurnTerminalRecord,
     pub(super) turn_record: TurnRecord,
+    pub(super) prepared_work_item_completion:
+        Option<Box<crate::runtime::PreparedWorkItemCompletion>>,
 }
 
 pub(crate) struct LoopControlOptions {
@@ -312,6 +316,10 @@ impl RuntimeHandle {
         &self,
         transition: &TurnTerminalTransition,
     ) -> Result<()> {
+        anyhow::ensure!(
+            transition.prepared_work_item_completion.is_none(),
+            "prepared WorkItem completion requires the canonical queue terminal settlement"
+        );
         self.commit_terminal_transition(transition, Vec::new())
             .await
             .map(|_| ())
@@ -361,6 +369,7 @@ impl RuntimeHandle {
             let transition = TurnTerminalTransition {
                 turn_record: self.build_turn_record(&record).await?,
                 terminal: record.clone(),
+                prepared_work_item_completion: None,
             };
             self.commit_terminal_transition(
                 &transition,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -18,7 +18,8 @@ use crate::{
     runtime_db::{
         evidence::{
             append_audit_event_tx, append_message_tx, append_transcript_entry_tx,
-            insert_brief_evidence_tx, insert_runtime_index_changes_tx, upsert_agent_state_tx,
+            insert_brief_evidence_tx, insert_runtime_index_changes_tx, insert_tool_evidence_tx,
+            upsert_agent_state_tx,
         },
         repositories::{
             compare_and_set_queue_entry_tx, insert_new_work_item_tx, queue_entry_transition,
@@ -32,8 +33,8 @@ use crate::{
     runtime_error::RuntimeError,
     types::{
         AgentState, AuditEvent, BriefRecord, MessageEnvelope, QueueEntryRecord, QueueEntryStatus,
-        TaskRecord, TranscriptEntry, TurnRecord, WaitConditionRecord, WorkItemContinuationFrame,
-        WorkItemRecord, WorkItemSchedulingState, WorkItemState,
+        TaskRecord, ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionRecord,
+        WorkItemContinuationFrame, WorkItemRecord, WorkItemSchedulingState, WorkItemState,
     },
 };
 
@@ -214,6 +215,16 @@ pub(crate) struct QueueTransitionCommand {
     pub notify_scheduler: bool,
     pub fault: Option<TransitionFaultPoint>,
     pub brief_evidence: Vec<BriefRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CompletionTransition {
+    pub requires_execution_continuation: bool,
+    pub work_items: Vec<WorkItemMutation>,
+    pub wait_conditions: Vec<WaitConditionRecord>,
+    pub continuations: Vec<WorkItemContinuationFrame>,
+    pub tool_execution: ToolExecutionRecord,
+    pub index_changes: Vec<RuntimeIndexChange>,
 }
 
 #[derive(Debug, Clone)]
@@ -715,6 +726,7 @@ impl RuntimeTransitionRepository<'_> {
                 &execution_protocol.commands,
                 &command.work_items,
                 &command.wait_conditions,
+                &command.continuations,
             )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
@@ -807,6 +819,7 @@ impl RuntimeTransitionRepository<'_> {
                 &execution_protocol.commands,
                 work_items,
                 &[],
+                &[],
             )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
             let mut applied = apply_work_item_mutation_tx(tx, &command.mutation)?;
@@ -886,6 +899,7 @@ impl RuntimeTransitionRepository<'_> {
                 &execution_protocol.commands,
                 &command.work_items,
                 &command.wait_conditions,
+                &[],
             )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
@@ -939,6 +953,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -947,7 +962,7 @@ impl RuntimeTransitionRepository<'_> {
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
     ) -> Result<TransitionCommit> {
-        self.commit_queue_transaction(command, execution_protocol, None, None, None)
+        self.commit_queue_transaction(command, execution_protocol, None, None, None, None)
     }
 
     pub fn commit_queue_with_wait_trigger(
@@ -961,6 +976,7 @@ impl RuntimeTransitionRepository<'_> {
             wait_transition,
             None,
             None,
+            None,
         )
     }
 
@@ -970,7 +986,14 @@ impl RuntimeTransitionRepository<'_> {
         execution_protocol: &ExecutionProtocolTransition,
         wait_transition: Option<&QueueWaitTransition>,
     ) -> Result<TransitionCommit> {
-        self.commit_queue_transaction(command, execution_protocol, wait_transition, None, None)
+        self.commit_queue_transaction(
+            command,
+            execution_protocol,
+            wait_transition,
+            None,
+            None,
+            None,
+        )
     }
 
     pub fn commit_queue_with_execution_protocol_and_task_expectation(
@@ -985,6 +1008,23 @@ impl RuntimeTransitionRepository<'_> {
             None,
             Some(task_expectation),
             None,
+            None,
+        )
+    }
+
+    pub fn commit_queue_with_completion(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        completion: &CompletionTransition,
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_transaction(
+            command,
+            execution_protocol,
+            None,
+            None,
+            None,
+            Some(completion),
         )
     }
 
@@ -1000,6 +1040,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             Some(scheduler_protocol),
+            None,
         )
     }
 
@@ -1010,6 +1051,7 @@ impl RuntimeTransitionRepository<'_> {
         wait_transition: Option<&QueueWaitTransition>,
         task_expectation: Option<&TaskExpectation>,
         legacy_scheduler_protocol: Option<&LegacySchedulerProtocolTransition>,
+        completion: Option<&CompletionTransition>,
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_queue_operation(command)?;
@@ -1023,6 +1065,24 @@ impl RuntimeTransitionRepository<'_> {
             }
             if let Some(task_expectation) = task_expectation {
                 validate_task_expectation_tx(tx, task_expectation)?;
+            }
+            if let Some(completion) = completion {
+                validate_completion_transition_tx(tx, &command.agent_id, completion)?;
+                if completion.requires_execution_continuation {
+                    validate_completion_execution_commands(
+                        completion,
+                        &execution_protocol.commands,
+                    )?;
+                }
+                for work_item in &completion.work_items {
+                    validate_work_item_mutation_tx(tx, work_item)?;
+                }
+                for condition in &completion.wait_conditions {
+                    validate_wait_condition_tx(tx, condition)?;
+                }
+                for continuation in &completion.continuations {
+                    validate_work_item_continuation_tx(tx, continuation)?;
+                }
             }
             if let QueueMutation::Consume(record) = &command.mutation {
                 let include_interrupted = match command.operation {
@@ -1100,17 +1160,33 @@ impl RuntimeTransitionRepository<'_> {
                     }
                 }
             };
+            let execution_work_items = if let Some(work_item) =
+                wait_transition.and_then(|transition| transition.work_item.as_ref())
+            {
+                std::slice::from_ref(work_item)
+            } else {
+                completion
+                    .map(|completion| completion.work_items.as_slice())
+                    .unwrap_or_default()
+            };
+            let execution_wait_conditions = if let Some(wait_transition) = wait_transition {
+                std::slice::from_ref(&wait_transition.record)
+            } else {
+                completion
+                    .map(|completion| completion.wait_conditions.as_slice())
+                    .unwrap_or_default()
+            };
+            let execution_continuations = completion
+                .map(|completion| completion.continuations.as_slice())
+                .unwrap_or_default();
             let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
                 tx,
                 &command.agent_id,
                 execution_protocol.bootstrap.as_ref(),
                 &execution_protocol.commands,
-                wait_transition
-                    .and_then(|transition| transition.work_item.as_ref())
-                    .map_or(&[], std::slice::from_ref),
-                wait_transition
-                    .map(|transition| std::slice::from_ref(&transition.record))
-                    .unwrap_or_default(),
+                execution_work_items,
+                execution_wait_conditions,
+                execution_continuations,
             )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
             let mutation_applied = match &command.mutation {
@@ -1153,12 +1229,51 @@ impl RuntimeTransitionRepository<'_> {
             } else {
                 false
             };
+            let mut completion_work_items = Vec::new();
+            let completion_applied = if let Some(completion) = completion {
+                let mut applied = false;
+                for work_item in &completion.work_items {
+                    if apply_work_item_mutation_tx(tx, work_item)? {
+                        completion_work_items.push(work_item.record().clone());
+                        applied = true;
+                    }
+                }
+                for condition in &completion.wait_conditions {
+                    applied |= upsert_wait_condition_tx(tx, condition)?;
+                }
+                for continuation in &completion.continuations {
+                    applied |= upsert_work_item_continuation_tx(tx, continuation)?;
+                }
+                let existing_tool_execution = tx
+                    .query_row(
+                        "SELECT payload_json FROM tool_executions WHERE evidence_id = ?1",
+                        [&completion.tool_execution.id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?
+                    .map(|payload| serde_json::from_str::<ToolExecutionRecord>(&payload))
+                    .transpose()?;
+                if let Some(existing) = existing_tool_execution {
+                    anyhow::ensure!(
+                        existing == completion.tool_execution,
+                        "conflicting CompleteWorkItem tool execution evidence for {}",
+                        completion.tool_execution.id
+                    );
+                } else {
+                    insert_tool_evidence_tx(tx, &completion.tool_execution)?;
+                    applied = true;
+                }
+                applied
+            } else {
+                false
+            };
             let applied = mutation_applied
                 || agent_state_applied
                 || protocol_applied
                 || execution_protocol_applied
                 || wait_transition_applied
-                || wait_work_item_applied;
+                || wait_work_item_applied
+                || completion_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
@@ -1188,13 +1303,19 @@ impl RuntimeTransitionRepository<'_> {
                 applied,
                 &command.agent_id,
                 &command.audit_events,
-                wait_transition.map_or(&[], |transition| transition.index_changes.as_slice()),
+                wait_transition
+                    .map(|transition| transition.index_changes.as_slice())
+                    .or_else(|| completion.map(|completion| completion.index_changes.as_slice()))
+                    .unwrap_or_default(),
                 command.fault,
                 PostCommitEffects {
                     agent_state: agent_state_applied
                         .then(|| command.agent_state.clone())
                         .flatten(),
-                    work_items: wait_work_items,
+                    work_items: wait_work_items
+                        .into_iter()
+                        .chain(completion_work_items)
+                        .collect(),
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
                 },
@@ -1379,7 +1500,9 @@ fn validate_agent_state_mutation_tx(
     };
     if let Some(expected) = mutation.expected.as_ref() {
         let actual = agent_state_tx(tx, &mutation.record.id)?;
-        if actual.as_ref() != Some(expected.as_ref()) {
+        if actual.as_ref() != Some(expected.as_ref())
+            && actual.as_ref() != Some(mutation.record.as_ref())
+        {
             return Err(RuntimeStateTransitionConflict::concurrent_mutation(
                 "agent_state",
                 &mutation.record.id,
@@ -1537,6 +1660,70 @@ fn validate_work_item_continuation_tx(
                 incoming.id
             ));
         }
+    }
+    Ok(())
+}
+
+fn validate_completion_transition_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    completion: &CompletionTransition,
+) -> Result<()> {
+    anyhow::ensure!(
+        completion.tool_execution.agent_id == agent_id
+            && completion.tool_execution.tool_name == crate::tool::names::COMPLETE_WORK_ITEM
+            && completion.tool_execution.status == crate::types::ToolExecutionStatus::Success,
+        "completion transition requires the committed CompleteWorkItem tool execution"
+    );
+    anyhow::ensure!(
+        completion
+            .work_items
+            .iter()
+            .any(|mutation| mutation.record().state == WorkItemState::Completed),
+        "completion transition requires an atomic completed WorkItem mutation"
+    );
+    for continuation in &completion.continuations {
+        let existing = tx
+            .query_row(
+                "SELECT payload_json FROM work_item_continuations WHERE continuation_id = ?1",
+                [&continuation.id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| serde_json::from_str::<WorkItemContinuationFrame>(&payload))
+            .transpose()?
+            .ok_or_else(|| anyhow!("completion continuation frame is missing"))?;
+        let matching_identity = existing.agent_id == agent_id
+            && existing.suspended_work_item_id == continuation.suspended_work_item_id
+            && existing.active_work_item_id == continuation.active_work_item_id;
+        let valid_transition = existing.state == crate::types::WorkItemContinuationState::Active
+            && continuation.state == crate::types::WorkItemContinuationState::Resumed;
+        anyhow::ensure!(
+            matching_identity && (valid_transition || existing == *continuation),
+            "completion continuation transition is stale or mismatched"
+        );
+    }
+    Ok(())
+}
+
+fn validate_completion_execution_commands(
+    completion: &CompletionTransition,
+    commands: &[crate::domain::execution_protocol::ExecutionProtocolCommand],
+) -> Result<()> {
+    for continuation in &completion.continuations {
+        if continuation.state != crate::types::WorkItemContinuationState::Resumed {
+            continue;
+        }
+        anyhow::ensure!(
+            commands.iter().any(|command| matches!(
+                command,
+                crate::domain::execution_protocol::ExecutionProtocolCommand::ResumeWorkItemContinuation(resume)
+                    if resume.continuation_id == continuation.id
+                        && resume.work_item_id == continuation.suspended_work_item_id
+                        && resume.active_work_item_id == continuation.active_work_item_id
+            )),
+            "completion continuation requires a matching canonical resume command"
+        );
     }
     Ok(())
 }
@@ -1877,9 +2064,10 @@ mod tests {
         runtime_db::{RuntimeIndexChange, RuntimeIndexOperation},
         types::{
             AgentIdentityRecord, AgentKind, AgentOwnership, AgentProfilePreset, AgentVisibility,
-            BriefKind, CompletionReportRequirement, CompletionReportState, Priority,
-            QueueEntryStatus, TaskKind, TaskStatus, WaitConditionKind, WaitConditionStatus,
-            WakeSource, WorkItemCompletionIntent, WorkItemContinuationState, WorkItemState,
+            AuthorityClass, BriefKind, CompletionReportRequirement, CompletionReportState,
+            Priority, QueueEntryStatus, TaskKind, TaskStatus, ToolExecutionStatus,
+            WaitConditionKind, WaitConditionStatus, WakeSource, WorkItemCompletionIntent,
+            WorkItemContinuationState, WorkItemState,
         },
     };
     use chrono::Utc;
@@ -2440,6 +2628,213 @@ mod tests {
         )?;
         assert_eq!(partitions, 0);
         assert_eq!(attempts, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn completion_commit_replay_is_a_noop_after_agent_state_advances() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let now = Utc::now();
+        let mut open = work_item("work-completion-replay");
+        open.updated_at = now;
+        db.work_items().insert_new(&open)?;
+        db.agent_identities().upsert(&AgentIdentityRecord::new(
+            "agent-a",
+            AgentKind::Named,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        ))?;
+        let mut initial_state = AgentState::new("agent-a");
+        initial_state.current_work_item_id = Some(open.id.clone());
+        initial_state.current_turn_work_item_id = Some(open.id.clone());
+        db.agent_states().upsert(&initial_state)?;
+
+        let queued = QueueEntryRecord {
+            message_id: "message-completion-replay".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.transitions().commit_queue_with_execution_protocol(
+            &QueueTransitionCommand {
+                agent_id: "agent-a".into(),
+                operation: QueueOperation::Admit,
+                mutation: QueueMutation::Upsert(queued.clone()),
+                scheduler_claim_work_item: None,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: Vec::new(),
+                notify_scheduler: false,
+                fault: None,
+                brief_evidence: Vec::new(),
+            },
+            &execution_admission(&queued.message_id, "attempt-completion-replay", &open.id),
+        )?;
+        let mut dequeued = queued.clone();
+        dequeued.status = QueueEntryStatus::Dequeued;
+        dequeued.updated_at = now + chrono::Duration::seconds(1);
+        db.transitions().commit_queue(&QueueTransitionCommand {
+            agent_id: "agent-a".into(),
+            operation: QueueOperation::Claim,
+            mutation: QueueMutation::Consume(dequeued.clone()),
+            scheduler_claim_work_item: None,
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: Vec::new(),
+            notify_scheduler: false,
+            fault: None,
+            brief_evidence: Vec::new(),
+        })?;
+
+        let turn_id = "turn-completion-replay";
+        let mut brief = BriefRecord::new(
+            "agent-a",
+            BriefKind::Result,
+            "completion replay result",
+            None,
+            None,
+        );
+        brief.work_item_id = Some(open.id.clone());
+        brief.turn_id = Some(turn_id.into());
+        brief.related_message_id = Some(queued.message_id.clone());
+        let mut completed = open.clone();
+        completed.revision = 2;
+        completed.state = WorkItemState::Completed;
+        completed.result_brief_id = Some(brief.id.clone());
+        completed.result_summary = Some(brief.text.clone());
+        completed.completion_intent = Some(WorkItemCompletionIntent {
+            work_item_id: completed.id.clone(),
+            source_activation_id: Some("attempt-completion-replay".into()),
+            source_message_id: Some(queued.message_id.clone()),
+            source_turn_id: Some(turn_id.into()),
+            expected_work_revision: open.revision,
+            report_requirement: CompletionReportRequirement::Required,
+            report_state: CompletionReportState::Bound,
+            result_brief_id: Some(brief.id.clone()),
+            created_at: now,
+            updated_at: now,
+        });
+        completed.updated_at = now + chrono::Duration::seconds(2);
+        let tool_execution = ToolExecutionRecord {
+            id: "tool-completion-replay".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some(open.id.clone()),
+            turn_index: 1,
+            turn_id: Some(turn_id.into()),
+            tool_name: crate::tool::names::COMPLETE_WORK_ITEM.into(),
+            created_at: now,
+            completed_at: Some(now + chrono::Duration::seconds(2)),
+            duration_ms: 1,
+            authority_class: AuthorityClass::RuntimeInstruction,
+            status: ToolExecutionStatus::Success,
+            input: serde_json::json!({"work_item_id": open.id}),
+            output: serde_json::json!({"status": "completed"}),
+            summary: "completed WorkItem".into(),
+            invocation_surface: None,
+        };
+        let mut turn = TurnRecord::new("agent-a", turn_id, 1);
+        turn.current_work_item_id = Some(open.id.clone());
+        turn.input_message_ids = vec![queued.message_id.clone()];
+        turn.tool_execution_ids = vec![tool_execution.id.clone()];
+        turn.produced_brief_ids = vec![brief.id.clone()];
+        turn.completed_work_item_ids = vec![open.id.clone()];
+        turn.created_at = now;
+        let mut processed = dequeued;
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at = now + chrono::Duration::seconds(2);
+        let mut committed_state = initial_state.clone();
+        committed_state.current_work_item_id = None;
+        committed_state.current_turn_work_item_id = None;
+        committed_state.current_turn_id = Some(turn_id.into());
+        let audit = AuditEvent::legacy(
+            "completion_commit_replay",
+            serde_json::json!({"work_item_id": open.id}),
+        );
+        let index_change = index_change("work_item", &open.id);
+        let command = QueueTransitionCommand {
+            agent_id: "agent-a".into(),
+            operation: QueueOperation::Settle,
+            mutation: QueueMutation::Upsert(processed),
+            scheduler_claim_work_item: None,
+            agent_state: Some(AgentStateMutation {
+                expected: Some(Box::new(initial_state)),
+                record: Box::new(committed_state.clone()),
+            }),
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: Some(turn),
+            audit_events: vec![audit],
+            notify_scheduler: true,
+            fault: None,
+            brief_evidence: vec![brief.clone()],
+        };
+        let execution = ExecutionProtocolTransition {
+            bootstrap: None,
+            commands: vec![ExecutionProtocolCommand::Settle(SettleExecution {
+                outcome: ExecutionOutcomeRecord {
+                    outcome_id: "outcome-completion-replay".into(),
+                    attempt_id: "attempt-completion-replay".into(),
+                    outcome: ExecutionOutcome::WorkItem(WorkItemOutcome::Complete {
+                        completion: brief.id.clone(),
+                    }),
+                    created_at: now.to_rfc3339(),
+                },
+            })],
+        };
+        let completion = CompletionTransition {
+            requires_execution_continuation: true,
+            work_items: vec![WorkItemMutation::Update {
+                record: completed,
+                expected_revision: open.revision,
+            }],
+            wait_conditions: Vec::new(),
+            continuations: Vec::new(),
+            tool_execution,
+            index_changes: vec![index_change],
+        };
+
+        assert!(
+            db.transitions()
+                .commit_queue_with_completion(&command, &execution, &completion)?
+                .applied
+        );
+        assert!(
+            !db.transitions()
+                .commit_queue_with_completion(&command, &execution, &completion)?
+                .applied
+        );
+        assert_eq!(db.agent_states().latest("agent-a")?, Some(committed_state));
+        assert_eq!(db.audit_events().recent(Some("agent-a"), 10)?.len(), 1);
+        assert_eq!(
+            db.runtime_index_outbox()
+                .read_after("agent-a", 0, 10)?
+                .len(),
+            1
+        );
+        let connection = db.connection()?;
+        for (table, expected) in [
+            ("queue_entries", 1_i64),
+            ("work_items", 1),
+            ("turn_records", 1),
+            ("briefs", 1),
+            ("tool_executions", 1),
+            ("execution_protocol_outcomes", 1),
+        ] {
+            let count: i64 =
+                connection.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })?;
+            assert_eq!(count, expected, "{table} must remain exactly-once");
+        }
         Ok(())
     }
 

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -43,6 +43,7 @@ pub(super) fn validate_execution_commands_tx(
     commands: &[ExecutionProtocolCommand],
     work_item_mutations: &[WorkItemMutation],
     wait_conditions: &[crate::types::WaitConditionRecord],
+    continuations: &[crate::types::WorkItemContinuationFrame],
 ) -> Result<Option<PreparedExecutionProtocolCommands>> {
     if commands.is_empty() {
         return Ok(None);
@@ -89,8 +90,17 @@ pub(super) fn validate_execution_commands_tx(
         if let ExecutionProtocolCommand::SetWorkItemReadiness(command) = command {
             validate_set_work_item_readiness(command, work_item_mutations, wait_conditions)?;
         }
+        if let ExecutionProtocolCommand::SuspendWorkItemContinuation(command) = command {
+            validate_suspend_work_item_continuation(tx, agent_id, command, continuations)?;
+        }
+        if let ExecutionProtocolCommand::ResumeWorkItemContinuation(command) = command {
+            validate_resume_work_item_continuation(tx, agent_id, command)?;
+        }
         if let ExecutionProtocolCommand::SetWorkItemWaiting(command) = command {
             validate_set_work_item_waiting(command, work_item_mutations, wait_conditions)?;
+        }
+        if let ExecutionProtocolCommand::CompleteWorkItem(command) = command {
+            validate_complete_work_item(command, work_item_mutations)?;
         }
         let transition = reduce(&state, command)
             .map_err(|error| anyhow!("execution protocol command rejected: {error}"))?;
@@ -136,6 +146,9 @@ pub(super) fn synchronize_work_item_revisions_tx(
                 command.work_item_id == record.id
             }
             ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
+                command.work_item_id == record.id
+            }
+            ExecutionProtocolCommand::SuspendWorkItemContinuation(command) => {
                 command.work_item_id == record.id
             }
             ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
@@ -267,8 +280,17 @@ fn reduce(
         ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
             execution_protocol::set_work_item_readiness(state, command)
         }
+        ExecutionProtocolCommand::SuspendWorkItemContinuation(command) => {
+            execution_protocol::suspend_work_item_continuation(state, command)
+        }
+        ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
+            execution_protocol::resume_work_item_continuation(state, command)
+        }
         ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
             execution_protocol::set_work_item_waiting(state, command)
+        }
+        ExecutionProtocolCommand::CompleteWorkItem(command) => {
+            execution_protocol::complete_work_item_execution(state, command)
         }
         ExecutionProtocolCommand::Admit(command) => {
             execution_protocol::admit_execution(state, command)
@@ -293,8 +315,17 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
         ExecutionProtocolCommand::SetWorkItemReadiness(command) => {
             ("set_work_item_readiness", &command.command_id)
         }
+        ExecutionProtocolCommand::SuspendWorkItemContinuation(command) => {
+            ("suspend_work_item_continuation", &command.command_id)
+        }
+        ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
+            ("resume_work_item_continuation", &command.command_id)
+        }
         ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
             ("set_work_item_waiting", &command.command_id)
+        }
+        ExecutionProtocolCommand::CompleteWorkItem(command) => {
+            ("complete_work_item_execution", &command.command_id)
         }
         ExecutionProtocolCommand::Admit(command) => {
             ("admit_execution", &command.attempt.attempt_id)
@@ -337,6 +368,26 @@ fn validate_set_work_item_waiting(
         })
     {
         bail!("WorkItem waiting transition does not match its atomic wait condition");
+    }
+    Ok(())
+}
+
+fn validate_complete_work_item(
+    command: &execution_protocol::CompleteWorkItemExecution,
+    mutations: &[WorkItemMutation],
+) -> Result<()> {
+    let Some(record) = mutations.iter().find_map(|mutation| match mutation {
+        WorkItemMutation::Update { record, .. } if record.id == command.work_item_id => {
+            Some(record)
+        }
+        _ => None,
+    }) else {
+        bail!("WorkItem completion transition requires an atomic WorkItem update");
+    };
+    if record.state != crate::types::WorkItemState::Completed
+        || record.result_brief_id.as_deref() != Some(command.completion.as_str())
+    {
+        bail!("WorkItem completion transition does not match its atomic WorkItem update");
     }
     Ok(())
 }
@@ -432,6 +483,75 @@ fn validate_set_work_item_readiness(
             }
         }
         _ => bail!("WorkItem readiness transition must target Runnable or Paused"),
+    }
+    Ok(())
+}
+
+fn validate_resume_work_item_continuation(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &execution_protocol::ResumeWorkItemContinuation,
+) -> Result<()> {
+    let frame = tx
+        .query_row(
+            "SELECT payload_json
+             FROM work_item_continuations
+             WHERE continuation_id = ?1 AND agent_id = ?2",
+            [&command.continuation_id, agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| {
+            serde_json::from_str::<crate::types::WorkItemContinuationFrame>(&payload)
+                .context("decoding continuation resume frame")
+        })
+        .transpose()?
+        .ok_or_else(|| anyhow!("continuation resume requires an existing frame"))?;
+    if frame.suspended_work_item_id != command.work_item_id
+        || frame.active_work_item_id != command.active_work_item_id
+        || !matches!(
+            frame.state,
+            crate::types::WorkItemContinuationState::Active
+                | crate::types::WorkItemContinuationState::Resumed
+        )
+    {
+        bail!("continuation resume command does not match its active frame");
+    }
+    Ok(())
+}
+
+fn validate_suspend_work_item_continuation(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &execution_protocol::SuspendWorkItemContinuation,
+    continuations: &[crate::types::WorkItemContinuationFrame],
+) -> Result<()> {
+    let frame = continuations
+        .iter()
+        .find(|frame| frame.id == command.continuation_id)
+        .ok_or_else(|| anyhow!("continuation suspension requires an atomic continuation frame"))?;
+    if frame.agent_id != agent_id
+        || frame.suspended_work_item_id != command.work_item_id
+        || frame.active_work_item_id != command.active_work_item_id
+        || frame.state != crate::types::WorkItemContinuationState::Active
+    {
+        bail!("continuation suspension command does not match its active frame");
+    }
+    let parent = tx
+        .query_row(
+            "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+            [&command.work_item_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<crate::types::WorkItemRecord>(&payload))
+        .transpose()?
+        .ok_or_else(|| anyhow!("continuation suspension parent WorkItem is missing"))?;
+    if parent.agent_id != agent_id
+        || parent.state != crate::types::WorkItemState::Open
+        || parent.revision != command.expected.source_revision
+    {
+        bail!("continuation suspension parent WorkItem fence is stale");
     }
     Ok(())
 }

--- a/src/tool/spec.rs
+++ b/src/tool/spec.rs
@@ -60,6 +60,9 @@ pub struct ToolResult {
     pub terminal_transition: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sleep_duration_ms: Option<u64>,
+    #[serde(skip)]
+    pub(crate) prepared_work_item_completion:
+        Option<Box<crate::runtime::PreparedWorkItemCompletion>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -99,6 +102,7 @@ impl ToolResult {
             should_sleep: false,
             terminal_transition: false,
             sleep_duration_ms: None,
+            prepared_work_item_completion: None,
         }
     }
 
@@ -120,6 +124,7 @@ impl ToolResult {
             should_sleep: true,
             terminal_transition: false,
             sleep_duration_ms,
+            prepared_work_item_completion: None,
         }
     }
 
@@ -136,6 +141,7 @@ impl ToolResult {
             should_sleep: false,
             terminal_transition: false,
             sleep_duration_ms: None,
+            prepared_work_item_completion: None,
         }
     }
 

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -109,6 +109,7 @@ pub(crate) async fn execute(
         };
     let context = query_context(runtime).await?;
     let work_item = view_for_record(runtime, &context, completed, true, None, None).await?;
+    let terminal_transition = continuation_resumed.is_some();
     let mut result = serde_json::to_value(
         WorkItemMutationResult::with_completion_transition(
             work_item,
@@ -130,8 +131,10 @@ pub(crate) async fn execute(
         }
     }
     let mut result = serialize_success(NAME, &result)?;
-    result.should_sleep = true;
-    result.terminal_transition = true;
+    if terminal_transition {
+        result.should_sleep = true;
+        result.terminal_transition = true;
+    }
     result.prepared_work_item_completion = prepared.map(Box::new);
     Ok(result)
 }

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -4,9 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    runtime::{
-        RuntimeHandle, WorkItemCompletionAuthority, WorkItemCompletionReportPromotionOutcome,
-    },
+    runtime::{RuntimeHandle, WorkItemCompletionAuthority},
     runtime_error::RuntimeError,
     tool::helpers::{parse_tool_args, validate_non_empty},
     tool::spec::{typed_spec, ToolExecutionContext},
@@ -72,9 +70,9 @@ pub(crate) async fn execute(
                 "CompleteWorkItem requires an active agent execution binding",
             )
         })?;
-    let outcome = runtime
-        .complete_work_item_with_report(
-            work_item_id,
+    let prepared = runtime
+        .prepare_work_item_completion_with_report(
+            work_item_id.clone(),
             WorkItemCompletionAuthority::AgentExecution(execution_binding),
             candidate
                 .map(|candidate| candidate.text.clone())
@@ -92,17 +90,25 @@ pub(crate) async fn execute(
         )
         .await?;
     let (completed, completed_transition, completion_report_promoted, continuation_resumed) =
-        match outcome {
-            WorkItemCompletionReportPromotionOutcome::Promoted(promotion) => {
-                (promotion.record, true, true, promotion.continuation_resumed)
-            }
-            WorkItemCompletionReportPromotionOutcome::Unchanged(record) => {
-                (record, false, false, None)
-            }
+        match prepared.as_ref() {
+            Some(prepared) => (
+                prepared.record.clone(),
+                true,
+                true,
+                prepared.continuation_resumed.clone(),
+            ),
+            None => (
+                runtime
+                    .latest_work_item(&work_item_id)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("work item {work_item_id} not found"))?,
+                false,
+                false,
+                None,
+            ),
         };
     let context = query_context(runtime).await?;
     let work_item = view_for_record(runtime, &context, completed, true, None, None).await?;
-    let terminal_transition = continuation_resumed.is_some();
     let mut result = serde_json::to_value(
         WorkItemMutationResult::with_completion_transition(
             work_item,
@@ -124,10 +130,9 @@ pub(crate) async fn execute(
         }
     }
     let mut result = serialize_success(NAME, &result)?;
-    if terminal_transition {
-        result.should_sleep = true;
-        result.terminal_transition = true;
-    }
+    result.should_sleep = true;
+    result.terminal_transition = true;
+    result.prepared_work_item_completion = prepared.map(Box::new);
     Ok(result)
 }
 

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -322,7 +322,7 @@ async fn run_once_prefers_completed_work_item_result_brief_over_latest_turn_text
     );
     assert_eq!(
         second.raw_final_text.as_deref(),
-        Some("Implemented broad prompt/context snapshot coverage")
+        Some("Fixed two test annotation issues.")
     );
     let runtime = host
         .get_public_agent_for_external_ingress("default")

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -322,7 +322,7 @@ async fn run_once_prefers_completed_work_item_result_brief_over_latest_turn_text
     );
     assert_eq!(
         second.raw_final_text.as_deref(),
-        Some("Fixed two test annotation issues.")
+        Some("Implemented broad prompt/context snapshot coverage")
     );
     let runtime = host
         .get_public_agent_for_external_ingress("default")

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -628,7 +628,7 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
         .await?;
     runtime.pick_work_item(first.id.clone()).await?;
 
-    let pick: serde_json::Value = client
+    let pick_response = client
         .post(format!(
             "{base}/api/control/agents/default/work-items/{second_id}/pick",
             second_id = second.id
@@ -638,9 +638,13 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
             "authority_class": "integration_signal"
         }))
         .send()
-        .await?
-        .json()
         .await?;
+    let pick_status = pick_response.status();
+    let pick: serde_json::Value = pick_response.json().await?;
+    assert!(
+        pick_status.is_success(),
+        "pick request failed with {pick_status}: {pick}"
+    );
     assert_eq!(pick["current_work_item_id"], second.id);
     assert_eq!(pick["previous_work_item"]["id"], first.id);
     assert_eq!(
@@ -675,7 +679,7 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
     assert!(update["recheck_at"].is_string());
     assert_eq!(update["todo_list"].as_array().expect("todo array").len(), 2);
 
-    let complete: serde_json::Value = client
+    let complete_response = client
         .post(format!(
             "{base}/api/control/agents/default/work-items/{second_id}/complete",
             second_id = second.id
@@ -685,9 +689,13 @@ pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> 
             "authority_class": "integration_signal"
         }))
         .send()
-        .await?
-        .json()
         .await?;
+    let complete_status = complete_response.status();
+    let complete: serde_json::Value = complete_response.json().await?;
+    assert!(
+        complete_status.is_success(),
+        "complete request failed with {complete_status}: {complete}"
+    );
     assert_eq!(complete["id"], second.id);
     assert_eq!(complete["state"], "completed");
     assert!(complete.get("blocked_by").is_none());


### PR DESCRIPTION
## Summary

Introduces a single canonical `CompletionCommit` transaction that atomically commits the `CompleteWorkItem` tool execution, WorkItem state transition, result brief, terminal Turn record, queue claim, audit events, wait cancellation, and continuation resume/cancel through one shared WorkItem outcome planner.

## Problem (#2540)

When completing a child WorkItem and restoring a continuation, the legacy focus was restored but the canonical `WorkItemExecutionState` remained `Paused(yielded_to:...)`. The `CompleteWorkItem` tool persisted evidence incrementally instead of through a single canonical transaction, and a standalone Turn writer could accept a prepared completion it should reject.

## Changes

- **`PreparedWorkItemCompletion`**: The `CompleteWorkItem` tool now prepares a `PreparedWorkItemCompletion` holding all evidence (brief, WorkItem record, tool execution record, audit events, transcript entries, wait conditions, continuations). This evidence is committed atomically in `commit_queue_with_completion`.
- **Execution protocol commands**: New `CompleteWorkItemExecution` and `ResumeWorkItemContinuation` commands for canonical execution protocol transitions, derived from the prepared completion through `execution_protocol_completion_transition_from_prepared`.
- **Shared outcome planner**: Completion uses the same WorkItem outcome planner as ordinary settlement, ensuring `WorkItemExecutionState` transitions to `Terminal` canonically.
- **Standalone writer rejection**: A standalone Turn writer must reject a prepared completion; `persist_terminal_transition` asserts no prepared completion is present.
- **Committed replay idempotency**: Replaying the same completion command does not duplicate Turn, queue, audit, brief, tool, or index-outbox facts.
- **Legacy compatibility**: The direct-finalizer path (`finalize_work_item_completion_with_brief_mode`) is preserved for non-canonical scheduler engines.
- **RFCs**: Updated `scheduler-work-item-unified-execution-protocol`, `turn-based-context-projection`, and `work-item-continuation-stack`.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- Full test suite: 1 pre-existing flaky test (`sleep_only_completion_keeps_last_assistant_message_from_previous_round`) fails under parallel load due to 3s `eventually` timeout; passes in isolation with `--test-threads=1`
- New tests for canonical completion lifecycle, standalone writer rejection, committed replay idempotency, and legacy compatibility

Closes #2540