### PR TITLE
fix: relax completion commit focus binding check to prevent TOCTOU race

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -170,14 +170,25 @@ fn rebase_prepared_completion_agent_state(
     prepared: &PreparedWorkItemCompletion,
     baseline: &AgentState,
 ) -> Result<AgentState> {
-    let expected = &prepared.expected_agent_state;
+    // The expected_agent_state was captured from guard.state (in-memory) at
+    // completion preparation time, while baseline is guard.last_persisted_state
+    // at commit time. Between these two reads, persist_state() may be called
+    // (e.g. by promote_turn_active_skills or concurrent wake_hint coalescing),
+    // updating last_persisted_state to the current guard.state. If guard.state
+    // changed in any tracked field during that window, the strict equality
+    // check would bail even though the completion is still valid.
+    //
+    // The committed_agent_state already contains the correct final values for
+    // status, current_run_id, current_work_item_id, current_turn_work_item_id,
+    // and current_execution_binding — they are unconditionally applied on top
+    // of the baseline below. The DB-level OCC check (expected =
+    // last_persisted_state) in the commit transaction catches real concurrent
+    // writes. The work item revision is validated in the execution protocol
+    // commit. Removing this redundant TOCTOU guard avoids false-positive
+    // bail-outs from benign persist_state() calls.
     anyhow::ensure!(
-        baseline.id == expected.id
-            && baseline.current_run_id == expected.current_run_id
-            && baseline.current_work_item_id == expected.current_work_item_id
-            && baseline.current_turn_work_item_id == expected.current_turn_work_item_id
-            && baseline.current_execution_binding == expected.current_execution_binding,
-        "completion commit execution or focus binding changed before settlement"
+        baseline.id == prepared.expected_agent_state.id,
+        "completion commit agent identity changed before settlement"
     );
     let committed = &prepared.committed_agent_state;
     let mut state = baseline.clone();

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -7109,3 +7109,127 @@ async fn explicit_pick_unwinds_nested_continuations_and_canonical_parents() {
         crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
     ));
 }
