### PR TITLE
fix: map DeepSeek apply patch tool name

### DIFF
--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -311,10 +311,10 @@ fn deepseek_reasoning_and_tool_call_sse_response(response_id: &str) -> String {
                 "text": "inspect the workspace first"
             }]
         }, {
-            "type": "function_call",
-            "call_id": "exec-1",
-            "name": "ExecCommand",
-            "arguments": "{\"cmd\":\"printf ok\"}"
+            "type": "custom_tool_call",
+            "call_id": "patch-1",
+            "name": "apply_patch",
+            "input": "*** Begin Patch\n*** Add File: note.txt\n+ok\n*** End Patch\n"
         }]
     });
     format!(
@@ -511,6 +511,13 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
     )
     .unwrap();
     let mut first_request = provider_turn_request_with_prompt_frame();
+    first_request.tools = vec![
+        crate::tool::tools::apply_patch_tool::definition_for_surface(
+            crate::tool::apply_patch::ApplyPatchSurface::CodexDslFreeform,
+        )
+        .unwrap()
+        .spec,
+    ];
     first_request.native_web_search = Some(ProviderNativeWebSearchRequest {
         kind: ProviderNativeWebSearchKind::DeepSeek,
         provider_id: "deepseek".into(),
@@ -526,7 +533,10 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
     ));
     assert!(matches!(
         &first.blocks[1],
-        ModelBlock::ToolUse { id, name, .. } if id == "exec-1" && name == "ExecCommand"
+        ModelBlock::ToolUse { id, name, kind, .. }
+            if id == "patch-1"
+                && name == "ApplyPatch"
+                && *kind == crate::provider::ModelToolCallKind::Custom
     ));
     let diagnostics = first
         .request_diagnostics
@@ -557,10 +567,17 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
     let restored_blocks: Vec<ModelBlock> = serde_json::from_slice(&persisted_blocks).unwrap();
 
     let mut followup = provider_turn_request_with_prompt_frame();
