### PR TITLE
fix: reconcile TaskResult execution revisions

### DIFF
--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -609,6 +609,21 @@ pub struct InterruptExecution {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoverInterruptedTaskResultClaim {
+    pub command_id: String,
+    pub attempt_id: String,
+    pub outcome_id: String,
+    pub work_item_id: String,
+    pub task_id: String,
+    pub result_message_id: String,
+    pub wait_id: String,
+    pub rejoin: RejoinFence,
+    pub expected_source_revision: u64,
+    pub source_revision: u64,
+    pub interrupted_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "command", content = "payload", rename_all = "snake_case")]
 pub enum ExecutionProtocolCommand {
     RegisterWorkItem(Box<RegisterWorkItemExecution>),
@@ -622,6 +637,7 @@ pub enum ExecutionProtocolCommand {
     Admit(Box<AdmitExecution>),
     Settle(SettleExecution),
     Interrupt(InterruptExecution),
+    RecoverInterruptedTaskResultClaim(Box<RecoverInterruptedTaskResultClaim>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1079,6 +1095,86 @@ pub fn interrupt_execution(
         .expect("settlement preserved attempt");
     attempt.state = ExecutionAttemptState::Interrupted;
     assert_invariants(&transition.state)?;
+    Ok(transition)
+}
+
+pub fn recover_interrupted_task_result_claim(
+    state: &ExecutionProtocolState,
+    command: &RecoverInterruptedTaskResultClaim,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.attempt_id.is_empty()
+        || command.outcome_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.task_id.is_empty()
+        || command.result_message_id.is_empty()
+        || command.wait_id.is_empty()
+        || command.expected_source_revision == 0
+        || command.source_revision <= command.expected_source_revision
+    {
+        return Err("TaskResult claim recovery requires complete monotonic identity".into());
+    }
+    let attempt = state
+        .attempts
+        .get(&command.attempt_id)
+        .ok_or_else(|| "TaskResult claim recovery references an unknown attempt".to_string())?;
+    if attempt.state != ExecutionAttemptState::Open
+        || attempt.source_message_id.as_deref() != Some(command.result_message_id.as_str())
+        || attempt.source.identity
+            != (ExecutionSourceIdentity::TaskResult {
+                task_id: command.task_id.clone(),
+                result_message_id: command.result_message_id.clone(),
+            })
+        || attempt.binding
+            != (ExecutionBinding::WorkItem {
+                work_item_id: command.work_item_id.clone(),
+            })
+        || attempt.admitted_fences.work_item_source_revision
+            != Some(command.expected_source_revision)
+        || attempt.admitted_fences.rejoin.as_ref() != Some(&command.rejoin)
+    {
+        return Err("TaskResult claim recovery attempt fence is stale".into());
+    }
+    let work = state
+        .work_items
+        .get(&command.work_item_id)
+        .ok_or_else(|| "TaskResult claim recovery WorkItem authority is missing".to_string())?;
+    if !matches!(
+        work.source_revision,
+        revision
+            if revision == command.expected_source_revision
+                || revision == command.source_revision
+    ) || !matches!(
+        &work.state,
+        WorkItemExecutionState::InFlight { attempt_id, generation }
+            if attempt_id == &command.attempt_id
+                && Some(*generation) == attempt.admitted_fences.work_item_generation
+    ) {
+        return Err("TaskResult claim recovery WorkItem fence is stale".into());
+    }
+    let mut transition = interrupt_execution(
+        state,
+        &InterruptExecution {
+            attempt_id: command.attempt_id.clone(),
+            outcome_id: command.outcome_id.clone(),
+            reason: "runtime_interrupted".into(),
+            interrupted_at: command.interrupted_at.clone(),
+        },
+    )?;
+    transition
+        .state
+        .work_items
+        .get_mut(&command.work_item_id)
+        .expect("interruption preserved WorkItem authority")
+        .source_revision = command.source_revision;
+    assert_invariants(&transition.state)?;
+    transition.references.extend([
+        format!("task:{}", command.task_id),
+        format!("message:{}", command.result_message_id),
+        format!("wait:{}", command.wait_id),
+        format!("work_item:{}", command.work_item_id),
+    ]);
     Ok(transition)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2506,6 +2506,20 @@ fn print_scheduler_recovery_report(
             candidate.target_queue_status
         );
     }
+    for candidate in report.task_result_claim_recoveries {
+        println!(
+            "- task_result_claim:{} attempt={} work_item={} eligible={} reason={} target={:?}",
+            candidate.message_id,
+            candidate.activation_id,
+            candidate.work_item_id,
+            candidate.eligible,
+            candidate.reason,
+            candidate
+                .proposed_queue_entry
+                .as_ref()
+                .map(|entry| &entry.status),
+        );
+    }
     for candidate in report.legacy_adoptions {
         println!(
             "- work_item:{}: adoption eligible={} reason={}",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1467,6 +1467,200 @@ fn execution_attempt_for_message<'a>(
         })
 }
 
+fn exact_task_result_claim_recovery(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    message: &MessageEnvelope,
+    attempt: &crate::domain::execution_protocol::ExecutionAttempt,
+    work_item_id: &str,
+    interrupted_at: chrono::DateTime<Utc>,
+) -> Result<Option<crate::runtime_db::transitions::ExecutionProtocolTransition>> {
+    use crate::domain::execution_protocol::{
+        ExecutionSourceIdentity, RecoverInterruptedTaskResultClaim,
+    };
+
+    let ExecutionSourceIdentity::TaskResult {
+        task_id,
+        result_message_id,
+    } = &attempt.source.identity
+    else {
+        return Ok(None);
+    };
+    if result_message_id != &message.id
+        || message.kind != MessageKind::TaskResult
+        || message.authority_class != AuthorityClass::RuntimeInstruction
+        || message.admission_context != Some(AdmissionContext::RuntimeOwned)
+        || message.delivery_surface != Some(MessageDeliverySurface::TaskRejoin)
+        || message.task_id.as_deref() != Some(task_id.as_str())
+        || message.work_item_id.as_deref() != Some(work_item_id)
+        || !matches!(&message.origin, MessageOrigin::Task { task_id: origin } if origin == task_id)
+    {
+        return Ok(None);
+    }
+    let Some(task) = storage.latest_task_record(task_id)? else {
+        return Ok(None);
+    };
+    let Ok(rejoin) = task.rejoin_fence() else {
+        return Ok(None);
+    };
+    if task.agent_id != message.agent_id
+        || task.work_item_id.as_deref() != Some(work_item_id)
+        || task.parent_message_id.as_deref() != Some(message.id.as_str())
+        || !task.terminal_reentry()
+        || attempt.admitted_fences.rejoin.as_ref() != Some(&rejoin)
+    {
+        return Ok(None);
+    }
+    let matching_waits = storage
+        .latest_wait_conditions()?
+        .into_iter()
+        .filter(|wait| {
+            wait.agent_id == message.agent_id
+                && wait.work_item_id.as_deref() == Some(work_item_id)
+                && wait.status == WaitConditionStatus::Resolved
+                && wait.kind == crate::types::WaitConditionKind::Task
+                && wait.trigger_message_id() == Some(message.id.as_str())
+                && wait.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        crate::types::WakeSource::TaskResult { task_id: expected }
+                            if expected == task_id
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    let [wait] = matching_waits.as_slice() else {
+        return Ok(None);
+    };
+    let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
+        return Ok(None);
+    };
+    let Some(expected_source_revision) = attempt.admitted_fences.work_item_source_revision else {
+        return Ok(None);
+    };
+    if work_item.state != WorkItemState::Open
+        || work_item.blocked_by.is_some()
+        || work_item.revision <= expected_source_revision
+    {
+        return Ok(None);
+    }
+    Ok(Some(
+        crate::runtime_db::transitions::ExecutionProtocolTransition {
+            bootstrap: None,
+            commands: vec![
+                crate::domain::execution_protocol::ExecutionProtocolCommand::
+                    RecoverInterruptedTaskResultClaim(Box::new(
+                        RecoverInterruptedTaskResultClaim {
+                            command_id: format!(
+                                "recover_task_result_claim:{}:{}",
+                                attempt.attempt_id, work_item.revision
+                            ),
+                            attempt_id: attempt.attempt_id.clone(),
+                            outcome_id: format!("outcome:interrupted:{}", attempt.attempt_id),
+                            work_item_id: work_item_id.to_string(),
+                            task_id: task_id.clone(),
+                            result_message_id: message.id.clone(),
+                            wait_id: wait.id.clone(),
+                            rejoin,
+                            expected_source_revision,
+                            source_revision: work_item.revision,
+                            interrupted_at: interrupted_at.to_rfc3339(),
+                        },
+                    )),
+            ],
+        },
+    ))
+}
+
+fn scheduler_task_result_claim_recovery_candidates(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    execution_state: Option<&crate::domain::execution_protocol::ExecutionProtocolState>,
+) -> Result<Vec<SchedulerTaskResultClaimRecoveryCandidate>> {
+    let queue_entries = runtime_db
+        .queue_entries()
+        .recent(Some(agent_id), usize::MAX)?;
+    execution_state
+        .into_iter()
+        .flat_map(|state| state.attempts.values())
+        .filter(|attempt| {
+            attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Open
+        })
+        .filter_map(|attempt| {
+            let crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } =
+                &attempt.binding
+            else {
+                return None;
+            };
+            let message_id = attempt.source_message_id.as_deref()?;
+            let entry = queue_entries.iter().find(|entry| {
+                entry.message_id == message_id && entry.status == QueueEntryStatus::Dequeued
+            })?;
+            Some((attempt, work_item_id, entry))
+        })
+        .map(|(attempt, work_item_id, entry)| {
+            let mut candidate = SchedulerTaskResultClaimRecoveryCandidate {
+                message_id: entry.message_id.clone(),
+                activation_id: attempt.attempt_id.clone(),
+                work_item_id: work_item_id.clone(),
+                queue_status: entry.status.clone(),
+                expected_queue_entry: None,
+                eligible: false,
+                reason: "task_result_claim_evidence_incomplete".into(),
+                evidence: vec![
+                    format!("work_item:{work_item_id}"),
+                    format!("open_execution_attempt:{}", attempt.attempt_id),
+                    format!(
+                        "admitted_work_item_revision:{}",
+                        attempt
+                            .admitted_fences
+                            .work_item_source_revision
+                            .unwrap_or_default()
+                    ),
+                ],
+                proposed_queue_entry: None,
+                proposed_command: None,
+            };
+            let Some(message) = storage.read_message_by_id(&entry.message_id)? else {
+                candidate.reason = "message_missing".into();
+                return Ok(candidate);
+            };
+            let Some(transition) = exact_task_result_claim_recovery(
+                storage,
+                runtime_db,
+                &message,
+                attempt,
+                work_item_id,
+                Utc::now(),
+            )?
+            else {
+                return Ok(candidate);
+            };
+            let [command] = transition.commands.as_slice() else {
+                return Ok(candidate);
+            };
+            let mut proposed_entry = entry.clone();
+            proposed_entry.status = QueueEntryStatus::Queued;
+            proposed_entry.updated_at = Utc::now();
+            candidate.eligible = true;
+            candidate.reason = "stale_task_result_claim_revision".into();
+            candidate.evidence.push(format!(
+                "durable_work_item_revision:{}",
+                runtime_db
+                    .work_items()
+                    .latest(work_item_id)?
+                    .map(|work| work.revision)
+                    .unwrap_or_default()
+            ));
+            candidate.proposed_queue_entry = Some(proposed_entry);
+            candidate.expected_queue_entry = Some(entry.clone());
+            candidate.proposed_command = Some(command.clone());
+            Ok(candidate)
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SchedulerRecoveryReport {
     pub agent_id: String,
@@ -1475,8 +1669,23 @@ pub struct SchedulerRecoveryReport {
     pub authority_inventory: Vec<SchedulerAuthorityInventoryEntry>,
     pub retired_rollout_metadata: SchedulerRetiredRolloutMetadata,
     pub candidates: Vec<SchedulerRecoveryCandidate>,
+    pub task_result_claim_recoveries: Vec<SchedulerTaskResultClaimRecoveryCandidate>,
     pub legacy_adoptions: Vec<SchedulerLegacyAdoptionCandidate>,
     pub continuation_reconciliations: Vec<SchedulerContinuationReconciliationCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerTaskResultClaimRecoveryCandidate {
+    pub message_id: String,
+    pub activation_id: String,
+    pub work_item_id: String,
+    pub queue_status: QueueEntryStatus,
+    pub expected_queue_entry: Option<QueueEntryRecord>,
+    pub eligible: bool,
+    pub reason: String,
+    pub evidence: Vec<String>,
+    pub proposed_queue_entry: Option<QueueEntryRecord>,
+    pub proposed_command: Option<crate::domain::execution_protocol::ExecutionProtocolCommand>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1953,6 +2162,12 @@ pub fn scheduler_recovery_report(
         execution_state.as_ref(),
         &active_continuations,
     )?;
+    let task_result_claim_recoveries = scheduler_task_result_claim_recovery_candidates(
+        storage,
+        runtime_db,
+        agent_id,
+        execution_state.as_ref(),
+    )?;
     let Some(snapshot) = runtime_db
         .transitions()
         .load_scheduler_protocol_snapshot_if_initialized(agent_id)?
@@ -1964,6 +2179,7 @@ pub fn scheduler_recovery_report(
             authority_inventory,
             retired_rollout_metadata,
             candidates: Vec::new(),
+            task_result_claim_recoveries,
             legacy_adoptions: runtime_db
                 .transitions()
                 .legacy_scheduler_adoption_candidates(agent_id)?
@@ -2026,6 +2242,12 @@ pub fn scheduler_recovery_report(
             attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Open
         })
     {
+        if task_result_claim_recoveries
+            .iter()
+            .any(|candidate| candidate.activation_id == attempt.attempt_id)
+        {
+            continue;
+        }
         let crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } =
             &attempt.binding
         else {
@@ -2340,6 +2562,7 @@ pub fn scheduler_recovery_report(
         authority_inventory,
         retired_rollout_metadata,
         candidates,
+        task_result_claim_recoveries,
         legacy_adoptions: runtime_db
             .transitions()
             .legacy_scheduler_adoption_candidates(agent_id)?
@@ -2368,6 +2591,7 @@ pub fn apply_scheduler_recovery_plan(
         report,
         SchedulerRecoveryBackupPolicy::Required,
         true,
+        None,
         |_| Ok(()),
     )
 }
@@ -2393,6 +2617,7 @@ pub fn apply_scheduler_recovery_plan_with_backup_policy(
         report,
         backup_policy,
         true,
+        None,
         |_| Ok(()),
     )
 }
@@ -2412,7 +2637,28 @@ fn apply_scheduler_recovery_plan_with_hook(
         report,
         SchedulerRecoveryBackupPolicy::Required,
         true,
+        None,
         &mut before_legacy_adoption_commit,
+    )
+}
+
+#[cfg(test)]
+fn apply_scheduler_recovery_plan_with_task_result_fault(
+    storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+    agent_id: &str,
+    report: &SchedulerRecoveryReport,
+    fault: crate::runtime_db::transitions::TransitionFaultPoint,
+) -> Result<(usize, Option<std::path::PathBuf>)> {
+    apply_scheduler_recovery_plan_with_options(
+        storage,
+        runtime_db,
+        agent_id,
+        report,
+        SchedulerRecoveryBackupPolicy::SkipApproved,
+        true,
+        Some(fault),
+        |_| Ok(()),
     )
 }
 
@@ -2423,6 +2669,7 @@ fn apply_scheduler_recovery_plan_with_options(
     report: &SchedulerRecoveryReport,
     backup_policy: SchedulerRecoveryBackupPolicy,
     include_authority_repair: bool,
+    task_result_fault: Option<crate::runtime_db::transitions::TransitionFaultPoint>,
     mut before_legacy_adoption_commit: impl FnMut(&str) -> Result<()>,
 ) -> Result<(usize, Option<std::path::PathBuf>)> {
     let legacy_adoptions = report
@@ -2460,10 +2707,24 @@ fn apply_scheduler_recovery_plan_with_options(
         .filter(|candidate| candidate.eligible)
         .filter_map(|candidate| candidate.proposed_command.clone())
         .collect::<Vec<_>>();
+    let task_result_claim_recovery = report
+        .task_result_claim_recoveries
+        .iter()
+        .filter(|candidate| candidate.eligible)
+        .filter_map(|candidate| {
+            Some((
+                candidate,
+                candidate.expected_queue_entry.as_ref()?,
+                candidate.proposed_queue_entry.as_ref()?,
+                candidate.proposed_command.as_ref()?,
+            ))
+        })
+        .collect::<Vec<_>>();
     if legacy_adoptions.is_empty()
         && settlement_recovery.is_empty()
         && authority_recovery.is_empty()
         && continuation_reconciliation.is_empty()
+        && task_result_claim_recovery.is_empty()
     {
         return Ok((0, None));
     }
@@ -2481,6 +2742,63 @@ fn apply_scheduler_recovery_plan_with_options(
         SchedulerRecoveryBackupPolicy::SkipApproved => None,
     };
     let mut applied = false;
+    for (candidate, expected_entry, proposed_entry, command) in task_result_claim_recovery {
+        let Some(current_entry) = runtime_db
+            .queue_entries()
+            .recent(Some(agent_id), usize::MAX)?
+            .into_iter()
+            .find(|entry| entry.message_id == candidate.message_id)
+        else {
+            return Err(anyhow!(
+                "TaskResult claim recovery queue entry disappeared: {}",
+                candidate.message_id
+            ));
+        };
+        if &current_entry == proposed_entry {
+            continue;
+        }
+        if &current_entry != expected_entry {
+            return Err(anyhow!(
+                "TaskResult claim recovery queue fence changed: {}",
+                candidate.message_id
+            ));
+        }
+        let commit = runtime_db
+            .transitions()
+            .commit_queue_with_execution_protocol(
+                &crate::runtime_db::transitions::QueueTransitionCommand {
+                    agent_id: agent_id.to_string(),
+                    operation: crate::runtime_db::transitions::QueueOperation::Requeue,
+                    mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                        expected: expected_entry.clone(),
+                        record: proposed_entry.clone(),
+                    },
+                    scheduler_claim_work_item: None,
+                    agent_state: None,
+                    message_evidence: Vec::new(),
+                    transcript_entries: Vec::new(),
+                    turn_record: None,
+                    audit_events: vec![AuditEvent::legacy(
+                        "scheduler_task_result_claim_recovered",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "message_id": candidate.message_id,
+                            "activation_id": candidate.activation_id,
+                            "work_item_id": candidate.work_item_id,
+                            "reason": candidate.reason,
+                        }),
+                    )],
+                    notify_scheduler: true,
+                    fault: task_result_fault,
+                    brief_evidence: Vec::new(),
+                },
+                &crate::runtime_db::transitions::ExecutionProtocolTransition {
+                    bootstrap: None,
+                    commands: vec![command.clone()],
+                },
+            )?;
+        applied |= commit.applied;
+    }
     if !continuation_reconciliation.is_empty() {
         let audit_events = report
             .continuation_reconciliations
@@ -2596,6 +2914,11 @@ fn apply_scheduler_recovery_plan_with_options(
             "backup_path": backup_path,
             "authority_repair_included": include_authority_repair,
             "continuation_reconciliation_count": continuation_reconciliation.len(),
+            "task_result_claim_recovery_count": report
+                .task_result_claim_recoveries
+                .iter()
+                .filter(|candidate| candidate.eligible)
+                .count(),
         }),
     ))?;
     Ok((usize::from(applied), backup_path))
@@ -3113,6 +3436,23 @@ impl RuntimeHandle {
                 .runtime_db
                 .transitions()
                 .commit_work_item_focus(command)
+        }
+    }
+
+    pub(super) fn commit_task_transition(
+        &self,
+        command: &crate::runtime_db::transitions::TaskTransitionCommand,
+    ) -> Result<crate::runtime_db::transitions::TransitionCommit> {
+        if self.inner.scheduler_engine.is_canonical() {
+            self.inner
+                .runtime_db
+                .transitions()
+                .commit_task_with_execution_protocol(
+                    command,
+                    &crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+                )
+        } else {
+            self.inner.runtime_db.transitions().commit_task(command)
         }
     }
 
@@ -5447,16 +5787,27 @@ impl RuntimeHandle {
                     continue;
                 }
             };
-            if let Some(work_item_id) = work_item_id.as_deref() {
-                if !matches!(
+            let task_result_recovery = if let Some(work_item_id) = work_item_id.as_deref() {
+                let work_queue_claim = matches!(
                     (&message.kind, &message.origin),
                     (MessageKind::SystemTick, MessageOrigin::System { subsystem })
                         if subsystem == "work_queue"
-                ) || message.work_item_id.as_deref() != Some(work_item_id)
-                {
+                ) && message.work_item_id.as_deref() == Some(work_item_id);
+                let task_result_recovery = exact_task_result_claim_recovery(
+                    &self.inner.storage,
+                    &self.inner.runtime_db,
+                    &message,
+                    &attempt,
+                    work_item_id,
+                    self.now(),
+                )?;
+                if !work_queue_claim && task_result_recovery.is_none() {
                     continue;
                 }
-            }
+                task_result_recovery
+            } else {
+                None
+            };
 
             let terminal_turn = turns.iter().find(|turn| {
                 turn.terminal.is_some()
@@ -5473,6 +5824,59 @@ impl RuntimeHandle {
                     terminal.kind == crate::types::TurnTerminalKind::Completed
                 })
             });
+            if attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Open
+                && terminal_turn.is_none()
+                && task_result_recovery.is_some()
+            {
+                entry.status = QueueEntryStatus::Queued;
+                entry.updated_at = self.now();
+                let message_id = entry.message_id.clone();
+                let execution_protocol =
+                    task_result_recovery.expect("TaskResult recovery was checked");
+                let commit = self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_execution_protocol(
+                        &crate::runtime_db::transitions::QueueTransitionCommand {
+                            agent_id: agent_id.clone(),
+                            operation: crate::runtime_db::transitions::QueueOperation::Requeue,
+                            mutation:
+                                crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                                    expected: expected_entry,
+                                    record: entry,
+                                },
+                            scheduler_claim_work_item: None,
+                            agent_state: None,
+                            message_evidence: Vec::new(),
+                            transcript_entries: Vec::new(),
+                            turn_record: None,
+                            audit_events: vec![AuditEvent::legacy(
+                                "scheduler_bootstrap_claim_recovered",
+                                serde_json::json!({
+                                    "agent_id": agent_id,
+                                    "message_id": message_id,
+                                    "activation_id": activation_id,
+                                    "work_item_id": work_item_id,
+                                    "queue_status": QueueEntryStatus::Queued,
+                                    "recovery_outcome": "task_result_attempt_requeued_for_reentry",
+                                    "provenance": "bootstrap_reconciliation",
+                                }),
+                            )],
+                            notify_scheduler: true,
+                            fault: self.take_transition_fault(),
+                            brief_evidence: Vec::new(),
+                        },
+                        &execution_protocol,
+                    )?;
+                if commit.applied {
+                    recovered += 1;
+                    guard.restore_bootstrap_replay_message(&self.inner.storage, &message)?;
+                }
+                drop(guard);
+                self.apply_transition_commit(commit).await;
+                continue;
+            }
             // Execution attempt state is authoritative. Terminal attempts only
             // reconcile the retained legacy queue claim.
             if attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Settled {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -18,9 +18,38 @@ impl RuntimeHandle {
         scheduler_state: &AgentState,
     ) -> Result<MessageDispatchPlan> {
         let task = match message.kind {
-            MessageKind::TaskStatus | MessageKind::TaskResult => {
+            MessageKind::TaskStatus => {
                 tasks::task_from_message(message, &message.agent_id).map(Some)
             }
+            MessageKind::TaskResult => tasks::task_from_message(message, &message.agent_id)
+                .or_else(|error| {
+                    let durable_task = message
+                        .task_id
+                        .as_deref()
+                        .filter(|task_id| {
+                            message.authority_class == AuthorityClass::RuntimeInstruction
+                                && message.admission_context == Some(AdmissionContext::RuntimeOwned)
+                                && message.delivery_surface
+                                    == Some(MessageDeliverySurface::TaskRejoin)
+                                && matches!(
+                                    &message.origin,
+                                    MessageOrigin::Task {
+                                        task_id: origin_task_id
+                                    } if origin_task_id == *task_id
+                                )
+                        })
+                        .map(|task_id| self.inner.storage.latest_task_record(task_id))
+                        .transpose()?
+                        .flatten()
+                        .filter(|task| {
+                            task.agent_id == message.agent_id
+                                && task.work_item_id == message.work_item_id
+                                && task.parent_message_id.as_deref() == Some(message.id.as_str())
+                                && task.terminal_reentry()
+                        });
+                    durable_task.ok_or(error)
+                })
+                .map(Some),
             _ => Ok(None),
         };
         let continuation_trigger =

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1187,6 +1187,38 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let authoritative_work = existing_execution
             .as_ref()
             .and_then(|state| state.work_items.get(work_item_id));
+        let interrupted_task_result_attempt = if matches!(
+            scenario,
+            scheduler::CanonicalActivationScenario::ExactTaskRejoin { .. }
+        ) {
+            existing_execution.as_ref().and_then(|state| {
+                let matching = state
+                    .attempts
+                    .values()
+                    .filter(|attempt| {
+                        attempt.state
+                            == crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+                            && execution_attempt_matches_scenario(attempt, message, &scenario)
+                    })
+                    .collect::<Vec<_>>();
+                let [attempt] = matching.as_slice() else {
+                    return None;
+                };
+                Some((*attempt).clone())
+            })
+        } else {
+            None
+        };
+        let interrupted_task_result_replay = interrupted_task_result_attempt.is_some()
+            && authoritative_work.is_some_and(|record| {
+                matches!(
+                    &record.state,
+                    crate::domain::execution_protocol::WorkItemExecutionState::Runnable {
+                        recovery_ref: Some(recovery_ref),
+                        ..
+                    } if recovery_ref == "interrupted"
+                )
+            });
         if let scheduler::CanonicalActivationScenario::WorkItemAutonomousContinuation {
             expected_work_item_revision,
             ..
@@ -1205,7 +1237,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 });
             }
         }
-        let recovery_of_attempt_id = if matches!(
+        let recovery_of_attempt_id = if interrupted_task_result_replay {
+            interrupted_task_result_attempt.map(|attempt| attempt.attempt_id)
+        } else if matches!(
             scenario,
             scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
         ) {
@@ -1269,7 +1303,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 &authoritative_work.state,
                 crate::domain::execution_protocol::WorkItemExecutionState::Waiting { wait, .. }
                     if wait.wait_id == wait_id
-            ) {
+            ) && !interrupted_task_result_replay
+            {
                 return Ok(CanonicalClaimOutcome::RejectQueued {
                     scenario_class,
                     reason: "canonical_wait_execution_authority_mismatch",
@@ -1278,12 +1313,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         } else if !matches!(
             scenario,
             scheduler::CanonicalActivationScenario::ProviderRecovery { .. }
-        ) && authoritative_work.is_some_and(|record| {
-            !matches!(
-                record.state,
-                crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
-            )
-        }) {
+        ) && !interrupted_task_result_replay
+            && authoritative_work.is_some_and(|record| {
+                !matches!(
+                    record.state,
+                    crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+                )
+            })
+        {
             return Ok(CanonicalClaimOutcome::RejectQueued {
                 scenario_class,
                 reason: "canonical_work_item_execution_not_runnable",

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -301,8 +301,8 @@ impl RuntimeHandle {
             })
             .into_iter()
             .collect();
-        let commit = self.inner.runtime_db.transitions().commit_task(
-            &crate::runtime_db::transitions::TaskTransitionCommand {
+        let commit =
+            self.commit_task_transition(&crate::runtime_db::transitions::TaskTransitionCommand {
                 agent_id,
                 task: persisted_task,
                 work_items,
@@ -316,8 +316,7 @@ impl RuntimeHandle {
                     && !task_will_change
                     && is_terminal_task_status(&task.status),
                 fault: self.take_transition_fault(),
-            },
-        )?;
+            })?;
         self.apply_transition_commit(commit).await;
         Ok(())
     }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -119,36 +119,7 @@ fn copy_task_rejoin_contract(task: &TaskRecord, detail: &mut serde_json::Value) 
 pub(super) fn task_rejoin_fence(
     task: &TaskRecord,
 ) -> Result<crate::domain::execution_protocol::RejoinFence> {
-    let detail = task
-        .detail
-        .as_ref()
-        .and_then(serde_json::Value::as_object)
-        .ok_or_else(|| anyhow!("task rejoin contract is missing task detail"))?;
-    let obligation_id = detail
-        .get(REJOIN_OBLIGATION_ID_DETAIL)
-        .and_then(serde_json::Value::as_str)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| anyhow!("task rejoin contract is missing obligation identity"))?;
-    if obligation_id != task.id {
-        return Err(anyhow!(
-            "task rejoin obligation identity does not match task identity"
-        ));
-    }
-    let generation = detail
-        .get(REJOIN_GENERATION_DETAIL)
-        .and_then(serde_json::Value::as_u64)
-        .filter(|generation| *generation > 0)
-        .ok_or_else(|| anyhow!("task rejoin contract is missing generation"))?;
-    let parent_turn_id = detail
-        .get(PARENT_TURN_ID_DETAIL)
-        .and_then(serde_json::Value::as_str)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| anyhow!("task rejoin contract is missing parent turn identity"))?;
-    Ok(crate::domain::execution_protocol::RejoinFence {
-        obligation_id: obligation_id.to_string(),
-        generation,
-        parent_turn_id: parent_turn_id.to_string(),
-    })
+    task.rejoin_fence().map_err(anyhow::Error::msg)
 }
 
 fn spawn_agent_task_label(initial_message: &str) -> String {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -456,6 +456,11 @@ fn persist_execution_transition_only(
             ExecutionProtocolCommand::Interrupt(command) => {
                 crate::domain::execution_protocol::interrupt_execution(&state, &command)
             }
+            ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) => {
+                crate::domain::execution_protocol::recover_interrupted_task_result_claim(
+                    &state, &command,
+                )
+            }
         }
         .expect("test execution transition should be valid")
         .state;
@@ -2080,6 +2085,662 @@ async fn bootstrap_recovery_interrupts_open_attempt_and_releases_message_for_ree
                 && event.data["message_id"] == message.id
                 && event.data["activation_id"] == activation_id
         }));
+}
+
+#[tokio::test]
+async fn bootstrap_recovery_replays_task_result_claim_after_canonical_revision_sync() {
+    use crate::domain::execution_protocol::{
+        AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding, ExecutionOrigin,
+        ExecutionPriority, ExecutionProtocolState, ExecutionProvenance, ExecutionSource,
+        ExecutionSourceIdentity, ExecutionTrust, WorkItemExecutionRecord, WorkItemExecutionState,
+    };
+
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            "recover stale TaskResult claim".into(),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    append_running_rejoin_task(&runtime, "task-stale-bootstrap", &work_item.id);
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some("task-stale-bootstrap".into()),
+            "waiting for stale bootstrap task".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let waiting_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem");
+    let stale_revision = waiting_work.revision;
+    let rejoin = crate::domain::execution_protocol::RejoinFence {
+        obligation_id: "task-stale-bootstrap".into(),
+        generation: 1,
+        parent_turn_id: "turn-stale-bootstrap-parent".into(),
+    };
+    let mut terminal_task = TaskRecord {
+        id: "task-stale-bootstrap".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: Some(work_item.id.clone()),
+        summary: Some("task-stale-bootstrap completed".into()),
+        detail: Some(serde_json::json!({
+            "terminal_reentry": true,
+            "rejoin_obligation_id": rejoin.obligation_id,
+            "rejoin_generation": rejoin.generation,
+            "parent_turn_id": rejoin.parent_turn_id,
+        })),
+        recovery: None,
+    };
+    let mut result = task_result_message("task-stale-bootstrap").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    result.task_id = Some("task-stale-bootstrap".into());
+    result.work_item_id = Some(work_item.id.clone());
+    result.turn_id = Some("turn-stale-bootstrap-result".into());
+    terminal_task.parent_message_id = Some(result.id.clone());
+    runtime
+        .persist_task_transition_with_message(&terminal_task, "task_completed", &result)
+        .await
+        .unwrap();
+    let result = runtime
+        .storage()
+        .read_message_by_id(&result.id)
+        .unwrap()
+        .expect("persisted TaskResult");
+    let current_work = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("resolved WorkItem");
+    assert!(current_work.revision > stale_revision);
+    assert_eq!(
+        registration.condition.id,
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|wait| wait.trigger_message_id() == Some(result.id.as_str()))
+            .expect("resolved exact task wait")
+            .id
+    );
+
+    let authority = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_authority_fences("default")
+        .unwrap();
+    let attempt_id = scheduler_executor::canonical_activation_id(&result.id);
+    let mut stale = ExecutionProtocolState::empty("default");
+    stale.work_items.insert(
+        work_item.id.clone(),
+        WorkItemExecutionRecord {
+            source_revision: current_work.revision,
+            state: WorkItemExecutionState::InFlight {
+                generation: stale_revision,
+                attempt_id: attempt_id.clone(),
+            },
+        },
+    );
+    stale.attempts.insert(
+        attempt_id.clone(),
+        ExecutionAttempt {
+            attempt_id: attempt_id.clone(),
+            agent_id: "default".into(),
+            source_message_id: Some(result.id.clone()),
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::TaskResult {
+                    task_id: "task-stale-bootstrap".into(),
+                    result_message_id: result.id.clone(),
+                },
+                generation: result.message_seq.expect("persisted message sequence"),
+            },
+            binding: ExecutionBinding::WorkItem {
+                work_item_id: work_item.id.clone(),
+            },
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::Task,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Normal,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: result.message_seq.unwrap(),
+                work_item_source_revision: Some(stale_revision),
+                work_item_generation: Some(stale_revision),
+                rejoin: Some(rejoin),
+                agent_control_revision: authority.agent_control_revision,
+                host_registry_revision: authority.host_registry_revision,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: result.turn_id.clone(),
+            recovery_of_attempt_id: None,
+            terminal_outcome_id: None,
+            admitted_at: Utc::now().to_rfc3339(),
+            terminal_at: None,
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &stale))
+        .unwrap();
+    runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .upsert(&QueueEntryRecord {
+            message_id: result.id.clone(),
+            agent_id: "default".into(),
+            priority: result.priority.clone(),
+            status: QueueEntryStatus::Dequeued,
+            created_at: result.created_at,
+            updated_at: Utc::now(),
+        })
+        .unwrap();
+
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        1
+    );
+    assert_eq!(
+        runtime.recover_scheduler_bootstrap_claims().await.unwrap(),
+        0
+    );
+    let recovered = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("recovered execution partition");
+    assert_eq!(
+        recovered.attempts[&attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        recovered.work_items[&work_item.id].source_revision,
+        current_work.revision
+    );
+    assert!(matches!(
+        recovered.work_items[&work_item.id].state,
+        WorkItemExecutionState::Runnable {
+            recovery_ref: Some(ref recovery_ref),
+            ..
+        } if recovery_ref == "interrupted"
+    ));
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("expected the interrupted TaskResult claim to re-enter");
+    };
+    assert_eq!(scheduled.message.id, result.id);
+    assert!(
+        matches!(
+            scheduled.dispatch_plan.execution_admission_provenance,
+            crate::types::ExecutionAdmissionProvenance::Canonical { .. }
+        ),
+        "expected canonical replay admission, got {:?}",
+        scheduled.dispatch_plan.execution_admission_provenance
+    );
+    let replayed = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("replayed execution partition");
+    let replay_attempts = replayed
+        .attempts
+        .values()
+        .filter(|attempt| {
+            attempt.state == ExecutionAttemptState::Open
+                && attempt.source_message_id.as_deref() == Some(result.id.as_str())
+                && attempt.recovery_of_attempt_id.as_deref() == Some(attempt_id.as_str())
+        })
+        .collect::<Vec<_>>();
+    let [replay_attempt] = replay_attempts.as_slice() else {
+        panic!("expected one exact TaskResult replay attempt: {replayed:#?}");
+    };
+    assert_eq!(replay_attempt.state, ExecutionAttemptState::Open);
+    assert_eq!(
+        replay_attempt.recovery_of_attempt_id.as_deref(),
+        Some(attempt_id.as_str())
+    );
+    assert_eq!(
+        replay_attempt.admitted_fences.work_item_source_revision,
+        Some(current_work.revision)
+    );
+    assert_eq!(
+        replay_attempt.source.identity,
+        ExecutionSourceIdentity::TaskResult {
+            task_id: "task-stale-bootstrap".into(),
+            result_message_id: result.id,
+        }
+    );
+}
+
+struct StaleTaskResultClaimFixture {
+    _dir: tempfile::TempDir,
+    _workspace: tempfile::TempDir,
+    runtime: RuntimeHandle,
+    work_item_id: String,
+    result: MessageEnvelope,
+    attempt_id: String,
+    current_revision: u64,
+}
+
+async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimFixture {
+    use crate::domain::execution_protocol::{
+        AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding, ExecutionOrigin,
+        ExecutionPriority, ExecutionProtocolState, ExecutionProvenance, ExecutionSource,
+        ExecutionSourceIdentity, ExecutionTrust, WorkItemExecutionRecord, WorkItemExecutionState,
+    };
+
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item(
+            format!("recover stale TaskResult claim {task_id}"),
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    append_running_rejoin_task(&runtime, task_id, &work_item.id);
+    runtime
+        .register_wait_for(
+            "default",
+            Some(work_item.id.clone()),
+            WaitForWakeKind::TaskResult,
+            Some(task_id.into()),
+            "waiting for stale recovery task".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let stale_revision = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("waiting WorkItem")
+        .revision;
+    let rejoin = crate::domain::execution_protocol::RejoinFence {
+        obligation_id: task_id.into(),
+        generation: 1,
+        parent_turn_id: format!("turn-{task_id}-parent"),
+    };
+    let mut terminal_task = TaskRecord {
+        id: task_id.into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: Some(work_item.id.clone()),
+        summary: Some(format!("{task_id} completed")),
+        detail: Some(serde_json::json!({
+            "terminal_reentry": true,
+            "rejoin_obligation_id": rejoin.obligation_id,
+            "rejoin_generation": rejoin.generation,
+            "parent_turn_id": rejoin.parent_turn_id,
+        })),
+        recovery: None,
+    };
+    let mut result = task_result_message(task_id).with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    result.task_id = Some(task_id.into());
+    result.work_item_id = Some(work_item.id.clone());
+    result.turn_id = Some(format!("turn-{task_id}-result"));
+    terminal_task.parent_message_id = Some(result.id.clone());
+    runtime
+        .persist_task_transition_with_message(&terminal_task, "task_completed", &result)
+        .await
+        .unwrap();
+    let result = runtime
+        .storage()
+        .read_message_by_id(&result.id)
+        .unwrap()
+        .expect("persisted TaskResult");
+    let current_revision = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("resolved WorkItem")
+        .revision;
+    let authority = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_authority_fences("default")
+        .unwrap();
+    let attempt_id = scheduler_executor::canonical_activation_id(&result.id);
+    let mut stale = ExecutionProtocolState::empty("default");
+    stale.work_items.insert(
+        work_item.id.clone(),
+        WorkItemExecutionRecord {
+            source_revision: current_revision,
+            state: WorkItemExecutionState::InFlight {
+                generation: stale_revision,
+                attempt_id: attempt_id.clone(),
+            },
+        },
+    );
+    stale.attempts.insert(
+        attempt_id.clone(),
+        ExecutionAttempt {
+            attempt_id: attempt_id.clone(),
+            agent_id: "default".into(),
+            source_message_id: Some(result.id.clone()),
+            source: ExecutionSource {
+                identity: ExecutionSourceIdentity::TaskResult {
+                    task_id: task_id.into(),
+                    result_message_id: result.id.clone(),
+                },
+                generation: result.message_seq.expect("persisted message sequence"),
+            },
+            binding: ExecutionBinding::WorkItem {
+                work_item_id: work_item.id.clone(),
+            },
+            provenance: ExecutionProvenance {
+                origin: ExecutionOrigin::Task,
+                trust: ExecutionTrust::RuntimeInstruction,
+                priority: ExecutionPriority::Normal,
+                correlation_id: None,
+                causation_id: None,
+            },
+            admitted_fences: AdmittedFences {
+                source_revision: result.message_seq.unwrap(),
+                work_item_source_revision: Some(stale_revision),
+                work_item_generation: Some(stale_revision),
+                rejoin: Some(rejoin),
+                agent_control_revision: authority.agent_control_revision,
+                host_registry_revision: authority.host_registry_revision,
+            },
+            state: ExecutionAttemptState::Open,
+            run_id: None,
+            turn_id: result.turn_id.clone(),
+            recovery_of_attempt_id: None,
+            terminal_outcome_id: None,
+            admitted_at: Utc::now().to_rfc3339(),
+            terminal_at: None,
+        },
+    );
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &stale))
+        .unwrap();
+    runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .upsert(&QueueEntryRecord {
+            message_id: result.id.clone(),
+            agent_id: "default".into(),
+            priority: result.priority.clone(),
+            status: QueueEntryStatus::Dequeued,
+            created_at: result.created_at,
+            updated_at: Utc::now(),
+        })
+        .unwrap();
+
+    StaleTaskResultClaimFixture {
+        _dir: dir,
+        _workspace: workspace,
+        runtime,
+        work_item_id: work_item.id,
+        result,
+        attempt_id,
+        current_revision,
+    }
+}
+
+fn isolated_task_result_claim_report(runtime: &RuntimeHandle) -> SchedulerRecoveryReport {
+    let mut report =
+        scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
+            .unwrap();
+    report.candidates.clear();
+    report.legacy_adoptions.clear();
+    report.continuation_reconciliations.clear();
+    report
+}
+
+#[tokio::test]
+async fn scheduler_recovery_task_result_claim_is_atomic_fenced_and_idempotent() {
+    use crate::domain::execution_protocol::{ExecutionAttemptState, WorkItemExecutionState};
+    use crate::runtime_db::transitions::TransitionFaultPoint;
+
+    let fixture = stale_task_result_claim_fixture("task-scheduler-recovery-apply").await;
+    let report = isolated_task_result_claim_report(&fixture.runtime);
+    let [candidate] = report.task_result_claim_recoveries.as_slice() else {
+        panic!("expected one stale TaskResult claim candidate: {report:#?}");
+    };
+    assert!(candidate.eligible);
+    assert_eq!(candidate.reason, "stale_task_result_claim_revision");
+    assert_eq!(candidate.message_id, fixture.result.id);
+    assert_eq!(candidate.activation_id, fixture.attempt_id);
+    assert_eq!(candidate.work_item_id, fixture.work_item_id);
+    assert_eq!(candidate.queue_status, QueueEntryStatus::Dequeued);
+    assert!(candidate.expected_queue_entry.is_some());
+
+    assert_eq!(
+        apply_scheduler_recovery_plan_with_backup_policy(
+            &fixture.runtime.inner.storage,
+            &fixture.runtime.inner.runtime_db,
+            "default",
+            &report,
+            SchedulerRecoveryBackupPolicy::SkipApproved,
+        )
+        .unwrap(),
+        (1, None)
+    );
+    let recovered_execution = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("recovered execution partition");
+    assert_eq!(
+        recovered_execution.attempts[&fixture.attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        recovered_execution.work_items[&fixture.work_item_id].source_revision,
+        fixture.current_revision
+    );
+    assert!(matches!(
+        recovered_execution.work_items[&fixture.work_item_id].state,
+        WorkItemExecutionState::Runnable { .. }
+    ));
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("requeued TaskResult")
+            .status,
+        QueueEntryStatus::Queued
+    );
+    assert_eq!(
+        apply_scheduler_recovery_plan_with_backup_policy(
+            &fixture.runtime.inner.storage,
+            &fixture.runtime.inner.runtime_db,
+            "default",
+            &report,
+            SchedulerRecoveryBackupPolicy::SkipApproved,
+        )
+        .unwrap(),
+        (0, None)
+    );
+
+    let fence_fixture = stale_task_result_claim_fixture("task-scheduler-recovery-fence").await;
+    let fence_report = isolated_task_result_claim_report(&fence_fixture.runtime);
+    let before_execution = fence_fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let mut changed_entry = fence_fixture
+        .runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest(&fence_fixture.result.id)
+        .unwrap()
+        .unwrap();
+    changed_entry.updated_at += chrono::Duration::seconds(1);
+    fence_fixture
+        .runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .upsert(&changed_entry)
+        .unwrap();
+    let error = apply_scheduler_recovery_plan_with_backup_policy(
+        &fence_fixture.runtime.inner.storage,
+        &fence_fixture.runtime.inner.runtime_db,
+        "default",
+        &fence_report,
+        SchedulerRecoveryBackupPolicy::SkipApproved,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("queue fence changed"));
+    assert_eq!(
+        fence_fixture
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .unwrap(),
+        before_execution
+    );
+    assert_eq!(
+        fence_fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fence_fixture.result.id)
+            .unwrap()
+            .unwrap(),
+        changed_entry
+    );
+
+    let fault_fixture = stale_task_result_claim_fixture("task-scheduler-recovery-fault").await;
+    let fault_report = isolated_task_result_claim_report(&fault_fixture.runtime);
+    let before_execution = fault_fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let before_queue = fault_fixture
+        .runtime
+        .inner
+        .runtime_db
+        .queue_entries()
+        .latest(&fault_fixture.result.id)
+        .unwrap()
+        .unwrap();
+    let error = apply_scheduler_recovery_plan_with_task_result_fault(
+        &fault_fixture.runtime.inner.storage,
+        &fault_fixture.runtime.inner.runtime_db,
+        "default",
+        &fault_report,
+        TransitionFaultPoint::AfterCanonicalWrites,
+    )
+    .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("injected runtime transition fault"));
+    assert_eq!(
+        fault_fixture
+            .runtime
+            .inner
+            .runtime_db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("default")
+            .unwrap()
+            .unwrap(),
+        before_execution
+    );
+    assert_eq!(
+        fault_fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fault_fixture.result.id)
+            .unwrap()
+            .unwrap(),
+        before_queue
+    );
 }
 
 #[tokio::test]
