### PR TITLE
fix: normalize benchmark provider usage

### DIFF
--- a/benchmark/lib/manifest.mjs
+++ b/benchmark/lib/manifest.mjs
@@ -41,7 +41,25 @@ const SUITE_ALLOWED_KEYS = {
     "pr",
     "timeouts"
   ],
-  runner: ["runner_id", "driver", "model_ref", "model", "env", "transport", "endpoint"],
+  runner: [
+    "runner_id",
+    "driver",
+    "model_ref",
+    "model",
+    "env",
+    "transport",
+    "endpoint",
+    "pricing"
+  ],
+  pricing: [
+    "currency",
+    "effective_at",
+    "source",
+    "cache_miss_input_per_million",
+    "cache_read_input_per_million",
+    "cache_creation_input_per_million",
+    "output_per_million"
+  ],
   execution: ["runner_order", "random_seed", "max_parallel_runners", "cooldown_ms"],
   pr: ["create_draft", "push_branch", "submit_pr", "draft_pr"],
   timeouts: ["ci_poll_minutes"]
@@ -329,6 +347,47 @@ export function validateBenchmarkSuite(suite, { filePath = "<memory>" } = {}) {
         throw new Error(
           `${filePath}.runners[].${field} must be a non-empty string when present`
         );
+      }
+    }
+    if ("pricing" in runner) {
+      ensureObject(runner.pricing, `${filePath}.runners[].pricing`);
+      assertAllowedKeys(
+        runner.pricing,
+        SUITE_ALLOWED_KEYS.pricing,
+        `${filePath}.runners[].pricing`
+      );
+      requireKeys(
+        runner.pricing,
+        SUITE_ALLOWED_KEYS.pricing,
+        `${filePath}.runners[].pricing`
+      );
+      if (runner.pricing.currency !== "USD") {
+        throw new Error(`${filePath}.runners[].pricing.currency must be USD`);
+      }
+      if (
+        typeof runner.pricing.effective_at !== "string" ||
+        !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+          runner.pricing.effective_at
+        ) ||
+        Number.isNaN(Date.parse(runner.pricing.effective_at))
+      ) {
+        throw new Error(
+          `${filePath}.runners[].pricing.effective_at must be an ISO-8601 timestamp`
+        );
+      }
+      if (typeof runner.pricing.source !== "string" || !runner.pricing.source.trim()) {
+        throw new Error(`${filePath}.runners[].pricing.source must be a non-empty string`);
+      }
+      for (const field of SUITE_ALLOWED_KEYS.pricing.slice(3)) {
+        if (
+          typeof runner.pricing[field] !== "number" ||
+          !Number.isFinite(runner.pricing[field]) ||
+          runner.pricing[field] < 0
+        ) {
+          throw new Error(
+            `${filePath}.runners[].pricing.${field} must be a non-negative finite number`
+          );
+        }
       }
     }
   }

--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -3371,7 +3371,6 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       transport: options.transport,
       pricing: options.pricing
     });
-    const cacheUsage = data?.provider_cache_usage ?? {};
     const inputTokens = usage.raw_input_tokens;
     const cacheReadInputTokens = usage.cache_read_input_tokens;
     const cacheCreationInputTokens = usage.cache_creation_input_tokens;
@@ -3382,7 +3381,10 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       modelRef,
       round,
       promptCacheKey: data?.prompt_cache_key,
-      cacheUsage,
+      cacheUsage: {
+        read_input_tokens: cacheReadInputTokens,
+        creation_input_tokens: cacheCreationInputTokens
+      },
       requestDiagnostics
     });
     const highInputZeroCacheRead =