+    followup.tools = vec![
+        crate::tool::tools::apply_patch_tool::definition_for_surface(
+            crate::tool::apply_patch::ApplyPatchSurface::CodexDslFreeform,
+        )
+        .unwrap()
+        .spec,
+    ];
     followup.conversation.extend([
         ConversationMessage::AssistantBlocks(restored_blocks),
         ConversationMessage::UserToolResults(vec![ToolResultBlock {
-            tool_use_id: "exec-1".into(),
+            tool_use_id: "patch-1".into(),
             content: "ok".into(),
             is_error: false,
             error: None,
@@ -595,18 +612,27 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
         .expect("DeepSeek tools")
         .iter()
         .any(|tool| tool == &json!({ "type": "web_search" })));
+    assert!(bodies.iter().all(|body| {
+        body["tools"]
+            .as_array()
+            .expect("DeepSeek tools")
+            .iter()
+            .any(|tool| tool["type"] == "custom" && tool["name"] == "apply_patch")
+    }));
     let replayed = bodies[1]["input"].as_array().unwrap();
     assert!(replayed.iter().any(|item| {
         item["type"] == "reasoning"
             && item["content"][0]["type"] == "reasoning_text"
             && item["content"][0]["text"] == "inspect the workspace first"
     }));
-    assert!(replayed
-        .iter()
-        .any(|item| item["type"] == "function_call" && item["call_id"] == "exec-1"));
     assert!(replayed.iter().any(|item| {
-        item["type"] == "function_call_output"
-            && item["call_id"] == "exec-1"
+        item["type"] == "custom_tool_call"
+            && item["call_id"] == "patch-1"
+            && item["name"] == "apply_patch"
+    }));
+    assert!(replayed.iter().any(|item| {
+        item["type"] == "custom_tool_call_output"
+            && item["call_id"] == "patch-1"
             && item["output"] == "ok"
     }));
     assert_eq!(compact_attempts.load(Ordering::SeqCst), 0);

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -478,6 +478,7 @@ fn deepseek_responses_request_uses_custom_apply_patch_tool_shape() {
     let apply_patch = apply_patch_tool::definition_for_surface(ApplyPatchSurface::CodexDslFreeform)
         .unwrap()
         .spec;
+    assert_eq!(apply_patch.name, "ApplyPatch");
     let request = provider_turn_request_with_tools(vec![apply_patch]);
     let body = build_openai_responses_request(
         "deepseek-v4-pro",
@@ -491,7 +492,7 @@ fn deepseek_responses_request_uses_custom_apply_patch_tool_shape() {
     .unwrap();
 
     assert_eq!(body["tools"][0]["type"], "custom");
-    assert_eq!(body["tools"][0]["name"], "ApplyPatch");
+    assert_eq!(body["tools"][0]["name"], "apply_patch");
     assert_eq!(body["tools"][0]["format"]["type"], "grammar");
     assert_eq!(body["reasoning"], json!({ "effort": "high" }));
 }

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -178,6 +178,24 @@ pub(crate) enum OpenAiResponsesTransportContract {
     DeepSeekStreaming,
 }
 
+impl OpenAiResponsesTransportContract {
+    fn wire_tool_name<'a>(self, name: &'a str) -> &'a str {
+        if self == Self::DeepSeekStreaming && name == "ApplyPatch" {
+            "apply_patch"
+        } else {
+            name
+        }
+    }
+
+    fn internal_tool_name<'a>(self, name: &'a str) -> &'a str {
+        if self == Self::DeepSeekStreaming && name == "apply_patch" {
+            "ApplyPatch"
+        } else {
+            name
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OpenAiResponsesContinuationContract {
     Standard,
@@ -249,7 +267,7 @@ async fn send_openai_responses_for_contract(
     provider: &str,
     model_ref: &str,
 ) -> Result<ParsedOpenAiResponse> {
-    match contract {
+    let parsed = match contract {
         OpenAiResponsesTransportContract::StandardJson => {
             send_openai_responses_request(
                 client, url, body, headers, trace, agent_id, provider, model_ref,
@@ -263,7 +281,8 @@ async fn send_openai_responses_for_contract(
             )
             .await
         }
-    }
+    }?;
+    Ok(parsed.with_internal_tool_names(contract))
 }
 
 #[derive(Debug)]
@@ -1183,6 +1202,15 @@ impl ProviderTurnResponse {
 impl ParsedOpenAiResponse {
     fn with_provider_request_id(mut self, provider_request_id: Option<String>) -> Self {
         self.response.provider_request_id = provider_request_id;
+        self
+    }
+
+    fn with_internal_tool_names(mut self, contract: OpenAiResponsesTransportContract) -> Self {
+        for block in &mut self.response.blocks {
+            if let ModelBlock::ToolUse { name, .. } = block {
+                *name = contract.internal_tool_name(name).to_string();
+            }
+        }
         self
     }
 }

--- a/src/provider/transports/openai/responses/plan.rs
+++ b/src/provider/transports/openai/responses/plan.rs
@@ -15,10 +15,11 @@ pub(crate) fn build_openai_responses_request(
         .tools
         .iter()
         .map(|tool| {
+            let name = contract.wire_tool_name(&tool.name);
             if let Some(grammar) = tool.freeform_grammar.as_ref() {
                 Ok(json!({
                     "type": "custom",
-                    "name": tool.name,
+                    "name": name,
                     "description": tool.description,
                     "format": {
                         "type": "grammar",
@@ -29,7 +30,7 @@ pub(crate) fn build_openai_responses_request(
             } else {
                 Ok(json!({
                     "type": "function",
-                    "name": tool.name,
+                    "name": name,
                     "description": tool.description,
                     "parameters": emitted_tool_json_schema(&tool.input_schema, tool_schema_contract)?,
                     "strict": matches!(tool_schema_contract, ToolSchemaContract::Strict),
@@ -44,7 +45,7 @@ pub(crate) fn build_openai_responses_request(
     let mut body = json!({
         "model": model,
         "instructions": request.prompt_frame.system_prompt,
-        "input": build_openai_input(&request.conversation)?,
+        "input": build_openai_input_for_contract(&request.conversation, contract)?,
         "store": false,
     });
     if !tools.is_empty() {
@@ -395,7 +396,15 @@ fn openai_append_match_lowering_mode(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result<Vec<Value>> {
+    build_openai_input_for_contract(conversation, OpenAiResponsesTransportContract::StandardJson)
+}
+
+fn build_openai_input_for_contract(
+    conversation: &[ConversationMessage],
+    contract: OpenAiResponsesTransportContract,
+) -> Result<Vec<Value>> {
     let mut items = Vec::new();
     let mut tool_call_kinds = HashMap::<String, ModelToolCallKind>::new();
     for message in conversation {
@@ -445,7 +454,7 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
                                 ModelToolCallKind::Function => items.push(json!({
                                     "type": "function_call",
                                     "call_id": id,
-                                    "name": name,
+                                    "name": contract.wire_tool_name(name),
                                     "arguments": canonical_json(
                                         &normalize_openai_function_arguments(Some(input))
                                     ),
@@ -453,7 +462,7 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
                                 ModelToolCallKind::Custom => items.push(json!({
                                     "type": "custom_tool_call",
                                     "call_id": id,
-                                    "name": name,
+                                    "name": contract.wire_tool_name(name),
                                     "input": openai_custom_tool_input(input)?,
                                 })),
                             }


### PR DESCRIPTION
## 概要

- 对 DeepSeek Responses wire contract 将公开工具名 `ApplyPatch` 映射为 `apply_patch`
- 解析响应时恢复内部工具名 `ApplyPatch`
- continuation/history replay 同样使用 DeepSeek wire 名称，保持 tool call/result 配对一致
- 补充 request、parse 与 replay 回归测试

Closes #2578

## 验证

- `cargo test deepseek_responses_ -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`