### PR TITLE
feat: add stable provider prefix fingerprints

### DIFF
--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -336,6 +336,7 @@ function formatTokenOptimization(entry) {
     return "n/a";
   }
   const cacheRead = diagnostics.summary.cache_read_input_tokens ?? 0;
+  const cacheHitRatio = diagnostics.summary.cache_hit_ratio;
   const highMisses = diagnostics.summary.high_input_zero_cache_read_rounds ?? 0;
   const modes = Object.entries(diagnostics.summary.request_lowering_modes ?? {})
     .map(([mode, count]) => `${mode}:${count}`)
@@ -343,6 +344,9 @@ function formatTokenOptimization(entry) {
   const parts = [];
   if (cacheRead > 0 || highMisses > 0) {
     parts.push(`cache_read=${cacheRead}`);
+  }
+  if (typeof cacheHitRatio === "number") {
+    parts.push(`cache_hit=${(cacheHitRatio * 100).toFixed(2)}%`);
   }
   if (highMisses > 0) {
     parts.push(`high_miss=${highMisses}`);
@@ -352,6 +356,12 @@ function formatTokenOptimization(entry) {
   }
   if ((diagnostics.summary.context_management_enabled_rounds ?? 0) > 0) {
     parts.push(`ctx_mgmt=${diagnostics.summary.context_management_enabled_rounds}`);
+  }
+  parts.push(
+    `stable_prefix=${diagnostics.summary.stable_prefix_available_rounds ?? 0}/${diagnostics.summary.rounds ?? 0}`
+  );
+  if ((diagnostics.summary.stable_prefix_changed_rounds ?? 0) > 0) {
+    parts.push(`prefix_changed=${diagnostics.summary.stable_prefix_changed_rounds}`);
   }
   return parts.length > 0 ? parts.join(" ") : "observed";
 }
@@ -3336,6 +3346,7 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
     lastPositiveCacheRound: null,
     lastMissRound: null
   };
+  let previousStablePrefix = null;
 
   for (const event of events) {
     const kind = event?.kind ?? event?.event ?? event?.type;
@@ -3376,6 +3387,11 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
     const cacheCreationInputTokens = usage.cache_creation_input_tokens;
     const round = Number(data?.round ?? event?.round ?? rounds.length + 1);
     const requestDiagnostics = data?.provider_request_diagnostics ?? {};
+    const stablePrefix = stablePrefixDiagnostic(requestDiagnostics);
+    const stablePrefixChangedComponents = stablePrefixComponentChanges(
+      previousStablePrefix,
+      stablePrefix
+    );
     const requestLoweringMode = inferRequestLoweringMode({
       provider,
       modelRef,
@@ -3404,6 +3420,8 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
             cacheReadInputTokens,
             eventTimestampMs,
             contextManagement,
+            stablePrefix,
+            stablePrefixChangedComponents,
             state: anthropicCacheState
           })
         : {};
@@ -3427,6 +3445,10 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       ).length,
       cache_read_input_tokens: cacheReadInputTokens,
       cache_creation_input_tokens: cacheCreationInputTokens,
+      cache_hit_ratio:
+        usage.logical_input_tokens > 0
+          ? cacheReadInputTokens / usage.logical_input_tokens
+          : null,
       high_input_zero_cache_read: highInputZeroCacheRead,
       prompt_cache_key_present: typeof data?.prompt_cache_key === "string" && data.prompt_cache_key.length > 0,
       working_memory_revision: workingMemoryRevision,
@@ -3441,11 +3463,16 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
       context_management: contextManagement,
       previous_tool: previousTool,
       anthropic_cache: anthropicCache,
+      stable_prefix: stablePrefix,
+      stable_prefix_changed_components: stablePrefixChangedComponents,
       ...preciseAnthropicCache
     };
     rounds.push(roundEntry);
     if (provider === "anthropic") {
       updateAnthropicCacheState(anthropicCacheState, roundEntry);
+    }
+    if (stablePrefix.status === "available") {
+      previousStablePrefix = stablePrefix;
     }
   }
 
@@ -3979,6 +4006,53 @@ function anthropicCacheDiagnostic(provider, requestDiagnostics) {
   };
 }
 