@@ -4370,6 +5031,17 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
         .unwrap()
         .expect("resolved WorkItem");
     assert!(resolved_work.revision > wait_generation);
+    let resolved_execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("task result should preserve execution authority");
+    assert_eq!(
+        resolved_execution.work_items[&work_item.id].source_revision,
+        resolved_work.revision
+    );
 
     let rejoin = runtime.enqueue(rejoin).await.unwrap();
 
@@ -4399,6 +5071,12 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
             ref result_message_id,
         } if task_id == "task-stale-legacy-rejoin" && result_message_id == &rejoin.id
     ));
+    assert_eq!(
+        claimed.attempts[&attempt_id]
+            .admitted_fences
+            .work_item_source_revision,
+        Some(resolved_work.revision)
+    );
     assert_eq!(
         runtime
             .storage()

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -102,6 +102,7 @@ pub(crate) enum QueueOperation {
     Admit,
     Claim,
     Interject,
+    Requeue,
     Settle,
     RepairDrop,
 }
@@ -1135,7 +1136,10 @@ impl RuntimeTransitionRepository<'_> {
                 let include_interrupted = match command.operation {
                     QueueOperation::Claim => true,
                     QueueOperation::Interject => false,
-                    QueueOperation::Admit | QueueOperation::Settle | QueueOperation::RepairDrop => {
+                    QueueOperation::Admit
+                    | QueueOperation::Requeue
+                    | QueueOperation::Settle
+                    | QueueOperation::RepairDrop => {
                         unreachable!("queue operation validation rejects this combination")
                     }
                 };
@@ -1240,7 +1244,10 @@ impl RuntimeTransitionRepository<'_> {
                 QueueMutation::Consume(record) => match command.operation {
                     QueueOperation::Claim => try_claim_queued_message_tx(tx, record)?,
                     QueueOperation::Interject => try_interject_queued_message_tx(tx, record)?,
-                    QueueOperation::Admit | QueueOperation::Settle | QueueOperation::RepairDrop => {
+                    QueueOperation::Admit
+                    | QueueOperation::Requeue
+                    | QueueOperation::Settle
+                    | QueueOperation::RepairDrop => {
                         unreachable!("queue operation validation rejects this combination")
                     }
                 },
@@ -1404,6 +1411,23 @@ impl RuntimeTransitionRepository<'_> {
     }
 
     pub fn commit_task(&self, command: &TaskTransitionCommand) -> Result<TransitionCommit> {
+        self.commit_task_internal(command, &ExecutionProtocolTransition::default(), false)
+    }
+
+    pub fn commit_task_with_execution_protocol(
+        &self,
+        command: &TaskTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+    ) -> Result<TransitionCommit> {
+        self.commit_task_internal(command, execution_protocol, true)
+    }
+
+    fn commit_task_internal(
+        &self,
+        command: &TaskTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        synchronize_execution_protocol: bool,
+    ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_task_tx(tx, &command.task)?;
             for work_item in &command.work_items {
@@ -1413,6 +1437,25 @@ impl RuntimeTransitionRepository<'_> {
                 validate_wait_condition_tx(tx, condition)?;
             }
             validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
+            let execution_protocol = if synchronize_execution_protocol {
+                execution_protocol_repository::synchronize_work_item_revisions_tx(
+                    tx,
+                    &command.agent_id,
+                    execution_protocol,
+                    &command.work_items,
+                )?
+            } else {
+                execution_protocol.clone()
+            };
+            let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
+                tx,
+                &command.agent_id,
+                execution_protocol.bootstrap.as_ref(),
+                &execution_protocol.commands,
+                &command.work_items,
+                &command.wait_conditions,
+                &[],
+            )?;
             inject_fault(command.fault, TransitionFaultPoint::AfterValidation)?;
 
             let task_applied = upsert_task_tx(tx, &command.task)?;
@@ -1435,9 +1478,13 @@ impl RuntimeTransitionRepository<'_> {
                 append_message_tx(tx, message)?;
             }
             applied |= command.commit_on_idempotent;
+            applied |= execution_protocol
+                .as_ref()
+                .is_some_and(|prepared| prepared.has_writes());
             if !applied {
                 return Ok(TransitionCommit::default());
             }
+            execution_protocol_repository::persist_execution_commands_tx(tx, execution_protocol)?;
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
 
             finish_transition_tx(
@@ -2152,6 +2199,18 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
                 status: QueueEntryStatus::Interjected,
                 ..
             })
