### PR TITLE
fix(web-gui): fall back to auto reasoning effort when target model rejects current level

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -16,9 +16,11 @@ import {
   timelineForDisplayLevel,
   timelineLayoutRevision,
   writeStoredComposerDraft,
+  resolveModelSwitchReasoningEffort,
 } from "./AgentPage";
 import { availableDisplayLevels } from "../../runtime/display-level";
 import type { TimelineTurn } from "./timeline-utils";
+import type { RuntimeModelOption } from "../../runtime/types";
 
 class MemoryStorage implements Storage {
   private readonly items = new Map<string, string>();
@@ -95,6 +97,41 @@ describe("composer draft storage", () => {
 
     expect(readStoredComposerDraft("agent-a")).toBe("");
     expect(storage.getItem(storedComposerDraftKey("agent-a"))).toBeNull();
+  });
+});
+
+describe("model switch reasoning effort", () => {
+  function modelOption(supportsReasoningEffort: boolean, reasoningEffortOptions: string[]): RuntimeModelOption {
+    return {
+      model: "glm-5.3",
+      routeRef: "bigmodel/glm-5.3",
+      provider: "bigmodel",
+      providerFamily: "bigmodel",
+      endpoint: "default",
+      routeProvider: "bigmodel",
+      displayName: "GLM-5.3",
+      available: true,
+      supportsImageInput: true,
+      supportsImageGeneration: false,
+      supportsReasoningEffort,
+      reasoningEffortOptions,
+    };
+  }
+
+  it("falls back to auto when the target model lacks the current effort level", () => {
+    expect(resolveModelSwitchReasoningEffort(modelOption(true, ["low", "high", "max"]), "medium")).toBe("auto");
+  });
+
+  it("keeps the current effort level when the target model supports it", () => {
+    expect(resolveModelSwitchReasoningEffort(modelOption(true, ["low", "medium", "high"]), "medium")).toBe("medium");
+  });
+
+  it("keeps auto untouched for reasoning models", () => {
+    expect(resolveModelSwitchReasoningEffort(modelOption(true, ["low", "high"]), "auto")).toBe("auto");
+  });
+
+  it("resets to auto for models without reasoning support", () => {
+    expect(resolveModelSwitchReasoningEffort(modelOption(false, []), "medium")).toBe("auto");
   });
 });
 

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -395,7 +395,7 @@ export function AgentPage({
     setReasoningPopoverOpen(false);
     setSelectedProvider(null);
     setSelectedReasoningEffort(activeAgent.modelReasoningEffort ?? "auto");
-  }, [activeAgent.id, displayLevel]);
+  }, [activeAgent.id, displayLevel, activeAgent.modelReasoningEffort]);
 
   useEffect(() => {
     return () => {
@@ -657,11 +657,10 @@ export function AgentPage({
   async function handleSelectModel(option: RuntimeModelOption, reasoningEffort = selectedReasoningEffort) {
     if (!option.available || changingModel) return;
 
-    // When switching to a non-reasoning model, reset thinking display to auto.
-    if (!option.supportsReasoningEffort) {
-      setSelectedReasoningEffort("auto");
-      reasoningEffort = "auto";
-    }
+    // Switching models must win over a stale thinking level: fall back to auto
+    // when the target model does not support the currently selected effort.
+    reasoningEffort = resolveModelSwitchReasoningEffort(option, reasoningEffort);
+    setSelectedReasoningEffort(reasoningEffort);
 
     setChangingModel(option.routeRef);
     try {
@@ -1019,6 +1018,12 @@ export function AgentPage({
 function shortModelLabel(model: string): string {
   const parts = model.split("/");
   return parts[parts.length - 1] || model;
+}
+
+export function resolveModelSwitchReasoningEffort(option: RuntimeModelOption, requestedEffort: string): string {
+  if (!option.supportsReasoningEffort) return "auto";
+  if (requestedEffort !== "auto" && !option.reasoningEffortOptions.includes(requestedEffort)) return "auto";
+  return requestedEffort;
 }
 
 function modelButtonTitle(model: string, reasoningEffort: string | undefined, isModelOverride: boolean): string {


### PR DESCRIPTION
## Summary

切换模型时，Web GUI 会把界面上遗留的 reasoning-effort 档位原样发给新模型。若新模型不支持该档位（如 GLM-5.3 仅支持 low/high/max，而界面遗留 medium），`POST /control/agents/:id/model` 会被服务端 `validate_reasoning_effort` 拒绝（400），导致模型切换整体失败并回滚。

本 PR 让模型切换优先成功，纯前端改动，不需要服务端/API 变更：

- 新增纯函数 `resolveModelSwitchReasoningEffort`：仅当目标模型支持当前档位时保留，否则降级为 `auto` 并向服务端发送 `undefined` 清除 override；无 reasoning 支持的模型同样重置为 auto（保持原有行为）。
- `selectedReasoningEffort` 同步 effect 增加 `activeAgent.modelReasoningEffort` 依赖，切换模型后本地档位与服务端一致，badge 立即如实显示 Auto。
- 档位合法性来源是服务端下发的 `RuntimeModelOption.reasoningEffortOptions`，与 policy 保持单一事实来源。

## Verification

- `vitest run src/features/agent/AgentPage.test.ts`：22/22 通过（含 4 个新增用例：降级、保留、auto 透传、无 reasoning 模型）
- `npm run typecheck`：无错误
- 同一改动上此前全量 `vitest run`：332/332 通过
