### PR TITLE
fix: recover equal-revision TaskResult claims on bootstrap

### DIFF
--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -624,6 +624,20 @@ pub struct RecoverInterruptedTaskResultClaim {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoverUnadvancedTaskResultClaim {
+    pub command_id: String,
+    pub attempt_id: String,
+    pub outcome_id: String,
+    pub work_item_id: String,
+    pub task_id: String,
+    pub result_message_id: String,
+    pub wait_id: String,
+    pub rejoin: RejoinFence,
+    pub expected_source_revision: u64,
+    pub interrupted_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "command", content = "payload", rename_all = "snake_case")]
 pub enum ExecutionProtocolCommand {
     RegisterWorkItem(Box<RegisterWorkItemExecution>),
@@ -638,6 +652,7 @@ pub enum ExecutionProtocolCommand {
     Settle(SettleExecution),
     Interrupt(InterruptExecution),
     RecoverInterruptedTaskResultClaim(Box<RecoverInterruptedTaskResultClaim>),
+    RecoverUnadvancedTaskResultClaim(Box<RecoverUnadvancedTaskResultClaim>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1168,6 +1183,74 @@ pub fn recover_interrupted_task_result_claim(
         .get_mut(&command.work_item_id)
         .expect("interruption preserved WorkItem authority")
         .source_revision = command.source_revision;
+    assert_invariants(&transition.state)?;
+    transition.references.extend([
+        format!("task:{}", command.task_id),
+        format!("message:{}", command.result_message_id),
+        format!("wait:{}", command.wait_id),
+        format!("work_item:{}", command.work_item_id),
+    ]);
+    Ok(transition)
+}
+
+pub fn recover_unadvanced_task_result_claim(
+    state: &ExecutionProtocolState,
+    command: &RecoverUnadvancedTaskResultClaim,
+) -> Result<ExecutionTransition, String> {
+    assert_invariants(state)?;
+    if command.command_id.is_empty()
+        || command.attempt_id.is_empty()
+        || command.outcome_id.is_empty()
+        || command.work_item_id.is_empty()
+        || command.task_id.is_empty()
+        || command.result_message_id.is_empty()
+        || command.wait_id.is_empty()
+        || command.expected_source_revision == 0
+    {
+        return Err("Unadvanced TaskResult claim recovery requires complete identity".into());
+    }
+    let attempt = state.attempts.get(&command.attempt_id).ok_or_else(|| {
+        "Unadvanced TaskResult claim recovery references an unknown attempt".to_string()
+    })?;
+    if attempt.state != ExecutionAttemptState::Open
+        || attempt.source_message_id.as_deref() != Some(command.result_message_id.as_str())
+        || attempt.source.identity
+            != (ExecutionSourceIdentity::TaskResult {
+                task_id: command.task_id.clone(),
+                result_message_id: command.result_message_id.clone(),
+            })
+        || attempt.binding
+            != (ExecutionBinding::WorkItem {
+                work_item_id: command.work_item_id.clone(),
+            })
+        || attempt.admitted_fences.work_item_source_revision
+            != Some(command.expected_source_revision)
+        || attempt.admitted_fences.rejoin.as_ref() != Some(&command.rejoin)
+    {
+        return Err("Unadvanced TaskResult claim recovery attempt fence is stale".into());
+    }
+    let work = state.work_items.get(&command.work_item_id).ok_or_else(|| {
+        "Unadvanced TaskResult claim recovery WorkItem authority is missing".to_string()
+    })?;
+    if work.source_revision != command.expected_source_revision
+        || !matches!(
+            &work.state,
+            WorkItemExecutionState::InFlight { attempt_id, generation }
+                if attempt_id == &command.attempt_id
+                    && Some(*generation) == attempt.admitted_fences.work_item_generation
+        )
+    {
+        return Err("Unadvanced TaskResult claim recovery WorkItem fence is stale".into());
+    }
+    let mut transition = interrupt_execution(
+        state,
+        &InterruptExecution {
+            attempt_id: command.attempt_id.clone(),
+            outcome_id: command.outcome_id.clone(),
+            reason: "runtime_interrupted".into(),
+            interrupted_at: command.interrupted_at.clone(),
+        },
+    )?;
     assert_invariants(&transition.state)?;
     transition.references.extend([
         format!("task:{}", command.task_id),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1536,6 +1536,21 @@ fn exact_resolved_task_result_wait(
     })
 }
 
+enum TaskResultClaimRecovery {
+    Eligible {
+        transition: crate::runtime_db::transitions::ExecutionProtocolTransition,
+        reason: &'static str,
+    },
+    RequiresInactiveRuntime,
+    Ineligible,
+}
+
+#[derive(Clone, Copy)]
+enum TaskResultClaimRecoveryAuthority {
+    Diagnostic,
+    RuntimeTerminatedBootstrap,
+}
+
 fn exact_task_result_claim_recovery(
     storage: &AppStorage,
     runtime_db: &RuntimeDb,
@@ -1543,9 +1558,11 @@ fn exact_task_result_claim_recovery(
     attempt: &crate::domain::execution_protocol::ExecutionAttempt,
     work_item_id: &str,
     interrupted_at: chrono::DateTime<Utc>,
-) -> Result<Option<crate::runtime_db::transitions::ExecutionProtocolTransition>> {
+    authority: TaskResultClaimRecoveryAuthority,
+) -> Result<TaskResultClaimRecovery> {
     use crate::domain::execution_protocol::{
         ExecutionSourceIdentity, RecoverInterruptedTaskResultClaim,
+        RecoverUnadvancedTaskResultClaim,
     };
 
     let ExecutionSourceIdentity::TaskResult {
@@ -1553,7 +1570,7 @@ fn exact_task_result_claim_recovery(
         result_message_id,
     } = &attempt.source.identity
     else {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     };
     if result_message_id != &message.id
         || message.kind != MessageKind::TaskResult
@@ -1564,46 +1581,67 @@ fn exact_task_result_claim_recovery(
         || message.work_item_id.as_deref() != Some(work_item_id)
         || !matches!(&message.origin, MessageOrigin::Task { task_id: origin } if origin == task_id)
     {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     }
     let Some(task) = storage.latest_task_record(task_id)? else {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     };
     let Ok(rejoin) = task.rejoin_fence() else {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     };
     if task.agent_id != message.agent_id
         || task.work_item_id.as_deref() != Some(work_item_id)
         || task.parent_message_id.as_deref() != Some(message.id.as_str())
         || attempt.admitted_fences.rejoin.as_ref() != Some(&rejoin)
     {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     }
     let Some(wait) = exact_resolved_task_result_wait(storage, message, task_id, work_item_id)?
     else {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     };
     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     };
     let Some(expected_source_revision) = attempt.admitted_fences.work_item_source_revision else {
-        return Ok(None);
+        return Ok(TaskResultClaimRecovery::Ineligible);
     };
-    if work_item.state != WorkItemState::Open
-        || work_item.blocked_by.is_some()
-        || work_item.revision <= expected_source_revision
-    {
-        return Ok(None);
+    if work_item.state != WorkItemState::Open || work_item.blocked_by.is_some() {
+        return Ok(TaskResultClaimRecovery::Ineligible);
     }
-    Ok(Some(
-        crate::runtime_db::transitions::ExecutionProtocolTransition {
-            bootstrap: None,
-            commands: vec![
+    let (command, reason) = match work_item.revision.cmp(&expected_source_revision) {
+        std::cmp::Ordering::Greater => (
+            crate::domain::execution_protocol::ExecutionProtocolCommand::
+                RecoverInterruptedTaskResultClaim(Box::new(
+                    RecoverInterruptedTaskResultClaim {
+                        command_id: format!(
+                            "recover_task_result_claim:{}:{}",
+                            attempt.attempt_id, work_item.revision
+                        ),
+                        attempt_id: attempt.attempt_id.clone(),
+                        outcome_id: format!("outcome:interrupted:{}", attempt.attempt_id),
+                        work_item_id: work_item_id.to_string(),
+                        task_id: task_id.clone(),
+                        result_message_id: message.id.clone(),
+                        wait_id: wait.id,
+                        rejoin,
+                        expected_source_revision,
+                        source_revision: work_item.revision,
+                        interrupted_at: interrupted_at.to_rfc3339(),
+                    },
+                )),
+            "stale_task_result_claim_revision",
+        ),
+        std::cmp::Ordering::Equal => {
+            if matches!(authority, TaskResultClaimRecoveryAuthority::Diagnostic) {
+                return Ok(TaskResultClaimRecovery::RequiresInactiveRuntime);
+            }
+            (
                 crate::domain::execution_protocol::ExecutionProtocolCommand::
-                    RecoverInterruptedTaskResultClaim(Box::new(
-                        RecoverInterruptedTaskResultClaim {
+                    RecoverUnadvancedTaskResultClaim(Box::new(
+                        RecoverUnadvancedTaskResultClaim {
                             command_id: format!(
-                                "recover_task_result_claim:{}:{}",
+                                "recover_unadvanced_task_result_claim:{}:{}",
                                 attempt.attempt_id, work_item.revision
                             ),
                             attempt_id: attempt.attempt_id.clone(),
@@ -1614,13 +1652,21 @@ fn exact_task_result_claim_recovery(
                             wait_id: wait.id,
                             rejoin,
                             expected_source_revision,
-                            source_revision: work_item.revision,
                             interrupted_at: interrupted_at.to_rfc3339(),
                         },
                     )),
-            ],
+                "unadvanced_task_result_claim",
+            )
+        }
+        std::cmp::Ordering::Less => return Ok(TaskResultClaimRecovery::Ineligible),
+    };
+    Ok(TaskResultClaimRecovery::Eligible {
+        transition: crate::runtime_db::transitions::ExecutionProtocolTransition {
+            bootstrap: None,
+            commands: vec![command],
         },
-    ))
+        reason,
+    })
 }
 
 fn scheduler_task_result_claim_recovery_candidates(
@@ -1677,16 +1723,22 @@ fn scheduler_task_result_claim_recovery_candidates(
                 candidate.reason = "message_missing".into();
                 return Ok(candidate);
             };
-            let Some(transition) = exact_task_result_claim_recovery(
+            let recovery = exact_task_result_claim_recovery(
                 storage,
                 runtime_db,
                 &message,
                 attempt,
                 work_item_id,
                 Utc::now(),
-            )?
-            else {
-                return Ok(candidate);
+                TaskResultClaimRecoveryAuthority::Diagnostic,
+            )?;
+            let (transition, reason) = match recovery {
+                TaskResultClaimRecovery::Eligible { transition, reason } => (transition, reason),
+                TaskResultClaimRecovery::RequiresInactiveRuntime => {
+                    candidate.reason = "requires_inactive_runtime_recovery".into();
+                    return Ok(candidate);
+                }
+                TaskResultClaimRecovery::Ineligible => return Ok(candidate),
             };
             let [command] = transition.commands.as_slice() else {
                 return Ok(candidate);
@@ -1695,7 +1747,7 @@ fn scheduler_task_result_claim_recovery_candidates(
             proposed_entry.status = QueueEntryStatus::Queued;
             proposed_entry.updated_at = Utc::now();
             candidate.eligible = true;
-            candidate.reason = "stale_task_result_claim_revision".into();
+            candidate.reason = reason.into();
             candidate.evidence.push(format!(
                 "durable_work_item_revision:{}",
                 runtime_db
@@ -5851,11 +5903,16 @@ impl RuntimeHandle {
                     &attempt,
                     work_item_id,
                     self.now(),
+                    TaskResultClaimRecoveryAuthority::RuntimeTerminatedBootstrap,
                 )?;
-                if !work_queue_claim && task_result_recovery.is_none() {
-                    continue;
+                match task_result_recovery {
+                    TaskResultClaimRecovery::Eligible { transition, .. } => Some(transition),
+                    TaskResultClaimRecovery::RequiresInactiveRuntime => {
+                        unreachable!("bootstrap authority permits equal-revision recovery")
+                    }
+                    TaskResultClaimRecovery::Ineligible if !work_queue_claim => continue,
+                    TaskResultClaimRecovery::Ineligible => None,
                 }
-                task_result_recovery
             } else {
                 None
             };

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -461,6 +461,11 @@ fn persist_execution_transition_only(
                     &state, &command,
                 )
             }
+            ExecutionProtocolCommand::RecoverUnadvancedTaskResultClaim(command) => {
+                crate::domain::execution_protocol::recover_unadvanced_task_result_claim(
+                    &state, &command,
+                )
+            }
         }
         .expect("test execution transition should be valid")
         .state;
@@ -2565,6 +2570,41 @@ async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimF
     }
 }
 
+async fn unadvanced_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimFixture {
+    use crate::domain::execution_protocol::WorkItemExecutionState;
+
+    let fixture = stale_task_result_claim_fixture(task_id).await;
+    let mut state = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("TaskResult fixture execution partition");
+    let attempt = state
+        .attempts
+        .get_mut(&fixture.attempt_id)
+        .expect("TaskResult fixture attempt");
+    attempt.admitted_fences.work_item_source_revision = Some(fixture.current_revision);
+    attempt.admitted_fences.work_item_generation = Some(fixture.current_revision);
+    state
+        .work_items
+        .get_mut(&fixture.work_item_id)
+        .expect("TaskResult fixture WorkItem")
+        .state = WorkItemExecutionState::InFlight {
+        generation: fixture.current_revision,
+        attempt_id: fixture.attempt_id.clone(),
+    };
+    fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &state))
+        .unwrap();
+    fixture
+}
+
 fn isolated_task_result_claim_report(runtime: &RuntimeHandle) -> SchedulerRecoveryReport {
     let mut report =
         scheduler_recovery_report(&runtime.inner.storage, &runtime.inner.runtime_db, "default")
@@ -2573,6 +2613,72 @@ fn isolated_task_result_claim_report(runtime: &RuntimeHandle) -> SchedulerRecove
     report.legacy_adoptions.clear();
     report.continuation_reconciliations.clear();
     report
+}
+
+#[tokio::test]
+async fn bootstrap_recovers_unadvanced_task_result_claim_but_diagnostic_apply_does_not() {
+    use crate::domain::execution_protocol::{ExecutionAttemptState, WorkItemExecutionState};
+
+    let fixture = unadvanced_task_result_claim_fixture("task-bootstrap-unadvanced-recovery").await;
+    let report = isolated_task_result_claim_report(&fixture.runtime);
+    let [candidate] = report.task_result_claim_recoveries.as_slice() else {
+        panic!("expected one unadvanced TaskResult claim candidate: {report:#?}");
+    };
+    assert!(!candidate.eligible);
+    assert_eq!(candidate.reason, "requires_inactive_runtime_recovery");
+    assert!(candidate.proposed_command.is_none());
+
+    assert_eq!(
+        fixture
+            .runtime
+            .recover_scheduler_bootstrap_claims()
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .recover_scheduler_bootstrap_claims()
+            .await
+            .unwrap(),
+        0
+    );
+    let recovered = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("recovered execution partition");
+    assert_eq!(
+        recovered.attempts[&fixture.attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        recovered.work_items[&fixture.work_item_id].source_revision,
+        fixture.current_revision
+    );
+    assert!(matches!(
+        recovered.work_items[&fixture.work_item_id].state,
+        WorkItemExecutionState::Runnable {
+            recovery_ref: Some(ref recovery_ref),
+            ..
+        } if recovery_ref == "interrupted"
+    ));
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("requeued TaskResult")
+            .status,
+        QueueEntryStatus::Queued
+    );
 }
 
 #[tokio::test]

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -96,6 +96,9 @@ pub(super) fn validate_execution_commands_tx(
         if let ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) = command {
             validate_recover_interrupted_task_result_claim(tx, agent_id, command)?;
         }
+        if let ExecutionProtocolCommand::RecoverUnadvancedTaskResultClaim(command) = command {
+            validate_recover_unadvanced_task_result_claim(tx, agent_id, command)?;
+        }
         if let ExecutionProtocolCommand::SetWorkItemReadiness(command) = command {
             validate_set_work_item_readiness(command, work_item_mutations, wait_conditions)?;
         }
@@ -329,6 +332,9 @@ fn reduce(
         ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) => {
             execution_protocol::recover_interrupted_task_result_claim(state, command)
         }
+        ExecutionProtocolCommand::RecoverUnadvancedTaskResultClaim(command) => {
+            execution_protocol::recover_unadvanced_task_result_claim(state, command)
+        }
     }
 }
 
@@ -370,6 +376,9 @@ fn command_identity(command: &ExecutionProtocolCommand) -> (&'static str, &str) 
         }
         ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(command) => {
             ("recover_interrupted_task_result_claim", &command.command_id)
+        }
+        ExecutionProtocolCommand::RecoverUnadvancedTaskResultClaim(command) => {
+            ("recover_unadvanced_task_result_claim", &command.command_id)
         }
     }
 }
@@ -484,6 +493,30 @@ fn validate_recover_interrupted_task_result_claim(
         bail!("TaskResult claim recovery requires one exact resolved task wait");
     }
     Ok(())
+}
+
+fn validate_recover_unadvanced_task_result_claim(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    command: &execution_protocol::RecoverUnadvancedTaskResultClaim,
+) -> Result<()> {
+    validate_recover_interrupted_task_result_claim(
+        tx,
+        agent_id,
+        &execution_protocol::RecoverInterruptedTaskResultClaim {
+            command_id: command.command_id.clone(),
+            attempt_id: command.attempt_id.clone(),
+            outcome_id: command.outcome_id.clone(),
+            work_item_id: command.work_item_id.clone(),
+            task_id: command.task_id.clone(),
+            result_message_id: command.result_message_id.clone(),
+            wait_id: command.wait_id.clone(),
+            rejoin: command.rejoin.clone(),
+            expected_source_revision: command.expected_source_revision,
+            source_revision: command.expected_source_revision,
+            interrupted_at: command.interrupted_at.clone(),
+        },
+    )
 }
 
 fn validate_set_work_item_waiting(
@@ -985,6 +1018,7 @@ impl RuntimeTransitionRepository<'_> {
                 command,
                 ExecutionProtocolCommand::ReconcileWorkItemContinuationYield(_)
                     | ExecutionProtocolCommand::RecoverInterruptedTaskResultClaim(_)
+                    | ExecutionProtocolCommand::RecoverUnadvancedTaskResultClaim(_)
             )
         }) {
             bail!("execution protocol recovery plan contains a non-recovery command");

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -500,6 +500,10 @@ fn validate_recover_unadvanced_task_result_claim(
     agent_id: &str,
     command: &execution_protocol::RecoverUnadvancedTaskResultClaim,
 ) -> Result<()> {
+    // This path intentionally synthesizes source_revision from the admitted
+    // revision because the durable WorkItem has not advanced. The shared
+    // repository validator may check equality, but must not require the strict
+    // monotonicity used by the interrupted-claim domain transition.
     validate_recover_interrupted_task_result_claim(
         tx,
         agent_id,


### PR DESCRIPTION
## 概要

- 新增专用的 `RecoverUnadvancedTaskResultClaim` transition，处理 durable WorkItem revision 与 admitted revision 相等的精确崩溃状态
- equal-revision 恢复仅允许由已终止 runtime 的 bootstrap authority 触发；diagnostic recovery 对此状态保持只读、不修改持久化状态
- 在 interrupt 遗留 attempt 并重新排队 TaskResult 前，完整校验 task、message、wait、WorkItem、generation、revision 与 rejoin fences
- 保留已有的 advanced-revision recovery 路径

## 原因

当持久化在 TaskResult admission 之后、durable WorkItem revision 前进之前失败时，queue entry 可能停留在 `Dequeued`，execution attempt 为 `Open`，WorkItem 为 `InFlight`。原 bootstrap recovery 要求 durable revision 严格大于 admitted revision，因此无法恢复这一精确崩溃状态，用户后续输入也会继续被遗留的 Open attempt 阻塞。

本 PR 仅实现 #2590 的 P0 equal-revision bootstrap recovery。Host activation linearization 与自动恢复协调器将在本 PR 合并后分别通过后续 PR 实现。

## 验证

- `cargo fmt --all -- --check`
- `cargo test bootstrap_recovers_unadvanced_task_result_claim_but_diagnostic_apply_does_not -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

本 PR 是 #2590 的 P0 部分；待计划中的 P1/P2 全部完成后再关闭该 issue。