+        ) | (
+            QueueOperation::Requeue,
+            QueueMutation::CompareAndSet {
+                expected: QueueEntryRecord {
+                    status: QueueEntryStatus::Dequeued | QueueEntryStatus::Interrupted,
+                    ..
+                },
+                record: QueueEntryRecord {
+                    status: QueueEntryStatus::Queued,
+                    ..
+                },
+            }
         ) | (
             QueueOperation::Settle,
             QueueMutation::Upsert(QueueEntryRecord {
@@ -3725,6 +3784,101 @@ mod tests {
                 .len(),
             2
         );
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_task_wait_release_rolls_back_execution_revision_with_durable_facts() -> Result<()> {
+        for fault in [
+            TransitionFaultPoint::AfterValidation,
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let mut initial_work = work_item("work-task");
+            initial_work.blocked_by = Some("waiting for task".into());
+            db.work_items().insert_new(&initial_work)?;
+            let active_wait = wait_condition("wait-task", &initial_work.id, "task-1");
+            db.wait_conditions().upsert(&active_wait)?;
+            let running = task("task-1", TaskStatus::Running);
+            db.tasks().upsert(&running)?;
+
+            let mut execution = ExecutionProtocolState::empty("agent-a");
+            execution.work_items.insert(
+                initial_work.id.clone(),
+                WorkItemExecutionRecord {
+                    source_revision: initial_work.revision,
+                    state: WorkItemExecutionState::Waiting {
+                        generation: initial_work.revision,
+                        wait: WaitReference {
+                            wait_id: active_wait.id.clone(),
+                        },
+                    },
+                },
+            );
+            db.transaction(|tx| persist_state_tx(tx, &execution))?;
+
+            let mut terminal = running.clone();
+            terminal.status = TaskStatus::Completed;
+            terminal.updated_at += chrono::Duration::seconds(1);
+            let mut resolved = active_wait.clone();
+            resolved.status = WaitConditionStatus::Resolved;
+            resolved.updated_at = terminal.updated_at;
+            resolved.resolved_at = Some(terminal.updated_at);
+            let mut cleared = initial_work.clone();
+            cleared.revision += 1;
+            cleared.blocked_by = None;
+            cleared.updated_at = terminal.updated_at;
+            let command = TaskTransitionCommand {
+                agent_id: "agent-a".into(),
+                task: terminal,
+                work_items: vec![WorkItemMutation::Update {
+                    record: cleared,
+                    expected_revision: initial_work.revision,
+                }],
+                wait_conditions: vec![resolved],
+                agent_state: None,
+                message_evidence: Vec::new(),
+                audit_events: Vec::new(),
+                index_changes: Vec::new(),
+                notify_scheduler: true,
+                commit_on_idempotent: false,
+                fault: Some(fault),
+            };
+
+            db.transitions()
+                .commit_task_with_execution_protocol(
+                    &command,
+                    &ExecutionProtocolTransition::default(),
+                )
+                .unwrap_err();
+
+            assert_eq!(
+                db.tasks().latest(&running.id)?.unwrap().status,
+                TaskStatus::Running
+            );
+            assert_eq!(
+                db.work_items().latest(&initial_work.id)?.unwrap(),
+                initial_work
+            );
+            assert_eq!(
+                db.wait_conditions().latest_all()?[0].status,
+                WaitConditionStatus::Active
+            );
+            let persisted = db
+                .transitions()
+                .load_execution_protocol_state_if_initialized("agent-a")?
+                .expect("execution authority");
+            assert_eq!(
+                persisted.work_items[&initial_work.id].source_revision,
+                initial_work.revision
+            );
+            assert!(matches!(
+                persisted.work_items[&initial_work.id].state,
+                WorkItemExecutionState::Waiting { .. }
+            ));
+        }
         Ok(())
     }
 }

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -93,6 +93,9 @@ pub(super) fn validate_execution_commands_tx(
         if let ExecutionProtocolCommand::AdvanceWorkItemSourceRevision(command) = command {
             validate_work_item_source_revision_advance(command, work_item_mutations)?;
         }
+        if let ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) = command {
+            validate_recover_interrupted_task_result_claim(tx, agent_id, command)?;
+        }
         if let ExecutionProtocolCommand::SetWorkItemReadiness(command) = command {
             validate_set_work_item_readiness(command, work_item_mutations, wait_conditions)?;
         }
@@ -323,6 +326,9 @@ fn reduce(
         ExecutionProtocolCommand::Interrupt(command) => {
             execution_protocol::interrupt_execution(state, command)
         }
+        ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) => {
+            execution_protocol::recover_interrupted_task_result_claim(state, command)
+        }
     }
 }
 
