### PR TITLE
feat: add GLM-5.3 model to provider catalog

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1648,7 +1648,7 @@ fn reasoning_effort_options(
         ("venice", "zai-org-glm-4.7" | "qwen3-235b-a22b-thinking-2507") => {
             &["low", "medium", "high"][..]
         }
-        ("zai" | "bigmodel", "glm-5.2") => &["high", "max"][..],
+        ("zai" | "bigmodel", "glm-5.2" | "glm-5.3") => &["high", "max"][..],
         ("moonshot", "kimi-k3") => &["low", "high", "max"][..],
         ("xiaomi", "mimo-v2.5-pro" | "mimo-v2.5")
             if endpoint
@@ -2247,17 +2247,19 @@ mod tests {
                 .preferred_model_for_provider(&ProviderId::parse("zai").unwrap())
                 .unwrap()
                 .as_string(),
-            "zai/glm-5.2"
+            "zai/glm-5.3"
         );
         assert_eq!(
             catalog
                 .preferred_model_for_provider(&ProviderId::parse("bigmodel").unwrap())
                 .unwrap()
                 .as_string(),
-            "bigmodel/glm-5.2"
+            "bigmodel/glm-5.3"
         );
 
-        for model in ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.6"] {
+        for model in [
+            "glm-5.3", "glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.6",
+        ] {
             assert!(catalog
                 .get(&ModelRef::new(ProviderId::parse("zai").unwrap(), model))
                 .is_some());
@@ -2717,7 +2719,7 @@ mod tests {
             .filter(|entry| entry.model_ref.provider == synthetic)
             .collect::<Vec<_>>();
 
-        assert_eq!(models.len(), 11);
+        assert_eq!(models.len(), 12);
         for model in &models {
             assert!(model.capabilities.supports_reasoning);
             assert_eq!(
@@ -3041,6 +3043,7 @@ mod tests {
             "dashscope@token-plan/qwen3.8-max",
             "dashscope@token-plan/deepseek-v4-flash-0731",
             "dashscope@token-plan/kimi-k2.7-code",
+            "dashscope@token-plan/glm-5.3",
             "dashscope@token-plan/glm-5.2",
             "dashscope@token-plan/MiniMax-M2.5",
             "dashscope@coding-plan/qwen3-coder-plus",
@@ -3060,6 +3063,7 @@ mod tests {
             "dashscope@token-plan/ZHIPU/GLM-5.2",
             "dashscope@token-plan/MiniMax/MiniMax-M3",
             "dashscope@coding-plan/glm-5.2",
+            "dashscope@coding-plan/glm-5.3",
             "dashscope@coding-plan/kimi-k2.7-code",
         ] {
             assert!(
@@ -3546,7 +3550,7 @@ mod tests {
             );
         }
 
-        for route_ref in ["volcengine@plan/glm-5.2"] {
+        for route_ref in ["volcengine@plan/glm-5.2", "volcengine@plan/glm-5.3"] {
             let policy = catalog.resolve_route_policy(
                 &ModelRouteRef::parse(route_ref).unwrap(),
                 &HashMap::new(),
@@ -3567,7 +3571,9 @@ mod tests {
         for route_ref in [
             "volcengine@default/doubao-seed-2-0-pro-260215",
             "volcengine@coding/glm-5.2",
+            "volcengine@coding/glm-5.3",
             "volcengine@plan/glm-5.2",
+            "volcengine@plan/glm-5.3",
         ] {
             let policy = catalog.resolve_route_policy(
                 &ModelRouteRef::parse(route_ref).unwrap(),
@@ -3824,7 +3830,7 @@ mod tests {
             .filter(|model| model.model_ref.provider == provider)
             .collect::<Vec<_>>();
 
-        assert_eq!(models.len(), 14);
+        assert_eq!(models.len(), 15);
         for model in &models {
             assert!(model.capabilities.supports_reasoning);
             assert!(model.reasoning_effort_options.is_empty());
@@ -3834,6 +3840,7 @@ mod tests {
         for model in [
             "deepseek-v4-pro",
             "deepseek-v4-flash",
+            "glm-5.3",
             "glm-5.2",
             "glm-5.1",
             "kimi-k2.7-code",
@@ -3903,7 +3910,7 @@ mod tests {
             .filter(|model| model.model_ref.provider == provider)
             .collect::<Vec<_>>();
 
-        assert_eq!(models.len(), 27);
+        assert_eq!(models.len(), 28);
         for model in &models {
             assert_eq!(model.source, ModelMetadataSource::ConservativeBuiltin);
             assert!(model.reasoning_effort_options.is_empty());

--- a/src/model_catalog/providers/china.rs
+++ b/src/model_catalog/providers/china.rs
@@ -103,6 +103,7 @@ pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
             ("kimi-k2.7-code", None, Some(65_536)),
             ("kimi-k2.6", None, Some(65_536)),
             ("kimi-k2.5", None, None),
+            ("glm-5.3", Some(1_000_000), Some(65_536)),
             ("glm-5.2", Some(1_000_000), Some(65_536)),
             ("glm-5.1", None, Some(65_536)),
             ("glm-5", None, None),
@@ -173,6 +174,7 @@ pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
             ("deepseek-v4-flash", None),
             ("kimi-k2.6", None),
             ("kimi-k2.7-code", None),
+            ("glm-5.3", None),
             ("glm-5.2", None),
         ]
         .into_iter()
@@ -489,6 +491,15 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "volcengine-coding",
+            "glm-5.3",
+            "GLM-5.3",
+            204_800,
+            128_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "volcengine-coding",
             "glm-5.2",
             "GLM-5.2",
             204_800,
@@ -598,6 +609,7 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
             source: ModelMetadataSource::BuiltInCatalog,
             endpoint: None,
         },
+        catalog_model("zai", "glm-5.3", "GLM-5.3", 1_000_000, 131_072, true, false),
         catalog_model("zai", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false),
         catalog_model("zai", "glm-5.1", "GLM-5.1", 202_800, 131_072, true, false),
         catalog_model("zai", "glm-5", "GLM-5", 202_800, 131_072, true, false),
@@ -707,6 +719,9 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
         ),
     ];
     entries.extend([
+        catalog_model(
+            "bigmodel", "glm-5.3", "GLM-5.3", 1_000_000, 131_072, true, false,
+        ),
         catalog_model(
             "bigmodel", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false,
         ),
@@ -878,10 +893,28 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "dashscope",
+            "ZHIPU/GLM-5.3",
+            "ZHIPU/GLM-5.3",
+            1_000_000,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
             "ZHIPU/GLM-5.2",
             "ZHIPU/GLM-5.2",
             1_000_000,
             131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "glm-5.3",
+            "glm-5.3",
+            204_800,
+            128_000,
             true,
             false,
         ),

--- a/src/model_catalog/providers/gateways.rs
+++ b/src/model_catalog/providers/gateways.rs
@@ -120,6 +120,15 @@ pub(super) fn opencode_entries() -> Vec<BuiltInModelMetadata> {
             None,
         ),
         opencode_go_model(
+            "glm-5.3",
+            "GLM-5.3",
+            1_000_000,
+            Some(131_072),
+            true,
+            false,
+            None,
+        ),
+        opencode_go_model(
             "glm-5.2",
             "GLM-5.2",
             1_000_000,

--- a/src/model_catalog/providers/hosted.rs
+++ b/src/model_catalog/providers/hosted.rs
@@ -793,6 +793,7 @@ pub(super) fn middle_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         nvidia_model("minimaxai/minimax-m3", "MiniMax M3", 1_000_000, true, true),
+        nvidia_model("z-ai/glm-5.3", "GLM-5.3", 1_000_000, true, false),
         nvidia_model("z-ai/glm-5.2", "GLM-5.2", 1_000_000, true, false),
     ]
 }
@@ -840,6 +841,15 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
             "hf:openai/gpt-oss-120b",
             "OpenAI GPT OSS 120B",
             131_072,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "synthetic",
+            "hf:zai-org/GLM-5.3",
+            "Z.ai GLM-5.3",
+            524_288,
             65_536,
             true,
             false,
@@ -915,6 +925,7 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
             true,
         ),
         together_model("moonshotai/Kimi-K2.6", "Kimi K2.6", 262_144, true, true),
+        together_model("zai-org/GLM-5.3", "GLM-5.3", 262_144, false, false),
         together_model("zai-org/GLM-5.2", "GLM-5.2", 262_144, false, false),
         together_model("openai/gpt-oss-120b", "GPT-OSS 120B", 128_000, true, false),
         together_model(

--- a/src/model_catalog/providers/tencent_tokenhub.rs
+++ b/src/model_catalog/providers/tencent_tokenhub.rs
@@ -91,6 +91,14 @@ const TENCENT_TOKENHUB_MODELS: &[TencentTokenHubModelSpec] = &[
         false,
     ),
     (
+        "glm-5.3",
+        "GLM-5.3",
+        Some(1_000_000),
+        Some(131_072),
+        true,
+        false,
+    ),
+    (
         "glm-5.2",
         "GLM-5.2",
         Some(1_000_000),


### PR DESCRIPTION
## Summary

Add GLM-5.3 — Zhipu AI's newly released flagship model — to the model catalog across all supported providers.

## Changes

- **New model entries** for `glm-5.3` across all providers: `zai`, `bigmodel`, `dashscope` (both `glm-5.3` and `ZHIPU/GLM-5.3`), `volcengine`, `opencode`, `nvidia`, `synthetic` (HF), `together`, and `tencent-tokenhub`
- **Preferred model** updated from `glm-5.2` → `glm-5.3` for `zai` and `bigmodel` providers
- **Reasoning effort** options `["high", "max"]` configured for `glm-5.3` (same as `glm-5.2`)
- **Specs**: 1M context window, 128K–131K max output tokens, reasoning-capable
- **Tests**: all model count assertions, routing policy tests, and preferred-model assertions updated to include `glm-5.3`

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib` — 2721 passed, 0 failed ✅

## Model specs

| Provider | Context | Max Output | Reasoning |
|----------|---------|------------|-----------|
| zai / bigmodel | 1,000,000 | 131,072 | ✅ |
| dashscope (direct) | 204,800 | 128,000 | ✅ |
| dashscope (ZHIPU/) | 1,000,000 | 131,072 | ✅ |
| volcengine | 204,800 | 128,000 | ✅ |
| opencode | 1,000,000 | 131,072 | ✅ |
| nvidia | 1,000,000 | — | ✅ |
| synthetic (HF) | 524,288 | 65,536 | ✅ |
| together | 262,144 | — | ✅ |
| tencent-tokenhub | 1,000,000 | 131,072 | ✅ |