### PR TITLE
refactor: extract conversation and read state

### DIFF
--- a/web-gui/app/src/runtime/conversation-store.test.ts
+++ b/web-gui/app/src/runtime/conversation-store.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import type { StreamEventEnvelopeDto } from "./client";
+import {
+  emptyAgentSession,
+  hasEventIdentityConflict,
+  mergeCachedSessionIntoCurrent,
+  mergeEventPageIntoConversation,
+  semanticHistoryState,
+  semanticTimelineHasNewItem,
+  semanticTimelineItemIds,
+  sessionForEventLogEpoch,
+  withSemanticHistoryState,
+} from "./conversation-store";
+
+function event(
+  eventSeq: number,
+  type: string,
+  payload: Record<string, unknown> = {},
+): StreamEventEnvelopeDto {
+  return {
+    id: `event-${eventSeq}`,
+    event_seq: eventSeq,
+    event_log_epoch: "epoch-1",
+    ts: `2026-08-11T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    agent_id: "agent-a",
+    type,
+    payload,
+  };
+}
+
+describe("conversation state", () => {
+  it("drops projection and semantic history when the event log epoch changes", () => {
+    const current = mergeEventPageIntoConversation(
+      emptyAgentSession(),
+      [event(7, "message_enqueued", {
+        message_id: "message-7",
+        origin: { kind: "operator" },
+        body: "old message",
+      })],
+      7,
+      true,
+      "info",
+      {
+        eventLogEpoch: "epoch-1",
+        historyDisplayLevel: "info",
+      },
+    );
+
+    const reset = sessionForEventLogEpoch(current, "epoch-2");
+
+    expect(reset).toMatchObject({
+      eventLogEpoch: "epoch-2",
+      eventsBySeq: {},
+      eventSeqs: [],
+      messagesById: {},
+      semanticHistoryByDisplayLevel: {},
+    });
+    expect(reset.newestSeq).toBeUndefined();
+    expect(reset.oldestSeq).toBeUndefined();
+  });
+
+  it("detects conflicting immutable content for the same epoch and sequence", () => {
+    const existing = event(7, "legacy_event", { value: 1 });
+    const current = {
+      ...emptyAgentSession(),
+      eventLogEpoch: "epoch-1",
+      eventsBySeq: { 7: existing },
+      eventSeqs: [7],
+    };
+
+    expect(hasEventIdentityConflict(current, [{ ...existing }])).toBe(false);
+    expect(
+      hasEventIdentityConflict(current, [
+        { ...existing, id: "event-conflict", payload: { value: 2 } },
+      ]),
+    ).toBe(true);
+  });
+
+  it("restores cached projection only into an empty session and preserves UI state", () => {
+    const current = {
+      ...emptyAgentSession(),
+      loading: true,
+      liveStatus: "connecting" as const,
+    };
+    const cached = mergeEventPageIntoConversation(
+      emptyAgentSession(),
+      [event(1, "legacy_event")],
+      1,
+      false,
+      "info",
+      {
+        eventLogEpoch: "epoch-1",
+        historyDisplayLevel: "info",
+      },
+    );
+
+    const restored = mergeCachedSessionIntoCurrent(current, cached);
+
+    expect(restored.eventSeqs).toEqual([1]);
+    expect(restored.semanticHistoryByDisplayLevel.info).toMatchObject({
+      cursorSeq: 1,
+      hasOlder: false,
+    });
+    expect(restored.loading).toBe(true);
+    expect(restored.liveStatus).toBe("connecting");
+    expect(mergeCachedSessionIntoCurrent(restored, cached)).toBe(restored);
+  });
+
+  it("merges raw pages while updating only the requested semantic history cursor", () => {
+    const current = withSemanticHistoryState(
+      withSemanticHistoryState(emptyAgentSession(), "info", {
+        eventLogEpoch: "epoch-1",
+        cursorSeq: 90,
+        hasOlder: true,
+        loading: true,
+      }),
+      "verbose",
+      {
+        eventLogEpoch: "epoch-1",
+        cursorSeq: 70,
+        hasOlder: true,
+        loading: false,
+      },
+    );
+    const merged = mergeEventPageIntoConversation(
+      current,
+      [
+        event(89, "legacy_event"),
+        event(80, "message_enqueued", {
+          message_id: "message-80",
+          origin: { kind: "operator" },
+          body: "older operator message",
+        }),
+      ],
+      80,
+      false,
+      "info",
+      {
+        newestSeq: 89,
+        eventLogEpoch: "epoch-1",
+        historyDisplayLevel: "info",
+        historyLoading: false,
+      },
+    );
+
+    expect(merged).toMatchObject({
+      eventSeqs: [80, 89],
+      oldestSeq: 80,
+      newestSeq: 89,
+      semanticHistoryByDisplayLevel: {
+        info: { cursorSeq: 80, hasOlder: false, loading: false },
+        verbose: { cursorSeq: 70, hasOlder: true, loading: false },
+      },
+    });
+    expect(semanticHistoryState(merged, "info").cursorSeq).toBe(80);
+  });
+
+  it("detects when a merged page adds an item visible at the selected display level", () => {
+    const initial = emptyAgentSession();
+    const initialIds = semanticTimelineItemIds(initial, "info");
+    const rawOnly = mergeEventPageIntoConversation(
+      initial,
+      [event(2, "legacy_event")],
+      2,
+      true,
+      "info",
+      { eventLogEpoch: "epoch-1" },
+    );
+    const withMessage = mergeEventPageIntoConversation(
+      rawOnly,
+      [event(1, "message_enqueued", {
+        message_id: "message-1",
+        origin: { kind: "operator" },
+        body: "visible message",
+      })],
+      1,
+      false,
+      "info",
+      { eventLogEpoch: "epoch-1" },
+    );
+
+    expect(semanticTimelineHasNewItem(rawOnly, "info", initialIds)).toBe(false);
+    expect(semanticTimelineHasNewItem(withMessage, "info", initialIds)).toBe(true);
+  });
+});

--- a/web-gui/app/src/runtime/conversation-store.ts
+++ b/web-gui/app/src/runtime/conversation-store.ts
@@ -1,0 +1,300 @@
+import type { StreamEventEnvelopeDto } from "./client";
+import {
+  compactAgentTimelineItems,
+  filterTimelineByDisplayLevel,
+} from "./session-reducer";
+import {
+  createSessionProjectionState,
+  deriveSessionTimeline,
+  eventIdentityConflicts,
+  reduceSessionProjection,
+  type SessionProjectionAction,
+  type SessionProjectionState,
+} from "./session-projection";
+import type {
+  AgentSessionState,
+  SemanticHistoryState,
+} from "./runtime-store-helpers";
+import type {
+  AgentDetail,
+  AgentTimelineItem,
+  DisplayLevel,
+} from "./types";
+
+export const OPTIMISTIC_OPERATOR_PROMPT_SOURCE = "pending-operator-prompt";
+export const OPTIMISTIC_OPERATOR_MESSAGE_PREFIX = "operator-prompt-message:";
+
+export interface MergeConversationEventPageOptions {
+  newestSeq?: number;
+  eventLogEpoch?: string;
+  historyDisplayLevel?: DisplayLevel;
+  historyLoading?: boolean;
+}
+
+export function emptyAgentSession(): AgentSessionState {
+  return {
+    ...createSessionProjectionState(),
+    loading: false,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
+    liveStatus: "idle",
+    cacheStatus: "unchecked",
+    contentStatus: "unknown",
+    syncStatus: "idle",
+    sendingPrompt: false,
+    detail: null,
+    workItemDetailsById: {},
+    taskDetailsById: {},
+    toolExecutionDetailsById: {},
+  };
+}
+
+export function mergeCachedSessionIntoCurrent(
+  current: AgentSessionState,
+  cached: Partial<AgentSessionState>,
+): AgentSessionState {
+  if (
+    current.detail ||
+    current.eventSeqs.length > 0 ||
+    Object.keys(current.messagesById).length > 0 ||
+    Object.keys(current.transcriptEntriesById).length > 0 ||
+    Object.keys(current.briefRecordsById).length > 0
+  ) {
+    return current;
+  }
+  return {
+    ...current,
+    ...cached,
+    loading: current.loading,
+    semanticHistoryByDisplayLevel:
+      Object.keys(current.semanticHistoryByDisplayLevel).length > 0
+        ? current.semanticHistoryByDisplayLevel
+        : (cached.semanticHistoryByDisplayLevel ?? {}),
+    targetEventLoading: current.targetEventLoading,
+    liveStatus: current.liveStatus,
+    sendingPrompt: current.sendingPrompt,
+  };
+}
+
+export function applyProjectionAction(
+  current: AgentSessionState,
+  action: SessionProjectionAction,
+  displayLevel: DisplayLevel = "debug",
+  detailBase: AgentDetail | null = current.detail,
+): AgentSessionState {
+  const projection = reduceSessionProjection(current, action);
+  return {
+    ...current,
+    ...projection,
+    detail: materializeProjectionDetail(detailBase, projection, displayLevel),
+  };
+}
+
+export function materializeProjectionDetail(
+  detail: AgentDetail | null,
+  projection: SessionProjectionState,
+  displayLevel: DisplayLevel,
+): AgentDetail | null {
+  if (!detail) return null;
+  const projectedTimeline = deriveSessionTimeline(projection, displayLevel);
+  const projectedMessageIds = new Set(
+    projectedTimeline.flatMap((item) =>
+      item.kind === "operator" && item.id.startsWith("message:")
+        ? [item.id.slice("message:".length)]
+        : [],
+    ),
+  );
+  const optimisticItems = detail.timeline.filter((item) => {
+    if (!item.sourceIds.includes(OPTIMISTIC_OPERATOR_PROMPT_SOURCE)) return false;
+    const canonicalMessageId = item.sourceIds
+      .find((sourceId) => sourceId.startsWith(OPTIMISTIC_OPERATOR_MESSAGE_PREFIX))
+      ?.slice(OPTIMISTIC_OPERATOR_MESSAGE_PREFIX.length);
+    return !canonicalMessageId || !projectedMessageIds.has(canonicalMessageId);
+  });
+  const timeline = compactAgentTimelineItems([
+    ...projectedTimeline,
+    ...optimisticItems,
+  ]).sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
+  return {
+    ...detail,
+    timeline,
+    events: projection.eventSeqs.map((seq) => projection.eventsBySeq[seq]),
+    eventLogEpoch: projection.eventLogEpoch,
+    newestEventSeq: projection.newestSeq,
+    oldestEventSeq: projection.oldestSeq,
+    briefRecordsById: projection.briefRecordsById,
+  };
+}
+
+export function eventLogEpochFromEvents(events: StreamEventEnvelopeDto[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const epoch = events[index]?.event_log_epoch;
+    if (epoch) return epoch;
+  }
+  return undefined;
+}
+
+export function shouldResetForEventLogEpoch(
+  current: AgentSessionState,
+  incomingEpoch: string | undefined,
+): boolean {
+  if (!incomingEpoch) return false;
+  return (
+    (current.eventLogEpoch != null || current.eventSeqs.length > 0) &&
+    current.eventLogEpoch !== incomingEpoch
+  );
+}
+
+export function sessionForEventLogEpoch(
+  current: AgentSessionState,
+  incomingEpoch: string | undefined,
+): AgentSessionState {
+  if (!incomingEpoch) return current;
+  if (!shouldResetForEventLogEpoch(current, incomingEpoch)) {
+    return current.eventLogEpoch === incomingEpoch
+      ? current
+      : { ...current, eventLogEpoch: incomingEpoch };
+  }
+  const reset = applyProjectionAction(current, { type: "reset", eventLogEpoch: incomingEpoch });
+  return {
+    ...reset,
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
+    targetEventError: undefined,
+    detail: reset.detail
+      ? {
+          ...reset.detail,
+          eventCursorSeq: undefined,
+          hasOlderEvents: undefined,
+        }
+      : null,
+  };
+}
+
+export function hasEventIdentityConflict(
+  current: AgentSessionState,
+  incomingEvents: StreamEventEnvelopeDto[],
+): boolean {
+  return eventIdentityConflicts(current, incomingEvents);
+}
+
+export function resetSessionForEventConflict(
+  current: AgentSessionState,
+  eventLogEpoch?: string,
+): AgentSessionState {
+  return {
+    ...applyProjectionAction(current, {
+      type: "reset",
+      eventLogEpoch: eventLogEpoch ?? current.eventLogEpoch,
+      reason: "event_identity_conflict",
+    }),
+    liveStatus: "stale",
+    semanticHistoryByDisplayLevel: {},
+    targetEventLoading: false,
+    error: "runtime event identity conflict; refreshing projection",
+  };
+}
+
+export function semanticHistoryState(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+): SemanticHistoryState {
+  return session?.semanticHistoryByDisplayLevel[displayLevel] ?? {
+    eventLogEpoch: session?.eventLogEpoch,
+    cursorSeq: undefined,
+    hasOlder: false,
+    loading: false,
+  };
+}
+
+export function withSemanticHistoryState(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+  history: SemanticHistoryState,
+): AgentSessionState {
+  const current = session ?? emptyAgentSession();
+  return {
+    ...current,
+    semanticHistoryByDisplayLevel: {
+      ...current.semanticHistoryByDisplayLevel,
+      [displayLevel]: history,
+    },
+  };
+}
+
+export function semanticTimelineItemIds(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+): Set<string> {
+  return new Set(semanticTimeline(session, displayLevel).map((item) => item.id));
+}
+
+export function semanticTimelineHasNewItem(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+  initialItemIds: Set<string>,
+): boolean {
+  return semanticTimeline(session, displayLevel).some((item) => !initialItemIds.has(item.id));
+}
+
+export function semanticTimeline(
+  session: AgentSessionState | undefined,
+  displayLevel: DisplayLevel,
+): AgentTimelineItem[] {
+  return session
+    ? filterTimelineByDisplayLevel(
+        deriveSessionTimeline(session, displayLevel),
+        displayLevel,
+        { itemLimit: Number.MAX_SAFE_INTEGER },
+      )
+    : [];
+}
+
+export function mergeEventPageIntoConversation(
+  session: AgentSessionState | undefined,
+  pageEvents: StreamEventEnvelopeDto[],
+  pageOldestSeq: number | undefined,
+  pageHasOlder: boolean | undefined,
+  displayLevel: DisplayLevel,
+  options: MergeConversationEventPageOptions = {},
+): AgentSessionState {
+  const epochSession = sessionForEventLogEpoch(
+    session ?? emptyAgentSession(),
+    options.eventLogEpoch,
+  );
+  const current = hasEventIdentityConflict(epochSession, pageEvents)
+    ? resetSessionForEventConflict(epochSession, options.eventLogEpoch)
+    : epochSession;
+  const projected = applyProjectionAction(current, {
+    type: "events_received",
+    events: pageEvents,
+    eventLogEpoch: options.eventLogEpoch,
+  }, displayLevel, current.detail);
+  const historyDisplayLevel = options.historyDisplayLevel;
+  const semanticHistoryByDisplayLevel = historyDisplayLevel
+    ? {
+        ...projected.semanticHistoryByDisplayLevel,
+        [historyDisplayLevel]: {
+          eventLogEpoch: options.eventLogEpoch ?? projected.eventLogEpoch,
+          cursorSeq: pageOldestSeq,
+          hasOlder: pageHasOlder ?? false,
+          loading: options.historyLoading ?? false,
+        },
+      }
+    : projected.semanticHistoryByDisplayLevel;
+
+  return {
+    ...projected,
+    newestSeq: Math.max(options.newestSeq ?? 0, projected.newestSeq ?? 0) || undefined,
+    oldestSeq:
+      pageOldestSeq != null && projected.oldestSeq != null
+        ? Math.min(pageOldestSeq, projected.oldestSeq)
+        : (pageOldestSeq ?? projected.oldestSeq),
+    semanticHistoryByDisplayLevel,
+  };
+}
+
+function sortableTime(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}

--- a/web-gui/app/src/runtime/read-state.test.ts
+++ b/web-gui/app/src/runtime/read-state.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import type { StreamEventEnvelopeDto } from "./client";
+import {
+  cachedReadState,
+  canMarkConversationRead,
+  latestBriefDeliverySeq,
+  markAgentDeliveriesRead,
+  mergeCachedReadState,
+  mergeCachedReadStates,
+  readStoredRosterActivity,
+  touchRosterActivityFromEvent,
+  writeStoredRosterActivity,
+  type AgentRosterActivity,
+} from "./read-state";
+import { emptyAgentSession } from "./conversation-store";
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length() {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+function event(
+  eventSeq: number,
+  type: string,
+  payload: Record<string, unknown> = {},
+): StreamEventEnvelopeDto {
+  return {
+    id: `event-${eventSeq}`,
+    agent_id: "agent-a",
+    event_seq: eventSeq,
+    ts: `2026-08-11T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    type,
+    payload,
+  };
+}
+
+describe("read state", () => {
+  it("persists activity per remote and migrates legacy read marker names", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      "holon.webGui.rosterActivityByRemote.v1",
+      JSON.stringify({
+        local: {
+          "agent-a": {
+            unreadCount: 2,
+            lastUnreadSeq: 12,
+            lastReadSeq: 7,
+            briefAt: "2026-08-11T00:00:00Z",
+          },
+        },
+      }),
+    );
+
+    expect(readStoredRosterActivity("local", storage)).toEqual({
+      "agent-a": {
+        unreadCount: 2,
+        lastUnreadDeliverySeq: 12,
+        lastReadDeliverySeq: 7,
+        briefAt: "2026-08-11T00:00:00Z",
+      },
+    });
+
+    writeStoredRosterActivity(
+      "https://remote.example",
+      { "agent-b": { unreadCount: 1 } },
+      storage,
+    );
+    expect(readStoredRosterActivity("https://remote.example", storage)).toEqual({
+      "agent-b": { unreadCount: 1 },
+    });
+    expect(readStoredRosterActivity("local", storage)["agent-a"]?.lastReadDeliverySeq).toBe(7);
+  });
+
+  it("merges cached read state only when no local read marker exists", () => {
+    const cached = {
+      unreadCount: 3,
+      lastUnreadDeliverySeq: 12,
+      lastReadDeliverySeq: 7,
+    };
+    const activity = { operatorAt: "2026-08-11T00:00:00Z" };
+
+    expect(mergeCachedReadState(activity, cached)).toEqual({ ...activity, ...cached });
+    expect(mergeCachedReadStates({ "agent-a": activity }, { "agent-a": cached })).toEqual({
+      "agent-a": { ...activity, ...cached },
+    });
+
+    const localState = { unreadCount: 1, lastReadDeliverySeq: 19 };
+    expect(mergeCachedReadState(localState, cached)).toBe(localState);
+    expect(cachedReadState({ ...activity, ...cached })).toEqual(cached);
+    expect(cachedReadState(activity)).toBeUndefined();
+  });
+
+  it("deduplicates replayed brief deliveries and ignores non-operator messages", () => {
+    const afterBrief = touchRosterActivityFromEvent(
+      {},
+      "agent-a",
+      event(10, "brief_created"),
+      "agent-b",
+    );
+    const afterDuplicate = touchRosterActivityFromEvent(
+      afterBrief,
+      "agent-a",
+      event(10, "brief_created"),
+      "agent-b",
+    );
+    const afterAgentMessage = touchRosterActivityFromEvent(
+      afterDuplicate,
+      "agent-a",
+      event(11, "message_enqueued", { origin: { kind: "agent" } }),
+      "agent-b",
+    );
+
+    expect(afterAgentMessage["agent-a"]).toMatchObject({
+      unreadCount: 1,
+      lastUnreadDeliverySeq: 10,
+    });
+  });
+
+  it("advances read markers monotonically and does not recount replayed deliveries", () => {
+    let activity: Record<string, AgentRosterActivity> = {
+      "agent-a": { unreadCount: 2, lastUnreadDeliverySeq: 10, lastReadDeliverySeq: 7 },
+    };
+
+    activity = markAgentDeliveriesRead(activity, "agent-a", 9);
+    expect(activity["agent-a"]).toMatchObject({
+      unreadCount: 0,
+      lastReadDeliverySeq: 10,
+    });
+
+    const unchanged = markAgentDeliveriesRead(activity, "agent-a", 8);
+    expect(unchanged).toBe(activity);
+    const replayed = touchRosterActivityFromEvent(
+      activity,
+      "agent-a",
+      event(10, "brief_created"),
+      "agent-b",
+    );
+    expect(replayed["agent-a"]).toMatchObject({
+      unreadCount: 0,
+      lastUnreadDeliverySeq: 10,
+      lastReadDeliverySeq: 10,
+    });
+
+    const next = touchRosterActivityFromEvent(
+      replayed,
+      "agent-a",
+      event(11, "brief_created"),
+      "agent-b",
+    );
+    expect(next["agent-a"]).toMatchObject({
+      unreadCount: 1,
+      lastUnreadDeliverySeq: 11,
+      lastReadDeliverySeq: 10,
+    });
+  });
+
+  it("marks a conversation readable only after its synchronized projection is visible", () => {
+    const session = {
+      ...emptyAgentSession(),
+      eventsBySeq: {
+        8: event(8, "brief_created"),
+        10: event(10, "brief_created"),
+      },
+      eventSeqs: [8, 10],
+      syncStatus: "streaming" as const,
+      liveStatus: "streaming" as const,
+    };
+    const context = {
+      route: "agent",
+      selectedAgentId: "agent-a",
+      documentVisible: true,
+      session,
+    };
+
+    expect(canMarkConversationRead(context, "agent-a")).toBe(true);
+    expect(latestBriefDeliverySeq(session)).toBe(10);
+    expect(canMarkConversationRead({ ...context, documentVisible: false }, "agent-a")).toBe(false);
+    expect(
+      canMarkConversationRead(
+        { ...context, session: { ...session, liveStatus: "recovering" } },
+        "agent-a",
+      ),
+    ).toBe(false);
+  });
+});