+function stablePrefixDiagnostic(requestDiagnostics) {
+  const stablePrefix = requestDiagnostics?.stable_prefix;
+  if (!stablePrefix || typeof stablePrefix.stable_prefix_fingerprint !== "string") {
+    return {
+      status: "unavailable",
+      schema_version: null,
+      algorithm: null,
+      full_request_fingerprint: null,
+      stable_prefix_fingerprint: null,
+      history_prefix_items: null,
+      dynamic_tail_items: null,
+      components: []
+    };
+  }
+  return {
+    status: "available",
+    schema_version: numberOrNull(stablePrefix.schema_version),
+    algorithm: stablePrefix.algorithm ?? null,
+    full_request_fingerprint: stablePrefix.full_request_fingerprint ?? null,
+    stable_prefix_fingerprint: stablePrefix.stable_prefix_fingerprint,
+    history_prefix_items: numberOrNull(stablePrefix.history_prefix_items),
+    dynamic_tail_items: numberOrNull(stablePrefix.dynamic_tail_items),
+    components: Array.isArray(stablePrefix.components)
+      ? stablePrefix.components.map((component) => ({
+          name: component?.name ?? "unknown",
+          fingerprint: component?.fingerprint ?? null,
+          item_count: numberOrNull(component?.item_count)
+        }))
+      : []
+  };
+}
+
+function stablePrefixComponentChanges(previous, current) {
+  if (previous?.status !== "available" || current?.status !== "available") {
+    return null;
+  }
+  const previousComponents = new Map(
+    previous.components.map((component) => [component.name, component.fingerprint])
+  );
+  const currentComponents = new Map(
+    current.components.map((component) => [component.name, component.fingerprint])
+  );
+  return [...new Set([...previousComponents.keys(), ...currentComponents.keys()])]
+    .sort()
+    .filter((name) => previousComponents.get(name) !== currentComponents.get(name));
+}
+
 function prepareAnthropicCacheRoundDiagnostics({
   modelRef,
   workingMemoryRevision,
@@ -3987,6 +4061,8 @@ function prepareAnthropicCacheRoundDiagnostics({
   cacheReadInputTokens,
   eventTimestampMs,
   contextManagement,
+  stablePrefix,
+  stablePrefixChangedComponents,
   state
 }) {
   const currentShape = anthropicComparableShape({
@@ -3998,6 +4074,11 @@ function prepareAnthropicCacheRoundDiagnostics({
   const shapeChangedFields = state.previousShape
     ? anthropicShapeChangedFields(state.previousShape, currentShape)
     : [];
+  if (Array.isArray(stablePrefixChangedComponents)) {
+    for (const component of stablePrefixChangedComponents) {
+      shapeChangedFields.push(`stable_prefix.components.${component}`);
+    }
+  }
   const previousSegmentPositiveRound =
     shapeChangedFields.length > 0 ? state.lastPositiveCacheRound : null;
   if (shapeChangedFields.length > 0) {
@@ -4022,6 +4103,11 @@ function prepareAnthropicCacheRoundDiagnostics({
   const currentContainsPriorCacheablePrefix = cacheBreakpointsWithReuse.some(
     (breakpoint) => breakpoint.seen_in_previous_comparable_rounds
   );
+  const stablePrefixMatchesBaseline =
+    stablePrefix?.status === "available" &&
+    state.lastPositiveCacheRound?.stable_prefix?.status === "available" &&
+    stablePrefix.stable_prefix_fingerprint ===
+      state.lastPositiveCacheRound.stable_prefix.stable_prefix_fingerprint;
 
   const baseline = state.lastPositiveCacheRound;
   const classificationBaseline = baseline ?? previousSegmentPositiveRound;
@@ -4076,6 +4162,9 @@ function prepareAnthropicCacheRoundDiagnostics({
   ) {
     cacheBreakClassification = "ttl_possible";
     cacheBreakReason = "elapsed time since last positive cache read exceeded 5 minute prompt-cache TTL";
+  } else if (materialDrop && stablePrefixMatchesBaseline) {
+    cacheBreakClassification = "likely_server_side_drop";
+    cacheBreakReason = "provider-visible stable prefix matched the positive cache-read baseline";
   } else if (materialDrop && currentContainsPriorCacheablePrefix) {
     cacheBreakClassification = "likely_server_side_drop";
     cacheBreakReason = "known prior cacheable prefix remained present but cache read dropped";
@@ -4103,6 +4192,7 @@ function prepareAnthropicCacheRoundDiagnostics({
       : null,
     cache_break_baseline_round: classificationBaseline?.round ?? null,
     contains_prior_known_cacheable_prefix: currentContainsPriorCacheablePrefix,
+    stable_prefix_matches_cache_baseline: stablePrefixMatchesBaseline,
     cache_break_classification: cacheBreakClassification,
     cache_break_reason: cacheBreakReason,
     prev_cache_read_input_tokens: previousCacheRead,
@@ -4388,6 +4478,8 @@ function summarizeTokenOptimizationRounds(rounds) {
   let expectedAfterCompactionCacheBreakRounds = 0;
   let continuedCacheMissRounds = 0;
   let movingBreakpointNonReuseRounds = 0;
+  let stablePrefixAvailableRounds = 0;
+  let stablePrefixChangedRounds = 0;
 
   for (const round of rounds) {
     requestLoweringModes[round.request_lowering_mode] =
@@ -4409,6 +4501,12 @@ function summarizeTokenOptimizationRounds(rounds) {
     providerAttemptCount += round.provider_attempt_count;
     providerRetryCount += round.provider_retry_count;
     providerErrorCount += round.provider_error_count;
+    if (round.stable_prefix?.status === "available") {
+      stablePrefixAvailableRounds += 1;
+    }
+    if ((round.stable_prefix_changed_components?.length ?? 0) > 0) {
+      stablePrefixChangedRounds += 1;
+    }
     if (round.high_input_zero_cache_read) {
       highInputZeroCacheReadRounds += 1;
     }
@@ -4498,6 +4596,8 @@ function summarizeTokenOptimizationRounds(rounds) {
     cache_read_input_tokens: cacheReadInputTokens,
     cache_miss_input_tokens: cacheMissInputTokens,
     cache_creation_input_tokens: cacheCreationInputTokens,
+    cache_hit_ratio:
+      logicalInputTokens > 0 ? cacheReadInputTokens / logicalInputTokens : null,
     output_tokens: outputTokens,
     estimated_cost_usd:
       rounds.length > 0 && pricedRounds === rounds.length ? estimatedCostUsd : null,
@@ -4536,6 +4636,8 @@ function summarizeTokenOptimizationRounds(rounds) {
     expected_after_compaction_cache_break_rounds: expectedAfterCompactionCacheBreakRounds,
     continued_cache_miss_rounds: continuedCacheMissRounds,
     moving_breakpoint_non_reuse_rounds: movingBreakpointNonReuseRounds,
+    stable_prefix_available_rounds: stablePrefixAvailableRounds,
+    stable_prefix_changed_rounds: stablePrefixChangedRounds,
     top_cache_miss_rounds: topCacheMissRounds
   };
 }

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -1968,6 +1968,48 @@ test("summarizeHolonTokenOptimization classifies client prefix cache drops", () 
   assert.deepEqual(diagnostics.rounds[1].shape_changed_fields, ["anthropic_cache.system_hash"]);
 });
 
+test("summarizeHolonTokenOptimization explains stable-prefix component changes", () => {
+  const diagnostics = summarizeHolonTokenOptimization([
+    anthropicProviderRound({
+      round: 1,
+      cacheRead: 18_000,
+      stablePrefixFingerprint: "stable-a"
+    }),
+    anthropicProviderRound({
+      round: 2,
+      cacheRead: 0,
+      stablePrefixFingerprint: "stable-b",
+      stablePrefixComponents: [
+        { name: "contract", fingerprint: "contract" },
+        { name: "request_controls", fingerprint: "controls" },
+        { name: "system", fingerprint: "system" },
+        { name: "tools", fingerprint: "tools-changed" },
+        { name: "history_prefix", fingerprint: "history" }
+      ]
+    })
+  ]);
+
+  assert.equal(diagnostics.rounds[0].stable_prefix.status, "available");
+  assert.deepEqual(diagnostics.rounds[1].stable_prefix_changed_components, ["tools"]);
+  assert.equal(diagnostics.rounds[1].cache_break_classification, "client_prefix_changed");
+  assert.equal(
+    diagnostics.rounds[1].shape_changed_fields.includes("stable_prefix.components.tools"),
+    true
+  );
+  assert.equal(diagnostics.summary.stable_prefix_available_rounds, 2);
+  assert.equal(diagnostics.summary.stable_prefix_changed_rounds, 1);
+});
+
+test("summarizeHolonTokenOptimization keeps missing stable-prefix diagnostics unavailable", () => {
+  const diagnostics = summarizeHolonTokenOptimization([
+    anthropicProviderRound({ round: 1, cacheRead: 18_000 })
+  ]);
+
+  assert.equal(diagnostics.rounds[0].stable_prefix.status, "unavailable");
+  assert.equal(diagnostics.rounds[0].stable_prefix_changed_components, null);
+  assert.equal(diagnostics.summary.stable_prefix_available_rounds, 0);
+});
+
 test("summarizeHolonTokenOptimization reports client prefix changes inside a segment", () => {
   const diagnostics = summarizeHolonTokenOptimization([
     anthropicProviderRound({
@@ -2105,7 +2147,9 @@ function anthropicProviderRound({
   breakpointStability = "conversation_tail",
   workingMemoryRevision = 4,
   compressionEpoch = 1,
-  appliedEdits = []
+  appliedEdits = [],
+  stablePrefixFingerprint = null,
+  stablePrefixComponents = null
 }) {
   return {
     kind: "provider_round_completed",
@@ -2122,6 +2166,26 @@ function anthropicProviderRound({
       compression_epoch: compressionEpoch,
       provider_request_diagnostics: {
         request_lowering_mode: "prompt_cache_blocks",
+        ...(stablePrefixFingerprint
+          ? {
+              stable_prefix: {
+                schema_version: 1,
+                algorithm: "sha256",
+                full_request_fingerprint: `full-${round}`,
+                stable_prefix_fingerprint: stablePrefixFingerprint,
+                history_prefix_items: 3,
+                dynamic_tail_items: 1,
+                components:
+                  stablePrefixComponents ?? [
+                    { name: "contract", fingerprint: "contract" },
+                    { name: "request_controls", fingerprint: "controls" },
+                    { name: "system", fingerprint: "system" },
+                    { name: "tools", fingerprint: "tools" },
+                    { name: "history_prefix", fingerprint: "history" }
+                  ]
+              }
+            }
+          : {}),
         anthropic_cache: {
           tools_count: 3,
           tools_hash: toolsHash,

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -1926,6 +1926,30 @@ test("summarizeHolonTokenOptimization reports non-material zero cache reads accu
   );
 });
 
+test("summarizeHolonTokenOptimization classifies matching stable-prefix cache drops as server-side", () => {
+  const diagnostics = summarizeHolonTokenOptimization([
+    anthropicProviderRound({
+      round: 1,
+      cacheRead: 18_000,
+      createdAt: "2026-04-28T00:00:00Z",
+      stablePrefixFingerprint: "stable-x"
+    }),
+    anthropicProviderRound({
+      round: 2,
+      cacheRead: 0,
+      createdAt: "2026-04-28T00:00:20Z",
+      stablePrefixFingerprint: "stable-x"
+    })
+  ]);
+
+  assert.equal(diagnostics.rounds[1].cache_break_classification, "likely_server_side_drop");
+  assert.equal(diagnostics.rounds[1].stable_prefix_matches_cache_baseline, true);
+  assert.equal(
+    diagnostics.rounds[1].cache_break_reason,
+    "provider-visible stable prefix matched the positive cache-read baseline"
+  );
+});
+
 test("summarizeHolonTokenOptimization classifies stable-prefix cache drop as likely server-side", () => {
   const diagnostics = summarizeHolonTokenOptimization([
     anthropicProviderRound({

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -21,6 +21,7 @@ mod retry;
 pub mod test_support;
 mod tool_schema;
 mod transports;
+mod wire_fingerprint;
 
 pub(crate) use catalog::build_candidate_from_model_route;
 pub use catalog::{build_provider_from_config, build_provider_from_model_chain};
@@ -212,6 +213,27 @@ pub struct ProviderRequestDiagnostics {
     pub native_web_search: Option<ProviderNativeWebSearchDiagnostics>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ProviderResponseFormatDiagnostics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_prefix: Option<ProviderStablePrefixDiagnostics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderStablePrefixDiagnostics {
+    pub schema_version: u32,
+    pub algorithm: String,
+    pub full_request_fingerprint: String,
+    pub stable_prefix_fingerprint: String,
+    pub history_prefix_items: usize,
+    pub dynamic_tail_items: usize,
+    pub components: Vec<ProviderStablePrefixComponentDiagnostics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderStablePrefixComponentDiagnostics {
+    pub name: String,
+    pub fingerprint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/provider/tests/anthropic_messages.rs
+++ b/src/provider/tests/anthropic_messages.rs
@@ -62,6 +62,16 @@ async fn anthropic_request_lowers_prompt_frame_blocks_to_cache_control() {
     let cache_diagnostics = diagnostics.anthropic_cache.as_ref().unwrap();
     assert_eq!(cache_diagnostics.system_block_count, 1);
     assert!(!cache_diagnostics.cache_breakpoints.is_empty());
+    let stable_prefix = diagnostics
+        .stable_prefix
+        .as_ref()
+        .expect("stable prefix diagnostics");
+    assert_eq!(stable_prefix.schema_version, 1);
+    assert_eq!(stable_prefix.algorithm, "sha256");
+    assert_eq!(stable_prefix.dynamic_tail_items, 0);
+    let serialized = serde_json::to_string(stable_prefix).unwrap();
+    assert!(!serialized.contains("stable system"));
+    assert!(!serialized.contains("agent context"));
 
     let body = captured_body
         .lock()

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -554,6 +554,17 @@ async fn deepseek_responses_streams_and_replays_full_history_across_provider_res
     assert_eq!(diagnostics.endpoint_dialect.as_deref(), Some("responses"));
     assert_eq!(diagnostics.streaming, Some(true));
     assert_eq!(diagnostics.reasoning_effort.as_deref(), Some("high"));
+    let stable_prefix = diagnostics
+        .stable_prefix
+        .as_ref()
+        .expect("stable prefix diagnostics");
+    assert_eq!(stable_prefix.schema_version, 1);
+    assert_eq!(stable_prefix.algorithm, "sha256");
+    assert_eq!(stable_prefix.dynamic_tail_items, 1);
+    assert!(stable_prefix
+        .components
+        .iter()
+        .any(|component| component.name == "tools"));
     assert_eq!(
         diagnostics
             .native_web_search

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -732,7 +732,20 @@ fn anthropic_messages_response_to_turn_response(
         betas,
     );
     let request_lowering_mode = anthropic_request_lowering_mode(request, cache_strategy);
-
+    let (stable_history_prefix, dynamic_tail_items) =
+        anthropic_stable_history_prefix(request_payload, rolling_cache_marker);
+    let stable_prefix = crate::provider::wire_fingerprint::stable_prefix_diagnostics(
+        request_payload,
+        request_payload,
+        &stable_history_prefix,
+        dynamic_tail_items,
+        &json!({
+            "provider_transport": "anthropic_messages",
+            "endpoint_dialect": "anthropic_messages",
+            "request_lowering_mode": request_lowering_mode,
+            "contract_version": 1,
+        }),
+    );
     Ok(ProviderTurnResponse {
         blocks,
         stop_reason: parsed.stop_reason,
@@ -760,8 +773,35 @@ fn anthropic_messages_response_to_turn_response(
             openai_remote_compaction: None,
             native_web_search: native_web_search_diagnostics(request),
             response_format: response_format_diagnostics(request),
+            stable_prefix: Some(stable_prefix),
         }),
     })
+}
+
+fn anthropic_stable_history_prefix(
+    request_payload: &Value,
+    rolling_cache_marker: Option<(usize, usize)>,
+) -> (Vec<Value>, usize) {
+    let messages = request_payload
+        .get("messages")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let Some((message_index, content_index)) = rolling_cache_marker else {
+        let prefix_items = messages.len().saturating_sub(1);
+        return (
+            messages[..prefix_items].to_vec(),
+            messages.len().saturating_sub(prefix_items),
+        );
+    };
+    let end = message_index.saturating_add(1).min(messages.len());
+    let mut prefix = messages[..end].to_vec();
+    if let Some(message) = prefix.get_mut(message_index) {
+        if let Some(content) = message.get_mut("content").and_then(Value::as_array_mut) {
+            content.truncate(content_index.saturating_add(1));
+        }
+    }
+    (prefix, messages.len().saturating_sub(end))
 }
 
 fn provider_request_id_from_headers(headers: &HeaderMap) -> Option<String> {

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -440,6 +440,7 @@ fn gemini_response_to_provider_turn_response(
             openai_remote_compaction: None,
             native_web_search: None,
             response_format: None,
+            stable_prefix: None,
         }),
     })
 }

--- a/src/provider/transports/openai/continuation.rs
+++ b/src/provider/transports/openai/continuation.rs
@@ -142,6 +142,7 @@ pub(super) fn incremental_diagnostics(
         }),
         native_web_search,
         response_format,
+        stable_prefix: None,
     }
 }
 

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -36,8 +36,9 @@ use crate::{
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
         ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
         ProviderPromptFrame, ProviderRequestDiagnostics, ProviderResponseFormatDiagnostics,
-        ProviderResponseFormatRequest, ProviderTransportDiagnostics, ProviderTurnRequest,
-        ProviderTurnResponse, ToolSchemaContract,
+        ProviderResponseFormatRequest, ProviderStablePrefixDiagnostics,
+        ProviderTransportDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
+        ToolSchemaContract,
     },
     token_estimate::estimate_json_tokens,
 };
@@ -520,6 +521,12 @@ impl AgentProvider for OpenAiProvider {
                     plan.diagnostics.request_lowering_mode.clone();
             }
         }
+        sent_diagnostics.stable_prefix = Some(openai_stable_prefix_diagnostics(
+            &plan.body,
+            &plan.request_shape.wire_shape,
+            &plan.provider_input,
+            &sent_diagnostics,
+        ));
         let mut final_provider_input = plan.provider_input.clone();
         let mut final_replay_loss_reason = plan.replay_loss_reason.clone();
         let parsed = match send_openai_responses_for_contract(
@@ -832,6 +839,12 @@ impl AgentProvider for OpenAiCodexProvider {
             sent_diagnostics.openai_remote_compaction = Some(remote_compaction);
             sent_diagnostics.request_lowering_mode = plan.diagnostics.request_lowering_mode.clone();
         }
+        sent_diagnostics.stable_prefix = Some(openai_stable_prefix_diagnostics(
+            &plan.body,
+            &plan.request_shape.wire_shape,
+            &plan.provider_input,
+            &sent_diagnostics,
+        ));
         let parsed = match send_openai_responses_streaming_request(
             &self.client,
             openai_codex_responses_url(&self.base_url),
@@ -1197,6 +1210,27 @@ impl ProviderTurnResponse {
         self.request_diagnostics = Some(diagnostics);
         self
     }
+}
+
+pub(in crate::provider::transports::openai) fn openai_stable_prefix_diagnostics(
+    actual_body: &Value,
+    stable_shape: &Value,
+    provider_input: &[Value],
+    diagnostics: &ProviderRequestDiagnostics,
+) -> ProviderStablePrefixDiagnostics {
+    let history_prefix_items = provider_input.len().saturating_sub(1);
+    crate::provider::wire_fingerprint::stable_prefix_diagnostics(
+        actual_body,
+        stable_shape,
+        &provider_input[..history_prefix_items],
+        provider_input.len().saturating_sub(history_prefix_items),
+        &json!({
+            "provider_transport": diagnostics.provider_transport,
+            "endpoint_dialect": diagnostics.endpoint_dialect,
+            "request_lowering_mode": diagnostics.request_lowering_mode,
+            "contract_version": 1,
+        }),
+    )
 }
 
 impl ParsedOpenAiResponse {

--- a/src/provider/transports/openai/responses/plan.rs
+++ b/src/provider/transports/openai/responses/plan.rs
@@ -372,6 +372,7 @@ pub(in super::super) fn plan_openai_responses_request(
             }),
             native_web_search: native_web_search_diagnostics(request),
             response_format: response_format_diagnostics(true, request),
+            stable_prefix: None,
         },
     })
 }

--- a/src/provider/transports/openai/responses/send.rs
+++ b/src/provider/transports/openai/responses/send.rs
@@ -134,6 +134,17 @@ pub(in super::super) async fn retry_openai_responses_with_lossless_replay(
         continuation.fallback_reason = Some("previous_response_id_rejected".into());
         continuation.server_side_context_may_be_lost = None;
     }
+    let mut stable_shape = fallback_body.clone();
+    if let Some(object) = stable_shape.as_object_mut() {
+        object.remove("input");
+        object.remove("previous_response_id");
+    }
+    diagnostics.stable_prefix = Some(openai_stable_prefix_diagnostics(
+        &fallback_body,
+        &stable_shape,
+        final_provider_input,
+        diagnostics,
+    ));
     send_openai_responses_request(
         client,
         url,

--- a/src/provider/wire_fingerprint.rs
+++ b/src/provider/wire_fingerprint.rs
@@ -1,0 +1,188 @@
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::{ProviderStablePrefixComponentDiagnostics, ProviderStablePrefixDiagnostics};
+
+const STABLE_PREFIX_SCHEMA_VERSION: u32 = 1;
+const HASH_ALGORITHM: &str = "sha256";
+
+pub(crate) fn stable_prefix_diagnostics(
+    actual_request: &Value,
+    stable_shape: &Value,
+    history_prefix: &[Value],
+    dynamic_tail_items: usize,
+    contract: &Value,
+) -> ProviderStablePrefixDiagnostics {
+    let request_controls = request_controls(stable_shape);
+    let system = stable_shape
+        .get("instructions")
+        .or_else(|| stable_shape.get("system"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let tools = stable_shape
+        .get("tools")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let history = Value::Array(history_prefix.to_vec());
+    let components = vec![
+        component("contract", contract, None),
+        component("request_controls", &request_controls, None),
+        component("system", &system, value_item_count(&system)),
+        component("tools", &tools, value_item_count(&tools)),
+        component("history_prefix", &history, Some(history_prefix.len())),
+    ];
+    let stable_identity = Value::Array(
+        components
+            .iter()
+            .map(|component| {
+                json!({
+                    "name": component.name,
+                    "fingerprint": component.fingerprint,
+                })
+            })
+            .collect(),
+    );
+
+    ProviderStablePrefixDiagnostics {
+        schema_version: STABLE_PREFIX_SCHEMA_VERSION,
+        algorithm: HASH_ALGORITHM.to_string(),
+        full_request_fingerprint: fingerprint("full_request", actual_request),
+        stable_prefix_fingerprint: fingerprint("stable_prefix", &stable_identity),
+        history_prefix_items: history_prefix.len(),
+        dynamic_tail_items,
+        components,
+    }
+}
+
+fn component(
+    name: &str,
+    value: &Value,
+    item_count: Option<usize>,
+) -> ProviderStablePrefixComponentDiagnostics {
+    ProviderStablePrefixComponentDiagnostics {
+        name: name.to_string(),
+        fingerprint: fingerprint(name, value),
+        item_count,
+    }
+}
+
+fn request_controls(stable_shape: &Value) -> Value {
+    let mut controls = Map::new();
+    if let Some(object) = stable_shape.as_object() {
+        for (key, value) in object {
+            if !matches!(
+                key.as_str(),
+                "instructions" | "system" | "tools" | "input" | "messages" | "previous_response_id"
+            ) {
+                controls.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    Value::Object(controls)
+}
+
+fn value_item_count(value: &Value) -> Option<usize> {
+    value.as_array().map(Vec::len)
+}
+
+fn fingerprint(domain: &str, value: &Value) -> String {
+    let canonical = canonical_json(value);
+    let payload = format!(
+        "holon-provider-stable-prefix:v{STABLE_PREFIX_SCHEMA_VERSION}:{domain}:{canonical}"
+    );
+    let digest = Sha256::digest(payload.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => serde_json::to_string(value).unwrap_or_else(|_| "\"\"".into()),
+        Value::Array(values) => {
+            let values = values.iter().map(canonical_json).collect::<Vec<_>>();
+            format!("[{}]", values.join(","))
+        }
+        Value::Object(map) => {
+            let mut keys = map.keys().collect::<Vec<_>>();
+            keys.sort();
+            let fields = keys
+                .into_iter()
+                .map(|key| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(key).unwrap_or_else(|_| "\"\"".into()),
+                        canonical_json(&map[key])
+                    )
+                })
+                .collect::<Vec<_>>();
+            format!("{{{}}}", fields.join(","))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_fingerprints_ignore_object_insertion_order() {
+        let left = json!({"b": 2, "a": {"y": 2, "x": 1}});
+        let right = json!({"a": {"x": 1, "y": 2}, "b": 2});
+
+        assert_eq!(
+            fingerprint("fixture", &left),
+            fingerprint("fixture", &right)
+        );
+        assert_eq!(
+            fingerprint("fixture", &left),
+            "5a3ce91ba76ca4af924d0cca6f765671bc3924c2554eea1f9b26ea3ac6b321c2"
+        );
+    }
+
+    #[test]
+    fn dynamic_tail_does_not_change_stable_prefix() {
+        let stable_shape = json!({
+            "model": "model",
+            "instructions": "secret instructions",
+            "tools": [{"name": "tool"}],
+        });
+        let first = json!({
+            "model": "model",
+            "instructions": "secret instructions",
+            "tools": [{"name": "tool"}],
+            "input": [{"role": "user", "content": "first"}],
+        });
+        let second = json!({
+            "model": "model",
+            "instructions": "secret instructions",
+            "tools": [{"name": "tool"}],
+            "input": [{"role": "user", "content": "second"}],
+        });
+        let contract = json!({"transport": "responses", "dialect": "test"});
+
+        let first = stable_prefix_diagnostics(&first, &stable_shape, &[], 1, &contract);
+        let second = stable_prefix_diagnostics(&second, &stable_shape, &[], 1, &contract);
+
+        assert_ne!(
+            first.full_request_fingerprint,
+            second.full_request_fingerprint
+        );
+        assert_eq!(
+            first.stable_prefix_fingerprint,
+            second.stable_prefix_fingerprint
+        );
+        let serialized = serde_json::to_string(&first).unwrap();
+        assert!(!serialized.contains("secret instructions"));
+        assert!(!serialized.contains("\"content\":\"first\""));
+    }
+
+    #[test]
+    fn request_diagnostics_remain_compatible_without_stable_prefix() {
+        let diagnostics: super::super::ProviderRequestDiagnostics =
+            serde_json::from_value(json!({"request_lowering_mode": "legacy"})).unwrap();
+
+        assert!(diagnostics.stable_prefix.is_none());
+    }
+}

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -6,6 +6,44 @@ struct PickThenExecProvider {
     target_work_item_id: String,
 }
 
+struct StablePrefixDiagnosticsProvider;
+
+#[async_trait]
+impl AgentProvider for StablePrefixDiagnosticsProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        Ok(ProviderTurnResponse {
+            blocks: vec![ModelBlock::Text {
+                text: "done".into(),
+            }],
+            stop_reason: None,
+            input_tokens: 42,
+            output_tokens: 7,
+            cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: Some(
+                serde_json::from_value(serde_json::json!({
+                    "request_lowering_mode": "full_replay",
+                    "stable_prefix": {
+                        "schema_version": 1,
+                        "algorithm": "sha256",
+                        "full_request_fingerprint": "full-fingerprint",
+                        "stable_prefix_fingerprint": "stable-fingerprint",
+                        "history_prefix_items": 2,
+                        "dynamic_tail_items": 1,
+                        "components": [{
+                            "name": "tools",
+                            "fingerprint": "tools-fingerprint",
+                            "item_count": 3
+                        }]
+                    }
+                }))
+                .unwrap(),
+            ),
+        })
+    }
+}
+
 #[tokio::test]
 async fn terminal_pick_ends_turn_before_later_tools_or_provider_rounds() {
     let dir = tempdir().unwrap();
@@ -298,6 +336,54 @@ async fn first_provider_round_records_prompt_cache_identity_fields() {
         assistant_round.data["context_fingerprint"].as_str(),
         Some("fingerprint-ce3")
     );
+}
+
+#[tokio::test]
+async fn provider_round_records_secret_safe_stable_prefix_diagnostics() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StablePrefixDiagnosticsProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let events = runtime.storage().read_recent_events(10).unwrap();
+    let provider_event = events
+        .iter()
+        .find(|event| event.kind == "provider_round_completed")
+        .expect("missing provider_round_completed");
+    let stable_prefix = &provider_event.data["provider_request_diagnostics"]["stable_prefix"];
+    assert_eq!(
+        stable_prefix["stable_prefix_fingerprint"].as_str(),
+        Some("stable-fingerprint")
+    );
+    assert_eq!(stable_prefix["dynamic_tail_items"].as_u64(), Some(1));
+    assert_eq!(
+        stable_prefix["components"][0]["name"].as_str(),
+        Some("tools")
+    );
+    let serialized = serde_json::to_string(&provider_event.data).unwrap();
+    assert!(!serialized.contains("system_prompt"));
+    assert!(!serialized.contains("conversation"));
+    assert!(!serialized.contains("tool_arguments"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- derive versioned, fixed-length stable-prefix fingerprints from the final provider-visible request shape
- expose secret-safe component fingerprints and stable-boundary metadata through `ProviderRequestDiagnostics` and `provider_round_completed`
- add benchmark per-round cache-hit ratios, changed-component diagnostics, and cache-break classification while preserving compatibility with older events
- cover Responses and Anthropic lowering, runtime persistence, secret safety, compatibility, benchmark reporting, and a fixed cross-process fingerprint vector

Closes #2584

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` — 2725 passed, 0 failed, 1 ignored
