### PR TITLE
feat: add paired repeated transport benchmarks

### DIFF
--- a/benchmark/lib/manifest.mjs
+++ b/benchmark/lib/manifest.mjs
@@ -1,8 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { CANONICAL_RUNNER_IDS } from "./naming.mjs";
-
 let yamlModulePromise = null;
 
 const TASK_ALLOWED_KEYS = {
@@ -33,8 +31,18 @@ const TASK_ALLOWED_KEYS = {
 };
 
 const SUITE_ALLOWED_KEYS = {
-  root: ["suite_id", "label_prefix", "tasks", "runners", "pr", "timeouts"],
-  runner: ["runner_id", "driver", "model_ref", "model", "env"],
+  root: [
+    "suite_id",
+    "label_prefix",
+    "tasks",
+    "runners",
+    "repetitions",
+    "execution",
+    "pr",
+    "timeouts"
+  ],
+  runner: ["runner_id", "driver", "model_ref", "model", "env", "transport", "endpoint"],
+  execution: ["runner_order", "random_seed", "max_parallel_runners", "cooldown_ms"],
   pr: ["create_draft", "push_branch", "submit_pr", "draft_pr"],
   timeouts: ["ci_poll_minutes"]
 };
@@ -246,6 +254,14 @@ export function validateBenchmarkSuite(suite, { filePath = "<memory>" } = {}) {
   requireKeys(suite, ["suite_id", "label_prefix", "tasks", "runners", "pr", "timeouts"], `${filePath}`);
   ensureObject(suite.pr, `${filePath}.pr`);
   ensureObject(suite.timeouts, `${filePath}.timeouts`);
+  if ("execution" in suite) {
+    ensureObject(suite.execution, `${filePath}.execution`);
+    assertAllowedKeys(
+      suite.execution,
+      SUITE_ALLOWED_KEYS.execution,
+      `${filePath}.execution`
+    );
+  }
   assertAllowedKeys(suite.pr, SUITE_ALLOWED_KEYS.pr, `${filePath}.pr`);
   assertAllowedKeys(suite.timeouts, SUITE_ALLOWED_KEYS.timeouts, `${filePath}.timeouts`);
   requireKeys(suite.timeouts, SUITE_ALLOWED_KEYS.timeouts, `${filePath}.timeouts`);
@@ -258,15 +274,18 @@ export function validateBenchmarkSuite(suite, { filePath = "<memory>" } = {}) {
     throw new Error(`${filePath}.runners must be a non-empty array`);
   }
 
+  const runnerIds = new Set();
   for (const runner of suite.runners) {
     ensureObject(runner, `${filePath}.runners[]`);
     assertAllowedKeys(runner, SUITE_ALLOWED_KEYS.runner, `${filePath}.runners[]`);
     requireKeys(runner, ["runner_id", "driver"], `${filePath}.runners[]`);
-    if (!CANONICAL_RUNNER_IDS.includes(runner.runner_id)) {
-      throw new Error(
-        `${filePath}.runners[] runner_id must be one of ${CANONICAL_RUNNER_IDS.join(", ")}`
-      );
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(String(runner.runner_id))) {
+      throw new Error(`${filePath}.runners[] runner_id must be a stable lowercase slug`);
     }
+    if (runnerIds.has(runner.runner_id)) {
+      throw new Error(`${filePath}.runners[] runner_id must be unique`);
+    }
+    runnerIds.add(runner.runner_id);
     if (!["holon", "codex", "claude_cli"].includes(runner.driver)) {
       throw new Error(`${filePath}.runners[] driver must be holon, codex, or claude_cli`);
     }
@@ -301,6 +320,63 @@ export function validateBenchmarkSuite(suite, { filePath = "<memory>" } = {}) {
           throw new Error(`${filePath}.runners[].env.${key} must be a string`);
         }
       }
+    }
+    for (const field of ["transport", "endpoint"]) {
+      if (
+        field in runner &&
+        (typeof runner[field] !== "string" || !runner[field].trim())
+      ) {
+        throw new Error(
+          `${filePath}.runners[].${field} must be a non-empty string when present`
+        );
+      }
+    }
+  }
+
+  if (
+    "repetitions" in suite &&
+    (!Number.isInteger(suite.repetitions) || suite.repetitions <= 0)
+  ) {
+    throw new Error(`${filePath}.repetitions must be a positive integer`);
+  }
+
+  if (suite.execution) {
+    if (
+      "runner_order" in suite.execution &&
+      !["configured", "paired_randomized", "alternating"].includes(
+        suite.execution.runner_order
+      )
+    ) {
+      throw new Error(
+        `${filePath}.execution.runner_order must be configured, paired_randomized, or alternating`
+      );
+    }
+    if (
+      "random_seed" in suite.execution &&
+      !Number.isInteger(suite.execution.random_seed)
+    ) {
+      throw new Error(`${filePath}.execution.random_seed must be an integer`);
+    }
+    for (const field of ["max_parallel_runners", "cooldown_ms"]) {
+      if (
+        field in suite.execution &&
+        (!Number.isInteger(suite.execution[field]) ||
+          suite.execution[field] < (field === "cooldown_ms" ? 0 : 1))
+      ) {
+        throw new Error(
+          `${filePath}.execution.${field} must be a ${
+            field === "cooldown_ms" ? "non-negative" : "positive"
+          } integer`
+        );
+      }
+    }
+    if (
+      ["paired_randomized", "alternating"].includes(suite.execution.runner_order) &&
+      suite.execution.max_parallel_runners !== 1
+    ) {
+      throw new Error(
+        `${filePath}.execution.max_parallel_runners must be 1 for paired runner ordering`
+      );
     }
   }
 