--- a/web-gui/app/src/runtime/read-state.ts
+++ b/web-gui/app/src/runtime/read-state.ts
@@ -1,0 +1,273 @@
+import type { StreamEventEnvelopeDto } from "./client";
+import type { CachedAgentReadState } from "./idb-cache";
+import { briefIdsForProjectionHydration } from "./session-projection";
+import { canApplySessionEvent } from "./session-events";
+import type { AgentSessionState } from "./runtime-store-helpers";
+
+const ROSTER_ACTIVITY_STORAGE_KEY = "holon.webGui.rosterActivityByRemote.v1";
+
+export interface AgentRosterActivity {
+  operatorAt?: string;
+  briefAt?: string;
+  unreadCount?: number;
+  lastUnreadDeliverySeq?: number;
+  lastReadDeliverySeq?: number;
+}
+
+export interface ConversationReadContext {
+  route: string;
+  selectedAgentId: string;
+  documentVisible: boolean;
+  session: AgentSessionState | undefined;
+}
+
+export function readStoredRosterActivity(
+  remoteKey: string,
+  storage: Storage | undefined = typeof window === "undefined" ? undefined : window.localStorage,
+): Record<string, AgentRosterActivity> {
+  if (!storage) return {};
+  try {
+    const parsed = readStoredJson(storage, ROSTER_ACTIVITY_STORAGE_KEY);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const rawActivity = (parsed as Record<string, unknown>)[remoteKey];
+    if (!rawActivity || typeof rawActivity !== "object" || Array.isArray(rawActivity)) return {};
+    const activityByAgentId: Record<string, AgentRosterActivity> = {};
+    for (const [agentId, value] of Object.entries(rawActivity)) {
+      if (!agentId || !value || typeof value !== "object" || Array.isArray(value)) continue;
+      const activity = coerceRosterActivity(value);
+      if (activity) activityByAgentId[agentId] = activity;
+    }
+    return activityByAgentId;
+  } catch {
+    return {};
+  }
+}
+
+export function writeStoredRosterActivity(
+  remoteKey: string,
+  activityByAgentId: Record<string, AgentRosterActivity>,
+  storage: Storage | undefined = typeof window === "undefined" ? undefined : window.localStorage,
+): void {
+  if (!storage) return;
+  try {
+    const parsed = readStoredJson(storage, ROSTER_ACTIVITY_STORAGE_KEY);
+    const byRemote =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, Record<string, AgentRosterActivity>>)
+        : {};
+    byRemote[remoteKey] = activityByAgentId;
+    storage.setItem(ROSTER_ACTIVITY_STORAGE_KEY, JSON.stringify(byRemote));
+  } catch {
+    // Ignore storage failures; unread state falls back to memory-only.
+  }
+}
+
+export function mergeCachedReadState(
+  current: AgentRosterActivity | undefined,
+  cached: CachedAgentReadState | undefined,
+): AgentRosterActivity | undefined {
+  if (!cached) return current;
+  const currentHasReadState =
+    current?.unreadCount != null ||
+    current?.lastUnreadDeliverySeq != null ||
+    current?.lastReadDeliverySeq != null;
+  if (currentHasReadState) return current;
+  return {
+    ...current,
+    ...cached,
+  };
+}
+
+export function mergeCachedReadStates(
+  current: Record<string, AgentRosterActivity>,
+  cached: Record<string, CachedAgentReadState>,
+): Record<string, AgentRosterActivity> {
+  let merged = current;
+  for (const [agentId, readState] of Object.entries(cached)) {
+    const activity = mergeCachedReadState(merged[agentId], readState);
+    if (!activity || activity === merged[agentId]) continue;
+    if (merged === current) merged = { ...current };
+    merged[agentId] = activity;
+  }
+  return merged;
+}
+
+export function cachedReadState(
+  activity: AgentRosterActivity | undefined,
+): CachedAgentReadState | undefined {
+  if (!activity) return undefined;
+  const readState: CachedAgentReadState = {};
+  if (activity.unreadCount != null) readState.unreadCount = activity.unreadCount;
+  if (activity.lastUnreadDeliverySeq != null) {
+    readState.lastUnreadDeliverySeq = activity.lastUnreadDeliverySeq;
+  }
+  if (activity.lastReadDeliverySeq != null) {
+    readState.lastReadDeliverySeq = activity.lastReadDeliverySeq;
+  }
+  return Object.keys(readState).length ? readState : undefined;
+}
+
+export function touchRosterActivity(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  kind: "operator" | "brief",
+  timestamp: string | undefined,
+): Record<string, AgentRosterActivity> {
+  if (!timestamp) return current;
+  const existing = current[agentId];
+  const field = kind === "operator" ? "operatorAt" : "briefAt";
+  if (sortableTime(existing?.[field] ?? "") >= sortableTime(timestamp)) return current;
+  return {
+    ...current,
+    [agentId]: {
+      ...existing,
+      [field]: timestamp,
+    },
+  };
+}
+
+export function markAgentDeliveriesRead(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  deliverySeq: number,
+): Record<string, AgentRosterActivity> {
+  const existing = current[agentId];
+  const lastReadDeliverySeq = Math.max(
+    deliverySeq,
+    existing?.lastUnreadDeliverySeq ?? 0,
+    existing?.lastReadDeliverySeq ?? 0,
+  );
+  if (!existing?.unreadCount && existing?.lastReadDeliverySeq === lastReadDeliverySeq) return current;
+  return {
+    ...current,
+    [agentId]: {
+      ...existing,
+      unreadCount: 0,
+      lastReadDeliverySeq,
+    },
+  };
+}
+
+export function touchRosterActivityFromEvent(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  event: StreamEventEnvelopeDto,
+  _selectedAgentId: string,
+): Record<string, AgentRosterActivity> {
+  if (!canApplySessionEvent(event)) return current;
+  let next = current;
+  if (event.type === "brief_created") {
+    next = touchRosterActivity(next, agentId, "brief", eventTimestamp(event));
+  }
+  if (event.type === "message_enqueued" && messageOrigin(event.payload) === "operator") {
+    next = touchRosterActivity(next, agentId, "operator", eventTimestamp(event));
+  }
+  if (event.type === "brief_created") {
+    next = incrementUnreadFromEvent(next, agentId, event);
+  }
+  return next;
+}
+
+export function latestBriefDeliverySeq(session: AgentSessionState): number | undefined {
+  for (let index = session.eventSeqs.length - 1; index >= 0; index -= 1) {
+    const seq = session.eventSeqs[index];
+    if (session.eventsBySeq[seq]?.type === "brief_created") return seq;
+  }
+  return undefined;
+}
+
+export function canMarkConversationRead({
+  route,
+  selectedAgentId,
+  documentVisible,
+  session,
+}: ConversationReadContext, agentId: string): boolean {
+  return Boolean(
+    route === "agent" &&
+    selectedAgentId === agentId &&
+    documentVisible &&
+    session &&
+    !session.loading &&
+    session.gaps.length === 0 &&
+    session.syncStatus !== "refreshing" &&
+    session.syncStatus !== "recovering" &&
+    session.syncStatus !== "stale" &&
+    session.syncStatus !== "error" &&
+    session.liveStatus !== "connecting" &&
+    session.liveStatus !== "reconnecting" &&
+    session.liveStatus !== "recovering" &&
+    session.liveStatus !== "stale" &&
+    session.liveStatus !== "error" &&
+    briefIdsForProjectionHydration(session).length === 0
+  );
+}
+
+function coerceRosterActivity(value: unknown): AgentRosterActivity | undefined {
+  const parsed = value as Partial<AgentRosterActivity> & {
+    lastUnreadSeq?: number;
+    lastReadSeq?: number;
+  };
+  const activity: AgentRosterActivity = {};
+  if (typeof parsed.operatorAt === "string") activity.operatorAt = parsed.operatorAt;
+  if (typeof parsed.briefAt === "string") activity.briefAt = parsed.briefAt;
+  if (typeof parsed.unreadCount === "number" && Number.isFinite(parsed.unreadCount) && parsed.unreadCount > 0) {
+    activity.unreadCount = Math.floor(parsed.unreadCount);
+  }
+  const lastUnreadDeliverySeq = parsed.lastUnreadDeliverySeq ?? parsed.lastUnreadSeq;
+  if (typeof lastUnreadDeliverySeq === "number" && Number.isFinite(lastUnreadDeliverySeq)) {
+    activity.lastUnreadDeliverySeq = Math.floor(lastUnreadDeliverySeq);
+  }
+  const lastReadDeliverySeq = parsed.lastReadDeliverySeq ?? parsed.lastReadSeq;
+  if (typeof lastReadDeliverySeq === "number" && Number.isFinite(lastReadDeliverySeq)) {
+    activity.lastReadDeliverySeq = Math.floor(lastReadDeliverySeq);
+  }
+  return Object.keys(activity).length ? activity : undefined;
+}
+
+function incrementUnreadFromEvent(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  event: StreamEventEnvelopeDto,
+): Record<string, AgentRosterActivity> {
+  const existing = current[agentId];
+  const seq = event.event_seq;
+  if (seq != null && existing?.lastReadDeliverySeq != null && seq <= existing.lastReadDeliverySeq) return current;
+  if (seq != null && existing?.lastUnreadDeliverySeq != null && seq <= existing.lastUnreadDeliverySeq) return current;
+  return {
+    ...current,
+    [agentId]: {
+      ...existing,
+      unreadCount: (existing?.unreadCount ?? 0) + 1,
+      lastUnreadDeliverySeq: seq ?? existing?.lastUnreadDeliverySeq,
+    },
+  };
+}
+
+function eventTimestamp(event: StreamEventEnvelopeDto): string | undefined {
+  const payload = asRecord(event.payload);
+  return stringField(payload, "created_at") ?? event.ts;
+}
+
+function messageOrigin(payload: unknown): string | undefined {
+  const origin = asRecord(asRecord(payload)?.origin);
+  return stringField(origin, "kind") ?? stringField(origin, "role") ?? stringField(asRecord(payload), "origin");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function sortableTime(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function readStoredJson(storage: Storage, key: string): unknown {
+  const raw = storage.getItem(key);
+  return raw ? JSON.parse(raw) : undefined;
+}

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -7,13 +7,10 @@ import {
   backfillRetryDelayMs,
   buildResumeRefreshes,
   canUseRemoteRuntimeConnections,
-  hasEventIdentityConflict,
   isSessionCacheContextCurrent,
   isLoopbackWebHostname,
   materializeProjectionDetail,
   mergeBootstrapAgentState,
-  mergeCachedReadState,
-  mergeCachedSessionIntoCurrent,
   mergeTimelineEventPage,
   missingBriefIdsForHydration,
   readStoredRemoteConnectionProfiles,
@@ -21,7 +18,6 @@ import {
   resetTransientRuntimeStateForResume,
   readStoredRuntimeConnectionConfig,
   runWithConcurrencyLimit,
-  sessionForEventLogEpoch,
   skillDetailCacheKey,
   streamEventFromBackfill,
   useRuntimeStore,
@@ -380,68 +376,6 @@ describe("timeline events state", () => {
 });
 
 describe("runtime event epoch", () => {
-  it("drops seq-indexed history and hydration caches when the epoch changes", () => {
-    const current = sessionState({
-      eventLogEpoch: "epoch-old",
-      eventsBySeq: { 7: { id: "evt-old" } },
-      eventSeqs: [7],
-      messagesById: { msg: { id: "msg" } },
-      newestSeq: 7,
-      oldestSeq: 7,
-      semanticHistoryByDisplayLevel: {
-        info: { cursorSeq: 7, hasOlder: true, loading: false },
-      },
-      detail: {
-        agent: { id: "agent-1" } as NonNullable<AgentSessionState["detail"]>["agent"],
-        source: "http",
-        timeline: [],
-        events: [],
-        eventCursorSeq: 7,
-        hasOlderEvents: true,
-      },
-    });
-
-    const reset = sessionForEventLogEpoch(current, "epoch-new");
-
-    expect(reset.eventLogEpoch).toBe("epoch-new");
-    expect(reset.eventsBySeq).toEqual({});
-    expect(reset.eventSeqs).toEqual([]);
-    expect(reset.messagesById).toEqual({});
-    expect(reset.newestSeq).toBeUndefined();
-    expect(reset.oldestSeq).toBeUndefined();
-    expect(reset.semanticHistoryByDisplayLevel).toEqual({});
-    expect(reset.detail?.eventCursorSeq).toBeUndefined();
-    expect(reset.detail?.hasOlderEvents).toBeUndefined();
-  });
-
-  it("detects conflicting immutable content for the same epoch and sequence", () => {
-    const existing: StreamEventEnvelopeDto = {
-      id: "evt-1",
-      event_seq: 7,
-      event_log_epoch: "epoch-1",
-      contract_version: 1,
-      ts: "2026-07-16T00:00:00Z",
-      agent_id: "agent-1",
-      type: "legacy_event",
-      payload_schema: "holon.runtime_event.legacy",
-      payload_schema_version: 1,
-      provenance: {},
-      payload: { value: 1 },
-    };
-    const current = sessionState({
-      eventLogEpoch: "epoch-1",
-      eventsBySeq: { 7: existing },
-      eventSeqs: [7],
-    });
-
-    expect(hasEventIdentityConflict(current, [{ ...existing }])).toBe(false);
-    expect(
-      hasEventIdentityConflict(current, [
-        { ...existing, id: "evt-conflict", payload: { value: 2 } },
-      ]),
-    ).toBe(true);
-  });
-
   it("preserves typed contract metadata when rebuilding gap backfill events", () => {
     const provenance = {
       source: "runtime",
@@ -485,55 +419,6 @@ describe("session cache restoration", () => {
     expect(isSessionCacheContextCurrent(captured, "https://old.example", 8)).toBe(false);
   });
 
-  it("does not overwrite HTTP or SSE state that arrived while cache was loading", () => {
-    const current = sessionState({
-      eventLogEpoch: "epoch-live",
-      eventsBySeq: { 9: { id: "live-event", event_seq: 9 } },
-      eventSeqs: [9],
-      newestSeq: 9,
-      oldestSeq: 9,
-      liveStatus: "streaming",
-    });
-    const cached = {
-      ...createSessionProjectionState("epoch-cache"),
-      eventsBySeq: { 1: { id: "cached-event", event_seq: 1 } },
-      eventSeqs: [1],
-      newestSeq: 1,
-      oldestSeq: 1,
-    };
-
-    expect(mergeCachedSessionIntoCurrent(current, cached)).toBe(current);
-  });
-
-  it("restores cached projection into an empty session without changing UI state", () => {
-    const current = sessionState({ loading: true, liveStatus: "connecting" });
-    const cached = {
-      ...createSessionProjectionState("epoch-cache"),
-      eventsBySeq: { 1: { id: "cached-event", event_seq: 1 } },
-      eventSeqs: [1],
-      newestSeq: 1,
-      oldestSeq: 1,
-      semanticHistoryByDisplayLevel: {
-        info: {
-          eventLogEpoch: "epoch-cache",
-          cursorSeq: 1,
-          hasOlder: false,
-          loading: false,
-        },
-      },
-    };
-
-    const restored = mergeCachedSessionIntoCurrent(current, cached);
-
-    expect(restored.eventSeqs).toEqual([1]);
-    expect(restored.semanticHistoryByDisplayLevel.info).toMatchObject({
-      cursorSeq: 1,
-      hasOlder: false,
-      loading: false,
-    });
-    expect(restored.loading).toBe(true);
-    expect(restored.liveStatus).toBe("connecting");
-  });
 });
 
 function installWindow(localStorage: Storage, sessionStorage: Storage, hostname = "localhost") {
@@ -726,118 +611,6 @@ describe("agent deletion cache cleanup", () => {
 describe("roster activity unread state", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
-  });
-
-  it("hydrates persisted roster activity per remote key", async () => {
-    const sharedLocalStorage = new MemoryStorage();
-    installWindow(sharedLocalStorage, new MemoryStorage());
-    sharedLocalStorage.setItem(
-      "holon.webGui.rosterActivityByRemote.v1",
-      JSON.stringify({
-        local: {
-          localAgent: { unreadCount: 2, lastUnreadSeq: 12, lastReadSeq: 7, briefAt: "2026-01-01T00:00:00.000Z" },
-        },
-        "http://remote.example:7878": {
-          remoteAgent: { unreadCount: 4, lastUnreadSeq: 20 },
-        },
-      }),
-    );
-
-    const { readStoredRosterActivity } = await import("./runtime-store");
-
-    expect(readStoredRosterActivity("local")).toEqual({
-      localAgent: {
-        unreadCount: 2,
-        lastUnreadDeliverySeq: 12,
-        lastReadDeliverySeq: 7,
-        briefAt: "2026-01-01T00:00:00.000Z",
-      },
-    });
-    expect(readStoredRosterActivity("http://remote.example:7878")).toEqual({
-      remoteAgent: { unreadCount: 4, lastUnreadDeliverySeq: 20 },
-    });
-  });
-
-  it("uses IndexedDB read state only when localStorage has no read marker", () => {
-    const cached = {
-      unreadCount: 3,
-      lastUnreadDeliverySeq: 12,
-      lastReadDeliverySeq: 7,
-    };
-
-    expect(
-      mergeCachedReadState(
-        { operatorAt: "2026-01-01T00:00:00.000Z" },
-        cached,
-      ),
-    ).toEqual({
-      operatorAt: "2026-01-01T00:00:00.000Z",
-      ...cached,
-    });
-    const localStorageState = {
-      unreadCount: 1,
-      lastUnreadDeliverySeq: 20,
-      lastReadDeliverySeq: 19,
-    };
-    expect(mergeCachedReadState(localStorageState, cached)).toBe(localStorageState);
-  });
-
-  it("counts unread brief events once by seq, ignores non-operator messages", async () => {
-    const { touchRosterActivityFromEvent } = await import("./runtime-store");
-    const afterBrief = touchRosterActivityFromEvent(
-      {},
-      "agent-a",
-      { agent_id: "agent-a", event_seq: 10, ts: "2026-01-01T00:00:00.000Z", type: "brief_created", payload: {} },
-      "agent-b",
-    );
-    const afterDuplicate = touchRosterActivityFromEvent(
-      afterBrief,
-      "agent-a",
-      { agent_id: "agent-a", event_seq: 10, ts: "2026-01-01T00:00:01.000Z", type: "brief_created", payload: {} },
-      "agent-b",
-    );
-    const afterAgentMessage = touchRosterActivityFromEvent(
-      afterDuplicate,
-      "agent-a",
-      {
-        agent_id: "agent-a",
-        event_seq: 11,
-        ts: "2026-01-01T00:00:02.000Z",
-        type: "message_enqueued",
-        payload: { origin: { kind: "agent" } },
-      },
-      "agent-b",
-    );
-
-    expect(afterAgentMessage["agent-a"]).toMatchObject({
-      unreadCount: 1,
-      lastUnreadDeliverySeq: 10,
-    });
-  });
-
-  it("counts a selected brief until the conversation confirms it was viewed", async () => {
-    const { touchRosterActivityFromEvent } = await import("./runtime-store");
-    const afterSelectedBrief = touchRosterActivityFromEvent(
-      {},
-      "agent-a",
-      { agent_id: "agent-a", event_seq: 10, ts: "2026-01-01T00:00:00.000Z", type: "brief_created", payload: {} },
-      "agent-a",
-    );
-    const afterOperatorMessage = touchRosterActivityFromEvent(
-      afterSelectedBrief,
-      "agent-a",
-      {
-        agent_id: "agent-a",
-        event_seq: 11,
-        ts: "2026-01-01T00:00:01.000Z",
-        type: "message_enqueued",
-        payload: { origin: { kind: "operator" }, created_at: "2026-01-01T00:00:01.000Z" },
-      },
-      "agent-b",
-    );
-
-    expect(afterOperatorMessage["agent-a"]?.unreadCount).toBe(1);
-    expect(afterOperatorMessage["agent-a"]?.operatorAt).toBe("2026-01-01T00:00:01.000Z");
   });
 
   it("advances the delivery read marker only after the synchronized conversation is visible", async () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -10,8 +10,36 @@ import {
 import { EventGapRecoveryTracker, recoverEventGap } from "./event-gap-recovery";
 import {
   cacheDeleteSession,
-  type CachedAgentReadState,
 } from "./idb-cache";
+import {
+  applyProjectionAction,
+  emptyAgentSession,
+  eventLogEpochFromEvents,
+  hasEventIdentityConflict,
+  materializeProjectionDetail,
+  mergeCachedSessionIntoCurrent,
+  mergeEventPageIntoConversation,
+  resetSessionForEventConflict,
+  semanticHistoryState,
+  semanticTimelineHasNewItem,
+  semanticTimelineItemIds,
+  sessionForEventLogEpoch,
+  shouldResetForEventLogEpoch,
+  withSemanticHistoryState,
+} from "./conversation-store";
+import {
+  cachedReadState,
+  canMarkConversationRead,
+  latestBriefDeliverySeq,
+  markAgentDeliveriesRead,
+  mergeCachedReadState,
+  mergeCachedReadStates,
+  readStoredRosterActivity,
+  touchRosterActivity,
+  touchRosterActivityFromEvent,
+  writeStoredRosterActivity,
+  type AgentRosterActivity,
+} from "./read-state";
 import { ResumeReconciliationCoordinator } from "./resume-reconciliation";
 import {
   currentRemoteKey,
@@ -28,21 +56,15 @@ import {
 } from "./runtime-trace";
 import type { AgentSessionState as AgentSessionStateBase } from "./runtime-store-helpers";
 import {
-  compactAgentTimelineItems,
   briefIdForPayload,
-  filterTimelineByDisplayLevel,
 } from "./session-reducer";
 import {
   briefIdsForProjectionHydration,
-  createSessionProjectionState,
   deriveSessionTimeline,
-  eventIdentityConflicts,
   messageIdsForProjectionHydration,
   projectionEvents,
-  reduceSessionProjection,
   transcriptEntryIdsForProjectionHydration,
   type SessionProjectionAction,
-  type SessionProjectionState,
 } from "./session-projection";
 import { canApplySessionEvent } from "./session-events";
 import type {
@@ -95,6 +117,18 @@ import type {
   ToolExecutionDetailState,
 } from "./runtime-store-helpers";
 export type { AgentLiveStatus, AgentSessionState, SemanticHistoryState, TimelineEventsState };
+export {
+  hasEventIdentityConflict,
+  materializeProjectionDetail,
+  mergeCachedSessionIntoCurrent,
+  sessionForEventLogEpoch,
+} from "./conversation-store";
+export {
+  mergeCachedReadState,
+  readStoredRosterActivity,
+  touchRosterActivityFromEvent,
+} from "./read-state";
+export type { AgentRosterActivity } from "./read-state";
 
 export interface BootstrapRefreshOptions {
   background?: boolean;
@@ -201,14 +235,6 @@ function rebuildProvisionalDetailsWithAgents(
     changed = true;
   }
   return changed ? updated : null;
-}
-
-export interface AgentRosterActivity {
-  operatorAt?: string;
-  briefAt?: string;
-  unreadCount?: number;
-  lastUnreadDeliverySeq?: number;
-  lastReadDeliverySeq?: number;
 }
 
 const OPTIMISTIC_OPERATOR_PROMPT_SOURCE = "pending-operator-prompt";
@@ -458,7 +484,6 @@ const LEGACY_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1
 const ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.activeRuntimeConnection.v1";
 const RUNTIME_CONNECTION_PROFILES_STORAGE_KEY = "holon.webGui.runtimeConnectionProfiles.v1";
 const DISPLAY_LEVEL_STORAGE_KEY = "holon.webGui.displayLevelsByAgentId.v1";
-const ROSTER_ACTIVITY_STORAGE_KEY = "holon.webGui.rosterActivityByRemote.v1";
 let runtimeConnectionConfig = readStoredRuntimeConnectionConfig();
 let runtimeClient = createRuntimeClient(runtimeClientOptions(runtimeConnectionConfig));
 const activeEventStreams = new Map<string, AgentEventStreamSubscription>();
@@ -935,63 +960,6 @@ function writeStoredDisplayLevels(displayLevelsByAgentId: Record<string, Display
   }
 }
 
-export function readStoredRosterActivity(remoteKey: string): Record<string, AgentRosterActivity> {
-  if (typeof window === "undefined") return {};
-  try {
-    const parsed = readStoredJson(window.localStorage, ROSTER_ACTIVITY_STORAGE_KEY);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    const byRemote = parsed as Record<string, unknown>;
-    const rawActivity = byRemote[remoteKey];
-    if (!rawActivity || typeof rawActivity !== "object" || Array.isArray(rawActivity)) return {};
-    const activityByAgentId: Record<string, AgentRosterActivity> = {};
-    for (const [agentId, value] of Object.entries(rawActivity)) {
-      if (typeof agentId !== "string" || !agentId || !value || typeof value !== "object" || Array.isArray(value)) continue;
-      const activity = coerceRosterActivity(value);
-      if (activity) activityByAgentId[agentId] = activity;
-    }
-    return activityByAgentId;
-  } catch {
-    return {};
-  }
-}
-
-function writeStoredRosterActivity(remoteKey: string, activityByAgentId: Record<string, AgentRosterActivity>): void {
-  if (typeof window === "undefined") return;
-  try {
-    const parsed = readStoredJson(window.localStorage, ROSTER_ACTIVITY_STORAGE_KEY);
-    const byRemote =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, Record<string, AgentRosterActivity>>)
-        : {};
-    byRemote[remoteKey] = activityByAgentId;
-    window.localStorage.setItem(ROSTER_ACTIVITY_STORAGE_KEY, JSON.stringify(byRemote));
-  } catch {
-    // Ignore storage failures; unread state falls back to memory-only.
-  }
-}
-
-function coerceRosterActivity(value: unknown): AgentRosterActivity | undefined {
-  const parsed = value as Partial<AgentRosterActivity> & {
-    lastUnreadSeq?: number;
-    lastReadSeq?: number;
-  };
-  const activity: AgentRosterActivity = {};
-  if (typeof parsed.operatorAt === "string") activity.operatorAt = parsed.operatorAt;
-  if (typeof parsed.briefAt === "string") activity.briefAt = parsed.briefAt;
-  if (typeof parsed.unreadCount === "number" && Number.isFinite(parsed.unreadCount) && parsed.unreadCount > 0) {
-    activity.unreadCount = Math.floor(parsed.unreadCount);
-  }
-  const lastUnreadDeliverySeq = parsed.lastUnreadDeliverySeq ?? parsed.lastUnreadSeq;
-  if (typeof lastUnreadDeliverySeq === "number" && Number.isFinite(lastUnreadDeliverySeq)) {
-    activity.lastUnreadDeliverySeq = Math.floor(lastUnreadDeliverySeq);
-  }
-  const lastReadDeliverySeq = parsed.lastReadDeliverySeq ?? parsed.lastReadSeq;
-  if (typeof lastReadDeliverySeq === "number" && Number.isFinite(lastReadDeliverySeq)) {
-    activity.lastReadDeliverySeq = Math.floor(lastReadDeliverySeq);
-  }
-  return Object.keys(activity).length ? activity : undefined;
-}
-
 function isDisplayLevel(value: unknown): value is DisplayLevel {
   return value === "info" || value === "verbose" || value === "debug";
 }
@@ -1150,63 +1118,6 @@ function initSessionCacheForRemote(set: StoreSet, get?: () => RuntimeStoreState)
   );
 }
 
-export function mergeCachedSessionIntoCurrent(
-  current: AgentSessionState,
-  cached: Partial<AgentSessionState>,
-): AgentSessionState {
-  if (
-    current.detail ||
-    current.eventSeqs.length > 0 ||
-    Object.keys(current.messagesById).length > 0 ||
-    Object.keys(current.transcriptEntriesById).length > 0 ||
-    Object.keys(current.briefRecordsById).length > 0
-  ) {
-    return current;
-  }
-  return {
-    ...current,
-    ...cached,
-    loading: current.loading,
-    semanticHistoryByDisplayLevel:
-      Object.keys(current.semanticHistoryByDisplayLevel).length > 0
-        ? current.semanticHistoryByDisplayLevel
-        : (cached.semanticHistoryByDisplayLevel ?? {}),
-    targetEventLoading: current.targetEventLoading,
-    liveStatus: current.liveStatus,
-    sendingPrompt: current.sendingPrompt,
-  };
-}
-
-export function mergeCachedReadState(
-  current: AgentRosterActivity | undefined,
-  cached: CachedAgentReadState | undefined,
-): AgentRosterActivity | undefined {
-  if (!cached) return current;
-  const currentHasReadState =
-    current?.unreadCount != null ||
-    current?.lastUnreadDeliverySeq != null ||
-    current?.lastReadDeliverySeq != null;
-  if (currentHasReadState) return current;
-  return {
-    ...current,
-    ...cached,
-  };
-}
-
-function mergeCachedReadStates(
-  current: Record<string, AgentRosterActivity>,
-  cached: Record<string, CachedAgentReadState>,
-): Record<string, AgentRosterActivity> {
-  let merged = current;
-  for (const [agentId, readState] of Object.entries(cached)) {
-    const activity = mergeCachedReadState(merged[agentId], readState);
-    if (!activity || activity === merged[agentId]) continue;
-    if (merged === current) merged = { ...current };
-    merged[agentId] = activity;
-  }
-  return merged;
-}
-
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   route: "dashboard",
   selectedAgentId: "",
@@ -1292,25 +1203,12 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   markAgentConversationRead: (agentId) => {
     const state = get();
     const session = state.sessionsByAgentId[agentId];
-    if (
-      state.route !== "agent" ||
-      state.selectedAgentId !== agentId ||
-      typeof document === "undefined" ||
-      document.visibilityState !== "visible" ||
-      !session ||
-      session.loading ||
-      session.gaps.length > 0 ||
-      session.syncStatus === "refreshing" ||
-      session.syncStatus === "recovering" ||
-      session.syncStatus === "stale" ||
-      session.syncStatus === "error" ||
-      session.liveStatus === "connecting" ||
-      session.liveStatus === "reconnecting" ||
-      session.liveStatus === "recovering" ||
-      session.liveStatus === "stale" ||
-      session.liveStatus === "error" ||
-      missingBriefIdsForHydration(session).length > 0
-    ) {
+    if (!session || !canMarkConversationRead({
+      route: state.route,
+      selectedAgentId: state.selectedAgentId,
+      documentVisible: typeof document !== "undefined" && document.visibilityState === "visible",
+      session,
+    }, agentId)) {
       return;
     }
     const deliverySeq = latestBriefDeliverySeq(session);
@@ -3423,24 +3321,6 @@ function installResumeReconciliationListeners(): ResumeReconciliationCoordinator
   return coordinator;
 }
 
-function emptyAgentSession(): AgentSessionState {
-  return {
-    ...createSessionProjectionState(),
-    loading: false,
-    semanticHistoryByDisplayLevel: {},
-    targetEventLoading: false,
-    liveStatus: "idle",
-    cacheStatus: "unchecked",
-    contentStatus: "unknown",
-    syncStatus: "idle",
-    sendingPrompt: false,
-    detail: null,
-    workItemDetailsById: {},
-    taskDetailsById: {},
-    toolExecutionDetailsById: {},
-  };
-}
-
 function emptyTimelineEventsState(): TimelineEventsState {
   return {
     eventsBySeq: {},
@@ -3492,125 +3372,6 @@ function timelineEventIdentity(event: { id?: string; type?: string; event_seq?: 
   return `${event.event_seq ?? ""}:${event.id ?? ""}:${event.type ?? ""}`;
 }
 
-function applyProjectionAction(
-  current: AgentSessionState,
-  action: SessionProjectionAction,
-  displayLevel: DisplayLevel = "debug",
-  detailBase: AgentDetail | null = current.detail,
-): AgentSessionState {
-  const projection = reduceSessionProjection(current, action);
-  return {
-    ...current,
-    ...projection,
-    detail: materializeProjectionDetail(detailBase, projection, displayLevel),
-  };
-}
-
-export function materializeProjectionDetail(
-  detail: AgentDetail | null,
-  projection: SessionProjectionState,
-  displayLevel: DisplayLevel,
-): AgentDetail | null {
-  if (!detail) return null;
-  const projectedTimeline = deriveSessionTimeline(projection, displayLevel);
-  const projectedMessageIds = new Set(
-    projectedTimeline.flatMap((item) =>
-      item.kind === "operator" && item.id.startsWith("message:")
-        ? [item.id.slice("message:".length)]
-        : [],
-    ),
-  );
-  const optimisticItems = detail.timeline.filter((item) => {
-    if (!item.sourceIds.includes(OPTIMISTIC_OPERATOR_PROMPT_SOURCE)) return false;
-    const canonicalMessageId = item.sourceIds
-      .find((sourceId) => sourceId.startsWith(OPTIMISTIC_OPERATOR_MESSAGE_PREFIX))
-      ?.slice(OPTIMISTIC_OPERATOR_MESSAGE_PREFIX.length);
-    return !canonicalMessageId || !projectedMessageIds.has(canonicalMessageId);
-  });
-  const timeline = compactAgentTimelineItems([
-    ...projectedTimeline,
-    ...optimisticItems,
-  ]).sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
-  return {
-    ...detail,
-    timeline,
-    events: projectionEvents(projection),
-    eventLogEpoch: projection.eventLogEpoch,
-    newestEventSeq: projection.newestSeq,
-    oldestEventSeq: projection.oldestSeq,
-    briefRecordsById: projection.briefRecordsById,
-  };
-}
-
-function eventLogEpochFromEvents(events: StreamEventEnvelopeDto[]): string | undefined {
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const epoch = events[index]?.event_log_epoch;
-    if (epoch) return epoch;
-  }
-  return undefined;
-}
-
-function shouldResetForEventLogEpoch(
-  current: AgentSessionState,
-  incomingEpoch: string | undefined,
-): boolean {
-  if (!incomingEpoch) return false;
-  return (
-    (current.eventLogEpoch != null || current.eventSeqs.length > 0) &&
-    current.eventLogEpoch !== incomingEpoch
-  );
-}
-
-export function sessionForEventLogEpoch(
-  current: AgentSessionState,
-  incomingEpoch: string | undefined,
-): AgentSessionState {
-  if (!incomingEpoch) return current;
-  if (!shouldResetForEventLogEpoch(current, incomingEpoch)) {
-    return current.eventLogEpoch === incomingEpoch
-      ? current
-      : { ...current, eventLogEpoch: incomingEpoch };
-  }
-  const reset = applyProjectionAction(current, { type: "reset", eventLogEpoch: incomingEpoch });
-  return {
-    ...reset,
-    semanticHistoryByDisplayLevel: {},
-    targetEventLoading: false,
-    targetEventError: undefined,
-    detail: reset.detail
-      ? {
-          ...reset.detail,
-          eventCursorSeq: undefined,
-          hasOlderEvents: undefined,
-        }
-      : null,
-  };
-}
-
-export function hasEventIdentityConflict(
-  current: AgentSessionState,
-  incomingEvents: StreamEventEnvelopeDto[],
-): boolean {
-  return eventIdentityConflicts(current, incomingEvents);
-}
-
-function resetSessionForEventConflict(
-  current: AgentSessionState,
-  eventLogEpoch?: string,
-): AgentSessionState {
-  return {
-    ...applyProjectionAction(current, {
-      type: "reset",
-      eventLogEpoch: eventLogEpoch ?? current.eventLogEpoch,
-      reason: "event_identity_conflict",
-    }),
-    liveStatus: "stale",
-    semanticHistoryByDisplayLevel: {},
-    targetEventLoading: false,
-    error: "runtime event identity conflict; refreshing projection",
-  };
-}
-
 type StoreSet = (
   partial:
     | Partial<RuntimeStoreState>
@@ -3633,21 +3394,6 @@ function scheduleCacheWrite(get: () => RuntimeStoreState, agentId: string): void
     session,
     cachedReadState(state.rosterActivityByAgentId[agentId]),
   );
-}
-
-function cachedReadState(
-  activity: AgentRosterActivity | undefined,
-): CachedAgentReadState | undefined {
-  if (!activity) return undefined;
-  const readState: CachedAgentReadState = {};
-  if (activity.unreadCount != null) readState.unreadCount = activity.unreadCount;
-  if (activity.lastUnreadDeliverySeq != null) {
-    readState.lastUnreadDeliverySeq = activity.lastUnreadDeliverySeq;
-  }
-  if (activity.lastReadDeliverySeq != null) {
-    readState.lastReadDeliverySeq = activity.lastReadDeliverySeq;
-  }
-  return Object.keys(readState).length ? readState : undefined;
 }
 
 function scheduleAgentDetailRetry(
@@ -4667,115 +4413,6 @@ function compareIsoDesc(left: string | undefined, right: string | undefined): nu
   return rightTime - leftTime;
 }
 
-function touchRosterActivity(
-  current: Record<string, AgentRosterActivity>,
-  agentId: string,
-  kind: "operator" | "brief",
-  timestamp: string | undefined,
-): Record<string, AgentRosterActivity> {
-  if (!timestamp) return current;
-  const existing = current[agentId];
-  const field = kind === "operator" ? "operatorAt" : "briefAt";
-  if (sortableTime(existing?.[field] ?? "") >= sortableTime(timestamp)) return current;
-  return {
-    ...current,
-    [agentId]: {
-      ...existing,
-      [field]: timestamp,
-    },
-  };
-}
-
-function markAgentDeliveriesRead(
-  current: Record<string, AgentRosterActivity>,
-  agentId: string,
-  deliverySeq: number,
-): Record<string, AgentRosterActivity> {
-  const existing = current[agentId];
-  if (!existing?.unreadCount && existing?.lastReadDeliverySeq === deliverySeq) return current;
-  return {
-    ...current,
-    [agentId]: {
-      ...existing,
-      unreadCount: 0,
-      lastReadDeliverySeq: Math.max(
-        deliverySeq,
-        existing?.lastUnreadDeliverySeq ?? 0,
-        existing?.lastReadDeliverySeq ?? 0,
-      ),
-    },
-  };
-}
-
-export function touchRosterActivityFromEvent(
-  current: Record<string, AgentRosterActivity>,
-  agentId: string,
-  event: StreamEventEnvelopeDto,
-  _selectedAgentId: string,
-): Record<string, AgentRosterActivity> {
-  if (!canApplySessionEvent(event)) return current;
-  let next = current;
-  if (event.type === "brief_created") {
-    next = touchRosterActivity(next, agentId, "brief", eventTimestamp(event));
-  }
-  if (event.type === "message_enqueued" && messageOrigin(event.payload) === "operator") {
-    next = touchRosterActivity(next, agentId, "operator", eventTimestamp(event));
-  }
-  if (isUnreadEvent(event)) {
-    next = incrementUnreadFromEvent(next, agentId, event);
-  }
-  return next;
-}
-
-function isUnreadEvent(event: StreamEventEnvelopeDto): boolean {
-  return event.type === "brief_created";
-}
-
-function incrementUnreadFromEvent(
-  current: Record<string, AgentRosterActivity>,
-  agentId: string,
-  event: StreamEventEnvelopeDto,
-): Record<string, AgentRosterActivity> {
-  const existing = current[agentId];
-  const seq = event.event_seq;
-  if (
-    seq != null &&
-    existing?.lastReadDeliverySeq != null &&
-    seq <= existing.lastReadDeliverySeq
-  ) return current;
-  if (
-    seq != null &&
-    existing?.lastUnreadDeliverySeq != null &&
-    seq <= existing.lastUnreadDeliverySeq
-  ) return current;
-  return {
-    ...current,
-    [agentId]: {
-      ...existing,
-      unreadCount: (existing?.unreadCount ?? 0) + 1,
-      lastUnreadDeliverySeq: seq ?? existing?.lastUnreadDeliverySeq,
-    },
-  };
-}
-
-function latestBriefDeliverySeq(session: AgentSessionState): number | undefined {
-  for (let index = session.eventSeqs.length - 1; index >= 0; index -= 1) {
-    const seq = session.eventSeqs[index];
-    if (session.eventsBySeq[seq]?.type === "brief_created") return seq;
-  }
-  return undefined;
-}
-
-function eventTimestamp(event: StreamEventEnvelopeDto): string | undefined {
-  const payload = asRecord(event.payload);
-  return stringField(payload, "created_at") ?? event.ts;
-}
-
-function messageOrigin(payload: unknown): string | undefined {
-  const origin = asRecord(asRecord(payload)?.origin);
-  return stringField(origin, "kind") ?? stringField(origin, "role") ?? stringField(asRecord(payload), "origin");
-}
-
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
 }
@@ -5654,63 +5291,16 @@ function patchAgentDetail(
   };
 }
 
-function semanticHistoryState(
-  session: AgentSessionState | undefined,
-  displayLevel: DisplayLevel,
-): SemanticHistoryState {
-  return session?.semanticHistoryByDisplayLevel[displayLevel] ?? {
-    eventLogEpoch: session?.eventLogEpoch,
-    cursorSeq: undefined,
-    hasOlder: false,
-    loading: false,
-  };
-}
-
-function semanticTimelineItemIds(
-  session: AgentSessionState | undefined,
-  displayLevel: DisplayLevel,
-): Set<string> {
-  return new Set(semanticTimeline(session, displayLevel).map((item) => item.id));
-}
-
-function semanticTimelineHasNewItem(
-  session: AgentSessionState | undefined,
-  displayLevel: DisplayLevel,
-  initialItemIds: Set<string>,
-): boolean {
-  return semanticTimeline(session, displayLevel).some((item) => !initialItemIds.has(item.id));
-}
-
-function semanticTimeline(
-  session: AgentSessionState | undefined,
-  displayLevel: DisplayLevel,
-): AgentTimelineItem[] {
-  return session
-    ? filterTimelineByDisplayLevel(
-        deriveSessionTimeline(session, displayLevel),
-        displayLevel,
-        { itemLimit: Number.MAX_SAFE_INTEGER },
-      )
-    : [];
-}
-
 function updateSemanticHistoryState(
   state: RuntimeStoreState,
   agentId: string,
   displayLevel: DisplayLevel,
   history: SemanticHistoryState,
 ): Partial<RuntimeStoreState> {
-  const session = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
   return {
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
-      [agentId]: {
-        ...session,
-        semanticHistoryByDisplayLevel: {
-          ...session.semanticHistoryByDisplayLevel,
-          [displayLevel]: history,
-        },
-      },
+      [agentId]: withSemanticHistoryState(state.sessionsByAgentId[agentId], displayLevel, history),
     },
   };
 }
@@ -5730,45 +5320,17 @@ function mergeEventPageIntoSession(
     historyLoading?: boolean;
   } = {},
 ): Partial<RuntimeStoreState> {
-  const epochSession = sessionForEventLogEpoch(
-    state.sessionsByAgentId[agentId] ?? emptyAgentSession(),
-    options.eventLogEpoch,
-  );
-  const current = hasEventIdentityConflict(epochSession, pageEvents)
-    ? resetSessionForEventConflict(epochSession, options.eventLogEpoch)
-    : epochSession;
-  const projected = applyProjectionAction(current, {
-    type: "events_received",
-    events: pageEvents,
-    eventLogEpoch: options.eventLogEpoch,
-  }, displayLevel, current.detail);
-  const historyDisplayLevel = options.historyDisplayLevel;
-  const semanticHistoryByDisplayLevel = historyDisplayLevel
-    ? {
-        ...projected.semanticHistoryByDisplayLevel,
-        [historyDisplayLevel]: {
-          eventLogEpoch: options.eventLogEpoch ?? projected.eventLogEpoch,
-          cursorSeq: pageOldestSeq,
-          hasOlder: pageHasOlder ?? false,
-          loading: options.historyLoading ?? false,
-        },
-      }
-    : projected.semanticHistoryByDisplayLevel;
-
   return {
     sessionsByAgentId: {
       ...state.sessionsByAgentId,
-      [agentId]: {
-        ...projected,
-        newestSeq: Math.max(options.newestSeq ?? 0, projected.newestSeq ?? 0) || undefined,
-        // Take the true oldest across all events (cached + new page) so
-        // descending-order pages don't clobber the cached oldest seq.
-        oldestSeq:
-          pageOldestSeq != null && projected.oldestSeq != null
-            ? Math.min(pageOldestSeq, projected.oldestSeq)
-            : (pageOldestSeq ?? projected.oldestSeq),
-        semanticHistoryByDisplayLevel,
-      },
+      [agentId]: mergeEventPageIntoConversation(
+        state.sessionsByAgentId[agentId],
+        pageEvents,
+        pageOldestSeq,
+        pageHasOlder,
+        displayLevel,
+        options,
+      ),
     },
   };
 }


### PR DESCRIPTION
## 概要

- 提取 `read-state.ts`，集中处理 roster activity 持久化、unread delivery、单调 read marker 与缓存 read state 合并
- 提取 `conversation-store.ts`，集中处理 session projection、event-log epoch、semantic history 与 raw event page 合并
- 保留 `runtime-store.ts` 作为 Zustand UI/action facade，并兼容原有公开导出
- 将纯状态测试迁移到新模块，补齐重复 brief、cache merge、read marker 与 semantic page/history 覆盖

## 验证

- `npm run typecheck`
- `npm test`（31 个测试文件，322 项测试）
- `npm run build`
