### PR TITLE
fix: repair release E2E first-run failures

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -12,6 +12,10 @@ on:
       previous_image:
         description: Previous release image used by upgrade cases.
         required: false
+      previous_ref:
+        description: Git tag of the previous release. Used to build the previous image when previous_image is not published.
+        required: false
+        default: v0.30.0
       model:
         description: Real model route.
         required: false
@@ -122,9 +126,56 @@ jobs:
           docker pull "${CANDIDATE_IMAGE}"
           scripts/docker-smoke.sh "${CANDIDATE_IMAGE}"
 
+      - name: Prepare previous release image
+        id: previous
+        env:
+          PREVIOUS_IMAGE_INPUT: ${{ inputs.previous_image }}
+          PREVIOUS_REF: ${{ inputs.previous_ref }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PREVIOUS_IMAGE_INPUT}" ] \
+            && docker manifest inspect "${PREVIOUS_IMAGE_INPUT}" >/dev/null 2>&1; then
+            echo "image=${PREVIOUS_IMAGE_INPUT}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          version="${PREVIOUS_REF#v}"
+          workdir="$(mktemp -d)"
+          base_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${PREVIOUS_REF}"
+          curl -fsSL -o "${workdir}/checksums.txt" "${base_url}/checksums.txt"
+          curl -fsSL -o "${workdir}/holon-linux-amd64.tar.gz" "${base_url}/holon-linux-amd64.tar.gz"
+          (
+            cd "${workdir}"
+            sha256sum --check --ignore-missing checksums.txt
+            tar -xzf holon-linux-amd64.tar.gz
+            test -x holon || chmod +x holon
+          )
+          cat > "${workdir}/Dockerfile" <<'DOCKERFILE'
+          FROM debian:trixie-slim
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends \
+                 bash ca-certificates curl git gzip openssh-client tar \
+              && rm -rf /var/lib/apt/lists/* \
+              && useradd --create-home --home-dir /var/lib/holon --uid 10001 holon \
+              && mkdir -p /workspace \
+              && chown holon:holon /workspace
+          COPY holon /usr/local/bin/holon
+          RUN chmod +x /usr/local/bin/holon
+          ENV HOME=/var/lib/holon \
+              HOLON_HOME=/var/lib/holon \
+              HOLON_WORKSPACE_DIR=/workspace
+          WORKDIR /workspace
+          USER holon
+          EXPOSE 7878
+          ENTRYPOINT ["holon"]
+          CMD ["serve", "--listen", "0.0.0.0:7878"]
+          DOCKERFILE
+          tag="holon-e2e-previous:${version}"
+          docker build --tag "${tag}" "${workdir}"
+          echo "image=${tag}" >> "$GITHUB_OUTPUT"
+
       - name: Run release core E2E
         env:
-          HOLON_E2E_PREVIOUS_IMAGE: ${{ inputs.previous_image || 'ghcr.io/holon-run/holon:v0.30.0' }}
+          HOLON_E2E_PREVIOUS_IMAGE: ${{ steps.previous.outputs.image }}
           HOLON_E2E_PROVIDER_ENV_FILE: /tmp/holon-e2e.env
         run: |
           set -euo pipefail

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -140,12 +140,18 @@ jobs:
           fi
           version="${PREVIOUS_REF#v}"
           workdir="$(mktemp -d)"
+          trap 'rm -rf "${workdir}"' EXIT
           base_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${PREVIOUS_REF}"
           curl -fsSL -o "${workdir}/checksums.txt" "${base_url}/checksums.txt"
           curl -fsSL -o "${workdir}/holon-linux-amd64.tar.gz" "${base_url}/holon-linux-amd64.tar.gz"
           (
             cd "${workdir}"
-            sha256sum --check --ignore-missing checksums.txt
+            expected="$(awk 'match($0, /holon-linux-amd64\.tar\.gz$/) { print $1 }' checksums.txt)"
+            if [ -z "${expected}" ]; then
+              echo "checksums.txt has no entry for holon-linux-amd64.tar.gz" >&2
+              exit 1
+            fi
+            printf '%s  holon-linux-amd64.tar.gz\n' "${expected}" | sha256sum --check --strict -
             tar -xzf holon-linux-amd64.tar.gz
             test -x holon || chmod +x holon
           )

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -159,6 +159,70 @@ def normalize_model_route(model: str) -> str:
     return f"{provider}/{name}"
 
 
+def model_route_provider(model: str) -> str:
+    return model.split("/", 1)[0]
+
+
+def canonical_model_route_entry(entry: dict[str, Any]) -> str | None:
+    family = str(entry.get("provider_family") or "")
+    endpoint = str(entry.get("endpoint") or "")
+    model_ref = str((entry.get("policy") or {}).get("model_ref") or "")
+    model = model_ref.split("/", 1)[-1] if "/" in model_ref else ""
+    if not (family and endpoint and model):
+        return None
+    return f"{family}@{endpoint}/{model}"
+
+
+def require_runtime_model_route(
+    harness: "CaseHarness",
+    label: str,
+    runtime_route: str,
+    models_payload: dict[str, Any],
+) -> None:
+    """Require the runtime route to serve the requested model route.
+
+    The runtime canonicalizes provider and model aliases while loading the
+    configured route (``dashscope-token-plan/qwen-3.7`` becomes
+    ``dashscope@token-plan/qwen3.7-max``), so literal equality only holds for
+    requests that already use canonical routes. When the strings differ, the
+    runtime route is accepted only when the runtime's own model catalog
+    confirms the resolution: an availability entry for the requested provider
+    that reconstructs to the served route and reports it as available.
+    """
+    requested = normalize_model_route(harness.model)
+    served = normalize_model_route(str(runtime_route))
+    if served == requested:
+        return
+    requested_provider = model_route_provider(harness.model)
+    confirmations = []
+    for entry in models_payload.get("model_availability") or []:
+        canonical = canonical_model_route_entry(entry)
+        if canonical is None or normalize_model_route(canonical) != served:
+            continue
+        entry_providers = {
+            str(entry.get("route_provider") or ""),
+            model_route_provider(canonical),
+        }
+        if requested_provider not in entry_providers:
+            continue
+        confirmations.append(entry)
+    require(
+        confirmations,
+        f"{label} model route mismatch: runtime served {runtime_route!r} for "
+        f"requested {harness.model!r}; the runtime model catalog did not "
+        "confirm the canonical resolution",
+    )
+    unavailable = [
+        str(entry.get("unavailable_reason"))
+        for entry in confirmations
+        if entry.get("available") is not True
+    ]
+    require(
+        not unavailable,
+        f"{label} model route is not available: {unavailable}",
+    )
+
+
 def load_runtime_config(path: Path | None) -> dict[str, Any]:
     if path is None:
         return {}
@@ -2146,14 +2210,17 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     readiness = harness.request("GET", "/api/control/runtime/readiness")
     write_json(harness.evidence / "readiness.json", readiness)
     runtime_surface = readiness["runtime_surface"]
-    require(
-        normalize_model_route(runtime_surface["model_default"])
-        == normalize_model_route(harness.model),
-        f"runtime model route mismatch: {runtime_surface['model_default']}",
-    )
+    models_payload = harness.request("GET", "/api/models")
+    write_json(harness.evidence / "models.json", models_payload)
     require(
         runtime_surface["disable_provider_fallback"] is True,
         "provider fallback must be disabled for release E2E",
+    )
+    require_runtime_model_route(
+        harness,
+        "runtime default",
+        runtime_surface["model_default"],
+        models_payload,
     )
 
     phase = case["phases"][0]
@@ -2196,9 +2263,11 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
         f"provider token usage is missing: {provider}",
     )
     winning = timeline.get("winning_model_ref")
-    require(
-        normalize_model_route(str(winning)) == normalize_model_route(harness.model),
-        f"winning model {winning!r} did not match {harness.model!r}",
+    require_runtime_model_route(
+        harness,
+        "winning",
+        str(winning),
+        models_payload,
     )
 
     briefs = harness.request("GET", harness.agent_path("briefs?limit=20"))

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -140,11 +140,13 @@ class Scenario:
             ):
                 return 200, response([text_item("Deterministic Holon test runtime ready.")], "resp_intro")
             if self.name == "runtime-upgrade-v030":
-                match = re.search(r"UPGRADE-V030-(?:OLD|NEW)-[0-9a-f]+", raw)
-                if match and self.phase < self.expected_phase():
+                # Serialized history carries the earlier phase marker, so the
+                # current prompt's marker is the last occurrence in the payload.
+                markers = re.findall(r"UPGRADE-V030-(?:OLD|NEW)-[0-9a-f]+", raw)
+                if markers and self.phase < self.expected_phase():
                     self.phase += 1
                     return 200, response(
-                        [text_item(match.group(0))],
+                        [text_item(markers[-1])],
                         f"resp_runtime_upgrade_v030_{self.phase}",
                     )
             if self.phase == self.expected_phase() - 1:

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -546,6 +546,70 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(scenario.status()["extra_requests"], 1)
         self.assertFalse(scenario.status()["complete"])
 
+    def test_openai_stub_upgrade_v030_echoes_current_marker_not_history(self) -> None:
+        scenario = stub.Scenario("runtime-upgrade-v030")
+        old_prompt = {
+            "instructions": "agent instructions",
+            "input": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": (
+                                "## current_input\nCurrent input:\n"
+                                "- [operator] Reply with the exact marker "
+                                "UPGRADE-V030-OLD-0011aabb."
+                            ),
+                        }
+                    ],
+                }
+            ],
+        }
+        status, response = scenario.consume(old_prompt)
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            response["output"][0]["content"][0]["text"],
+            "UPGRADE-V030-OLD-0011aabb",
+        )
+        self.assertEqual(scenario.phase, 1)
+
+        new_prompt = {
+            "instructions": "agent instructions",
+            "input": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": (
+                                "## recent_turns\n"
+                                "- [operator] Reply with the exact marker "
+                                "UPGRADE-V030-OLD-0011aabb.\n"
+                                "- [assistant] UPGRADE-V030-OLD-0011aabb\n"
+                                "## current_input\nCurrent input:\n"
+                                "- [operator] Reply with the exact marker "
+                                "UPGRADE-V030-NEW-0022ccdd."
+                            ),
+                        }
+                    ],
+                }
+            ],
+        }
+        status, response = scenario.consume(new_prompt)
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            response["output"][0]["content"][0]["text"],
+            "UPGRADE-V030-NEW-0022ccdd",
+        )
+        self.assertEqual(scenario.phase, 2)
+
+        status, response = scenario.consume(new_prompt)
+        self.assertEqual(status, 409)
+        self.assertEqual(response["error"]["type"], "transcript_exhausted")
+        self.assertEqual(scenario.status()["extra_requests"], 1)
+        self.assertFalse(scenario.status()["complete"])
+
     def test_openai_stub_multi_waits_for_second_autonomous_turn(self) -> None:
         scenario = stub.Scenario("scheduler-multi")
         scenario.phase = 7
@@ -2364,6 +2428,87 @@ class DockerE2ERunnerTests(unittest.TestCase):
                     expected_state="completed",
                     label="duplicate",
                 )
+
+    def _route_oracle_harness(self, model: str) -> "runner.CaseHarness":
+        harness = runner.CaseHarness(
+            case_id="runtime-auth-model-delivery",
+            image="unused",
+            model=model,
+            credential_envs=[],
+            env_file=None,
+            runtime_env={},
+            evidence_root=Path(tempfile.mkdtemp()),
+            timeout_seconds=1,
+            keep=True,
+        )
+        harness.agent_id = "default"
+        return harness
+
+    def _models_payload(self) -> dict:
+        return {
+            "model_availability": [
+                {
+                    "model": "dashscope/qwen3.7-max",
+                    "provider_family": "dashscope",
+                    "endpoint": "token-plan",
+                    "route_provider": "dashscope-token-plan",
+                    "available": True,
+                    "policy": {"model_ref": "dashscope/qwen3.7-max"},
+                },
+                {
+                    "model": "dashscope/qwen3.7-max",
+                    "provider_family": "dashscope",
+                    "endpoint": "default",
+                    "route_provider": "dashscope",
+                    "available": False,
+                    "unavailable_reason": "credential_missing",
+                    "policy": {"model_ref": "dashscope/qwen3.7-max"},
+                },
+            ]
+        }
+
+    def test_runtime_model_route_accepts_confirmed_canonical_resolution(self) -> None:
+        harness = self._route_oracle_harness("dashscope-token-plan/qwen-3.7")
+        runner.require_runtime_model_route(
+            harness,
+            "runtime default",
+            "dashscope@token-plan/qwen3.7-max",
+            self._models_payload(),
+        )
+
+    def test_runtime_model_route_accepts_literal_match(self) -> None:
+        harness = self._route_oracle_harness("openai/gpt-5.4")
+        runner.require_runtime_model_route(
+            harness,
+            "winning",
+            "openai/gpt-5.4",
+            {"model_availability": []},
+        )
+
+    def test_runtime_model_route_rejects_unconfirmed_provider(self) -> None:
+        harness = self._route_oracle_harness("dashscope-token-plan/qwen-3.7")
+        with self.assertRaisesRegex(
+            AssertionError, "model catalog did not confirm"
+        ):
+            runner.require_runtime_model_route(
+                harness,
+                "runtime default",
+                "deepseek@default/deepseek-chat",
+                self._models_payload(),
+            )
+
+    def test_runtime_model_route_rejects_unavailable_canonical_route(self) -> None:
+        harness = self._route_oracle_harness("dashscope-token-plan/qwen-3.7")
+        payload = self._models_payload()
+        payload["model_availability"][0]["available"] = False
+        payload["model_availability"][0]["unavailable_reason"] = "credential_missing"
+        with self.assertRaisesRegex(AssertionError, "not available"):
+            runner.require_runtime_model_route(
+                harness,
+                "runtime default",
+                "dashscope@token-plan/qwen3.7-max",
+                payload,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Release E2E first run (run 31921625429, candidate `3b0cbda2`) failed two core cases. Both root causes are in the E2E harness, not in the candidate runtime:

1. **runtime-upgrade-v030** — the published `ghcr.io/holon-run/holon:v0.30.0` image uses the old image layout without `bash`/`git`, so the harness failed driving the git fixture with docker exit 125. Deeper down, the OpenAI stub echoed the **first** `UPGRADE-V030-*` marker found in the serialized request, which after upgrade is the historical OLD marker, so the upgraded agent could never persist the NEW marker.
2. **runtime-auth-model-delivery** — the runner asserted literal route equality, but the runtime canonicalizes `dashscope-token-plan/qwen-3.7` to `dashscope@token-plan/qwen3.7-max` while serving the requested model (single attempt, no fallback).

## Changes

- `.github/workflows/release-e2e.yml`: new `previous_ref` input (default `v0.30.0`); when `previous_image` is not provided/usable, download the official release tarball, verify `checksums.txt`, and build `holon-e2e-previous:<version>` locally with `bash`/`git` present.
- `scripts/docker_e2e/runner.py`: `require_runtime_model_route` accepts a canonicalized route only when the runtime model catalog confirms the requested provider resolves to the served route and reports it available; records `models.json` evidence.
- `tests/e2e/docker/openai_stub/server.py`: echo the **last** `UPGRADE-V030-(OLD|NEW)` marker in the payload (the current prompt) instead of the first (history).
- `tests/test_docker_e2e_runner.py`: regression tests for the stub marker echo and the catalog-confirmed route assertion.

No runtime code changed; the candidate image is functionally equivalent to `3b0cbda2`.

## Verification

- `python3 -m pytest tests/test_docker_e2e_runner.py` — 75 passed.
- Local docker E2E rerun against candidate image `ghcr.io/holon-run/holon@sha256:0685ccb2…` with a tarball-built `holon-e2e-previous:0.30.0`:
  - `runtime-upgrade-v030` PASS (schema 25 → 46, baseline provenance preserved, both markers persisted)
  - `runtime-auth-model-delivery` PASS (winning route `dashscope@token-plan/qwen3.7-max`, tokens delivered)