### PR TITLE
feat: add DeepSeek Responses endpoint dialect

### DIFF
--- a/docs/implementation-decisions/103-deepseek-responses-endpoint-dialect.md
+++ b/docs/implementation-decisions/103-deepseek-responses-endpoint-dialect.md
@@ -1,0 +1,36 @@
+# DeepSeek Responses Endpoint Dialect
+
+## Choice
+
+Keep `deepseek@default/*` on the existing Anthropic Messages endpoint and add
+`deepseek@responses/*` as an explicit opt-in route over the Responses API.
+
+The Responses route uses an endpoint-specific contract:
+
+- streaming Responses transport
+- complete conversation history on every request
+- no `previous_response_id` continuation
+- no provider remote compaction
+- no inherited Anthropic-native web-search capability
+
+Plain `reasoning_text` output is stored as `ModelBlock::ReasoningText`. It is
+replayed as a Responses reasoning item, but it is excluded from user-visible
+assistant text and from transports that cannot preserve that semantic block.
+
+## Reason
+
+DeepSeek's Responses endpoint is wire-compatible with only part of the OpenAI
+Responses contract. Treating it as the standard stateful dialect would make
+provider restart behavior depend on unavailable remote response state and
+would attempt unsupported remote compaction.
+
+Keeping the reasoning block durable preserves the exact history needed after a
+tool call or runtime restart without leaking provider reasoning into the
+operator-facing result.
+
+## Preserved boundary
+
+This route does not change the legacy DeepSeek default, introduce a model
+alias, or change the OpenAI and xAI endpoint contracts. Endpoint dialect is
+selected from the resolved canonical `(provider, endpoint)` identity rather
+than from the model name.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -110,3 +110,4 @@ Current decision notes:
 - [097 Storage-Backed Agent State Projection](./097-storage-backed-agent-state-projection.md)
 - [098 Scheduler Protocol Transition Wraps Legacy Boundaries Atomically](./098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md)
 - [101 Scheduler Authority Convergence](./101-scheduler-authority-convergence.md)
