### PR TITLE
test: stabilize wake-hint re-entry synchronization

### DIFF
--- a/tests/support/runtime_providers.rs
+++ b/tests/support/runtime_providers.rs
@@ -10,7 +10,7 @@ use holon::provider::{
     AgentProvider, ConversationMessage, ModelBlock, ProviderTurnRequest, ProviderTurnResponse,
 };
 use serde_json::json;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 
 use tokio::time::{sleep, Duration};
 
@@ -576,27 +576,51 @@ impl AgentProvider for DelegatedBoundaryProvider {
 /// Provider that demonstrates wake hint functionality
 pub struct WakeHintProvider {
     calls: Mutex<usize>,
+    first_call_started: Semaphore,
+    release_first_call: Semaphore,
 }
 
 impl WakeHintProvider {
     pub fn new() -> Self {
         Self {
             calls: Mutex::new(0),
+            first_call_started: Semaphore::new(0),
+            release_first_call: Semaphore::new(0),
         }
     }
 
     pub async fn calls(&self) -> usize {
         *self.calls.lock().await
     }
+
+    pub async fn wait_for_first_call(&self) {
+        self.first_call_started
+            .acquire()
+            .await
+            .expect("wake hint provider semaphore should remain open")
+            .forget();
+    }
+
+    pub fn release_first_call(&self) {
+        self.release_first_call.add_permits(1);
+    }
 }
 
 #[async_trait]
 impl AgentProvider for WakeHintProvider {
     async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
-        let mut calls = self.calls.lock().await;
-        *calls += 1;
-        if *calls == 1 {
-            sleep(Duration::from_millis(250)).await;
+        let call = {
+            let mut calls = self.calls.lock().await;
+            *calls += 1;
+            *calls
+        };
+        if call == 1 {
+            self.first_call_started.add_permits(1);
+            self.release_first_call
+                .acquire()
+                .await
+                .expect("wake hint provider semaphore should remain open")
+                .forget();
             Ok(ProviderTurnResponse {
                 blocks: vec![
                     ModelBlock::Text {

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -682,7 +682,16 @@ pub async fn wake_hint_coalesces_while_running_and_reenters_once() -> Result<()>
     provider.release_first_call();
 
     wait_until_async_for(Duration::from_secs(10), || async {
-        Ok(provider.calls().await == 2)
+        if provider.calls().await != 2 {
+            return Ok(false);
+        }
+        let state = runtime.storage().read_agent()?;
+        Ok(state
+            .and_then(|state| state.last_continuation)
+            .is_some_and(|continuation| {
+                continuation.class == holon::types::ContinuationClass::ResumeExpectedWait
+                    && continuation.model_reentry
+            }))
     })
     .await?;
 

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -646,7 +646,7 @@ pub async fn wake_hint_coalesces_while_running_and_reenters_once() -> Result<()>
         ))
         .await?;
 
-    sleep(Duration::from_millis(50)).await;
+    tokio::time::timeout(Duration::from_secs(10), provider.wait_for_first_call()).await?;
     let first = runtime
         .submit_wake_hint(WakeHint {
             agent_id: "default".into(),
@@ -679,6 +679,7 @@ pub async fn wake_hint_coalesces_while_running_and_reenters_once() -> Result<()>
         .await?;
     assert_eq!(first, WakeDisposition::Coalesced);
     assert_eq!(second, WakeDisposition::Coalesced);
+    provider.release_first_call();
 
     wait_until_async_for(Duration::from_secs(10), || async {
         Ok(provider.calls().await == 2)


### PR DESCRIPTION
## Summary

- replace timing-based wake-hint test coordination with an explicit provider entry/release barrier
- submit coalesced wake hints only after the first model invocation is confirmed running
- preserve assertions for exactly one `SystemTick` and one model re-entry

Closes #2556

## Verification

- focused regression test repeated 20 times
- full `runtime_waiting_and_delivery_regressions` integration test
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`