### PR TITLE
fix: unify terminal TaskResult, wait trigger, and restart rejoin protocol

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -846,10 +846,11 @@ callback capability does not make one semantic wait reusable.
 
 External and operator events trigger waits but do not resolve them. The
 consuming activation must resolve, cancel, or rearm. A matching runtime-owned
-terminal task result may persist the task/message evidence and exact resolved
-wait binding in one transaction, then atomically consume that same wait
-generation during canonical activation claim while retaining all logical audit
-facts.
+terminal task result persists the terminal task, message evidence, queued
+message row, and exact `Triggered(message_id)` wait binding in one transaction.
+Canonical activation claim then atomically changes that same wait generation to
+`Resolved(message_id)` while creating the execution attempt and retaining all
+logical audit facts.
 
 `recheck_after_ms` is a fallback wake source for the same wait generation, not
 a separate generic blocker timer.
@@ -1566,12 +1567,14 @@ commands and never edits scheduler tables directly.
 #### Restart Task Rejoin
 
 Daemon restart marks each non-reattached in-flight task `interrupted` exactly
-once and enqueues one standard runtime-owned `TaskResult` per task. The
-message preserves the original task id and effective WorkItem binding and
-uses the ordinary `TaskRejoin` delivery surface. Tasks from different
-WorkItems never share an aggregate model turn. The former unbound
-`task_restart` content message is not an execution or scheduling mechanism;
-restart aggregation may remain only as audit evidence.
+once through the ordinary typed terminal-result transaction. That transaction
+atomically persists one standard runtime-owned `TaskResult`, its queued row,
+and any exact `Triggered(message_id)` wait. The message preserves the original
+task id and effective WorkItem binding and uses the ordinary `TaskRejoin`
+delivery surface. Tasks from different WorkItems never share an aggregate
+model turn. The former unbound `task_restart` content message is not an
+execution or scheduling mechanism; restart aggregation may remain only as
+audit evidence.
 
 #### Pre-claim Authority Failure
 

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -703,7 +703,10 @@ same final projection.
 
 Coverage:
 
-- terminal task persisted before task result enqueue;
+- terminal task, TaskResult admission, queued row, and exact wait trigger
+  commit atomically or all roll back;
+- restart replay of an already committed terminal-result transition does not
+  duplicate the message, queue row, or wait trigger;
 - Dequeued message replay after restart;
 - pending wake hint recovery;
 - current work item with queued follow-up;

--- a/docs/rfcs/runtime-transition-commit-contract.md
+++ b/docs/rfcs/runtime-transition-commit-contract.md
@@ -219,15 +219,18 @@ audit is absent because of a later transaction failure.
 | --- | --- | --- | --- |
 | create/running/cancelling | monotonic task phase/revision | Task, lifecycle audit, index outbox | cache Task, publish audit, notify indexer and scheduler |
 | terminal without wait | non-terminal task or equivalent replay | terminal Task, lifecycle audit, index outbox | cache Task, publish audit, notify indexer and scheduler |
-| terminal with wait | non-terminal task, active matching wait, expected WorkItem blocker | terminal Task, resolved waits, optional WorkItem blocker revision, lifecycle audits, Task and WorkItem index outbox | cache Task and WorkItem, publish audits, notify indexer and scheduler |
+| terminal result | non-terminal task or equivalent replay, result message, optional active exact task wait | terminal Task, result message, queued message row, optional `Triggered(message_id)` wait, lifecycle/message/wait audits, Task index outbox, AgentState pending projection | cache Task, append the result to the in-memory queue, publish audits, notify indexer and scheduler |
 
-Terminal task persistence and wait release are one transition. A restart cannot
-observe a terminal task with an otherwise matching active task wait solely
-because the runtime crashed between repository calls.
+Terminal task persistence, result admission, and exact wait trigger are one
+transition. A terminal task fact without result-message evidence does not
+trigger or resolve a task wait. The canonical activation claim later changes
+the exact `Triggered(message_id)` wait to `Resolved(message_id)` and clears any
+matching WorkItem blocker while creating the execution attempt.
 
-An equivalent terminal replay may commit only residual wait and WorkItem
-repairs. It reuses stable lifecycle audit identity and does not rewrite the
-terminal Task or enqueue another Task index change.
+Normal completion, failure, cancellation, daemon-restart interruption, and
+agent-stop interruption use the same typed terminal-result transition. An
+equivalent replay reuses stable message and lifecycle identities and does not
+duplicate queue rows, wait triggers, or Task index changes.
 
 ## Commit And Effect Ordering
 

--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -679,9 +679,11 @@ resource
 
 External ingress, timer, operator input, and system tick should enqueue
 continuation that asks the agent to reconcile the wait, rather than implicitly
-resolving the wait. Terminal task results are the exception: a matching
-`task_result` wait is resolved because the awaited runtime-owned task has
-reached a terminal state.
+resolving the wait. A terminal task result atomically admits its structured
+message and changes the exact matching `task_result` wait from `Active` to
+`Triggered(message_id)`. The canonical activation claim changes that wait to
+`Resolved(message_id)`; terminal task state alone is not sufficient evidence
+that a continuation consumed the result.
 
 ### 5. Add external wait audit
 

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -695,6 +695,56 @@ class CaseHarness:
         self.stop()
         self.start(wait_idle=wait_idle)
 
+    def crash_restart(self, *, wait_idle: bool = True) -> None:
+        # Kill the container directly with SIGKILL.  This avoids the
+        # SIGSTOP/SIGKILL race where the daemon could detect child-process
+        # death and record a terminal TaskResult before being stopped.
+        crash = self.docker(
+            "kill",
+            "--signal",
+            "KILL",
+            self.container,
+            check=False,
+            timeout=DOCKER_CONTROL_TIMEOUT_SECONDS,
+        )
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            state = self.docker(
+                "inspect",
+                "--format",
+                "{{.State.Running}}",
+                self.container,
+                check=False,
+            )
+            if state.returncode != 0 or state.stdout.strip() == "false":
+                break
+            time.sleep(0.25)
+        require(
+            state.returncode != 0 or state.stdout.strip() == "false",
+            "Holon container did not stop after Docker SIGKILL: "
+            + (crash.stderr or crash.stdout).strip(),
+        )
+        self.capture_logs()
+        self.docker("rm", "-f", self.container, check=False)
+        # Clean up stale daemon state files (socket, pid, metadata) left
+        # behind by SIGKILL.  Without this, the replacement container's
+        # PID 1 matches the dead daemon's recorded PID, causing probe_runtime
+        # to falsely report "runtime is already running".
+        self.docker(
+            "run",
+            "--rm",
+            "--volume",
+            f"{self.volume}:/var/lib/holon",
+            "--entrypoint",
+            "bash",
+            self.image,
+            "-c",
+            "rm -rf /var/lib/holon/run",
+            check=False,
+        )
+        self.base_url = ""
+        self.start(wait_idle=wait_idle)
+
     def restart_with_image(self, image: str, *, wait_idle: bool = True) -> None:
         self.stop()
         self.image = image
@@ -2649,6 +2699,7 @@ def run_scheduler_task_wait_resume_case(
         expected_scheduling_state="waiting_task",
         label="scheduler-task-wait-task",
     )
+    harness.crash_restart(wait_idle=False)
     external_waiting = harness.wait_work_item_scheduling_state(
         objective_marker=objective_marker,
         expected_scheduling_state="waiting_external",
@@ -2781,13 +2832,33 @@ def run_scheduler_task_wait_resume_case(
         work_item_id=work_item_id,
         wait_ids={wait["wait_condition_id"] for wait in waits},
     )
-    harness.restart()
-    restarted_items = harness.work_items("scheduler-task-wait-after-restart")
-    restarted = next(item for item in restarted_items if item["id"] == work_item_id)
+    restart_messages = [
+        row
+        for row in snapshot["messages"]
+        if row["kind"] == "task_result"
+        and row["message_id"].startswith("message:task-restart:")
+    ]
     require(
-        restarted["state"] == "completed"
-        and restarted.get("result_brief_id") == result_brief_id,
-        f"task/wait WorkItem did not survive restart: {restarted}",
+        len(restart_messages) == 1,
+        f"canonical rejoin did not use the deterministic restart TaskResult: {restart_messages}",
+    )
+    restart_message_id = restart_messages[0]["message_id"]
+    task_result_turns = [
+        row for row in turns if row["trigger_message_id"] == restart_message_id
+    ]
+    require(
+        len(task_result_turns) == 1,
+        f"restart task result did not create exactly one model rejoin: {task_result_turns}",
+    )
+    restart_task_waits = [
+        wait
+        for wait in task_waits
+        if wait.get("trigger_message_id") == restart_message_id
+    ]
+    require(
+        len(restart_task_waits) == 1,
+        "restart TaskResult did not resolve the exact task wait with message provenance: "
+        f"{task_waits}",
     )
 
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -6116,7 +6116,18 @@ mod tests {
                 .and_then(|detail| detail["interrupted_reason"].as_str()),
             Some("agent_stopped")
         );
-        assert!(task.parent_message_id.is_none());
+        let result_message_id = task
+            .parent_message_id
+            .as_deref()
+            .expect("agent stop should atomically persist a TaskResult");
+        assert_eq!(
+            storage
+                .read_message_by_id(result_message_id)
+                .unwrap()
+                .expect("agent stop TaskResult")
+                .kind,
+            MessageKind::TaskResult
+        );
         assert!(storage
             .read_message_by_id("message:task-restart:task-stopped-owner")
             .unwrap()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1467,11 +1467,12 @@ fn execution_attempt_for_message<'a>(
         })
 }
 
