### PR TITLE
fix: reconcile continuation authority drift

### DIFF
--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -44,6 +44,9 @@ pub fn resume_work_item_continuation(
     ) {
         return Err("continuation resume cannot complete or yield the resumed WorkItem".into());
     }
+    if continuation_resume_outcome(&command.work_item_id, &command.source)? != command.outcome {
+        return Err("continuation resume outcome does not match its source fence".into());
+    }
     let mut next = state.clone();
     let record = next
         .work_items
@@ -96,6 +99,56 @@ pub fn suspend_work_item_continuation(
         state: next,
         references: vec![
             format!("work_item:{}", command.work_item_id),
+            format!("work_item:{}", command.active_work_item_id),
+            format!("continuation:{}", command.continuation_id),
+        ],
+    })
+}
+
+pub fn reconcile_work_item_continuation_yield(
+    state: &ExecutionProtocolState,
+    command: &ReconcileWorkItemContinuationYield,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.continuation_id.is_empty()
+        || command.stale_active_work_item_id.is_empty()
+        || command.active_work_item_id.is_empty()
+        || command.expected_frame_updated_at.is_empty()
+        || command.active_work_item_source_revision == 0
+        || command.stale_active_work_item_source_revision == 0
+        || command.stale_active_work_item_id == command.active_work_item_id
+    {
+        return Err("continuation reconciliation requires complete distinct identity".into());
+    }
+    if state.work_items.get(&command.work_item_id) != Some(&command.expected) {
+        return Err("continuation reconciliation WorkItem fence is stale".into());
+    }
+    let WorkItemExecutionState::Paused { generation, reason } = &command.expected.state else {
+        return Err("continuation reconciliation requires a Paused WorkItem".into());
+    };
+    if reason != &format!("yielded_to:{}", command.stale_active_work_item_id) {
+        return Err("continuation reconciliation requires the exact stale yielded target".into());
+    }
+    let next_generation = generation
+        .checked_add(1)
+        .ok_or_else(|| "WorkItem scheduling generation overflow".to_string())?;
+    let mut next = state.clone();
+    let record = next
+        .work_items
+        .get_mut(&command.work_item_id)
+        .expect("continuation reconciliation preserved WorkItem");
+    record.state = WorkItemExecutionState::Paused {
+        generation: next_generation,
+        reason: format!("yielded_to:{}", command.active_work_item_id),
+    };
+    assert_invariants(&next)?;
+    Ok(ExecutionTransition {
+        state: next,
+        references: vec![
+            format!("work_item:{}", command.work_item_id),
+            format!("work_item:{}", command.stale_active_work_item_id),
             format!("work_item:{}", command.active_work_item_id),
             format!("continuation:{}", command.continuation_id),
         ],
@@ -479,7 +532,48 @@ pub struct ResumeWorkItemContinuation {
     pub active_work_item_id: String,
     pub continuation_id: String,
     pub expected: WorkItemExecutionRecord,
+    pub source: WorkItemContinuationResumeSource,
     pub outcome: WorkItemOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkItemContinuationResumeSource {
+    pub work_item_revision: u64,
+    pub blocked_by: Option<String>,
+    pub active_wait_ids: Vec<String>,
+}
+
+pub fn continuation_resume_outcome(
+    work_item_id: &str,
+    source: &WorkItemContinuationResumeSource,
+) -> Result<WorkItemOutcome, String> {
+    if work_item_id.is_empty()
+        || source.work_item_revision == 0
+        || source.active_wait_ids.iter().any(String::is_empty)
+        || source
+            .active_wait_ids
+            .windows(2)
+            .any(|pair| pair[0] >= pair[1])
+    {
+        return Err("continuation resume source fence is invalid".into());
+    }
+    Ok(match source.active_wait_ids.as_slice() {
+        [wait_id] => WorkItemOutcome::Wait {
+            wait: WaitReference {
+                wait_id: wait_id.clone(),
+            },
+        },
+        [] if source.blocked_by.is_some() => WorkItemOutcome::Pause {
+            reason: source
+                .blocked_by
+                .clone()
+                .expect("continuation resume blocker checked above"),
+        },
+        [] => WorkItemOutcome::Continue,
+        _ => WorkItemOutcome::NeedsRepair {
+            repair_id: format!("work_item_waits_ambiguous:{work_item_id}"),
+        },
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -489,6 +583,19 @@ pub struct SuspendWorkItemContinuation {
     pub active_work_item_id: String,
     pub continuation_id: String,
     pub expected: WorkItemExecutionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileWorkItemContinuationYield {
+    pub command_id: String,
+    pub work_item_id: String,
+    pub continuation_id: String,
+    pub stale_active_work_item_id: String,
+    pub active_work_item_id: String,
+    pub expected: WorkItemExecutionRecord,
+    pub expected_frame_updated_at: String,
+    pub active_work_item_source_revision: u64,
+    pub stale_active_work_item_source_revision: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -507,6 +614,7 @@ pub enum ExecutionProtocolCommand {
     SetWorkItemReadiness(Box<SetWorkItemReadiness>),
     SuspendWorkItemContinuation(Box<SuspendWorkItemContinuation>),
     ResumeWorkItemContinuation(Box<ResumeWorkItemContinuation>),
+    ReconcileWorkItemContinuationYield(Box<ReconcileWorkItemContinuationYield>),
     SetWorkItemWaiting(Box<SetWorkItemWaiting>),
     CompleteWorkItem(Box<CompleteWorkItemExecution>),
     Admit(Box<AdmitExecution>),
@@ -1277,6 +1385,11 @@ mod tests {
                 active_work_item_id: "work-b".into(),
                 continuation_id: "continuation-a".into(),
                 expected: paused.clone(),
+                source: WorkItemContinuationResumeSource {
+                    work_item_revision: 1,
+                    blocked_by: None,
+                    active_wait_ids: Vec::new(),
+                },
                 outcome: WorkItemOutcome::Continue,
             },
         )
@@ -1295,6 +1408,11 @@ mod tests {
             active_work_item_id: "work-b".into(),
             continuation_id: "continuation-a".into(),
             expected: paused,
+            source: WorkItemContinuationResumeSource {
+                work_item_revision: 1,
+                blocked_by: None,
+                active_wait_ids: Vec::new(),
+            },
             outcome: WorkItemOutcome::Continue,
         };
         assert!(resume_work_item_continuation(&resumed.state, &stale)
@@ -1340,6 +1458,63 @@ mod tests {
         assert!(suspend_work_item_continuation(&suspended.state, &stale)
             .unwrap_err()
             .contains("stale"));
+    }
+
+    #[test]
+    fn continuation_reconciliation_advances_generation_and_preserves_source_revision() {
+        let expected = work_item_record(WorkItemExecutionState::Paused {
+            generation: 7,
+            reason: "yielded_to:old-child".into(),
+        });
+        let state = ExecutionProtocolState {
+            agent_id: "agent-a".into(),
+            attempts: BTreeMap::new(),
+            work_items: BTreeMap::from([("parent".into(), expected.clone())]),
+            outcomes: BTreeMap::new(),
+        };
+        let command = ReconcileWorkItemContinuationYield {
+            command_id: "reconcile:frame-a".into(),
+            work_item_id: "parent".into(),
+            continuation_id: "frame-a".into(),
+            stale_active_work_item_id: "old-child".into(),
+            active_work_item_id: "new-child".into(),
+            expected: expected.clone(),
+            expected_frame_updated_at: "2026-08-11T00:00:00Z".into(),
+            active_work_item_source_revision: 3,
+            stale_active_work_item_source_revision: 4,
+        };
+
+        let transition = reconcile_work_item_continuation_yield(&state, &command).unwrap();
+        assert_eq!(
+            transition.state.work_items["parent"],
+            WorkItemExecutionRecord {
+                source_revision: expected.source_revision,
+                state: WorkItemExecutionState::Paused {
+                    generation: 8,
+                    reason: "yielded_to:new-child".into(),
+                },
+            }
+        );
+        let stale = ReconcileWorkItemContinuationYield {
+            expected: WorkItemExecutionRecord {
+                source_revision: expected.source_revision,
+                state: WorkItemExecutionState::Paused {
+                    generation: 6,
+                    reason: "yielded_to:old-child".into(),
+                },
+            },
+            ..command.clone()
+        };
+        assert!(reconcile_work_item_continuation_yield(&state, &stale)
+            .unwrap_err()
+            .contains("fence is stale"));
+        let matched = ReconcileWorkItemContinuationYield {
+            stale_active_work_item_id: "new-child".into(),
+            ..command
+        };
+        assert!(reconcile_work_item_continuation_yield(&state, &matched)
+            .unwrap_err()
+            .contains("distinct identity"));
     }
 
     #[test]

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -118,6 +118,8 @@ pub fn reconcile_work_item_continuation_yield(
         || command.expected_frame_updated_at.is_empty()
         || command.active_work_item_source_revision == 0
         || command.stale_active_work_item_source_revision == 0
+        || command.work_item_id == command.stale_active_work_item_id
+        || command.work_item_id == command.active_work_item_id
         || command.stale_active_work_item_id == command.active_work_item_id
     {
         return Err("continuation reconciliation requires complete distinct identity".into());
@@ -1510,11 +1512,20 @@ mod tests {
             .contains("fence is stale"));
         let matched = ReconcileWorkItemContinuationYield {
             stale_active_work_item_id: "new-child".into(),
-            ..command
+            ..command.clone()
         };
         assert!(reconcile_work_item_continuation_yield(&state, &matched)
             .unwrap_err()
             .contains("distinct identity"));
+        for aliased_child in ["old-child", "new-child"] {
+            let aliased = ReconcileWorkItemContinuationYield {
+                work_item_id: aliased_child.into(),
+                ..command.clone()
+            };
+            assert!(reconcile_work_item_continuation_yield(&state, &aliased)
+                .unwrap_err()
+                .contains("distinct identity"));
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2471,8 +2471,10 @@ fn print_scheduler_recovery_report(
         }));
     }
     println!(
-        "Scheduler recovery candidates for {} (partition initialized: {})",
-        report.agent_id, report.partition_initialized
+        "Scheduler recovery candidates for {} (scheduler partition initialized: {}, execution partition initialized: {})",
+        report.agent_id,
+        report.partition_initialized,
+        report.execution_partition_initialized
     );
     println!(
         "- retired rollout metadata: marked={} present={} mode={} stale_authoritative={}",
@@ -2508,6 +2510,17 @@ fn print_scheduler_recovery_report(
         println!(
             "- work_item:{}: adoption eligible={} reason={}",
             candidate.work_item_id, candidate.eligible, candidate.reason
+        );
+    }
+    for candidate in report.continuation_reconciliations {
+        println!(
+            "- continuation:{} parent={} stale_target={:?} active_target={} eligible={} reason={}",
+            candidate.continuation_id,
+            candidate.work_item_id,
+            candidate.stale_active_work_item_id,
+            candidate.active_work_item_id,
+            candidate.eligible,
+            candidate.reason,
         );
     }
     Ok(())

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -127,8 +127,9 @@ use crate::{
         SkillsRuntimeView, TaskKind, TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec,
         TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
         TranscriptEntryKind, TurnRecord, TurnTerminalKind, ViewImageObservation,
-        WaitConditionStatus, WaitingReason, WorkItemExecutionBinding, WorkItemLifecycleAuditEvent,
-        WorkItemState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
+        WaitConditionRecord, WaitConditionStatus, WaitingReason, WorkItemExecutionBinding,
+        WorkItemLifecycleAuditEvent, WorkItemRecord, WorkItemState, WorkspaceEntry,
+        AGENT_HOME_WORKSPACE_ID,
     },
     web::{WebConfig, WebProviderKind},
 };
@@ -457,6 +458,57 @@ fn canonical_command_batch_rejection(
         proposed = outcome.outcome.snapshot;
     }
     None
+}
+
+fn work_item_continuation_resume_source(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    parent_work_item_id: &str,
+    projected_parent: Option<&WorkItemRecord>,
+    projected_wait_conditions: &[WaitConditionRecord],
+) -> Result<(
+    crate::domain::execution_protocol::WorkItemContinuationResumeSource,
+    crate::domain::execution_protocol::WorkItemOutcome,
+)> {
+    use crate::domain::execution_protocol::{
+        continuation_resume_outcome, WorkItemContinuationResumeSource,
+    };
+
+    let durable_parent = runtime_db
+        .work_items()
+        .latest(parent_work_item_id)?
+        .ok_or_else(|| anyhow!("continuation parent WorkItem is missing"))?;
+    let parent = projected_parent
+        .filter(|parent| parent.id == parent_work_item_id)
+        .unwrap_or(&durable_parent);
+    anyhow::ensure!(
+        parent.agent_id == agent_id && parent.state == WorkItemState::Open,
+        "continuation parent WorkItem is not open for this agent"
+    );
+    let mut parent_waits = storage
+        .raw_active_wait_conditions_for_agent(agent_id)?
+        .into_iter()
+        .filter(|wait| wait.work_item_id.as_deref() == Some(parent_work_item_id))
+        .map(|wait| (wait.id.clone(), wait))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for wait in projected_wait_conditions {
+        parent_waits.remove(&wait.id);
+        if wait.agent_id == agent_id
+            && wait.work_item_id.as_deref() == Some(parent_work_item_id)
+            && wait.status == WaitConditionStatus::Active
+        {
+            parent_waits.insert(wait.id.clone(), wait.clone());
+        }
+    }
+    let source = WorkItemContinuationResumeSource {
+        work_item_revision: parent.revision,
+        blocked_by: parent.blocked_by.clone(),
+        active_wait_ids: parent_waits.into_keys().collect(),
+    };
+    let outcome = continuation_resume_outcome(parent_work_item_id, &source)
+        .map_err(|error| anyhow!(error))?;
+    Ok((source, outcome))
 }
 
 fn execution_protocol_completion_transition_from_prepared(
@@ -1419,10 +1471,12 @@ fn execution_attempt_for_message<'a>(
 pub struct SchedulerRecoveryReport {
     pub agent_id: String,
     pub partition_initialized: bool,
+    pub execution_partition_initialized: bool,
     pub authority_inventory: Vec<SchedulerAuthorityInventoryEntry>,
     pub retired_rollout_metadata: SchedulerRetiredRolloutMetadata,
     pub candidates: Vec<SchedulerRecoveryCandidate>,
     pub legacy_adoptions: Vec<SchedulerLegacyAdoptionCandidate>,
+    pub continuation_reconciliations: Vec<SchedulerContinuationReconciliationCandidate>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1458,6 +1512,18 @@ pub struct SchedulerLegacyAdoptionCandidate {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SchedulerContinuationReconciliationCandidate {
+    pub continuation_id: String,
+    pub work_item_id: String,
+    pub stale_active_work_item_id: Option<String>,
+    pub active_work_item_id: String,
+    pub eligible: bool,
+    pub reason: String,
+    pub evidence: Vec<String>,
+    pub proposed_command: Option<crate::domain::execution_protocol::ExecutionProtocolCommand>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct SchedulerRecoveryCandidate {
     pub kind: SchedulerRecoveryCandidateKind,
     pub message_id: String,
@@ -1478,6 +1544,167 @@ pub enum SchedulerRecoveryCandidateKind {
     NeedsSettlement,
     LegacyDequeued,
     AuthorityDrift,
+}
+
+fn scheduler_continuation_reconciliation_candidates(
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    execution_state: Option<&crate::domain::execution_protocol::ExecutionProtocolState>,
+    active_continuations: &[crate::types::WorkItemContinuationFrame],
+) -> Result<Vec<SchedulerContinuationReconciliationCandidate>> {
+    use crate::domain::execution_protocol::{
+        ExecutionProtocolCommand, ReconcileWorkItemContinuationYield, WorkItemExecutionState,
+    };
+
+    let mut candidates = Vec::new();
+    for frame in active_continuations {
+        let mut candidate = SchedulerContinuationReconciliationCandidate {
+            continuation_id: frame.id.clone(),
+            work_item_id: frame.suspended_work_item_id.clone(),
+            stale_active_work_item_id: None,
+            active_work_item_id: frame.active_work_item_id.clone(),
+            eligible: false,
+            reason: "execution_partition_missing".into(),
+            evidence: vec![format!("continuation:{}", frame.id)],
+            proposed_command: None,
+        };
+        let Some(state) = execution_state else {
+            candidates.push(candidate);
+            continue;
+        };
+        if frame.id.is_empty()
+            || frame.suspended_work_item_id.is_empty()
+            || frame.active_work_item_id.is_empty()
+        {
+            candidate.reason = "identity_incomplete".into();
+            candidates.push(candidate);
+            continue;
+        }
+        let parent_edges = active_continuations
+            .iter()
+            .filter(|other| other.suspended_work_item_id == frame.suspended_work_item_id)
+            .count();
+        let child_edges = active_continuations
+            .iter()
+            .filter(|other| other.active_work_item_id == frame.active_work_item_id)
+            .count();
+        if parent_edges != 1 || child_edges != 1 {
+            candidate.reason = "competing_active_continuation".into();
+            candidates.push(candidate);
+            continue;
+        }
+        let mut cursor = frame.active_work_item_id.as_str();
+        let mut visited = HashSet::new();
+        let mut cycle = false;
+        while let Some(next) = active_continuations
+            .iter()
+            .find(|other| other.suspended_work_item_id == cursor)
+        {
+            if !visited.insert(next.id.as_str())
+                || next.active_work_item_id == frame.suspended_work_item_id
+            {
+                cycle = true;
+                break;
+            }
+            cursor = next.active_work_item_id.as_str();
+        }
+        if cycle {
+            candidate.reason = "active_continuation_cycle".into();
+            candidates.push(candidate);
+            continue;
+        }
+        let Some(parent_execution) = state.work_items.get(&frame.suspended_work_item_id) else {
+            candidate.reason = "parent_execution_missing".into();
+            candidates.push(candidate);
+            continue;
+        };
+        let WorkItemExecutionState::Paused { generation, reason } = &parent_execution.state else {
+            candidate.reason = "parent_not_paused".into();
+            candidates.push(candidate);
+            continue;
+        };
+        let Some(stale_target) = reason.strip_prefix("yielded_to:") else {
+            candidate.reason = "pause_not_yielded".into();
+            candidates.push(candidate);
+            continue;
+        };
+        candidate.stale_active_work_item_id = Some(stale_target.to_string());
+        candidate.evidence.extend([
+            format!("parent_generation:{generation}"),
+            format!(
+                "parent_source_revision:{}",
+                parent_execution.source_revision
+            ),
+            format!("canonical_target:{stale_target}"),
+            format!("frame_target:{}", frame.active_work_item_id),
+        ]);
+        if stale_target == frame.active_work_item_id {
+            candidate.reason = "already_matched".into();
+            candidates.push(candidate);
+            continue;
+        }
+        let Some(parent) = runtime_db
+            .work_items()
+            .latest(&frame.suspended_work_item_id)?
+        else {
+            candidate.reason = "parent_missing".into();
+            candidates.push(candidate);
+            continue;
+        };
+        let Some(active) = runtime_db.work_items().latest(&frame.active_work_item_id)? else {
+            candidate.reason = "active_target_missing".into();
+            candidates.push(candidate);
+            continue;
+        };
+        let Some(stale) = runtime_db.work_items().latest(stale_target)? else {
+            candidate.reason = "stale_target_missing".into();
+            candidates.push(candidate);
+            continue;
+        };
+        if parent.agent_id != agent_id || active.agent_id != agent_id || stale.agent_id != agent_id
+        {
+            candidate.reason = "cross_agent_identity".into();
+            candidates.push(candidate);
+            continue;
+        }
+        if parent.state != WorkItemState::Open
+            || parent.revision != parent_execution.source_revision
+        {
+            candidate.reason = "parent_source_fence_stale".into();
+            candidates.push(candidate);
+            continue;
+        }
+        if active.state != WorkItemState::Open {
+            candidate.reason = "active_target_not_open".into();
+            candidates.push(candidate);
+            continue;
+        }
+        if stale.state != WorkItemState::Completed {
+            candidate.reason = "stale_target_not_completed".into();
+            candidates.push(candidate);
+            continue;
+        }
+        candidate.eligible = true;
+        candidate.reason = "stale_yield_target_reconcilable".into();
+        candidate.proposed_command = Some(
+            ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(Box::new(
+                ReconcileWorkItemContinuationYield {
+                    command_id: format!("continuation:reconcile:{}", frame.id),
+                    work_item_id: frame.suspended_work_item_id.clone(),
+                    continuation_id: frame.id.clone(),
+                    stale_active_work_item_id: stale.id.clone(),
+                    active_work_item_id: active.id.clone(),
+                    expected: parent_execution.clone(),
+                    expected_frame_updated_at: frame.updated_at.to_rfc3339(),
+                    active_work_item_source_revision: active.revision,
+                    stale_active_work_item_source_revision: stale.revision,
+                },
+            )),
+        );
+        candidates.push(candidate);
+    }
+    candidates.sort_by(|left, right| left.continuation_id.cmp(&right.continuation_id));
+    Ok(candidates)
 }
 
 fn canonical_settlement_recovery_commands(
@@ -1714,6 +1941,18 @@ pub fn scheduler_recovery_report(
         hard_blocker_count: retired.hard_blocker_count,
         command_result_count: retired.command_result_count,
     };
+    let execution_state = runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized(agent_id)?;
+    let active_continuations = runtime_db
+        .work_item_continuations()
+        .active_for_agent(agent_id)?;
+    let continuation_reconciliations = scheduler_continuation_reconciliation_candidates(
+        runtime_db,
+        agent_id,
+        execution_state.as_ref(),
+        &active_continuations,
+    )?;
     let Some(snapshot) = runtime_db
         .transitions()
         .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
@@ -1721,6 +1960,7 @@ pub fn scheduler_recovery_report(
         return Ok(SchedulerRecoveryReport {
             agent_id: agent_id.to_string(),
             partition_initialized: false,
+            execution_partition_initialized: execution_state.is_some(),
             authority_inventory,
             retired_rollout_metadata,
             candidates: Vec::new(),
@@ -1735,17 +1975,12 @@ pub fn scheduler_recovery_report(
                     proposed_command: candidate.command,
                 })
                 .collect(),
+            continuation_reconciliations,
         });
     };
     let all_queue_entries = runtime_db
         .queue_entries()
         .recent(Some(agent_id), usize::MAX)?;
-    let execution_state = runtime_db
-        .transitions()
-        .load_execution_protocol_state_if_initialized(agent_id)?;
-    let active_continuations = runtime_db
-        .work_item_continuations()
-        .active_for_agent(agent_id)?;
     let mut candidates = Vec::new();
     if let Some(command) = canonical_authority_convergence_command(storage, &snapshot, agent_id)? {
         let crate::domain::scheduler_protocol::ProtocolCommand::ConvergeAuthority(repair) =
@@ -2101,6 +2336,7 @@ pub fn scheduler_recovery_report(
     Ok(SchedulerRecoveryReport {
         agent_id: agent_id.to_string(),
         partition_initialized: true,
+        execution_partition_initialized: execution_state.is_some(),
         authority_inventory,
         retired_rollout_metadata,
         candidates,
@@ -2115,6 +2351,7 @@ pub fn scheduler_recovery_report(
                 proposed_command: candidate.command,
             })
             .collect(),
+        continuation_reconciliations,
     })
 }
 
@@ -2217,9 +2454,16 @@ fn apply_scheduler_recovery_plan_with_options(
         })
         .flat_map(|candidate| candidate.proposed_commands.iter().cloned())
         .collect::<Vec<_>>();
+    let continuation_reconciliation = report
+        .continuation_reconciliations
+        .iter()
+        .filter(|candidate| candidate.eligible)
+        .filter_map(|candidate| candidate.proposed_command.clone())
+        .collect::<Vec<_>>();
     if legacy_adoptions.is_empty()
         && settlement_recovery.is_empty()
         && authority_recovery.is_empty()
+        && continuation_reconciliation.is_empty()
     {
         return Ok((0, None));
     }
@@ -2237,6 +2481,45 @@ fn apply_scheduler_recovery_plan_with_options(
         SchedulerRecoveryBackupPolicy::SkipApproved => None,
     };
     let mut applied = false;
+    if !continuation_reconciliation.is_empty() {
+        let audit_events = report
+            .continuation_reconciliations
+            .iter()
+            .filter(|candidate| candidate.eligible && candidate.proposed_command.is_some())
+            .map(|candidate| {
+                AuditEvent::legacy(
+                    "work_item_continuation_reconciled",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "continuation_id": candidate.continuation_id,
+                        "work_item_id": candidate.work_item_id,
+                        "stale_active_work_item_id": candidate.stale_active_work_item_id,
+                        "active_work_item_id": candidate.active_work_item_id,
+                        "reason": candidate.reason,
+                    }),
+                )
+            })
+            .collect::<Vec<_>>();
+        match runtime_db
+            .transitions()
+            .commit_execution_protocol_recovery_plan(
+                agent_id,
+                &continuation_reconciliation,
+                &audit_events,
+            )?
+        {
+            crate::runtime_db::transitions::execution_protocol_repository::ExecutionProtocolRecoveryCommitOutcome::Applied(
+                changed,
+            ) => applied |= changed,
+            crate::runtime_db::transitions::execution_protocol_repository::ExecutionProtocolRecoveryCommitOutcome::Rejected {
+                reason,
+            } => {
+                return Err(anyhow!(
+                    "continuation reconciliation unexpectedly rejected: {reason}"
+                ));
+            }
+        }
+    }
     if !authority_recovery.is_empty() {
         match runtime_db
             .transitions()
@@ -2312,6 +2595,7 @@ fn apply_scheduler_recovery_plan_with_options(
             "backup_created": backup_path.is_some(),
             "backup_path": backup_path,
             "authority_repair_included": include_authority_repair,
+            "continuation_reconciliation_count": continuation_reconciliation.len(),
         }),
     ))?;
     Ok((usize::from(applied), backup_path))
@@ -4341,44 +4625,14 @@ impl RuntimeHandle {
                         .work_items
                         .get(&continuation.suspended_work_item_id)
                         .ok_or_else(|| anyhow!("completion parent execution state is missing"))?;
-                    let parent_record = self
-                        .inner
-                        .runtime_db
-                        .work_items()
-                        .latest(&continuation.suspended_work_item_id)?
-                        .ok_or_else(|| anyhow!("completion parent WorkItem is missing"))?;
-                    let parent_waits = self
-                        .inner
-                        .storage
-                        .raw_active_wait_conditions_for_agent(&record.agent_id)?
-                        .into_iter()
-                        .filter(|wait| {
-                            wait.work_item_id.as_deref()
-                                == Some(continuation.suspended_work_item_id.as_str())
-                        })
-                        .collect::<Vec<_>>();
-                    let outcome = match parent_waits.as_slice() {
-                        [wait] => crate::domain::execution_protocol::WorkItemOutcome::Wait {
-                            wait: crate::domain::execution_protocol::WaitReference {
-                                wait_id: wait.id.clone(),
-                            },
-                        },
-                        [] if parent_record.blocked_by.is_some() => {
-                            crate::domain::execution_protocol::WorkItemOutcome::Pause {
-                                reason: parent_record
-                                    .blocked_by
-                                    .clone()
-                                    .expect("parent blocker checked above"),
-                            }
-                        }
-                        [] => crate::domain::execution_protocol::WorkItemOutcome::Continue,
-                        _ => crate::domain::execution_protocol::WorkItemOutcome::NeedsRepair {
-                            repair_id: format!(
-                                "work_item_waits_ambiguous:{}",
-                                continuation.suspended_work_item_id
-                            ),
-                        },
-                    };
+                    let (source, outcome) = work_item_continuation_resume_source(
+                        &self.inner.storage,
+                        &self.inner.runtime_db,
+                        &record.agent_id,
+                        &continuation.suspended_work_item_id,
+                        None,
+                        &prepared.wait_conditions,
+                    )?;
                     execution_protocol.commands.push(
                         crate::domain::execution_protocol::ExecutionProtocolCommand::ResumeWorkItemContinuation(
                             Box::new(
@@ -4388,6 +4642,7 @@ impl RuntimeHandle {
                                     active_work_item_id: continuation.active_work_item_id.clone(),
                                     continuation_id: continuation.id.clone(),
                                     expected: parent.clone(),
+                                    source,
                                     outcome,
                                 },
                             ),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -14,7 +14,7 @@ use crate::types::{
     SpawnAgentModelRequest, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
     SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult,
     TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef,
-    WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
+    WaitConditionRecord, WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
     WorkItemContinuationReturnPolicy, WorkItemContinuationState, WorkItemDelegationRecord,
     WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
     CHILD_AGENT_TASK_KIND,
@@ -2755,6 +2755,52 @@ impl RuntimeHandle {
         )))
     }
 
+    fn plan_work_item_execution_continuation_resume(
+        &self,
+        agent_id: &str,
+        continuation: &WorkItemContinuationFrame,
+        command_reason: &str,
+        projected_parent: Option<&WorkItemRecord>,
+        projected_wait_conditions: &[WaitConditionRecord],
+    ) -> Result<Option<crate::domain::execution_protocol::ExecutionProtocolCommand>> {
+        use crate::domain::execution_protocol::{
+            ExecutionProtocolCommand, ResumeWorkItemContinuation,
+        };
+
+        if !self.inner.scheduler_engine.is_canonical() {
+            return Ok(None);
+        }
+        let state = self
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized(agent_id)?
+            .ok_or_else(|| anyhow!("continuation resume requires canonical execution state"))?;
+        let authoritative = state
+            .work_items
+            .get(&continuation.suspended_work_item_id)
+            .ok_or_else(|| anyhow!("continuation resume parent execution state is missing"))?;
+        let (source, outcome) = work_item_continuation_resume_source(
+            &self.inner.storage,
+            &self.inner.runtime_db,
+            agent_id,
+            &continuation.suspended_work_item_id,
+            projected_parent,
+            projected_wait_conditions,
+        )?;
+        Ok(Some(ExecutionProtocolCommand::ResumeWorkItemContinuation(
+            Box::new(ResumeWorkItemContinuation {
+                command_id: format!("continuation:{command_reason}:{}", continuation.id),
+                work_item_id: continuation.suspended_work_item_id.clone(),
+                active_work_item_id: continuation.active_work_item_id.clone(),
+                continuation_id: continuation.id.clone(),
+                expected: authoritative.clone(),
+                source,
+                outcome,
+            }),
+        )))
+    }
+
     pub async fn pick_work_item(
         &self,
         work_item_id: String,
@@ -2849,38 +2895,79 @@ impl RuntimeHandle {
         let mut continuation_created = None;
         let mut continuation_resolved = None;
         let mut continuation_records = Vec::new();
-        let target_yielded_frame = self
+        let active_continuations = self
             .inner
             .storage
-            .latest_active_work_item_continuation_for_suspended(&agent_id, &record.id)?;
-        let target_was_yielded = target_yielded_frame.is_some();
-        if let Some(frame) = target_yielded_frame {
-            let resolved = frame.resume("explicit_pick");
-            continuation_resolved = Some(continuation_summary(&resolved, "explicit_pick"));
-            audit_events.push(AuditEvent::legacy(
-                "work_item_continuation_resumed",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "continuation": continuation_summary(&resolved, "explicit_pick"),
-                }),
-            ));
-            continuation_records.push(resolved);
-        }
-        if let Some(id) = current_id.as_deref() {
-            if let Some(frame) = self
-                .inner
-                .storage
-                .latest_active_work_item_continuation_for_suspended(&agent_id, id)?
-            {
-                let cancelled = frame.cancel("current_focus_reselected");
+            .latest_active_work_item_continuations_for_agent(&agent_id)?;
+        let by_suspended = active_continuations
+            .iter()
+            .map(|frame| (frame.suspended_work_item_id.as_str(), frame))
+            .collect::<BTreeMap<_, _>>();
+        let target_was_yielded = by_suspended.contains_key(record.id.as_str());
+        let mut resolved_frame_ids = std::collections::BTreeSet::new();
+        if target_was_yielded {
+            let mut parent_id = record.id.as_str();
+            let mut first = true;
+            loop {
+                let frame = by_suspended
+                    .get(parent_id)
+                    .copied()
+                    .ok_or_else(|| anyhow!("continuation unwind path is incomplete"))?;
+                anyhow::ensure!(
+                    resolved_frame_ids.insert(frame.id.clone()),
+                    "continuation unwind path contains a cycle"
+                );
+                let (resolved, reason, event_kind) = if first {
+                    (
+                        frame.clone().resume("explicit_pick"),
+                        "explicit_pick",
+                        "work_item_continuation_resumed",
+                    )
+                } else {
+                    (
+                        frame.clone().cancel("current_focus_reselected"),
+                        "current_focus_reselected",
+                        "work_item_continuation_cancelled",
+                    )
+                };
+                let summary = continuation_summary(&resolved, reason);
+                if first {
+                    continuation_resolved = Some(summary.clone());
+                }
+                audit_events.push(AuditEvent::legacy(
+                    event_kind,
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "continuation": summary,
+                    }),
+                ));
+                continuation_records.push(resolved);
+                if current_id.as_deref() == Some(frame.active_work_item_id.as_str()) {
+                    break;
+                }
+                parent_id = frame.active_work_item_id.as_str();
+                first = false;
+            }
+        } else if let Some(id) = current_id.as_deref() {
+            let mut parent_id = id;
+            while let Some(frame) = by_suspended.get(parent_id).copied() {
+                anyhow::ensure!(
+                    resolved_frame_ids.insert(frame.id.clone()),
+                    "continuation cancellation path contains a cycle"
+                );
+                let cancelled = frame.clone().cancel("current_focus_reselected");
                 audit_events.push(AuditEvent::legacy(
                     "work_item_continuation_cancelled",
                     serde_json::json!({
                         "agent_id": agent_id,
-                        "continuation": continuation_summary(&cancelled, "current_focus_reselected"),
+                        "continuation": continuation_summary(
+                            &cancelled,
+                            "current_focus_reselected"
+                        ),
                     }),
                 ));
                 continuation_records.push(cancelled);
+                parent_id = frame.active_work_item_id.as_str();
             }
         }
         let yield_current = switching
@@ -3005,6 +3092,25 @@ impl RuntimeHandle {
         } else {
             Default::default()
         };
+        for continuation in &continuation_records {
+            if continuation.state == WorkItemContinuationState::Active {
+                continue;
+            }
+            let command_reason = match continuation.state {
+                WorkItemContinuationState::Resumed => "resume",
+                WorkItemContinuationState::Cancelled => "cancel",
+                WorkItemContinuationState::Active => unreachable!(),
+            };
+            if let Some(command) = self.plan_work_item_execution_continuation_resume(
+                &agent_id,
+                continuation,
+                command_reason,
+                (record.id == continuation.suspended_work_item_id).then_some(&record),
+                &wait_conditions,
+            )? {
+                execution_protocol.commands.push(command);
+            }
+        }
         if yield_current && !terminal_transition {
             let previous = previous
                 .as_ref()

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -436,6 +436,11 @@ fn persist_execution_transition_only(
             ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
                 crate::domain::execution_protocol::resume_work_item_continuation(&state, &command)
             }
+            ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(command) => {
+                crate::domain::execution_protocol::reconcile_work_item_continuation_yield(
+                    &state, &command,
+                )
+            }
             ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
                 crate::domain::execution_protocol::set_work_item_waiting(&state, &command)
             }
@@ -11991,6 +11996,127 @@ async fn scheduler_recovery_converges_completed_work_item_lane_reservation() {
         .candidates
         .iter()
         .any(|candidate| candidate.kind == SchedulerRecoveryCandidateKind::AuthorityDrift));
+}
+
+#[tokio::test]
+async fn scheduler_recovery_reconciles_stale_continuation_yield_without_legacy_partition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let parent = WorkItemRecord::new("default", "stale continuation parent", WorkItemState::Open);
+    let active = WorkItemRecord::new("default", "current continuation child", WorkItemState::Open);
+    let stale = WorkItemRecord::new(
+        "default",
+        "completed historical continuation child",
+        WorkItemState::Completed,
+    );
+    runtime.storage().append_work_item(&parent).unwrap();
+    runtime.storage().append_work_item(&active).unwrap();
+    runtime.storage().append_work_item(&stale).unwrap();
+    let frame = crate::types::WorkItemContinuationFrame::new_on_completed(
+        "default",
+        parent.id.clone(),
+        active.id.clone(),
+        None,
+    );
+    runtime
+        .storage()
+        .append_work_item_continuation(&frame)
+        .unwrap();
+    let execution = crate::domain::execution_protocol::ExecutionProtocolState {
+        agent_id: "default".into(),
+        attempts: Default::default(),
+        work_items: std::collections::BTreeMap::from([(
+            parent.id.clone(),
+            crate::domain::execution_protocol::WorkItemExecutionRecord {
+                source_revision: parent.revision,
+                state: crate::domain::execution_protocol::WorkItemExecutionState::Paused {
+                    generation: 7,
+                    reason: format!("yielded_to:{}", stale.id),
+                },
+            },
+        )]),
+        outcomes: Default::default(),
+    };
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &execution))
+        .unwrap();
+
+    let report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    assert!(!report.partition_initialized);
+    assert!(report.execution_partition_initialized);
+    let candidate = report
+        .continuation_reconciliations
+        .iter()
+        .find(|candidate| candidate.continuation_id == frame.id)
+        .expect("continuation reconciliation candidate");
+    assert!(
+        candidate.eligible,
+        "candidate rejected: {}",
+        candidate.reason
+    );
+    assert_eq!(
+        candidate.stale_active_work_item_id.as_deref(),
+        Some(stale.id.as_str())
+    );
+
+    let (changed, backup) = apply_scheduler_recovery_plan_with_backup_policy(
+        &runtime.inner.storage,
+        &runtime.inner.runtime_db,
+        "default",
+        &report,
+        SchedulerRecoveryBackupPolicy::SkipApproved,
+    )
+    .unwrap();
+    assert_eq!(changed, 1);
+    assert!(backup.is_none());
+    let repaired = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        repaired.work_items[&parent.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused {
+            generation: 8,
+            reason: format!("yielded_to:{}", active.id),
+        }
+    );
+    let after =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    let after_candidate = after
+        .continuation_reconciliations
+        .iter()
+        .find(|candidate| candidate.continuation_id == frame.id)
+        .unwrap();
+    assert!(!after_candidate.eligible);
+    assert_eq!(after_candidate.reason, "already_matched");
+    assert!(runtime
+        .storage()
+        .read_recent_events(64)
+        .unwrap()
+        .iter()
+        .any(|event| event.kind == "work_item_continuation_reconciled"
+            && event.data["continuation_id"] == frame.id));
 }
 
 #[tokio::test]

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -7018,4 +7018,94 @@ async fn explicit_pick_of_yielded_work_item_resolves_frame_without_new_yield() {
     let frames = runtime.storage().latest_work_item_continuations().unwrap();
     assert_eq!(frames.len(), 1);
     assert_eq!(frames[0].state, WorkItemContinuationState::Resumed);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        execution.work_items[&current.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+
+    runtime.pick_work_item(next.id.clone()).await.unwrap();
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        &execution.work_items[&current.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Paused { reason, .. }
+            if reason == &format!("yielded_to:{}", next.id)
+    ));
+}
+
+#[tokio::test]
+async fn explicit_pick_unwinds_nested_continuations_and_canonical_parents() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let parent = runtime
+        .create_work_item("parent".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let child = runtime
+        .create_work_item("child".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let leaf = runtime
+        .create_work_item("leaf".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(parent.id.clone()).await.unwrap();
+    runtime.pick_work_item(child.id.clone()).await.unwrap();
+    runtime.pick_work_item(leaf.id.clone()).await.unwrap();
+
+    runtime.pick_work_item(parent.id.clone()).await.unwrap();
+
+    let active = runtime
+        .storage()
+        .latest_active_work_item_continuations_for_agent("default")
+        .unwrap();
+    assert!(active.is_empty());
+    let frames = runtime.storage().latest_work_item_continuations().unwrap();
+    assert_eq!(frames.len(), 2);
+    assert!(frames
+        .iter()
+        .any(|frame| frame.suspended_work_item_id == parent.id
+            && frame.state == WorkItemContinuationState::Resumed));
+    assert!(frames
+        .iter()
+        .any(|frame| frame.suspended_work_item_id == child.id
+            && frame.state == WorkItemContinuationState::Cancelled));
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        execution.work_items[&parent.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+    assert!(matches!(
+        execution.work_items[&child.id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
 }

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -4,7 +4,7 @@
 // wiring begins; repository tests exercise it without granting scheduler authority.
 #[cfg(test)]
 mod execution_protocol_fixture_repository;
-mod execution_protocol_repository;
+pub(crate) mod execution_protocol_repository;
 pub(crate) use execution_protocol_repository::{authority_fences_tx, persist_state_tx};
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) mod scheduler_protocol_repository;

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -23,6 +23,12 @@ pub(super) struct PreparedExecutionProtocolCommands {
     results: Vec<PreparedCommandResult>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExecutionProtocolRecoveryCommitOutcome {
+    Applied(bool),
+    Rejected { reason: String },
+}
+
 impl PreparedExecutionProtocolCommands {
     pub(super) fn has_writes(&self) -> bool {
         self.initialized_partition || !self.results.is_empty()
@@ -94,7 +100,17 @@ pub(super) fn validate_execution_commands_tx(
             validate_suspend_work_item_continuation(tx, agent_id, command, continuations)?;
         }
         if let ExecutionProtocolCommand::ResumeWorkItemContinuation(command) = command {
-            validate_resume_work_item_continuation(tx, agent_id, command)?;
+            validate_resume_work_item_continuation(
+                tx,
+                agent_id,
+                command,
+                work_item_mutations,
+                wait_conditions,
+                continuations,
+            )?;
+        }
+        if let ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(command) = command {
+            validate_reconcile_work_item_continuation_yield(tx, agent_id, command)?;
         }
         if let ExecutionProtocolCommand::SetWorkItemWaiting(command) = command {
             validate_set_work_item_waiting(command, work_item_mutations, wait_conditions)?;
@@ -149,6 +165,9 @@ pub(super) fn synchronize_work_item_revisions_tx(
                 command.work_item_id == record.id
             }
             ExecutionProtocolCommand::SuspendWorkItemContinuation(command) => {
+                command.work_item_id == record.id
+            }
+            ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
                 command.work_item_id == record.id
             }
             ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
@@ -286,6 +305,9 @@ fn reduce(
         ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
             execution_protocol::resume_work_item_continuation(state, command)
         }
+        ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(command) => {
+            execution_protocol::reconcile_work_item_continuation_yield(state, command)
+        }
         ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
             execution_protocol::set_work_item_waiting(state, command)
         }
@@ -321,6 +343,10 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
         ExecutionProtocolCommand::ResumeWorkItemContinuation(command) => {
             ("resume_work_item_continuation", &command.command_id)
         }
+        ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(command) => (
+            "reconcile_work_item_continuation_yield",
+            &command.command_id,
+        ),
         ExecutionProtocolCommand::SetWorkItemWaiting(command) => {
             ("set_work_item_waiting", &command.command_id)
         }
@@ -491,6 +517,9 @@ fn validate_resume_work_item_continuation(
     tx: &Transaction<'_>,
     agent_id: &str,
     command: &execution_protocol::ResumeWorkItemContinuation,
+    mutations: &[WorkItemMutation],
+    wait_conditions: &[crate::types::WaitConditionRecord],
+    continuations: &[crate::types::WorkItemContinuationFrame],
 ) -> Result<()> {
     let frame = tx
         .query_row(
@@ -507,15 +536,79 @@ fn validate_resume_work_item_continuation(
         })
         .transpose()?
         .ok_or_else(|| anyhow!("continuation resume requires an existing frame"))?;
+    let resolved = continuations
+        .iter()
+        .find(|candidate| candidate.id == command.continuation_id)
+        .ok_or_else(|| anyhow!("continuation resume requires an atomic frame resolution"))?;
     if frame.suspended_work_item_id != command.work_item_id
         || frame.active_work_item_id != command.active_work_item_id
+        || frame.state != crate::types::WorkItemContinuationState::Active
+        || resolved.agent_id != agent_id
+        || resolved.suspended_work_item_id != command.work_item_id
+        || resolved.active_work_item_id != command.active_work_item_id
         || !matches!(
-            frame.state,
-            crate::types::WorkItemContinuationState::Active
-                | crate::types::WorkItemContinuationState::Resumed
+            resolved.state,
+            crate::types::WorkItemContinuationState::Resumed
+                | crate::types::WorkItemContinuationState::Cancelled
         )
     {
-        bail!("continuation resume command does not match its active frame");
+        bail!("continuation resume command does not match its atomic frame resolution");
+    }
+    let durable_parent = tx
+        .query_row(
+            "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+            [&command.work_item_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<crate::types::WorkItemRecord>(&payload))
+        .transpose()?
+        .ok_or_else(|| anyhow!("continuation resume parent WorkItem is missing"))?;
+    let parent = mutations
+        .iter()
+        .find_map(|mutation| match mutation {
+            WorkItemMutation::Update { record, .. } if record.id == command.work_item_id => {
+                Some(record)
+            }
+            _ => None,
+        })
+        .unwrap_or(&durable_parent);
+    let mut active_wait_ids = {
+        let mut statement = tx.prepare(
+            "SELECT wait_condition_id
+             FROM wait_conditions
+             WHERE agent_id = ?1 AND work_item_id = ?2 AND status = 'active'
+             ORDER BY wait_condition_id ASC",
+        )?;
+        let wait_ids = statement
+            .query_map([agent_id, command.work_item_id.as_str()], |row| {
+                row.get::<_, String>(0)
+            })?
+            .collect::<std::result::Result<std::collections::BTreeSet<_>, _>>()?;
+        wait_ids
+    };
+    for wait in wait_conditions {
+        active_wait_ids.remove(&wait.id);
+        if wait.agent_id == agent_id
+            && wait.work_item_id.as_deref() == Some(command.work_item_id.as_str())
+            && wait.status == crate::types::WaitConditionStatus::Active
+        {
+            active_wait_ids.insert(wait.id.clone());
+        }
+    }
+    let source = execution_protocol::WorkItemContinuationResumeSource {
+        work_item_revision: parent.revision,
+        blocked_by: parent.blocked_by.clone(),
+        active_wait_ids: active_wait_ids.into_iter().collect(),
+    };
+    if parent.agent_id != agent_id
+        || parent.state != crate::types::WorkItemState::Open
+        || source != command.source
+        || execution_protocol::continuation_resume_outcome(&command.work_item_id, &source)
+            .map_err(anyhow::Error::msg)?
+            != command.outcome
+    {
+        bail!("continuation resume source fence is stale");
     }
     Ok(())
 }
@@ -552,6 +645,88 @@ fn validate_suspend_work_item_continuation(
         || parent.revision != command.expected.source_revision
     {
         bail!("continuation suspension parent WorkItem fence is stale");
+    }
+    Ok(())
+}
+
+fn validate_reconcile_work_item_continuation_yield(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &execution_protocol::ReconcileWorkItemContinuationYield,
+) -> Result<()> {
+    let active_frames = {
+        let mut statement = tx.prepare(
+            "SELECT payload_json
+             FROM work_item_continuations
+             WHERE agent_id = ?1 AND state = 'active'
+             ORDER BY continuation_id ASC",
+        )?;
+        let records = statement
+            .query_map([agent_id], |row| row.get::<_, String>(0))?
+            .map(|row| {
+                serde_json::from_str::<crate::types::WorkItemContinuationFrame>(&row?)
+                    .context("decoding continuation reconciliation frame")
+            })
+            .collect::<Result<Vec<_>>>()?;
+        records
+    };
+    let frame = active_frames
+        .iter()
+        .find(|frame| frame.id == command.continuation_id)
+        .ok_or_else(|| anyhow!("continuation reconciliation requires an active frame"))?;
+    if frame.suspended_work_item_id != command.work_item_id
+        || frame.active_work_item_id != command.active_work_item_id
+        || frame.updated_at.to_rfc3339() != command.expected_frame_updated_at
+    {
+        bail!("continuation reconciliation frame fence is stale");
+    }
+    if active_frames
+        .iter()
+        .filter(|candidate| {
+            candidate.suspended_work_item_id == command.work_item_id
+                || candidate.active_work_item_id == command.active_work_item_id
+        })
+        .count()
+        != 1
+    {
+        bail!("continuation reconciliation has a competing active frame");
+    }
+    let mut cursor = command.active_work_item_id.as_str();
+    let mut visited = std::collections::BTreeSet::new();
+    while let Some(next) = active_frames
+        .iter()
+        .find(|candidate| candidate.suspended_work_item_id == cursor)
+    {
+        if !visited.insert(next.id.as_str()) || next.active_work_item_id == command.work_item_id {
+            bail!("continuation reconciliation active topology contains a cycle");
+        }
+        cursor = next.active_work_item_id.as_str();
+    }
+    let load_work_item = |work_item_id: &str| -> Result<crate::types::WorkItemRecord> {
+        tx.query_row(
+            "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+            [work_item_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str(&payload).context("decoding reconciliation WorkItem"))
+        .transpose()?
+        .ok_or_else(|| anyhow!("continuation reconciliation WorkItem is missing"))
+    };
+    let parent = load_work_item(&command.work_item_id)?;
+    let active = load_work_item(&command.active_work_item_id)?;
+    let stale = load_work_item(&command.stale_active_work_item_id)?;
+    if parent.agent_id != agent_id
+        || parent.state != crate::types::WorkItemState::Open
+        || parent.revision != command.expected.source_revision
+        || active.agent_id != agent_id
+        || active.state != crate::types::WorkItemState::Open
+        || active.revision != command.active_work_item_source_revision
+        || stale.agent_id != agent_id
+        || stale.state != crate::types::WorkItemState::Completed
+        || stale.revision != command.stale_active_work_item_source_revision
+    {
+        bail!("continuation reconciliation WorkItem source fence is stale");
     }
     Ok(())
 }
@@ -668,6 +843,46 @@ impl RuntimeTransitionRepository<'_> {
         let state = load_state_tx(&transaction, agent_id)?;
         transaction.commit()?;
         Ok(Some(state))
+    }
+
+    pub(crate) fn commit_execution_protocol_recovery_plan(
+        &self,
+        agent_id: &str,
+        commands: &[ExecutionProtocolCommand],
+        audit_events: &[crate::types::AuditEvent],
+    ) -> Result<ExecutionProtocolRecoveryCommitOutcome> {
+        if commands.is_empty() {
+            return Ok(ExecutionProtocolRecoveryCommitOutcome::Applied(false));
+        }
+        if commands.iter().any(|command| {
+            !matches!(
+                command,
+                ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(_)
+            )
+        }) {
+            bail!("execution protocol recovery plan contains a non-recovery command");
+        }
+        self.db.transaction(|tx| {
+            let prepared =
+                match validate_execution_commands_tx(tx, agent_id, None, commands, &[], &[], &[]) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        return Ok(ExecutionProtocolRecoveryCommitOutcome::Rejected {
+                            reason: error.to_string(),
+                        });
+                    }
+                };
+            let changed = prepared
+                .as_ref()
+                .is_some_and(PreparedExecutionProtocolCommands::has_writes);
+            persist_execution_commands_tx(tx, prepared)?;
+            if changed {
+                for event in audit_events {
+                    crate::runtime_db::evidence::append_audit_event_tx(tx, Some(agent_id), event)?;
+                }
+            }
+            Ok(ExecutionProtocolRecoveryCommitOutcome::Applied(changed))
+        })
     }
 }
 

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -540,6 +540,8 @@ fn validate_resume_work_item_continuation(
         .iter()
         .find(|candidate| candidate.id == command.continuation_id)
         .ok_or_else(|| anyhow!("continuation resume requires an atomic frame resolution"))?;
+    // A resolved durable frame means its matching canonical resume already committed.
+    // Retries are fenced by the atomic batch rather than replayed from Resumed state.
     if frame.suspended_work_item_id != command.work_item_id
         || frame.active_work_item_id != command.active_work_item_id
         || frame.state != crate::types::WorkItemContinuationState::Active


### PR DESCRIPTION
## 背景

Closes #2552。

active `WorkItemContinuationFrame` 与 canonical `WorkItemExecutionState::Paused(yielded_to: ...)` 漂移时，严格 continuation resume fence 会阻止 child completion。该状态既可能来自升级前遗留数据，也可能由 `PickWorkItem` 的显式返回/重选焦点路径在线制造。

## 改动

- 新增 typed `ReconcileWorkItemContinuationYield` transition：保持 expected-state/source fence，通过 reducer-backed 事务原子修复 stale canonical yield authority，并推进 generation、保留 source revision，支持可审计、幂等和 fail-closed recovery。
- 将 scheduler recovery 扩展为 continuation reconciliation candidate 发现与执行；CLI recovery report 会明确展示 candidate、eligibility 与原因，不直接修改 SQLite 业务状态。
- 修复 `PickWorkItem` 在线路径：显式返回已 yielded parent、重选当前焦点及 nested continuation unwind 时，将 frame resolution、canonical parent resume 与 focus 切换纳入同一事务，避免继续制造 authority drift。
- 补充 reducer、scheduler recovery、显式 pick/nested unwind 回归测试。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --lib continuation_reconciliation_advances_generation_and_preserves_source_revision -- --nocapture --test-threads=1`
- `cargo test --lib explicit_pick_of_yielded_work_item_resolves_frame_without_new_yield -- --nocapture --test-threads=1`
- `cargo test --lib explicit_pick_unwinds_nested_continuations_and_canonical_parents -- --nocapture --test-threads=1`
- `cargo test --lib scheduler_recovery_reconciles_stale_continuation_yield_without_legacy_partition -- --nocapture --test-threads=1`

以上检查均通过。
