### PR TITLE
fix: support deferred completion reports

### DIFF
--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -257,6 +257,13 @@ queue terminal state, Turn terminal record, attempt outcome, owner state, and
 wait/continuation mutations commits. A terminal tool returns success only
 after that commit and then ends the provider/tool loop.
 
+`CompleteWorkItem` may first return a non-terminal `Deferred` receipt when a
+tool-only call must acquire its operator-facing report. This is not completion
+success and does not mutate the WorkItem lifecycle. The canonical tool evidence
+transition is `Deferred -> Success` inside `CompletionCommit`, or
+`Deferred -> Interrupted` inside any competing terminal Turn transaction.
+`Deferred` must never survive a terminal Turn.
+
 For `CompleteWorkItem`, this transaction is the `CompletionCommit`. It also
 binds the result brief, completes the legacy WorkItem, records the successful
 tool execution, cancels child waits, resumes or cancels the matching

--- a/docs/rfcs/turn-based-context-projection.md
+++ b/docs/rfcs/turn-based-context-projection.md
@@ -146,9 +146,12 @@ produce a completion-report brief, and that brief is simultaneously the
 canonical report stored on the completed WorkItem.
 
 `CompleteWorkItem` is both a WorkItem lifecycle boundary and a hard provider
-turn boundary:
+turn boundary once completion commits:
 
-- the provider/tool loop stops at the first successful `CompleteWorkItem`;
+- a call with a report candidate prepares completion immediately;
+- a tool-only call stops the current tool batch and enters a text-only,
+  turn-local report acquisition round;
+- the provider/tool loop stops when the completion commit succeeds;
 - tool calls after it in the same assistant response are not executed;
 - the completion report, WorkItem transition, waits, continuation, Turn
   terminal record, queue settlement, and canonical execution outcome commit in
@@ -158,7 +161,8 @@ turn boundary:
 The completion-report brief may also be the turn's operator-facing result. The
 runtime must not ask the model to restate it after commit.
 