-fn exact_resolved_task_result_wait(
+fn exact_task_result_wait_with_status(
     storage: &AppStorage,
     message: &MessageEnvelope,
     task_id: &str,
     work_item_id: &str,
+    status_matches: impl Fn(&WaitConditionStatus) -> bool,
 ) -> Result<Option<WaitConditionRecord>> {
     let matching_waits = storage
         .latest_wait_conditions()?
@@ -1479,7 +1480,7 @@ fn exact_resolved_task_result_wait(
         .filter(|wait| {
             wait.agent_id == message.agent_id
                 && wait.work_item_id.as_deref() == Some(work_item_id)
-                && wait.status == WaitConditionStatus::Resolved
+                && status_matches(&wait.status)
                 && wait.kind == crate::types::WaitConditionKind::Task
                 && wait.trigger_message_id() == Some(message.id.as_str())
                 && wait.wake_sources.iter().any(|source| {
@@ -1495,6 +1496,31 @@ fn exact_resolved_task_result_wait(
         return Ok(None);
     };
     Ok(Some(wait.clone()))
+}
+
+fn exact_triggered_or_resolved_task_result_wait(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+    task_id: &str,
+    work_item_id: &str,
+) -> Result<Option<WaitConditionRecord>> {
+    exact_task_result_wait_with_status(storage, message, task_id, work_item_id, |status| {
+        matches!(
+            status,
+            WaitConditionStatus::Triggered | WaitConditionStatus::Resolved
+        )
+    })
+}
+
+fn exact_resolved_task_result_wait(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+    task_id: &str,
+    work_item_id: &str,
+) -> Result<Option<WaitConditionRecord>> {
+    exact_task_result_wait_with_status(storage, message, task_id, work_item_id, |status| {
+        status == &WaitConditionStatus::Resolved
+    })
 }
 
 fn exact_task_result_claim_recovery(
@@ -6056,7 +6082,6 @@ impl RuntimeHandle {
     }
 
     async fn bootstrap_recovery(&self) -> Result<()> {
-        let mut interrupted_for_delivery = self.missing_interrupted_task_results().await?;
         if let Some(tasks) = self.inner.recovered_tasks.lock().await.take() {
             if self.agent_state().await?.status == AgentStatus::Stopped {
                 self.interrupt_active_tasks_for_lifecycle_stop(tasks)
@@ -6074,14 +6099,8 @@ impl RuntimeHandle {
                         }),
                     ))?;
                 }
-                interrupted_for_delivery.extend(interrupted);
+                drop(interrupted);
             }
-        }
-        interrupted_for_delivery.sort_by(|left, right| left.id.cmp(&right.id));
-        interrupted_for_delivery.dedup_by(|left, right| left.id == right.id);
-        if !interrupted_for_delivery.is_empty() {
-            self.emit_task_results_from_interrupted_tasks(&interrupted_for_delivery)
-                .await?;
         }
         if let Some(timers) = self.inner.recovered_timers.lock().await.take() {
             self.recover_active_timers(timers).await?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -343,6 +343,8 @@ struct RuntimeInner {
     #[cfg(test)]
     task_transition_conflicts_remaining: AtomicUsize,
     #[cfg(test)]
+    terminal_task_transition_conflicts_remaining: AtomicUsize,
+    #[cfg(test)]
     fail_after_next_runtime_claim: AtomicBool,
     #[cfg(test)]
     claim_work_item_plan_status_before_commit:

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -474,6 +474,8 @@ impl RuntimeHandle {
                 #[cfg(test)]
                 task_transition_conflicts_remaining: AtomicUsize::new(0),
                 #[cfg(test)]
+                terminal_task_transition_conflicts_remaining: AtomicUsize::new(0),
+                #[cfg(test)]
                 fail_after_next_runtime_claim: AtomicBool::new(false),
                 #[cfg(test)]
                 claim_work_item_plan_status_before_commit: StdMutex::new(None),

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -800,18 +800,6 @@ impl RuntimeHandle {
             Some(&result_message),
         )
         .await?;
-        let enqueue_result = self.enqueue(result_message).await;
-        if let Err(err) = enqueue_result {
-            self.inner
-                .storage
-                .append_event(&crate::types::AuditEvent::legacy(
-                    "command_task_result_enqueue_failed",
-                    serde_json::json!({
-                        "task_id": task_record.id,
-                        "error": err.to_string(),
-                    }),
-                ))?;
-        }
 
         self.inner.task_handles.lock().await.remove(&task_record.id);
         Ok(())
@@ -962,12 +950,20 @@ impl RuntimeHandle {
             detail: Some(self.task_detail_preserving_rejoin_contract(task_record, detail)),
             recovery: task_record.recovery.clone(),
         };
-        let mut transition =
-            task_state_reducer::TaskTransition::new(&fallback, "command_task_terminal_persisted");
         if let Some(message_evidence) = message_evidence {
-            transition = transition.with_message_evidence(message_evidence);
+            self.commit_terminal_task_result(
+                &fallback,
+                "command_task_terminal_persisted",
+                message_evidence,
+            )
+            .await?;
+        } else {
+            self.apply_task_transition_silent(task_state_reducer::TaskTransition::new(
+                &fallback,
+                "command_task_terminal_persisted",
+            ))
+            .await?;
         }
-        self.apply_task_transition_silent(transition).await?;
         Ok(())
     }
 
@@ -1795,9 +1791,11 @@ mod tests {
             .contains("failed to query command status"));
 
         let events = runtime.inner.storage.read_recent_events(20).unwrap();
-        assert!(!events
-            .iter()
-            .any(|event| event.kind == "command_task_terminal_persisted"));
+        assert!(events.iter().any(|event| {
+            event.kind == "command_task_terminal_persisted"
+                && event.data["task_id"].as_str() == Some(task.id.as_str())
+                && event.data["status"].as_str() == Some("failed")
+        }));
         assert!(!events
             .iter()
             .any(|event| event.kind == "command_task_running_persisted"));

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -932,68 +932,6 @@ impl RuntimeHandle {
         let _ = self.enqueue(message).await?;
         Ok(())
     }
-
-    pub(super) async fn emit_task_results_from_interrupted_tasks(
-        &self,
-        tasks: &[TaskRecord],
-    ) -> Result<()> {
-        let agent_id = self.agent_id().await?;
-        let mut message_ids = Vec::with_capacity(tasks.len());
-        for task in tasks {
-            let status_before_restart = task
-                .detail
-                .as_ref()
-                .and_then(|detail| detail.get("status_before_restart"))
-                .and_then(|value| value.as_str())
-                .unwrap_or("running");
-            let message = MessageEnvelope {
-                id: super::tasks::restart_task_result_message_id(&task.id),
-                turn_id: Some(crate::ids::turn_id()),
-                work_item_id: task.effective_work_item_id().map(ToString::to_string),
-                metadata: Some(serde_json::json!({
-                    "task_id": task.id,
-                    "task_kind": task.kind,
-                    "task_status": "interrupted",
-                    "task_summary": task.summary,
-                    "task_detail": task.detail,
-                    "task_recovery": task.recovery,
-                    "work_item_id": task.effective_work_item_id(),
-                    "status_before_restart": status_before_restart,
-                    "interrupted_reason": "runtime_restarted"
-                })),
-                ..MessageEnvelope::new(
-                    agent_id.clone(),
-                    MessageKind::TaskResult,
-                    MessageOrigin::Task {
-                        task_id: task.id.clone(),
-                    },
-                    AuthorityClass::RuntimeInstruction,
-                    Priority::Next,
-                    MessageBody::Text {
-                        text: format!(
-                            "task {} was interrupted because the runtime restarted",
-                            task.id
-                        ),
-                    },
-                )
-                .with_admission(
-                    MessageDeliverySurface::TaskRejoin,
-                    AdmissionContext::RuntimeOwned,
-                )
-            };
-            message_ids.push(message.id.clone());
-            let _ = self.enqueue(message).await?;
-        }
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "task_restart_results_emitted",
-            serde_json::json!({
-                "agent_id": agent_id,
-                "task_ids": tasks.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
-                "message_ids": message_ids,
-            }),
-        ))?;
-        Ok(())
-    }
 }
 
 fn latest_nonempty_result_brief_for_work_item<'a>(

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -49,19 +49,18 @@ impl RuntimeHandle {
                     let Some(task) = durable_task else {
                         return Err(error);
                     };
-                    let resolved_wait_authority =
-                        if let Some(work_item_id) = task.work_item_id.as_deref() {
-                            exact_resolved_task_result_wait(
-                                &self.inner.storage,
-                                message,
-                                &task.id,
-                                work_item_id,
-                            )?
-                            .is_some()
-                        } else {
-                            false
-                        };
-                    if task.terminal_reentry() || resolved_wait_authority {
+                    let wait_authority = if let Some(work_item_id) = task.work_item_id.as_deref() {
+                        exact_triggered_or_resolved_task_result_wait(
+                            &self.inner.storage,
+                            message,
+                            &task.id,
+                            work_item_id,
+                        )?
+                        .is_some()
+                    } else {
+                        false
+                    };
+                    if task.terminal_reentry() || wait_authority {
                         Ok(task)
                     } else {
                         Err(error)

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -114,6 +114,8 @@ impl RuntimeHandle {
                         && attempt + 1 < TASK_TRANSITION_MAX_ATTEMPTS =>
                 {
                     if transition.admit_result_message {
+                        // The attempt future has returned, so its local agent
+                        // guard is dropped before this refresh re-locks it.
                         let agent_id = transition.task.agent_id.as_str();
                         if !self.refresh_enqueue_agent_state_baseline(agent_id).await? {
                             return Err(error);
@@ -235,6 +237,8 @@ impl RuntimeHandle {
         }
         #[cfg(test)]
         self.inject_task_transition_conflict_if_armed().await?;
+        #[cfg(test)]
+        self.inject_terminal_task_transition_conflict_if_armed()?;
         let existing_queue_entry = transition
             .message_evidence
             .filter(|_| transition.admit_result_message)
@@ -400,6 +404,48 @@ impl RuntimeHandle {
     pub(crate) fn inject_task_transition_conflicts(&self, count: usize) {
         self.inner
             .task_transition_conflicts_remaining
+            .store(count, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn inject_terminal_task_transition_conflict_if_armed(&self) -> Result<()> {
+        let remaining = match self
+            .inner
+            .terminal_task_transition_conflicts_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            }) {
+            Ok(remaining) => remaining,
+            Err(_) => return Ok(()),
+        };
+        let mut state = self
+            .inner
+            .runtime_db
+            .agent_states()
+            .latest(&self.inner.default_agent_id)?
+            .expect("test runtime agent state");
+        state.pending_wake_hint = Some(crate::types::PendingWakeHint {
+            reason: "test_terminal_conflict".into(),
+            description: Some(format!(
+                "concurrent terminal task transition test attempt {remaining}"
+            )),
+            source: Some("test".into()),
+            scope: None,
+            external_trigger_id: None,
+            resource: None,
+            body: None,
+            content_type: None,
+            correlation_id: None,
+            causation_id: None,
+            created_at: Utc::now(),
+        });
+        self.inner.storage.write_agent(&state)
+    }
+
+    #[cfg(test)]
+    fn inject_terminal_task_transition_conflicts(&self, count: usize) {
+        self.inner
+            .terminal_task_transition_conflicts_remaining
             .store(count, Ordering::SeqCst);
     }
 
@@ -900,6 +946,44 @@ mod tests {
                 .as_ref()
                 .and_then(|hint| hint.description.as_deref()),
             Some("concurrent task transition test attempt 1")
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_task_result_retry_releases_agent_lock_before_refresh() {
+        let runtime = runtime();
+        runtime.inject_terminal_task_transition_conflicts(1);
+        let message = task_result_message("task-1");
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            runtime.commit_terminal_task_result(
+                &task("task-1", TaskStatus::Completed, true),
+                "task_completed",
+                &message,
+            ),
+        )
+        .await
+        .expect("terminal task transition retry should not deadlock")
+        .unwrap();
+
+        assert_eq!(
+            runtime
+                .agent_state()
+                .await
+                .unwrap()
+                .pending_wake_hint
+                .as_ref()
+                .map(|hint| hint.reason.as_str()),
+            Some("test_terminal_conflict")
+        );
+        assert_eq!(
+            runtime
+                .storage()
+                .read_message_by_id(&message.id)
+                .unwrap()
+                .map(|stored| stored.id),
+            Some(message.id)
         );
     }
 

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -1,8 +1,5 @@
 use super::{scheduler, *};
-use crate::types::{
-    BriefKind, ExecutionAdmissionProvenance, WaitConditionKind, WaitConditionStatus, WakeSource,
-    WorkItemRecord, WorkItemState,
-};
+use crate::types::{BriefKind, ExecutionAdmissionProvenance};
 use sha2::{Digest, Sha256};
 
 const TASK_TRANSITION_MAX_ATTEMPTS: usize = 3;
@@ -63,6 +60,7 @@ pub(super) struct TaskTransition<'a> {
     pub(super) task: &'a TaskRecord,
     pub(super) event_kind: &'static str,
     pub(super) message_evidence: Option<&'a MessageEnvelope>,
+    pub(super) admit_result_message: bool,
 }
 
 impl<'a> TaskTransition<'a> {
@@ -71,11 +69,19 @@ impl<'a> TaskTransition<'a> {
             task,
             event_kind,
             message_evidence: None,
+            admit_result_message: false,
         }
     }
 
+    #[cfg(test)]
     pub(super) fn with_message_evidence(mut self, message: &'a MessageEnvelope) -> Self {
         self.message_evidence = Some(message);
+        self
+    }
+
+    pub(super) fn with_terminal_result(mut self, message: &'a MessageEnvelope) -> Self {
+        self.message_evidence = Some(message);
+        self.admit_result_message = true;
         self
     }
 }
@@ -107,6 +113,12 @@ impl RuntimeHandle {
                     if task_transition_error_is_retryable_conflict(&error)
                         && attempt + 1 < TASK_TRANSITION_MAX_ATTEMPTS =>
                 {
+                    if transition.admit_result_message {
+                        let agent_id = transition.task.agent_id.as_str();
+                        if !self.refresh_enqueue_agent_state_baseline(agent_id).await? {
+                            return Err(error);
+                        }
+                    }
                     continue;
                 }
                 Err(error) if task_transition_error_is_retryable_conflict(&error) => {
@@ -153,13 +165,24 @@ impl RuntimeHandle {
         };
 
         let agent_id = self.agent_id().await?;
-        let mut state = self.agent_state().await?;
-        let expected_state = state.clone();
+        let mut agent_guard = if transition.admit_result_message {
+            Some(self.inner.agent.lock().await)
+        } else {
+            None
+        };
+        let (mut state, expected_state) = if let Some(guard) = agent_guard.as_ref() {
+            (guard.state.clone(), guard.last_persisted_state.clone())
+        } else {
+            let state = self.agent_state().await?;
+            let expected_state = state.clone();
+            (state, expected_state)
+        };
         if !matches!(state.status, AgentStatus::Stopped) && state.current_run_id.is_none() {
             scheduler::apply_idle_projection(&mut state, &self.inner.storage)?;
         }
+        let mut expected_wait_conditions = Vec::new();
         let mut wait_conditions = Vec::new();
-        let mut work_items = Vec::new();
+        let work_items = Vec::new();
         let mut audit_events = Vec::new();
         let mut index_changes = Vec::new();
         if task_will_change {
@@ -194,103 +217,113 @@ impl RuntimeHandle {
             }
         }
         if is_terminal_task_status(&task.status) {
-            let matching = self
-                .inner
-                .storage
-                .active_wait_conditions_for_agent(&agent_id)?
-                .into_iter()
-                .filter(|condition| {
-                    condition.wake_sources.iter().any(|source| {
-                        matches!(source, WakeSource::TaskResult { task_id } if task_id == &task.id)
-                    })
-                })
-                .collect::<Vec<_>>();
-            let now = Utc::now();
-            let trigger_message_id = transition
-                .message_evidence
-                .map(|message| message.id.as_str());
-            let mut resolved_ids = Vec::with_capacity(matching.len());
-            let mut updated_work_item_ids = std::collections::BTreeSet::new();
-            for condition in matching {
-                let mut resolved = condition.clone();
-                resolved.status = WaitConditionStatus::Resolved;
-                resolved.updated_at = now;
-                resolved.resolved_at = Some(now);
-                if resolved.kind == WaitConditionKind::Task {
-                    resolved.trigger_message_id = trigger_message_id.map(ToString::to_string);
+            if let Some(message) = transition.message_evidence {
+                if let Some(wait_trigger) = self.wait_trigger_transition_for_message(message)? {
+                    expected_wait_conditions.push(wait_trigger.expected);
+                    wait_conditions.push(wait_trigger.record.clone());
+                    audit_events.push(AuditEvent::legacy(
+                        "wait_condition_triggered",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "wait_condition_id": wait_trigger.record.id,
+                            "trigger_message_id": message.id,
+                            "work_item_id": wait_trigger.record.work_item_id,
+                        }),
+                    ));
                 }
-                wait_conditions.push(resolved.clone());
-                resolved_ids.push(condition.id);
-                if resolved.kind == WaitConditionKind::Task {
-                    if let Some(work_item_id) = resolved.work_item_id.as_deref() {
-                        if updated_work_item_ids.insert(work_item_id.to_string()) {
-                            if let Some(existing) =
-                                self.inner.runtime_db.work_items().latest(work_item_id)?
-                            {
-                                if existing.state == WorkItemState::Open
-                                    && existing.blocked_by.as_deref()
-                                        == Some(resolved.waiting_for.as_str())
-                                {
-                                    let mut record = WorkItemRecord {
-                                        revision: existing.revision + 1,
-                                        blocked_by: None,
-                                        recheck_at: None,
-                                        recheck_consumed_at: None,
-                                        updated_at: now,
-                                        ..existing.clone()
-                                    };
-                                    let plan_artifact_changed =
-                                        crate::work_item_plan::refresh_plan_artifact_metadata(
-                                            self.agent_home().as_path(),
-                                            &mut record,
-                                        )?;
-                                    if plan_artifact_changed {
-                                        if let Some(event) =
-                                            self.work_item_plan_artifact_refreshed_event(&record)
-                                        {
-                                            audit_events.push(event);
-                                        }
-                                    }
-                                    audit_events.push(self.work_item_written_event(
-                                        "wait_for_task_resolved",
-                                        &record,
-                                        serde_json::json!({
-                                            "wait_condition_id": resolved.id,
-                                        }),
-                                    ));
-                                    index_changes.extend(
-                                        self.inner.storage.index_changes_for_work_item(&record)?,
-                                    );
-                                    work_items.push(
-                                        crate::runtime_db::transitions::WorkItemMutation::Update {
-                                            record,
-                                            expected_revision: existing.revision,
-                                        },
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if !resolved_ids.is_empty() {
-                audit_events.push(AuditEvent::legacy(
-                    "wait_conditions_resolved",
-                    serde_json::json!({
-                        "agent_id": agent_id,
-                        "task_id": task.id,
-                        "reason": "task_result",
-                        "wait_condition_ids": resolved_ids,
-                    }),
-                ));
             }
         }
         #[cfg(test)]
         self.inject_task_transition_conflict_if_armed().await?;
+        let existing_queue_entry = transition
+            .message_evidence
+            .filter(|_| transition.admit_result_message)
+            .map(|message| self.inner.runtime_db.queue_entries().latest(&message.id))
+            .transpose()?
+            .flatten();
+        let result_message_is_new = transition
+            .message_evidence
+            .filter(|_| transition.admit_result_message)
+            .map(|message| self.inner.storage.read_message_by_id(&message.id))
+            .transpose()?
+            .flatten()
+            .is_none();
+        let queue_entry = transition
+            .message_evidence
+            .filter(|_| transition.admit_result_message)
+            .filter(|_| {
+                existing_queue_entry.as_ref().is_none_or(|entry| {
+                    matches!(
+                        entry.status,
+                        QueueEntryStatus::Queued | QueueEntryStatus::Interrupted
+                    )
+                })
+            })
+            .map(|message| QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority.clone(),
+                status: QueueEntryStatus::Queued,
+                created_at: existing_queue_entry
+                    .as_ref()
+                    .map_or(message.created_at, |entry| entry.created_at),
+                updated_at: Utc::now(),
+            });
+        if let Some(message) = transition
+            .message_evidence
+            .filter(|_| queue_entry.is_some() && result_message_is_new)
+        {
+            audit_events.extend([
+                AuditEvent::legacy(
+                    "message_admitted",
+                    serde_json::json!({
+                        "message_id": message.id,
+                        "agent_id": message.agent_id,
+                        "kind": message.kind,
+                        "origin": message.origin,
+                        "authority_class": message.authority_class,
+                        "delivery_surface": message.delivery_surface,
+                        "admission_context": message.admission_context,
+                        "trigger_kind": message.trigger_kind,
+                        "work_item_id": message.work_item_id,
+                        "task_id": message.task_id,
+                        "source_refs": message.source_refs,
+                        "correlation_id": message.correlation_id,
+                        "causation_id": message.causation_id,
+                    }),
+                ),
+                AuditEvent::typed(
+                    RuntimeEventKind::MessageEnqueued,
+                    &MessageLifecycleAuditEvent::from_message(message),
+                )?,
+            ]);
+        }
+        let queue_needs_push = queue_entry.as_ref().is_some_and(|entry| {
+            agent_guard.as_ref().is_some_and(|guard| {
+                guard
+                    .queue
+                    .peek_next_matching(|message| message.id == entry.message_id)
+                    .is_none()
+            })
+        });
+        if queue_needs_push {
+            state.pending = agent_guard
+                .as_ref()
+                .map_or(state.pending.saturating_add(1), |guard| {
+                    guard.queue.len().saturating_add(1)
+                });
+            state.last_wake_reason = Some("TaskResult".into());
+            state.total_message_count = self
+                .inner
+                .storage
+                .count_messages()?
+                .saturating_add(usize::from(result_message_is_new));
+            scheduler::apply_message_wake_projection(&mut state);
+        }
         let agent_state =
             (state != expected_state).then(|| crate::runtime_db::transitions::AgentStateMutation {
                 expected: Some(Box::new(expected_state)),
-                record: Box::new(state),
+                record: Box::new(state.clone()),
             });
         let message_evidence = transition
             .message_evidence
@@ -305,18 +338,31 @@ impl RuntimeHandle {
             self.commit_task_transition(&crate::runtime_db::transitions::TaskTransitionCommand {
                 agent_id,
                 task: persisted_task,
+                queue_entry,
                 work_items,
+                expected_wait_conditions,
                 wait_conditions,
                 agent_state,
                 message_evidence,
                 audit_events,
                 index_changes,
-                notify_scheduler: false,
+                notify_scheduler: queue_needs_push,
                 commit_on_idempotent: emit_event
                     && !task_will_change
                     && is_terminal_task_status(&task.status),
                 fault: self.take_transition_fault(),
             })?;
+        let mut commit = commit;
+        if let (Some(guard), Some(message)) = (
+            agent_guard.as_mut(),
+            transition.message_evidence.filter(|_| queue_needs_push),
+        ) {
+            guard.queue.push(message.clone());
+            guard.state = state.clone();
+            guard.last_persisted_state = state;
+            commit.effects.agent_state = None;
+        }
+        drop(agent_guard);
         self.apply_transition_commit(commit).await;
         Ok(())
     }
@@ -366,6 +412,7 @@ impl RuntimeHandle {
             .await
     }
 
+    #[cfg(test)]
     pub(super) async fn persist_task_transition_with_message(
         &self,
         task: &TaskRecord,
@@ -374,6 +421,20 @@ impl RuntimeHandle {
     ) -> Result<()> {
         self.apply_task_transition(
             TaskTransition::new(task, event_kind).with_message_evidence(message),
+        )
+        .await
+    }
+
+    pub(super) async fn commit_terminal_task_result(
+        &self,
+        task: &TaskRecord,
+        event_kind: &'static str,
+        message: &MessageEnvelope,
+    ) -> Result<()> {
+        let mut message = message.clone();
+        message.normalize_admission_fields();
+        self.apply_task_transition(
+            TaskTransition::new(task, event_kind).with_terminal_result(&message),
         )
         .await
     }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -216,6 +216,68 @@ pub(super) fn restart_task_result_message_id(task_id: &str) -> String {
     format!("message:task-restart:{task_id}")
 }
 
+fn interrupted_task_result_message(
+    task: &TaskRecord,
+    interrupted_reason: &'static str,
+) -> MessageEnvelope {
+    let status_before = task
+        .detail
+        .as_ref()
+        .and_then(|detail| {
+            detail
+                .get("status_before_restart")
+                .or_else(|| detail.get("status_before_stop"))
+        })
+        .and_then(|value| value.as_str())
+        .unwrap_or("running");
+    let mut message = MessageEnvelope {
+        id: if interrupted_reason == "runtime_restarted" {
+            restart_task_result_message_id(&task.id)
+        } else {
+            crate::ids::message_id()
+        },
+        turn_id: Some(crate::ids::turn_id()),
+        work_item_id: task.effective_work_item_id().map(ToString::to_string),
+        metadata: Some(serde_json::json!({
+            "task_id": task.id,
+            "task_kind": task.kind,
+            "task_status": "interrupted",
+            "task_summary": task.summary,
+            "task_detail": task.detail,
+            "task_recovery": task.recovery,
+            "work_item_id": task.effective_work_item_id(),
+            "status_before_restart": status_before,
+            "interrupted_reason": interrupted_reason,
+        })),
+        ..MessageEnvelope::new(
+            task.agent_id.clone(),
+            MessageKind::TaskResult,
+            MessageOrigin::Task {
+                task_id: task.id.clone(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Next,
+            MessageBody::Text {
+                text: format!(
+                    "task {} was interrupted because the {}",
+                    task.id,
+                    if interrupted_reason == "runtime_restarted" {
+                        "runtime restarted"
+                    } else {
+                        "agent stopped"
+                    }
+                ),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::TaskRejoin,
+            AdmissionContext::RuntimeOwned,
+        )
+    };
+    message.task_id = Some(task.id.clone());
+    message
+}
+
 impl RuntimeHandle {
     pub(super) async fn task_creation_detail(
         &self,
@@ -428,11 +490,7 @@ impl RuntimeHandle {
             let terminal_task =
                 task_with_result_message(&task_record, status, Some(task_detail), &result_message);
             if let Err(error) = runtime
-                .persist_task_transition_with_message(
-                    &terminal_task,
-                    "task_status_updated",
-                    &result_message,
-                )
+                .commit_terminal_task_result(&terminal_task, "task_status_updated", &result_message)
                 .await
             {
                 tracing::warn!(
@@ -441,7 +499,7 @@ impl RuntimeHandle {
                     "failed to persist terminal task status before task result"
                 );
             }
-            let _ = runtime.enqueue(result_message).await;
+
             runtime
                 .inner
                 .task_handles
@@ -941,11 +999,7 @@ impl RuntimeHandle {
             let terminal_task =
                 task_with_result_message(&task_record, status, Some(task_detail), &result_message);
             if let Err(error) = runtime
-                .persist_task_transition_with_message(
-                    &terminal_task,
-                    "task_status_updated",
-                    &result_message,
-                )
+                .commit_terminal_task_result(&terminal_task, "task_status_updated", &result_message)
                 .await
             {
                 tracing::warn!(
@@ -954,7 +1008,7 @@ impl RuntimeHandle {
                     "failed to persist terminal task status before task result"
                 );
             }
-            let _ = runtime.enqueue(result_message).await;
+
             runtime
                 .inner
                 .task_handles
@@ -1085,7 +1139,7 @@ impl RuntimeHandle {
                         &result_message,
                     );
                     if let Err(error) = runtime
-                        .persist_task_transition_with_message(
+                        .commit_terminal_task_result(
                             &failed_task,
                             "task_status_updated",
                             &result_message,
@@ -1098,7 +1152,7 @@ impl RuntimeHandle {
                             "failed to persist terminal task status before task result"
                         );
                     }
-                    let _ = runtime.enqueue(result_message).await;
+
                     runtime
                         .inner
                         .task_handles
@@ -1402,11 +1456,7 @@ impl RuntimeHandle {
         let terminal_task =
             task_with_result_message(&task_record, status, Some(task_detail), &result_message);
         if let Err(error) = self
-            .persist_task_transition_with_message(
-                &terminal_task,
-                "task_status_updated",
-                &result_message,
-            )
+            .commit_terminal_task_result(&terminal_task, "task_status_updated", &result_message)
             .await
         {
             tracing::warn!(
@@ -1415,7 +1465,7 @@ impl RuntimeHandle {
                 "failed to persist terminal task status before task result"
             );
         }
-        let _ = self.enqueue(result_message).await;
+
         Ok(())
     }
 
@@ -1569,43 +1619,29 @@ impl RuntimeHandle {
                 status: TaskStatus::Interrupted,
                 created_at: task.created_at,
                 updated_at: Utc::now(),
-                parent_message_id: Some(restart_task_result_message_id(&task.id)),
+                parent_message_id: None,
                 work_item_id: task.work_item_id.clone(),
                 summary: task.summary.clone(),
                 detail: Some(detail),
                 recovery: task.recovery.clone(),
             };
-            self.persist_task_status_direct(&interrupted_task, "task_interrupted_on_restart")
-                .await?;
+            let result_message =
+                interrupted_task_result_message(&interrupted_task, "runtime_restarted");
+            let interrupted_task = task_with_result_message(
+                &interrupted_task,
+                TaskStatus::Interrupted,
+                interrupted_task.detail.clone(),
+                &result_message,
+            );
+            self.commit_terminal_task_result(
+                &interrupted_task,
+                "task_interrupted_on_restart",
+                &result_message,
+            )
+            .await?;
             interrupted.push(interrupted_task);
         }
         Ok(interrupted)
-    }
-
-    pub(super) async fn missing_interrupted_task_results(&self) -> Result<Vec<TaskRecord>> {
-        let agent_id = self.agent_id().await?;
-        let mut missing = Vec::new();
-        for task in self
-            .inner
-            .runtime_db
-            .tasks()
-            .latest_for_agent(&agent_id, usize::MAX)?
-        {
-            if task.status != TaskStatus::Interrupted {
-                continue;
-            }
-            let Some(message_id) = task
-                .parent_message_id
-                .as_deref()
-                .filter(|message_id| message_id.starts_with("message:task-restart:"))
-            else {
-                continue;
-            };
-            if self.inner.storage.read_message_by_id(message_id)?.is_none() {
-                missing.push(task);
-            }
-        }
-        Ok(missing)
     }
 
     pub(super) async fn interrupt_active_tasks_for_lifecycle_stop(
@@ -1666,8 +1702,20 @@ impl RuntimeHandle {
                 detail: Some(detail),
                 recovery: task.recovery.clone(),
             };
-            self.persist_task_status_direct(&interrupted_task, "task_interrupted_on_agent_stop")
-                .await?;
+            let result_message =
+                interrupted_task_result_message(&interrupted_task, "agent_stopped");
+            let interrupted_task = task_with_result_message(
+                &interrupted_task,
+                TaskStatus::Interrupted,
+                interrupted_task.detail.clone(),
+                &result_message,
+            );
+            self.commit_terminal_task_result(
+                &interrupted_task,
+                "task_interrupted_on_agent_stop",
+                &result_message,
+            )
+            .await?;
             interrupted.push(interrupted_task);
         }
         Ok(interrupted)

--- a/src/runtime/tests/contracts/task.rs
+++ b/src/runtime/tests/contracts/task.rs
@@ -1,4 +1,6 @@
 use super::super::support::*;
+use crate::runtime::WaitForWakeKind;
+use crate::types::WaitConditionStatus;
 
 #[tokio::test]
 async fn task_runtime_path_rolls_back_each_pre_commit_fault() {
@@ -104,6 +106,93 @@ async fn task_post_commit_fault_recovers_active_projection_after_restart() {
             .unwrap()
             .iter()
             .any(|record| record.id == task.id));
+    }
+}
+
+#[tokio::test]
+async fn terminal_task_result_rolls_back_task_wait_message_and_queue_together() {
+    for fault in PRE_COMMIT_FAULTS {
+        let harness = LifecycleHarness::new();
+        let work_item = harness
+            .runtime()
+            .create_work_item(
+                "terminal task result fault contract".into(),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        let now = harness.now();
+        let running = TaskRecord {
+            id: "task-terminal-result-fault".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: Some(work_item.id.clone()),
+            summary: Some("terminal task result fault".into()),
+            detail: None,
+            recovery: None,
+        };
+        harness.runtime().storage().append_task(&running).unwrap();
+        let registration = harness
+            .runtime()
+            .register_wait_for(
+                "default",
+                Some(work_item.id),
+                WaitForWakeKind::TaskResult,
+                Some(running.id.clone()),
+                "waiting for terminal task result".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        let before = harness.snapshot();
+        harness.arm_fault(fault);
+
+        let error = harness
+            .runtime()
+            .interrupt_active_tasks(vec![running.clone()])
+            .await
+            .unwrap_err();
+
+        assert_injected_transition_fault(&error);
+        harness.assert_unchanged(&before);
+
+        let interrupted = harness
+            .runtime()
+            .interrupt_active_tasks(vec![running])
+            .await
+            .unwrap();
+        assert_eq!(interrupted.len(), 1);
+        let result_message_id =
+            super::super::super::tasks::restart_task_result_message_id(&interrupted[0].id);
+        let after = harness.snapshot();
+        assert_eq!(after.tasks.last().unwrap().status, TaskStatus::Interrupted);
+        assert_eq!(
+            after.tasks.last().unwrap().parent_message_id.as_deref(),
+            Some(result_message_id.as_str())
+        );
+        assert!(after
+            .messages
+            .iter()
+            .any(|message| message.id == result_message_id));
+        assert!(after.queue_entries.iter().any(|entry| {
+            entry.message_id == result_message_id && entry.status == QueueEntryStatus::Queued
+        }));
+        let triggered = after
+            .wait_conditions
+            .iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .unwrap();
+        assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+        assert_eq!(
+            triggered.trigger_message_id(),
+            Some(result_message_id.as_str())
+        );
     }
 }
 
@@ -289,7 +378,7 @@ async fn task_restart_interrupts_inflight_task_once() {
 }
 
 #[tokio::test]
-async fn task_restart_recovers_interrupted_task_with_missing_result_message() {
+async fn task_restart_does_not_repair_legacy_interrupted_task_with_missing_result_message() {
     let mut harness = LifecycleHarness::new();
     let now = harness.now();
     harness
@@ -318,33 +407,13 @@ async fn task_restart_recovers_interrupted_task_with_missing_result_message() {
     harness.restart();
     let runtime = harness.runtime().clone();
     let runtime_task = tokio::spawn(runtime.clone().run());
-    wait_for_audit_events(
-        &runtime,
-        100,
-        |events| {
-            events
-                .iter()
-                .any(|event| event.kind == "task_restart_results_emitted")
-        },
-        "missing interrupted task result recovery",
-    )
-    .await;
+    tokio::task::yield_now().await;
     runtime_task.abort();
 
-    let message = harness
-        .snapshot()
-        .messages
-        .into_iter()
-        .find(|message| {
-            message.id
-                == super::super::super::tasks::restart_task_result_message_id(
-                    "task-restart-missing-result",
-                )
-        })
-        .expect("restart should recover the missing interrupted task result");
-    assert_eq!(message.kind, MessageKind::TaskResult);
-    assert_eq!(
-        message.work_item_id.as_deref(),
-        Some("work-restart-missing-result")
-    );
+    assert!(harness.snapshot().messages.into_iter().all(|message| {
+        message.id
+            != super::super::super::tasks::restart_task_result_message_id(
+                "task-restart-missing-result",
+            )
+    }));
 }

--- a/src/runtime/tests/contracts/wait.rs
+++ b/src/runtime/tests/contracts/wait.rs
@@ -784,11 +784,8 @@ async fn terminal_task_replay_repairs_wait_once_across_restart() {
         .create_work_item("repair task wait".into(), None, None, Vec::new())
         .await
         .unwrap();
-    harness
-        .runtime()
-        .storage()
-        .append_task(&running_task("task-replay", &work.id, harness.now()))
-        .unwrap();
+    let running = running_task("task-replay", &work.id, harness.now());
+    harness.runtime().storage().append_task(&running).unwrap();
     let registration = harness
         .runtime()
         .register_wait_for(
@@ -801,19 +798,14 @@ async fn terminal_task_replay_repairs_wait_once_across_restart() {
         )
         .await
         .unwrap();
-    let terminal = TaskRecord {
-        id: "task-replay".into(),
-        agent_id: "default".into(),
-        kind: TaskKind::CommandTask,
-        status: TaskStatus::Completed,
-        created_at: harness.now(),
-        updated_at: harness.now(),
-        parent_message_id: Some("message-replay".into()),
-        work_item_id: Some(work.id.clone()),
-        summary: Some("task-replay".into()),
-        detail: None,
-        recovery: None,
-    };
+    persist_waiting_work_execution(&harness, &work.id, &registration.condition.id).await;
+    let mut message = task_result_message("task-replay").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.task_id = Some("task-replay".into());
+    message.work_item_id = Some(work.id.clone());
+    let terminal = terminal_task_with_result(&running, &message, harness.now());
     harness.runtime().storage().append_task(&terminal).unwrap();
     let before = harness
         .runtime()
@@ -823,21 +815,59 @@ async fn terminal_task_replay_repairs_wait_once_across_restart() {
         .high_watermark_for_agent("default")
         .unwrap();
 
-    let mut message = task_result_message("task-replay");
-    message.task_id = Some("task-replay".into());
-    message.work_item_id = Some(work.id.clone());
     harness
         .runtime()
-        .reduce_task_result_message(&message, terminal.clone(), false, None)
+        .commit_terminal_task_result(&terminal, "task_result_received", &message)
         .await
         .unwrap();
     let repaired = harness.snapshot();
+    let triggered = repaired
+        .wait_conditions
+        .iter()
+        .find(|condition| condition.id == registration.condition.id)
+        .unwrap();
+    assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+    assert_eq!(triggered.trigger_message_id(), Some(message.id.as_str()));
+    assert_eq!(
+        repaired.work_items[0].blocked_by.as_deref(),
+        Some("waiting for task-replay")
+    );
     harness.restart();
     harness
         .runtime()
-        .reduce_task_result_message(&message, terminal, false, None)
+        .commit_terminal_task_result(&terminal, "task_result_received", &message)
         .await
         .unwrap();
+    let replayed = harness.snapshot();
+    assert_eq!(replayed.tasks, repaired.tasks);
+    assert_eq!(replayed.messages, repaired.messages);
+    assert_eq!(replayed.wait_conditions, repaired.wait_conditions);
+    assert_eq!(replayed.audit_events, repaired.audit_events);
+    assert_eq!(replayed.queue_entries.len(), 1);
+    assert_eq!(replayed.queue_entries[0].message_id, message.id);
+    assert_eq!(
+        replayed.queue_entries[0].status,
+        repaired.queue_entries[0].status
+    );
+    let wait_transition = harness
+        .runtime()
+        .wait_resolution_transition_for_message(&message)
+        .unwrap()
+        .expect("replayed TaskResult should plan exact wait settlement");
+    assert_eq!(wait_transition.record.status, WaitConditionStatus::Resolved);
+    assert!(
+        wait_transition.work_item.is_some(),
+        "exact wait settlement should clear the matching WorkItem blocker"
+    );
+    let poll =
+        super::super::super::scheduler_executor::SchedulerDecisionExecutor::new(harness.runtime())
+            .poll()
+            .await
+            .unwrap();
+    let super::super::super::scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("replayed task result should be claimed after restart");
+    };
+    assert_eq!(scheduled.message.id, message.id);
 
     let latest = harness
         .runtime()
@@ -873,5 +903,4 @@ async fn terminal_task_replay_repairs_wait_once_across_restart() {
             .count(),
         1
     );
-    assert_eq!(harness.snapshot(), repaired);
 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2170,9 +2170,16 @@ async fn bootstrap_recovery_replays_task_result_claim_after_canonical_revision_s
     terminal_task.parent_message_id = Some(result.id.clone());
     assert!(!terminal_task.terminal_reentry());
     runtime
-        .persist_task_transition_with_message(&terminal_task, "task_completed", &result)
+        .commit_terminal_task_result(&terminal_task, "task_completed", &result)
         .await
         .unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
     let result = runtime
         .storage()
         .read_message_by_id(&result.id)
@@ -2449,9 +2456,16 @@ async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimF
     terminal_task.parent_message_id = Some(result.id.clone());
     assert!(!terminal_task.terminal_reentry());
     runtime
-        .persist_task_transition_with_message(&terminal_task, "task_completed", &result)
+        .commit_terminal_task_result(&terminal_task, "task_completed", &result)
         .await
         .unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
     let result = runtime
         .storage()
         .read_message_by_id(&result.id)
@@ -4850,21 +4864,17 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
     }));
     rejoin.turn_id = Some("turn-lifecycle-handoff-rejoin".into());
     reopened
-        .persist_task_transition_with_message(&terminal_task, "task_completed", &rejoin)
+        .commit_terminal_task_result(&terminal_task, "task_completed", &rejoin)
         .await
         .unwrap();
-    assert!(reopened
+    let triggered = reopened
         .storage()
-        .active_wait_conditions_for_work_item("default", &work_item.id)
+        .latest_wait_conditions()
         .unwrap()
-        .is_empty());
-    let resolved_work_item = reopened
-        .latest_work_item(&work_item.id)
-        .await
-        .unwrap()
-        .expect("task result should retain the WorkItem");
-    assert!(resolved_work_item.revision > work_generation);
-    let rejoin = reopened.enqueue(rejoin).await.unwrap();
+        .into_iter()
+        .find(|condition| condition.id == work_wait.condition.id)
+        .expect("triggered task wait");
+    assert_eq!(triggered.status, WaitConditionStatus::Triggered);
     assert!(matches!(
         scheduler_executor::SchedulerDecisionExecutor::new(&reopened)
             .poll()
@@ -4872,6 +4882,12 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
             .unwrap(),
         scheduler_executor::RunLoopPoll::Message(_)
     ));
+    let resolved_work_item = reopened
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .expect("task result should retain the WorkItem");
+    assert!(resolved_work_item.revision > work_generation);
     let rejoined = reopened
         .inner
         .runtime_db
@@ -5024,9 +5040,14 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
     }));
     rejoin.turn_id = Some("turn-stale-legacy-rejoin".into());
     runtime
-        .persist_task_transition_with_message(&terminal_task, "task_completed", &rejoin)
+        .commit_terminal_task_result(&terminal_task, "task_completed", &rejoin)
         .await
         .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
     let resolved_work = runtime
         .latest_work_item(&work_item.id)
         .await
@@ -5044,14 +5065,6 @@ async fn exact_task_rejoin_prefers_canonical_wait_when_legacy_revision_advanced(
         resolved_execution.work_items[&work_item.id].source_revision,
         resolved_work.revision
     );
-
-    let rejoin = runtime.enqueue(rejoin).await.unwrap();
-
-    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-        .poll()
-        .await
-        .unwrap();
-    assert!(matches!(poll, scheduler_executor::RunLoopPoll::Message(_)));
     let claimed = runtime
         .inner
         .runtime_db
@@ -5345,6 +5358,15 @@ async fn pre_cutover_task_rejoin_without_execution_owner_is_dropped() {
     runtime
         .persist_task_transition_with_message(&terminal, "task_status_updated", &stale)
         .await
+        .unwrap();
+    let mut legacy_resolved = registration.condition.clone();
+    legacy_resolved.status = WaitConditionStatus::Resolved;
+    legacy_resolved.trigger_message_id = Some(stale.id.clone());
+    legacy_resolved.resolved_at = Some(Utc::now());
+    legacy_resolved.updated_at = Utc::now();
+    runtime
+        .storage()
+        .append_wait_condition(&legacy_resolved)
         .unwrap();
     let completing = runtime
         .complete_work_item(work_item.id.clone(), Vec::new())
@@ -5972,13 +5994,27 @@ async fn terminal_task_result_resumes_exact_agent_lifecycle_task_wait() {
             .unwrap()
     };
     runtime
-        .persist_task_transition_with_message(
-            &terminal,
-            "command_task_terminal_persisted",
-            &message,
-        )
+        .commit_terminal_task_result(&terminal, "command_task_terminal_persisted", &message)
         .await
         .unwrap();
+    let triggered = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == registration.condition.id)
+        .unwrap();
+    assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+    assert_eq!(triggered.trigger_message_id(), Some(message.id.as_str()));
+
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("exact lifecycle task wait should resume into the model");
+    };
+    assert_eq!(scheduled.message.id, message.id);
     let resolved = runtime
         .storage()
         .latest_wait_conditions()
@@ -5988,16 +6024,6 @@ async fn terminal_task_result_resumes_exact_agent_lifecycle_task_wait() {
         .unwrap();
     assert_eq!(resolved.status, WaitConditionStatus::Resolved);
     assert_eq!(resolved.trigger_message_id(), Some(message.id.as_str()));
-
-    let queued = runtime.enqueue(message).await.unwrap();
-    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-        .poll()
-        .await
-        .unwrap();
-    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
-        panic!("exact lifecycle task wait should resume into the model");
-    };
-    assert_eq!(scheduled.message.id, queued.id);
     let execution = runtime
         .inner
         .runtime_db
@@ -6005,13 +6031,13 @@ async fn terminal_task_result_resumes_exact_agent_lifecycle_task_wait() {
         .load_execution_protocol_state_if_initialized("default")
         .unwrap()
         .unwrap();
-    let attempt = &execution.attempts[&scheduler_executor::canonical_activation_id(&queued.id)];
+    let attempt = &execution.attempts[&scheduler_executor::canonical_activation_id(&message.id)];
     assert!(matches!(
         &attempt.source.identity,
         crate::domain::execution_protocol::ExecutionSourceIdentity::TriggeredWait {
             wait_id,
             trigger_message_id,
-        } if wait_id == &registration.condition.id && trigger_message_id == &queued.id
+        } if wait_id == &registration.condition.id && trigger_message_id == &message.id
     ));
 }
 
@@ -6082,14 +6108,9 @@ async fn exact_agent_lifecycle_task_wait_runs_one_model_continuation() {
             .unwrap()
     };
     runtime
-        .persist_task_transition_with_message(
-            &terminal,
-            "command_task_terminal_persisted",
-            &message,
-        )
+        .commit_terminal_task_result(&terminal, "command_task_terminal_persisted", &message)
         .await
         .unwrap();
-    runtime.enqueue(message).await.unwrap();
 
     let runner = tokio::spawn(runtime.clone().run());
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -10289,7 +10310,7 @@ async fn register_wait_for_external_recheck_sets_recoverable_work_item_deadline(
 }
 
 #[tokio::test]
-async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocker() {
+async fn canonical_task_result_claim_resolves_wait_and_clears_matching_blocker() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -10310,7 +10331,7 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
         .await
         .unwrap();
     append_running_rejoin_task(&runtime, "task-1", &work.id);
-    runtime
+    let registration = runtime
         .register_wait_for(
             "default",
             Some(work.id.clone()),
@@ -10321,7 +10342,15 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
         )
         .await
         .unwrap();
+    let work = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    persist_waiting_work_execution(&runtime, &work, &registration.condition.id);
 
+    let mut message = task_result_message("task-1").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.task_id = Some("task-1".into());
+    message.work_item_id = Some(work.id.clone());
     let task = TaskRecord {
         id: "task-1".into(),
         agent_id: "default".into(),
@@ -10329,31 +10358,67 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
         status: TaskStatus::Completed,
         created_at: Utc::now(),
         updated_at: Utc::now(),
-        parent_message_id: None,
+        parent_message_id: Some(message.id.clone()),
         work_item_id: Some(work.id.clone()),
         summary: Some("task-1".into()),
-        detail: None,
+        detail: Some(serde_json::json!({
+            "rejoin_obligation_id": "task-1",
+            "rejoin_generation": 1,
+            "parent_turn_id": "turn-task-1-parent",
+        })),
         recovery: None,
     };
-    let mut message = task_result_message("task-1");
-    message.task_id = Some("task-1".into());
-    message.work_item_id = Some(work.id.clone());
     runtime
-        .reduce_task_result_message(&message, task, false, None)
+        .commit_terminal_task_result(&task, "task_status_updated", &message)
         .await
         .unwrap();
 
     let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
-    assert_eq!(latest.blocked_by, None);
-    let active_conditions = runtime
+    assert_eq!(latest.blocked_by.as_deref(), Some("waiting for task-1"));
+    let triggered = runtime
         .storage()
-        .active_wait_conditions_for_work_item("default", &work.id)
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.work_item_id.as_deref() == Some(work.id.as_str()))
+        .expect("triggered task wait");
+    assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+    let planned_wait_resolution = runtime
+        .wait_resolution_transition_for_message(&message)
+        .unwrap()
+        .expect("triggered task wait should plan claim-time resolution");
+    assert!(
+        planned_wait_resolution.work_item.is_some(),
+        "claim-time wait resolution should clear the matching WorkItem blocker"
+    );
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
         .unwrap();
-    assert!(active_conditions.is_empty());
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("canonical task result should be claimed");
+    };
+    assert_eq!(scheduled.message.id, message.id);
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    let resolved = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == triggered.id)
+        .expect("resolved task wait");
+    assert_eq!(
+        (
+            resolved.status,
+            latest.revision,
+            latest.blocked_by.as_deref()
+        ),
+        (WaitConditionStatus::Resolved, work.revision + 1, None)
+    );
     let events = runtime.storage().read_recent_events(100).unwrap();
     assert!(events
         .iter()
-        .any(|event| event.kind == "wait_conditions_resolved"));
+        .any(|event| event.kind == "wait_condition_triggered"));
 }
 
 #[tokio::test]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -6862,10 +6862,20 @@ async fn authoritative_completion_resumes_parent_canonically_and_writes_terminal
         execution.work_items[&child.id].state,
         crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
     ));
-    assert!(matches!(
-        execution.work_items[&parent.id].state,
-        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
-    ));
+    match &execution.work_items[&parent.id].state {
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. } => {}
+        crate::domain::execution_protocol::WorkItemExecutionState::InFlight {
+            attempt_id, ..
+        } => {
+            assert!(matches!(
+                execution.attempts[attempt_id].binding,
+                crate::domain::execution_protocol::ExecutionBinding::WorkItem {
+                    ref work_item_id
+                } if work_item_id == &parent.id
+            ));
+        }
+        state => panic!("resumed parent execution state: {state:?}"),
+    }
     assert_eq!(
         runtime
             .storage()

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -133,16 +133,14 @@ impl RuntimeHandle {
         &self,
         message: &MessageEnvelope,
     ) -> Result<Option<crate::runtime_db::transitions::QueueWaitTransition>> {
-        let Some(condition) = self
+        let unresolved = self
             .inner
             .storage
-            .raw_unresolved_wait_conditions_for_agent(&message.agent_id)?
-            .into_iter()
-            .find(|condition| {
-                condition.status == WaitConditionStatus::Triggered
-                    && condition.trigger_message_id() == Some(message.id.as_str())
-            })
-        else {
+            .raw_unresolved_wait_conditions_for_agent(&message.agent_id)?;
+        let Some(condition) = unresolved.into_iter().find(|condition| {
+            condition.status == WaitConditionStatus::Triggered
+                && condition.trigger_message_id() == Some(message.id.as_str())
+        }) else {
             return Ok(None);
         };
         let now = self.now();

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -284,7 +284,9 @@ pub(crate) struct ExecutionAuthorityFences {
 pub(crate) struct TaskTransitionCommand {
     pub agent_id: String,
     pub task: TaskRecord,
+    pub queue_entry: Option<QueueEntryRecord>,
     pub work_items: Vec<WorkItemMutation>,
+    pub expected_wait_conditions: Vec<WaitConditionExpectation>,
     pub wait_conditions: Vec<WaitConditionRecord>,
     pub agent_state: Option<AgentStateMutation>,
     pub message_evidence: Vec<MessageEnvelope>,
@@ -1430,8 +1432,14 @@ impl RuntimeTransitionRepository<'_> {
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_task_tx(tx, &command.task)?;
+            if let Some(queue_entry) = command.queue_entry.as_ref() {
+                validate_queue_mutation_tx(tx, &QueueMutation::Upsert(queue_entry.clone()))?;
+            }
             for work_item in &command.work_items {
                 validate_work_item_mutation_tx(tx, work_item)?;
+            }
+            for expected in &command.expected_wait_conditions {
+                validate_wait_condition_expectation_tx(tx, expected)?;
             }
             for condition in &command.wait_conditions {
                 validate_wait_condition_tx(tx, condition)?;
@@ -1460,6 +1468,9 @@ impl RuntimeTransitionRepository<'_> {
 
             let task_applied = upsert_task_tx(tx, &command.task)?;
             let mut applied = task_applied;
+            if let Some(queue_entry) = command.queue_entry.as_ref() {
+                applied |= upsert_queue_entry_tx(tx, queue_entry)?;
+            }
             let mut work_items = Vec::new();
             for work_item in &command.work_items {
                 let work_item_applied = apply_work_item_mutation_tx(tx, work_item)?;
@@ -3723,10 +3734,12 @@ mod tests {
         let command = TaskTransitionCommand {
             agent_id: "agent-a".into(),
             task: terminal.clone(),
+            queue_entry: None,
             work_items: vec![WorkItemMutation::Update {
                 record: cleared.clone(),
                 expected_revision: 1,
             }],
+            expected_wait_conditions: Vec::new(),
             wait_conditions: vec![resolved],
             agent_state: None,
             message_evidence: Vec::new(),
@@ -3833,10 +3846,12 @@ mod tests {
             let command = TaskTransitionCommand {
                 agent_id: "agent-a".into(),
                 task: terminal,
+                queue_entry: None,
                 work_items: vec![WorkItemMutation::Update {
                     record: cleared,
                     expected_revision: initial_work.revision,
                 }],
+                expected_wait_conditions: Vec::new(),
                 wait_conditions: vec![resolved],
                 agent_state: None,
                 message_evidence: Vec::new(),

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -194,7 +194,7 @@
       "tier": "extended",
       "tags": ["scheduler", "workitem", "task-result", "yield", "wait", "restart", "replay", "delivery"],
       "timeout_seconds": 120,
-      "description": "Verify one WorkItem crosses autonomous scheduling, promoted task-result rejoin, external wait-resume, exact completion delivery, and process restart.",
+      "description": "Verify one WorkItem crosses autonomous scheduling, an in-flight promoted command interrupted by a real daemon crash/restart, exact task-result rejoin, external wait-resume, and completion delivery.",
       "phases": [
         {
           "id": "task-result-wait-complete",

--- a/tests/e2e/scheduler/README.md
+++ b/tests/e2e/scheduler/README.md
@@ -17,7 +17,7 @@ implicitly.
 
 | Scenario ID | Case ID | Description | Key Assertions |
 |---|---|---|---|
-| SCHED-E2E-001 | `scheduler-task-wait-resume` | Autonomous task-result and external-wait continuity | brief binding; task yield/rejoin; wait resolved; restart persistence |
+| SCHED-E2E-001 | `scheduler-task-wait-resume` | Autonomous task-result and external-wait continuity across an in-flight daemon crash | promoted command interruption; deterministic restart TaskResult; exact rejoin; brief binding; waits resolved |
 | SCHED-E2E-002 | `scheduler-multi-workitem-scheduling` | Multi-WorkItem concurrent scheduling | both complete; no conflicts; 2 activations; 2 settlements; restart persistence |
 | SCHED-E2E-003 | `scheduler-provider-failure-work-queue-retry` | Provider failure recovery | recovery turn scheduled; final brief; no death loop; idempotency key preserved |
 | SCHED-E2E-005 | `scheduler-external-wait-resume` | WaitFor external trigger + resume | wait state correct; external callback wakes; WorkItem resumes; wait resolved |

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -1544,6 +1544,66 @@ class DockerE2ERunnerTests(unittest.TestCase):
             )
             self.assertNotIn("HOLON_SCHEDULER", case.get("runtime_env", {}))
 
+    def test_scheduler_task_wait_crashes_daemon_before_task_result_rejoin(self) -> None:
+        source = inspect.getsource(runner.run_scheduler_task_wait_resume_case)
+        self.assertLess(
+            source.index('expected_scheduling_state="waiting_task"'),
+            source.index("harness.crash_restart(wait_idle=False)"),
+        )
+        self.assertLess(
+            source.index("harness.crash_restart(wait_idle=False)"),
+            source.index('expected_scheduling_state="waiting_external"'),
+        )
+        self.assertNotIn(
+            'harness.work_items("scheduler-task-wait-after-restart")',
+            source,
+        )
+
+    def test_crash_restart_uses_docker_sigkill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            harness = runner.CaseHarness(
+                case_id="crash-restart-test",
+                image="holon:test",
+                model="deepseek/deepseek-v4-flash",
+                credential_envs=[],
+                env_file=None,
+                runtime_env={},
+                evidence_root=Path(directory),
+                timeout_seconds=1,
+                keep=False,
+            )
+            commands: list[tuple[str, ...]] = []
+
+            def fake_docker(
+                *args: str, **_: object
+            ) -> subprocess.CompletedProcess[str]:
+                commands.append(args)
+                if args[:2] == ("inspect", "--format"):
+                    return subprocess.CompletedProcess(
+                        ["docker", *args], 0, "false\n", ""
+                    )
+                return subprocess.CompletedProcess(["docker", *args], 0, "", "")
+
+            harness.docker = fake_docker
+            harness.capture_logs = lambda: None
+            harness.start = lambda *, wait_idle=True: commands.append(
+                ("start", str(wait_idle))
+            )
+
+            harness.crash_restart(wait_idle=False)
+
+            self.assertEqual(
+                commands[0],
+                (
+                    "kill",
+                    "--signal",
+                    "KILL",
+                    harness.container,
+                ),
+            )
+            self.assertIn(("rm", "-f", harness.container), commands)
+            self.assertEqual(commands[-1], ("start", "False"))
+
     def test_scheduler_matrix_expands_only_scheduler_cases(self) -> None:
         selected = runner.select_cases(
             self.manifest, requested=None, suite="core", tags=[]


### PR DESCRIPTION
## Summary

Fixes #2565.

Daemon restart after interrupting a background command task failed to reactivate the exact `WaitFor(wake=task_result)` because the terminal TaskResult, wait-condition resolution, and queue admission were split across separate phases. This PR unifies them into a single atomic transaction and adds the required real-daemon-restart E2E.

## Changes

### Runtime core
- **`commit_terminal_task_result`** (`task_state_reducer.rs`): new method that atomically persists task transition + wait-condition resolution + message evidence + queue admission in one DB transaction via `TaskTransition::with_terminal_result`.
- Migrated all terminal task producers to the unified transaction:
  - Normal task completion/failure (`tasks.rs`)
  - Command task terminal state (`command_task.rs`)
  - Restart interrupted tasks (`persist_interrupted_tasks`)
  - Agent-stop interrupted tasks (`interrupt_active_tasks_for_lifecycle_stop`)
- Removed the separate `enqueue(result_message)` call and the two-phase `emit_task_results_from_interrupted_tasks` / `missing_interrupted_task_results` restart path in `memory_refresh.rs` and `runtime.rs`.
- Added **three-stage wait semantics** (Registered → Triggered → Resolved): `exact_triggered_or_resolved_task_result_wait` in `message_dispatch.rs` matches `Triggered` waits so message dispatch and canonical claim recovery can proceed before the scheduler fully resolves the wait.

### Tests
- Transition fault-injection tests for retryable conflict recovery (`contracts/task.rs`, `contracts/wait.rs`, `runtime_state.rs`).
- Required daemon-restart Scheduler E2E (`scheduler-task-wait-resume`): autonomous task-wait → crash → deterministic restart TaskResult rejoin → external-wake → completion.
- 70 runner unit tests in `test_docker_e2e_runner.py`.

### E2E infrastructure
- Fixed `crash_restart` race: removed `kill -STOP 1; kill -KILL -1` which let the daemon observe child-process death as a normal task failure before being stopped. Now uses `docker kill --signal KILL` directly.
- Clean up stale daemon state files (socket, pid, metadata) after crash so the replacement container can start without "runtime is already running" false positive.

## Verification
- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✓
- 3 targeted Rust regression tests ✓
- 70 runner unit tests ✓
- Required E2E `scheduler-task-wait-resume` ✓