--- a/benchmark/lib/naming.mjs
+++ b/benchmark/lib/naming.mjs
@@ -1,16 +1,9 @@
-export const CANONICAL_RUNNER_IDS = [
-  "holon-openai",
-  "codex-openai",
-  "holon-anthropic",
-  "claude-cli"
-];
-
-export function branchNameForTask(taskId, runnerId) {
-  return `bench/${taskId}/${runnerId}`;
+export function branchNameForTask(taskId, runnerId, repetition = 1, suiteLabel = "adhoc") {
+  return `bench/${stableSlug(suiteLabel)}/${taskId}/${runnerId}/run-${String(repetition).padStart(2, "0")}`;
 }
 
-export function worktreeNameForTask(issueNumber, runnerId) {
-  return `bench-${String(issueNumber).padStart(4, "0")}-${runnerId}`;
+export function worktreeNameForTask(issueNumber, runnerId, repetition = 1) {
+  return `bench-${String(issueNumber).padStart(4, "0")}-${runnerId}-run-${String(repetition).padStart(2, "0")}`;
 }
 
 export function prTitleForTask(issueNumber, issueTitle, runnerId) {
@@ -24,4 +17,13 @@ export function benchmarkLabelsForTask(issueNumber, runnerId) {
 export function artifactDirForTask(resultsRoot, suiteLabel, taskId, runnerId, repetition = 1) {
   const runId = `run-${String(repetition).padStart(2, "0")}`;
   return { runId, path: `${resultsRoot}/${suiteLabel}/${taskId}/${runnerId}/${runId}` };
+}
+
+function stableSlug(value) {
+  return (
+    String(value)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "run"
+  );
 }

--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -13,6 +13,7 @@ import {
 } from "./lib/manifest.mjs";
 import { loadProjectionEvalSuite } from "./lib/projection-eval.mjs";
 import {
+  artifactDirForTask,
   benchmarkLabelsForTask,
   branchNameForTask,
   prTitleForTask,
@@ -199,7 +200,10 @@ async function compareSuites(args) {
   const candidate = await readJson(path.join(resultsRoot, args.candidate, "summary.json"));
   const byKey = (entries) =>
     new Map(
-      entries.map((entry) => [`${entry.task_id ?? entry.task_name}:${entry.runner}`, entry])
+      entries.map((entry) => [
+        `${entry.task_id ?? entry.task_name}:${entry.runner}:${entry.repetition ?? 1}`,
+        entry
+      ])
     );
 
   const baselineMap = byKey(baseline);
@@ -532,7 +536,7 @@ async function runRealManifestCommand(args, runnerEnv) {
     )
   );
 
-  await finalizeRealSuite(suiteLabel, results);
+  await finalizeRealSuite(suiteLabel, results, suiteConfig);
   return { label: suiteLabel, results };
 }
 
@@ -573,8 +577,21 @@ async function runRealSuiteCommand(args, runnerEnv) {
   const results = [];
   for (const manifestPath of taskPaths) {
     const manifest = await loadRealTaskManifest(manifestPath);
-    const taskResults = await Promise.all(
-      runnerConfigs.map((runnerConfig) =>
+    for (let repetition = 1; repetition <= (effectiveSuite.repetitions ?? 1); repetition += 1) {
+      const orderedRunners = orderPairedRunners({
+        runnerConfigs,
+        runnerOrder: effectiveSuite.execution?.runner_order ?? "configured",
+        randomSeed: effectiveSuite.execution?.random_seed ?? 0,
+        taskId: manifest.task_id,
+        repetition
+      }).map((runnerConfig, pairIndex) => ({
+        ...runnerConfig,
+        pair_order: pairIndex + 1
+      }));
+      const taskResults = await runWithConcurrency(
+        orderedRunners,
+        effectiveSuite.execution?.max_parallel_runners ?? orderedRunners.length,
+        (runnerConfig) =>
         runRealBenchmarkTask({
           manifest,
           manifestPath,
@@ -582,15 +599,62 @@ async function runRealSuiteCommand(args, runnerEnv) {
           suiteConfig: effectiveSuite,
           suiteLabel,
           runnerEnv,
+          repetition,
           worktreeRootOverride: args.worktreeRoot
-        })
-      )
-    );
-    results.push(...taskResults);
+        }),
+        effectiveSuite.execution?.cooldown_ms ?? 0
+      );
+      results.push(...taskResults);
+    }
   }
 
-  await finalizeRealSuite(suiteLabel, results);
+  await finalizeRealSuite(suiteLabel, results, effectiveSuite);
   return { label: suiteLabel, results };
+}
+
+export function orderPairedRunners({
+  runnerConfigs,
+  runnerOrder = "configured",
+  randomSeed = 0,
+  taskId,
+  repetition
+}) {
+  const ordered = [...runnerConfigs];
+  if (runnerOrder === "alternating") {
+    return repetition % 2 === 0 ? ordered.reverse() : ordered;
+  }
+  if (runnerOrder !== "paired_randomized") {
+    return ordered;
+  }
+
+  let state = stableSeed(`${randomSeed}:${taskId}:${repetition}`);
+  for (let index = ordered.length - 1; index > 0; index -= 1) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    const swapIndex = state % (index + 1);
+    [ordered[index], ordered[swapIndex]] = [ordered[swapIndex], ordered[index]];
+  }
+  return ordered;
+}
+
+function stableSeed(value) {
+  let hash = 2166136261;
+  for (const byte of Buffer.from(String(value), "utf8")) {
+    hash ^= byte;
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+async function runWithConcurrency(items, maxParallel, execute, cooldownMs = 0) {
+  const results = [];
+  for (let index = 0; index < items.length; index += maxParallel) {
+    const batch = items.slice(index, index + maxParallel);
+    results.push(...(await Promise.all(batch.map(execute))));
+    if (cooldownMs > 0 && index + maxParallel < items.length) {
+      await sleep(cooldownMs);
+    }
+  }
+  return results;
 }
 
 async function runProjectionEvalCommand(args) {
@@ -773,11 +837,135 @@ function shellEscape(value) {
   return `'${String(value).split("'").join(`'"'"'`)}'`;
 }
 
-async function finalizeRealSuite(suiteLabel, results) {
+async function finalizeRealSuite(suiteLabel, results, suiteConfig = null) {
   const suiteDir = path.join(resultsRoot, suiteLabel);
+  const pairedSummary = buildPairedSummary(results, suiteConfig?.runners ?? []);
   await mkdir(suiteDir, { recursive: true });
   await writeJson(path.join(suiteDir, "summary.json"), results);
   await writeFile(path.join(suiteDir, "summary.md"), renderSuiteSummary(results), "utf8");
+  await writeJson(path.join(suiteDir, "paired-summary.json"), pairedSummary);
+  await writeFile(
+    path.join(suiteDir, "paired-summary.md"),
+    renderPairedSummary(pairedSummary),
+    "utf8"
+  );
+}
+
+export function buildPairedSummary(results, runnerConfigs = []) {
+  const configuredOrder = new Map(
+    runnerConfigs.map((runner, index) => [runner.runner_id, index])
+  );
+  const expectedRunnerIds = new Set(runnerConfigs.map((runner) => runner.runner_id));
+  const groups = new Map();
+  for (const result of results) {
+    const key = `${result.task_id}#${result.repetition}`;
+    const group = groups.get(key) ?? {
+      task_id: result.task_id,
+      repetition: result.repetition,
+      runs: []
+    };
+    group.runs.push(result);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()]
+    .sort(
+      (left, right) =>
+        left.task_id.localeCompare(right.task_id) ||
+        left.repetition - right.repetition
+    )
+    .map((group) => {
+      const runs = [...group.runs].sort(
+        (left, right) =>
+          (configuredOrder.get(left.runner) ?? Number.MAX_SAFE_INTEGER) -
+            (configuredOrder.get(right.runner) ?? Number.MAX_SAFE_INTEGER) ||
+          left.runner.localeCompare(right.runner)
+      );
+      const comparisons = [];
+      for (let leftIndex = 0; leftIndex < runs.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < runs.length; rightIndex += 1) {
+          comparisons.push(comparePairedRuns(runs[leftIndex], runs[rightIndex]));
+        }
+      }
+      return {
+        task_id: group.task_id,
+        repetition: group.repetition,
+        complete:
+          runnerConfigs.length === 0 ||
+          (runs.length === expectedRunnerIds.size &&
+            runs.every((run) => expectedRunnerIds.has(run.runner))),
+        scheduled_runner_order: [...runs]
+          .sort((left, right) => (left.pair_order ?? 0) - (right.pair_order ?? 0))
+          .map((run) => run.runner),
+        runs: runs.map(compactPairedRun),
+        comparisons
+      };
+    });
+}
+
+function compactPairedRun(run) {
+  return {
+    runner: run.runner,
+    transport: run.transport ?? null,
+    endpoint: run.endpoint ?? null,
+    pair_order: run.pair_order ?? null,
+    success: run.success,
+    duration_ms: run.duration_ms,
+    input_tokens: run.input_tokens ?? 0,
+    output_tokens: run.output_tokens ?? 0,
+    provider_duration_ms: run.provider_duration_ms ?? 0,
+    provider_retry_count: run.provider_retry_count ?? 0,
+    provider_error_count: run.provider_error_count ?? 0,
+    reasoning_tokens: run.reasoning_tokens ?? 0,
+    cache_read_input_tokens: run.cache_read_input_tokens ?? 0,
+    cache_creation_input_tokens: run.cache_creation_input_tokens ?? 0,
+    error_kind: run.error_kind ?? null
+  };
+}
+
+function comparePairedRuns(left, right) {
+  return {
+    runner_a: left.runner,
+    runner_b: right.runner,
+    success_delta: Number(Boolean(right.success)) - Number(Boolean(left.success)),
+    duration_ms_delta: (right.duration_ms ?? 0) - (left.duration_ms ?? 0),
+    total_tokens_delta:
+      (right.input_tokens ?? 0) +
+      (right.output_tokens ?? 0) -
+      (left.input_tokens ?? 0) -
+      (left.output_tokens ?? 0),
+    provider_duration_ms_delta:
+      (right.provider_duration_ms ?? 0) - (left.provider_duration_ms ?? 0),
+    provider_retry_count_delta:
+      (right.provider_retry_count ?? 0) - (left.provider_retry_count ?? 0),
+    provider_error_count_delta:
+      (right.provider_error_count ?? 0) - (left.provider_error_count ?? 0),
+    reasoning_tokens_delta:
+      (right.reasoning_tokens ?? 0) - (left.reasoning_tokens ?? 0),
+    cache_read_input_tokens_delta:
+      (right.cache_read_input_tokens ?? 0) - (left.cache_read_input_tokens ?? 0),
+    cache_creation_input_tokens_delta:
+      (right.cache_creation_input_tokens ?? 0) -
+      (left.cache_creation_input_tokens ?? 0)
+  };
+}
+
+function renderPairedSummary(entries) {
+  const lines = ["# Paired Benchmark Summary", ""];
+  for (const entry of entries) {
+    lines.push(`## ${entry.task_id} (run ${entry.repetition})`, "");
+    lines.push(
+      "| Runner | Transport | Success | Duration | Provider | Retries | Reasoning | Cache read/create |"
+    );
+    lines.push("|---|---|---:|---:|---:|---:|---:|---:|");
+    for (const run of entry.runs) {
+      lines.push(
+        `| ${run.runner} | ${run.transport ?? "-"} | ${boolWord(run.success)} | ${formatMs(run.duration_ms)} | ${formatMs(run.provider_duration_ms)} | ${run.provider_retry_count} | ${run.reasoning_tokens} | ${run.cache_read_input_tokens}/${run.cache_creation_input_tokens} |`
+      );
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
 }
 
 async function runRealBenchmarkTask({
@@ -787,13 +975,19 @@ async function runRealBenchmarkTask({
   suiteConfig,
   suiteLabel,
   runnerEnv,
+  repetition = 1,
   worktreeRootOverride
 }) {
   const manifestDir = path.dirname(manifestPath);
   const repoPath = resolveRepoPath(manifest.repo.local_path, manifestDir);
   await ensureBaseShaExists(repoPath, manifest.base.sha, runCommand);
   const runnerId = runnerConfig.runner_id;
-  const branchName = branchNameForTask(manifest.task_id, runnerId);
+  const branchName = branchNameForTask(
+    manifest.task_id,
+    runnerId,
+    repetition,
+    suiteLabel
+  );
   const worktreeRoot =
     worktreeRootOverride ??
     path.join(
@@ -804,10 +998,15 @@ async function runRealBenchmarkTask({
     );
   const worktreePath = path.join(
     worktreeRoot,
-    worktreeNameForTask(manifest.issue.number, runnerId)
+    worktreeNameForTask(manifest.issue.number, runnerId, repetition)
   );
-  const runId = "run-01";
-  const taskDir = path.join(resultsRoot, suiteLabel, manifest.task_id, runnerId, runId);
+  const { runId, path: taskDir } = artifactDirForTask(
+    resultsRoot,
+    suiteLabel,
+    manifest.task_id,
+    runnerId,
+    repetition
+  );
   await mkdir(taskDir, { recursive: true });
   await copyFile(manifestPath, path.join(taskDir, "manifest.yaml"));
 
@@ -840,7 +1039,8 @@ async function runRealBenchmarkTask({
       worktreePath,
       taskDir,
       runnerEnv,
-      manifest
+      manifest,
+      repetition
     });
   } catch (error) {
     await writeFile(path.join(taskDir, "runner-error.log"), `${error?.stack ?? error}\n`, "utf8");
@@ -859,6 +1059,13 @@ async function runRealBenchmarkTask({
     };
   }
 
+  const verifier = shouldRunManifestVerifier(suiteConfig)
+    ? await runVerificationCommands(manifest.verification.commands, worktreePath, runnerEnv)
+    : null;
+  if (verifier) {
+    await writeFile(path.join(taskDir, "verify.log"), verifier.log, "utf8");
+    await writeJson(path.join(taskDir, "verification.json"), verifier);
+  }
   const changedFiles = await diffAgainstBase(repoPath, worktreePath, manifest.base.sha, taskDir);
   await writeJson(path.join(taskDir, "changed-files.json"), changedFiles);
   const scopeViolation = detectScopeViolation(changedFiles, manifest.evaluation);
@@ -916,7 +1123,10 @@ async function runRealBenchmarkTask({
     issue_number: manifest.issue.number,
     issue_title: manifest.issue.title,
     runner: runnerId,
-    repetition: 1,
+    transport: runnerConfig.transport ?? null,
+    endpoint: runnerConfig.endpoint ?? null,
+    pair_order: runnerConfig.pair_order ?? null,
+    repetition,
     success:
       evaluateRealTaskSuccess({
         runnerResult,
@@ -924,9 +1134,11 @@ async function runRealBenchmarkTask({
         scopeViolation,
         scopePolicy: manifest.evaluation.scope_policy,
         expectedOutcome: manifest.evaluation.expected_outcome ?? "change_required"
-      }) && githubCi.success !== false,
-    verify_success: null,
-    verify_status: "not_run_github_ci_source",
+      }) &&
+      githubCi.success !== false &&
+      verifier?.success !== false,
+    verify_success: verifier?.success ?? null,
+    verify_status: verifier?.status ?? "not_run_github_ci_source",
     scope_violation: scopeViolation,
     scope_policy: manifest.evaluation.scope_policy,
     expected_outcome: manifest.evaluation.expected_outcome ?? "change_required",
@@ -940,7 +1152,7 @@ async function runRealBenchmarkTask({
     error_kind: runnerResult.errorKind ?? null,
     completion_classification: runnerResult.completionClassification ?? null,
     completion_terminal_state: runnerResult.terminalState ?? null,
-    verify_exit_code: null,
+    verify_exit_code: verifier?.exitCode ?? null,
     github_ci_status: githubCi.status,
     github_ci_success: githubCi.success,
     github_ci_pending: githubCi.pending,
@@ -954,6 +1166,20 @@ async function runRealBenchmarkTask({
     total_tool_latency_ms: runnerResult.totalToolLatencyMs ?? 0,
     per_tool_latency_ms: runnerResult.perToolLatencyMs ?? {},
     token_optimization: compactTokenOptimization(runnerResult.tokenOptimization),
+    provider_duration_ms:
+      runnerResult.tokenOptimization?.summary?.provider_duration_ms ?? 0,
+    provider_attempt_count:
+      runnerResult.tokenOptimization?.summary?.provider_attempt_count ?? 0,
+    provider_retry_count:
+      runnerResult.tokenOptimization?.summary?.provider_retry_count ?? 0,
+    provider_error_count:
+      runnerResult.tokenOptimization?.summary?.provider_error_count ?? 0,
+    reasoning_tokens:
+      runnerResult.tokenOptimization?.summary?.reasoning_tokens ?? 0,
+    cache_read_input_tokens:
+      runnerResult.tokenOptimization?.summary?.cache_read_input_tokens ?? 0,
+    cache_creation_input_tokens:
+      runnerResult.tokenOptimization?.summary?.cache_creation_input_tokens ?? 0,
     base_sha: manifest.base.sha,
     benchmark_mode: manifest.benchmark.mode,
     branch: branchName,
@@ -1033,6 +1259,10 @@ function normalizePrPolicy(pr = {}) {
     submit_pr: submitPr,
     draft_pr: submitPr ? draftPr : false
   };
+}
+
+export function shouldRunManifestVerifier(suiteConfig) {
+  return !suiteConfig?.pr?.submit_pr;
 }
 
 async function withRepoSideEffectLock(repoPath, fn) {
@@ -1115,9 +1345,25 @@ export function buildHolonBenchmarkEnv(runnerEnv, runnerConfig, manifest) {
   return env;
 }
 
-async function executeRealRunner({ runnerConfig, prompt, worktreePath, taskDir, runnerEnv, manifest }) {
+async function executeRealRunner({
+  runnerConfig,
+  prompt,
+  worktreePath,
+  taskDir,
+  runnerEnv,
+  manifest,
+  repetition
+}) {
   if (runnerConfig.driver === "holon") {
-    return runHolonRealTask({ runnerConfig, prompt, worktreePath, taskDir, runnerEnv, manifest });
+    return runHolonRealTask({
+      runnerConfig,
+      prompt,
+      worktreePath,
+      taskDir,
+      runnerEnv,
+      manifest,
+      repetition
+    });
   }
   if (runnerConfig.driver === "codex") {
     return runCodexRealTask({ runnerConfig, prompt, worktreePath, taskDir, runnerEnv });
@@ -1128,9 +1374,17 @@ async function executeRealRunner({ runnerConfig, prompt, worktreePath, taskDir, 
   throw new Error(`unsupported real runner driver ${runnerConfig.driver}`);
 }
 
-async function runHolonRealTask({ runnerConfig, prompt, worktreePath, taskDir, runnerEnv, manifest }) {
+async function runHolonRealTask({
+  runnerConfig,
+  prompt,
+  worktreePath,
+  taskDir,
+  runnerEnv,
+  manifest,
+  repetition
+}) {
   const homeDir = path.join(taskDir, "holon-home");
-  const agentId = manifest.task_id;
+  const agentId = `${manifest.task_id}-${runnerConfig.runner_id}-run-${String(repetition).padStart(2, "0")}`;
   const env = buildHolonBenchmarkEnv(runnerEnv, runnerConfig, manifest);
   await ensureHolonBuilt(worktreePath);
   const holonBinary = resolveHolonBinary(worktreePath);
@@ -2948,6 +3202,9 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       null;
     const provider = attempt?.provider ?? providerFromModelRef(modelRef);
     const cacheUsage = data?.provider_cache_usage ?? {};
+    const attempts = Array.isArray(data?.provider_attempt_timeline?.attempts)
+      ? data.provider_attempt_timeline.attempts
+      : [];
     const inputTokens = Number(data?.input_tokens ?? data?.token_usage?.input_tokens ?? 0);
     const cacheReadInputTokens = Number(cacheUsage.read_input_tokens ?? 0);
     const cacheCreationInputTokens = Number(cacheUsage.creation_input_tokens ?? 0);
@@ -2989,6 +3246,16 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       request_lowering_mode: requestLoweringMode,
       input_tokens: inputTokens,
       output_tokens: Number(data?.output_tokens ?? data?.token_usage?.output_tokens ?? 0),
+      reasoning_tokens: reasoningTokenCount(data),
+      provider_duration_ms: attempts.reduce(
+        (sum, providerAttempt) => sum + Number(providerAttempt?.duration_ms ?? 0),
+        0
+      ),
+      provider_attempt_count: attempts.length,
+      provider_retry_count: Math.max(0, attempts.length - 1),
+      provider_error_count: attempts.filter(
+        (providerAttempt) => providerAttempt?.outcome !== "succeeded"
+      ).length,
       cache_read_input_tokens: cacheReadInputTokens,
       cache_creation_input_tokens: cacheCreationInputTokens,
       high_input_zero_cache_read: highInputZeroCacheRead,
@@ -3318,6 +3585,24 @@ function providerFromModelRef(modelRef) {
     return "openai";
   }
   return "unknown";
+}
+
+function reasoningTokenCount(data) {
+  const candidates = [
+    data?.reasoning_tokens,
+    data?.token_usage?.reasoning_tokens,
+    data?.token_usage?.output_tokens_details?.reasoning_tokens,
+    data?.provider_attempt_timeline?.aggregated_token_usage?.reasoning_tokens,
+    data?.provider_attempt_timeline?.aggregated_token_usage?.output_tokens_details
+      ?.reasoning_tokens
+  ];
+  for (const candidate of candidates) {
+    const value = Number(candidate);
+    if (Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return 0;
 }
 
 function isProviderRoundEvent(event) {
@@ -3887,6 +4172,11 @@ function summarizeTokenOptimizationRounds(rounds) {
   const requestLoweringModes = {};
   let cacheReadInputTokens = 0;
   let cacheCreationInputTokens = 0;
+  let reasoningTokens = 0;
+  let providerDurationMs = 0;
+  let providerAttemptCount = 0;
+  let providerRetryCount = 0;
+  let providerErrorCount = 0;
   let highInputZeroCacheReadRounds = 0;
   const incrementalFallbackReasons = {};
   let contextManagementEnabledRounds = 0;
@@ -3918,6 +4208,11 @@ function summarizeTokenOptimizationRounds(rounds) {
       (requestLoweringModes[round.request_lowering_mode] ?? 0) + 1;
     cacheReadInputTokens += round.cache_read_input_tokens;
     cacheCreationInputTokens += round.cache_creation_input_tokens;
+    reasoningTokens += round.reasoning_tokens;
+    providerDurationMs += round.provider_duration_ms;
+    providerAttemptCount += round.provider_attempt_count;
+    providerRetryCount += round.provider_retry_count;
+    providerErrorCount += round.provider_error_count;
     if (round.high_input_zero_cache_read) {
       highInputZeroCacheReadRounds += 1;
     }
@@ -4005,6 +4300,11 @@ function summarizeTokenOptimizationRounds(rounds) {
     request_lowering_modes: requestLoweringModes,
     cache_read_input_tokens: cacheReadInputTokens,
     cache_creation_input_tokens: cacheCreationInputTokens,
+    reasoning_tokens: reasoningTokens,
+    provider_duration_ms: providerDurationMs,
+    provider_attempt_count: providerAttemptCount,
+    provider_retry_count: providerRetryCount,
+    provider_error_count: providerErrorCount,
     high_input_zero_cache_read_rounds: highInputZeroCacheReadRounds,
     incremental_fallback_reasons: incrementalFallbackReasons,
     incremental_mismatch_kinds: incrementalMismatchKinds,

--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -621,7 +621,10 @@ export function orderPairedRunners({
 }) {
   const ordered = [...runnerConfigs];
   if (runnerOrder === "alternating") {
-    return repetition % 2 === 0 ? ordered.reverse() : ordered;
+    if (repetition % 2 === 0) {
+      ordered.reverse();
+    }
+    return ordered;
   }
   if (runnerOrder !== "paired_randomized") {
     return ordered;
@@ -3597,7 +3600,7 @@ function reasoningTokenCount(data) {
       ?.reasoning_tokens
   ];
   for (const candidate of candidates) {
-    const value = Number(candidate);
+    const value = Number(candidate ?? Number.NaN);
     if (Number.isFinite(value)) {
       return value;
     }

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -1029,6 +1029,7 @@ test("summarizeHolonTokenOptimization reports Anthropic cache miss rounds safely
         kind: "provider_round_completed",
         data: {
           round: 7,
+          reasoning_tokens: null,
           input_tokens: 35_000,
           output_tokens: 120,
           provider_cache_usage: {

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -11,6 +11,7 @@ import {
   validateRealTaskManifest
 } from "../lib/manifest.mjs";
 import {
+  buildPairedSummary,
   buildHolonBenchmarkEnv,
   buildOperatorPrompt,
   classifyVerificationResult,
@@ -23,13 +24,16 @@ import {
   codexBenchmarkConfigToml,
   detectScopeViolation,
   evaluateRealTaskSuccess,
+  orderPairedRunners,
   parseClaudeCliJsonl,
   parseCodexJsonl,
   selectHolonFinalMessage,
+  shouldRunManifestVerifier,
   summarizeHolonTokenOptimization,
   tokenOptimizationEvents
 } from "../run.mjs";
 import {
+  artifactDirForTask,
   benchmarkLabelsForTask,
   branchNameForTask,
   prTitleForTask,
@@ -752,18 +756,94 @@ test("github ci summary classifies check buckets", () => {
   );
 });
 
-test("validateBenchmarkSuite rejects unknown runner ids", () => {
+test("validateBenchmarkSuite rejects invalid and duplicate runner ids", () => {
   assert.throws(
     () =>
       validateBenchmarkSuite({
         suite_id: "openai-phase1",
         label_prefix: "openai-phase1",
         tasks: ["benchmarks/tasks/task.yaml"],
-        runners: [{ runner_id: "not-a-runner", driver: "holon", model_ref: "openai-codex/gpt-5.3-codex-spark" }],
+        runners: [{ runner_id: "Not_A_Runner", driver: "holon", model_ref: "openai-codex/gpt-5.3-codex-spark" }],
         pr: { submit_pr: true, draft_pr: true, push_branch: true },
         timeouts: { ci_poll_minutes: 30 }
       }),
-    /runner_id must be one of/
+    /runner_id must be a stable lowercase slug/
+  );
+  assert.throws(
+    () =>
+      validateBenchmarkSuite({
+        suite_id: "deepseek-pilot",
+        label_prefix: "deepseek-pilot",
+        tasks: ["benchmarks/tasks/task.yaml"],
+        runners: [
+          { runner_id: "deepseek", driver: "holon", model_ref: "deepseek/model-a" },
+          { runner_id: "deepseek", driver: "holon", model_ref: "deepseek/model-b" }
+        ],
+        pr: { submit_pr: false },
+        timeouts: { ci_poll_minutes: 30 }
+      }),
+    /runner_id must be unique/
+  );
+});
+
+test("validateBenchmarkSuite accepts repeated paired execution metadata", () => {
+  const suite = validateBenchmarkSuite({
+    suite_id: "deepseek-pilot",
+    label_prefix: "deepseek-pilot",
+    tasks: ["benchmarks/tasks/task.yaml"],
+    repetitions: 5,
+    execution: {
+      runner_order: "paired_randomized",
+      random_seed: 20260814,
+      max_parallel_runners: 1,
+      cooldown_ms: 5000
+    },
+    runners: [
+      {
+        runner_id: "deepseek-anthropic-messages",
+        driver: "holon",
+        model_ref: "deepseek@default/deepseek-v4-flash",
+        transport: "anthropic_messages",
+        endpoint: "default"
+      },
+      {
+        runner_id: "deepseek-openai-responses",
+        driver: "holon",
+        model_ref: "deepseek@responses/deepseek-v4-flash",
+        transport: "openai_responses",
+        endpoint: "responses"
+      }
+    ],
+    pr: { submit_pr: false },
+    timeouts: { ci_poll_minutes: 30 }
+  });
+
+  assert.equal(suite.repetitions, 5);
+  assert.equal(suite.execution.max_parallel_runners, 1);
+  assert.equal(suite.runners[1].endpoint, "responses");
+});
+
+test("validateBenchmarkSuite requires serial execution for paired ordering", () => {
+  assert.throws(
+    () =>
+      validateBenchmarkSuite({
+        suite_id: "deepseek-pilot",
+        label_prefix: "deepseek-pilot",
+        tasks: ["benchmarks/tasks/task.yaml"],
+        execution: {
+          runner_order: "paired_randomized",
+          random_seed: 1,
+          max_parallel_runners: 2,
+          cooldown_ms: 0
+        },
+        runners: [
+          { runner_id: "one", driver: "holon", model_ref: "deepseek/model-a" },
+          { runner_id: "two", driver: "holon", model_ref: "deepseek/model-b" }
+        ],
+        pr: { submit_pr: false },
+        timeouts: { ci_poll_minutes: 30 }
+      }),
+    /max_parallel_runners must be 1/
   );
 });
 
@@ -828,10 +908,22 @@ test("validateBenchmarkSuite accepts anthropic holon and claude-cli runners", ()
 
 test("naming helpers follow canonical conventions", () => {
   assert.equal(
-    branchNameForTask("holon-0015-tool-guidance-registry", "holon-openai"),
-    "bench/holon-0015-tool-guidance-registry/holon-openai"
+    branchNameForTask(
+      "holon-0015-tool-guidance-registry",
+      "holon-openai",
+      1,
+      "OpenAI Phase 1"
+    ),
+    "bench/openai-phase-1/holon-0015-tool-guidance-registry/holon-openai/run-01"
   );
-  assert.equal(worktreeNameForTask(15, "codex-openai"), "bench-0015-codex-openai");
+  assert.equal(
+    worktreeNameForTask(15, "codex-openai", 3),
+    "bench-0015-codex-openai-run-03"
+  );
+  assert.deepEqual(
+    artifactDirForTask("/results", "suite", "task", "runner", 3),
+    { runId: "run-03", path: "/results/suite/task/runner/run-03" }
+  );
   assert.equal(
     prTitleForTask(15, "Dogfood: tool guidance", "holon-openai"),
     "[bench][holon-openai][#15] Dogfood: tool guidance"
@@ -841,6 +933,87 @@ test("naming helpers follow canonical conventions", () => {
     "bench:task-15",
     "runner:holon-openai"
   ]);
+});
+
+test("orderPairedRunners is deterministic and alternating reverses even repetitions", () => {
+  const runners = [
+    { runner_id: "one" },
+    { runner_id: "two" },
+    { runner_id: "three" }
+  ];
+  const first = orderPairedRunners({
+    runnerConfigs: runners,
+    runnerOrder: "paired_randomized",
+    randomSeed: 20260814,
+    taskId: "task-a",
+    repetition: 1
+  });
+  const second = orderPairedRunners({
+    runnerConfigs: runners,
+    runnerOrder: "paired_randomized",
+    randomSeed: 20260814,
+    taskId: "task-a",
+    repetition: 1
+  });
+  assert.deepEqual(first, second);
+  assert.deepEqual(
+    orderPairedRunners({
+      runnerConfigs: runners,
+      runnerOrder: "alternating",
+      taskId: "task-a",
+      repetition: 2
+    }).map((runner) => runner.runner_id),
+    ["three", "two", "one"]
+  );
+  assert.deepEqual(runners.map((runner) => runner.runner_id), ["one", "two", "three"]);
+});
+
+test("buildPairedSummary preserves execution order and emits metric deltas", () => {
+  const entries = buildPairedSummary(
+    [
+      {
+        task_id: "task-a",
+        repetition: 1,
+        runner: "responses",
+        pair_order: 1,
+        transport: "openai_responses",
+        success: true,
+        duration_ms: 80,
+        input_tokens: 90,
+        output_tokens: 20,
+        provider_duration_ms: 50,
+        provider_retry_count: 0,
+        reasoning_tokens: 8,
+        cache_read_input_tokens: 4
+      },
+      {
+        task_id: "task-a",
+        repetition: 1,
+        runner: "anthropic",
+        pair_order: 2,
+        transport: "anthropic_messages",
+        success: false,
+        duration_ms: 100,
+        input_tokens: 100,
+        output_tokens: 30,
+        provider_duration_ms: 70,
+        provider_retry_count: 1,
+        reasoning_tokens: 5,
+        cache_read_input_tokens: 10
+      }
+    ],
+    [{ runner_id: "anthropic" }, { runner_id: "responses" }]
+  );
+
+  assert.deepEqual(entries[0].scheduled_runner_order, ["responses", "anthropic"]);
+  assert.equal(entries[0].complete, true);
+  assert.equal(entries[0].comparisons[0].duration_ms_delta, -20);
+  assert.equal(entries[0].comparisons[0].provider_retry_count_delta, -1);
+});
+
+test("manifest verifier runs only when GitHub CI is not the verification source", () => {
+  assert.equal(shouldRunManifestVerifier({ pr: { submit_pr: false } }), true);
+  assert.equal(shouldRunManifestVerifier({ pr: { submit_pr: true } }), false);
 });
 
 test("summarizeHolonTokenOptimization reports Anthropic cache miss rounds safely", () => {
@@ -870,9 +1043,21 @@ test("summarizeHolonTokenOptimization reports Anthropic cache miss rounds safely
               {
                 provider: "anthropic",
                 model_ref: "anthropic/claude-sonnet-4-6",
-                outcome: "succeeded"
+                outcome: "failed",
+                duration_ms: 25
+              },
+              {
+                provider: "anthropic",
+                model_ref: "anthropic/claude-sonnet-4-6",
+                outcome: "succeeded",
+                duration_ms: 75
               }
             ],
+            aggregated_token_usage: {
+              output_tokens_details: {
+                reasoning_tokens: 40
+              }
+            },
             winning_model_ref: "anthropic/claude-sonnet-4-6"
           }
         }
@@ -895,6 +1080,11 @@ test("summarizeHolonTokenOptimization reports Anthropic cache miss rounds safely
   assert.equal(diagnostics.secret_safe, true);
   assert.equal(diagnostics.summary.high_input_zero_cache_read_rounds, 1);
   assert.equal(diagnostics.summary.request_lowering_modes.prompt_cache_blocks, 1);
+  assert.equal(diagnostics.summary.provider_duration_ms, 100);
+  assert.equal(diagnostics.summary.provider_attempt_count, 2);
+  assert.equal(diagnostics.summary.provider_retry_count, 1);
+  assert.equal(diagnostics.summary.provider_error_count, 1);
+  assert.equal(diagnostics.summary.reasoning_tokens, 40);
   assert.equal(diagnostics.rounds[0].request_lowering_mode, "prompt_cache_blocks");
   assert.equal(diagnostics.rounds[0].previous_tool.name, "ExecCommand");
   assert.equal(typeof diagnostics.rounds[0].previous_tool.input_bytes, "number");

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,10 +16,21 @@ Real-repo benchmarks are modeled as issue-driven operator assignments:
   - `draft_pr`
   - `push_branch`
 - The runner renders PR policy into natural language in the issue template.
-- Live head-to-head runs currently compare:
-  - `holon-openai`
-  - `codex-openai`
-- These two runners are executed in parallel for each task; tasks themselves still advance in suite order.
+- Runner IDs are suite-defined unique lowercase slugs. Optional `transport` and
+  `endpoint` fields label route-specific comparisons.
+- Suites may set `repetitions` and deterministic `execution` controls:
+  - `runner_order: configured | paired_randomized | alternating`
+  - `random_seed`
+  - `max_parallel_runners`
+  - `cooldown_ms`
+- Every task/repetition is one paired group. Paired order modes require serial
+  runner execution. Run, branch, worktree, artifact,
+  and Holon agent identities include the repetition so state cannot leak
+  between samples.
+- Non-PR runs execute the manifest verifier after the runner. PR runs continue
+  to use GitHub CI as their verification source.
+- Raw per-run summaries remain under each `run-NN` directory. Suites also emit
+  `paired-summary.json` and `paired-summary.md`.
 - `holon-openai` live benchmark runs now set `HOLON_DISABLE_PROVIDER_FALLBACK=1` so deterministic live comparisons do not silently switch to a fallback provider/model.
 - Codex live runs now use the configured or default shared `CODEX_HOME`/user environment by default rather than an isolated benchmark-specific home.
 
@@ -41,6 +52,17 @@ node benchmark/run.mjs real --manifest /absolute/path/to/workspace/projects/holo
 node benchmark/run.mjs suite --suite benchmarks/suites/openai-phase1.local.yaml --label bench-openai-phase1
 node benchmark/run.mjs suite --suite benchmarks/suites/performance-diagnostics.local.yaml --label bench-perf-diagnostics
 ```
+
+The checked-in DeepSeek pilot suite compares the two canonical routes with five
+seeded, serial repetitions:
+
+```bash
+node benchmark/run.mjs suite --suite benchmarks/suites/deepseek-transport-pilot.local.yaml --label deepseek-transport-pilot
+```
+
+This command uses paid provider traffic. Run it only with operator authorization
+and required credentials. The suite disables provider fallback and does not
+create PRs or change the default DeepSeek route.
 
 To push benchmark branches and create draft PRs, either:
 

--- a/benchmarks/suites/deepseek-transport-pilot.local.yaml
+++ b/benchmarks/suites/deepseek-transport-pilot.local.yaml
@@ -1,0 +1,31 @@
+suite_id: deepseek-transport-pilot
+label_prefix: deepseek-transport-pilot
+tasks:
+  - ../tasks/holon-0015-tool-guidance-registry.yaml
+repetitions: 5
+execution:
+  runner_order: paired_randomized
+  random_seed: 20260814
+  max_parallel_runners: 1
+  cooldown_ms: 5000
+runners:
+  - runner_id: deepseek-anthropic-messages
+    driver: holon
+    model_ref: deepseek@default/deepseek-v4-flash
+    transport: anthropic_messages
+    endpoint: default
+    env:
+      HOLON_DISABLE_PROVIDER_FALLBACK: "1"
+  - runner_id: deepseek-openai-responses
+    driver: holon
+    model_ref: deepseek@responses/deepseek-v4-flash
+    transport: openai_responses
+    endpoint: responses
+    env:
+      HOLON_DISABLE_PROVIDER_FALLBACK: "1"
+pr:
+  submit_pr: false
+  draft_pr: false
+  push_branch: false
+timeouts:
+  ci_poll_minutes: 30

--- a/docs/implementation-decisions/103-deepseek-responses-endpoint-dialect.md
+++ b/docs/implementation-decisions/103-deepseek-responses-endpoint-dialect.md
@@ -34,3 +34,18 @@ This route does not change the legacy DeepSeek default, introduce a model
 alias, or change the OpenAI and xAI endpoint contracts. Endpoint dialect is
 selected from the resolved canonical `(provider, endpoint)` identity rather
 than from the model name.
+
+## Benchmark protocol
+
+Route comparisons use repeated task-level pairs rather than one aggregate run.
+Each task/repetition runs both canonical routes with a deterministic seeded
+order and isolated branch, worktree, artifact, and agent identities. Raw
+per-run results remain authoritative; the harness additionally emits a paired
+summary with success, duration, provider-attempt, retry/error, reasoning-token,
+and transport-specific cache-token fields. Pair deltas use `runner_b - runner_a`.
+
+The checked-in pilot suite uses `deepseek-v4-flash`, five repetitions, serial
+runner execution, cooldown, and disabled provider fallback. Running that paid
+suite and using `deepseek-v4-pro` for route confirmation/default-route evidence
+remain separate operator-authorized steps. Benchmark infrastructure does not
+change `deepseek@default`.


### PR DESCRIPTION
## Summary

- add real-suite repetitions with deterministic paired randomized or alternating serial runner order
- isolate branch, worktree, artifact, and Holon agent identities by suite and repetition
- collect provider attempt duration/retry/error, reasoning, and cache metrics and emit separate paired summaries
- run manifest verification for non-PR benchmarks before final diff/scope evaluation
- add the local five-repetition DeepSeek Flash transport pilot suite without running paid traffic or changing the default route

## Verification

- `cd benchmark && node --check run.mjs`
- `cd benchmark && npm test` (60/60)
- direct parse of `benchmarks/suites/deepseek-transport-pilot.local.yaml`
- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2572