+- [103 DeepSeek Responses Endpoint Dialect](./103-deepseek-responses-endpoint-dialect.md)

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -399,7 +399,7 @@ pub struct RuntimeModelCatalog {
     pub image_generation_model: Option<ModelRouteRef>,
     pub vision_candidate_models: Vec<ModelRouteRef>,
     pub disable_provider_fallback: bool,
-    pub provider_endpoints: HashMap<ProviderId, ResolvedProviderEndpointConfig>,
+    pub provider_endpoints: Vec<ResolvedProviderEndpointConfig>,
     pub built_in_catalog: BuiltInModelCatalog,
     pub discovered_models: HashMap<ModelRef, BuiltInModelMetadata>,
     pub model_overrides: HashMap<ModelRef, ModelRuntimeOverride>,
@@ -409,6 +409,30 @@ pub struct RuntimeModelCatalog {
 
 impl RuntimeModelCatalog {
     pub fn from_config(config: &AppConfig) -> Self {
+        let mut provider_endpoints = config
+            .providers
+            .iter()
+            .filter_map(|(provider, config)| {
+                resolved_provider_endpoint_config(provider.clone(), config.clone()).ok()
+            })
+            .collect::<Vec<_>>();
+        if let Some(default) = provider_endpoints.iter().find(|endpoint| {
+            endpoint.provider.as_str() == "deepseek"
+                && endpoint.endpoint == ProviderEndpointId::default_endpoint()
+        }) {
+            let mut runtime_config = default.runtime_config.clone();
+            runtime_config.route_endpoint =
+                ProviderEndpointId::parse("responses").expect("valid built-in endpoint");
+            runtime_config.transport = ProviderTransportKind::OpenAiResponses;
+            runtime_config.base_url = "https://api.deepseek.com/v1".to_string();
+            runtime_config.context_management = Default::default();
+            runtime_config.builtin_web_search = None;
+            provider_endpoints.push(ResolvedProviderEndpointConfig {
+                provider: default.provider.clone(),
+                endpoint: runtime_config.route_endpoint.clone(),
+                runtime_config,
+            });
+        }
         Self {
             default_model: config.default_model.clone(),
             fallback_models: config.fallback_models.clone(),
@@ -416,15 +440,7 @@ impl RuntimeModelCatalog {
             image_generation_model: config.image_generation_model.clone(),
             vision_candidate_models: config.vision_candidate_models.clone(),
             disable_provider_fallback: config.provider_fallback_disabled(),
-            provider_endpoints: config
-                .providers
-                .iter()
-                .filter_map(|(provider, config)| {
-                    resolved_provider_endpoint_config(provider.clone(), config.clone())
-                        .ok()
-                        .map(|endpoint| (provider.clone(), endpoint))
-                })
-                .collect(),
+            provider_endpoints,
             built_in_catalog: BuiltInModelCatalog::default(),
             discovered_models: config
                 .model_discovery_cache
@@ -499,7 +515,7 @@ impl RuntimeModelCatalog {
             route_ref.endpoint.clone(),
             canonical_model_ref.model.clone(),
         );
-        let endpoint = self.provider_endpoints.values().find(|endpoint| {
+        let endpoint = self.provider_endpoints.iter().find(|endpoint| {
             endpoint.provider == canonical_route_ref.provider
                 && endpoint.endpoint == canonical_route_ref.endpoint
         })?;
@@ -531,10 +547,14 @@ impl RuntimeModelCatalog {
             // Model declares a specific non-default endpoint: find by (provider, endpoint)
             Some(endpoint) => self
                 .provider_endpoints
-                .values()
+                .iter()
                 .find(|e| e.provider == model_ref.provider && e.endpoint == endpoint),
-            // Default endpoint or no catalog metadata: direct key lookup
-            None => self.provider_endpoints.get(&model_ref.provider),
+            // Default endpoint or no catalog metadata: resolve the canonical
+            // default endpoint explicitly.
+            None => self.provider_endpoints.iter().find(|endpoint| {
+                endpoint.provider == model_ref.provider
+                    && endpoint.endpoint == ProviderEndpointId::default_endpoint()
+            }),
         }
     }
 
@@ -846,7 +866,7 @@ impl Default for RuntimeModelCatalog {
             image_generation_model: None,
             vision_candidate_models: Vec::new(),
             disable_provider_fallback: false,
-            provider_endpoints: HashMap::new(),
+            provider_endpoints: Vec::new(),
             built_in_catalog: BuiltInModelCatalog::default(),
             discovered_models: HashMap::new(),
             model_overrides: HashMap::new(),

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -420,13 +420,7 @@ impl RuntimeModelCatalog {
             endpoint.provider.as_str() == "deepseek"
                 && endpoint.endpoint == ProviderEndpointId::default_endpoint()
         }) {
-            let mut runtime_config = default.runtime_config.clone();
-            runtime_config.route_endpoint =
-                ProviderEndpointId::parse("responses").expect("valid built-in endpoint");
-            runtime_config.transport = ProviderTransportKind::OpenAiResponses;
-            runtime_config.base_url = "https://api.deepseek.com/v1".to_string();
-            runtime_config.context_management = Default::default();
-            runtime_config.builtin_web_search = None;
+            let runtime_config = deepseek_responses_runtime_config(&default.runtime_config);
             provider_endpoints.push(ResolvedProviderEndpointConfig {
                 provider: default.provider.clone(),
                 endpoint: runtime_config.route_endpoint.clone(),
@@ -853,6 +847,35 @@ impl RuntimeModelCatalog {
             pending_fallback_model,
         )
         .map(|route| route.route_ref)
+    }
+}
+
+fn deepseek_responses_runtime_config(default: &ProviderRuntimeConfig) -> ProviderRuntimeConfig {
+    ProviderRuntimeConfig {
+        id: default.id.clone(),
+        route_provider: default.route_provider.clone(),
+        route_endpoint: ProviderEndpointId::parse("responses").expect("valid built-in endpoint"),
+        transport: ProviderTransportKind::OpenAiResponses,
+        base_url: deepseek_responses_base_url(&default.base_url),
+        auth: default.auth.clone(),
+        credential: default.credential.clone(),
+        credential_store_path: default.credential_store_path.clone(),
+        codex_home: None,
+        originator: None,
+        reasoning_effort: default.reasoning_effort.clone(),
+        context_management: Default::default(),
+        builtin_web_search: None,
+    }
+}
+
+fn deepseek_responses_base_url(default_base_url: &str) -> String {
+    let base_url = default_base_url.trim_end_matches('/');
+    if let Some(prefix) = base_url.strip_suffix("/anthropic") {
+        format!("{prefix}/v1")
+    } else if base_url.ends_with("/v1") {
+        base_url.to_string()
+    } else {
+        format!("{base_url}/v1")
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2893,6 +2893,66 @@ fn runtime_model_catalog_materializes_legacy_provider_as_default_route_endpoint(
 }
 
 #[test]
+fn runtime_model_catalog_exposes_deepseek_responses_without_changing_default_route() {
+    let mut fixture = test_app_config("deepseek/deepseek-v4-pro", &[]);
+    let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+    let deepseek = ProviderId::parse("deepseek").unwrap();
+    fixture
+        .config
+        .providers
+        .insert(deepseek.clone(), built_ins.get(&deepseek).unwrap().clone());
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+    let default_route = catalog
+        .resolve_explicit_model_route(
+            &ContextConfig::default(),
+            &route_ref("deepseek@default/deepseek-v4-pro"),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+    assert_eq!(
+        default_route.endpoint.runtime_config.transport,
+        ProviderTransportKind::AnthropicMessages
+    );
+    assert_eq!(
+        default_route.endpoint.runtime_config.base_url,
+        "https://api.deepseek.com/anthropic"
+    );
+
+    let responses_route = catalog
+        .resolve_explicit_model_route(
+            &ContextConfig::default(),
+            &route_ref("deepseek@responses/deepseek-v4-pro"),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+    assert_eq!(
+        responses_route.route_ref.as_string(),
+        "deepseek@responses/deepseek-v4-pro"
+    );
+    assert_eq!(
+        responses_route.endpoint.runtime_config.transport,
+        ProviderTransportKind::OpenAiResponses
+    );
+    assert_eq!(
+        responses_route.endpoint.runtime_config.base_url,
+        "https://api.deepseek.com/v1"
+    );
+    assert!(responses_route
+        .endpoint
+        .runtime_config
+        .builtin_web_search
+        .is_none());
+
+    assert_eq!(
+        ModelRouteRef::parse_compatible("deepseek/deepseek-v4-pro")
+            .unwrap()
+            .as_string(),
+        "deepseek@default/deepseek-v4-pro"
+    );
+}
+
+#[test]
 fn runtime_model_catalog_routes_opencode_go_models_by_published_transport() {
     let mut fixture = test_app_config("opencode-go/minimax-m3", &[]);
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2953,6 +2953,36 @@ fn runtime_model_catalog_exposes_deepseek_responses_without_changing_default_rou
 }
 
 #[test]
+fn runtime_model_catalog_derives_deepseek_responses_from_an_explicit_allowlist() {
+    let mut fixture = test_app_config("deepseek/deepseek-v4-pro", &[]);
+    let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+    let deepseek = ProviderId::parse("deepseek").unwrap();
+    let mut runtime = built_ins.get(&deepseek).unwrap().clone();
+    runtime.base_url = "https://proxy.example/deepseek/anthropic/".into();
+    runtime.reasoning_effort = Some("high".into());
+    runtime.codex_home = Some(PathBuf::from("/should-not-leak"));
+    runtime.originator = Some("anthropic-only-originator".into());
+    runtime.context_management.enabled = true;
+    fixture.config.providers.insert(deepseek, runtime);
+
+    let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+    let responses_route = catalog
+        .resolve_explicit_model_route(
+            &ContextConfig::default(),
+            &route_ref("deepseek@responses/deepseek-v4-pro"),
+            ModelRouteCapability::Turn,
+        )
+        .unwrap();
+    let runtime = &responses_route.endpoint.runtime_config;
+
+    assert_eq!(runtime.base_url, "https://proxy.example/deepseek/v1");
+    assert_eq!(runtime.reasoning_effort.as_deref(), Some("high"));
+    assert!(runtime.codex_home.is_none());
+    assert!(runtime.originator.is_none());
+    assert!(!runtime.context_management.enabled);
+}
+
+#[test]
 fn runtime_model_catalog_routes_opencode_go_models_by_published_transport() {
     let mut fixture = test_app_config("opencode-go/minimax-m3", &[]);
     let built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1973,6 +1973,20 @@ mod tests {
                 &metadata.capabilities,
             )
             .is_empty());
+            assert!(catalog
+                .get_route(&ModelRouteRef::new(
+                    provider_id("deepseek"),
+                    ProviderEndpointId::parse("responses").unwrap(),
+                    model,
+                ))
+                .is_some());
+            assert_eq!(
+                catalog
+                    .preferred_route_for_model(&metadata.model_ref)
+                    .unwrap()
+                    .endpoint,
+                ProviderEndpointId::default_endpoint()
+            );
         }
 
         for removed_model in ["deepseek-chat", "deepseek-reasoner"] {

--- a/src/model_catalog/providers/mod.rs
+++ b/src/model_catalog/providers/mod.rs
@@ -28,5 +28,16 @@ pub(super) fn entries_for_registration(
 pub(super) fn route_definitions() -> Vec<super::BuiltInModelRouteDefinition> {
     let mut definitions = china::route_definitions();
     definitions.extend(tencent_tokenhub::route_definitions());
+    definitions.extend(
+        ["deepseek-v4-flash", "deepseek-v4-pro"]
+            .into_iter()
+            .map(|model| super::BuiltInModelRouteDefinition {
+                legacy_provider: super::provider_id("deepseek"),
+                model_ref: super::ModelRef::new(super::provider_id("deepseek"), model),
+                endpoint: super::ProviderEndpointId::parse("responses")
+                    .expect("valid built-in endpoint"),
+                policy: super::BuiltInModelRoutePolicy::default(),
+            }),
+    );
     definitions
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -441,6 +441,11 @@ pub enum ModelBlock {
         /// Must be passed back verbatim in subsequent requests.
         signature: String,
     },
+    ReasoningText {
+        /// Plain provider reasoning that must be replayed as reasoning, never
+        /// rendered as user-visible assistant text.
+        text: String,
+    },
     RedactedThinking {
         /// Opaque encrypted/redacted thinking payload returned by the provider.
         /// Must be passed back verbatim in subsequent requests.

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -7,10 +7,12 @@ use std::sync::{
 
 use super::support::*;
 use super::*;
-use crate::config::{ModelRef, ProviderId};
+use crate::config::{ModelRef, ProviderEndpointId, ProviderId, ProviderTransportKind};
 use crate::model_catalog::ModelRuntimeOverride;
 use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
-use crate::provider::transports::set_stream_idle_timeout_override_for_tests;
+use crate::provider::transports::{
+    set_stream_idle_timeout_override_for_tests, OpenAiCompactionPolicy,
+};
 use crate::provider::{
     ContinuationScopeId, ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
 };
@@ -297,6 +299,70 @@ fn openai_reasoning_and_tool_call_sse_response(response_id: &str) -> String {
     )
 }
 
+fn deepseek_reasoning_and_tool_call_sse_response(response_id: &str) -> String {
+    let response = json!({
+        "id": response_id,
+        "status": "completed",
+        "usage": { "input_tokens": 12, "output_tokens": 4 },
+        "output": [{
+            "type": "reasoning",
+            "content": [{
+                "type": "reasoning_text",
+                "text": "inspect the workspace first"
+            }]
+        }, {
+            "type": "function_call",
+            "call_id": "exec-1",
+            "name": "ExecCommand",
+            "arguments": "{\"cmd\":\"printf ok\"}"
+        }]
+    });
+    format!(
+        "event: response.completed\ndata: {}\n\n",
+        json!({
+            "type": "response.completed",
+            "response": response,
+        })
+    )
+}
+
+#[test]
+fn reasoning_text_round_trips_without_becoming_assistant_text() {
+    let encoded = serde_json::to_value(ModelBlock::ReasoningText {
+        text: "durable provider reasoning".into(),
+    })
+    .unwrap();
+    assert_eq!(
+        encoded,
+        json!({
+            "type": "reasoning_text",
+            "text": "durable provider reasoning",
+        })
+    );
+
+    let decoded: ModelBlock = serde_json::from_value(encoded).unwrap();
+    assert!(matches!(
+        decoded,
+        ModelBlock::ReasoningText { text } if text == "durable provider reasoning"
+    ));
+
+    let input = build_openai_input(&[ConversationMessage::AssistantBlocks(vec![
+        ModelBlock::Text {
+            text: "visible".into(),
+        },
+        ModelBlock::ReasoningText {
+            text: "durable provider reasoning".into(),
+        },
+    ])])
+    .unwrap();
+    assert_eq!(input[0]["content"][0]["text"], json!("visible"));
+    assert_eq!(input[1]["type"], json!("reasoning"));
+    assert_eq!(
+        input[1]["content"][0]["text"],
+        json!("durable provider reasoning")
+    );
+}
+
 fn openai_unicode_text_and_tool_call_sse_response(response_id: &str) -> String {
     let response = json!({
         "id": response_id,
@@ -371,6 +437,143 @@ async fn openai_from_config_uses_resolved_max_output_override_on_the_wire() {
 
     let response_bodies = response_bodies.lock().unwrap();
     assert_eq!(response_bodies[0]["max_output_tokens"], json!(1_234));
+}
+
+#[tokio::test]
+async fn deepseek_responses_streams_and_replays_full_history_across_provider_restart() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let response_attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts_for_server = response_attempts.clone();
+    let compact_attempts = Arc::new(AtomicUsize::new(0));
+    let compact_attempts_for_server = compact_attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = captured_for_server.clone();
+                    let attempts = response_attempts_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        let response = if attempt == 0 {
+                            deepseek_reasoning_and_tool_call_sse_response("resp_1")
+                        } else {
+                            openai_text_sse_response("resp_2", "done")
+                        };
+                        ([("content-type", "text/event-stream")], response)
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(_body): Json<Value>| {
+                    let attempts = compact_attempts_for_server.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                }),
+            ),
+    )
+    .await;
+    let fixture = test_config(
+        "deepseek/deepseek-v4-pro",
+        &[],
+        Some("deepseek-key"),
+        None,
+        false,
+    );
+    let mut provider_config = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai())
+        .unwrap()
+        .clone();
+    let deepseek = ProviderId::parse("deepseek").unwrap();
+    provider_config.id = deepseek.clone();
+    provider_config.route_provider = deepseek;
+    provider_config.route_endpoint = ProviderEndpointId::parse("responses").unwrap();
+    provider_config.transport = ProviderTransportKind::OpenAiResponses;
+    provider_config.base_url = base_url;
+    provider_config.builtin_web_search = None;
+
+    let first_provider = OpenAiProvider::from_runtime_config_with_compaction_policy(
+        &provider_config,
+        "deepseek-v4-pro",
+        384_000,
+        fixture.config.home_dir.as_path(),
+        OpenAiCompactionPolicy {
+            trigger_input_tokens: 1,
+        },
+    )
+    .unwrap();
+    let first = first_provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    assert!(matches!(
+        &first.blocks[0],
+        ModelBlock::ReasoningText { text } if text == "inspect the workspace first"
+    ));
+    assert!(matches!(
+        &first.blocks[1],
+        ModelBlock::ToolUse { id, name, .. } if id == "exec-1" && name == "ExecCommand"
+    ));
+
+    let persisted_blocks = serde_json::to_vec(&first.blocks).unwrap();
+    drop(first_provider);
+    let restored_blocks: Vec<ModelBlock> = serde_json::from_slice(&persisted_blocks).unwrap();
+
+    let mut followup = provider_turn_request_with_prompt_frame();
+    followup.conversation.extend([
+        ConversationMessage::AssistantBlocks(restored_blocks),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "exec-1".into(),
+            content: "ok".into(),
+            is_error: false,
+            error: None,
+        }]),
+    ]);
+    let restarted_provider = OpenAiProvider::from_runtime_config_with_compaction_policy(
+        &provider_config,
+        "deepseek-v4-pro",
+        384_000,
+        fixture.config.home_dir.as_path(),
+        OpenAiCompactionPolicy {
+            trigger_input_tokens: 1,
+        },
+    )
+    .unwrap();
+    let second = restarted_provider.complete_turn(followup).await.unwrap();
+    assert!(matches!(
+        &second.blocks[0],
+        ModelBlock::Text { text } if text == "done"
+    ));
+
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    for body in bodies.iter() {
+        assert_eq!(body["stream"], json!(true));
+        assert!(body.get("previous_response_id").is_none());
+        assert!(body.get("prompt_cache_key").is_none());
+    }
+    let replayed = bodies[1]["input"].as_array().unwrap();
+    assert!(replayed.iter().any(|item| {
+        item["type"] == "reasoning"
+            && item["content"][0]["type"] == "reasoning_text"
+            && item["content"][0]["text"] == "inspect the workspace first"
+    }));
+    assert!(replayed
+        .iter()
+        .any(|item| item["type"] == "function_call" && item["call_id"] == "exec-1"));
+    assert!(replayed.iter().any(|item| {
+        item["type"] == "function_call_output"
+            && item["call_id"] == "exec-1"
+            && item["output"] == "ok"
+    }));
+    assert_eq!(compact_attempts.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -1453,7 +1453,12 @@ fn conversation_message_to_api(
             content: Value::Array(
                 blocks
                     .iter()
-                    .filter(|block| !matches!(block, ModelBlock::Citations { .. }))
+                    .filter(|block| {
+                        !matches!(
+                            block,
+                            ModelBlock::ReasoningText { .. } | ModelBlock::Citations { .. }
+                        )
+                    })
                     .enumerate()
                     .map(|(block_index, block)| {
                         maybe_mark_cache_control(
@@ -1486,6 +1491,9 @@ fn conversation_message_to_api(
                                     "type": "redacted_thinking",
                                     "data": data,
                                 }),
+                                ModelBlock::ReasoningText { .. } => unreachable!(
+                                    "reasoning text blocks are filtered before Anthropic encoding"
+                                ),
                                 ModelBlock::Citations { .. } => unreachable!(
                                     "citation blocks are filtered before Anthropic encoding"
                                 ),
@@ -2155,6 +2163,7 @@ fn model_block_kind(block: &ModelBlock) -> &'static str {
         ModelBlock::Text { .. } => "assistant_text",
         ModelBlock::ToolUse { .. } => "tool_use",
         ModelBlock::Thinking { .. } => "thinking",
+        ModelBlock::ReasoningText { .. } => "reasoning_text",
         ModelBlock::RedactedThinking { .. } => "redacted_thinking",
         ModelBlock::Citations { .. } => "citations",
     }
@@ -2169,6 +2178,10 @@ fn hash_model_block(block: &ModelBlock) -> String {
         ModelBlock::Thinking { text, .. } => {
             // Include a stable prefix so thinking blocks hash differently from text blocks
             let value = json!({ "type": "thinking", "thinking": text });
+            sha256_hex(canonical_json(&value).as_bytes())
+        }
+        ModelBlock::ReasoningText { text } => {
+            let value = json!({ "type": "reasoning", "text": text });
             sha256_hex(canonical_json(&value).as_bytes())
         }
         ModelBlock::RedactedThinking { data } => {
@@ -2208,6 +2221,7 @@ fn estimate_model_block_tokens(block: &ModelBlock) -> u64 {
         ModelBlock::Text { text } => estimate_tokens_from_chars(text.len()),
         ModelBlock::ToolUse { .. } => 50,
         ModelBlock::Thinking { text, .. } => estimate_tokens_from_chars(text.len()),
+        ModelBlock::ReasoningText { text } => estimate_tokens_from_chars(text.len()),
         ModelBlock::RedactedThinking { data } => estimate_tokens_from_chars(data.len()),
         ModelBlock::Citations { citations } => citations
             .iter()

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -347,7 +347,9 @@ fn conversation_message_to_gemini_content(message: &ConversationMessage) -> Opti
                         }),
                         function_response: None,
                     },
-                    ModelBlock::Thinking { .. } | ModelBlock::RedactedThinking { .. } => {
+                    ModelBlock::Thinking { .. }
+                    | ModelBlock::ReasoningText { .. }
+                    | ModelBlock::RedactedThinking { .. } => {
                         GeminiPart {
                             text: None,
                             function_call: None,

--- a/src/provider/transports/openai/chat/plan.rs
+++ b/src/provider/transports/openai/chat/plan.rs
@@ -302,6 +302,7 @@ pub(crate) fn build_chat_completion_messages(
                             }));
                         }
                         ModelBlock::Thinking { .. }
+                        | ModelBlock::ReasoningText { .. }
                         | ModelBlock::RedactedThinking { .. }
                         | ModelBlock::Citations { .. } => {}
                     }

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -118,7 +118,7 @@ pub struct OpenAiProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
-    continuation_contract: OpenAiResponsesContinuationContract,
+    endpoint_contract: OpenAiResponsesEndpointContract,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
@@ -173,12 +173,27 @@ pub struct OpenAiChatCompletionsProvider {
 pub(crate) enum OpenAiResponsesTransportContract {
     StandardJson,
     CodexStreaming,
+    DeepSeekStreaming,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OpenAiResponsesContinuationContract {
     Standard,
     StoreResponsesAndOmitInstructionsWithPreviousResponseId,
+    FullHistoryOnly,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OpenAiResponsesRemoteCompactionContract {
+    Supported,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OpenAiResponsesEndpointContract {
+    transport: OpenAiResponsesTransportContract,
+    continuation: OpenAiResponsesContinuationContract,
+    remote_compaction: OpenAiResponsesRemoteCompactionContract,
 }
 
 const OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND: &str = "responses_compact";
@@ -219,6 +234,27 @@ fn openai_codex_responses_url(base_url: &str) -> String {
 
 fn openai_codex_responses_compact_url(base_url: &str) -> String {
     format!("{}/responses/compact", openai_codex_api_base_url(base_url))
+}
+
+async fn send_openai_responses_for_contract(
+    contract: OpenAiResponsesTransportContract,
+    client: &Client,
+    url: String,
+    body: Value,
+    headers: Vec<(&str, String)>,
+    trace: Option<&ProviderHttpTrace>,
+    agent_id: Option<&str>,
+) -> Result<ParsedOpenAiResponse> {
+    match contract {
+        OpenAiResponsesTransportContract::StandardJson => {
+            send_openai_responses_request(client, url, body, headers, trace, agent_id).await
+        }
+        OpenAiResponsesTransportContract::CodexStreaming
+        | OpenAiResponsesTransportContract::DeepSeekStreaming => {
+            send_openai_responses_streaming_request(client, url, body, headers, trace, agent_id)
+                .await
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -282,10 +318,26 @@ impl OpenAiProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
-            continuation_contract: if provider_config.id.as_str() == "xai" {
-                OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId
+            endpoint_contract: if provider_config.route_provider.as_str() == "deepseek"
+                && provider_config.route_endpoint.as_str() == "responses"
+            {
+                OpenAiResponsesEndpointContract {
+                    transport: OpenAiResponsesTransportContract::DeepSeekStreaming,
+                    continuation: OpenAiResponsesContinuationContract::FullHistoryOnly,
+                    remote_compaction: OpenAiResponsesRemoteCompactionContract::Unsupported,
+                }
+            } else if provider_config.id.as_str() == "xai" {
+                OpenAiResponsesEndpointContract {
+                    transport: OpenAiResponsesTransportContract::StandardJson,
+                    continuation: OpenAiResponsesContinuationContract::StoreResponsesAndOmitInstructionsWithPreviousResponseId,
+                    remote_compaction: OpenAiResponsesRemoteCompactionContract::Supported,
+                }
             } else {
-                OpenAiResponsesContinuationContract::Standard
+                OpenAiResponsesEndpointContract {
+                    transport: OpenAiResponsesTransportContract::StandardJson,
+                    continuation: OpenAiResponsesContinuationContract::Standard,
+                    remote_compaction: OpenAiResponsesRemoteCompactionContract::Supported,
+                }
             },
             builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
@@ -386,7 +438,7 @@ impl AgentProvider for OpenAiProvider {
             &self.model,
             self.max_output_tokens,
             &request,
-            OpenAiResponsesTransportContract::StandardJson,
+            self.endpoint_contract.transport,
             ToolSchemaContract::Relaxed,
             self.reasoning_effort.as_deref(),
             None,
@@ -395,32 +447,39 @@ impl AgentProvider for OpenAiProvider {
             body,
             &request,
             &self.continuation,
-            true,
-            self.continuation_contract,
+            self.endpoint_contract.continuation
+                != OpenAiResponsesContinuationContract::FullHistoryOnly,
+            self.endpoint_contract.continuation,
         )?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
         let mut headers = self.resolve_auth_headers().await?;
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
-        if let Some(remote_compaction) = maybe_compact_openai_request_plan(
-            &self.continuation,
-            &mut plan,
-            self.compaction_policy,
-            &self.client,
-            openai_responses_compact_url(&self.base_url),
-            headers.clone(),
-            trace.as_ref(),
-            request_agent_id(&request),
-        )
-        .await
+        if self.endpoint_contract.remote_compaction
+            == OpenAiResponsesRemoteCompactionContract::Supported
         {
-            sent_diagnostics.openai_remote_compaction = Some(remote_compaction);
-            sent_diagnostics.request_lowering_mode = plan.diagnostics.request_lowering_mode.clone();
+            if let Some(remote_compaction) = maybe_compact_openai_request_plan(
+                &self.continuation,
+                &mut plan,
+                self.compaction_policy,
+                &self.client,
+                openai_responses_compact_url(&self.base_url),
+                headers.clone(),
+                trace.as_ref(),
+                request_agent_id(&request),
+            )
+            .await
+            {
+                sent_diagnostics.openai_remote_compaction = Some(remote_compaction);
+                sent_diagnostics.request_lowering_mode =
+                    plan.diagnostics.request_lowering_mode.clone();
+            }
         }
         let mut final_provider_input = plan.provider_input.clone();
         let mut final_replay_loss_reason = plan.replay_loss_reason.clone();
-        let parsed = match send_openai_responses_request(
+        let parsed = match send_openai_responses_for_contract(
+            self.endpoint_contract.transport,
             &self.client,
             openai_responses_url(&self.base_url),
             plan.body.clone(),
@@ -436,7 +495,8 @@ impl AgentProvider for OpenAiProvider {
                     self.refresh_auth_headers_after_failure(&error).await?
                 {
                     headers = refreshed_headers;
-                    send_openai_responses_request(
+                    send_openai_responses_for_contract(
+                        self.endpoint_contract.transport,
                         &self.client,
                         openai_responses_url(&self.base_url),
                         plan.body.clone(),
@@ -450,26 +510,38 @@ impl AgentProvider for OpenAiProvider {
                 };
                 match retried {
                     Ok(parsed) => parsed,
-                    Err(error) => match retry_openai_responses_with_lossless_replay(
-                        &self.client,
-                        openai_responses_url(&self.base_url),
-                        &plan,
-                        headers.clone(),
-                        trace.as_ref(),
-                        request_agent_id(&request),
-                        error,
-                        &mut sent_diagnostics,
-                        &mut final_provider_input,
-                        &mut final_replay_loss_reason,
-                    )
-                    .await
+                    Err(error)
+                        if self.endpoint_contract.transport
+                            == OpenAiResponsesTransportContract::StandardJson =>
                     {
-                        Ok(parsed) => parsed,
-                        Err(error) => {
-                            invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
-                            return Err(error);
+                        match retry_openai_responses_with_lossless_replay(
+                            &self.client,
+                            openai_responses_url(&self.base_url),
+                            &plan,
+                            headers.clone(),
+                            trace.as_ref(),
+                            request_agent_id(&request),
+                            error,
+                            &mut sent_diagnostics,
+                            &mut final_provider_input,
+                            &mut final_replay_loss_reason,
+                        )
+                        .await
+                        {
+                            Ok(parsed) => parsed,
+                            Err(error) => {
+                                invalidate_openai_continuation(
+                                    &self.continuation,
+                                    plan.scope.as_ref(),
+                                );
+                                return Err(error);
+                            }
                         }
-                    },
+                    }
+                    Err(error) => {
+                        invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
+                        return Err(error);
+                    }
                 }
             }
         };
@@ -482,7 +554,10 @@ impl AgentProvider for OpenAiProvider {
             final_replay_loss_reason,
             &parsed,
         );
-        if sent_diagnostics.openai_remote_compaction.is_none() {
+        if self.endpoint_contract.remote_compaction
+            == OpenAiResponsesRemoteCompactionContract::Supported
+            && sent_diagnostics.openai_remote_compaction.is_none()
+        {
             sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
                 &self.continuation,
                 plan_scope.as_ref(),

--- a/src/provider/transports/openai/responses/parse.rs
+++ b/src/provider/transports/openai/responses/parse.rs
@@ -415,6 +415,22 @@ pub(in super::super) fn parse_openai_response_with_transport_state(
                     kind: ModelToolCallKind::Function,
                 });
             }
+            Some("reasoning") => {
+                saw_nonempty_wire_item = true;
+                if let Some(content) = item.get("content").and_then(Value::as_array) {
+                    for content_item in content {
+                        if content_item.get("type").and_then(Value::as_str)
+                            == Some("reasoning_text")
+                        {
+                            if let Some(text) = content_item.get("text").and_then(Value::as_str) {
+                                blocks.push(ModelBlock::ReasoningText {
+                                    text: text.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
             Some("custom_tool_call") => {
                 saw_nonempty_wire_item = true;
                 let id = item

--- a/src/provider/transports/openai/responses/plan.rs
+++ b/src/provider/transports/openai/responses/plan.rs
@@ -77,6 +77,13 @@ pub(crate) fn build_openai_responses_request(
                 body["include"] = Value::Array(Vec::new());
             }
         }
+        OpenAiResponsesTransportContract::DeepSeekStreaming => {
+            body["stream"] = Value::Bool(true);
+            body["max_output_tokens"] = Value::from(max_output_tokens);
+            body.as_object_mut()
+                .expect("OpenAI Responses request body should be an object")
+                .remove("prompt_cache_key");
+        }
     }
     Ok(body)
 }
@@ -441,6 +448,16 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
                                     "input": openai_custom_tool_input(input)?,
                                 })),
                             }
+                        }
+                        ModelBlock::ReasoningText { text } => {
+                            flush_assistant_text(&mut items, &mut pending_text);
+                            items.push(json!({
+                                "type": "reasoning",
+                                "content": [{
+                                    "type": "reasoning_text",
+                                    "text": text,
+                                }],
+                            }));
                         }
                         ModelBlock::Thinking { .. }
                         | ModelBlock::RedactedThinking { .. }

--- a/src/runtime/subagent.rs
+++ b/src/runtime/subagent.rs
@@ -329,6 +329,7 @@ impl RuntimeHandle {
                     ModelBlock::Text { text } => Some(text),
                     ModelBlock::ToolUse { .. } => None,
                     ModelBlock::Thinking { .. }
+                    | ModelBlock::ReasoningText { .. }
                     | ModelBlock::RedactedThinking { .. }
                     | ModelBlock::Citations { .. } => None,
                 })

--- a/src/runtime/turn/completion.rs
+++ b/src/runtime/turn/completion.rs
@@ -172,7 +172,9 @@ pub(super) fn completion_report_texts_by_tool_id(
                     }
                 }
             }
-            ModelBlock::Thinking { .. } | ModelBlock::RedactedThinking { .. } => {}
+            ModelBlock::Thinking { .. }
+            | ModelBlock::ReasoningText { .. }
+            | ModelBlock::RedactedThinking { .. } => {}
         }
     }
     reports

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1608,7 +1608,9 @@ impl TurnExecution<'_> {
                     ModelBlock::Citations { citations } => {
                         extend_unique_citations(&mut citation_blocks, citations.iter().cloned());
                     }
-                    ModelBlock::Thinking { .. } | ModelBlock::RedactedThinking { .. } => {
+                    ModelBlock::Thinking { .. }
+                    | ModelBlock::ReasoningText { .. }
+                    | ModelBlock::RedactedThinking { .. } => {
                         thinking_block_count += 1;
                     }
                 }

--- a/src/runtime/turn/projection.rs
+++ b/src/runtime/turn/projection.rs
@@ -76,6 +76,7 @@ pub(super) fn estimate_model_block_tokens(block: &ModelBlock) -> usize {
             id, name, input, ..
         } => estimate_text_tokens(id) + estimate_text_tokens(name) + estimate_json_tokens(input),
         ModelBlock::Thinking { text, .. } => estimate_text_tokens(text),
+        ModelBlock::ReasoningText { text } => estimate_text_tokens(text),
         ModelBlock::RedactedThinking { data } => estimate_text_tokens(data),
         ModelBlock::Citations { citations } => citations
             .iter()

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -158,6 +158,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
             ModelBlock::Text { text } => Some(text.as_str()),
             ModelBlock::ToolUse { .. } => None,
             ModelBlock::Thinking { .. }
+            | ModelBlock::ReasoningText { .. }
             | ModelBlock::RedactedThinking { .. }
             | ModelBlock::Citations { .. } => None,
         })

--- a/tests/live_llm_baseline.rs
+++ b/tests/live_llm_baseline.rs
@@ -40,6 +40,7 @@ fn response_text(blocks: &[ModelBlock]) -> String {
             ModelBlock::Text { text } => Some(text.as_str()),
             ModelBlock::ToolUse { .. }
             | ModelBlock::Thinking { .. }
+            | ModelBlock::ReasoningText { .. }
             | ModelBlock::RedactedThinking { .. }
             | ModelBlock::Citations { .. } => None,
         })

--- a/tests/support/runtime_helpers.rs
+++ b/tests/support/runtime_helpers.rs
@@ -252,6 +252,7 @@ pub fn compact_request_snapshot(
                         ModelBlock::Text { text } => Some(text.clone()),
                         ModelBlock::ToolUse { .. } => None,
                         ModelBlock::Thinking { .. }
+                        | ModelBlock::ReasoningText { .. }
                         | ModelBlock::RedactedThinking { .. }
                         | ModelBlock::Citations { .. } => None,
                     })


### PR DESCRIPTION
## 概要

- 新增 opt-in canonical route `deepseek@responses`，保持 `deepseek@default` 不变
- 为 Responses transport 引入显式 endpoint dialect，使 DeepSeek 使用 streaming + full-history replay，并禁用 continuation/remote compaction
- 新增 durable `ModelBlock::ReasoningText`，支持 reasoning 跨轮与 provider restart 持久化，但不投影为用户可见 assistant text
- 补齐 route、reasoning 可见性、tool continuation、streaming full-history 与 provider restart contract tests
- 记录 endpoint dialect 实现决策

## 验证

- `cargo test --lib`（2712 passed, 0 failed, 1 ignored）
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2568