### PR TITLE
feat: complete DeepSeek effort, native tools, and provider-aware diagnostics

### DIFF
--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1252,8 +1252,17 @@ pub(crate) fn bigmodel_builtin_web_search_config() -> ProviderBuiltinWebSearchCo
 pub(crate) fn deepseek_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
     ProviderBuiltinWebSearchConfig {
         enabled: true,
-        kind: ProviderNativeWebSearchKind::Anthropic,
+        kind: ProviderNativeWebSearchKind::DeepSeek,
         advertised_tool_type: "web_search_20250305".to_string(),
+        backend_kind: "deepseek_web_search".to_string(),
+    }
+}
+
+pub(crate) fn deepseek_responses_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::DeepSeek,
+        advertised_tool_type: "web_search".to_string(),
         backend_kind: "deepseek_web_search".to_string(),
     }
 }
@@ -1416,6 +1425,29 @@ pub(crate) fn validate_provider_builtin_web_search(
             } else {
                 Err(anyhow!(
                     "providers.{}.builtin_web_search.advertised_tool_type must be web_search_20250305 for Anthropic Messages native search",
+                    provider_id.as_str()
+                ))
+            }
+        }
+        (ProviderTransportKind::AnthropicMessages, ProviderNativeWebSearchKind::DeepSeek) => {
+            if search.advertised_tool_type == "web_search_20250305" {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search_20250305 for DeepSeek Anthropic-compatible native search",
+                    provider_id.as_str()
+                ))
+            }
+        }
+        (ProviderTransportKind::OpenAiResponses, ProviderNativeWebSearchKind::DeepSeek) => {
+            if matches!(
+                search.advertised_tool_type.as_str(),
+                "web_search" | "web_search_2025_08_26"
+            ) {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search or web_search_2025_08_26 for DeepSeek Responses native search",
                     provider_id.as_str()
                 ))
             }

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -358,7 +358,7 @@ impl ResolvedModelRoute {
         &self,
         value: &str,
     ) -> Result<(), ReasoningEffortValidationError> {
-        if self.provider_config().transport == ProviderTransportKind::OpenAiCodexResponses {
+        if !self.policy.reasoning_effort_options.is_empty() {
             return self.policy.validate_reasoning_effort(value);
         }
 
@@ -864,7 +864,9 @@ fn deepseek_responses_runtime_config(default: &ProviderRuntimeConfig) -> Provide
         originator: None,
         reasoning_effort: default.reasoning_effort.clone(),
         context_management: Default::default(),
-        builtin_web_search: None,
+        builtin_web_search: Some(
+            super::builtin_providers::deepseek_responses_builtin_web_search_config(),
+        ),
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1038,7 +1038,7 @@ fn built_in_provider_registry_declares_provider_specific_builtin_search() {
         .get(&ProviderId::parse("deepseek").unwrap())
         .unwrap();
     let deepseek_search = deepseek.builtin_web_search.as_ref().unwrap();
-    assert_eq!(deepseek_search.kind, ProviderNativeWebSearchKind::Anthropic);
+    assert_eq!(deepseek_search.kind, ProviderNativeWebSearchKind::DeepSeek);
     assert_eq!(deepseek_search.advertised_tool_type, "web_search_20250305");
     assert_eq!(deepseek_search.backend_kind, "deepseek_web_search");
 
@@ -2938,11 +2938,14 @@ fn runtime_model_catalog_exposes_deepseek_responses_without_changing_default_rou
         responses_route.endpoint.runtime_config.base_url,
         "https://api.deepseek.com/v1"
     );
-    assert!(responses_route
+    let responses_search = responses_route
         .endpoint
         .runtime_config
         .builtin_web_search
-        .is_none());
+        .as_ref()
+        .expect("DeepSeek Responses should advertise native web search");
+    assert_eq!(responses_search.kind, ProviderNativeWebSearchKind::DeepSeek);
+    assert_eq!(responses_search.advertised_tool_type, "web_search");
 
     assert_eq!(
         ModelRouteRef::parse_compatible("deepseek/deepseek-v4-pro")

--- a/src/host.rs
+++ b/src/host.rs
@@ -1982,8 +1982,7 @@ impl RuntimeHost {
             .clone()
             .map(Ok)
             .unwrap_or_else(|| build_provider_from_config(&config))?;
-        let apply_patch_surface =
-            ApplyPatchSurface::for_model_ref(&model_ref.model_ref().as_string());
+        let apply_patch_surface = ApplyPatchSurface::for_model_route_ref(&model_ref.as_string());
         let registry = ToolRegistry::new(execution.execution_root.clone());
         let available_tools = registry
             .tool_specs_with_families_for_apply_patch_surface(apply_patch_surface)?

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1629,6 +1629,10 @@ fn reasoning_effort_options(
         }
         ("openai-codex", "gpt-5.6-luna") => &["low", "medium", "high", "xhigh", "max"][..],
         ("openai", _) | ("openai-codex", _) => &["low", "medium", "high", "xhigh"][..],
+        ("deepseek", _) if endpoint.is_some_and(|endpoint| endpoint.as_str() == "responses") => {
+            &["none", "minimal", "low", "medium", "high", "xhigh", "max"][..]
+        }
+        ("deepseek", _) => &["low", "high", "max"][..],
         ("xai", "grok-4.3") => &["none", "low", "medium", "high"][..],
         ("xai", "grok-4.5") => &["low", "medium", "high"][..],
         ("stepfun", "step-3.7-flash") => &["low", "medium", "high"][..],
@@ -1967,19 +1971,34 @@ mod tests {
             assert_eq!(metadata.max_output_tokens_upper_limit, Some(384_000));
             assert!(metadata.capabilities.supports_reasoning);
             assert!(!metadata.capabilities.image_input);
-            assert!(reasoning_effort_options(
-                &metadata.model_ref,
-                metadata.endpoint.as_ref(),
-                &metadata.capabilities,
-            )
-            .is_empty());
-            assert!(catalog
-                .get_route(&ModelRouteRef::new(
-                    provider_id("deepseek"),
-                    ProviderEndpointId::parse("responses").unwrap(),
-                    model,
-                ))
-                .is_some());
+            assert_eq!(
+                reasoning_effort_options(
+                    &metadata.model_ref,
+                    metadata.endpoint.as_ref(),
+                    &metadata.capabilities,
+                ),
+                ["low", "high", "max"]
+            );
+            let responses_route = ModelRouteRef::new(
+                provider_id("deepseek"),
+                ProviderEndpointId::parse("responses").unwrap(),
+                model,
+            );
+            catalog
+                .get_route(&responses_route)
+                .unwrap_or_else(|| panic!("{model}@responses should be registered"));
+            let responses_policy = catalog.resolve_route_policy(
+                &responses_route,
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+                &base_context(),
+                8192,
+            );
+            assert_eq!(
+                responses_policy.reasoning_effort_options,
+                ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            );
             assert_eq!(
                 catalog
                     .preferred_route_for_model(&metadata.model_ref)

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -187,6 +187,18 @@ pub struct ProviderCacheUsage {
 pub struct ProviderRequestDiagnostics {
     pub request_lowering_mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_model_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_transport: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_dialect: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub streaming: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic_cache: Option<AnthropicPromptCacheDiagnostics>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic_context_management: Option<serde_json::Value>,
@@ -207,6 +219,7 @@ pub struct ProviderRequestDiagnostics {
 pub enum ProviderNativeWebSearchKind {
     OpenAi,
     Anthropic,
+    DeepSeek,
     Gemini,
     Xai,
 }

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -498,6 +498,7 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
     provider_config.transport = ProviderTransportKind::OpenAiResponses;
     provider_config.base_url = base_url;
     provider_config.builtin_web_search = None;
+    provider_config.reasoning_effort = Some("high".into());
 
     let first_provider = OpenAiProvider::from_runtime_config_with_compaction_policy(
         &provider_config,
@@ -509,10 +510,16 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
         },
     )
     .unwrap();
-    let first = first_provider
-        .complete_turn(provider_turn_request_with_prompt_frame())
-        .await
-        .unwrap();
+    let mut first_request = provider_turn_request_with_prompt_frame();
+    first_request.native_web_search = Some(ProviderNativeWebSearchRequest {
+        kind: ProviderNativeWebSearchKind::DeepSeek,
+        provider_id: "deepseek".into(),
+        provider_model_ref: "deepseek@responses/deepseek-v4-pro".into(),
+        advertised_tool_type: "web_search".into(),
+        backend_kind: "deepseek_web_search".into(),
+        max_results: None,
+    });
+    let first = first_provider.complete_turn(first_request).await.unwrap();
     assert!(matches!(
         &first.blocks[0],
         ModelBlock::ReasoningText { text } if text == "inspect the workspace first"
@@ -521,6 +528,29 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
         &first.blocks[1],
         ModelBlock::ToolUse { id, name, .. } if id == "exec-1" && name == "ExecCommand"
     ));
+    let diagnostics = first
+        .request_diagnostics
+        .as_ref()
+        .expect("DeepSeek request diagnostics");
+    assert_eq!(diagnostics.provider_id.as_deref(), Some("deepseek"));
+    assert_eq!(
+        diagnostics.provider_model_ref.as_deref(),
+        Some("deepseek@responses/deepseek-v4-pro")
+    );
+    assert_eq!(
+        diagnostics.provider_transport.as_deref(),
+        Some("openai_responses")
+    );
+    assert_eq!(diagnostics.endpoint_dialect.as_deref(), Some("responses"));
+    assert_eq!(diagnostics.streaming, Some(true));
+    assert_eq!(diagnostics.reasoning_effort.as_deref(), Some("high"));
+    assert_eq!(
+        diagnostics
+            .native_web_search
+            .as_ref()
+            .map(|search| search.lowered),
+        Some(true)
+    );
 
     let persisted_blocks = serde_json::to_vec(&first.blocks).unwrap();
     drop(first_provider);
@@ -556,9 +586,15 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
     assert_eq!(bodies.len(), 2);
     for body in bodies.iter() {
         assert_eq!(body["stream"], json!(true));
+        assert_eq!(body["reasoning"], json!({ "effort": "high" }));
         assert!(body.get("previous_response_id").is_none());
         assert!(body.get("prompt_cache_key").is_none());
     }
+    assert!(bodies[0]["tools"]
+        .as_array()
+        .expect("DeepSeek tools")
+        .iter()
+        .any(|tool| tool == &json!({ "type": "web_search" })));
     let replayed = bodies[1]["input"].as_array().unwrap();
     assert!(replayed.iter().any(|item| {
         item["type"] == "reasoning"

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -1140,7 +1140,10 @@ async fn openai_provider_fails_fast_on_contract_errors() {
         .expect("status failures should carry transport diagnostics");
     assert_eq!(transport.stage, "response_status");
     assert_eq!(transport.provider.as_deref(), Some("openai"));
-    assert_eq!(transport.model_ref.as_deref(), Some("openai/gpt-5.4"));
+    assert_eq!(
+        transport.model_ref.as_deref(),
+        Some("openai@default/gpt-5.4")
+    );
     assert_eq!(transport.status, Some(400));
     assert_eq!(transport.reqwest, None);
     if let Some(http_trace) = transport.http_trace.as_ref() {
@@ -1445,7 +1448,7 @@ async fn anthropic_status_errors_preserve_transport_diagnostics() {
     assert_eq!(transport.provider.as_deref(), Some("anthropic"));
     assert_eq!(
         transport.model_ref.as_deref(),
-        Some("anthropic/claude-sonnet-4-6")
+        Some("anthropic@default/claude-sonnet-4-6")
     );
     assert_eq!(transport.status, Some(401));
     assert!(transport

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -474,6 +474,29 @@ fn openai_codex_request_uses_custom_codex_dsl_tool_shape_for_apply_patch() {
 }
 
 #[test]
+fn deepseek_responses_request_uses_custom_apply_patch_tool_shape() {
+    let apply_patch = apply_patch_tool::definition_for_surface(ApplyPatchSurface::CodexDslFreeform)
+        .unwrap()
+        .spec;
+    let request = provider_turn_request_with_tools(vec![apply_patch]);
+    let body = build_openai_responses_request(
+        "deepseek-v4-pro",
+        256,
+        &request,
+        OpenAiResponsesTransportContract::DeepSeekStreaming,
+        ToolSchemaContract::Relaxed,
+        Some("high"),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(body["tools"][0]["type"], "custom");
+    assert_eq!(body["tools"][0]["name"], "ApplyPatch");
+    assert_eq!(body["tools"][0]["format"]["type"], "grammar");
+    assert_eq!(body["reasoning"], json!({ "effort": "high" }));
+}
+
+#[test]
 fn built_in_tool_source_schemas_remain_valid() {
     for spec in trusted_tool_specs() {
         crate::tool::schema::validate_source_tool_schema(&spec.input_schema)

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -39,7 +39,8 @@ use crate::provider::retry::{
 #[derive(Clone)]
 pub struct AnthropicProvider {
     client: Client,
-    provider_id: String,
+    route_provider: String,
+    route_endpoint: String,
     base_url: String,
     auth_token: String,
     model: String,
@@ -59,6 +60,8 @@ struct MessagesRequest<'a> {
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<ThinkingRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_config: Option<OutputConfigRequest<'a>>,
     stream: bool,
     system: Value,
     messages: Vec<ApiMessage>,
@@ -80,6 +83,11 @@ struct ThinkingRequest {
     #[serde(rename = "type")]
     kind: &'static str,
     budget_tokens: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct OutputConfigRequest<'a> {
+    effort: &'a str,
 }
 
 #[derive(Debug, Serialize)]
@@ -186,7 +194,8 @@ impl AnthropicProvider {
             })?;
         Ok(Self {
             client,
-            provider_id: provider_config.id.as_str().to_string(),
+            route_provider: provider_config.route_provider.as_str().to_string(),
+            route_endpoint: provider_config.route_endpoint.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             auth_token,
             model: model.to_string(),
@@ -215,10 +224,10 @@ impl AnthropicProvider {
 /// The budget is computed as a percentage of `max_output_tokens`, clamped to
 /// the Anthropic minimum of 1024 and capped at `max_output_tokens - 1`.
 fn reasoning_effort_to_thinking(
-    reasoning_effort: &Option<String>,
+    reasoning_effort: Option<&str>,
     max_output_tokens: u32,
 ) -> Option<ThinkingRequest> {
-    let effort = reasoning_effort.as_ref()?;
+    let effort = reasoning_effort?;
     let ratio: f64 = match effort.to_ascii_lowercase().as_str() {
         "low" => 0.10,
         "medium" => 0.25,
@@ -240,6 +249,26 @@ fn reasoning_effort_to_thinking(
     })
 }
 
+fn anthropic_reasoning_controls<'a>(
+    route_provider: &str,
+    supports_reasoning: bool,
+    reasoning_effort: Option<&'a str>,
+    max_output_tokens: u32,
+) -> (Option<ThinkingRequest>, Option<OutputConfigRequest<'a>>) {
+    if route_provider == "deepseek" {
+        return (
+            None,
+            reasoning_effort.map(|effort| OutputConfigRequest { effort }),
+        );
+    }
+    (
+        supports_reasoning
+            .then(|| reasoning_effort_to_thinking(reasoning_effort, max_output_tokens))
+            .flatten(),
+        None,
+    )
+}
+
 #[async_trait]
 impl AgentProvider for AnthropicProvider {
     async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
@@ -249,14 +278,17 @@ impl AgentProvider for AnthropicProvider {
             rolling_conversation_cache_marker(&wire_conversation, cache_strategy);
         let messages = build_anthropic_messages(&wire_conversation, rolling_cache_marker);
         let response_format_tool_choice = anthropic_response_format_tool_choice(&request);
+        let (thinking, output_config) = anthropic_reasoning_controls(
+            &self.route_provider,
+            self.supports_reasoning,
+            self.reasoning_effort.as_deref(),
+            self.max_output_tokens,
+        );
         let request_body = MessagesRequest {
             model: &self.model,
             max_tokens: self.max_output_tokens,
-            thinking: if self.supports_reasoning {
-                reasoning_effort_to_thinking(&self.reasoning_effort, self.max_output_tokens)
-            } else {
-                None
-            },
+            thinking,
+            output_config,
             stream: true,
             system: build_anthropic_system(&request, cache_strategy),
             messages,
@@ -271,7 +303,10 @@ impl AgentProvider for AnthropicProvider {
         let request_payload = serde_json::to_value(&request_body)?;
 
         let url = format!("{}/v1/messages", self.base_url);
-        let model_ref = format!("anthropic/{}", self.model);
+        let model_ref = format!(
+            "{}@{}/{}",
+            self.route_provider, self.route_endpoint, self.model
+        );
         let mut headers = vec![
             ("content-type", "application/json".to_string()),
             ("authorization", format!("Bearer {}", self.auth_token)),
@@ -297,7 +332,7 @@ impl AgentProvider for AnthropicProvider {
                     .cache
                     .as_ref()
                     .map(|cache| cache.agent_id.as_str()),
-                "anthropic",
+                &self.route_provider,
                 Some(&model_ref),
                 url.as_str(),
                 "messages",
@@ -318,7 +353,7 @@ impl AgentProvider for AnthropicProvider {
                 classify_reqwest_transport_error_with_trace(
                     "Anthropic request failed",
                     "request_send",
-                    "anthropic",
+                    &self.route_provider,
                     Some(&model_ref),
                     Some(url.as_str()),
                     error,
@@ -342,7 +377,7 @@ impl AgentProvider for AnthropicProvider {
             return Err(classify_status_error_with_trace(
                 "Anthropic request failed",
                 "response_status",
-                Some("anthropic"),
+                Some(&self.route_provider),
                 Some(&model_ref),
                 Some(url.as_str()),
                 status,
@@ -354,14 +389,21 @@ impl AgentProvider for AnthropicProvider {
         let parsed = if anthropic_response_is_sse(&response) {
             read_anthropic_streaming_response(
                 response,
+                &self.route_provider,
                 &model_ref,
                 url.as_str(),
                 request_trace.as_ref(),
             )
             .await?
         } else {
-            read_anthropic_json_response(response, &model_ref, url.as_str(), request_trace.as_ref())
-                .await?
+            read_anthropic_json_response(
+                response,
+                &self.route_provider,
+                &model_ref,
+                url.as_str(),
+                request_trace.as_ref(),
+            )
+            .await?
         };
         anthropic_messages_response_to_turn_response(
             parsed,
@@ -370,7 +412,7 @@ impl AgentProvider for AnthropicProvider {
             &wire_conversation,
             rolling_cache_marker,
             &request_payload,
-            self.provider_id.as_str(),
+            self.route_provider.as_str(),
             self.model.as_str(),
             cache_strategy,
             &self.context_management.betas,
@@ -382,7 +424,10 @@ impl AgentProvider for AnthropicProvider {
 
     #[cfg(test)]
     fn configured_model_refs(&self) -> Vec<String> {
-        vec![format!("anthropic/{}", self.model)]
+        vec![format!(
+            "{}@{}/{}",
+            self.route_provider, self.route_endpoint, self.model
+        )]
     }
 
     fn prompt_capabilities(&self) -> Vec<ProviderPromptCapability> {
@@ -400,8 +445,11 @@ impl AgentProvider for AnthropicProvider {
         let config = self.builtin_web_search.as_ref()?;
         Some(ProviderBuiltinWebSearchCapability {
             kind: config.kind,
-            provider_id: self.provider_id.clone(),
-            provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            provider_id: self.route_provider.clone(),
+            provider_model_ref: format!(
+                "{}@{}/{}",
+                self.route_provider, self.route_endpoint, self.model
+            ),
             provider_transport: "anthropic_messages".into(),
             provider_base_url: self.base_url.clone(),
             advertised_tool_type: config.advertised_tool_type.clone(),
@@ -422,7 +470,7 @@ impl AgentProvider for AnthropicProvider {
         self.context_management
             .enabled
             .then(|| ProviderContextManagementPolicy {
-                provider: "anthropic".to_string(),
+                provider: self.route_provider.clone(),
                 strategy: "clear_tool_uses_20250919".to_string(),
                 keep_recent_tool_uses: self.context_management.keep_recent_tool_uses as usize,
                 trigger_input_tokens: self.context_management.trigger_input_tokens,
@@ -451,6 +499,7 @@ fn anthropic_response_is_sse(response: &Response) -> bool {
 
 async fn read_anthropic_json_response(
     response: Response,
+    provider: &str,
     model_ref: &str,
     url: &str,
     trace: Option<&ProviderHttpTraceRequest>,
@@ -461,7 +510,7 @@ async fn read_anthropic_json_response(
             return Err(classify_reqwest_transport_error_with_trace(
                 "Anthropic response body failed",
                 "response_body",
-                "anthropic",
+                provider,
                 Some(model_ref),
                 Some(url),
                 error,
@@ -472,7 +521,7 @@ async fn read_anthropic_json_response(
             return Err(timeout_transport_error_with_trace(
                 "Anthropic response body read timed out",
                 "response_body",
-                "anthropic",
+                provider,
                 Some(model_ref),
                 Some(url),
                 format!("timed out after {:?}", response_body_timeout()),
@@ -487,7 +536,7 @@ async fn read_anthropic_json_response(
         invalid_response_error_with_trace(
             "invalid Anthropic JSON",
             "response_parse",
-            "anthropic",
+            provider,
             Some(model_ref),
             Some(url),
             error.to_string(),
@@ -498,6 +547,7 @@ async fn read_anthropic_json_response(
 
 async fn read_anthropic_streaming_response(
     mut response: Response,
+    provider: &str,
     model_ref: &str,
     url: &str,
     trace: Option<&ProviderHttpTraceRequest>,
@@ -513,7 +563,7 @@ async fn read_anthropic_streaming_response(
                 timeout_transport_error_with_trace(
                     "Anthropic streaming response timed out",
                     "streaming_response_body",
-                    "anthropic",
+                    provider,
                     Some(model_ref),
                     Some(url),
                     format!(
@@ -533,7 +583,7 @@ async fn read_anthropic_streaming_response(
                     invalid_response_error_with_trace(
                         "invalid Anthropic stream event",
                         "streaming_response_parse",
-                        "anthropic",
+                        provider,
                         Some(model_ref),
                         Some(url),
                         error,
@@ -547,7 +597,7 @@ async fn read_anthropic_streaming_response(
                 return Err(classify_reqwest_transport_error_with_trace(
                     "Anthropic streaming response body failed",
                     "streaming_response_body",
-                    "anthropic",
+                    provider,
                     Some(model_ref),
                     Some(url),
                     error,
@@ -562,7 +612,7 @@ async fn read_anthropic_streaming_response(
         invalid_response_error_with_trace(
             "invalid Anthropic stream event",
             "streaming_response_parse",
-            "anthropic",
+            provider,
             Some(model_ref),
             Some(url),
             error,
@@ -571,7 +621,7 @@ async fn read_anthropic_streaming_response(
     })? {
         accumulator.apply(event, model_ref, url, trace)?;
     }
-    let response = accumulator.finish(model_ref, url, trace)?;
+    let response = accumulator.finish(provider, model_ref, url, trace)?;
     if let Some(trace) = trace {
         trace.write_stream_terminal(&serde_json::to_value(&response).unwrap_or_else(|_| json!({})));
     }
@@ -611,7 +661,7 @@ fn anthropic_messages_response_to_turn_response(
         return Err(empty_response_error_with_trace(
             "empty Anthropic response",
             "response_protocol",
-            "anthropic",
+            provider_id,
             Some(model_ref),
             Some(url),
             "Anthropic response contained no content blocks",
@@ -645,7 +695,7 @@ fn anthropic_messages_response_to_turn_response(
         return Err(invalid_response_error_with_trace(
             "invalid Anthropic tool response",
             "response_protocol",
-            "anthropic",
+            provider_id,
             Some(model_ref),
             Some(url),
             "stop_reason=tool_use without native tool_use block; text block contains tool-call-looking markup",
@@ -664,7 +714,7 @@ fn anthropic_messages_response_to_turn_response(
         return Err(invalid_response_error_with_trace(
             "invalid Anthropic response",
             "response_protocol",
-            "anthropic",
+            provider_id,
             Some(model_ref),
             Some(url),
             "Anthropic response contained no supported content blocks",
@@ -693,6 +743,16 @@ fn anthropic_messages_response_to_turn_response(
         provider_request_id,
         request_diagnostics: Some(crate::provider::ProviderRequestDiagnostics {
             request_lowering_mode: request_lowering_mode.to_string(),
+            provider_id: Some(provider_id.to_string()),
+            provider_model_ref: Some(model_ref.to_string()),
+            provider_transport: Some("anthropic_messages".to_string()),
+            endpoint_dialect: Some("anthropic_messages".to_string()),
+            streaming: Some(true),
+            reasoning_effort: request_payload
+                .pointer("/output_config/effort")
+                .or_else(|| request_payload.pointer("/thinking/type"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
             anthropic_cache: Some(cache_diagnostics),
             anthropic_context_management: parsed.context_management,
             openai_request_controls: None,
@@ -942,6 +1002,7 @@ impl AnthropicStreamAccumulator {
 
     fn finish(
         mut self,
+        provider: &str,
         model_ref: &str,
         url: &str,
         trace: Option<&ProviderHttpTraceRequest>,
@@ -950,7 +1011,7 @@ impl AnthropicStreamAccumulator {
             return Err(invalid_response_error_with_trace(
                 "invalid Anthropic stream",
                 "streaming_response_protocol",
-                "anthropic",
+                provider,
                 Some(model_ref),
                 Some(url),
                 "stream completed without message_start",
@@ -961,7 +1022,7 @@ impl AnthropicStreamAccumulator {
             return Err(invalid_response_error_with_trace(
                 "invalid Anthropic stream",
                 "streaming_response_protocol",
-                "anthropic",
+                provider,
                 Some(model_ref),
                 Some(url),
                 "stream completed without message_stop",
@@ -1251,7 +1312,7 @@ fn build_anthropic_tools(request: &ProviderTurnRequest) -> Vec<Value> {
         .collect::<Vec<_>>();
     if matches!(
         request.native_web_search.as_ref().map(|native| native.kind),
-        Some(ProviderNativeWebSearchKind::Anthropic)
+        Some(ProviderNativeWebSearchKind::Anthropic | ProviderNativeWebSearchKind::DeepSeek)
     ) {
         tools.push(json!({
             "type": request
@@ -1301,7 +1362,10 @@ fn native_web_search_diagnostics(
     request: &ProviderTurnRequest,
 ) -> Option<ProviderNativeWebSearchDiagnostics> {
     let native = request.native_web_search.as_ref()?;
-    let lowered = native.kind == ProviderNativeWebSearchKind::Anthropic;
+    let lowered = matches!(
+        native.kind,
+        ProviderNativeWebSearchKind::Anthropic | ProviderNativeWebSearchKind::DeepSeek
+    );
     Some(ProviderNativeWebSearchDiagnostics {
         kind: native.kind,
         provider_id: native.provider_id.clone(),
@@ -1309,8 +1373,9 @@ fn native_web_search_diagnostics(
         advertised_tool_type: native.advertised_tool_type.clone(),
         backend_kind: native.backend_kind.clone(),
         lowered,
-        fallback_reason: (!lowered)
-            .then(|| "anthropic transport only supports Anthropic-native web search".into()),
+        fallback_reason: (!lowered).then(|| {
+            "anthropic transport only supports Anthropic/DeepSeek-native web search".into()
+        }),
     })
 }
 
@@ -2830,6 +2895,7 @@ mod tests {
             model: "claude-sonnet-4-6",
             max_tokens: 4096,
             thinking: None,
+            output_config: None,
             stream: true,
             system: if request.prompt_frame.has_structured_system_blocks() {
                 Value::Array(
@@ -2867,6 +2933,31 @@ mod tests {
             provider_model_ref: "anthropic/claude-test".into(),
             advertised_tool_type: "web_search_20250305".into(),
             backend_kind: "anthropic_web_search".into(),
+            max_results: None,
+        });
+
+        let payload = anthropic_request_payload_for_test(&request);
+
+        assert!(payload["tools"]
+            .as_array()
+            .expect("tools should be an array")
+            .iter()
+            .any(|tool| tool == &json!({ "type": "web_search_20250305", "name": "web_search" })));
+    }
+
+    #[test]
+    fn deepseek_anthropic_request_payload_lowers_native_web_search_tool() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("search the web".into())],
+            vec![],
+        );
+        request.native_web_search = Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::DeepSeek,
+            provider_id: "deepseek".into(),
+            provider_model_ref: "deepseek@default/deepseek-v4-pro".into(),
+            advertised_tool_type: "web_search_20250305".into(),
+            backend_kind: "deepseek_web_search".into(),
             max_results: None,
         });
 
@@ -2929,7 +3020,12 @@ mod tests {
         }
 
         let response = accumulator
-            .finish("anthropic/claude-test", "https://example.test", None)
+            .finish(
+                "anthropic",
+                "anthropic/claude-test",
+                "https://example.test",
+                None,
+            )
             .expect("stream should finish");
 
         assert_eq!(response.stop_reason.as_deref(), Some("tool_use"));
@@ -2972,7 +3068,12 @@ mod tests {
                 .expect("event should accumulate");
         }
         let parsed = accumulator
-            .finish("anthropic/claude-test", "https://example.test", None)
+            .finish(
+                "anthropic",
+                "anthropic/claude-test",
+                "https://example.test",
+                None,
+            )
             .expect("stream should finish");
         let request = ProviderTurnRequest::plain("system", Vec::new(), Vec::new());
         let error = anthropic_messages_response_to_turn_response(
@@ -3361,52 +3462,52 @@ mod tests {
 
     #[test]
     fn reasoning_effort_to_thinking_none_when_absent() {
-        assert!(reasoning_effort_to_thinking(&None, 16384).is_none());
+        assert!(reasoning_effort_to_thinking(None, 16384).is_none());
     }
 
     #[test]
     fn reasoning_effort_to_thinking_maps_levels() {
         // low = 10% of 16384 = ~1638, clamped to min 1024
-        let low = reasoning_effort_to_thinking(&Some("low".into()), 16384).unwrap();
+        let low = reasoning_effort_to_thinking(Some("low"), 16384).unwrap();
         assert_eq!(low.kind, "enabled");
         assert_eq!(low.budget_tokens, 1638);
 
         // medium = 25% of 16384 = ~4096
-        let medium = reasoning_effort_to_thinking(&Some("medium".into()), 16384).unwrap();
+        let medium = reasoning_effort_to_thinking(Some("medium"), 16384).unwrap();
         assert_eq!(medium.budget_tokens, 4096);
 
         // high = 50% of 16384 = ~8192
-        let high = reasoning_effort_to_thinking(&Some("high".into()), 16384).unwrap();
+        let high = reasoning_effort_to_thinking(Some("high"), 16384).unwrap();
         assert_eq!(high.budget_tokens, 8192);
 
         // xhigh = 80% of 16384 = ~13107
-        let xhigh = reasoning_effort_to_thinking(&Some("xhigh".into()), 16384).unwrap();
+        let xhigh = reasoning_effort_to_thinking(Some("xhigh"), 16384).unwrap();
         assert_eq!(xhigh.budget_tokens, 13107);
     }
 
     #[test]
     fn reasoning_effort_to_thinking_case_insensitive() {
-        let result = reasoning_effort_to_thinking(&Some("HIGH".into()), 16384).unwrap();
+        let result = reasoning_effort_to_thinking(Some("HIGH"), 16384).unwrap();
         assert_eq!(result.budget_tokens, 8192);
     }
 
     #[test]
     fn reasoning_effort_to_thinking_unknown_defaults_medium() {
-        let result = reasoning_effort_to_thinking(&Some("bogus".into()), 16384).unwrap();
+        let result = reasoning_effort_to_thinking(Some("bogus"), 16384).unwrap();
         assert_eq!(result.budget_tokens, 4096); // 25% = medium
     }
 
     #[test]
     fn reasoning_effort_to_thinking_clamps_to_min_1024() {
         // 10% of 4096 = ~410, should be clamped to 1024
-        let result = reasoning_effort_to_thinking(&Some("low".into()), 4096).unwrap();
+        let result = reasoning_effort_to_thinking(Some("low"), 4096).unwrap();
         assert_eq!(result.budget_tokens, 1024);
     }
 
     #[test]
     fn reasoning_effort_to_thinking_capped_below_max_tokens() {
         // budget must be <= max_output_tokens - 1
-        let result = reasoning_effort_to_thinking(&Some("xhigh".into()), 2048).unwrap();
+        let result = reasoning_effort_to_thinking(Some("xhigh"), 2048).unwrap();
         assert!(result.budget_tokens <= 2047);
         assert_eq!(result.budget_tokens, 1638); // 80% of 2048
     }
@@ -3414,7 +3515,27 @@ mod tests {
     #[test]
     fn reasoning_effort_to_thinking_skips_when_too_small() {
         // max_output_tokens = 1024 → max_tokens - 1 = 1023 < 1024 min → skip
-        assert!(reasoning_effort_to_thinking(&Some("high".into()), 1024).is_none());
+        assert!(reasoning_effort_to_thinking(Some("high"), 1024).is_none());
+    }
+
+    #[test]
+    fn deepseek_anthropic_reasoning_uses_output_config_effort_only() {
+        let (thinking, output_config) =
+            anthropic_reasoning_controls("deepseek", true, Some("high"), 16384);
+        assert!(thinking.is_none());
+        assert_eq!(
+            serde_json::to_value(output_config).unwrap(),
+            json!({ "effort": "high" })
+        );
+
+        let (thinking, output_config) = anthropic_reasoning_controls("deepseek", true, None, 16384);
+        assert!(thinking.is_none());
+        assert!(output_config.is_none());
+
+        let (thinking, output_config) =
+            anthropic_reasoning_controls("anthropic", true, Some("high"), 16384);
+        assert_eq!(thinking.unwrap().budget_tokens, 8192);
+        assert!(output_config.is_none());
     }
 
     #[test]

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -427,6 +427,12 @@ fn gemini_response_to_provider_turn_response(
         provider_request_id: None,
         request_diagnostics: Some(ProviderRequestDiagnostics {
             request_lowering_mode: "gemini_generate_content".to_string(),
+            provider_id: Some("gemini".to_string()),
+            provider_model_ref: None,
+            provider_transport: Some("gemini_generate_content".to_string()),
+            endpoint_dialect: Some("gemini".to_string()),
+            streaming: Some(false),
+            reasoning_effort: None,
             anthropic_cache: None,
             anthropic_context_management: None,
             openai_request_controls: None,

--- a/src/provider/transports/openai/continuation.rs
+++ b/src/provider/transports/openai/continuation.rs
@@ -112,6 +112,12 @@ pub(super) fn incremental_diagnostics(
     let mismatch = mismatch.unwrap_or_default();
     ProviderRequestDiagnostics {
         request_lowering_mode: request_lowering_mode.into(),
+        provider_id: None,
+        provider_model_ref: None,
+        provider_transport: None,
+        endpoint_dialect: None,
+        streaming: None,
+        reasoning_effort: None,
         anthropic_cache: None,
         anthropic_context_management: None,
         openai_request_controls,

--- a/src/provider/transports/openai/images.rs
+++ b/src/provider/transports/openai/images.rs
@@ -254,8 +254,17 @@ pub(super) async fn send_openai_codex_image_generation_request(
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Result<Vec<ProviderGeneratedImage>> {
-    let terminal_response =
-        send_openai_responses_streaming_request(client, url, body, headers, trace, agent_id)
-            .await?;
+    let model_ref = provider_model_ref("openai-codex", &body);
+    let terminal_response = send_openai_responses_streaming_request(
+        client,
+        url,
+        body,
+        headers,
+        trace,
+        agent_id,
+        "openai-codex",
+        &model_ref,
+    )
+    .await?;
     parse_openai_codex_image_generation_response_items(terminal_response.output_items)
 }

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -113,6 +113,8 @@ use http::{
 pub struct OpenAiProvider {
     client: Client,
     provider_id: String,
+    route_provider: String,
+    route_endpoint: String,
     base_url: String,
     auth: OpenAiBearerAuth,
     model: String,
@@ -244,15 +246,22 @@ async fn send_openai_responses_for_contract(
     headers: Vec<(&str, String)>,
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
+    provider: &str,
+    model_ref: &str,
 ) -> Result<ParsedOpenAiResponse> {
     match contract {
         OpenAiResponsesTransportContract::StandardJson => {
-            send_openai_responses_request(client, url, body, headers, trace, agent_id).await
+            send_openai_responses_request(
+                client, url, body, headers, trace, agent_id, provider, model_ref,
+            )
+            .await
         }
         OpenAiResponsesTransportContract::CodexStreaming
         | OpenAiResponsesTransportContract::DeepSeekStreaming => {
-            send_openai_responses_streaming_request(client, url, body, headers, trace, agent_id)
-                .await
+            send_openai_responses_streaming_request(
+                client, url, body, headers, trace, agent_id, provider, model_ref,
+            )
+            .await
         }
     }
 }
@@ -313,6 +322,8 @@ impl OpenAiProvider {
         Ok(Self {
             client,
             provider_id: provider_config.id.as_str().to_string(),
+            route_provider: provider_config.route_provider.as_str().to_string(),
+            route_endpoint: provider_config.route_endpoint.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             auth,
             model: model.to_string(),
@@ -452,6 +463,18 @@ impl AgentProvider for OpenAiProvider {
             self.endpoint_contract.continuation,
         )?;
         let mut sent_diagnostics = plan.diagnostics.clone();
+        let model_ref = format!(
+            "{}@{}/{}",
+            self.route_provider, self.route_endpoint, self.model
+        );
+        sent_diagnostics.provider_id = Some(self.route_provider.clone());
+        sent_diagnostics.provider_model_ref = Some(model_ref.clone());
+        sent_diagnostics.provider_transport = Some("openai_responses".into());
+        sent_diagnostics.endpoint_dialect = Some(self.route_endpoint.clone());
+        sent_diagnostics.streaming = Some(
+            self.endpoint_contract.transport != OpenAiResponsesTransportContract::StandardJson,
+        );
+        sent_diagnostics.reasoning_effort = self.reasoning_effort.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
         let mut headers = self.resolve_auth_headers().await?;
@@ -468,6 +491,8 @@ impl AgentProvider for OpenAiProvider {
                 headers.clone(),
                 trace.as_ref(),
                 request_agent_id(&request),
+                &self.route_provider,
+                &model_ref,
             )
             .await
             {
@@ -486,6 +511,8 @@ impl AgentProvider for OpenAiProvider {
             headers.clone(),
             trace.as_ref(),
             request_agent_id(&request),
+            &self.route_provider,
+            &model_ref,
         )
         .await
         {
@@ -503,6 +530,8 @@ impl AgentProvider for OpenAiProvider {
                         headers.clone(),
                         trace.as_ref(),
                         request_agent_id(&request),
+                        &self.route_provider,
+                        &model_ref,
                     )
                     .await
                 } else {
@@ -525,6 +554,8 @@ impl AgentProvider for OpenAiProvider {
                             &mut sent_diagnostics,
                             &mut final_provider_input,
                             &mut final_replay_loss_reason,
+                            &self.route_provider,
+                            &model_ref,
                         )
                         .await
                         {
@@ -568,6 +599,8 @@ impl AgentProvider for OpenAiProvider {
                 headers,
                 trace.as_ref(),
                 request_agent_id(&request),
+                &self.route_provider,
+                &model_ref,
             )
             .await;
         }
@@ -663,6 +696,10 @@ impl AgentProvider for OpenAiProvider {
         )?;
         let mut headers = self.resolve_auth_headers().await?;
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        let model_ref = format!(
+            "{}@{}/{}",
+            self.route_provider, self.route_endpoint, self.model
+        );
         match send_openai_responses_request(
             &self.client,
             openai_responses_url(&self.base_url),
@@ -670,6 +707,8 @@ impl AgentProvider for OpenAiProvider {
             headers.clone(),
             trace.as_ref(),
             None,
+            &self.route_provider,
+            &model_ref,
         )
         .await
         {
@@ -688,6 +727,8 @@ impl AgentProvider for OpenAiProvider {
                     headers,
                     trace.as_ref(),
                     None,
+                    &self.route_provider,
+                    &model_ref,
                 )
                 .await?;
             }
@@ -764,6 +805,8 @@ impl AgentProvider for OpenAiCodexProvider {
             headers.clone(),
             trace.as_ref(),
             request_agent_id(&request),
+            "openai-codex",
+            &model_ref,
         )
         .await
         {
@@ -777,6 +820,8 @@ impl AgentProvider for OpenAiCodexProvider {
             headers.clone(),
             trace.as_ref(),
             request_agent_id(&request),
+            "openai-codex",
+            &model_ref,
         )
         .await
         {
@@ -807,6 +852,8 @@ impl AgentProvider for OpenAiCodexProvider {
                             headers.clone(),
                             trace.as_ref(),
                             request_agent_id(&request),
+                            "openai-codex",
+                            &model_ref,
                         )
                         .await
                         {
@@ -849,6 +896,8 @@ impl AgentProvider for OpenAiCodexProvider {
                 headers,
                 trace.as_ref(),
                 request_agent_id(&request),
+                "openai-codex",
+                &model_ref,
             )
             .await;
         }
@@ -996,6 +1045,7 @@ impl AgentProvider for OpenAiCodexProvider {
         )?;
         let headers = openai_codex_headers(&credential, &self.originator);
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        let model_ref = format!("openai-codex@default/{}", self.model);
         send_openai_responses_streaming_request(
             &self.client,
             openai_codex_responses_url(&self.base_url),
@@ -1003,6 +1053,8 @@ impl AgentProvider for OpenAiCodexProvider {
             headers,
             trace.as_ref(),
             None,
+            "openai-codex",
+            &model_ref,
         )
         .await?;
         Ok(())

--- a/src/provider/transports/openai/responses/compaction.rs
+++ b/src/provider/transports/openai/responses/compaction.rs
@@ -19,6 +19,8 @@ pub(in super::super) async fn maybe_compact_openai_provider_window(
     headers: Vec<(&str, String)>,
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
+    provider: &str,
+    model_ref: &str,
 ) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
     let Some(scope) = scope else {
         return None;
@@ -79,6 +81,8 @@ pub(in super::super) async fn maybe_compact_openai_provider_window(
         headers,
         trace,
         agent_id,
+        provider,
+        model_ref,
     )
     .await
     {
@@ -256,6 +260,8 @@ pub(in super::super) async fn maybe_compact_openai_request_plan(
     headers: Vec<(&str, String)>,
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
+    provider: &str,
+    model_ref: &str,
 ) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
     if plan.diagnostics.request_lowering_mode != "incremental_continuation" {
         return None;
@@ -331,6 +337,8 @@ pub(in super::super) async fn maybe_compact_openai_request_plan(
         headers,
         trace,
         agent_id,
+        provider,
+        model_ref,
     )
     .await
     {
@@ -800,13 +808,14 @@ pub(in super::super) async fn send_openai_compact_request(
     headers: Vec<(&str, String)>,
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
+    provider: &str,
+    model_ref: &str,
 ) -> Result<Vec<Value>> {
-    let model_ref = provider_model_ref("openai", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
-            "openai",
-            Some(&model_ref),
+            provider,
+            Some(model_ref),
             url.as_str(),
             OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND,
             &headers,
@@ -822,8 +831,8 @@ pub(in super::super) async fn send_openai_compact_request(
         request.json(&body),
         "OpenAI compact request failed",
         "request_send",
-        "openai",
-        Some(&model_ref),
+        provider,
+        Some(model_ref),
         Some(url.as_str()),
         true,
         request_trace.as_ref(),
@@ -845,8 +854,8 @@ pub(in super::super) async fn send_openai_compact_request(
         return Err(classify_status_error_with_trace(
             "OpenAI compact request failed",
             "response_status",
-            Some("openai"),
-            Some(&model_ref),
+            Some(provider),
+            Some(model_ref),
             Some(url.as_str()),
             status,
             body,
@@ -860,8 +869,8 @@ pub(in super::super) async fn send_openai_compact_request(
             return Err(classify_reqwest_transport_error_with_trace(
                 "OpenAI compact response body failed",
                 "response_body",
-                "openai",
-                Some(&model_ref),
+                provider,
+                Some(model_ref),
                 Some(url.as_str()),
                 error,
                 request_trace.as_ref(),
@@ -871,8 +880,8 @@ pub(in super::super) async fn send_openai_compact_request(
             return Err(timeout_transport_error_with_trace(
                 "OpenAI compact response body read timed out",
                 "response_body",
-                "openai",
-                Some(&model_ref),
+                provider,
+                Some(model_ref),
                 Some(url.as_str()),
                 format!("timed out after {:?}", response_body_timeout()),
                 request_trace.as_ref(),

--- a/src/provider/transports/openai/responses/continuation.rs
+++ b/src/provider/transports/openai/responses/continuation.rs
@@ -194,7 +194,9 @@ pub(in super::super) fn native_web_search_diagnostics(
     let native = request.native_web_search.as_ref()?;
     let lowered = matches!(
         native.kind,
-        ProviderNativeWebSearchKind::OpenAi | ProviderNativeWebSearchKind::Xai
+        ProviderNativeWebSearchKind::OpenAi
+            | ProviderNativeWebSearchKind::DeepSeek
+            | ProviderNativeWebSearchKind::Xai
     );
     Some(ProviderNativeWebSearchDiagnostics {
         kind: native.kind,
@@ -204,7 +206,7 @@ pub(in super::super) fn native_web_search_diagnostics(
         backend_kind: native.backend_kind.clone(),
         lowered,
         fallback_reason: (!lowered).then(|| {
-            "openai responses transport only supports OpenAI/xAI-native web search".into()
+            "responses transport only supports OpenAI/DeepSeek/xAI-native web search".into()
         }),
     })
 }

--- a/src/provider/transports/openai/responses/plan.rs
+++ b/src/provider/transports/openai/responses/plan.rs
@@ -103,6 +103,9 @@ fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value>
     let native = request.native_web_search.as_ref()?;
     match native.kind {
         ProviderNativeWebSearchKind::OpenAi => Some(json!({ "type": native.advertised_tool_type })),
+        ProviderNativeWebSearchKind::DeepSeek => {
+            Some(json!({ "type": native.advertised_tool_type }))
+        }
         ProviderNativeWebSearchKind::Xai => Some(json!({ "type": native.advertised_tool_type })),
         _ => None,
     }
@@ -336,6 +339,12 @@ pub(in super::super) fn plan_openai_responses_request(
                 replay_is_compacted,
                 continuation_contract,
             ),
+            provider_id: None,
+            provider_model_ref: None,
+            provider_transport: None,
+            endpoint_dialect: None,
+            streaming: None,
+            reasoning_effort: None,
             anthropic_cache: None,
             anthropic_context_management: None,
             openai_request_controls: request_controls,

--- a/src/provider/transports/openai/responses/send.rs
+++ b/src/provider/transports/openai/responses/send.rs
@@ -9,13 +9,14 @@ pub(in super::super) async fn send_openai_responses_request(
     headers: Vec<(&str, String)>,
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
+    provider: &str,
+    model_ref: &str,
 ) -> Result<ParsedOpenAiResponse> {
-    let model_ref = provider_model_ref("openai", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
-            "openai",
-            Some(&model_ref),
+            provider,
+            Some(model_ref),
             url.as_str(),
             "responses",
             &headers,
@@ -31,8 +32,8 @@ pub(in super::super) async fn send_openai_responses_request(
         request.json(&body),
         "OpenAI-style request failed",
         "request_send",
-        "openai",
-        Some(&model_ref),
+        provider,
+        Some(model_ref),
         Some(url.as_str()),
         true,
         request_trace.as_ref(),
@@ -55,8 +56,8 @@ pub(in super::super) async fn send_openai_responses_request(
         return Err(classify_status_error_with_trace(
             "OpenAI-style request failed",
             "response_status",
-            Some("openai"),
-            Some(&model_ref),
+            Some(provider),
+            Some(model_ref),
             Some(url.as_str()),
             status,
             body,
@@ -70,8 +71,8 @@ pub(in super::super) async fn send_openai_responses_request(
             return Err(classify_reqwest_transport_error_with_trace(
                 "OpenAI-style response body failed",
                 "response_body",
-                "openai",
-                Some(&model_ref),
+                provider,
+                Some(model_ref),
                 Some(url.as_str()),
                 error,
                 request_trace.as_ref(),
@@ -81,8 +82,8 @@ pub(in super::super) async fn send_openai_responses_request(
             return Err(timeout_transport_error_with_trace(
                 "OpenAI-style response body read timed out",
                 "response_body",
-                "openai",
-                Some(&model_ref),
+                provider,
+                Some(model_ref),
                 Some(url.as_str()),
                 format!("timed out after {:?}", response_body_timeout()),
                 request_trace.as_ref(),
@@ -107,6 +108,8 @@ pub(in super::super) async fn retry_openai_responses_with_lossless_replay(
     diagnostics: &mut ProviderRequestDiagnostics,
     final_provider_input: &mut Vec<Value>,
     final_replay_loss_reason: &mut Option<String>,
+    provider: &str,
+    model_ref: &str,
 ) -> Result<ParsedOpenAiResponse> {
     if !matches!(error_status(&error), Some(400..=499))
         || plan.body.get("previous_response_id").is_none()
@@ -131,7 +134,17 @@ pub(in super::super) async fn retry_openai_responses_with_lossless_replay(
         continuation.fallback_reason = Some("previous_response_id_rejected".into());
         continuation.server_side_context_may_be_lost = None;
     }
-    send_openai_responses_request(client, url, fallback_body, headers, trace, agent_id).await
+    send_openai_responses_request(
+        client,
+        url,
+        fallback_body,
+        headers,
+        trace,
+        agent_id,
+        provider,
+        model_ref,
+    )
+    .await
 }
 
 pub(in super::super) async fn send_openai_responses_streaming_request(
@@ -141,13 +154,14 @@ pub(in super::super) async fn send_openai_responses_streaming_request(
     headers: Vec<(&str, String)>,
     trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
+    provider: &str,
+    model_ref: &str,
 ) -> Result<ParsedOpenAiResponse> {
-    let model_ref = provider_model_ref("openai-codex", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
-            "openai-codex",
-            Some(&model_ref),
+            provider,
+            Some(model_ref),
             url.as_str(),
             "responses_streaming",
             &headers,
@@ -163,8 +177,8 @@ pub(in super::super) async fn send_openai_responses_streaming_request(
         request.json(&body),
         "OpenAI-style streaming request failed",
         "streaming_request_send",
-        "openai-codex",
-        Some(&model_ref),
+        provider,
+        Some(model_ref),
         Some(url.as_str()),
         false,
         request_trace.as_ref(),
@@ -185,10 +199,14 @@ pub(in super::super) async fn send_openai_responses_streaming_request(
         };
         trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error_with_trace(
-            openai_codex_status_error_context(status),
+            if provider == "openai-codex" {
+                openai_codex_status_error_context(status)
+            } else {
+                "OpenAI-style streaming request failed"
+            },
             "response_status",
-            Some("openai-codex"),
-            Some(&model_ref),
+            Some(provider),
+            Some(model_ref),
             Some(url.as_str()),
             status,
             body,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -545,7 +545,7 @@ impl RuntimeHandle {
         let route_ref = self
             .selected_model_ref_for_state(state, fallback_model)
             .unwrap_or_else(|| self.model_state_for(state).effective_model);
-        ApplyPatchSurface::for_model_ref(&route_ref.model_ref().as_string())
+        ApplyPatchSurface::for_model_route_ref(&route_ref.as_string())
     }
 
     fn selected_model_ref_for_state(

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -574,6 +574,9 @@ async fn probe_builtin_web_search_capability(
     ) {
         (ProviderNativeWebSearchKind::OpenAi, "openai_responses", "web_search_preview")
         | (ProviderNativeWebSearchKind::OpenAi, "openai_codex_responses", "web_search")
+        | (ProviderNativeWebSearchKind::DeepSeek, "openai_responses", "web_search")
+        | (ProviderNativeWebSearchKind::DeepSeek, "openai_responses", "web_search_2025_08_26")
+        | (ProviderNativeWebSearchKind::DeepSeek, "anthropic_messages", "web_search_20250305")
         | (ProviderNativeWebSearchKind::Anthropic, "anthropic_messages", "web_search_20250305") => {
             true
         }

--- a/src/tool/apply_patch.rs
+++ b/src/tool/apply_patch.rs
@@ -28,8 +28,11 @@ pub enum ApplyPatchSurface {
 }
 
 impl ApplyPatchSurface {
-    pub(crate) fn for_model_ref(model_ref: &str) -> Self {
-        if model_ref.starts_with("openai-codex/") {
+    pub(crate) fn for_model_route_ref(model_ref: &str) -> Self {
+        if model_ref.starts_with("openai-codex/")
+            || model_ref.starts_with("openai-codex@")
+            || model_ref.starts_with("deepseek@responses/")
+        {
             Self::CodexDslFreeform
         } else {
             Self::UnifiedDiffJson
@@ -1852,6 +1855,22 @@ fn resolve_patch_path(workspace_root: &Path, path: &str) -> Result<PathBuf> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn apply_patch_surface_is_route_specific_for_deepseek_responses() {
+        assert_eq!(
+            ApplyPatchSurface::for_model_route_ref("deepseek@responses/deepseek-v4-pro"),
+            ApplyPatchSurface::CodexDslFreeform
+        );
+        assert_eq!(
+            ApplyPatchSurface::for_model_route_ref("deepseek@default/deepseek-v4-pro"),
+            ApplyPatchSurface::UnifiedDiffJson
+        );
+        assert_eq!(
+            ApplyPatchSurface::for_model_route_ref("deepseek/deepseek-v4-pro"),
+            ApplyPatchSurface::UnifiedDiffJson
+        );
+    }
 
     async fn apply_patch(workspace_root: &Path, input: &str) -> Result<ApplyPatchOutcome> {
         super::apply_patch(workspace_root, input, ApplyPatchSurface::UnifiedDiffJson).await


### PR DESCRIPTION
## 概要

完成 DeepSeek 双 transport 集成的第二阶段，使 effort、native tools 与 diagnostics 按 provider/endpoint dialect 精确 lowering 与归属：

- `deepseek@default` 使用 `output_config.effort`，不再发送无效的 `thinking.budget_tokens`，未配置时保留服务端默认
- 两条 DeepSeek route 分别 lowering Anthropic-compatible 与 Responses native Web Search shape
- `deepseek@responses` 仅为受支持的 `apply_patch` 声明 custom/freeform tool capability
- 将共享 Responses 路径中的 OpenAI 硬编码诊断改为 provider-aware attribution
- 保持 `deepseek@default` 为默认 route，不包含 benchmark repetition/paired scheduling

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib deepseek_`（9 个聚焦测试）
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2570