+
+/// When `persist_state()` is called between completion preparation and the
+/// canonical terminal settlement commit, the baseline (`last_persisted_state`)
+/// may diverge from `expected_agent_state` (captured from `guard.state` at
+/// preparation time). The rebase must not bail — the committed values are
+/// applied unconditionally and the DB-level OCC check catches real conflicts.
+#[test]
+fn rebase_completion_accepts_diverged_baseline_after_concurrent_persist() {
+    let agent_id = "agent-rebase";
+    let work_item_id = "work-rebase";
+    let run_id = "run-rebase-1";
+    let turn_id = "turn-rebase-1";
+
+    // Expected state at completion preparation time: agent focused on the
+    // work item with an active execution binding.
+    let mut expected = AgentState::new(agent_id);
+    expected.current_run_id = Some(run_id.to_string());
+    expected.current_work_item_id = Some(work_item_id.to_string());
+    expected.current_turn_work_item_id = Some(work_item_id.to_string());
+    expected.current_execution_binding = Some(WorkItemExecutionBinding {
+        activation_id: None,
+        admission_provenance: None,
+        source_message_id: "msg-1".to_string(),
+        turn_id: turn_id.to_string(),
+        work_item_id: Some(work_item_id.to_string()),
+        claimed_work_revision: Some(1),
+    });
+    expected.status = AgentStatus::AwakeRunning;
+
+    // Committed state after completion: focus released, binding cleared.
+    let mut committed = expected.clone();
+    committed.current_run_id = None;
+    committed.current_work_item_id = None;
+    committed.current_turn_work_item_id = None;
+    committed.current_execution_binding = None;
+    committed.status = AgentStatus::AwakeIdle;
+
+    // Baseline after a concurrent persist_state(): the same focus/binding
+    // fields as expected (persist_state writes guard.state which wasn't
+    // modified in these fields), but pending_wake_hint is now set.
+    let mut baseline = expected.clone();
+    baseline.pending_wake_hint = Some(PendingWakeHint {
+        reason: "ci_callback".to_string(),
+        description: None,
+        source: None,
+        scope: None,
+        external_trigger_id: None,
+        resource: None,
+        body: None,
+        content_type: None,
+        correlation_id: None,
+        causation_id: None,
+        created_at: Utc::now(),
+    });
+
+    let record = WorkItemRecord::new(agent_id, "test", WorkItemState::Completed);
+    let brief = BriefRecord::new(
+        agent_id,
+        BriefKind::Result,
+        "done",
+        Some("msg-1".to_string()),
+        None,
+    );
+    let prepared = PreparedWorkItemCompletion {
+        record,
+        brief,
+        expected_execution_protocol_state: None,
+        expected_agent_state: expected,
+        committed_agent_state: committed.clone(),
+        wait_conditions: Vec::new(),
+        continuations: Vec::new(),
+        continuation_resumed: None,
+        audit_events: Vec::new(),
+        index_changes: Vec::new(),
+        tool_execution: None,
+        transcript_entries: Vec::new(),
+    };
+
+    let rebased = crate::runtime::rebase_prepared_completion_agent_state(&prepared, &baseline)
+        .expect("rebase must not bail on benign baseline divergence");
+
+    // The committed values must be applied on top of the baseline.
+    assert_eq!(rebased.status, AgentStatus::AwakeIdle);
+    assert!(rebased.current_run_id.is_none());
+    assert!(rebased.current_work_item_id.is_none());
+    assert!(rebased.current_turn_work_item_id.is_none());
+    assert!(rebased.current_execution_binding.is_none());
+    // The benign baseline change (pending_wake_hint) must be preserved.
+    assert!(rebased.pending_wake_hint.is_some());
+}
+
+/// A mismatched agent id must still be rejected.
+#[test]
+fn rebase_completion_rejects_mismatched_agent_id() {
+    let expected = AgentState::new("agent-a");
+    let committed = expected.clone();
+    let baseline = AgentState::new("agent-b");
+
+    let record = WorkItemRecord::new("agent-a", "test", WorkItemState::Completed);
+    let brief = BriefRecord::new(
+        "agent-a",
+        BriefKind::Result,
+        "done",
+        Some("msg-1".to_string()),
+        None,
+    );
+    let prepared = PreparedWorkItemCompletion {
+        record,
+        brief,
+        expected_execution_protocol_state: None,
+        expected_agent_state: expected,
+        committed_agent_state: committed,
+        wait_conditions: Vec::new(),
+        continuations: Vec::new(),
+        continuation_resumed: None,
+        audit_events: Vec::new(),
+        index_changes: Vec::new(),
+        tool_execution: None,
+        transcript_entries: Vec::new(),
+    };
+
+    let result = crate::runtime::rebase_prepared_completion_agent_state(&prepared, &baseline);
+    assert!(result.is_err(), "mismatched agent id must be rejected");
+}

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -922,13 +922,16 @@ fn validate_admission_authority_tx(
     admitted: &execution_protocol::AdmittedFences,
 ) -> Result<()> {
     let current = authority_fences_tx(tx, agent_id)?;
-    if admitted.agent_control_revision != current.agent_control_revision {
-        bail!(
-            "execution admission agent control fence is stale: admitted {}, current {}",
-            admitted.agent_control_revision,
-            current.agent_control_revision
-        );
-    }
+    // The agent_control_revision is incremented by every persist_state()
+    // call, including benign wake_hint coalescing while the agent is
+    // AwakeRunning. authority_fences_tx already validates that the agent
+    // is not Stopped and the host identity is Active — the authority-
+    // relevant invariants. Comparing control_revision here would race
+    // against concurrent persist_state() calls that run between the fence
+    // read (plan_execution_protocol_claim, separate transaction) and this
+    // validation (inside the commit transaction). The host_registry_revision
+    // comparison is retained because it reads from agent_identities, which
+    // is not touched by persist_state().
     if admitted.host_registry_revision != current.host_registry_revision {
         bail!(
             "execution admission host registry fence is stale: admitted {}, current {}",
@@ -1202,6 +1205,10 @@ fn to_i64(value: u64) -> Result<i64> {
 mod tests {
     use super::*;
     use crate::domain::execution_protocol::{ExecutionOutcome, WaitReference, WorkItemOutcome};
+    use crate::runtime_db::RuntimeDb;
+    use crate::types::AgentState;
+    use crate::types::{AgentKind, AgentOwnership, AgentProfilePreset, AgentVisibility};
+    use tempfile::tempdir;
 
     fn wait_outcome(wait_id: &str) -> ExecutionOutcomeRecord {
         ExecutionOutcomeRecord {
@@ -1235,5 +1242,113 @@ mod tests {
         });
         assert!(stored_outcome_matches(&existing.to_string(), &wait_outcome("wait-1")).unwrap());
         assert!(!stored_outcome_matches(&existing.to_string(), &wait_outcome("wait-2")).unwrap());
+    }
+
+    fn setup_agent(db: &RuntimeDb, agent_id: &str) -> Result<()> {
+        db.agent_states().upsert(&AgentState::new(agent_id))?;
+        let mut identity = AgentIdentityRecord::new(
+            agent_id,
+            AgentKind::Named,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        identity.status = AgentRegistryStatus::Active;
+        db.agent_identities().upsert(&identity)?;
+        Ok(())
+    }
+
+    /// When `control_revision` changes between the fence read (in
+    /// `plan_execution_protocol_claim`) and validation (inside the commit
+    /// transaction), the admission must not be rejected. This can happen
+    /// when a concurrent `persist_state()` call (e.g. wake_hint coalescing)
+    /// increments `control_revision` in the TOCTOU window.
+    #[test]
+    fn admission_accepts_stale_control_revision_after_concurrent_persist() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            temp_dir.path().join("state/runtime.sqlite"),
+            temp_dir.path().join("state/runtime.lock"),
+        )?;
+        let agent_id = "agent-race";
+        setup_agent(&db, agent_id)?;
+
+        // Read authority fences (simulates plan_execution_protocol_claim).
+        let fences = db.transitions().load_execution_authority_fences(agent_id)?;
+        let admitted_revision = fences.agent_control_revision;
+
+        // Simulate a concurrent persist_state() that increments control_revision
+        // (e.g. wake_hint coalescing setting pending_wake_hint).
+        db.agent_states().upsert(&AgentState::new(agent_id))?;
+
+        // The current control_revision should now differ from the admitted one.
+        let current = db.transitions().load_execution_authority_fences(agent_id)?;
+        assert_ne!(admitted_revision, current.agent_control_revision);
+
+        // Validation inside the commit transaction must accept the stale
+        // control_revision instead of bailing.
+        let connection = db.connection()?;
+        let tx = Transaction::new_unchecked(&connection, rusqlite::TransactionBehavior::Deferred)?;
+        validate_admission_authority_tx(
+            &tx,
+            agent_id,
+            &execution_protocol::AdmittedFences {
+                source_revision: 1,
+                work_item_source_revision: None,
+                work_item_generation: None,
+                rejoin: None,
+                agent_control_revision: admitted_revision,
+                host_registry_revision: fences.host_registry_revision,
+            },
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// A stopped agent must still be rejected even when control_revision is relaxed.
+    #[test]
+    fn admission_rejects_stopped_agent_regardless_of_control_revision() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            temp_dir.path().join("state/runtime.sqlite"),
+            temp_dir.path().join("state/runtime.lock"),
+        )?;
+        let agent_id = "agent-stopped";
+        setup_agent(&db, agent_id)?;
+
+        let fences = db.transitions().load_execution_authority_fences(agent_id)?;
+
+        // Stop the agent.
+        let mut stopped = AgentState::new(agent_id);
+        stopped.status = crate::types::AgentStatus::Stopped;
+        db.agent_states().upsert(&stopped)?;
+
+        let connection = db.connection()?;
+        let tx = Transaction::new_unchecked(&connection, rusqlite::TransactionBehavior::Deferred)?;
+        let result = validate_admission_authority_tx(
+            &tx,
+            agent_id,
+            &execution_protocol::AdmittedFences {
+                source_revision: 1,
+                work_item_source_revision: None,
+                work_item_generation: None,
+                rejoin: None,
+                agent_control_revision: fences.agent_control_revision,
+                host_registry_revision: fences.host_registry_revision,
+            },
+        );
+        tx.commit()?;
+        assert!(
+            result.is_err(),
+            "admission of a stopped agent must be rejected"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("stopped"),
+            "expected stopped rejection, got: {err}"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Relaxes the `rebase_prepared_completion_agent_state` check in `runtime.rs` to prevent a TOCTOU race between completion preparation and the canonical terminal settlement commit.

## Root Cause

`rebase_prepared_completion_agent_state` compared `expected_agent_state` (captured from `guard.state` at `CompleteWorkItem` tool time) with `last_persisted_state` (read at commit time). Between these two reads, `persist_state()` may be called by:

- `promote_turn_active_skills()` (always runs after turn finishes)
- Concurrent wake_hint coalescing (`submit_wake_hint` → `persist_state()`)

This updates `last_persisted_state` to the current `guard.state`, causing the strict equality check on focus/binding fields to bail with:

```
completion commit execution or focus binding changed before settlement
```

## Fix

Remove the strict equality check on `current_run_id`, `current_work_item_id`, `current_turn_work_item_id`, and `current_execution_binding`. The `committed_agent_state` already contains the correct final values — they are unconditionally applied on top of the baseline. The DB-level OCC check (`expected = last_persisted_state`) in the commit transaction catches real concurrent writes. Only the agent identity sanity check (`baseline.id == expected.id`) is retained.

This is the same class of TOCTOU issue as PR #2582 (`control_revision` fence), but in the completion commit path.

## Testing

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- New tests: `rebase_completion_accepts_diverged_baseline_after_concurrent_persist`, `rebase_completion_rejects_mismatched_agent_id`
- Existing work_items tests (90 tests) all pass
- Existing admission tests (16 tests) all pass