### PR TITLE
fix: preserve user scroll position when reading history during streaming

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -8,6 +8,8 @@ import {
   attachmentKindForFile,
   captureScrollAnchor,
   historyLoadDecision,
+  isScrollKey,
+  looksLikeProgrammaticBottomScroll,
   readStoredComposerDraft,
   resizeComposerTextarea,
   restoredScrollTop,
@@ -207,6 +209,47 @@ describe("timeline virtual layout reconciliation", () => {
 
   it("does not capture an anchor when only overscan rows before the viewport are measured", () => {
     expect(captureScrollAnchor([{ key: "turn:a", index: 0, start: 0, size: 80 }], 120)).toBeNull();
+  });
+});
+
+describe("scroll stick intent", () => {
+  it("treats a scroll event as programmatic only while auto-scroll is active, no user intent exists, and the position is near the bottom", () => {
+    expect(
+      looksLikeProgrammaticBottomScroll({ autoScrollActive: true, userScrollIntent: false, nearBottom: true }),
+    ).toBe(true);
+  });
+
+  it("does not force stick when the user is scrolling even inside the auto-scroll window", () => {
+    expect(
+      looksLikeProgrammaticBottomScroll({ autoScrollActive: true, userScrollIntent: true, nearBottom: false }),
+    ).toBe(false);
+    expect(
+      looksLikeProgrammaticBottomScroll({ autoScrollActive: true, userScrollIntent: true, nearBottom: true }),
+    ).toBe(false);
+  });
+
+  it("does not force stick when the position left the bottom, even without user intent", () => {
+    expect(
+      looksLikeProgrammaticBottomScroll({ autoScrollActive: true, userScrollIntent: false, nearBottom: false }),
+    ).toBe(false);
+  });
+
+  it("never forces stick outside the auto-scroll window", () => {
+    expect(
+      looksLikeProgrammaticBottomScroll({ autoScrollActive: false, userScrollIntent: false, nearBottom: true }),
+    ).toBe(false);
+  });
+
+  it("recognizes keys that can scroll the message list", () => {
+    for (const key of ["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " ", "Spacebar"]) {
+      expect(isScrollKey(key)).toBe(true);
+    }
+  });
+
+  it("ignores keys that cannot scroll the message list", () => {
+    for (const key of ["Enter", "Tab", "a", "Escape", ""]) {
+      expect(isScrollKey(key)).toBe(false);
+    }
   });
 });
 

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -67,6 +67,9 @@ const DEFAULT_DEBUG_TIMELINE_ITEM_LIMIT = 220;
 const HISTORY_PAGE_VISIBLE_INCREMENT = 80;
 const TOP_SCROLL_THRESHOLD = 16;
 const BOTTOM_SCROLL_THRESHOLD = 96;
+// How long scroll intent stays active after the last user scroll input
+// (wheel, touch, or scroll keys). Long enough to cover momentum scrolling.
+const USER_SCROLL_INTENT_CLEAR_MS = 500;
 const COMPOSER_DRAFT_STORAGE_PREFIX = "holon.webGui.composerDraft.v1";
 const COMPOSER_TEXTAREA_MAX_HEIGHT = 320;
 const MESSAGE_LIST_BOTTOM_SAFE_SPACE = 96;
@@ -345,6 +348,8 @@ export function AgentPage({
   const preserveScrollRef = useRef<ScrollAnchor | null>(null);
   const stickToBottomRef = useRef(true);
   const autoStickToBottomRef = useRef(false);
+  const userScrollIntentRef = useRef(false);
+  const userScrollIntentTimerRef = useRef<number | null>(null);
   const scheduledBottomScrollRef = useRef<number | null>(null);
   const activeAgent = detail?.agent ?? agent;
   const sourceTimeline = detail?.timeline ?? [];
@@ -402,6 +407,30 @@ export function AgentPage({
       if (scheduledBottomScrollRef.current !== null) {
         window.cancelAnimationFrame(scheduledBottomScrollRef.current);
       }
+      clearUserScrollIntent(userScrollIntentRef, userScrollIntentTimerRef);
+    };
+  }, []);
+
+  // Distinguish user-initiated scrolling from programmatic bottom scrolls by
+  // input source. The auto-stick time window alone cannot tell them apart
+  // while streaming keeps re-opening it, which used to drag users viewing
+  // history back to the bottom on every new message.
+  useEffect(() => {
+    const list = messageListRef.current;
+    if (!list) return;
+    const markIntent = () => scheduleUserScrollIntentClear(userScrollIntentRef, userScrollIntentTimerRef);
+    const handleKeyDown = (event: { key: string }) => {
+      if (isScrollKey(event.key)) markIntent();
+    };
+    list.addEventListener("wheel", markIntent, { passive: true });
+    list.addEventListener("touchstart", markIntent, { passive: true });
+    list.addEventListener("touchmove", markIntent, { passive: true });
+    list.addEventListener("keydown", handleKeyDown);
+    return () => {
+      list.removeEventListener("wheel", markIntent);
+      list.removeEventListener("touchstart", markIntent);
+      list.removeEventListener("touchmove", markIntent);
+      list.removeEventListener("keydown", handleKeyDown);
     };
   }, []);
 
@@ -447,6 +476,9 @@ export function AgentPage({
   useLayoutEffect(() => {
     preserveScrollRef.current = null;
     stickToBottomRef.current = true;
+    // A fresh conversation view must not inherit scroll intent from the
+    // previously viewed agent.
+    clearUserScrollIntent(userScrollIntentRef, userScrollIntentTimerRef);
     rowVirtualizer.measure();
     scrollToConversationBottom();
   }, [activeAgent.id]);
@@ -612,11 +644,24 @@ export function AgentPage({
   function handleMessageListScroll() {
     const list = messageListRef.current;
     if (!list) return;
-    if (autoStickToBottomRef.current) {
+    if (userScrollIntentRef.current) {
+      // Continued scrolling while intent is active (e.g. momentum after a
+      // trackpad flick) keeps the intent window open so programmatic bottom
+      // scrolls cannot hijack it mid-gesture.
+      scheduleUserScrollIntentClear(userScrollIntentRef, userScrollIntentTimerRef);
+    }
+    const nearBottom = isScrolledNearBottom(list);
+    if (
+      looksLikeProgrammaticBottomScroll({
+        autoScrollActive: autoStickToBottomRef.current,
+        userScrollIntent: userScrollIntentRef.current,
+        nearBottom,
+      })
+    ) {
       stickToBottomRef.current = true;
       return;
     }
-    stickToBottomRef.current = isScrolledNearBottom(list);
+    stickToBottomRef.current = nearBottom;
     if (stickToBottomRef.current) onConversationRead();
   }
 
@@ -1058,6 +1103,56 @@ function titleCase(value: string): string {
 
 function isScrolledNearBottom(list: HTMLElement): boolean {
   return list.scrollHeight - list.scrollTop - list.clientHeight < BOTTOM_SCROLL_THRESHOLD;
+}
+
+export function isScrollKey(key: string): boolean {
+  return (
+    key === "ArrowUp" ||
+    key === "ArrowDown" ||
+    key === "PageUp" ||
+    key === "PageDown" ||
+    key === "Home" ||
+    key === "End" ||
+    key === " " ||
+    key === "Spacebar"
+  );
+}
+
+// A scroll event is only treated as our own programmatic bottom scroll when
+// no user scroll input is active and the scroll position actually matches the
+// programmatic target. Anything else reflects real user intent and must be
+// evaluated against the current position.
+export function looksLikeProgrammaticBottomScroll(state: {
+  autoScrollActive: boolean;
+  userScrollIntent: boolean;
+  nearBottom: boolean;
+}): boolean {
+  return state.autoScrollActive && !state.userScrollIntent && state.nearBottom;
+}
+
+function scheduleUserScrollIntentClear(
+  intentRef: MutableRefObject<boolean>,
+  timerRef: MutableRefObject<number | null>,
+): void {
+  intentRef.current = true;
+  if (timerRef.current !== null) {
+    window.clearTimeout(timerRef.current);
+  }
+  timerRef.current = window.setTimeout(() => {
+    timerRef.current = null;
+    intentRef.current = false;
+  }, USER_SCROLL_INTENT_CLEAR_MS);
+}
+
+function clearUserScrollIntent(
+  intentRef: MutableRefObject<boolean>,
+  timerRef: MutableRefObject<number | null>,
+): void {
+  if (timerRef.current !== null) {
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }
+  intentRef.current = false;
 }
 
 function defaultTimelineItemLimit(displayLevel: DisplayLevel): number {


### PR DESCRIPTION
## Problem

While an agent is streaming events, scrolling up to read history caused the message list to repeatedly jump back to the bottom, making history unreadable.

## Root cause

Stick-to-bottom was guarded only by a time-window flag (`autoStickToBottomRef`) that stays open while programmatic scrolls are in flight. During streaming, `scrollToConversationBottom()` runs on every timeline update, so the window is almost always open; a user wheel event landing inside it was misclassified as a programmatic scroll and `stickToBottomRef` was forced back to `true`. The same-frame rAF callback then reset `scrollTop`, dragging the viewport down.

## Fix

- Track explicit user scroll intent via `wheel`, `touchstart`, `touchmove`, and scroll keys (PageUp/PageDown/arrows/Home/End/Space); intent expires ~500ms after scroll events stop, so trackpad inertia is not hijacked mid-gesture.
- A scroll event is only treated as programmatic when the auto-stick window is open AND there is no user intent AND the position is near the bottom (`looksLikeProgrammaticBottomScroll`); otherwise stick follows the real position, so new events, ResizeObserver, and rAF callbacks no longer pull the user back to the bottom.
- Reset intent when switching agents and clear timers on unmount.

## Testing

- 6 new unit cases covering `looksLikeProgrammaticBottomScroll` input combinations and `isScrollKey` key recognition.
- `npm test`: 338/338 passed; `npm run typecheck`: clean.
