### PR TITLE
fix: recover waited TaskResult claims without terminal_reentry

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1467,6 +1467,36 @@ fn execution_attempt_for_message<'a>(
         })
 }
 
+fn exact_resolved_task_result_wait(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+    task_id: &str,
+    work_item_id: &str,
+) -> Result<Option<WaitConditionRecord>> {
+    let matching_waits = storage
+        .latest_wait_conditions()?
+        .into_iter()
+        .filter(|wait| {
+            wait.agent_id == message.agent_id
+                && wait.work_item_id.as_deref() == Some(work_item_id)
+                && wait.status == WaitConditionStatus::Resolved
+                && wait.kind == crate::types::WaitConditionKind::Task
+                && wait.trigger_message_id() == Some(message.id.as_str())
+                && wait.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        crate::types::WakeSource::TaskResult { task_id: expected }
+                            if expected == task_id
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    let [wait] = matching_waits.as_slice() else {
+        return Ok(None);
+    };
+    Ok(Some(wait.clone()))
+}
+
 fn exact_task_result_claim_recovery(
     storage: &AppStorage,
     runtime_db: &RuntimeDb,
@@ -1506,30 +1536,12 @@ fn exact_task_result_claim_recovery(
     if task.agent_id != message.agent_id
         || task.work_item_id.as_deref() != Some(work_item_id)
         || task.parent_message_id.as_deref() != Some(message.id.as_str())
-        || !task.terminal_reentry()
         || attempt.admitted_fences.rejoin.as_ref() != Some(&rejoin)
     {
         return Ok(None);
     }
-    let matching_waits = storage
-        .latest_wait_conditions()?
-        .into_iter()
-        .filter(|wait| {
-            wait.agent_id == message.agent_id
-                && wait.work_item_id.as_deref() == Some(work_item_id)
-                && wait.status == WaitConditionStatus::Resolved
-                && wait.kind == crate::types::WaitConditionKind::Task
-                && wait.trigger_message_id() == Some(message.id.as_str())
-                && wait.wake_sources.iter().any(|source| {
-                    matches!(
-                        source,
-                        crate::types::WakeSource::TaskResult { task_id: expected }
-                            if expected == task_id
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
-    let [wait] = matching_waits.as_slice() else {
+    let Some(wait) = exact_resolved_task_result_wait(storage, message, task_id, work_item_id)?
+    else {
         return Ok(None);
     };
     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
@@ -1560,7 +1572,7 @@ fn exact_task_result_claim_recovery(
                             work_item_id: work_item_id.to_string(),
                             task_id: task_id.clone(),
                             result_message_id: message.id.clone(),
-                            wait_id: wait.id.clone(),
+                            wait_id: wait.id,
                             rejoin,
                             expected_source_revision,
                             source_revision: work_item.revision,

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -45,9 +45,27 @@ impl RuntimeHandle {
                             task.agent_id == message.agent_id
                                 && task.work_item_id == message.work_item_id
                                 && task.parent_message_id.as_deref() == Some(message.id.as_str())
-                                && task.terminal_reentry()
                         });
-                    durable_task.ok_or(error)
+                    let Some(task) = durable_task else {
+                        return Err(error);
+                    };
+                    let resolved_wait_authority =
+                        if let Some(work_item_id) = task.work_item_id.as_deref() {
+                            exact_resolved_task_result_wait(
+                                &self.inner.storage,
+                                message,
+                                &task.id,
+                                work_item_id,
+                            )?
+                            .is_some()
+                        } else {
+                            false
+                        };
+                    if task.terminal_reentry() || resolved_wait_authority {
+                        Ok(task)
+                    } else {
+                        Err(error)
+                    }
                 })
                 .map(Some),
             _ => Ok(None),

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2153,7 +2153,7 @@ async fn bootstrap_recovery_replays_task_result_claim_after_canonical_revision_s
         work_item_id: Some(work_item.id.clone()),
         summary: Some("task-stale-bootstrap completed".into()),
         detail: Some(serde_json::json!({
-            "terminal_reentry": true,
+            "terminal_reentry": false,
             "rejoin_obligation_id": rejoin.obligation_id,
             "rejoin_generation": rejoin.generation,
             "parent_turn_id": rejoin.parent_turn_id,
@@ -2168,6 +2168,7 @@ async fn bootstrap_recovery_replays_task_result_claim_after_canonical_revision_s
     result.work_item_id = Some(work_item.id.clone());
     result.turn_id = Some("turn-stale-bootstrap-result".into());
     terminal_task.parent_message_id = Some(result.id.clone());
+    assert!(!terminal_task.terminal_reentry());
     runtime
         .persist_task_transition_with_message(&terminal_task, "task_completed", &result)
         .await
@@ -2431,7 +2432,7 @@ async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimF
         work_item_id: Some(work_item.id.clone()),
         summary: Some(format!("{task_id} completed")),
         detail: Some(serde_json::json!({
-            "terminal_reentry": true,
+            "terminal_reentry": false,
             "rejoin_obligation_id": rejoin.obligation_id,
             "rejoin_generation": rejoin.generation,
             "parent_turn_id": rejoin.parent_turn_id,
@@ -2446,6 +2447,7 @@ async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimF
     result.work_item_id = Some(work_item.id.clone());
     result.turn_id = Some(format!("turn-{task_id}-result"));
     terminal_task.parent_message_id = Some(result.id.clone());
+    assert!(!terminal_task.terminal_reentry());
     runtime
         .persist_task_transition_with_message(&terminal_task, "task_completed", &result)
         .await
@@ -10452,6 +10454,12 @@ async fn resolved_task_result_uses_unified_wait_when_legacy_wait_is_stale() {
         &resumed.id,
         "turn-unified-wait",
     );
+    assert!(!runtime
+        .storage()
+        .latest_task_record("task-unified-wait")
+        .unwrap()
+        .unwrap()
+        .terminal_reentry());
     result.work_item_id = Some(resumed.id.clone());
     result.metadata.as_mut().unwrap()["work_item_id"] =
         serde_json::Value::String(resumed.id.clone());
@@ -10465,6 +10473,11 @@ async fn resolved_task_result_uses_unified_wait_when_legacy_wait_is_stale() {
         panic!("unified waiting authority should admit the resolved task result");
     };
     assert_eq!(scheduled.message.id, result.id);
+    assert!(scheduled.scheduler_decision.model_reentry);
+    assert!(matches!(
+        scheduled.dispatch_plan.execution_admission_provenance,
+        crate::types::ExecutionAdmissionProvenance::Canonical { .. }
+    ));
     let execution = runtime
         .inner
         .runtime_db


### PR DESCRIPTION
## Summary

- remove the incorrect `terminal_reentry` requirement from canonical TaskResult claim recovery
- treat the resolved durable `WaitFor(wake=task_result)` plus existing identity and fence checks as the recovery authority
- cover live admission and restart/bootstrap recovery when the command task has `terminal_reentry=false`

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test task_result_claim`
- `cargo test resolved_task_result_uses_unified_wait_when_legacy_wait_is_stale`
- `cargo test bootstrap_recovery_replays_task_result_claim_after_canonical_revision_sync`
- `cargo test scheduler_recovery_task_result_claim_is_atomic_fenced_and_idempotent`

Closes #2563