-Completion report capture should be deterministic and local to the tool call.
+Completion report capture should be deterministic and local to the tool call or
+its typed follow-up request.
 For a response such as:
 
 ```text
@@ -170,6 +174,13 @@ tool call: some_other_tool()
 the report is bound to `A`, `some_other_tool` is not executed, and the Turn
 closes at the completion settlement. Completing another WorkItem requires a
 later activation with its own execution binding.
+
+For a tool-only call, the original `ToolExecutionRecord` remains `Deferred`
+until the bound report commits it as `Success`. If the Turn instead terminates
+because of cancellation, shutdown, runtime error, restart, or report-protocol
+abandonment, terminal settlement updates that same record to `Interrupted` in
+the terminal transaction. No terminal Turn may retain a deferred tool
+execution.
 
 ### 5.3 Link Operator Inputs And Briefs Through Turns
 

--- a/docs/rfcs/work-item-centered-agent-runtime.md
+++ b/docs/rfcs/work-item-centered-agent-runtime.md
@@ -22,9 +22,9 @@ The direction is:
   reactivation signals;
 - context compaction should preserve current WorkItem truth and compress older
   WorkItem history around completed reports and process notes;
-- a successful `CompleteWorkItem` should promote the same assistant round's
-  operator-facing completion report text into the canonical report for a
-  completed WorkItem.
+- a successful `CompleteWorkItem` should promote its bound operator-facing
+  completion report text into the canonical report for a completed WorkItem,
+  whether supplied before the tool call or in its typed follow-up round.
 
 This RFC is intentionally cross-cutting. It does not replace the lower-level
 RFCs for WorkItem schema, scheduler decisions, waiting intents, or context
@@ -168,9 +168,10 @@ future resumption.
 The final WorkItem completion report.
 
 The canonical source should be an explicit operator-facing assistant text block
-emitted in the same assistant round as a successful `CompleteWorkItem` call. The
-tool call marks the WorkItem completed; the same-round text is promoted by the
-runtime into the WorkItem result report and completion brief.
+bound to a `CompleteWorkItem` request. The runtime accepts either text
+immediately preceding the tool call or a text-only follow-up round requested by
+a tool-only call. In both cases the report is promoted only by the successful
+atomic completion commit.
 
 `CompleteWorkItem` should not require a duplicate `result_summary` argument in
 the target contract.
@@ -439,23 +440,27 @@ WorkItem mutations. They should capture:
 - scope changes.
 
 Most assistant messages remain process trace. A completion report is the
-exception: when an assistant round contains operator-facing report text
-immediately before `CompleteWorkItem` for the focused WorkItem, the runtime
-should bind that text into the atomic completion command as the canonical short
-answer for what the WorkItem accomplished.
+exception: the runtime binds either operator-facing report text immediately
+before `CompleteWorkItem` or the text-only response to a typed turn-local report
+request into the atomic completion command as the canonical short answer for
+what the WorkItem accomplished.
 
 The report promotion rules should be explicit:
 
-- the tool call must have a unique, non-empty immediately preceding report
-  candidate;
+- the report must be a unique, non-empty candidate from the same execution and
+  WorkItem binding;
+- a tool-only call may create a turn-local report request fenced by request id,
+  WorkItem revision, execution binding, and source tool call;
 - the text should be written as a final operator-facing report, not as a plan,
   progress note, or "I will complete this" preamble;
 - report persistence, binding, terminal lifecycle, and scheduling side effects
   commit atomically;
 - if completion succeeds with structured warnings, such as unfinished todos, the
   completion result must preserve or surface those warnings;
-- if a tool call has no unique report candidate, completion must fail without
-  mutating the WorkItem.
+- while a follow-up report is pending, the WorkItem remains open and the tool
+  execution remains `Deferred`;
+- a terminal Turn without a committed report must settle that deferred tool
+  execution to `Interrupted` in the same transaction.
 
 Other briefs may cite or render the promoted report, but should not compete with
 it as the durable source of truth.
@@ -494,15 +499,15 @@ default. It should preserve selected process notes and completed reports.
 ## Briefs And Operator Output
 
 The operator-visible completion brief for a WorkItem should be the promoted
-completion report text from the assistant round that successfully completed the
-WorkItem.
+completion report text that successfully completed the WorkItem, whether it
+preceded the tool call or arrived in the bound follow-up round.
 
 During execution, assistant messages can remain conversational process updates.
 The runtime should not require every assistant message to become a durable
 report.
 
-When a WorkItem completes with a same-round completion report candidate, the
-runtime should atomically persist:
+When a WorkItem completes with a bound completion report candidate, the runtime
+should atomically persist:
 
 - a `BriefRecord(kind=result, work_item_id=...)` using the report text;
 - any provider-neutral citations attached to that same report segment;
@@ -512,10 +517,12 @@ That delivery projection is terminal for the current turn. Normal turn-final
 brief generation should not emit a second user-facing result for the same
 completion report.
 
-If a WorkItem has no same-round report text, completion must fail with
-`missing_completion_report`. The runtime must not synthesize a generic result
+If the initial tool call has no report text, the runtime may request one
+text-only follow-up in the same Turn. It must not synthesize a generic result
 report from arbitrary runtime evidence or leave a persistent intermediate
-completion state.
+WorkItem completion state. Abandonment, interruption, restart, or binding
+failure leaves the WorkItem open and records the deferred tool execution as
+interrupted.
 
 ## Relationship To Other RFCs
 
@@ -644,10 +651,12 @@ be referenced, synced, displayed, or retained independently of their sources.
 The target `CompleteWorkItem` contract should not ask the model to pass
 `result_summary`.
 
-Instead, the agent should write the final completion report as assistant text in
-the same round immediately before calling `CompleteWorkItem`. The runtime should
-resolve that text as a completion-report candidate before mutation and include
-it in the atomic completion command.
+Instead, the agent should write the final completion report as assistant text.
+The preferred one-round form places it immediately before
+`CompleteWorkItem`. A tool-only call enters a typed turn-local acquisition
+protocol: the runtime returns an `awaiting_completion_report` result, accepts
+only final text from the bound follow-up round, and then includes that candidate
+in the same atomic completion command.
 
 This keeps the agent from writing the same result twice:
 
@@ -662,8 +671,10 @@ It also keeps responsibilities separated:
   result brief.
 
 Promotion should be conservative. Arbitrary assistant progress text must not
-become a result report just because the WorkItem was current. If there is no
-unique non-empty same-round report candidate, the WorkItem remains open.
+become a result report just because the WorkItem was current. Follow-up text
+must retain the original execution binding and expected WorkItem revision.
+Empty text or another tool call receives at most one corrective prompt; protocol
+abandonment leaves the WorkItem open.
 
 ### CompleteWorkItem With Unfinished Todos
 

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -595,16 +595,20 @@ Shape:
 The target tool contract should not ask the agent to duplicate the completion
 report in a tool argument.
 
-Before executing `CompleteWorkItem`, the runtime associates the immediately
-preceding same-round operator-facing text with that tool call. A unique,
-non-empty report candidate is required. The WorkItem terminal state, completion
-intent binding, result brief, focus/wait cleanup, and continuation effects are
-committed atomically as one `Open -> Completed` transition.
+Before committing `CompleteWorkItem`, the runtime requires a unique, non-empty
+operator-facing report candidate. It may come from immediately preceding
+same-round text or from a text-only follow-up round requested after a tool-only
+call. The WorkItem terminal state, completion intent binding, result brief,
+focus/wait cleanup, and continuation effects are committed atomically as one
+`Open -> Completed` transition.
 
-If the report candidate is missing or empty, the tool fails with
-`missing_completion_report` and the WorkItem remains open without completion
-side effects. The normal agent-tool path does not persist an intermediate
-`Completing` state.
+A tool-only call validates ownership, execution binding, and current WorkItem
+revision, then records an `awaiting_completion_report` request and a `Deferred`
+tool execution without changing the WorkItem lifecycle. The follow-up report is
+accepted only while those fences remain unchanged. If acquisition is abandoned
+or the Turn terminates first, the WorkItem remains open and the deferred tool
+execution becomes `Interrupted`; the normal agent-tool path does not persist an
+intermediate `Completing` state.
 
 When completion succeeds, the runtime promotes the report text into the
 WorkItem completion brief.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -8210,8 +8210,10 @@
           "output": true,
           "status": {
             "enum": [
+              "deferred",
               "success",
-              "error"
+              "error",
+              "interrupted"
             ],
             "type": "string"
           },

--- a/docs/website/reference/runtime-status-enum-inventory.json
+++ b/docs/website/reference/runtime-status-enum-inventory.json
@@ -92,6 +92,7 @@
     {
       "name": "ToolResultStatus",
       "serialized_values": [
+        "deferred",
         "success",
         "error"
       ],

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -138,7 +138,7 @@ current WorkItem is the focus for the current turn:
 | `PickWorkItem` | Set current focus to an existing open WorkItem; optionally clear a resolved blocker |
 | `GetWorkItem` | Read a single WorkItem with plan preview |
 | `ListWorkItems` | Query with filters: all, open, completed, current, queued, blocked, waiting_for_operator, runnable |
-| `CompleteWorkItem` | Mark complete; same-round assistant text is promoted as the completion report |
+| `CompleteWorkItem` | Mark complete; bound assistant text is promoted as the completion report |
 | `WaitFor` | Attach a task, external, or operator wait to the current WorkItem and yield |
 
 **Key contract:**
@@ -155,14 +155,17 @@ current WorkItem is the focus for the current turn:
   `PickWorkItem(clear_blocker=true, reason=...)` only after confirming the
   blocker is resolved; this clears `blocked_by`, fallback recheck fields, and
   active WorkItem-scoped waits.
-- `CompleteWorkItem` promotion: the operator-facing completion report must be
-  written immediately before the tool call as assistant text **in the same
-  round**. The runtime requires that report before mutation and atomically
-  commits the `Open -> Completed` transition, canonical result brief, focus and
-  wait cleanup, and continuation effects.
-- If the same-round completion report is missing or empty,
-  `CompleteWorkItem` fails with `missing_completion_report`; the WorkItem stays
-  open and retains its focus, waits, and continuation state.
+- `CompleteWorkItem` promotion: the operator-facing completion report can be
+  written immediately before the tool call in the same assistant round. A
+  tool-only call instead returns an `awaiting_completion_report` receipt and
+  requests one text-only follow-up round.
+- The runtime binds a non-empty report to the same execution, WorkItem revision,
+  completion request, and source tool call before atomically committing the
+  `Open -> Completed` transition, canonical result brief, focus and wait
+  cleanup, and continuation effects.
+- While a follow-up report is pending, the WorkItem remains open and the tool
+  execution is `Deferred`. If the Turn terminates or the report protocol is
+  abandoned, that execution becomes `Interrupted` in the terminal transaction.
 - New agent-tool completions do not create the legacy `Completing` state.
   Existing `Completing` records can still be finalized through the control
   completion API.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -2471,8 +2471,10 @@ fn tool_execution_rollup_ref(record: &ToolExecutionRecord) -> String {
 
 fn status_label(status: &ToolExecutionStatus) -> &'static str {
     match status {
+        ToolExecutionStatus::Deferred => "deferred",
         ToolExecutionStatus::Success => "success",
         ToolExecutionStatus::Error => "error",
+        ToolExecutionStatus::Interrupted => "interrupted",
     }
 }
 

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -40,6 +40,10 @@ pub fn tool_execution_id() -> String {
     runtime_id("tool")
 }
 
+pub fn completion_report_request_id() -> String {
+    runtime_id("completion")
+}
+
 /// Derive a workspace ID deterministically from a (normalized) anchor path.
 /// Same path always produces the same ID, preventing stale-ID accumulation.
 pub fn deterministic_workspace_id(anchor: &Path) -> String {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4259,6 +4259,7 @@ impl RuntimeHandle {
                 agent_id: terminal_transition.turn_record.agent_id.clone(),
                 agent_state,
                 turn_record: terminal_transition.turn_record.clone(),
+                terminal_tool_executions: terminal_transition.terminal_tool_executions.clone(),
                 audit_events: transition_audit_events,
                 fault: self.take_transition_fault(),
             };
@@ -4489,6 +4490,19 @@ impl RuntimeHandle {
                             tool_execution,
                             index_changes: prepared.index_changes.clone(),
                         },
+                    )
+            } else if terminal_transition
+                .is_some_and(|transition| !transition.terminal_tool_executions.is_empty())
+            {
+                self.inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_execution_protocol_and_terminal_tool_executions(
+                        &command,
+                        &execution_protocol,
+                        &terminal_transition
+                            .expect("terminal tool executions require a terminal transition")
+                            .terminal_tool_executions,
                     )
             } else {
                 self.inner
@@ -4926,6 +4940,7 @@ impl RuntimeHandle {
                         terminal,
                         turn_record,
                         prepared_work_item_completion: None,
+                        terminal_tool_executions: Vec::new(),
                     };
                     let committed_state = {
                         let guard = self.inner.agent.lock().await;

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -254,6 +254,7 @@ impl RuntimeHandle {
             terminal: outcome.terminal,
             turn_record,
             prepared_work_item_completion: outcome.prepared_work_item_completion,
+            terminal_tool_executions: outcome.terminal_tool_executions,
         })
     }
 

--- a/src/runtime/scheduler_acceptance.rs
+++ b/src/runtime/scheduler_acceptance.rs
@@ -637,6 +637,7 @@ async fn seed_scheduler_waiting_work(
         terminal,
         turn_record,
         prepared_work_item_completion: None,
+        terminal_tool_executions: Vec::new(),
     };
     let task_id = format!("scheduler-restart-task-{agent_id}");
     let registration = runtime
@@ -827,6 +828,7 @@ async fn scheduler_acceptance_terminal_transition(
         terminal,
         turn_record,
         prepared_work_item_completion: None,
+        terminal_tool_executions: Vec::new(),
     })
 }
 

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3569,6 +3569,7 @@ impl RuntimeHandle {
         source_message_id: Option<String>,
         source_assistant_round_id: Option<String>,
         source_tool_call_id: Option<String>,
+        report_source: &'static str,
         warnings: Vec<serde_json::Value>,
     ) -> Result<Option<PreparedWorkItemCompletion>> {
         let agent_id = self.agent_id().await?;
@@ -3628,7 +3629,7 @@ impl RuntimeHandle {
                     "source_round": source_round,
                     "source_assistant_round_id": source_assistant_round_id,
                     "source_tool_call_id": source_tool_call_id,
-                    "source": "same_assistant_round_preceding_text",
+                    "source": report_source,
                     "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
                     "warnings": warnings.clone(),
                     "warning_count": warnings.len(),
@@ -3639,6 +3640,54 @@ impl RuntimeHandle {
             true,
         )
         .await
+    }
+
+    pub(crate) async fn validate_work_item_completion_request(
+        &self,
+        work_item_id: &str,
+        authority: &WorkItemCompletionAuthority,
+    ) -> Result<u64> {
+        let agent_id = self.agent_id().await?;
+        let existing = self.validate_owned_work_item(&agent_id, work_item_id)?;
+        if existing.state != WorkItemState::Open {
+            return Err(RuntimeError::new(
+                RuntimeErrorDomain::Conflict,
+                "work_item_completion_in_progress",
+                format!("work item {work_item_id} is not open"),
+            )
+            .with_safe_context("work_item_id", work_item_id)
+            .into());
+        }
+        let WorkItemCompletionAuthority::AgentExecution(binding) = authority else {
+            return Ok(existing.revision);
+        };
+        let mut brief = BriefRecord::new(
+            agent_id,
+            BriefKind::Result,
+            "completion report request validation",
+            None,
+            None,
+        );
+        brief.work_item_id = Some(existing.id.clone());
+        brief.workspace_id = existing.workspace_id.clone();
+        brief.turn_id = Some(binding.turn_id.clone());
+        brief.related_message_id = Some(binding.source_message_id.clone());
+        self.plan_work_item_completion_with_brief_mode(
+            work_item_id,
+            Some(authority),
+            &brief,
+            AuditEvent::legacy(
+                "work_item_completion_request_validated",
+                serde_json::json!({
+                    "agent_id": brief.agent_id,
+                    "work_item_id": work_item_id,
+                }),
+            ),
+            true,
+            false,
+        )
+        .await?;
+        Ok(existing.revision)
     }
 
     pub(super) async fn promote_work_item_completion_report_with_metadata(

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -128,6 +128,7 @@ pub(crate) fn terminal_transition(
         terminal,
         turn_record,
         prepared_work_item_completion: None,
+        terminal_tool_executions: Vec::new(),
     }
 }
 

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -106,6 +106,40 @@ impl AgentProvider for CompleteWorkItemReportProvider {
     }
 }
 
+struct AbandonCompletionReportProvider {
+    work_item_id: String,
+    calls: Mutex<usize>,
+}
+
+#[async_trait]
+impl AgentProvider for AbandonCompletionReportProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        if *calls >= 3 {
+            drop(calls);
+            return std::future::pending::<Result<ProviderTurnResponse>>().await;
+        }
+        *calls += 1;
+        Ok(ProviderTurnResponse {
+            blocks: vec![ModelBlock::ToolUse {
+                id: format!("complete-work-{}", *calls),
+                name: "CompleteWorkItem".into(),
+                input: serde_json::json!({
+                    "work_item_id": self.work_item_id.clone()
+                }),
+                kind: crate::provider::ModelToolCallKind::Function,
+            }],
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 10,
+            cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
 struct CompleteThenExecProvider {
     work_item_id: String,
     calls: Mutex<usize>,
@@ -170,15 +204,12 @@ impl AgentProvider for StaleTextThenCompleteProvider {
         let blocks = if *calls == 1 {
             vec![
                 ModelBlock::Text {
-                    text: "This text belongs to the ExecCommand tool call.".into(),
+                    text: "This text belongs to the AgentGet tool call.".into(),
                 },
                 ModelBlock::ToolUse {
                     id: "inspect".into(),
-                    name: "ExecCommand".into(),
-                    input: serde_json::json!({
-                        "cmd": "printf 'inspected'",
-                        "shell": "sh"
-                    }),
+                    name: "AgentGet".into(),
+                    input: serde_json::json!({}),
                     kind: crate::provider::ModelToolCallKind::Function,
                 },
                 ModelBlock::ToolUse {
@@ -192,7 +223,7 @@ impl AgentProvider for StaleTextThenCompleteProvider {
             ]
         } else {
             vec![ModelBlock::Text {
-                text: "No completion report was provided.".into(),
+                text: "Completed after inspection.".into(),
             }]
         };
         Ok(ProviderTurnResponse {
@@ -2783,7 +2814,7 @@ async fn completion_retry_rejects_replaced_execution_binding() {
 }
 
 #[tokio::test]
-async fn later_final_report_does_not_complete_after_missing_same_round_report() {
+async fn followup_final_report_completes_child_and_resumes_caller() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let seed_runtime = RuntimeHandle::new(
@@ -2833,58 +2864,93 @@ async fn later_final_report_does_not_complete_after_missing_same_round_report() 
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
         "http://127.0.0.1:7878".into(),
-        provider,
+        provider.clone(),
         "default".into(),
         continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "complete the child and return to the caller".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(completed_work.id.clone());
 
-    runtime
-        .process_interactive_message(
-            &message,
-            None,
-            LoopControlOptions {
-                max_tool_rounds: None,
-            },
-        )
-        .await
-        .unwrap();
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            let completed = runtime
+                .latest_work_item(&completed_work.id)
+                .await
+                .unwrap()
+                .is_some_and(|record| record.state == WorkItemState::Completed);
+            let caller_resumed = runtime
+                .agent_state()
+                .await
+                .unwrap()
+                .current_work_item_id
+                .as_deref()
+                == Some(caller.id.as_str());
+            if completed && caller_resumed {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before follow-up completion resumed the caller: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for follow-up completion and continuation resume");
+    runtime_task.abort();
 
-    let incomplete = runtime
+    assert!(
+        *provider.calls.lock().await >= 2,
+        "completion report handshake requires a follow-up provider round"
+    );
+    let completed = runtime
         .latest_work_item(&completed_work.id)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(incomplete.state, WorkItemState::Open);
-    assert!(incomplete.result_brief_id.is_none());
-    assert!(incomplete.completion_intent.is_none());
+    assert_eq!(completed.state, WorkItemState::Completed);
+    assert!(completed.result_brief_id.is_some());
+    assert!(completed.completion_intent.is_some());
     let state = runtime.agent_state().await.unwrap();
     assert_eq!(
         state.current_work_item_id.as_deref(),
-        Some(completed_work.id.as_str())
+        Some(caller.id.as_str())
     );
     assert_eq!(
         state.current_turn_work_item_id.as_deref(),
-        Some(completed_work.id.as_str())
+        Some(caller.id.as_str())
     );
     let continuations = runtime.storage().latest_work_item_continuations().unwrap();
     assert!(
         continuations.iter().any(|frame| {
             frame.suspended_work_item_id == caller.id
                 && frame.active_work_item_id == completed_work.id
-                && frame.state == WorkItemContinuationState::Active
+                && frame.state == WorkItemContinuationState::Resumed
         }),
-        "failed completion must preserve the active continuation"
+        "follow-up completion must resume the active continuation"
     );
 
     let restarted = RuntimeHandle::new(
@@ -2897,14 +2963,22 @@ async fn later_final_report_does_not_complete_after_missing_same_round_report() 
         context_config(),
     )
     .unwrap();
-    let restarted_incomplete = restarted
+    let restarted_completed = restarted
         .latest_work_item(&completed_work.id)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(restarted_incomplete.state, WorkItemState::Open);
-    assert!(restarted_incomplete.result_brief_id.is_none());
-    assert!(restarted_incomplete.completion_intent.is_none());
+    assert_eq!(restarted_completed.state, WorkItemState::Completed);
+    assert!(restarted_completed.result_brief_id.is_some());
+    assert_eq!(
+        restarted
+            .agent_state()
+            .await
+            .unwrap()
+            .current_work_item_id
+            .as_deref(),
+        Some(caller.id.as_str())
+    );
 }
 
 #[tokio::test]
@@ -3194,7 +3268,7 @@ async fn complete_work_item_followed_by_same_round_tool_keeps_terminal_brief() {
 }
 
 #[tokio::test]
-async fn complete_work_item_rejects_text_before_other_tool() {
+async fn complete_work_item_uses_followup_report_after_text_before_other_tool() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let seed_runtime = RuntimeHandle::new(
@@ -3225,54 +3299,87 @@ async fn complete_work_item_rejects_text_before_other_tool() {
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
         "http://127.0.0.1:7878".into(),
-        provider,
+        provider.clone(),
         "default".into(),
         continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "inspect then complete".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(work_item.id.clone());
 
-    runtime
-        .process_interactive_message(
-            &message,
-            None,
-            LoopControlOptions {
-                max_tool_rounds: None,
-            },
-        )
-        .await
-        .unwrap();
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    let completion = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            if runtime
+                .latest_work_item(&work_item.id)
+                .await
+                .unwrap()
+                .is_some_and(|record| record.state == WorkItemState::Completed)
+            {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before follow-up completion commit: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    if completion.is_err() {
+        let calls = *provider.calls.lock().await;
+        let latest = runtime.latest_work_item(&work_item.id).await.unwrap();
+        let event_kinds = runtime
+            .storage()
+            .read_recent_events(50)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.kind)
+            .collect::<Vec<_>>();
+        panic!(
+            "timed out waiting for follow-up completion commit: calls={calls}, latest={latest:?}, events={event_kinds:?}"
+        );
+    }
+    runtime_task.abort();
 
-    let incomplete = runtime
+    let completed = runtime
         .latest_work_item(&work_item.id)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(incomplete.state, WorkItemState::Open);
-    assert_eq!(incomplete.result_summary, None);
-    assert_eq!(
-        runtime
-            .agent_state()
-            .await
-            .unwrap()
-            .current_work_item_id
-            .as_deref(),
-        Some(work_item.id.as_str())
-    );
-    assert!(runtime
-        .storage()
-        .latest_delivery_summary(&work_item.id)
-        .unwrap()
-        .is_none());
+    assert_eq!(completed.state, WorkItemState::Completed);
+    let result_brief_id = completed
+        .result_brief_id
+        .as_deref()
+        .expect("follow-up report should create a result brief");
+    let briefs = runtime.recent_briefs(10).await.unwrap();
+    assert!(briefs.iter().any(|brief| {
+        brief.id == result_brief_id && brief.text == "Completed after inspection."
+    }));
+    assert!(briefs
+        .iter()
+        .all(|brief| brief.text != "This text belongs to the AgentGet tool call."));
     let transcript = runtime.storage().read_recent_transcript(10).unwrap();
     let tool_results = transcript
         .iter()
@@ -3296,8 +3403,8 @@ async fn complete_work_item_rejects_text_before_other_tool() {
         .expect("provider_visible_text");
     let content_json: serde_json::Value = serde_json::from_str(content).unwrap();
     assert_eq!(
-        content_json["kind"].as_str(),
-        Some("missing_completion_report")
+        content_json["result"]["disposition"].as_str(),
+        Some("awaiting_completion_report")
     );
 }
 
@@ -3423,7 +3530,7 @@ async fn promoted_completion_report_resumes_next_queued_work_item_via_system_tic
 }
 
 #[tokio::test]
-async fn complete_work_item_without_same_round_report_fails_without_mutation() {
+async fn complete_work_item_without_same_round_report_uses_followup_final_text() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let seed_runtime = RuntimeHandle::new(
@@ -3457,53 +3564,101 @@ async fn complete_work_item_without_same_round_report_fails_without_mutation() {
         "http://127.0.0.1:7878".into(),
         provider.clone(),
         "default".into(),
-        context_config(),
+        continuation_context_config(),
     )
     .unwrap();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
         AuthorityClass::OperatorInstruction,
         Priority::Normal,
         MessageBody::Text {
             text: "finish the tracked work".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
     );
+    message.work_item_id = Some(work_item.id.clone());
 
-    runtime
-        .process_interactive_message(
-            &message,
-            None,
-            LoopControlOptions {
-                max_tool_rounds: None,
-            },
-        )
-        .await
-        .unwrap();
-    let incomplete = runtime
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    let completion = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if runtime
+                .latest_work_item(&work_item.id)
+                .await
+                .unwrap()
+                .is_some_and(|record| record.state == WorkItemState::Completed)
+            {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before follow-up completion commit: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    if completion.is_err() {
+        let calls = *provider.calls.lock().await;
+        let latest = runtime.latest_work_item(&work_item.id).await.unwrap();
+        let event_kinds = runtime
+            .storage()
+            .read_recent_events(50)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.kind)
+            .collect::<Vec<_>>();
+        panic!(
+            "timed out waiting for follow-up completion commit: calls={calls}, latest={latest:?}, events={event_kinds:?}"
+        );
+    }
+
+    assert_eq!(
+        *provider.calls.lock().await,
+        2,
+        "tool-only completion should request one follow-up text round"
+    );
+    let completed = runtime
         .latest_work_item(&work_item.id)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(incomplete.state, WorkItemState::Open);
-    assert_eq!(incomplete.result_summary, None);
-    assert!(incomplete.completion_intent.is_none());
-    assert!(incomplete.result_brief_id.is_none());
+    assert_eq!(completed.state, WorkItemState::Completed);
+    let result_brief_id = completed
+        .result_brief_id
+        .as_deref()
+        .expect("follow-up report should create a result brief");
+    let briefs = runtime.recent_briefs(10).await.unwrap();
+    let result_briefs = briefs
+        .iter()
+        .filter(|brief| brief.kind == BriefKind::Result && brief.text == "done")
+        .collect::<Vec<_>>();
+    assert_eq!(result_briefs.len(), 1);
+    assert_eq!(result_briefs[0].id, result_brief_id);
+
+    let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
+    let completion_tools = tools
+        .iter()
+        .filter(|tool| tool.tool_name == "CompleteWorkItem")
+        .collect::<Vec<_>>();
+    assert_eq!(completion_tools.len(), 1);
     assert_eq!(
-        runtime
-            .agent_state()
-            .await
-            .unwrap()
-            .current_work_item_id
-            .as_deref(),
-        Some(work_item.id.as_str())
+        completion_tools[0].status,
+        crate::types::ToolExecutionStatus::Success
     );
-    assert!(runtime
-        .storage()
-        .latest_delivery_summary(&work_item.id)
-        .unwrap()
-        .is_none());
+
     let transcript = runtime.storage().read_recent_transcript(10).unwrap();
     let tool_results = transcript
         .iter()
@@ -3521,18 +3676,193 @@ async fn complete_work_item_without_same_round_report_fails_without_mutation() {
         .expect("provider_visible_text");
     let tool_result: serde_json::Value = serde_json::from_str(content).unwrap();
     assert_eq!(
-        tool_result["kind"].as_str(),
-        Some("missing_completion_report")
+        tool_result["result"]["disposition"].as_str(),
+        Some("awaiting_completion_report")
     );
-    let events = runtime.storage().read_recent_events(20).unwrap();
-    assert!(events.iter().all(|event| {
-        event.kind != "work_item_completion_warning"
-            && !(event.kind == "work_item_written"
-                && matches!(
-                    event.data["action"].as_str(),
-                    Some("completing" | "completed")
-                ))
-    }));
+    let events = runtime.storage().read_recent_events(200).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "completion_report_request_created"));
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "completion_report_request_completed"));
+    assert!(events
+        .iter()
+        .all(|event| event.kind != "tool_execution_failed"));
+    runtime_task.abort();
+}
+
+#[tokio::test]
+async fn abandoned_completion_report_protocol_interrupts_deferred_tool_atomically() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = seed_runtime
+        .create_work_item(
+            "abandon completion report protocol".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(work_item.id.clone())
+        .await
+        .unwrap();
+
+    let provider = Arc::new(AbandonCompletionReportProvider {
+        work_item_id: work_item.id.clone(),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "finish the tracked work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    let abandonment = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            let interrupted_tool_id = runtime
+                .storage()
+                .read_recent_tool_executions(10)
+                .unwrap()
+                .into_iter()
+                .find(|tool| {
+                    tool.tool_name == "CompleteWorkItem"
+                        && tool.status == crate::types::ToolExecutionStatus::Interrupted
+                })
+                .map(|tool| tool.id);
+            let terminal_projected = interrupted_tool_id.is_some_and(|tool_id| {
+                runtime
+                    .storage()
+                    .read_recent_turns(10)
+                    .unwrap()
+                    .iter()
+                    .any(|turn| {
+                        turn.tool_execution_ids.contains(&tool_id)
+                            && turn
+                                .terminal
+                                .as_ref()
+                                .is_some_and(|terminal| terminal.kind == TurnTerminalKind::Aborted)
+                    })
+            });
+            if terminal_projected {
+                break;
+            }
+            assert!(
+                !runtime_task.is_finished(),
+                "runtime exited before the deferred completion tool and terminal were projected"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    if abandonment.is_err() {
+        let calls = *provider.calls.lock().await;
+        let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
+        let turns = runtime.storage().read_recent_turns(10).unwrap();
+        let state = runtime.agent_state().await.unwrap();
+        let events = runtime
+            .storage()
+            .read_recent_events(200)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.kind)
+            .collect::<Vec<_>>();
+        panic!(
+            "timed out waiting for completion report protocol abandonment: calls={calls}, tools={tools:?}, turns={turns:?}, terminal={:?}, events={events:?}, runtime_finished={}",
+            state.last_turn_terminal,
+            runtime_task.is_finished()
+        );
+    }
+
+    assert_eq!(*provider.calls.lock().await, 3);
+    let current = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(current.state, WorkItemState::Open);
+    assert!(current.result_brief_id.is_none());
+
+    let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
+    let completion_tools = tools
+        .iter()
+        .filter(|tool| tool.tool_name == "CompleteWorkItem")
+        .collect::<Vec<_>>();
+    assert_eq!(completion_tools.len(), 1);
+    assert_eq!(
+        completion_tools[0].status,
+        crate::types::ToolExecutionStatus::Interrupted
+    );
+    assert_eq!(
+        completion_tools[0].output["reason"],
+        "report_protocol_abandoned"
+    );
+    let completed_at = completion_tools[0]
+        .completed_at
+        .expect("interrupted execution must record completion time");
+    assert_eq!(
+        completion_tools[0].duration_ms,
+        completed_at
+            .signed_duration_since(completion_tools[0].created_at)
+            .num_milliseconds()
+            .max(0) as u64
+    );
+
+    let terminal = runtime
+        .storage()
+        .read_recent_turns(10)
+        .unwrap()
+        .into_iter()
+        .find(|turn| {
+            turn.tool_execution_ids.contains(&completion_tools[0].id) && turn.terminal.is_some()
+        })
+        .and_then(|turn| turn.terminal)
+        .expect("protocol abandonment must write a terminal Turn");
+    assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
+    let events = runtime.storage().read_recent_events(200).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "completion_report_request_abandoned"));
+    assert!(events
+        .iter()
+        .all(|event| event.kind != "tool_execution_failed"));
+    runtime_task.abort();
 }
 
 #[tokio::test]

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -140,6 +140,49 @@ impl AgentProvider for AbandonCompletionReportProvider {
     }
 }
 
+struct RevisionChangeCompletionReportProvider {
+    work_item_id: String,
+    calls: Mutex<usize>,
+    followup_started: Arc<tokio::sync::Notify>,
+    release_followup: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl AgentProvider for RevisionChangeCompletionReportProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        let call = *calls;
+        drop(calls);
+        let blocks = if call == 1 {
+            vec![ModelBlock::ToolUse {
+                id: "complete-work".into(),
+                name: "CompleteWorkItem".into(),
+                input: serde_json::json!({
+                    "work_item_id": self.work_item_id.clone()
+                }),
+                kind: crate::provider::ModelToolCallKind::Function,
+            }]
+        } else {
+            self.followup_started.notify_one();
+            self.release_followup.notified().await;
+            vec![ModelBlock::Text {
+                text: "This report arrived after the WorkItem changed.".into(),
+            }]
+        };
+        Ok(ProviderTurnResponse {
+            blocks,
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 10,
+            cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
 struct CompleteThenExecProvider {
     work_item_id: String,
     calls: Mutex<usize>,
@@ -3818,6 +3861,16 @@ async fn abandoned_completion_report_protocol_interrupts_deferred_tool_atomicall
         .unwrap();
     assert_eq!(current.state, WorkItemState::Open);
     assert!(current.result_brief_id.is_none());
+    assert!(current.completion_intent.is_none());
+    assert!(
+        runtime
+            .recent_briefs(10)
+            .await
+            .unwrap()
+            .iter()
+            .all(|brief| brief.kind != BriefKind::Result),
+        "abandoned completion report protocol must not create a result brief"
+    );
 
     let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
     let completion_tools = tools
@@ -3859,6 +3912,169 @@ async fn abandoned_completion_report_protocol_interrupts_deferred_tool_atomicall
     assert!(events
         .iter()
         .any(|event| event.kind == "completion_report_request_abandoned"));
+    assert!(events
+        .iter()
+        .all(|event| event.kind != "tool_execution_failed"));
+    runtime_task.abort();
+}
+
+#[tokio::test]
+async fn invalidated_completion_report_binding_interrupts_deferred_tool_atomically() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = seed_runtime
+        .create_work_item(
+            "invalidate completion report binding".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(work_item.id.clone())
+        .await
+        .unwrap();
+
+    let followup_started = Arc::new(tokio::sync::Notify::new());
+    let release_followup = Arc::new(tokio::sync::Notify::new());
+    let provider = Arc::new(RevisionChangeCompletionReportProvider {
+        work_item_id: work_item.id.clone(),
+        calls: Mutex::new(0),
+        followup_started: followup_started.clone(),
+        release_followup: release_followup.clone(),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "finish the tracked work".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        followup_started.notified(),
+    )
+    .await
+    .expect("follow-up completion report round should start");
+    runtime
+        .update_work_item_fields(
+            work_item.id.clone(),
+            Some("changed while awaiting completion report".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    release_followup.notify_one();
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            let interrupted_tool_id = runtime
+                .storage()
+                .read_recent_tool_executions(10)
+                .unwrap()
+                .into_iter()
+                .find(|tool| {
+                    tool.tool_name == "CompleteWorkItem"
+                        && tool.status == crate::types::ToolExecutionStatus::Interrupted
+                })
+                .map(|tool| tool.id);
+            if interrupted_tool_id.is_some_and(|tool_id| {
+                runtime
+                    .storage()
+                    .read_recent_turns(10)
+                    .unwrap()
+                    .iter()
+                    .any(|turn| {
+                        turn.tool_execution_ids.contains(&tool_id)
+                            && turn
+                                .terminal
+                                .as_ref()
+                                .is_some_and(|terminal| terminal.kind == TurnTerminalKind::Aborted)
+                    })
+            }) {
+                break;
+            }
+            assert!(
+                !runtime_task.is_finished(),
+                "runtime exited before invalidated completion report settlement"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("invalidated completion report should settle atomically");
+
+    let current = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(current.state, WorkItemState::Open);
+    assert!(current.result_brief_id.is_none());
+    assert!(current.completion_intent.is_none());
+    assert!(
+        runtime
+            .recent_briefs(10)
+            .await
+            .unwrap()
+            .iter()
+            .all(|brief| brief.kind != BriefKind::Result),
+        "invalidated completion report binding must not create a result brief"
+    );
+    let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
+    let completion_tool = tools
+        .iter()
+        .find(|tool| tool.tool_name == "CompleteWorkItem")
+        .expect("completion tool execution");
+    assert_eq!(
+        completion_tool.status,
+        crate::types::ToolExecutionStatus::Interrupted
+    );
+    assert_eq!(
+        completion_tool.output["reason"],
+        "work_item_revision_changed"
+    );
+    let events = runtime.storage().read_recent_events(200).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "completion_report_request_invalidated"));
     assert!(events
         .iter()
         .all(|event| event.kind != "tool_execution_failed"));

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -80,7 +80,7 @@ struct PendingCompletionReport {
     request_tool_call_id: String,
     tool_execution: ToolExecutionRecord,
     warnings: Vec<Value>,
-    corrective_retries: usize,
+    corrective_retry_attempted: bool,
 }
 
 impl TurnModelSelection {
@@ -1863,8 +1863,8 @@ impl TurnExecution<'_> {
                     } else {
                         "empty_completion_report"
                     };
-                    if pending.corrective_retries == 0 {
-                        pending.corrective_retries += 1;
+                    if !pending.corrective_retry_attempted {
+                        pending.corrective_retry_attempted = true;
                         let continuation_text = "Completion report expected. Reply with the final operator-facing completion report as text only. Do not call any tool.".to_string();
                         completed_rounds.push(TurnRoundRecord {
                             round,
@@ -2614,7 +2614,7 @@ impl TurnExecution<'_> {
                                 request_tool_call_id: tool_call_id.clone(),
                                 tool_execution: record.clone(),
                                 warnings: directive.warnings,
-                                corrective_retries: 0,
+                                corrective_retry_attempted: false,
                             });
                         }
                         if prepared_work_item_completion.is_none()

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -22,8 +22,9 @@ use crate::tool::{ToolCall, ToolError};
 use crate::types::{
     AdmissionContext, AssistantRoundPurpose, AuditEvent, AuthorityClass, Citation, MessageBody,
     MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
-    QueueEntryRecord, QueueEntryStatus, TokenUsage, ToolExecutionAuditEvent, TranscriptEntry,
-    TranscriptEntryKind, TurnTerminalKind, TurnTerminalRecord,
+    QueueEntryRecord, QueueEntryStatus, TokenUsage, ToolExecutionAuditEvent, ToolExecutionRecord,
+    ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, TurnTerminalKind,
+    TurnTerminalRecord, WorkItemExecutionBinding,
 };
 
 use super::checkpoint::{
@@ -66,6 +67,20 @@ enum OperatorInterjectionPlan {
         scenario_class: Option<crate::domain::scheduler::SchedulerScenarioClass>,
         effective_mode: crate::domain::scheduler::ScenarioMode,
     },
+}
+
+struct PendingCompletionReport {
+    request_id: String,
+    work_item_id: String,
+    expected_work_revision: u64,
+    execution_binding: WorkItemExecutionBinding,
+    request_turn_index: u64,
+    request_round: usize,
+    request_assistant_round_id: String,
+    request_tool_call_id: String,
+    tool_execution: ToolExecutionRecord,
+    warnings: Vec<Value>,
+    corrective_retries: usize,
 }
 
 impl TurnModelSelection {
@@ -151,6 +166,7 @@ impl RuntimeHandle {
             allow_sleep_runnable_work_override: false,
             terminal_kind: TurnTerminalKind::Aborted,
             prepared_work_item_completion: None,
+            terminal_tool_executions: Vec::new(),
         }))
     }
 
@@ -161,6 +177,26 @@ impl RuntimeHandle {
         duration_ms: u64,
         checkpoint_state: Option<&TurnLocalCheckpointState>,
         persist: bool,
+    ) -> Result<TurnTerminalRecord> {
+        self.persist_turn_terminal_record_with_tool_executions(
+            kind,
+            last_assistant_message,
+            duration_ms,
+            checkpoint_state,
+            persist,
+            Vec::new(),
+        )
+        .await
+    }
+
+    pub(super) async fn persist_turn_terminal_record_with_tool_executions(
+        &self,
+        kind: TurnTerminalKind,
+        last_assistant_message: Option<String>,
+        duration_ms: u64,
+        checkpoint_state: Option<&TurnLocalCheckpointState>,
+        persist: bool,
+        terminal_tool_executions: Vec<ToolExecutionRecord>,
     ) -> Result<TurnTerminalRecord> {
         let record = {
             let guard = self.inner.agent.lock().await;
@@ -192,6 +228,7 @@ impl RuntimeHandle {
                 turn_record: self.build_turn_record(&record).await?,
                 terminal: record.clone(),
                 prepared_work_item_completion: None,
+                terminal_tool_executions,
             };
             self.persist_terminal_transition(&transition).await?;
         }
@@ -347,6 +384,7 @@ impl RuntimeHandle {
             allow_sleep_runnable_work_override: false,
             terminal_kind,
             prepared_work_item_completion: None,
+            terminal_tool_executions: Vec::new(),
         }))
     }
     pub(super) async fn complete_turn_with_abort(
@@ -907,6 +945,7 @@ impl TurnExecution<'_> {
         let mut sleep_duration_ms = None;
         let mut completed_work_item_this_turn = false;
         let mut prepared_work_item_completion = None;
+        let mut pending_completion_report: Option<PendingCompletionReport> = None;
         let mut round = 0usize;
         let mut truncated_text_history = Vec::new();
         let mut truncated_citation_history = Vec::<Citation>::new();
@@ -1002,10 +1041,11 @@ impl TurnExecution<'_> {
                         allow_sleep_runnable_work_override: false,
                         terminal_kind: TurnTerminalKind::Aborted,
                         prepared_work_item_completion: None,
+                        terminal_tool_executions: Vec::new(),
                     });
                 }
             }
-            if round > 1 {
+            if round > 1 && pending_completion_report.is_none() {
                 runtime
                     .append_operator_interjections_to_last_round(
                         agent_id,
@@ -1322,6 +1362,7 @@ impl TurnExecution<'_> {
                                 allow_sleep_runnable_work_override: false,
                                 terminal_kind: TurnTerminalKind::BaselineOverBudget,
                                 prepared_work_item_completion: None,
+                                terminal_tool_executions: Vec::new(),
                             });
                         }
                     }
@@ -1761,6 +1802,214 @@ impl TurnExecution<'_> {
                 }),
             ))?;
 
+            if let Some(mut pending) = pending_completion_report.take() {
+                if !tool_calls.is_empty() || combined_text.trim().is_empty() {
+                    let reason = if !tool_calls.is_empty() {
+                        "tool_call_not_allowed"
+                    } else {
+                        "empty_completion_report"
+                    };
+                    if pending.corrective_retries == 0 {
+                        pending.corrective_retries += 1;
+                        let continuation_text = "Completion report expected. Reply with the final operator-facing completion report as text only. Do not call any tool.".to_string();
+                        completed_rounds.push(TurnRoundRecord {
+                            round,
+                            estimated_tokens: build_round_estimated_tokens(
+                                &completed_round_assistant_blocks,
+                                &[],
+                                std::slice::from_ref(&continuation_text),
+                            ),
+                            assistant_blocks: completed_round_assistant_blocks,
+                            text_blocks,
+                            tool_calls: Vec::new(),
+                            tool_results: Vec::new(),
+                            tool_result_envelopes: Vec::new(),
+                            follow_up_user_texts: vec![continuation_text.clone()],
+                        });
+                        runtime.persist_transcript_evidence(&TranscriptEntry::new(
+                            agent_id.to_string(),
+                            TranscriptEntryKind::ContinuationPrompt,
+                            Some(round),
+                            None,
+                            serde_json::json!({
+                                "text": continuation_text,
+                                "reason": "completion_report_expected",
+                                "completion_request_id": pending.request_id,
+                            }),
+                        ))?;
+                        runtime.inner.storage.append_event(&AuditEvent::legacy(
+                            "completion_report_request_corrective_retry",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "completion_request_id": pending.request_id,
+                                "work_item_id": pending.work_item_id,
+                                "reason": reason,
+                            }),
+                        ))?;
+                        pending_completion_report = Some(pending);
+                        continue;
+                    }
+                    let completed_at = Utc::now();
+                    pending.tool_execution.status = ToolExecutionStatus::Interrupted;
+                    pending.tool_execution.completed_at = Some(completed_at);
+                    pending.tool_execution.duration_ms = completed_at
+                        .signed_duration_since(pending.tool_execution.created_at)
+                        .num_milliseconds()
+                        .max(0) as u64;
+                    pending.tool_execution.summary =
+                        "Interrupted: completion report protocol abandoned".into();
+                    pending.tool_execution.output = serde_json::json!({
+                        "disposition": "interrupted",
+                        "reason": "report_protocol_abandoned",
+                        "completion_request_id": pending.request_id,
+                    });
+                    runtime.inner.storage.append_event(&AuditEvent::legacy(
+                        "completion_report_request_abandoned",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "completion_request_id": pending.request_id,
+                            "work_item_id": pending.work_item_id,
+                            "reason": reason,
+                        }),
+                    ))?;
+                    let terminal = runtime
+                        .persist_turn_terminal_record_with_tool_executions(
+                            TurnTerminalKind::Aborted,
+                            last_assistant_message.clone(),
+                            turn_started_at.elapsed().as_millis() as u64,
+                            None,
+                            persist_terminal,
+                            vec![pending.tool_execution.clone()],
+                        )
+                        .await?;
+                    return Ok(AgentLoopOutcome {
+                        final_text: last_assistant_message.clone().unwrap_or_default(),
+                        final_citations: last_assistant_citations.clone(),
+                        final_text_source_assistant_round_id: last_assistant_round_id.clone(),
+                        turn_index: terminal.turn_index,
+                        terminal,
+                        should_sleep: false,
+                        sleep_duration_ms: None,
+                        allow_sleep_runnable_work_override: false,
+                        terminal_kind: TurnTerminalKind::Aborted,
+                        prepared_work_item_completion: None,
+                        terminal_tool_executions: vec![pending.tool_execution],
+                    });
+                }
+
+                let state = runtime.agent_state().await?;
+                anyhow::ensure!(
+                    state.current_execution_binding.as_ref() == Some(&pending.execution_binding),
+                    "completion report execution binding changed before commit"
+                );
+                let current = runtime
+                    .latest_work_item(&pending.work_item_id)
+                    .await?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "work item {} not found while binding completion report",
+                            pending.work_item_id
+                        )
+                    })?;
+                anyhow::ensure!(
+                    current.revision == pending.expected_work_revision,
+                    "completion report WorkItem revision changed before commit"
+                );
+                let candidate = crate::tool::spec::CompletionReportCandidate {
+                    text: combined_text.clone(),
+                    citations: citation_blocks.clone(),
+                    source_turn_index: turn_index,
+                    source_round: round,
+                    source_turn_id: Some(pending.execution_binding.turn_id.clone()),
+                    source_message_id: Some(pending.execution_binding.source_message_id.clone()),
+                    source_assistant_round_id: assistant_round_id.clone(),
+                    source_tool_call_id: pending.request_tool_call_id.clone(),
+                };
+                let warnings = pending
+                    .warnings
+                    .iter()
+                    .filter_map(|warning| serde_json::from_value(warning.clone()).ok())
+                    .collect::<Vec<_>>();
+                let mut result =
+                    crate::tool::tools::complete_work_item::complete_with_report_candidate(
+                        runtime,
+                        pending.work_item_id.clone(),
+                        crate::runtime::WorkItemCompletionAuthority::AgentExecution(
+                            pending.execution_binding.clone(),
+                        ),
+                        Some(&candidate),
+                        warnings,
+                        "followup_final_text",
+                    )
+                    .await?;
+                let result_envelope = result.envelope.clone();
+                let mut success_record = pending.tool_execution.clone();
+                let completed_at = Utc::now();
+                success_record.completed_at = Some(completed_at);
+                success_record.duration_ms = completed_at
+                    .signed_duration_since(success_record.created_at)
+                    .num_milliseconds()
+                    .max(0) as u64;
+                success_record.status = ToolExecutionStatus::Success;
+                success_record.output = serde_json::json!({
+                    "envelope": result_envelope,
+                    "is_error": false,
+                    "should_sleep": result.should_sleep,
+                    "sleep_duration_ms": result.sleep_duration_ms,
+                    "error": null,
+                    "completion_request_id": pending.request_id,
+                });
+                success_record.summary =
+                    crate::tool::summary::tool_result_summary(&result.envelope);
+                let mut prepared =
+                    result.prepared_work_item_completion.take().ok_or_else(|| {
+                        anyhow::anyhow!("follow-up completion did not prepare commit")
+                    })?;
+                prepared.tool_execution = Some(success_record);
+                prepared.audit_events.push(AuditEvent::legacy(
+                    "completion_report_request_completed",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "completion_request_id": pending.request_id,
+                        "work_item_id": pending.work_item_id,
+                        "request_turn_index": pending.request_turn_index,
+                        "request_round": pending.request_round,
+                        "request_assistant_round_id": pending.request_assistant_round_id,
+                        "report_assistant_round_id": assistant_round_id,
+                        "source": "followup_final_text",
+                    }),
+                ));
+                prepared_work_item_completion = Some(prepared);
+                let final_text = combined_text;
+                let terminal = TurnTerminalRecord {
+                    turn_id: state
+                        .current_turn_id
+                        .clone()
+                        .filter(|turn_id| !turn_id.trim().is_empty())
+                        .unwrap_or_else(crate::ids::turn_id),
+                    turn_index,
+                    kind: TurnTerminalKind::Completed,
+                    reason: None,
+                    last_assistant_message: Some(final_text.clone()),
+                    checkpoint: terminal_checkpoint_from_state(&checkpoint_state, turn_index),
+                    completed_at: Utc::now(),
+                    duration_ms: turn_started_at.elapsed().as_millis() as u64,
+                };
+                return Ok(AgentLoopOutcome {
+                    final_text,
+                    final_citations: citation_blocks,
+                    final_text_source_assistant_round_id: Some(assistant_round_id),
+                    turn_index,
+                    terminal,
+                    should_sleep: true,
+                    sleep_duration_ms: None,
+                    allow_sleep_runnable_work_override: true,
+                    terminal_kind: TurnTerminalKind::Completed,
+                    prepared_work_item_completion: prepared_work_item_completion.take(),
+                    terminal_tool_executions: Vec::new(),
+                });
+            }
+
             if tool_calls.is_empty() {
                 runtime.inner.storage.append_event(&AuditEvent::legacy(
                     "text_only_round_observed",
@@ -1960,6 +2209,7 @@ impl TurnExecution<'_> {
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
                     prepared_work_item_completion: prepared_work_item_completion.take(),
+                    terminal_tool_executions: Vec::new(),
                 });
             }
 
@@ -2192,6 +2442,7 @@ impl TurnExecution<'_> {
                     Ok((mut result, mut record)) => {
                         let result_content =
                             crate::tool::tools::render_tool_result_for_model(&result)?;
+                        let loop_directive = result.loop_directive.take();
                         let duration_ms = record.duration_ms;
                         let (turn_index, turn_id, run_id, current_work_item_id) = {
                             let guard = runtime.inner.agent.lock().await;
@@ -2275,6 +2526,47 @@ impl TurnExecution<'_> {
                             runtime.persist_tool_execution_evidence(&record)?;
                             runtime.inner.storage.append_event(&tool_executed_event)?;
                         }
+                        if let Some(crate::tool::spec::ToolLoopDirective::AwaitCompletionReport(
+                            directive,
+                        )) = loop_directive
+                        {
+                            let execution_binding = execution_binding.clone().ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "completion report request lost its execution binding"
+                                )
+                            })?;
+                            anyhow::ensure!(
+                                record.status == ToolExecutionStatus::Deferred,
+                                "completion report request must persist a deferred tool execution"
+                            );
+                            runtime.inner.storage.append_event(&AuditEvent::legacy(
+                                "completion_report_request_created",
+                                serde_json::json!({
+                                    "agent_id": agent_id,
+                                    "completion_request_id": directive.request_id,
+                                    "work_item_id": directive.work_item_id,
+                                    "expected_work_revision": directive.expected_work_revision,
+                                    "turn_index": turn_index,
+                                    "round": round,
+                                    "assistant_round_id": assistant_round_id,
+                                    "tool_call_id": tool_call_id,
+                                    "tool_execution_id": record.id,
+                                }),
+                            ))?;
+                            pending_completion_report = Some(PendingCompletionReport {
+                                request_id: directive.request_id,
+                                work_item_id: directive.work_item_id,
+                                expected_work_revision: directive.expected_work_revision,
+                                execution_binding,
+                                request_turn_index: turn_index,
+                                request_round: round,
+                                request_assistant_round_id: assistant_round_id.clone(),
+                                request_tool_call_id: tool_call_id.clone(),
+                                tool_execution: record.clone(),
+                                warnings: directive.warnings,
+                                corrective_retries: 0,
+                            });
+                        }
                         if prepared_work_item_completion.is_none()
                             && matches!(record.status, crate::types::ToolExecutionStatus::Success)
                         {
@@ -2288,11 +2580,14 @@ impl TurnExecution<'_> {
                         }
                         tool_result_envelopes.push(result.envelope.clone());
                         tool_results.push(ToolResultBlock {
-                            tool_use_id: tool_call_id,
+                            tool_use_id: tool_call_id.clone(),
                             content: result_content.clone(),
                             is_error: result.is_error(),
                             error: result.tool_error().cloned(),
                         });
+                        if pending_completion_report.is_some() {
+                            break;
+                        }
                         if result.terminal_transition || stops_tool_batch {
                             terminal_tool_transition = result.terminal_transition
                                 || tool_call_index + 1 < round_tool_calls.len();
@@ -2452,13 +2747,17 @@ impl TurnExecution<'_> {
             } else {
                 runtime.persist_transcript_evidence(&tool_results_transcript)?;
             }
-            let after_tool_results_interjections = runtime
-                .drain_operator_interjections(
-                    agent_id,
-                    round,
-                    scheduler::InterjectionBoundary::AfterToolResults,
-                )
-                .await?;
+            let after_tool_results_interjections = if pending_completion_report.is_some() {
+                Vec::new()
+            } else {
+                runtime
+                    .drain_operator_interjections(
+                        agent_id,
+                        round,
+                        scheduler::InterjectionBoundary::AfterToolResults,
+                    )
+                    .await?
+            };
             let mut interjections = before_tool_execution_interjections;
             interjections.extend(after_tool_results_interjections);
             let has_operator_interjections = !interjections.is_empty();
@@ -2528,6 +2827,7 @@ impl TurnExecution<'_> {
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
                     prepared_work_item_completion: prepared_work_item_completion.take(),
+                    terminal_tool_executions: Vec::new(),
                 });
             }
         }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -234,6 +234,56 @@ impl RuntimeHandle {
         }
         Ok(record)
     }
+
+    async fn interrupt_completion_report_protocol(
+        &self,
+        pending: &mut PendingCompletionReport,
+        reason: &str,
+        summary: &str,
+        last_assistant_message: Option<String>,
+        final_citations: Vec<Citation>,
+        final_text_source_assistant_round_id: Option<String>,
+        duration_ms: u64,
+        persist_terminal: bool,
+    ) -> Result<AgentLoopOutcome> {
+        let completed_at = Utc::now();
+        pending.tool_execution.status = ToolExecutionStatus::Interrupted;
+        pending.tool_execution.completed_at = Some(completed_at);
+        pending.tool_execution.duration_ms = completed_at
+            .signed_duration_since(pending.tool_execution.created_at)
+            .num_milliseconds()
+            .max(0) as u64;
+        pending.tool_execution.summary = summary.into();
+        pending.tool_execution.output = serde_json::json!({
+            "disposition": "interrupted",
+            "reason": reason,
+            "completion_request_id": pending.request_id,
+        });
+        let terminal = self
+            .persist_turn_terminal_record_with_tool_executions(
+                TurnTerminalKind::Aborted,
+                last_assistant_message.clone(),
+                duration_ms,
+                None,
+                persist_terminal,
+                vec![pending.tool_execution.clone()],
+            )
+            .await?;
+        Ok(AgentLoopOutcome {
+            final_text: last_assistant_message.unwrap_or_default(),
+            final_citations,
+            final_text_source_assistant_round_id,
+            turn_index: terminal.turn_index,
+            terminal,
+            should_sleep: false,
+            sleep_duration_ms: None,
+            allow_sleep_runnable_work_override: false,
+            terminal_kind: TurnTerminalKind::Aborted,
+            prepared_work_item_completion: None,
+            terminal_tool_executions: vec![pending.tool_execution.clone()],
+        })
+    }
+
     pub(super) async fn maybe_defer_provider_lineage_failure(
         &self,
         agent_id: &str,
@@ -1853,20 +1903,6 @@ impl TurnExecution<'_> {
                         pending_completion_report = Some(pending);
                         continue;
                     }
-                    let completed_at = Utc::now();
-                    pending.tool_execution.status = ToolExecutionStatus::Interrupted;
-                    pending.tool_execution.completed_at = Some(completed_at);
-                    pending.tool_execution.duration_ms = completed_at
-                        .signed_duration_since(pending.tool_execution.created_at)
-                        .num_milliseconds()
-                        .max(0) as u64;
-                    pending.tool_execution.summary =
-                        "Interrupted: completion report protocol abandoned".into();
-                    pending.tool_execution.output = serde_json::json!({
-                        "disposition": "interrupted",
-                        "reason": "report_protocol_abandoned",
-                        "completion_request_id": pending.request_id,
-                    });
                     runtime.inner.storage.append_event(&AuditEvent::legacy(
                         "completion_report_request_abandoned",
                         serde_json::json!({
@@ -1876,49 +1912,59 @@ impl TurnExecution<'_> {
                             "reason": reason,
                         }),
                     ))?;
-                    let terminal = runtime
-                        .persist_turn_terminal_record_with_tool_executions(
-                            TurnTerminalKind::Aborted,
+                    return runtime
+                        .interrupt_completion_report_protocol(
+                            &mut pending,
+                            "report_protocol_abandoned",
+                            "Interrupted: completion report protocol abandoned",
                             last_assistant_message.clone(),
+                            last_assistant_citations.clone(),
+                            last_assistant_round_id.clone(),
                             turn_started_at.elapsed().as_millis() as u64,
-                            None,
                             persist_terminal,
-                            vec![pending.tool_execution.clone()],
                         )
-                        .await?;
-                    return Ok(AgentLoopOutcome {
-                        final_text: last_assistant_message.clone().unwrap_or_default(),
-                        final_citations: last_assistant_citations.clone(),
-                        final_text_source_assistant_round_id: last_assistant_round_id.clone(),
-                        turn_index: terminal.turn_index,
-                        terminal,
-                        should_sleep: false,
-                        sleep_duration_ms: None,
-                        allow_sleep_runnable_work_override: false,
-                        terminal_kind: TurnTerminalKind::Aborted,
-                        prepared_work_item_completion: None,
-                        terminal_tool_executions: vec![pending.tool_execution],
-                    });
+                        .await;
                 }
 
                 let state = runtime.agent_state().await?;
-                anyhow::ensure!(
-                    state.current_execution_binding.as_ref() == Some(&pending.execution_binding),
-                    "completion report execution binding changed before commit"
-                );
-                let current = runtime
-                    .latest_work_item(&pending.work_item_id)
-                    .await?
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "work item {} not found while binding completion report",
-                            pending.work_item_id
+                let current = runtime.latest_work_item(&pending.work_item_id).await?;
+                let invalidation_reason = if state.current_execution_binding.as_ref()
+                    != Some(&pending.execution_binding)
+                {
+                    Some("execution_binding_changed")
+                } else if current.is_none() {
+                    Some("work_item_missing")
+                } else if current
+                    .as_ref()
+                    .is_some_and(|current| current.revision != pending.expected_work_revision)
+                {
+                    Some("work_item_revision_changed")
+                } else {
+                    None
+                };
+                if let Some(reason) = invalidation_reason {
+                    runtime.inner.storage.append_event(&AuditEvent::legacy(
+                        "completion_report_request_invalidated",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "completion_request_id": pending.request_id,
+                            "work_item_id": pending.work_item_id,
+                            "reason": reason,
+                        }),
+                    ))?;
+                    return runtime
+                        .interrupt_completion_report_protocol(
+                            &mut pending,
+                            reason,
+                            "Interrupted: completion report binding invalidated",
+                            last_assistant_message.clone(),
+                            last_assistant_citations.clone(),
+                            last_assistant_round_id.clone(),
+                            turn_started_at.elapsed().as_millis() as u64,
+                            persist_terminal,
                         )
-                    })?;
-                anyhow::ensure!(
-                    current.revision == pending.expected_work_revision,
-                    "completion report WorkItem revision changed before commit"
-                );
+                        .await;
+                }
                 let candidate = crate::tool::spec::CompletionReportCandidate {
                     text: combined_text.clone(),
                     citations: citation_blocks.clone(),

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -771,16 +771,18 @@ impl RuntimeHandle {
         loop_control: LoopControlOptions,
     ) -> Result<AgentLoopOutcome> {
         self.reconfigure_provider_for_turn(None).await?;
-        TurnExecution {
-            runtime: self,
-            agent_id,
-            authority_class,
-            effective_prompt,
-            model_selection: TurnModelSelection::default(),
-            loop_control,
-            persist_terminal: true,
-        }
-        .run()
+        Box::pin(
+            TurnExecution {
+                runtime: self,
+                agent_id,
+                authority_class,
+                effective_prompt,
+                model_selection: TurnModelSelection::default(),
+                loop_control,
+                persist_terminal: true,
+            }
+            .run(),
+        )
         .await
     }
 
@@ -792,16 +794,18 @@ impl RuntimeHandle {
         model_selection: TurnModelSelection,
         loop_control: LoopControlOptions,
     ) -> Result<AgentLoopOutcome> {
-        TurnExecution {
-            runtime: self,
-            agent_id,
-            authority_class,
-            effective_prompt,
-            model_selection,
-            loop_control,
-            persist_terminal: false,
-        }
-        .run()
+        Box::pin(
+            TurnExecution {
+                runtime: self,
+                agent_id,
+                authority_class,
+                effective_prompt,
+                model_selection,
+                loop_control,
+                persist_terminal: false,
+            }
+            .run(),
+        )
         .await
     }
 }

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -46,6 +46,7 @@ pub(crate) struct AgentLoopOutcome {
     pub(super) terminal_kind: TurnTerminalKind,
     pub(super) prepared_work_item_completion:
         Option<Box<crate::runtime::PreparedWorkItemCompletion>>,
+    pub(super) terminal_tool_executions: Vec<crate::types::ToolExecutionRecord>,
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +55,7 @@ pub(crate) struct TurnTerminalTransition {
     pub(super) turn_record: TurnRecord,
     pub(super) prepared_work_item_completion:
         Option<Box<crate::runtime::PreparedWorkItemCompletion>>,
+    pub(super) terminal_tool_executions: Vec<crate::types::ToolExecutionRecord>,
 }
 
 pub(crate) struct LoopControlOptions {
@@ -370,6 +372,7 @@ impl RuntimeHandle {
                 turn_record: self.build_turn_record(&record).await?,
                 terminal: record.clone(),
                 prepared_work_item_completion: None,
+                terminal_tool_executions: Vec::new(),
             };
             self.commit_terminal_transition(
                 &transition,

--- a/src/runtime/turn/tool_summary.rs
+++ b/src/runtime/turn/tool_summary.rs
@@ -16,6 +16,13 @@ use super::{TurnRoundRecord, RECAP_TEXT_PREVIEW_LIMIT};
 
 pub(super) fn summarize_tool_result_envelope(envelope: &ToolResultEnvelope) -> String {
     match envelope.status {
+        ToolResultStatus::Deferred => {
+            format!(
+                "{} deferred: {}",
+                envelope.tool_name,
+                tool_result_summary(envelope)
+            )
+        }
         ToolResultStatus::Error => {
             let error = envelope.error.as_ref();
             let kind = error

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -262,6 +262,7 @@ pub(crate) struct TurnTerminalTransitionCommand {
     pub agent_id: String,
     pub agent_state: AgentStateMutation,
     pub turn_record: TurnRecord,
+    pub terminal_tool_executions: Vec<ToolExecutionRecord>,
     pub audit_events: Vec<AuditEvent>,
     pub fault: Option<TransitionFaultPoint>,
 }
@@ -627,6 +628,11 @@ impl RuntimeTransitionRepository<'_> {
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_agent_state_mutation_tx(tx, Some(&command.agent_state))?;
+            validate_terminal_tool_execution_mutations_tx(
+                tx,
+                &command.agent_id,
+                &command.terminal_tool_executions,
+            )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
             let agent_state_applied =
@@ -647,11 +653,23 @@ impl RuntimeTransitionRepository<'_> {
                 .as_ref()
                 != Some(&command.turn_record);
             upsert_turn_record_tx(tx, &command.turn_record)?;
+            let mut terminal_tool_execution_applied = false;
+            for tool_execution in &command.terminal_tool_executions {
+                insert_tool_evidence_tx(tx, tool_execution)?;
+                terminal_tool_execution_applied = true;
+            }
+            terminal_tool_execution_applied |=
+                interrupt_deferred_tool_executions_for_terminal_turn_tx(
+                    tx,
+                    &command.agent_id,
+                    &command.turn_record,
+                )? > 0;
             inject_fault(
                 command.fault,
                 TransitionFaultPoint::AfterTerminalTurnRecordWrite,
             )?;
-            let applied = agent_state_applied || turn_record_applied;
+            let applied =
+                agent_state_applied || turn_record_applied || terminal_tool_execution_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
@@ -954,6 +972,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             None,
+            &[],
         )
     }
 
@@ -962,7 +981,24 @@ impl RuntimeTransitionRepository<'_> {
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
     ) -> Result<TransitionCommit> {
-        self.commit_queue_transaction(command, execution_protocol, None, None, None, None)
+        self.commit_queue_transaction(command, execution_protocol, None, None, None, None, &[])
+    }
+
+    pub fn commit_queue_with_execution_protocol_and_terminal_tool_executions(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        terminal_tool_executions: &[ToolExecutionRecord],
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_transaction(
+            command,
+            execution_protocol,
+            None,
+            None,
+            None,
+            None,
+            terminal_tool_executions,
+        )
     }
 
     pub fn commit_queue_with_wait_trigger(
@@ -977,6 +1013,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             None,
+            &[],
         )
     }
 
@@ -993,6 +1030,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             None,
+            &[],
         )
     }
 
@@ -1009,6 +1047,7 @@ impl RuntimeTransitionRepository<'_> {
             Some(task_expectation),
             None,
             None,
+            &[],
         )
     }
 
@@ -1025,6 +1064,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             Some(completion),
+            &[],
         )
     }
 
@@ -1041,6 +1081,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             Some(scheduler_protocol),
             None,
+            &[],
         )
     }
 
@@ -1052,6 +1093,7 @@ impl RuntimeTransitionRepository<'_> {
         task_expectation: Option<&TaskExpectation>,
         legacy_scheduler_protocol: Option<&LegacySchedulerProtocolTransition>,
         completion: Option<&CompletionTransition>,
+        terminal_tool_executions: &[ToolExecutionRecord],
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_queue_operation(command)?;
@@ -1084,6 +1126,11 @@ impl RuntimeTransitionRepository<'_> {
                     validate_work_item_continuation_tx(tx, continuation)?;
                 }
             }
+            validate_terminal_tool_execution_mutations_tx(
+                tx,
+                &command.agent_id,
+                terminal_tool_executions,
+            )?;
             if let QueueMutation::Consume(record) = &command.mutation {
                 let include_interrupted = match command.operation {
                     QueueOperation::Claim => true,
@@ -1254,11 +1301,29 @@ impl RuntimeTransitionRepository<'_> {
                     .map(|payload| serde_json::from_str::<ToolExecutionRecord>(&payload))
                     .transpose()?;
                 if let Some(existing) = existing_tool_execution {
-                    anyhow::ensure!(
-                        existing == completion.tool_execution,
-                        "conflicting CompleteWorkItem tool execution evidence for {}",
-                        completion.tool_execution.id
-                    );
+                    if existing != completion.tool_execution {
+                        anyhow::ensure!(
+                            existing.status == crate::types::ToolExecutionStatus::Deferred
+                                && completion.tool_execution.status
+                                    == crate::types::ToolExecutionStatus::Success
+                                && existing.agent_id == completion.tool_execution.agent_id
+                                && existing.work_item_id
+                                    == completion.tool_execution.work_item_id
+                                && existing.turn_index == completion.tool_execution.turn_index
+                                && existing.turn_id == completion.tool_execution.turn_id
+                                && existing.tool_name == completion.tool_execution.tool_name
+                                && existing.created_at == completion.tool_execution.created_at
+                                && existing.authority_class
+                                    == completion.tool_execution.authority_class
+                                && existing.input == completion.tool_execution.input
+                                && existing.invocation_surface
+                                    == completion.tool_execution.invocation_surface,
+                            "conflicting CompleteWorkItem tool execution evidence for {}",
+                            completion.tool_execution.id
+                        );
+                        insert_tool_evidence_tx(tx, &completion.tool_execution)?;
+                        applied = true;
+                    }
                 } else {
                     insert_tool_evidence_tx(tx, &completion.tool_execution)?;
                     applied = true;
@@ -1267,13 +1332,28 @@ impl RuntimeTransitionRepository<'_> {
             } else {
                 false
             };
+            let mut terminal_tool_execution_applied = false;
+            for tool_execution in terminal_tool_executions {
+                insert_tool_evidence_tx(tx, tool_execution)?;
+                terminal_tool_execution_applied = true;
+            }
+            if let Some(turn_record) = command.turn_record.as_ref() {
+                terminal_tool_execution_applied |=
+                    interrupt_deferred_tool_executions_for_terminal_turn_tx(
+                        tx,
+                        &command.agent_id,
+                        turn_record,
+                    )?
+                    > 0;
+            }
             let applied = mutation_applied
                 || agent_state_applied
                 || protocol_applied
                 || execution_protocol_applied
                 || wait_transition_applied
                 || wait_work_item_applied
-                || completion_applied;
+                || completion_applied
+                || terminal_tool_execution_applied;
             if !applied {
                 return Ok(TransitionCommit::default());
             }
@@ -1662,6 +1742,103 @@ fn validate_work_item_continuation_tx(
         }
     }
     Ok(())
+}
+
+fn validate_terminal_tool_execution_mutations_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    incoming: &[ToolExecutionRecord],
+) -> Result<()> {
+    for terminal in incoming {
+        anyhow::ensure!(
+            terminal.agent_id == agent_id
+                && terminal.status == crate::types::ToolExecutionStatus::Interrupted
+                && terminal.completed_at.is_some(),
+            "terminal tool execution mutation must be a completed interruption for the same agent"
+        );
+        let existing = tx
+            .query_row(
+                "SELECT payload_json FROM tool_executions WHERE evidence_id = ?1",
+                [&terminal.id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| serde_json::from_str::<ToolExecutionRecord>(&payload))
+            .transpose()?
+            .ok_or_else(|| anyhow!("deferred tool execution {} is missing", terminal.id))?;
+        anyhow::ensure!(
+            existing.status == crate::types::ToolExecutionStatus::Deferred
+                && existing.agent_id == terminal.agent_id
+                && existing.work_item_id == terminal.work_item_id
+                && existing.turn_index == terminal.turn_index
+                && existing.turn_id == terminal.turn_id
+                && existing.tool_name == terminal.tool_name
+                && existing.created_at == terminal.created_at
+                && existing.authority_class == terminal.authority_class
+                && existing.input == terminal.input
+                && existing.invocation_surface == terminal.invocation_surface,
+            "conflicting terminal tool execution mutation for {}",
+            terminal.id
+        );
+    }
+    Ok(())
+}
+
+fn interrupt_deferred_tool_executions_for_terminal_turn_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    turn_record: &TurnRecord,
+) -> Result<usize> {
+    let Some(terminal) = turn_record.terminal.as_ref() else {
+        return Ok(0);
+    };
+    let mut statement = tx.prepare(
+        "SELECT payload_json
+         FROM tool_executions
+         WHERE agent_id = ?1 AND turn_id = ?2
+         ORDER BY created_at, evidence_id",
+    )?;
+    let deferred = statement
+        .query_map(rusqlite::params![agent_id, turn_record.turn_id], |row| {
+            row.get::<_, String>(0)
+        })?
+        .map(|row| Ok(serde_json::from_str::<ToolExecutionRecord>(&row?)?))
+        .collect::<Result<Vec<_>>>()?;
+    drop(statement);
+
+    let reason = terminal
+        .reason
+        .as_deref()
+        .filter(|reason| !reason.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("turn_terminal_{:?}", terminal.kind).to_lowercase());
+    let mut interrupted = 0;
+    for mut record in deferred
+        .into_iter()
+        .filter(|record| record.status == crate::types::ToolExecutionStatus::Deferred)
+    {
+        let completion_request_id = record
+            .output
+            .pointer("/envelope/result/completion_request_id")
+            .cloned();
+        record.status = crate::types::ToolExecutionStatus::Interrupted;
+        record.completed_at = Some(terminal.completed_at);
+        record.duration_ms = terminal
+            .completed_at
+            .signed_duration_since(record.created_at)
+            .num_milliseconds()
+            .max(0) as u64;
+        record.summary = format!("Interrupted: {reason}");
+        record.output = serde_json::json!({
+            "disposition": "interrupted",
+            "reason": reason,
+            "turn_terminal_kind": terminal.kind,
+            "completion_request_id": completion_request_id,
+        });
+        insert_tool_evidence_tx(tx, &record)?;
+        interrupted += 1;
+    }
+    Ok(interrupted)
 }
 
 fn validate_completion_transition_tx(
@@ -2126,6 +2303,35 @@ mod tests {
         }
     }
 
+    fn deferred_completion_tool(
+        turn_id: &str,
+        created_at: chrono::DateTime<Utc>,
+    ) -> ToolExecutionRecord {
+        ToolExecutionRecord {
+            id: "tool-deferred-completion".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some("work-a".into()),
+            turn_index: 1,
+            turn_id: Some(turn_id.into()),
+            tool_name: crate::tool::names::COMPLETE_WORK_ITEM.into(),
+            created_at,
+            completed_at: None,
+            duration_ms: 1,
+            authority_class: AuthorityClass::RuntimeInstruction,
+            status: ToolExecutionStatus::Deferred,
+            input: serde_json::json!({"work_item_id": "work-a"}),
+            output: serde_json::json!({
+                "envelope": {
+                    "result": {
+                        "completion_request_id": "completion-request-a"
+                    }
+                }
+            }),
+            summary: "Awaiting the final operator-facing completion report.".into(),
+            invocation_surface: None,
+        }
+    }
+
     fn task(id: &str, status: TaskStatus) -> TaskRecord {
         let now = Utc::now();
         TaskRecord {
@@ -2570,6 +2776,150 @@ mod tests {
             assert!(db.transcript_entries().all(Some("agent-a"))?.is_empty());
             assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_terminal_settlement_interrupts_deferred_completion_tool_for_all_exit_reasons(
+    ) -> Result<()> {
+        for (case, reason, queue_status) in [
+            ("cancel", "operator_aborted", QueueEntryStatus::Interrupted),
+            ("shutdown", "daemon_shutdown", QueueEntryStatus::Interrupted),
+            ("runtime-error", "runtime_error", QueueEntryStatus::Aborted),
+            ("restart", "runtime_restart", QueueEntryStatus::Interrupted),
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let now = Utc::now();
+            let message_id = format!("message-deferred-completion-{case}");
+            let turn_id = format!("turn-deferred-completion-{case}");
+            let queued = QueueEntryRecord {
+                message_id,
+                agent_id: "agent-a".into(),
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Dequeued,
+                created_at: now,
+                updated_at: now,
+            };
+            db.queue_entries().upsert(&queued)?;
+            let deferred = deferred_completion_tool(&turn_id, now);
+            db.evidence().append_tool_execution(&deferred)?;
+            let terminal = crate::types::TurnTerminalRecord {
+                turn_id,
+                turn_index: 1,
+                kind: crate::types::TurnTerminalKind::Aborted,
+                reason: Some(reason.into()),
+                last_assistant_message: None,
+                checkpoint: None,
+                completed_at: now + chrono::Duration::seconds(2),
+                duration_ms: 2_000,
+            };
+            let mut turn = TurnRecord::new("agent-a", &terminal.turn_id, terminal.turn_index);
+            turn.tool_execution_ids = vec![deferred.id.clone()];
+            turn.terminal = Some(crate::types::TurnTerminalSummary::from_terminal(&terminal));
+            let mut settled_queue = queued;
+            settled_queue.status = queue_status;
+            settled_queue.updated_at = terminal.completed_at;
+
+            assert!(
+                db.transitions()
+                    .commit_queue_with_execution_protocol(
+                        &QueueTransitionCommand {
+                            agent_id: "agent-a".into(),
+                            operation: QueueOperation::Settle,
+                            mutation: QueueMutation::Upsert(settled_queue),
+                            scheduler_claim_work_item: None,
+                            agent_state: None,
+                            message_evidence: Vec::new(),
+                            transcript_entries: Vec::new(),
+                            turn_record: Some(turn),
+                            audit_events: Vec::new(),
+                            notify_scheduler: false,
+                            fault: None,
+                            brief_evidence: Vec::new(),
+                        },
+                        &ExecutionProtocolTransition::default(),
+                    )?
+                    .applied
+            );
+
+            let interrupted = db
+                .evidence()
+                .tool_execution_by_id("agent-a", &deferred.id)?
+                .expect("terminal settlement must retain the tool execution");
+            assert_eq!(interrupted.status, ToolExecutionStatus::Interrupted);
+            assert_eq!(interrupted.completed_at, Some(terminal.completed_at));
+            assert_eq!(interrupted.output["reason"], reason);
+            assert_eq!(
+                interrupted.output["completion_request_id"],
+                "completion-request-a"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_terminal_fault_rolls_back_deferred_tool_interruption() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-deferred-completion-fault".into(),
+            agent_id: "agent-a".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Dequeued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&queued)?;
+        let deferred = deferred_completion_tool("turn-deferred-completion-fault", now);
+        db.evidence().append_tool_execution(&deferred)?;
+        let terminal = crate::types::TurnTerminalRecord {
+            turn_id: "turn-deferred-completion-fault".into(),
+            turn_index: 1,
+            kind: crate::types::TurnTerminalKind::Aborted,
+            reason: Some("runtime_restart".into()),
+            last_assistant_message: None,
+            checkpoint: None,
+            completed_at: now + chrono::Duration::seconds(2),
+            duration_ms: 2_000,
+        };
+        let mut turn = TurnRecord::new("agent-a", &terminal.turn_id, terminal.turn_index);
+        turn.tool_execution_ids = vec![deferred.id.clone()];
+        turn.terminal = Some(crate::types::TurnTerminalSummary::from_terminal(&terminal));
+        let mut interrupted_queue = queued.clone();
+        interrupted_queue.status = QueueEntryStatus::Interrupted;
+        interrupted_queue.updated_at = terminal.completed_at;
+
+        db.transitions()
+            .commit_queue_with_execution_protocol(
+                &QueueTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    operation: QueueOperation::Settle,
+                    mutation: QueueMutation::Upsert(interrupted_queue),
+                    scheduler_claim_work_item: None,
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    turn_record: Some(turn),
+                    audit_events: Vec::new(),
+                    notify_scheduler: false,
+                    fault: Some(TransitionFaultPoint::AfterCanonicalWrites),
+                    brief_evidence: Vec::new(),
+                },
+                &ExecutionProtocolTransition::default(),
+            )
+            .unwrap_err();
+
+        assert_eq!(db.queue_entries().latest_all()?, vec![queued]);
+        assert_eq!(
+            db.evidence()
+                .tool_execution_by_id("agent-a", &deferred.id)?
+                .expect("deferred record must remain after rollback"),
+            deferred
+        );
+        assert!(db
+            .turn_records()
+            .recent_for_agent("agent-a", 10)?
+            .is_empty());
         Ok(())
     }
 

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -189,11 +189,16 @@ impl ToolRegistry {
             "sleep_duration_ms": result.sleep_duration_ms,
             "error": result.tool_error().cloned(),
         });
-        let completed_at = chrono::Utc::now();
-        let duration_ms = completed_at
+        let finished_at = chrono::Utc::now();
+        let duration_ms = finished_at
             .signed_duration_since(started_at)
             .num_milliseconds()
             .max(0) as u64;
+        let completed_at = (!matches!(
+            result.envelope.status,
+            crate::tool::spec::ToolResultStatus::Deferred
+        ))
+        .then_some(finished_at);
         let record = ToolExecutionRecord {
             id: crate::ids::tool_execution_id(),
             agent_id: agent_id.to_string(),
@@ -202,13 +207,13 @@ impl ToolRegistry {
             turn_id: None,
             tool_name: call.name.clone(),
             created_at: started_at,
-            completed_at: Some(completed_at),
+            completed_at,
             duration_ms,
             authority_class: authority_class.clone(),
-            status: if result.is_error() {
-                ToolExecutionStatus::Error
-            } else {
-                ToolExecutionStatus::Success
+            status: match result.envelope.status {
+                crate::tool::spec::ToolResultStatus::Deferred => ToolExecutionStatus::Deferred,
+                crate::tool::spec::ToolResultStatus::Success => ToolExecutionStatus::Success,
+                crate::tool::spec::ToolResultStatus::Error => ToolExecutionStatus::Error,
             },
             input: call.input.clone(),
             output: output_value,

--- a/src/tool/spec.rs
+++ b/src/tool/spec.rs
@@ -51,6 +51,19 @@ pub struct ToolExecutionContext {
     pub completion_report_candidate: Option<CompletionReportCandidate>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct AwaitCompletionReportDirective {
+    pub(crate) request_id: String,
+    pub(crate) work_item_id: String,
+    pub(crate) expected_work_revision: u64,
+    pub(crate) warnings: Vec<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ToolLoopDirective {
+    AwaitCompletionReport(AwaitCompletionReportDirective),
+}
+
 /// Result from executing a tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
@@ -63,11 +76,14 @@ pub struct ToolResult {
     #[serde(skip)]
     pub(crate) prepared_work_item_completion:
         Option<Box<crate::runtime::PreparedWorkItemCompletion>>,
+    #[serde(skip)]
+    pub(crate) loop_directive: Option<ToolLoopDirective>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolResultStatus {
+    Deferred,
     Success,
     Error,
 }
@@ -103,6 +119,7 @@ impl ToolResult {
             terminal_transition: false,
             sleep_duration_ms: None,
             prepared_work_item_completion: None,
+            loop_directive: None,
         }
     }
 
@@ -125,6 +142,30 @@ impl ToolResult {
             terminal_transition: false,
             sleep_duration_ms,
             prepared_work_item_completion: None,
+            loop_directive: None,
+        }
+    }
+
+    pub(crate) fn deferred(
+        tool_name: impl Into<String>,
+        result: Value,
+        summary_text: Option<String>,
+        directive: ToolLoopDirective,
+    ) -> Self {
+        let envelope = ToolResultEnvelope {
+            tool_name: tool_name.into(),
+            status: ToolResultStatus::Deferred,
+            summary_text,
+            result: Some(result),
+            error: None,
+        };
+        Self {
+            envelope,
+            should_sleep: false,
+            terminal_transition: false,
+            sleep_duration_ms: None,
+            prepared_work_item_completion: None,
+            loop_directive: Some(directive),
         }
     }
 
@@ -142,6 +183,7 @@ impl ToolResult {
             terminal_transition: false,
             sleep_duration_ms: None,
             prepared_work_item_completion: None,
+            loop_directive: None,
         }
     }
 

--- a/src/tool/summary.rs
+++ b/src/tool/summary.rs
@@ -12,6 +12,11 @@ const TOOL_RESULT_SUMMARY_LIMIT: usize = 200;
 
 pub(crate) fn tool_result_summary(envelope: &ToolResultEnvelope) -> String {
     let summary = match envelope.status {
+        ToolResultStatus::Deferred => envelope
+            .summary_text
+            .clone()
+            .or_else(|| summary_from_result_payload(envelope.result.as_ref()))
+            .unwrap_or_else(|| "deferred".into()),
         ToolResultStatus::Error => envelope
             .summary_text
             .clone()

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -7,8 +7,14 @@ use crate::{
     runtime::{RuntimeHandle, WorkItemCompletionAuthority},
     runtime_error::RuntimeError,
     tool::helpers::{parse_tool_args, validate_non_empty},
-    tool::spec::{typed_spec, ToolExecutionContext},
-    types::{AuthorityClass, TodoItem, TodoItemState, ToolCapabilityFamily, WorkItemRecord},
+    tool::spec::{
+        typed_spec, AwaitCompletionReportDirective, CompletionReportCandidate,
+        ToolExecutionContext, ToolLoopDirective,
+    },
+    types::{
+        AuthorityClass, TodoItem, TodoItemState, ToolCapabilityFamily, WorkItemRecord,
+        WorkItemState,
+    },
 };
 
 use super::{
@@ -26,7 +32,7 @@ pub(crate) struct CompleteWorkItemArgs {
     pub(crate) work_item_id: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct WorkItemCompletionWarning {
     pub(crate) kind: String,
     pub(crate) message: String,
@@ -59,7 +65,10 @@ pub(crate) async fn execute(
     let work_item_id = validate_non_empty(args.work_item_id, NAME, "work_item_id")?;
     let before = runtime.latest_work_item(&work_item_id).await?;
     let warnings = before.as_ref().map(completion_warnings).unwrap_or_default();
-    let candidate = context.completion_report_candidate.as_ref();
+    let candidate = context
+        .completion_report_candidate
+        .as_ref()
+        .filter(|candidate| !candidate.text.trim().is_empty());
     let execution_binding = runtime
         .agent_state()
         .await?
@@ -70,10 +79,58 @@ pub(crate) async fn execute(
                 "CompleteWorkItem requires an active agent execution binding",
             )
         })?;
+    let authority = WorkItemCompletionAuthority::AgentExecution(execution_binding);
+    if candidate.is_none()
+        && before
+            .as_ref()
+            .is_some_and(|record| record.state != WorkItemState::Completed)
+    {
+        let expected_work_revision = runtime
+            .validate_work_item_completion_request(&work_item_id, &authority)
+            .await?;
+        let request_id = crate::ids::completion_report_request_id();
+        return Ok(crate::tool::ToolResult::deferred(
+            NAME,
+            serde_json::json!({
+                "disposition": "awaiting_completion_report",
+                "completion_request_id": request_id,
+                "work_item_id": work_item_id,
+                "completed_transition": false,
+                "expected_output": "final_text_only",
+                "warnings": warnings_json(&warnings),
+            }),
+            Some("Awaiting the final operator-facing completion report.".into()),
+            ToolLoopDirective::AwaitCompletionReport(AwaitCompletionReportDirective {
+                request_id,
+                work_item_id,
+                expected_work_revision,
+                warnings: warnings_json(&warnings),
+            }),
+        ));
+    }
+    complete_with_report_candidate(
+        runtime,
+        work_item_id,
+        authority,
+        candidate,
+        warnings,
+        "same_assistant_round_preceding_text",
+    )
+    .await
+}
+
+pub(crate) async fn complete_with_report_candidate(
+    runtime: &RuntimeHandle,
+    work_item_id: String,
+    authority: WorkItemCompletionAuthority,
+    candidate: Option<&CompletionReportCandidate>,
+    warnings: Vec<WorkItemCompletionWarning>,
+    report_source: &'static str,
+) -> Result<crate::tool::ToolResult> {
     let prepared = runtime
         .prepare_work_item_completion_with_report(
             work_item_id.clone(),
-            WorkItemCompletionAuthority::AgentExecution(execution_binding),
+            authority,
             candidate
                 .map(|candidate| candidate.text.clone())
                 .unwrap_or_default(),
@@ -86,6 +143,7 @@ pub(crate) async fn execute(
             candidate.and_then(|candidate| candidate.source_message_id.clone()),
             candidate.map(|candidate| candidate.source_assistant_round_id.clone()),
             candidate.map(|candidate| candidate.source_tool_call_id.clone()),
+            report_source,
             warnings_json(&warnings),
         )
         .await?;
@@ -126,7 +184,7 @@ pub(crate) async fn execute(
         if completion_report_promoted {
             object.insert(
                 "completion_report_source".into(),
-                serde_json::json!("same_assistant_round_preceding_text"),
+                serde_json::json!(report_source),
             );
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4034,8 +4034,10 @@ pub struct QueueEntryRecord {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolExecutionStatus {
+    Deferred,
     Success,
     Error,
+    Interrupted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]


### PR DESCRIPTION
## 摘要

- 将 tool-only `CompleteWorkItem` 从立即失败改为 turn-local completion report 握手：工具调用先进入 Deferred，下一轮最终 assistant 文本提交 canonical completion
- 为 `ToolExecutionRecord` 增加 `Deferred -> Success | Interrupted` 生命周期，并保证完成、调用方 continuation 恢复及工具结果终结由同一 canonical 事务提交
- 在 provider failure、turn limit、取消及其他协议放弃路径中，将仍处于 Deferred 的调用原子终结为 Interrupted
- 更新 WorkItem/runtime RFC、公开规范与生成的 OpenAPI/状态枚举快照

## 运行时边界

- 保留旧的“工具前已有报告文本”快速路径
- 只接受完成工具后的最终 assistant 文本作为延迟报告；出现其他工具调用时不误用中间文本
- canonical completion commit 仍是 WorkItem 完成、result brief、continuation 恢复和 deferred tool success 的唯一 terminal writer
- 放弃握手时 WorkItem 保持未完成，Deferred 工具记录以明确原因终结为 Interrupted

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `env RUST_MIN_STACK=16777216 cargo test --all-targets`
- `cargo test --lib completion_report_protocol`
- 定向回归：follow-up report 顺序测试连续运行 5 次通过
- 独立只读代码审查：未发现阻塞合并的问题

Closes #2542