@@ -4806,6 +4808,12 @@ export async function readHolonAuditEvents({
       { ...env, HOLON_HOME: homeDir },
       false
     );
+    if (result.exitCode !== 0) {
+      const detail = String(result.stderr ?? result.stdout ?? "").trim();
+      throw new Error(
+        `holon DB event export failed with exit code ${result.exitCode}${detail ? `: ${detail}` : ""}`
+      );
+    }
     let page;
     try {
       page = JSON.parse(result.stdout);

--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -915,15 +915,22 @@ function compactPairedRun(run) {
     success: run.success,
     duration_ms: run.duration_ms,
     input_tokens: run.input_tokens ?? 0,
+    logical_input_tokens: run.logical_input_tokens ?? null,
     output_tokens: run.output_tokens ?? 0,
     provider_duration_ms: run.provider_duration_ms ?? 0,
     provider_retry_count: run.provider_retry_count ?? 0,
     provider_error_count: run.provider_error_count ?? 0,
     reasoning_tokens: run.reasoning_tokens ?? 0,
     cache_read_input_tokens: run.cache_read_input_tokens ?? 0,
+    cache_miss_input_tokens: run.cache_miss_input_tokens ?? null,
     cache_creation_input_tokens: run.cache_creation_input_tokens ?? 0,
+    estimated_cost_usd: run.estimated_cost_usd ?? null,
     error_kind: run.error_kind ?? null
   };
+}
+
+function nullableDelta(left, right) {
+  return Number.isFinite(left) && Number.isFinite(right) ? right - left : null;
 }
 
 function comparePairedRuns(left, right) {
@@ -937,6 +944,10 @@ function comparePairedRuns(left, right) {
       (right.output_tokens ?? 0) -
       (left.input_tokens ?? 0) -
       (left.output_tokens ?? 0),
+    logical_input_tokens_delta: nullableDelta(
+      left.logical_input_tokens,
+      right.logical_input_tokens
+    ),
     provider_duration_ms_delta:
       (right.provider_duration_ms ?? 0) - (left.provider_duration_ms ?? 0),
     provider_retry_count_delta:
@@ -947,9 +958,17 @@ function comparePairedRuns(left, right) {
       (right.reasoning_tokens ?? 0) - (left.reasoning_tokens ?? 0),
     cache_read_input_tokens_delta:
       (right.cache_read_input_tokens ?? 0) - (left.cache_read_input_tokens ?? 0),
+    cache_miss_input_tokens_delta: nullableDelta(
+      left.cache_miss_input_tokens,
+      right.cache_miss_input_tokens
+    ),
     cache_creation_input_tokens_delta:
       (right.cache_creation_input_tokens ?? 0) -
-      (left.cache_creation_input_tokens ?? 0)
+      (left.cache_creation_input_tokens ?? 0),
+    estimated_cost_usd_delta: nullableDelta(
+      left.estimated_cost_usd,
+      right.estimated_cost_usd
+    )
   };
 }
 
@@ -958,12 +977,12 @@ function renderPairedSummary(entries) {
   for (const entry of entries) {
     lines.push(`## ${entry.task_id} (run ${entry.repetition})`, "");
     lines.push(
-      "| Runner | Transport | Success | Duration | Provider | Retries | Reasoning | Cache read/create |"
+      "| Runner | Transport | Success | Duration | Provider | Retries | Logical input | Cache read/miss/create | Output | Est. cost USD |"
     );
-    lines.push("|---|---|---:|---:|---:|---:|---:|---:|");
+    lines.push("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|");
     for (const run of entry.runs) {
       lines.push(
-        `| ${run.runner} | ${run.transport ?? "-"} | ${boolWord(run.success)} | ${formatMs(run.duration_ms)} | ${formatMs(run.provider_duration_ms)} | ${run.provider_retry_count} | ${run.reasoning_tokens} | ${run.cache_read_input_tokens}/${run.cache_creation_input_tokens} |`
+        `| ${run.runner} | ${run.transport ?? "-"} | ${boolWord(run.success)} | ${formatMs(run.duration_ms)} | ${formatMs(run.provider_duration_ms)} | ${run.provider_retry_count} | ${run.logical_input_tokens ?? "-"} | ${run.cache_read_input_tokens}/${run.cache_miss_input_tokens ?? "-"}/${run.cache_creation_input_tokens} | ${run.output_tokens} | ${run.estimated_cost_usd === null ? "-" : run.estimated_cost_usd.toFixed(6)} |`
       );
     }
     lines.push("");
@@ -1179,10 +1198,16 @@ async function runRealBenchmarkTask({
       runnerResult.tokenOptimization?.summary?.provider_error_count ?? 0,
     reasoning_tokens:
       runnerResult.tokenOptimization?.summary?.reasoning_tokens ?? 0,
+    logical_input_tokens:
+      runnerResult.tokenOptimization?.summary?.logical_input_tokens ?? null,
     cache_read_input_tokens:
       runnerResult.tokenOptimization?.summary?.cache_read_input_tokens ?? 0,
+    cache_miss_input_tokens:
+      runnerResult.tokenOptimization?.summary?.cache_miss_input_tokens ?? null,
     cache_creation_input_tokens:
       runnerResult.tokenOptimization?.summary?.cache_creation_input_tokens ?? 0,
+    estimated_cost_usd:
+      runnerResult.tokenOptimization?.summary?.estimated_cost_usd ?? null,
     base_sha: manifest.base.sha,
     benchmark_mode: manifest.benchmark.mode,
     branch: branchName,
@@ -1423,7 +1448,6 @@ async function runHolonRealTask({
   }
   const agentDir = path.join(homeDir, "agents", agentId);
   await copyAgentJsonlArtifact(agentDir, taskDir, "briefs.jsonl");
-  await copyAgentJsonlArtifact(agentDir, taskDir, "events.jsonl");
   await copyAgentJsonlArtifact(agentDir, taskDir, "tools.jsonl");
   await copyAgentJsonlArtifact(agentDir, taskDir, "transcript.jsonl");
   await copyAgentStateArtifact(agentDir, taskDir, "agent.json");
@@ -1433,7 +1457,17 @@ async function runHolonRealTask({
   const briefs = await readAgentJsonlArtifact(agentDir, "briefs.jsonl", taskDir);
   const toolExecutions = await readAgentJsonlArtifact(agentDir, "tools.jsonl", taskDir);
   const toolMetrics = summarizeHolonToolExecutions(toolExecutions);
-  const events = await readAgentJsonlArtifact(agentDir, "events.jsonl", taskDir);
+  const events = await readHolonAuditEvents({
+    holonBinary,
+    agentId,
+    homeDir,
+    cwd: worktreePath,
+    env
+  });
+  await writeJsonl(
+    path.join(taskDir, "events.jsonl"),
+    events.map((event) => JSON.stringify(event))
+  );
   const transcript = await readAgentJsonlArtifact(agentDir, "transcript.jsonl", taskDir);
   const durableState = await summarizeHolonDurableState(agentDir, taskDir);
   await writeJson(path.join(taskDir, "holon-durable-state.json"), durableState);
@@ -1449,7 +1483,13 @@ async function runHolonRealTask({
     await writeJson(path.join(taskDir, "holon-run.json"), parsed);
   }
   const tokenOptimization = summarizeHolonTokenOptimization(tokenOptimizationEvents(events, transcript), toolExecutions, {
-    modelRef: runnerConfig.model_ref
+    modelRef: runnerConfig.model_ref,
+    transport: runnerConfig.transport,
+    pricing: runnerConfig.pricing
+  });
+  assertHolonProviderRoundTelemetry({
+    modelRounds: parsed?.model_rounds ?? durableState.agent_total_model_rounds,
+    tokenOptimization
   });
   await writeJson(path.join(taskDir, "token-optimization.json"), tokenOptimization);
   const completion = classifyHolonBenchmarkCompletion({
@@ -2512,7 +2552,13 @@ async function runHolonTask({ task, taskDir, workspaceDir, runnerEnv }) {
     (await readJsonIfExists(path.join(agentDir, "agent.json"))) ??
     (await readJsonIfExists(path.join(agentDir, ".holon", "state", "agent.json")));
   const briefs = await readAgentJsonlArtifact(agentDir, "briefs.jsonl", taskDir);
-  const events = await readAgentJsonlArtifact(agentDir, "events.jsonl", taskDir);
+  const events = await readHolonAuditEvents({
+    holonBinary,
+    agentId,
+    homeDir,
+    cwd: repoRoot,
+    env
+  });
   const tasks = await readAgentJsonlArtifact(agentDir, "tasks.jsonl", taskDir);
 
   await writeJson(path.join(taskDir, "status.json"), { agent: agentState });
@@ -2520,7 +2566,10 @@ async function runHolonTask({ task, taskDir, workspaceDir, runnerEnv }) {
   await writeJson(path.join(taskDir, "events.json"), events);
   await writeJson(path.join(taskDir, "tasks.json"), lastRun?.tasks ?? tasks);
 
-  await copyAgentJsonlArtifact(agentDir, taskDir, "events.jsonl");
+  await writeJsonl(
+    path.join(taskDir, "events.jsonl"),
+    events.map((event) => JSON.stringify(event))
+  );
   await copyAgentJsonlArtifact(agentDir, taskDir, "briefs.jsonl");
   await copyAgentJsonlArtifact(agentDir, taskDir, "tools.jsonl");
   await copyAgentJsonlArtifact(agentDir, taskDir, "transcript.jsonl");
@@ -2533,6 +2582,10 @@ async function runHolonTask({ task, taskDir, workspaceDir, runnerEnv }) {
   const transcript = await readAgentJsonlArtifact(agentDir, "transcript.jsonl", taskDir);
   const tokenOptimization = summarizeHolonTokenOptimization(tokenOptimizationEvents(events, transcript), toolExecutions, {
     modelRef: env.HOLON_MODEL
+  });
+  assertHolonProviderRoundTelemetry({
+    modelRounds: lastRun?.model_rounds,
+    tokenOptimization
   });
   await writeJson(path.join(taskDir, "token-optimization.json"), tokenOptimization);
   const failureKind = computeFailureKind(lastRun);
@@ -3163,6 +3216,110 @@ function summarizeHolonToolExecutions(entries) {
   };
 }
 
+function usageNumber(value, field, issues, { required = false } = {}) {
+  if (value === undefined || value === null) {
+    if (required) {
+      issues.push(`${field}_missing`);
+    }
+    return 0;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    issues.push(`${field}_not_finite`);
+    return 0;
+  }
+  if (numeric < 0) {
+    issues.push(`${field}_negative`);
+    return 0;
+  }
+  return numeric;
+}
+
+function usageSemantics(provider, modelRef, transport) {
+  const normalizedTransport = String(transport ?? "").toLowerCase();
+  if (normalizedTransport === "anthropic_messages") {
+    return "anthropic_messages";
+  }
+  if (normalizedTransport === "openai_responses") {
+    return "openai_responses";
+  }
+  if (normalizedTransport) {
+    return "total_input_with_cache";
+  }
+  if (provider === "anthropic") {
+    return "anthropic_messages";
+  }
+  if (String(modelRef ?? "").toLowerCase().includes("@responses/")) {
+    return "openai_responses";
+  }
+  return "total_input_with_cache";
+}
+
+export function normalizeProviderRoundUsage({
+  data,
+  provider,
+  modelRef,
+  transport,
+  pricing
+}) {
+  const issues = [];
+  const rawInputTokens = usageNumber(
+    data?.input_tokens ?? data?.token_usage?.input_tokens,
+    "input_tokens",
+    issues,
+    { required: true }
+  );
+  const outputTokens = usageNumber(
+    data?.output_tokens ?? data?.token_usage?.output_tokens,
+    "output_tokens",
+    issues,
+    { required: true }
+  );
+  const cacheUsage = data?.provider_cache_usage ?? {};
+  const cacheReadInputTokens = usageNumber(
+    cacheUsage.read_input_tokens,
+    "cache_read_input_tokens",
+    issues
+  );
+  const cacheCreationInputTokens = usageNumber(
+    cacheUsage.creation_input_tokens,
+    "cache_creation_input_tokens",
+    issues
+  );
+  const semantics = usageSemantics(provider, modelRef, transport);
+  const logicalInputTokens =
+    semantics === "anthropic_messages"
+      ? rawInputTokens + cacheReadInputTokens + cacheCreationInputTokens
+      : rawInputTokens;
+  if (cacheReadInputTokens > logicalInputTokens) {
+    issues.push("cache_read_exceeds_logical_input");
+  }
+  const cacheMissInputTokens =
+    semantics === "anthropic_messages"
+      ? rawInputTokens
+      : Math.max(0, logicalInputTokens - cacheReadInputTokens);
+  let estimatedCostUsd = null;
+  if (pricing && issues.length === 0) {
+    estimatedCostUsd =
+      (cacheMissInputTokens * pricing.cache_miss_input_per_million +
+        cacheReadInputTokens * pricing.cache_read_input_per_million +
+        cacheCreationInputTokens * pricing.cache_creation_input_per_million +
+        outputTokens * pricing.output_per_million) /
+      1_000_000;
+  }
+  return {
+    usage_semantics: semantics,
+    raw_input_tokens: rawInputTokens,
+    logical_input_tokens: logicalInputTokens,
+    cache_read_input_tokens: cacheReadInputTokens,
+    cache_miss_input_tokens: cacheMissInputTokens,
+    cache_creation_input_tokens: cacheCreationInputTokens,
+    output_tokens: outputTokens,
+    estimated_cost_usd: estimatedCostUsd,
+    usage_validation_issues: issues
+  };
+}
+
 export function summarizeHolonTokenOptimization(events, toolExecutions = [], options = {}) {
   const toolSummaries = toolExecutions.map(summarizeToolPayloadSize);
   const truncatedMutationToolCallRejections = events.filter((event) => {
@@ -3204,13 +3361,20 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       options.modelRef ??
       null;
     const provider = attempt?.provider ?? providerFromModelRef(modelRef);
-    const cacheUsage = data?.provider_cache_usage ?? {};
     const attempts = Array.isArray(data?.provider_attempt_timeline?.attempts)
       ? data.provider_attempt_timeline.attempts
       : [];
-    const inputTokens = Number(data?.input_tokens ?? data?.token_usage?.input_tokens ?? 0);
-    const cacheReadInputTokens = Number(cacheUsage.read_input_tokens ?? 0);
-    const cacheCreationInputTokens = Number(cacheUsage.creation_input_tokens ?? 0);
+    const usage = normalizeProviderRoundUsage({
+      data,
+      provider,
+      modelRef,
+      transport: options.transport,
+      pricing: options.pricing
+    });
+    const cacheUsage = data?.provider_cache_usage ?? {};
+    const inputTokens = usage.raw_input_tokens;
+    const cacheReadInputTokens = usage.cache_read_input_tokens;
+    const cacheCreationInputTokens = usage.cache_creation_input_tokens;
     const round = Number(data?.round ?? event?.round ?? rounds.length + 1);
     const requestDiagnostics = data?.provider_request_diagnostics ?? {};
     const requestLoweringMode = inferRequestLoweringMode({
@@ -3248,7 +3412,7 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       model_ref: modelRef,
       request_lowering_mode: requestLoweringMode,
       input_tokens: inputTokens,
-      output_tokens: Number(data?.output_tokens ?? data?.token_usage?.output_tokens ?? 0),
+      ...usage,
       reasoning_tokens: reasoningTokenCount(data),
       provider_duration_ms: attempts.reduce(
         (sum, providerAttempt) => sum + Number(providerAttempt?.duration_ms ?? 0),
@@ -3289,10 +3453,21 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
     exec_command_cost: summarizeExecCommandCost(toolSummaries)
   };
   return {
-    schema_version: 1,
-    generated_from: "holon_events",
+    schema_version: 2,
+    generated_from: "holon_runtime_db_events",
     secret_safe: true,
     large_cache_miss_input_threshold: 10_000,
+    pricing: options.pricing
+      ? {
+          currency: options.pricing.currency,
+          effective_at: options.pricing.effective_at,
+          source: options.pricing.source,
+          cache_miss_input_per_million: options.pricing.cache_miss_input_per_million,
+          cache_read_input_per_million: options.pricing.cache_read_input_per_million,
+          cache_creation_input_per_million: options.pricing.cache_creation_input_per_million,
+          output_per_million: options.pricing.output_per_million
+        }
+      : null,
     summary,
     rounds
   };
@@ -4173,8 +4348,14 @@ function numericField(object, fieldNames) {
 
 function summarizeTokenOptimizationRounds(rounds) {
   const requestLoweringModes = {};
+  let logicalInputTokens = 0;
   let cacheReadInputTokens = 0;
+  let cacheMissInputTokens = 0;
   let cacheCreationInputTokens = 0;
+  let outputTokens = 0;
+  let estimatedCostUsd = 0;
+  let pricedRounds = 0;
+  const usageValidationIssues = {};
   let reasoningTokens = 0;
   let providerDurationMs = 0;
   let providerAttemptCount = 0;
@@ -4209,8 +4390,18 @@ function summarizeTokenOptimizationRounds(rounds) {
   for (const round of rounds) {
     requestLoweringModes[round.request_lowering_mode] =
       (requestLoweringModes[round.request_lowering_mode] ?? 0) + 1;
+    logicalInputTokens += round.logical_input_tokens;
     cacheReadInputTokens += round.cache_read_input_tokens;
+    cacheMissInputTokens += round.cache_miss_input_tokens;
     cacheCreationInputTokens += round.cache_creation_input_tokens;
+    outputTokens += round.output_tokens;
+    if (round.estimated_cost_usd !== null) {
+      estimatedCostUsd += round.estimated_cost_usd;
+      pricedRounds += 1;
+    }
+    for (const issue of round.usage_validation_issues ?? []) {
+      usageValidationIssues[issue] = (usageValidationIssues[issue] ?? 0) + 1;
+    }
     reasoningTokens += round.reasoning_tokens;
     providerDurationMs += round.provider_duration_ms;
     providerAttemptCount += round.provider_attempt_count;
@@ -4301,8 +4492,18 @@ function summarizeTokenOptimizationRounds(rounds) {
   return {
     rounds: rounds.length,
     request_lowering_modes: requestLoweringModes,
+    logical_input_tokens: logicalInputTokens,
     cache_read_input_tokens: cacheReadInputTokens,
+    cache_miss_input_tokens: cacheMissInputTokens,
     cache_creation_input_tokens: cacheCreationInputTokens,
+    output_tokens: outputTokens,
+    estimated_cost_usd:
+      rounds.length > 0 && pricedRounds === rounds.length ? estimatedCostUsd : null,
+    priced_rounds: pricedRounds,
+    usage_validation_issue_counts: usageValidationIssues,
+    usage_validation_issue_rounds: rounds.filter(
+      (round) => (round.usage_validation_issues?.length ?? 0) > 0
+    ).length,
     reasoning_tokens: reasoningTokens,
     provider_duration_ms: providerDurationMs,
     provider_attempt_count: providerAttemptCount,
@@ -4530,6 +4731,109 @@ function agentJsonlArtifactCandidates(agentDir, filename, taskDir = null) {
     path.join(agentDir, filename),
     path.join(agentDir, ".holon", "ledger", filename)
   ].filter(Boolean);
+}
+
+export function normalizeHolonEventEnvelope(envelope) {
+  if (
+    !envelope ||
+    typeof envelope !== "object" ||
+    typeof envelope.type !== "string" ||
+    !envelope.payload ||
+    typeof envelope.payload !== "object" ||
+    Array.isArray(envelope.payload)
+  ) {
+    throw new Error("holon events tail returned an invalid event envelope");
+  }
+  const eventSeq = Number(envelope.event_seq);
+  if (!Number.isSafeInteger(eventSeq) || eventSeq <= 0) {
+    throw new Error("holon events tail returned an invalid event sequence");
+  }
+  return {
+    id: envelope.id,
+    event_seq: eventSeq,
+    event_log_epoch: envelope.event_log_epoch ?? "",
+    contract_version: envelope.contract_version,
+    created_at: envelope.ts,
+    kind: envelope.type,
+    payload_schema: envelope.payload_schema,
+    payload_schema_version: envelope.payload_schema_version,
+    data: envelope.payload
+  };
+}
+
+export function assertHolonProviderRoundTelemetry({ modelRounds, tokenOptimization }) {
+  if (
+    Number(modelRounds ?? 0) > 0 &&
+    Number(tokenOptimization?.summary?.rounds ?? 0) === 0
+  ) {
+    throw new Error(
+      `Holon reported ${modelRounds} model rounds but the runtime DB export contained no provider_round_completed telemetry`
+    );
+  }
+}
+
+export async function readHolonAuditEvents({
+  holonBinary,
+  agentId,
+  homeDir,
+  cwd,
+  env,
+  pageLimit = 512,
+  execute = runCommand
+}) {
+  const events = [];
+  let afterSeq = null;
+  let eventLogEpoch = null;
+  for (;;) {
+    const args = [
+      "events",
+      "tail",
+      "--agent",
+      agentId,
+      "--order",
+      "asc",
+      "--limit",
+      String(pageLimit),
+      "--offline"
+    ];
+    if (afterSeq !== null) {
+      args.push("--after-seq", String(afterSeq));
+    }
+    const result = await execute(
+      holonBinary,
+      args,
+      cwd,
+      { ...env, HOLON_HOME: homeDir },
+      false
+    );
+    let page;
+    try {
+      page = JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(`failed to parse holon DB event export: ${error.message}`);
+    }
+    if (!page || !Array.isArray(page.events) || typeof page.has_newer !== "boolean") {
+      throw new Error("holon DB event export returned an invalid page");
+    }
+    if (eventLogEpoch !== null && page.event_log_epoch !== eventLogEpoch) {
+      throw new Error("holon DB event export epoch changed during pagination");
+    }
+    eventLogEpoch = page.event_log_epoch;
+    const normalized = page.events.map(normalizeHolonEventEnvelope);
+    events.push(...normalized);
+    if (!page.has_newer) {
+      return events;
+    }
+    const newestSeq = Number(page.newest_seq);
+    if (
+      normalized.length === 0 ||
+      !Number.isSafeInteger(newestSeq) ||
+      newestSeq <= (afterSeq ?? 0)
+    ) {
+      throw new Error("holon DB event export cursor did not advance");
+    }
+    afterSeq = newestSeq;
+  }
 }
 
 async function readAgentJsonlArtifact(agentDir, filename, taskDir = null) {

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -15,6 +15,7 @@ import {
   validateRealTaskManifest
 } from "../lib/manifest.mjs";
 import {
+  assertHolonProviderRoundTelemetry,
   buildPairedSummary,
   buildHolonBenchmarkEnv,
   buildOperatorPrompt,
@@ -29,9 +30,12 @@ import {
   detectScopeViolation,
   evaluateRealTaskSuccess,
   orderPairedRunners,
+  normalizeHolonEventEnvelope,
+  normalizeProviderRoundUsage,
   parseClaudeCliJsonl,
   parseCodexJsonl,
   resolveDriverHolonBinary,
+  readHolonAuditEvents,
   selectHolonFinalMessage,
   shouldRunManifestVerifier,
   summarizeHolonTokenOptimization,
@@ -841,7 +845,16 @@ test("validateBenchmarkSuite accepts repeated paired execution metadata", () => 
         driver: "holon",
         model_ref: "deepseek@responses/deepseek-v4-flash",
         transport: "openai_responses",
-        endpoint: "responses"
+        endpoint: "responses",
+        pricing: {
+          currency: "USD",
+          effective_at: "2026-08-16T16:00:00Z",
+          source: "provider pricing page",
+          cache_miss_input_per_million: 0.28,
+          cache_read_input_per_million: 0.028,
+          cache_creation_input_per_million: 0,
+          output_per_million: 0.42
+        }
       }
     ],
     pr: { submit_pr: false },
@@ -851,6 +864,64 @@ test("validateBenchmarkSuite accepts repeated paired execution metadata", () => 
   assert.equal(suite.repetitions, 5);
   assert.equal(suite.execution.max_parallel_runners, 1);
   assert.equal(suite.runners[1].endpoint, "responses");
+  assert.equal(suite.runners[1].pricing.currency, "USD");
+});
+
+test("validateBenchmarkSuite rejects incomplete or invalid pricing", () => {
+  assert.throws(
+    () =>
+      validateBenchmarkSuite({
+        suite_id: "deepseek-pilot",
+        label_prefix: "deepseek-pilot",
+        tasks: ["benchmarks/tasks/task.yaml"],
+        runners: [
+          {
+            runner_id: "deepseek",
+            driver: "holon",
+            model_ref: "deepseek/model",
+            pricing: {
+              currency: "USD",
+              effective_at: "not-a-date",
+              source: "provider pricing page",
+              cache_miss_input_per_million: 0.28,
+              cache_read_input_per_million: 0.028,
+              cache_creation_input_per_million: 0,
+              output_per_million: 0.42
+            }
+          }
+        ],
+        pr: { submit_pr: false },
+        timeouts: { ci_poll_minutes: 30 }
+      }),
+    /effective_at must be an ISO-8601 timestamp/
+  );
+  assert.throws(
+    () =>
+      validateBenchmarkSuite({
+        suite_id: "deepseek-pilot",
+        label_prefix: "deepseek-pilot",
+        tasks: ["benchmarks/tasks/task.yaml"],
+        runners: [
+          {
+            runner_id: "deepseek",
+            driver: "holon",
+            model_ref: "deepseek/model",
+            pricing: {
+              currency: "USD",
+              effective_at: "2026",
+              source: "provider pricing page",
+              cache_miss_input_per_million: 0.28,
+              cache_read_input_per_million: 0.028,
+              cache_creation_input_per_million: 0,
+              output_per_million: 0.42
+            }
+          }
+        ],
+        pr: { submit_pr: false },
+        timeouts: { ci_poll_minutes: 30 }
+      }),
+    /effective_at must be an ISO-8601 timestamp/
+  );
 });
 
 test("validateBenchmarkSuite requires serial execution for paired ordering", () => {
@@ -1010,11 +1081,14 @@ test("buildPairedSummary preserves execution order and emits metric deltas", () 
         success: true,
         duration_ms: 80,
         input_tokens: 90,
+        logical_input_tokens: 90,
         output_tokens: 20,
         provider_duration_ms: 50,
         provider_retry_count: 0,
         reasoning_tokens: 8,
-        cache_read_input_tokens: 4
+        cache_read_input_tokens: 4,
+        cache_miss_input_tokens: 86,
+        estimated_cost_usd: 0.00004
       },
       {
         task_id: "task-a",
@@ -1025,11 +1099,14 @@ test("buildPairedSummary preserves execution order and emits metric deltas", () 
         success: false,
         duration_ms: 100,
         input_tokens: 100,
+        logical_input_tokens: 120,
         output_tokens: 30,
         provider_duration_ms: 70,
         provider_retry_count: 1,
         reasoning_tokens: 5,
-        cache_read_input_tokens: 10
+        cache_read_input_tokens: 10,
+        cache_miss_input_tokens: 100,
+        estimated_cost_usd: 0.00006
       }
     ],
     [{ runner_id: "anthropic" }, { runner_id: "responses" }]
@@ -1039,6 +1116,229 @@ test("buildPairedSummary preserves execution order and emits metric deltas", () 
   assert.equal(entries[0].complete, true);
   assert.equal(entries[0].comparisons[0].duration_ms_delta, -20);
   assert.equal(entries[0].comparisons[0].provider_retry_count_delta, -1);
+  assert.equal(entries[0].comparisons[0].logical_input_tokens_delta, -30);
+  assert.equal(entries[0].comparisons[0].cache_miss_input_tokens_delta, -14);
+  assert.ok(Math.abs(entries[0].comparisons[0].estimated_cost_usd_delta + 0.00002) < 1e-12);
+});
+
+test("readHolonAuditEvents paginates stable DB event envelopes", async () => {
+  const calls = [];
+  const pages = [
+    {
+      event_log_epoch: "epoch-1",
+      newest_seq: 2,
+      has_newer: true,
+      events: [
+        {
+          id: "audit-1",
+          event_seq: 1,
+          event_log_epoch: "epoch-1",
+          contract_version: 1,
+          ts: "2026-08-15T00:00:00Z",
+          agent_id: "agent",
+          type: "provider_round_completed",
+          payload_schema: "holon.runtime_event.legacy",
+          payload_schema_version: 1,
+          payload: { round: 1 }
+        },
+        {
+          id: "audit-2",
+          event_seq: 2,
+          event_log_epoch: "epoch-1",
+          contract_version: 1,
+          ts: "2026-08-15T00:00:01Z",
+          agent_id: "agent",
+          type: "tool_executed",
+          payload_schema: "holon.runtime_event.legacy",
+          payload_schema_version: 1,
+          payload: { tool_name: "ExecCommand" }
+        }
+      ]
+    },
+    {
+      event_log_epoch: "epoch-1",
+      newest_seq: 3,
+      has_newer: false,
+      events: [
+        {
+          id: "audit-3",
+          event_seq: 3,
+          event_log_epoch: "epoch-1",
+          contract_version: 1,
+          ts: "2026-08-15T00:00:02Z",
+          agent_id: "agent",
+          type: "provider_round_completed",
+          payload_schema: "holon.runtime_event.legacy",
+          payload_schema_version: 1,
+          payload: { round: 2 }
+        }
+      ]
+    }
+  ];
+  const events = await readHolonAuditEvents({
+    holonBinary: "holon",
+    agentId: "agent",
+    homeDir: "/tmp/home",
+    cwd: "/tmp/repo",
+    env: {},
+    execute: async (_command, args) => {
+      calls.push(args);
+      return { stdout: JSON.stringify(pages[calls.length - 1]), stderr: "", exitCode: 0 };
+    }
+  });
+
+  assert.deepEqual(events.map((event) => event.event_seq), [1, 2, 3]);
+  assert.equal(events[0].kind, "provider_round_completed");
+  assert.equal(events[0].data.round, 1);
+  assert.deepEqual(calls[1].slice(-2), ["--after-seq", "2"]);
+});
+
+test("event envelope normalization rejects invalid events", () => {
+  assert.throws(
+    () => normalizeHolonEventEnvelope({ event_seq: 0, type: "x", payload: {} }),
+    /invalid event sequence/
+  );
+});
+
+test("DB event export failures are explicit", async () => {
+  await assert.rejects(
+    readHolonAuditEvents({
+      holonBinary: "holon",
+      agentId: "agent",
+      homeDir: "/tmp/home",
+      cwd: "/tmp/repo",
+      env: {},
+      execute: async () => ({ stdout: "not-json", stderr: "", exitCode: 0 })
+    }),
+    /failed to parse holon DB event export/
+  );
+});
+
+test("provider usage normalization is transport-neutral and cost-aware", () => {
+  const pricing = {
+    currency: "USD",
+    effective_at: "2026-08-16T16:00:00Z",
+    source: "provider pricing page",
+    cache_miss_input_per_million: 1,
+    cache_read_input_per_million: 0.1,
+    cache_creation_input_per_million: 2,
+    output_per_million: 3
+  };
+  const responses = normalizeProviderRoundUsage({
+    provider: "deepseek",
+    modelRef: "deepseek@responses/deepseek-v4-flash",
+    transport: "openai_responses",
+    pricing,
+    data: {
+      input_tokens: 1000,
+      output_tokens: 100,
+      provider_cache_usage: { read_input_tokens: 800, creation_input_tokens: 0 }
+    }
+  });
+  assert.equal(responses.logical_input_tokens, 1000);
+  assert.equal(responses.cache_miss_input_tokens, 200);
+  assert.equal(responses.estimated_cost_usd, 0.00058);
+
+  const anthropic = normalizeProviderRoundUsage({
+    provider: "deepseek",
+    modelRef: "deepseek@default/deepseek-v4-flash",
+    transport: "anthropic_messages",
+    pricing,
+    data: {
+      input_tokens: 200,
+      output_tokens: 100,
+      provider_cache_usage: { read_input_tokens: 800, creation_input_tokens: 50 }
+    }
+  });
+  assert.equal(anthropic.logical_input_tokens, 1050);
+  assert.equal(anthropic.cache_miss_input_tokens, 200);
+  assert.equal(anthropic.estimated_cost_usd, 0.00068);
+
+  const fullHit = normalizeProviderRoundUsage({
+    provider: "deepseek",
+    modelRef: "deepseek@responses/deepseek-v4-flash",
+    transport: "openai_responses",
+    data: {
+      input_tokens: 1000,
+      output_tokens: 10,
+      provider_cache_usage: { read_input_tokens: 1000, creation_input_tokens: 0 }
+    }
+  });
+  assert.equal(fullHit.cache_miss_input_tokens, 0);
+
+  const noHit = normalizeProviderRoundUsage({
+    provider: "deepseek",
+    modelRef: "deepseek@responses/deepseek-v4-flash",
+    transport: "openai_responses",
+    data: {
+      input_tokens: 1000,
+      output_tokens: 10,
+      provider_cache_usage: { read_input_tokens: 0, creation_input_tokens: 0 }
+    }
+  });
+  assert.equal(noHit.cache_miss_input_tokens, 1000);
+
+  const explicitResponsesWins = normalizeProviderRoundUsage({
+    provider: "anthropic",
+    modelRef: "fallback/model",
+    transport: "openai_responses",
+    data: {
+      input_tokens: 1000,
+      output_tokens: 10,
+      provider_cache_usage: { read_input_tokens: 800, creation_input_tokens: 0 }
+    }
+  });
+  assert.equal(explicitResponsesWins.usage_semantics, "openai_responses");
+  assert.equal(explicitResponsesWins.logical_input_tokens, 1000);
+});
+
+test("provider usage normalization reports invalid or unavailable data explicitly", () => {
+  const usage = normalizeProviderRoundUsage({
+    provider: "openai",
+    modelRef: "openai/gpt",
+    data: {
+      input_tokens: -1,
+      output_tokens: null,
+      provider_cache_usage: { read_input_tokens: 5 }
+    }
+  });
+  assert.equal(usage.estimated_cost_usd, null);
+  assert.ok(usage.usage_validation_issues.includes("input_tokens_negative"));
+  assert.ok(usage.usage_validation_issues.includes("output_tokens_missing"));
+  assert.ok(usage.usage_validation_issues.includes("cache_read_exceeds_logical_input"));
+
+  const invalidPriced = normalizeProviderRoundUsage({
+    provider: "openai",
+    modelRef: "openai/gpt",
+    pricing: {
+      currency: "USD",
+      effective_at: "2026-08-16T16:00:00Z",
+      source: "provider pricing page",
+      cache_miss_input_per_million: 1,
+      cache_read_input_per_million: 0.1,
+      cache_creation_input_per_million: 2,
+      output_per_million: 3
+    },
+    data: { input_tokens: null, output_tokens: 10 }
+  });
+  assert.equal(invalidPriced.estimated_cost_usd, null);
+});
+
+test("provider round telemetry cannot silently disappear after model execution", () => {
+  assert.throws(
+    () =>
+      assertHolonProviderRoundTelemetry({
+        modelRounds: 2,
+        tokenOptimization: { summary: { rounds: 0 } }
+      }),
+    /contained no provider_round_completed telemetry/
+  );
+  assert.doesNotThrow(() =>
+    assertHolonProviderRoundTelemetry({
+      modelRounds: 2,
+      tokenOptimization: { summary: { rounds: 2 } }
+    })
+  );
 });
 
 test("manifest verifier runs only when GitHub CI is not the verification source", () => {

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -1208,6 +1208,22 @@ test("DB event export failures are explicit", async () => {
       homeDir: "/tmp/home",
       cwd: "/tmp/repo",
       env: {},
+      execute: async () => ({
+        stdout: "{\"events\":[]}",
+        stderr: "runtime DB unavailable",
+        exitCode: 2
+      })
+    }),
+    /holon DB event export failed with exit code 2: runtime DB unavailable/
+  );
+
+  await assert.rejects(
+    readHolonAuditEvents({
+      holonBinary: "holon",
+      agentId: "agent",
+      homeDir: "/tmp/home",
+      cwd: "/tmp/repo",
+      env: {},
       execute: async () => ({ stdout: "not-json", stderr: "", exitCode: 0 })
     }),
     /failed to parse holon DB event export/

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -284,8 +284,13 @@ contracts are stabilized.
 ```bash
 holon events tail --limit 20
 holon events tail --order asc --max-level info
+holon events tail --agent benchmark-run --order asc --offline
 holon events stream --after-seq 42 --max-events 100
 ```
+
+`events tail --offline` reads the same stable event envelope from the local
+runtime database without requiring a running daemon. Offline pages do not
+support `--max-level`.
 
 ### Terminal UI
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -493,6 +493,11 @@ pub enum EventsCommands {
         max_level: Option<EventMaxLevelCli>,
         #[arg(long)]
         agent: Option<String>,
+        #[arg(
+            long,
+            help = "Read directly from the local runtime database without requiring a running daemon"
+        )]
+        offline: bool,
     },
     #[command(
         about = "Stream stable event envelopes as newline-delimited JSON",

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -266,7 +266,7 @@ impl HttpErrorEnvelope {
 pub(crate) const CALLBACK_BODY_LIMIT_BYTES: usize = 256 * 1024;
 pub(crate) const CONTROL_PROMPT_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 pub(crate) const DEFAULT_EVENT_STREAM_WINDOW: usize = 128;
-pub(crate) const MAX_EVENT_STREAM_WINDOW: usize = 512;
+pub const MAX_EVENT_STREAM_WINDOW: usize = 512;
 pub(crate) const EVENT_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 
 impl AppState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,9 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
 fn runtime_command_uses_config_inspection(command: &Commands) -> bool {
     matches!(
         command,
-        Commands::Debug {
+        Commands::Events {
+            command: EventsCommands::Tail { offline: true, .. }
+        } | Commands::Debug {
             command: DebugCommands::SchedulerRecoveryFixture { .. }
                 | DebugCommands::SchedulerRestartFixture { .. }
         }
@@ -1594,6 +1596,7 @@ mod tests {
     #[test]
     fn hidden_offline_scheduler_commands_skip_runtime_model_resolution() {
         for args in [
+            vec!["holon", "events", "tail", "--agent", "runner", "--offline"],
             vec![
                 "holon",
                 "debug",
@@ -1617,6 +1620,60 @@ mod tests {
 
         let cli = Cli::parse_from(["holon", "debug", "scheduler-recovery"]);
         assert!(!runtime_command_uses_config_inspection(&cli.command));
+    }
+
+    #[test]
+    fn offline_event_page_reads_runtime_db_in_stable_envelope_shape() {
+        let config = test_config();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        runtime_db
+            .audit_events()
+            .append(
+                Some("runner"),
+                &AuditEvent::legacy(
+                    "provider_round_completed",
+                    serde_json::json!({ "round": 1, "input_tokens": 10 }),
+                ),
+            )
+            .unwrap();
+        runtime_db
+            .audit_events()
+            .append(
+                Some("runner"),
+                &AuditEvent::legacy("tool_executed", serde_json::json!({ "tool_name": "Read" })),
+            )
+            .unwrap();
+
+        let page = offline_event_page(
+            &config,
+            "runner",
+            None,
+            None,
+            1,
+            holon::cli::EventPageOrderCli::Asc,
+        )
+        .unwrap();
+
+        assert_eq!(page.events.len(), 1);
+        assert_eq!(page.events[0].event_type, "provider_round_completed");
+        assert_eq!(page.events[0].payload["round"], 1);
+        assert_eq!(page.newest_seq, Some(page.events[0].event_seq));
+        assert!(page.has_newer);
+        assert!(!page.has_older);
+
+        let clamped = offline_event_page(
+            &config,
+            "runner",
+            None,
+            None,
+            0,
+            holon::cli::EventPageOrderCli::Asc,
+        )
+        .unwrap();
+        assert_eq!(clamped.limit, 1);
+        assert_eq!(clamped.events.len(), 1);
     }
 
     #[test]
@@ -2295,8 +2352,18 @@ async fn handle_events_command(config: &AppConfig, command: EventsCommands) -> R
             order,
             max_level,
             agent,
+            offline,
         } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            if offline {
+                anyhow::ensure!(
+                    max_level.is_none(),
+                    "--max-level is not supported with --offline"
+                );
+                return print_json(&serde_json::to_value(offline_event_page(
+                    config, &agent, before_seq, after_seq, limit, order,
+                )?)?);
+            }
             let client = LocalClient::new(config.clone())?;
             let page = client
                 .agent_events_page(
@@ -2337,6 +2404,94 @@ async fn handle_events_command(config: &AppConfig, command: EventsCommands) -> R
             }
         }
     }
+}
+
+fn offline_event_page(
+    config: &AppConfig,
+    agent_id: &str,
+    before_seq: Option<u64>,
+    after_seq: Option<u64>,
+    limit: usize,
+    order: holon::cli::EventPageOrderCli,
+) -> Result<holon::client::EventPageResponse> {
+    let limit = limit.clamp(1, holon::http::MAX_EVENT_STREAM_WINDOW);
+    let runtime_db =
+        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+    let descending = matches!(order, holon::cli::EventPageOrderCli::Desc);
+    let mut events = runtime_db.audit_events().range(
+        Some(agent_id),
+        before_seq,
+        after_seq,
+        descending,
+        limit.saturating_add(1),
+    )?;
+    let has_more = events.len() > limit;
+    if has_more {
+        events.truncate(limit);
+    }
+    let oldest_seq = events.iter().map(|event| event.event_seq).min();
+    let newest_seq = events.iter().map(|event| event.event_seq).max();
+    let event_log_epoch = runtime_db.event_log_epoch()?;
+    let envelopes = events
+        .into_iter()
+        .map(|event| holon::client::StreamEventEnvelope {
+            id: event.id,
+            event_seq: event.event_seq,
+            event_log_epoch: Some(if event.event_log_epoch.is_empty() {
+                event_log_epoch.clone()
+            } else {
+                event.event_log_epoch
+            }),
+            contract_version: event.contract_version,
+            ts: event.created_at,
+            agent_id: agent_id.to_string(),
+            event_type: event.kind,
+            payload_schema: event.payload_schema,
+            payload_schema_version: event.payload_schema_version,
+            provenance: Some(event_replay_provenance(&event.data)),
+            payload: event.data,
+        })
+        .collect();
+    Ok(holon::client::EventPageResponse {
+        events: envelopes,
+        event_log_epoch,
+        oldest_seq,
+        newest_seq,
+        cursor_seq: runtime_db.audit_events().latest_event_seq(Some(agent_id))?,
+        has_older: descending && has_more,
+        has_newer: !descending && has_more,
+        order: order.to_string(),
+        limit,
+    })
+}
+
+fn event_replay_provenance(payload: &serde_json::Value) -> serde_json::Value {
+    let fields = [
+        "origin",
+        "authority_class",
+        "delivery_surface",
+        "admission_context",
+        "transport",
+        "source",
+        "reply_route",
+        "message_id",
+        "task_id",
+        "work_item_id",
+        "correlation_id",
+        "causation_id",
+    ];
+    serde_json::Value::Object(
+        fields
+            .into_iter()
+            .filter_map(|field| {
+                payload
+                    .get(field)
+                    .filter(|value| !value.is_null())
+                    .cloned()
+                    .map(|value| (field.to_string(), value))
+            })
+            .collect(),
+    )
 }
 
 async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Result<()> {

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1048,6 +1048,16 @@
         "required": false
       },
       {
+        "long": "offline",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
         "long": "order",
         "short": null,
         "default_value": "desc",


### PR DESCRIPTION
## Summary

- add `holon events tail --offline` so one-shot benchmark runs can page the canonical runtime DB event stream without a daemon or direct SQLite coupling
- make benchmark event export explicit, paginated, epoch-safe, artifact-compatible, and fail-fast when model rounds lack provider telemetry
- normalize Responses and Anthropic-compatible usage into logical input, cache read/miss/creation, output, and validated per-round diagnostics
- add explicit runner pricing snapshots with source/effective timestamp and nullable estimated cost
- extend paired JSON/Markdown reports and deltas while retaining legacy token fields

## Runtime concept

Audit events are already canonical in the runtime DB. This change aligns the benchmark with that storage boundary and separates provider-reported raw input from transport-neutral logical and billable usage.

## Verification

- `npm test --prefix benchmark` (69 passed)
- `cargo test --bin holon offline` (2 passed)
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2580