@@ -362,7 +368,122 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
         ExecutionProtocolCommand::Interrupt(command) => {
             ("interrupt_execution", &command.outcome_id)
         }
+        ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) => {
+            ("recover_interrupted_task_result_claim", &command.command_id)
+        }
     }
+}
+
+fn validate_recover_interrupted_task_result_claim(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &execution_protocol::RecoverInterruptedTaskResultClaim,
+) -> Result<()> {
+    let work_item = tx
+        .query_row(
+            "SELECT payload_json
+             FROM work_items
+             WHERE work_item_id = ?1 AND agent_id = ?2",
+            [&command.work_item_id, agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<crate::types::WorkItemRecord>(&payload))
+        .transpose()?
+        .ok_or_else(|| anyhow!("TaskResult claim recovery WorkItem is missing"))?;
+    if work_item.state != crate::types::WorkItemState::Open
+        || work_item.revision != command.source_revision
+        || work_item.blocked_by.is_some()
+    {
+        bail!("TaskResult claim recovery durable WorkItem fence is stale");
+    }
+    let task = tx
+        .query_row(
+            "SELECT payload_json FROM tasks WHERE task_id = ?1",
+            [&command.task_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<crate::types::TaskRecord>(&payload))
+        .transpose()?
+        .ok_or_else(|| anyhow!("TaskResult claim recovery task is missing"))?;
+    if task.agent_id != agent_id
+        || task.work_item_id.as_deref() != Some(command.work_item_id.as_str())
+        || task.parent_message_id.as_deref() != Some(command.result_message_id.as_str())
+        || !matches!(
+            task.status,
+            crate::types::TaskStatus::Completed
+                | crate::types::TaskStatus::Failed
+                | crate::types::TaskStatus::Cancelled
+                | crate::types::TaskStatus::Interrupted
+        )
+        || task.rejoin_fence().as_ref() != Ok(&command.rejoin)
+    {
+        bail!("TaskResult claim recovery durable task fence is stale");
+    }
+    let message = tx
+        .query_row(
+            "SELECT payload_json
+             FROM messages
+             WHERE agent_id = ?1 AND message_id = ?2",
+            [agent_id, command.result_message_id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| serde_json::from_str::<crate::types::MessageEnvelope>(&payload))
+        .transpose()?
+        .ok_or_else(|| anyhow!("TaskResult claim recovery message is missing"))?;
+    if message.kind != crate::types::MessageKind::TaskResult
+        || message.authority_class != crate::types::AuthorityClass::RuntimeInstruction
+        || message.admission_context != Some(crate::types::AdmissionContext::RuntimeOwned)
+        || message.delivery_surface != Some(crate::types::MessageDeliverySurface::TaskRejoin)
+        || message.task_id.as_deref() != Some(command.task_id.as_str())
+        || message.work_item_id.as_deref() != Some(command.work_item_id.as_str())
+        || !matches!(
+            &message.origin,
+            crate::types::MessageOrigin::Task { task_id } if task_id == &command.task_id
+        )
+    {
+        bail!("TaskResult claim recovery message provenance is invalid");
+    }
+    let matching_waits = {
+        let mut statement = tx.prepare(
+            "SELECT payload_json
+             FROM wait_conditions
+             WHERE agent_id = ?1
+               AND work_item_id = ?2
+               AND status = 'resolved'",
+        )?;
+        let count = statement
+            .query_map([agent_id, command.work_item_id.as_str()], |row| {
+                row.get::<_, String>(0)
+            })?
+            .map(|row| {
+                Ok(serde_json::from_str::<crate::types::WaitConditionRecord>(
+                    &row?,
+                )?)
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .filter(|wait| {
+                wait.id == command.wait_id
+                    && wait.kind == crate::types::WaitConditionKind::Task
+                    && wait.trigger_message_id() == Some(command.result_message_id.as_str())
+                    && wait.wake_sources.iter().any(|source| {
+                        matches!(
+                            source,
+                            crate::types::WakeSource::TaskResult { task_id }
+                                if task_id == &command.task_id
+                        )
+                    })
+            })
+            .count();
+        count
+    };
+    if matching_waits != 1 {
+        bail!("TaskResult claim recovery requires one exact resolved task wait");
+    }
+    Ok(())
 }
 
 fn validate_set_work_item_waiting(
@@ -860,6 +981,7 @@ impl RuntimeTransitionRepository<'_> {
             !matches!(
                 command,
                 ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(_)
+                    | ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(_)
             )
         }) {
             bail!("execution protocol recovery plan contains a non-recovery command");

--- a/src/types.rs
+++ b/src/types.rs
@@ -2807,6 +2807,39 @@ pub struct TaskRecord {
 }
 
 impl TaskRecord {
+    pub fn rejoin_fence(
+        &self,
+    ) -> std::result::Result<crate::domain::execution_protocol::RejoinFence, String> {
+        let detail = self
+            .detail
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| "task rejoin contract is missing task detail".to_string())?;
+        let obligation_id = detail
+            .get("rejoin_obligation_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "task rejoin contract is missing obligation identity".to_string())?;
+        if obligation_id != self.id {
+            return Err("task rejoin obligation identity does not match task identity".into());
+        }
+        let generation = detail
+            .get("rejoin_generation")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|generation| *generation > 0)
+            .ok_or_else(|| "task rejoin contract is missing generation".to_string())?;
+        let parent_turn_id = detail
+            .get("parent_turn_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "task rejoin contract is missing parent turn identity".to_string())?;
+        Ok(crate::domain::execution_protocol::RejoinFence {
+            obligation_id: obligation_id.to_string(),
+            generation,
+            parent_turn_id: parent_turn_id.to_string(),
+        })
+    }
+
     pub fn wait_policy(&self) -> TaskWaitPolicy {
         // Active tasks are never scheduler-blocking; terminal results drive re-entry.
         TaskWaitPolicy::Background


### PR DESCRIPTION
## Summary

Fixes #2558 by keeping terminal `TaskResult` WorkItem revision changes atomic with canonical execution authority, and by recovering already-persisted stale claims through typed bootstrap/scheduler recovery.

## Runtime change

- synchronizes the canonical WorkItem execution source revision when a terminal task transition clears an exact task wait and advances the durable WorkItem revision
- admits exact TaskResult rejoins against the current canonical/durable revision without weakening completion fences
- adds a typed recovery candidate for trusted terminal TaskResult claims with stale open attempts
- atomically interrupts stale attempts, restores queue ownership, and replays through normal admission
- exposes scheduler-recovery diagnose/apply support with revision fencing and idempotence
- centralizes durable requeue semantics used by bootstrap and explicit recovery

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- focused live/restart/fault-injection tests for terminal task wait release, exact rejoin, bootstrap replay, attempt interruption, completion settlement, and scheduler-recovery atomicity/fencing/idempotence

All checks pass locally. The full suite's pre-existing runtime DB lock concurrency failure was isolated and verified independently; the subsequent full suite passed after the test fixture lock cleanup was made deterministic in this branch.
